### PR TITLE
fix: add repository field to 14 packages for npm provenance

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -57,5 +57,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/animations"
+  }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -81,5 +81,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/auth"
+  }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -53,5 +53,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/cache"
+  }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,5 +49,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/config"
+  }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -132,5 +132,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/contracts"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -298,5 +298,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/core"
+  }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -239,5 +239,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/db"
+  }
 }

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -49,5 +49,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/openapi"
+  }
 }

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -83,5 +83,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/presentation"
+  }
 }

--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -41,5 +41,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/resilience"
+  }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -53,5 +53,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/router"
+  }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -43,5 +43,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/security"
+  }
 }

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -65,5 +65,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/sync"
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -54,5 +54,10 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/utils"
+  }
 }


### PR DESCRIPTION
## Summary
- npm OIDC provenance requires `repository.url` in package.json to match the GitHub repo
- 14 packages were missing this field, causing E422 on `changeset publish`
- 7 packages published successfully (cli, create-revealui, editors, mcp, paywall, services, setup)
- After merge: re-dispatch `release.yml` to publish the remaining 14

## Test plan
- [x] All 14 packages now have correct `repository` field
- [x] Format matches the 7 packages that already published
- [ ] CI passes
- [ ] Re-run `release.yml` publishes remaining packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)