### PR TITLE
fix(security,auth,db): resolve 10 critical and high-priority issues from codebase review

### DIFF
--- a/apps/cms/src/app/api/auth/recovery/request/route.ts
+++ b/apps/cms/src/app/api/auth/recovery/request/route.ts
@@ -14,6 +14,7 @@ import { getClient } from '@revealui/db';
 import { users } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendRecoveryEmail } from '@/lib/email';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import { createErrorResponse, createValidationErrorResponse } from '@/lib/utils/error-response';
 
@@ -61,8 +62,18 @@ async function requestHandler(request: NextRequest): Promise<NextResponse> {
     if (user) {
       const { token } = await createMagicLink(user.id);
 
-      // TODO: Send recovery email via Resend
-      // For v1, log the recovery URL in development only
+      // Send recovery email via configured provider (Resend/SMTP/mock)
+      const emailResult = await sendRecoveryEmail(email, token);
+
+      if (!emailResult.success) {
+        // Log error but don't reveal to user (prevents enumeration)
+        logger.error('Failed to send recovery email', {
+          email,
+          error: emailResult.error,
+        });
+      }
+
+      // Also log in development for easy debugging
       if (process.env.NODE_ENV !== 'production') {
         logger.info('Recovery link generated (dev only)', {
           email,

--- a/apps/cms/src/app/api/auth/sign-in/route.ts
+++ b/apps/cms/src/app/api/auth/sign-in/route.ts
@@ -57,8 +57,8 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
     const userAgent = request.headers.get('user-agent') || undefined;
     const xff = request.headers.get('x-forwarded-for');
     const ipAddress =
-      (xff ? xff.split(',').pop()?.trim() : undefined) ||
       request.headers.get('x-real-ip') ||
+      (xff ? xff.split(',')[0]?.trim() : undefined) ||
       undefined;
 
     const result = await signIn(sanitizedEmail, password, {

--- a/apps/cms/src/app/api/auth/sign-up/route.ts
+++ b/apps/cms/src/app/api/auth/sign-up/route.ts
@@ -125,8 +125,8 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
     const userAgent = request.headers.get('user-agent') || undefined;
     const xff = request.headers.get('x-forwarded-for');
     const ipAddress =
-      (xff ? xff.split(',').pop()?.trim() : undefined) ||
       request.headers.get('x-real-ip') ||
+      (xff ? xff.split(',')[0]?.trim() : undefined) ||
       undefined;
 
     const result = await signUp(sanitizedEmail, password, sanitizedName, {

--- a/apps/cms/src/lib/email/index.ts
+++ b/apps/cms/src/lib/email/index.ts
@@ -292,6 +292,74 @@ export async function sendEmail(
 }
 
 /**
+ * Send account recovery email (magic link)
+ *
+ * @param email - User email
+ * @param token - Magic link token
+ * @param recoveryUrl - Full recovery URL (optional, will construct if not provided)
+ */
+export async function sendRecoveryEmail(
+  email: string,
+  token: string,
+  recoveryUrl?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SERVER_URL ||
+    process.env.REVEALUI_PUBLIC_SERVER_URL;
+  if (!baseUrl) {
+    return {
+      success: false,
+      error: 'NEXT_PUBLIC_APP_URL (or NEXT_PUBLIC_SERVER_URL) is not set',
+    };
+  }
+  const finalRecoveryUrl =
+    recoveryUrl || `${baseUrl}/auth/recovery/verify?token=${encodeURIComponent(token)}`;
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Account Recovery</title>
+      </head>
+      <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h1 style="color: #ea580c;">Account Recovery</h1>
+        <p>You requested to recover your account. Click the button below to sign in:</p>
+        <p style="text-align: center; margin: 30px 0;">
+          <a href="${finalRecoveryUrl}" style="background-color: #ea580c; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+            Recover Account
+          </a>
+        </p>
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; color: #666;">${finalRecoveryUrl}</p>
+        <p style="color: #666; font-size: 14px; margin-top: 30px;">
+          This link will expire in 15 minutes. If you didn't request account recovery, you can safely ignore this email.
+        </p>
+      </body>
+    </html>
+  `;
+
+  const text = `
+Account Recovery
+
+You requested to recover your account. Click the link below to sign in:
+
+${finalRecoveryUrl}
+
+This link will expire in 15 minutes. If you didn't request account recovery, you can safely ignore this email.
+  `.trim();
+
+  return sendEmail({
+    to: email,
+    subject: 'Account Recovery — RevealUI',
+    html,
+    text,
+  });
+}
+
+/**
  * Send password reset email
  *
  * @param email - User email

--- a/apps/cms/src/proxy.ts
+++ b/apps/cms/src/proxy.ts
@@ -65,14 +65,16 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     const response = NextResponse.next();
     const origin = request.headers.get('origin');
 
-    // CORS headers
+    // CORS headers — only set when origin is in the allowed list
     if (allowedOrigins.includes(String(origin))) {
       response.headers.set('Access-Control-Allow-Origin', String(origin));
+      response.headers.set(
+        'Access-Control-Allow-Methods',
+        'GET, POST, OPTIONS, PUT, PATCH, DELETE',
+      );
+      response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      response.headers.set('Access-Control-Allow-Credentials', 'true');
     }
-
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    response.headers.set('Access-Control-Allow-Credentials', 'true');
 
     // Security headers
     response.headers.set('X-Frame-Options', 'DENY');

--- a/packages/auth/src/server/magic-link.ts
+++ b/packages/auth/src/server/magic-link.ts
@@ -11,7 +11,7 @@
 import crypto from 'node:crypto';
 import { getClient } from '@revealui/db/client';
 import { magicLinks } from '@revealui/db/schema';
-import { and, eq, isNull, lt } from 'drizzle-orm';
+import { and, eq, gt, isNull, lt } from 'drizzle-orm';
 
 // =============================================================================
 // Configuration (parameterization convention)
@@ -125,7 +125,7 @@ export async function verifyMagicLink(token: string): Promise<{ userId: string }
   const rows = await db
     .select()
     .from(magicLinks)
-    .where(and(isNull(magicLinks.usedAt)));
+    .where(and(isNull(magicLinks.usedAt), gt(magicLinks.expiresAt, new Date())));
 
   for (const row of rows) {
     const expectedHash = hashToken(token, row.tokenSalt);

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -12,7 +12,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "next": "^14.0.0 || ^15.0.0 || ^16.0.0"
+    "next": "^14.0.0 || ^15.0.0 || ^16.1.7"
   },
   "peerDependenciesMeta": {
     "next": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -12,8 +12,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@revealui/db": "workspace:*",
-    "drizzle-zod": "^0.8.3",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -105,7 +103,17 @@
     "registry": "https://registry.npmjs.org"
   },
   "peerDependencies": {
+    "@revealui/db": "workspace:*",
+    "drizzle-zod": "^0.8.3",
     "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@revealui/db": {
+      "optional": true
+    },
+    "drizzle-zod": {
+      "optional": true
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,14 @@
-// Main RevealUI exports - re-export core (server) and client functionality
+/**
+ * Main RevealUI exports — re-exports core (server) and client functionality.
+ *
+ * WARNING: Importing from '@revealui/core' pulls in BOTH server-only deps (pg,
+ * bcryptjs, PGlite) and client-side React code. For tree-shaking safety, prefer
+ * specific subpath imports:
+ *   - '@revealui/core/client' for client-only code
+ *   - '@revealui/core/server' for server-only code
+ *   - '@revealui/core/database' for the DB adapter
+ *   - '@revealui/core/richtext/client' for the rich text editor
+ */
 
 // Export core (server-side) functionality - now directly in root after flattening
 // REST API

--- a/packages/db/src/pool.ts
+++ b/packages/db/src/pool.ts
@@ -99,25 +99,47 @@ const poolConfig: PoolConfig = {
 };
 
 /**
- * Create connection pool
- * Note: assertProductionConfig() defers the check to pool-creation time,
- * not module-parse time, so tree-shaking and type-only imports don't crash.
+ * Create connection pool lazily.
+ *
+ * assertProductionConfig() is called when getPool() is first invoked,
+ * not at module-parse time, so tree-shaking and type-only imports don't crash.
  */
-assertProductionConfig();
-export const pool = new Pool(poolConfig);
+let _pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!_pool) {
+    assertProductionConfig();
+    _pool = new Pool(poolConfig);
+    _pool.on('error', onPoolError);
+    _pool.on('connect', onPoolConnect);
+    _pool.on('acquire', onPoolAcquire);
+    _pool.on('remove', onPoolRemove);
+    registerShutdown();
+  }
+  return _pool;
+}
+
+/**
+ * @deprecated Use getPool() instead. Eager pool creation risks crashes at module parse time.
+ */
+export const pool = new Proxy({} as Pool, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getPool(), prop, receiver);
+  },
+});
 
 // ===========================================================================
 // ERROR HANDLING
 // ===========================================================================
 
-pool.on('error', (err) => {
+function onPoolError(err: Error) {
   logger.error(
     'Unexpected error on idle database client',
     err instanceof Error ? err : new Error(String(err)),
   );
-});
+}
 
-pool.on('connect', (client) => {
+function onPoolConnect(client: PoolClient) {
   const pid = (client as PoolClientWithPID).processID;
   logger.info(`Database connection established (PID: ${pid})`);
 
@@ -126,8 +148,8 @@ pool.on('connect', (client) => {
       // Set timezone
       await client.query("SET timezone TO 'UTC'");
 
-      // Set statement timeout
-      await client.query(`SET statement_timeout TO ${poolConfig.statement_timeout || 10000}`);
+      // Set statement timeout (parameterized to prevent injection)
+      await client.query('SET statement_timeout TO $1', [poolConfig.statement_timeout || 10000]);
 
       // Enable query statistics
       await client.query('SET track_io_timing = on');
@@ -138,40 +160,44 @@ pool.on('connect', (client) => {
       );
     }
   })();
-});
+}
 
-pool.on('acquire', (client) => {
+function onPoolAcquire(client: PoolClient) {
   const pid = (client as PoolClientWithPID).processID;
   logger.debug(`Database client acquired (PID: ${pid})`);
-});
+}
 
-pool.on('remove', (client) => {
+function onPoolRemove(client: PoolClient) {
   const pid = (client as PoolClientWithPID).processID;
   logger.info(`Database client removed (PID: ${pid})`);
-});
+}
 
 // ===========================================================================
 // GRACEFUL SHUTDOWN
 // ===========================================================================
 
 async function gracefulShutdown(signal: string) {
+  if (!_pool) return;
   logger.info('Closing database pool', { signal });
 
   try {
-    await pool.end();
+    await _pool.end();
     logger.info('Database pool closed successfully');
-    process.exit(0);
   } catch (error) {
     logger.error(
       'Error closing database pool',
       error instanceof Error ? error : new Error(String(error)),
     );
-    process.exit(1);
   }
 }
 
-process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
-process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
+let _shutdownRegistered = false;
+function registerShutdown() {
+  if (_shutdownRegistered) return;
+  _shutdownRegistered = true;
+  process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
+  process.on('SIGINT', () => void gracefulShutdown('SIGINT'));
+}
 
 // ===========================================================================
 // HEALTH CHECK
@@ -311,4 +337,5 @@ export async function warmupPool(): Promise<void> {
 // EXPORTS
 // ===========================================================================
 
+export { getPool };
 export default pool;

--- a/packages/db/src/schema/vector.ts
+++ b/packages/db/src/schema/vector.ts
@@ -1,8 +1,15 @@
 /**
- * @revealui/db/schema/vector - Vector Database Schemas (Supabase)
+ * @revealui/db/schema/vector - Vector-Capable Database Schemas
  *
- * Vector-specific database schemas for AI/vector operations.
- * Currently only includes agent_memories table for semantic search.
+ * Schemas for AI/vector operations that require pgvector.
+ *
+ * ARCHITECTURE NOTE: Despite the "vector" naming, `agentMemories` currently
+ * lives in NeonDB (not Supabase) because its FK constraints reference
+ * NeonDB's `sites` and `users` tables. Cross-database FKs are not possible.
+ * The table is re-exported here for semantic grouping (it uses vector embeddings),
+ * but its data resides in the REST (Neon) database.
+ *
+ * RAG tables also require pgvector and follow the same pattern.
  */
 
 // Re-export for convenience (these types are also available from @revealui/contracts/agents)
@@ -12,7 +19,7 @@ export type {
   NewAgentMemory,
   NewAgentMemory as NewAgentMemoryType,
 } from './agents.js';
-// Only vector-related schemas
+// Vector-capable schemas (require pgvector, but live in NeonDB due to FK constraints)
 export { agentMemories } from './agents.js';
 // RAG tables (pgvector-backed, stored on Supabase)
 export * from './rag.js';

--- a/packages/openapi/src/openapi-hono.ts
+++ b/packages/openapi/src/openapi-hono.ts
@@ -6,7 +6,7 @@ import {
   OpenApiGeneratorV3,
   OpenApiGeneratorV31,
 } from '@asteasolutions/zod-to-openapi';
-import type { Env, Handler, Input, MiddlewareHandler, Schema, ToSchema } from 'hono';
+import type { Context, Env, Handler, Input, MiddlewareHandler, Schema, ToSchema } from 'hono';
 import { Hono } from 'hono';
 import type { MergePath } from 'hono/types';
 import { mergePath } from 'hono/utils/url';
@@ -36,6 +36,42 @@ import type {
   RouteMiddlewareParams,
 } from './types.js';
 import { zValidator } from './zod-validator.js';
+
+// ---------------------------------------------------------------------------
+// Internal helpers to reduce scattered `as any` casts
+// ---------------------------------------------------------------------------
+
+/**
+ * Access Hono's internal `_basePath` which is not part of the public API.
+ * Hono declares it as `private _basePath: string` (not a JS #private field),
+ * so it is accessible at runtime. This helper confines the cast to one place.
+ */
+function getBasePath(app: Hono<Env, Schema, string>): string {
+  // biome-ignore lint/style/useNamingConvention: _basePath is Hono's internal property name
+  return (app as unknown as { _basePath?: string })._basePath ?? '';
+}
+
+/**
+ * Discriminated union for `OpenAPIRegistry.definitions` entries.
+ * The library exports `OpenAPIDefinitions` but its member types are not
+ * individually exported, so we mirror the shapes here for safe narrowing.
+ */
+type RegistryComponentDef = {
+  type: 'component';
+  componentType: string;
+  name: string;
+  component: unknown;
+};
+type RegistryRouteDef = { type: 'route'; route: { path: string; [k: string]: unknown } };
+type RegistryWebhookDef = { type: 'webhook'; webhook: { path: string; [k: string]: unknown } };
+type RegistrySchemaDef = { type: 'schema'; schema: z.ZodType };
+type RegistryParameterDef = { type: 'parameter'; schema: z.ZodType };
+type RegistryDef =
+  | RegistryComponentDef
+  | RegistryRouteDef
+  | RegistryWebhookDef
+  | RegistrySchemaDef
+  | RegistryParameterDef;
 
 // Extend Zod with OpenAPI metadata methods (.openapi())
 extendZodWithOpenApi(z);
@@ -217,11 +253,8 @@ export class OpenAPIHono<
       this.openAPIRegistry.definitions,
       generatorConfig,
     ).generateDocument(objectConfig);
-    // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-    return (this as any)._basePath
-      ? // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-        addBasePathToDocument(document, (this as any)._basePath)
-      : document;
+    const basePath = getBasePath(this);
+    return basePath ? addBasePathToDocument(document, basePath) : document;
   };
 
   /**
@@ -235,12 +268,11 @@ export class OpenAPIHono<
       this.openAPIRegistry.definitions,
       generatorConfig,
     ).generateDocument(objectConfig);
-    // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-    return (this as any)._basePath
+    const basePath = getBasePath(this);
+    return basePath
       ? (addBasePathToDocument(
           document as unknown as OpenAPIObject,
-          // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-          (this as any)._basePath,
+          basePath,
         ) as unknown as OpenAPIObject31)
       : document;
   };
@@ -253,8 +285,7 @@ export class OpenAPIHono<
     configureObject: OpenAPIObjectConfigure<E, P>,
     configureGenerator?: OpenAPIGeneratorConfigure<E, P>,
   ) => {
-    // biome-ignore lint/suspicious/noExplicitAny: Hono context type flexibility for dynamic route handler
-    return this.get(path, (c: any) => {
+    return this.get(path, (c: Context<E, P>) => {
       const objectConfig =
         typeof configureObject === 'function' ? configureObject(c) : configureObject;
       const generatorConfig =
@@ -276,8 +307,7 @@ export class OpenAPIHono<
     configureObject: OpenAPIObjectConfigure<E, P>,
     configureGenerator?: OpenAPIGeneratorConfigure<E, P>,
   ) => {
-    // biome-ignore lint/suspicious/noExplicitAny: Hono context type flexibility for dynamic route handler
-    return this.get(path, (c: any) => {
+    return this.get(path, (c: Context<E, P>) => {
       const objectConfig =
         typeof configureObject === 'function' ? configureObject(c) : configureObject;
       const generatorConfig =
@@ -303,60 +333,46 @@ export class OpenAPIHono<
 
     if (!(app instanceof OpenAPIHono)) return this;
 
-    for (const def of app.openAPIRegistry.definitions) {
+    const appBasePath = getBasePath(app).replaceAll(/:([^/]+)/g, '{$1}');
+
+    for (const rawDef of app.openAPIRegistry.definitions) {
+      // Cast once per iteration: the library's OpenAPIDefinitions type does not
+      // expose individual member shapes, so we narrow via our local union.
+      const def = rawDef as RegistryDef;
       switch (def.type) {
         case 'component':
           this.openAPIRegistry.registerComponent(
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            (def as any).componentType,
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            (def as any).name,
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            (def as any).component,
+            // biome-ignore lint/suspicious/noExplicitAny: registerComponent's first param is a generic keyof ComponentsObject — our string type is correct at runtime but the generic signature requires the exact literal
+            def.componentType as any,
+            def.name,
+            // biome-ignore lint/suspicious/noExplicitAny: registerComponent's third param is a mapped generic — our unknown is correct at runtime
+            def.component as any,
           );
           break;
         case 'route':
           this.openAPIRegistry.registerPath({
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            ...(def as any).route,
-            path: mergePath(
-              pathForOpenAPI,
-              // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-              ((app as any)._basePath || '').replaceAll(/:([^/]+)/g, '{$1}'),
-              // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-              (def as any).route.path,
-            ),
+            // biome-ignore lint/suspicious/noExplicitAny: registerPath expects RouteConfig which has a complex shape; spread preserves all fields
+            ...(def.route as any),
+            path: mergePath(pathForOpenAPI, appBasePath, def.route.path),
           });
           break;
         case 'webhook':
           this.openAPIRegistry.registerWebhook({
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            ...(def as any).webhook,
-            path: mergePath(
-              pathForOpenAPI,
-              // biome-ignore lint/suspicious/noExplicitAny: accessing internal _basePath property
-              ((app as any)._basePath || '').replaceAll(/:([^/]+)/g, '{$1}'),
-              // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-              (def as any).webhook.path,
-            ),
+            // biome-ignore lint/suspicious/noExplicitAny: registerWebhook expects RouteConfig; spread preserves all fields
+            ...(def.webhook as any),
+            path: mergePath(pathForOpenAPI, appBasePath, def.webhook.path),
           });
           break;
         case 'schema': {
-          // biome-ignore lint/suspicious/noExplicitAny: OpenAPI metadata internal types
-          const meta = getOpenApiMetadata((def as any).schema);
-          // biome-ignore lint/suspicious/noExplicitAny: OpenAPI metadata internal types
-          this.openAPIRegistry.register((meta as any)?._internal?.refId, (def as any).schema);
+          // biome-ignore lint/style/useNamingConvention: _internal is the library's property name (not ours)
+          const meta = getOpenApiMetadata(def.schema) as { _internal?: { refId?: string } };
+          this.openAPIRegistry.register(meta?._internal?.refId, def.schema);
           break;
         }
         case 'parameter': {
-          // biome-ignore lint/suspicious/noExplicitAny: OpenAPI metadata internal types
-          const meta = getOpenApiMetadata((def as any).schema);
-          this.openAPIRegistry.registerParameter(
-            // biome-ignore lint/suspicious/noExplicitAny: OpenAPI metadata internal types
-            (meta as any)?._internal?.refId,
-            // biome-ignore lint/suspicious/noExplicitAny: registry definition type is loosely typed
-            (def as any).schema,
-          );
+          // biome-ignore lint/style/useNamingConvention: _internal is the library's property name (not ours)
+          const meta = getOpenApiMetadata(def.schema) as { _internal?: { refId?: string } };
+          this.openAPIRegistry.registerParameter(meta?._internal?.refId, def.schema);
           break;
         }
         default: {
@@ -373,11 +389,13 @@ export class OpenAPIHono<
    * Override basePath to return an OpenAPIHono with preserved registry state.
    */
   basePath<SubPath extends string>(path: SubPath) {
+    // super.basePath() returns a new Hono instance with internal state (_basePath, router, etc.).
+    // We spread it into a new OpenAPIHono to preserve registry + defaultHook. The spread requires
+    // treating the result as a plain object since Hono's return type is generic and non-spreadable.
     return new OpenAPIHono({
-      // biome-ignore lint/suspicious/noExplicitAny: spreading Hono's basePath result which has complex internal types
-      ...(super.basePath(path) as any),
+      ...(super.basePath(path) as unknown as Record<string, unknown>),
       defaultHook: this.defaultHook,
-      // biome-ignore lint/suspicious/noExplicitAny: return type must match Hono's basePath signature
+      // biome-ignore lint/suspicious/noExplicitAny: return type must match Hono's basePath() generic signature: Hono<E, S, MergePath<BasePath, SubPath>>
     }) as any;
   }
 }

--- a/packages/security/src/encryption.ts
+++ b/packages/security/src/encryption.ts
@@ -77,7 +77,7 @@ export class EncryptionSystem {
         name: this.config.algorithm,
         length: this.config.keySize,
       },
-      true,
+      this.config.extractable ?? false, // non-extractable by default — prevents key exfiltration
       ['encrypt', 'decrypt'],
     );
 


### PR DESCRIPTION
Critical fixes:
- Send recovery emails via configured provider instead of silently discarding tokens
- Fix encryption importKey() to respect extractable config (was hardcoded true)
- Add expiry filter to magic link verification preventing unbounded table scan DoS
- Bump cache package Next.js peer dep minimum to 16.1.7 (5 CVEs patched)

High-priority fixes:
- Move @revealui/db and drizzle-zod to optional peerDependencies in contracts
  to prevent leaking the entire DB layer as a transitive runtime dependency
- Fix X-Forwarded-For IP extraction: use first element (client IP) not last (proxy IP),
  prefer x-real-ip header
- Reduce openapi-hono.ts `as any` casts from ~30 to ~17 via getBasePath helper
  and typed RegistryDef discriminated union
- Make pool.ts lazy: defer assertProductionConfig() to first getPool() call
  instead of module parse time; remove process.exit() from shutdown handler
- Clarify agentMemories FK architecture: table lives in NeonDB (not Supabase)
  due to FK constraints on sites/users; update vector.ts documentation
- Move CORS Allow-Methods/Headers/Credentials headers inside origin check
- Add JSDoc warning to @revealui/core root export about client/server mixing
- Parameterize SET statement_timeout query to prevent SQL injection

https://claude.ai/code/session_01XJ8ExLon3UhBkvDo4jSrBC