### PR TITLE
feat: admin DX improvements + documentation sweep

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
       "onAutoForward": "notify"
     },
     "4000": {
-      "label": "CMS",
+      "label": "Admin",
       "onAutoForward": "notify"
     },
     "5432": {

--- a/README.md
+++ b/README.md
@@ -199,14 +199,44 @@ Pro packages are source-available under the [Functional Source License (FSL-1.1-
 
 ## Quick start
 
-For contributing to RevealUI itself:
+### Option A: Local development (recommended)
 
 ```bash
 git clone https://github.com/RevealUIStudio/revealui.git
 cd revealui
 pnpm install
-pnpm dev
+
+# Set up environment
+cp apps/admin/.env.example apps/admin/.env.local
+# Edit .env.local: set POSTGRES_URL, REVEALUI_SECRET (min 32 chars),
+# REVEALUI_PUBLIC_SERVER_URL=http://localhost:4000
+
+# Initialize database
+pnpm db:migrate
+pnpm db:seed
+
+# Start admin dashboard + API
+pnpm dev:app    # Admin (port 4000) + API (port 3004)
 ```
+
+Three dev modes:
+- `pnpm dev:app` — Admin + API (recommended for most work)
+- `pnpm dev:admin` — Admin only (if API already running)
+- `pnpm dev` — All apps in parallel (heavy)
+
+### Option B: Docker Compose
+
+```bash
+cp .env.production.example .env
+# Edit .env with your values
+docker compose up -d
+```
+
+Services: PostgreSQL (5432), API (3004), Admin (4000), Marketing (3000).
+
+### Option C: Dev Containers
+
+Open in VS Code or GitHub Codespaces — the `.devcontainer/` config handles everything.
 
 | Platform    | Recommended setup                 |
 | ----------- | --------------------------------- |

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -271,12 +271,34 @@ export default buildConfig({
       return;
     }
 
-    // Check if any users exist
-    const existingUsers = await revealui.find({
-      collection: 'users',
-      limit: 1,
-      depth: 0,
-    });
+    // Validate database connectivity before proceeding
+    let existingUsers: { totalDocs: number };
+    try {
+      existingUsers = await revealui.find({
+        collection: 'users',
+        limit: 1,
+        depth: 0,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isConnectionError =
+        message.includes('ECONNREFUSED') ||
+        message.includes('connection') ||
+        message.includes('ENOTFOUND') ||
+        message.includes('timeout');
+
+      if (isConnectionError) {
+        revealui.logger.error(
+          'Database connection failed. Check that POSTGRES_URL or DATABASE_URL is set and the database is reachable.',
+        );
+      } else {
+        revealui.logger.error(`Database query failed during initialization: ${message}`);
+      }
+      revealui.logger.warn(
+        'Admin app started without database. Dashboard will show errors until a database is connected.',
+      );
+      return;
+    }
 
     // If no users exist, create the first admin user
     if (existingUsers.totalDocs === 0) {

--- a/apps/admin/src/app/(backend)/error.tsx
+++ b/apps/admin/src/app/(backend)/error.tsx
@@ -9,10 +9,18 @@ export default function BackendError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const message = error.message.toLowerCase();
   const isNetworkError =
-    error.message.includes('fetch') ||
-    error.message.includes('network') ||
-    error.message.includes('ECONNREFUSED');
+    message.includes('fetch') || message.includes('network') || message.includes('econnrefused');
+
+  const isDatabaseError =
+    message.includes('econnrefused') ||
+    message.includes('connection') ||
+    message.includes('postgres') ||
+    message.includes('database') ||
+    message.includes('relation') ||
+    message.includes('timeout') ||
+    message.includes('enotfound');
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-5 p-8">
@@ -34,13 +42,33 @@ export default function BackendError({
         </svg>
       </div>
 
-      <h2 className="text-lg font-semibold text-white">Something went wrong</h2>
+      <h2 className="text-lg font-semibold text-white">
+        {isDatabaseError ? 'Database connection failed' : 'Something went wrong'}
+      </h2>
 
-      <p className="max-w-md text-center text-sm text-zinc-400">
-        {isNetworkError
-          ? 'Unable to reach the server. Check your connection and try again.'
-          : 'An unexpected error occurred while loading this page.'}
-      </p>
+      {isDatabaseError ? (
+        <div className="flex max-w-lg flex-col gap-3 text-center text-sm text-zinc-400">
+          <p>The admin dashboard cannot reach the database. To fix this:</p>
+          <ol className="list-inside list-decimal text-left text-xs text-zinc-500">
+            <li>
+              Set <code className="text-zinc-300">POSTGRES_URL</code> or{' '}
+              <code className="text-zinc-300">DATABASE_URL</code> in your environment
+            </li>
+            <li>
+              Run <code className="text-zinc-300">pnpm db:migrate</code> to create tables
+            </li>
+            <li>
+              Run <code className="text-zinc-300">pnpm db:seed</code> for sample content
+            </li>
+          </ol>
+        </div>
+      ) : (
+        <p className="max-w-md text-center text-sm text-zinc-400">
+          {isNetworkError
+            ? 'Unable to reach the server. Check your connection and try again.'
+            : 'An unexpected error occurred while loading this page.'}
+        </p>
+      )}
 
       {error.digest && <p className="font-mono text-xs text-zinc-600">Error ID: {error.digest}</p>}
 

--- a/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
+++ b/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
@@ -104,7 +104,7 @@ describe('GET /api/health', () => {
     const body = (res as unknown as { body: Record<string, unknown> }).body;
     expect(body).toHaveProperty('checks');
     expect(body).toHaveProperty('metrics');
-    expect(body.service).toBe('RevealUI CMS');
+    expect(body.service).toBe('RevealUI Admin');
   });
 
   it('returns 503 when database is unhealthy', async () => {

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -147,7 +147,7 @@ export async function GET(request: Request) {
     {
       status: overallStatus,
       timestamp: new Date().toISOString(),
-      service: 'RevealUI CMS',
+      service: 'RevealUI Admin',
       version: process.env.npm_package_version || 'unknown',
       checks,
       metrics,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
   #     - "443:443"
   #   depends_on:
   #     - api
-  #     - cms
+  #     - admin
   #     - marketing
   #   networks:
   #     - revealui

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,7 +486,7 @@ services:
 ### Shape Proxy Routes
 
 ```typescript
-// apps/cms/src/app/api/shapes/agent-contexts/route.ts
+// apps/admin/src/app/api/shapes/agent-contexts/route.ts
 export async function GET(request: NextRequest) {
   const session = await getSession(request.headers);
 
@@ -664,7 +664,7 @@ All collections implement tenant-aware access control:
 
 ### Access Control Functions
 
-Located in `apps/cms/src/lib/access/`:
+Located in `apps/admin/src/lib/access/`:
 
 - `isAdmin.ts` - Checks for user-admin or user-super-admin
 - `isSuperAdmin.ts` - Checks for user-super-admin only
@@ -787,7 +787,7 @@ function dbRowToContract<TContract, TDbRow>(
 **Usage in API Routes:**
 
 ```typescript
-// apps/cms/src/app/api/users/route.ts
+// apps/admin/src/app/api/users/route.ts
 import { getRestClient } from "@revealui/db/client";
 import { UserSchema } from "@revealui/contracts";
 import { dbRowToContract } from "@revealui/core/database/type-adapter";
@@ -879,7 +879,7 @@ Frontend → Generated Types → API Route → Contract Validation → Type Adap
 **Integration with Vector Database:**
 
 ```typescript
-// Server: apps/cms/src/app/api/chat/route.ts
+// Server: apps/admin/src/app/api/chat/route.ts
 import { streamText, convertToModelMessages } from 'ai'
 import { getVectorClient } from '@revealui/db/client'
 
@@ -905,7 +905,7 @@ export async function POST(request: NextRequest) {
   return result.toUIMessageStreamResponse()
 }
 
-// Client: apps/cms/src/lib/components/Agent/index.tsx
+// Client: apps/admin/src/lib/components/Agent/index.tsx
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from '@ai-sdk/react'
 
@@ -951,7 +951,7 @@ export type RPCRouter = {
 **Server-Side RPC Handler:**
 
 ```typescript
-// apps/cms/src/app/api/rpc/route.ts
+// apps/admin/src/app/api/rpc/route.ts
 import type { RPCRouter } from "@revealui/core/rpc/types";
 
 export async function POST(request: NextRequest) {
@@ -1036,7 +1036,7 @@ Media Upload → Next.js API → Vercel Blob Storage → Store URL in NeonDB
 **Setup:**
 
 ```typescript
-// apps/cms/src/app/(frontend)/layout.tsx
+// apps/admin/src/app/(frontend)/layout.tsx
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/react'
 
@@ -1071,7 +1071,7 @@ export default function RootLayout({ children }) {
 ### Development Mode
 
 ```javascript
-// apps/cms/next.config.mjs
+// apps/admin/next.config.mjs
 turbopack: {
   root: path.join(__dirname, '../..'), // Point to monorepo root
   resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.json'],
@@ -1087,7 +1087,7 @@ turbopack: {
 ### Production Mode
 
 ```json
-// apps/cms/package.json
+// apps/admin/package.json
 "vercel-build": "cross-env NODE_OPTIONS=--no-deprecation TURBOPACK=0 next build"
 ```
 
@@ -1138,7 +1138,7 @@ turbopack: {
 When re-evaluating Turbopack for production:
 
 - [ ] Remove `TURBOPACK=0` flag from build script
-- [ ] Run `pnpm build:cms` to test production build
+- [ ] Run `pnpm build:admin` to test production build
 - [ ] Check for module resolution errors
 - [ ] Verify all workspace package imports resolve
 - [ ] Test instrumentation.ts Edge Runtime warnings
@@ -1158,7 +1158,7 @@ When re-evaluating Turbopack for production:
 Client Request
     │
     ▼
-Next.js API Route (apps/cms/src/app/api/...)
+Next.js API Route (apps/admin/src/app/api/...)
     │
     ├─→ NeonDB (POSTGRES_URL) ──┐
     │                            │
@@ -1200,7 +1200,7 @@ Client (Browser)
     ├─→ Shape Request (/api/shapes/agent-contexts)
     │       │
     │       ▼
-    │   CMS API Route (apps/cms/src/app/api/shapes/...)
+    │   CMS API Route (apps/admin/src/app/api/shapes/...)
     │       │
     │       ▼
     │   ElectricSQL Service (localhost:5133)
@@ -1675,7 +1675,7 @@ This section provides a comprehensive mapping of all UI components, the business
 
 ### UI Components
 
-#### CMS Blocks (`apps/cms/src/lib/blocks/`)
+#### CMS Blocks (`apps/admin/src/lib/blocks/`)
 
 Blocks are the primary content building units in the CMS. Each block has a corresponding component and schema.
 
@@ -1756,7 +1756,7 @@ Blocks are the primary content building units in the CMS. Each block has a corre
   - **Type**: `BlockProps` (union of all block prop types)
   - **Mapping**: `blockComponents` object maps `blockType` to component
 
-#### CMS Components (`apps/cms/src/lib/components/`)
+#### CMS Components (`apps/admin/src/lib/components/`)
 
 Reusable UI components used throughout the CMS.
 
@@ -1898,7 +1898,7 @@ Frontend application components.
    - **HomeHero** (`Hero.tsx`)
    - **HomeContent** (`Content.tsx`)
 
-#### CMS RevealUI Elements (`apps/cms/src/components/revealui/elements/`)
+#### CMS RevealUI Elements (`apps/admin/src/components/revealui/elements/`)
 
 Reusable page elements.
 
@@ -1919,7 +1919,7 @@ Reusable page elements.
 15. `text.tsx`
 16. `wallpaper.tsx`
 
-#### CMS RevealUI Sections (`apps/cms/src/components/revealui/sections/`)
+#### CMS RevealUI Sections (`apps/admin/src/components/revealui/sections/`)
 
 Pre-built section components.
 
@@ -1931,7 +1931,7 @@ Pre-built section components.
 
 ### Business Logic
 
-#### React Hooks (`apps/cms/src/lib/hooks/`)
+#### React Hooks (`apps/admin/src/lib/hooks/`)
 
 1. **useChat** (`useChat.ts`)
    - **Purpose**: Chat interface with voice recognition
@@ -1993,7 +1993,7 @@ Pre-built section components.
 19. **revalidate** (`revalidate.ts`)
     - **Purpose**: General revalidation
 
-#### Collection Hooks (`apps/cms/src/lib/collections/*/hooks/`)
+#### Collection Hooks (`apps/admin/src/lib/collections/*/hooks/`)
 
 Business logic hooks that run on collection operations.
 
@@ -2082,7 +2082,7 @@ Memory management hooks.
 2. **useWorkingMemory** (`useWorkingMemory.ts`)
    - **Purpose**: Working memory management
 
-#### API Routes (`apps/cms/src/app/api/`)
+#### API Routes (`apps/admin/src/app/api/`)
 
 Server-side API endpoints that provide data to components.
 
@@ -2285,7 +2285,7 @@ The central contract layer defining all data structures.
    - `EMBEDDING_DIMENSIONS` - Model dimensions
    - `createEmbedding` - Factory function
 
-#### Generated Types (`apps/cms/src/types/revealui.ts`)
+#### Generated Types (`apps/admin/src/types/revealui.ts`)
 
 Auto-generated TypeScript types from RevealUI config.
 
@@ -2306,7 +2306,7 @@ Auto-generated TypeScript types from RevealUI config.
 5. **Auth Operations**
    - `UserAuthOperations` - Login, register, forgot password
 
-#### Validation Schemas (`apps/cms/src/lib/validation/`)
+#### Validation Schemas (`apps/admin/src/lib/validation/`)
 
 1. **Schemas** (`schemas.ts`)
    - Validation schemas for forms and data
@@ -2393,7 +2393,7 @@ All entities in `@revealui/contracts` use the dual representation pattern:
 #### 4. Data Flow
 
 1. **Schema Definition** → `@revealui/contracts`
-2. **Type Generation** → `apps/cms/src/types/revealui.ts`
+2. **Type Generation** → `apps/admin/src/types/revealui.ts`
 3. **Component Props** → Extracted from types
 4. **Business Logic** → Hooks and API routes
 5. **Data Validation** → Zod schemas
@@ -2408,17 +2408,17 @@ All entities in `@revealui/contracts` use the dual representation pattern:
 
 #### UI Components
 
-- **CMS Blocks**: `apps/cms/src/lib/blocks/`
-- **CMS Components**: `apps/cms/src/lib/components/`
+- **CMS Blocks**: `apps/admin/src/lib/blocks/`
+- **CMS Components**: `apps/admin/src/lib/components/`
 - **Framework UI**: `packages/core/src/client/ui/`
 - **Web App**: `apps/mainframe/src/components/`
-- **RevealUI Elements**: `apps/cms/src/components/revealui/`
+- **RevealUI Elements**: `apps/admin/src/components/revealui/`
 
 #### Business Logic
 
-- **Hooks**: `apps/cms/src/lib/hooks/`
-- **Collection Hooks**: `apps/cms/src/lib/collections/*/hooks/`
-- **API Routes**: `apps/cms/src/app/api/`
+- **Hooks**: `apps/admin/src/lib/hooks/`
+- **Collection Hooks**: `apps/admin/src/lib/collections/*/hooks/`
+- **API Routes**: `apps/admin/src/app/api/`
 - **Electric Hooks**: `packages/sync/src/hooks/`
 - **Memory Hooks**: `packages/ai/src/memory/src/client/hooks/`
 
@@ -2427,17 +2427,17 @@ All entities in `@revealui/contracts` use the dual representation pattern:
 - **Core Schemas**: `packages/contracts/src/core/`
 - **Block Schemas**: `packages/contracts/src/blocks/`
 - **Agent Schemas**: `packages/contracts/src/agents/`
-- **Generated Types**: `apps/cms/src/types/revealui.ts`
-- **Validation**: `apps/cms/src/lib/validation/`
+- **Generated Types**: `apps/admin/src/types/revealui.ts`
+- **Validation**: `apps/admin/src/lib/validation/`
 
 ### Extension Guide
 
 To extend this mapping:
 
-1. **Add New Block**: Create component in `apps/cms/src/lib/blocks/`, add schema in `packages/contracts/src/blocks/`, register in `RenderBlocks.tsx`
+1. **Add New Block**: Create component in `apps/admin/src/lib/blocks/`, add schema in `packages/contracts/src/blocks/`, register in `RenderBlocks.tsx`
 2. **Add New Hook**: Create in appropriate `hooks/` directory, reference in component
 3. **Add New Schema**: Create in `packages/contracts/src/`, export from `index.ts`, use in components
-4. **Add New API Route**: Create in `apps/cms/src/app/api/`, reference in hooks/components
+4. **Add New API Route**: Create in `apps/admin/src/app/api/`, reference in hooks/components
 
 ---
 

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -507,13 +507,13 @@ export async function withTransaction<T>(
   if (db === restClient && !restSupportsTransactions) {
     throw new Error(
       'Transaction not supported: REST database is using Neon HTTP driver. ' +
-        'Switch to Supabase pooler or pg driver for transaction support.',
+        'Use withSaga() for NeonDB-safe multi-step writes, or switch to Supabase pooler / pg driver for transaction support.',
     );
   }
   if (db === vectorClient && !vectorSupportsTransactions) {
     throw new Error(
       'Transaction not supported: Vector database is using Neon HTTP driver. ' +
-        'Switch to Supabase pooler or pg driver for transaction support.',
+        'Use withSaga() for NeonDB-safe multi-step writes, or switch to Supabase pooler / pg driver for transaction support.',
     );
   }
 
@@ -523,7 +523,7 @@ export async function withTransaction<T>(
   if (!hasPgTransaction) {
     throw new Error(
       'Transaction not supported: Database client is using Neon HTTP driver which does not support transactions. ' +
-        'To use transactions, configure your database with Supabase or localhost connection string. ' +
+        'Use withSaga() for NeonDB-safe multi-step writes, or configure your database with Supabase / localhost connection string. ' +
         'Neon HTTP driver uses stateless requests and cannot maintain transaction state.',
     );
   }

--- a/packages/db/src/transaction-blocker.test.ts
+++ b/packages/db/src/transaction-blocker.test.ts
@@ -39,7 +39,7 @@ describe('Critical Fix #1: Transaction Implementation', () => {
         await withTransaction(neonMockDb, async () => ({ success: true }));
         expect.fail('Should have thrown');
       } catch (error) {
-        expect((error as Error).message).toContain('Supabase or localhost');
+        expect((error as Error).message).toContain('Supabase / localhost');
       }
     });
 


### PR DESCRIPTION
## Summary

- **Documentation sweep**: 35+ files updated — `apps/cms` → `apps/admin`, `Resend/SMTP` → `Gmail API`, removed phantom `mainframe` references, removed dead `nodemailer` dependency
- **Error boundary**: DB-specific error page with setup instructions (env vars, migrate, seed) instead of generic "Something went wrong"
- **DB startup validation**: `onInit` now catches connection failures gracefully with clear `POSTGRES_URL` guidance instead of opaque crash
- **Transaction error messages**: Now suggest `withSaga()` as NeonDB-safe alternative
- **Getting-started docs**: README rewritten with 3 quick-start options (local, Docker Compose, Dev Containers)
- **Stale label fixes**: devcontainer, docker-compose, health endpoint service name

## Test plan

- [x] Studio tests pass locally (36/36 — StepEmail rewritten, StepVerify fixed)
- [x] DB package tests pass (943/943 — transaction error assertion updated)
- [x] Biome lint clean
- [x] Pre-push gate passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)