### PR TITLE
fix(ai): publish @revealui/ai@0.2.0 and update IngestionPipeline call site

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
     "node": ">=24.13.0"
   },
   "peerDependencies": {
-    "@revealui/ai": "^0.1.3",
+    "@revealui/ai": "^0.2.0",
     "@revealui/services": "^0.2.2"
   },
   "peerDependenciesMeta": {

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -61,7 +61,7 @@
     "node": ">=24.13.0"
   },
   "peerDependencies": {
-    "@revealui/ai": "^0.1.3",
+    "@revealui/ai": "^0.2.0",
     "@revealui/services": "^0.2.2"
   },
   "peerDependenciesMeta": {

--- a/apps/cms/src/lib/ai/indexer.ts
+++ b/apps/cms/src/lib/ai/indexer.ts
@@ -11,7 +11,7 @@
  * when the package is not installed.
  */
 
-import { getRestClient } from '@revealui/db/client';
+import { getClient, getRestClient } from '@revealui/db/client';
 
 let indexerInstance: {
   onDocumentChanged: (event: {
@@ -33,13 +33,14 @@ async function getIndexer(): Promise<typeof indexerInstance> {
 
   if (!(embeddingsMod && ingestionMod)) return null;
 
-  const db = getRestClient();
+  const db = getClient();
+  const restDb = getRestClient();
   const embeddingFn = async (text: string): Promise<number[]> => {
     const result = await embeddingsMod.generateEmbedding(text);
     return result.vector;
   };
 
-  const pipeline = new ingestionMod.IngestionPipeline(db, embeddingFn);
+  const pipeline = new ingestionMod.IngestionPipeline(db, restDb, embeddingFn);
 
   indexerInstance = new ingestionMod.CmsIndexer({
     ingestionPipeline: pipeline,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^0.5.3
         version: 0.5.3(hono@4.12.9)
       '@revealui/ai':
-        specifier: ^0.1.3
-        version: 0.1.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: ^0.2.0
+        version: 0.2.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(drizzle-zod@0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@revealui/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -299,8 +299,8 @@ importers:
         specifier: ^1.0.27
         version: 1.0.42(react@19.2.4)
       '@revealui/ai':
-        specifier: ^0.1.3
-        version: 0.1.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: ^0.2.0
+        version: 0.2.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(drizzle-zod@0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@revealui/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -3320,8 +3320,8 @@ packages:
     resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
     engines: {node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0}
 
-  '@revealui/ai@0.1.3':
-    resolution: {integrity: sha512-/ewPjuom/J2K/Wm/u8YZNBaqSKWDc87k490ZbvkrpkdpZMovpo9d4oBmEztuYSOUJ+uT8IwI3IhnEV2ov2XL/A==}
+  '@revealui/ai@0.2.0':
+    resolution: {integrity: sha512-ma6n+za0/XBqJa+VHluIsfL9M7cW6YdSiGBm1I2kHQxG2/M9Xqh4GijRQ6I3ndxjAR/mJPc/hUUo/sBouUdLxQ==}
     peerDependencies:
       drizzle-orm: ^0.45.1
       react: '>=19.2.4'
@@ -3334,12 +3334,6 @@ packages:
     peerDependenciesMeta:
       next:
         optional: true
-
-  '@revealui/contracts@1.1.0':
-    resolution: {integrity: sha512-jcOydfxd/J5TeZXjVEF9nanTPVBLZ5Py1KzuzMpEblOm5Z8EwwwEs8yvWhEiZljGwFlKg5w3K0T+bPZxfGaCLQ==}
-    peerDependencies:
-      '@revealui/db': workspace:*
-      typescript: '>=5.0.0'
 
   '@revealui/contracts@1.2.0':
     resolution: {integrity: sha512-qq9aOARGRc+4qaLIEw/xj7zbbL7gfrXf9uIfUD/lTp7G7n+raLjJyNGX8KwBNxwJyFp+sZ5qKwGSZ8kuqWqZ0Q==}
@@ -3359,13 +3353,6 @@ packages:
         optional: true
       drizzle-zod:
         optional: true
-
-  '@revealui/core@0.2.1':
-    resolution: {integrity: sha512-ZcK4oDD4aGa64fUF9rN3R0JSXJvS7TRmIH60kg37+P/SUNAW23FX917WFo/6XYSgKYGbdH3tWOMpHLUZTruZig==}
-    peerDependencies:
-      next: '>=15.5.10'
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
 
   '@revealui/core@0.3.0':
     resolution: {integrity: sha512-qZS3MGpSZNV/pFj2NO3MhV8D9McVEvyk1yx5KN++8+RxjRP3zMcwTTPJ96PZ2aDz+yzsLGOx01peuG7NkMUI2g==}
@@ -3393,9 +3380,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  '@revealui/utils@0.2.0':
-    resolution: {integrity: sha512-rdY5dK/7UyJ75tOTyLDnTcfK/lsF1JkBA+d4ZkAtC5YAEcJ04MxP7VJklly/cVz3XWV7NMm198wi+DSSSVuHlA==}
 
   '@revealui/utils@0.3.0':
     resolution: {integrity: sha512-YtkMa/Tu9XeP6TXreqHPumLJM9zV+7x8ThjJeTrKrGhM99wRYvblCtNtSHRqlv9YCurqLInKlhXLuwPqvAfcnQ==}
@@ -11876,16 +11860,17 @@ snapshots:
 
   '@renovatebot/pep440@4.2.1': {}
 
-  '@revealui/ai@0.1.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@revealui/ai@0.2.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(drizzle-zod@0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@revealui/contracts': 1.1.0(@revealui/db@packages+db)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(typescript@5.9.3)
-      '@revealui/core': 0.2.1(@revealui/db@packages+db)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@revealui/contracts': 1.3.0(@revealui/db@packages+db)(drizzle-zod@0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6))(typescript@5.9.3)
+      '@revealui/core': 0.3.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@revealui/db': link:packages/db
       drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
       lru-cache: 11.2.7
       react: 19.2.4
       zod: 4.3.6
     transitivePeerDependencies:
+      - drizzle-zod
       - next
       - pg-native
       - react-dom
@@ -11894,15 +11879,6 @@ snapshots:
   '@revealui/cache@0.2.0(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     optionalDependencies:
       next: 16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
-  '@revealui/contracts@1.1.0(@revealui/db@packages+db)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(typescript@5.9.3)':
-    dependencies:
-      '@revealui/db': link:packages/db
-      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6)
-      typescript: 5.9.3
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - drizzle-orm
 
   '@revealui/contracts@1.2.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(typescript@5.9.3)':
     dependencies:
@@ -11920,40 +11896,6 @@ snapshots:
     optionalDependencies:
       '@revealui/db': link:packages/db
       drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6)
-
-  '@revealui/core@0.2.1(@revealui/db@packages+db)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
-    dependencies:
-      '@electric-sql/pglite': 0.3.16
-      '@lexical/clipboard': 0.40.0
-      '@lexical/code': 0.40.0
-      '@lexical/html': 0.40.0
-      '@lexical/link': 0.40.0
-      '@lexical/list': 0.40.0
-      '@lexical/react': 0.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
-      '@lexical/rich-text': 0.40.0
-      '@lexical/selection': 0.40.0
-      '@lexical/table': 0.40.0
-      '@lexical/utils': 0.40.0
-      '@lexical/yjs': 0.40.0(yjs@13.6.30)
-      '@revealui/contracts': 1.1.0(@revealui/db@packages+db)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(typescript@5.9.3)
-      '@revealui/utils': 0.2.0
-      '@vercel/blob': 2.3.1
-      bcryptjs: 3.0.3
-      dataloader: 2.2.3
-      jose: 6.2.2
-      lexical: 0.40.0
-      next: 16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      pg: 8.20.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      sharp: 0.34.5
-      yjs: 13.6.30
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@revealui/db'
-      - drizzle-orm
-      - pg-native
-      - typescript
 
   '@revealui/core@0.3.0(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
@@ -12056,10 +11998,6 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
-
-  '@revealui/utils@0.2.0':
-    dependencies:
-      zod: 4.3.6
 
   '@revealui/utils@0.3.0':
     dependencies:


### PR DESCRIPTION
## Summary

- Published `@revealui/ai@0.2.0` to npm — includes the `restDb` parameter added to `IngestionPipeline` constructor (breaking: 2 args → 3 args)
- Updated `apps/cms/src/lib/ai/indexer.ts` to pass `(db, restDb, embeddingFn)` matching the new signature
- Bumped peer deps to semver ranges: `@revealui/ai: ^0.2.0`, `@revealui/services: ^0.2.2` in both `apps/cms` and `apps/api`

## Context

Follows RevealUIStudio/revealui#79 which fixed the stale `@revealui/services` peer dep. The workspace `IngestionPipeline` constructor already had 3 args but the published `@revealui/ai@0.1.3` only had 2. This PR syncs the published package with the workspace source and updates all consumers.

## Test plan

- [x] `pnpm turbo run build --filter=cms --force` — 13/13 tasks successful, no type errors
- [x] `pnpm validate:versions` — version policy passes
- [x] Pre-push CI gate — all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)