### PR TITLE
Potential fix for code scanning alert no. 44: Inefficient regular expression

### DIFF
--- a/apps/docs/app/utils/markdown.tsx
+++ b/apps/docs/app/utils/markdown.tsx
@@ -177,7 +177,7 @@ function highlightScriptLine(line: string): Token[] {
   const commentPart = commentIndex >= 0 ? line.slice(commentIndex) : '';
   const tokens: Token[] = [];
   const pattern =
-    /("(?:\\.|[^"])*"|'(?:\\.|[^'])*'|`(?:\\.|[^`])*`|\b\d+(?:\.\d+)?\b|\b[A-Za-z_$][\w$]*\b)/g;
+    /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`|\b\d+(?:\.\d+)?\b|\b[A-Za-z_$][\w$]*\b)/g;
   let lastIndex = 0;
 
   for (const match of activePart.matchAll(pattern)) {


### PR DESCRIPTION
Potential fix for [https://github.com/RevealUIStudio/revealui/security/code-scanning/44](https://github.com/RevealUIStudio/revealui/security/code-scanning/44)

In general, to fix this kind of problem you remove ambiguity inside quantified groups: ensure that the alternatives under `*` or `+` cannot both match the same substring. For string-literal patterns like `"(\.|[^"])*"`, a standard fix is to make the “non-terminator” alternative also exclude the escape character, so escaped characters are handled only by the `\\.` branch and other characters are handled by a branch that excludes both the terminator and the backslash.

Concretely, in `highlightScriptLine` at line 180, the string part of the regex is:

```ts
("(?:\\.|[^"])*"|'(?:\\.|[^'])*'|`(?:\\.|[^`])*`| ...)
```

We should change each `[^quote]` to also exclude backslash: `[^"\\]`, `[^'\\]`, and `[^`\\]`. After the change, inside each repetition, any character that is not the quote/backtick *and* not a backslash is matched by the second branch, while a backslash starting an escape sequence is matched only by `\\.`. This removes the overlap and thus the exponential backtracking risk, while preserving the semantics of “match a string starting and ending with this quote character, with support for backslash-escaped characters”.

No new methods or imports are needed; we only change the regex literal in `apps/docs/app/utils/markdown.tsx` at the existing declaration of `pattern` in `highlightScriptLine`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
