### PR TITLE
refactor: complete cms→admin rename across codebase

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -18,7 +18,7 @@ apps/api/src/routes/__tests__/webhooks-expansion.test.ts:stripe-access-token:143
 apps/api/src/routes/__tests__/webhook-signature-replay.test.ts:stripe-access-token:151
 apps/api/src/routes/__tests__/webhook-lifecycle-complete.test.ts:stripe-access-token:290
 apps/api/src/routes/__tests__/webhooks.test.ts:stripe-access-token:133
-apps/cms/src/__tests__/api/revalidate.test.ts:generic-api-key:31
+apps/admin/src/__tests__/api/revalidate.test.ts:generic-api-key:31
 packages/cli/src/commands/create.ts:stripe-access-token:79
 packages/cli/src/prompts/__tests__/prompts.test.ts:generic-api-key:242
 packages/cli/src/__tests__/create.test.ts:stripe-access-token:81

--- a/apps/admin/.env.production.template
+++ b/apps/admin/.env.production.template
@@ -1,11 +1,11 @@
 # =============================================================================
-# RevealUI CMS — Production Environment Variables
-# Vercel project: revealui-cms  (https://cms.revealui.com)
+# RevealUI Admin — Production Environment Variables
+# Vercel project: revealui-admin  (https://admin.revealui.com)
 #
 # This file documents every env var required or recommended for production.
 # Copy values from your secret vault (Revvault: revealui/env/cms-production).
 #
-# How to apply: Vercel Dashboard → revealui-cms → Settings → Environment Variables
+# How to apply: Vercel Dashboard → revealui-admin → Settings → Environment Variables
 # Or via CLI:   vercel env add <NAME> production
 # =============================================================================
 
@@ -19,7 +19,7 @@ NODE_ENV=production
 # Required. Pooled connection string for serverless Next.js functions.
 # Neon Dashboard: ep-your-endpoint-id → Connect → Connection string (pooled)
 # NOTE: The CMS uses a DIFFERENT NeonDB endpoint than the API.
-#       The API uses the NeonDB REST HTTP driver; the CMS uses the pooled pg driver.
+#       The API uses the NeonDB REST HTTP driver; the Admin app uses the pooled pg driver.
 # -----------------------------------------------------------------------------
 POSTGRES_URL=postgresql://user:password@ep-your-endpoint-id.us-east-1.aws.neon.tech/neondb?sslmode=require&pgbouncer=true
 
@@ -31,15 +31,15 @@ POSTGRES_URL=postgresql://user:password@ep-your-endpoint-id.us-east-1.aws.neon.t
 REVEALUI_SECRET=<32-byte-hex-secret>
 
 # -----------------------------------------------------------------------------
-# Public URLs — CMS self-reference
+# Public URLs — Admin self-reference
 # Required. Both vars must have the same value.
 # -----------------------------------------------------------------------------
-REVEALUI_PUBLIC_SERVER_URL=https://cms.revealui.com
-NEXT_PUBLIC_SERVER_URL=https://cms.revealui.com
+REVEALUI_PUBLIC_SERVER_URL=https://admin.revealui.com
+NEXT_PUBLIC_SERVER_URL=https://admin.revealui.com
 
 # -----------------------------------------------------------------------------
 # API URL — backend REST API
-# Required. Used by CMS proxy routes (/api/billing/*) to forward to the API.
+# Required. Used by Admin proxy routes (/api/billing/*) to forward to the API.
 # -----------------------------------------------------------------------------
 REVEALUI_API_URL=https://api.revealui.com
 NEXT_PUBLIC_API_URL=https://api.revealui.com
@@ -54,8 +54,8 @@ RESEND_FROM_EMAIL=noreply@revealui.com
 
 # -----------------------------------------------------------------------------
 # Stripe — Client-side (required for billing page)
-# Used by the CMS billing page to redirect to Stripe Checkout via API.
-# CMS does NOT handle Stripe webhooks — those go to the API project.
+# Used by the Admin app billing page to redirect to Stripe Checkout via API.
+# Admin app does NOT handle Stripe webhooks — those go to the API project.
 # Stripe Dashboard: API keys → Publishable key
 # Stripe Dashboard: Products → RevealUI Pro → Prices → price_...
 # -----------------------------------------------------------------------------
@@ -86,7 +86,7 @@ NEXT_PUBLIC_ELECTRIC_SERVICE_URL=https://your-electric-instance.up.railway.app
 ELECTRIC_SECRET=<your-electric-secret>
 
 # -----------------------------------------------------------------------------
-# Signup Gating (optional — controls who can create CMS accounts)
+# Signup Gating (optional — controls who can create admin accounts)
 # If neither var is set, signups are open to everyone.
 # Option A: Whitelist specific emails
 # REVEALUI_SIGNUP_WHITELIST=alice@example.com,bob@example.com
@@ -102,7 +102,7 @@ ELECTRIC_SECRET=<your-electric-secret>
 # NEXT_PUBLIC_SENTRY_DSN=https://key@sentry.io/project-id
 # SENTRY_AUTH_TOKEN=sntrys_...
 # SENTRY_ORG=revealui-studio
-# SENTRY_PROJECT=revealui-cms
+# SENTRY_PROJECT=revealui-admin
 
 # -----------------------------------------------------------------------------
 # Supabase — Vectors + Auth (optional — required for AI/vector features)

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -26,30 +26,30 @@ COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json ./packages/security/
 COPY packages/sync/package.json ./packages/sync/
 COPY packages/utils/package.json ./packages/utils/
-COPY apps/cms/package.json ./apps/cms/
+COPY apps/admin/package.json ./apps/admin/
 
 # Install dependencies with frozen lockfile
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter cms...
+    pnpm install --frozen-lockfile --filter admin...
 
 # Builder stage
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
-COPY --from=deps /app/apps/cms/node_modules ./apps/cms/node_modules
+COPY --from=deps /app/apps/admin/node_modules ./apps/admin/node_modules
 
 # Copy source code
 COPY turbo.json ./
 COPY tsconfig.json ./
 COPY packages ./packages
-COPY apps/cms ./apps/cms
+COPY apps/admin ./apps/admin
 
 # Build the application
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter cms run build
+RUN pnpm --filter admin run build
 
 # Runner stage
 FROM base AS runner
@@ -61,9 +61,9 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy built application
-COPY --from=builder /app/apps/cms/.next/standalone ./
-COPY --from=builder /app/apps/cms/.next/static ./apps/cms/.next/static
-COPY --from=builder /app/apps/cms/public ./apps/cms/public
+COPY --from=builder /app/apps/admin/.next/standalone ./
+COPY --from=builder /app/apps/admin/.next/static ./apps/admin/.next/static
+COPY --from=builder /app/apps/admin/public ./apps/admin/public
 
 # Set ownership
 RUN chown -R nextjs:nodejs /app
@@ -79,4 +79,4 @@ ENV HOSTNAME="0.0.0.0"
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD node -e "require('http').get('http://localhost:4000/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
-CMD ["node", "apps/cms/server.js"]
+CMD ["node", "apps/admin/server.js"]

--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# RevealUI Forge — CMS (Next.js standalone)
+# RevealUI Forge — Admin (Next.js standalone)
 
 # Build stage
 FROM node:24-alpine AS base
@@ -29,27 +29,27 @@ COPY packages/setup/package.json         ./packages/setup/
 COPY packages/sync/package.json          ./packages/sync/
 COPY packages/test/package.json          ./packages/test/
 COPY packages/utils/package.json         ./packages/utils/
-COPY apps/cms/package.json               ./apps/cms/
+COPY apps/admin/package.json               ./apps/admin/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter cms...
+    pnpm install --frozen-lockfile --filter admin...
 
 # Builder stage
 FROM base AS builder
 
 COPY --from=deps /app/node_modules         ./node_modules
 COPY --from=deps /app/packages             ./packages
-COPY --from=deps /app/apps/cms/node_modules ./apps/cms/node_modules
+COPY --from=deps /app/apps/admin/node_modules ./apps/admin/node_modules
 
 COPY turbo.json tsconfig.json ./
 COPY packages ./packages
-COPY apps/cms ./apps/cms
+COPY apps/admin ./apps/admin
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter cms run build
+RUN pnpm --filter admin run build
 
 # ---------------------------------------------------------------------------
 # Runtime stage — minimal image, production only
@@ -64,9 +64,9 @@ ENV HOSTNAME="0.0.0.0"
 WORKDIR /app
 
 # Copy standalone Next.js output — includes only required server files
-COPY --from=builder /app/apps/cms/.next/standalone ./
-COPY --from=builder /app/apps/cms/.next/static      ./apps/cms/.next/static
-COPY --from=builder /app/apps/cms/public            ./apps/cms/public
+COPY --from=builder /app/apps/admin/.next/standalone ./
+COPY --from=builder /app/apps/admin/.next/static      ./apps/admin/.next/static
+COPY --from=builder /app/apps/admin/public            ./apps/admin/public
 
 # Health check — reads PORT env var (default 3000)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
@@ -74,4 +74,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 EXPOSE 3000
 
-CMD ["node", "apps/cms/server.js"]
+CMD ["node", "apps/admin/server.js"]

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -86,7 +86,7 @@ Target commercial layers:
 
 ## Deployment
 
-Deployed to Vercel as `revealui-cms`. GitHub auto-deploy is enabled.
+Deployed to Vercel as `revealui-admin`. GitHub auto-deploy is enabled.
 
 ```bash
 # Vercel build uses a custom chain to build workspace dependencies first

--- a/apps/admin/deployment/dogfood.env.example
+++ b/apps/admin/deployment/dogfood.env.example
@@ -1,18 +1,18 @@
 # =============================================================================
 # RevealUI Dogfood Instance — revealui.com
 #
-# This file documents the env vars that make the CMS deployment at
-# cms.revealui.com a "dogfood instance" — RevealUI's own website running
+# This file documents the env vars that make the Admin deployment at
+# admin.revealui.com a "dogfood instance" — RevealUI's own website running
 # on top of the RevealUI product stack.
 #
 # Architecture:
 #   revealui.com         → apps/marketing  (Next.js, marketing + waitlist)
-#   cms.revealui.com     → apps/cms        (admin dashboard + content engine)
+#   admin.revealui.com     → apps/admin        (admin dashboard + content engine)
 #   docs.revealui.com    → apps/docs       (Vite/React documentation)
 #   api.revealui.com     → apps/api        (Hono REST API)
 #
 # HOW TO USE:
-# Start from the generic template: apps/cms/.env.production.template
+# Start from the generic template: apps/admin/.env.production.template
 # Then add the vars below on top of it in Vercel → Settings → Env Vars.
 #
 # What makes this "dogfood" vs a generic customer deployment:
@@ -66,5 +66,5 @@ LLM_MODEL=claude-sonnet-4-6
 
 # =============================================================================
 # All other required vars (database, auth, Stripe, email, etc.) come from
-# the generic production template: apps/cms/.env.production.template
+# the generic production template: apps/admin/.env.production.template
 # =============================================================================

--- a/apps/admin/public/sw.js
+++ b/apps/admin/public/sw.js
@@ -1,6 +1,6 @@
 // @ts-nocheck — plain JavaScript service worker (not processed by TypeScript)
 
-var CACHE_NAME = 'revealui-cms-v1';
+var CACHE_NAME = 'revealui-admin-v1';
 
 var PRE_CACHE_URLS = ['/', '/admin', '/login'];
 

--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -297,7 +297,7 @@ describe('GET /api/auth/[provider]', () => {
   // ---- Base URL resolution ----
 
   it('should prefer NEXT_PUBLIC_APP_URL for base URL', async () => {
-    process.env.NEXT_PUBLIC_APP_URL = 'https://cms.revealui.com';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://admin.revealui.com';
     process.env.NEXT_PUBLIC_SERVER_URL = 'https://server.revealui.com';
 
     mockGenerateOAuthState.mockReturnValue({ state: 's', cookieValue: 's.h', codeChallenge: 'c' });
@@ -308,7 +308,7 @@ describe('GET /api/auth/[provider]', () => {
 
     expect(mockBuildAuthUrl).toHaveBeenCalledWith(
       'github',
-      'https://cms.revealui.com/api/auth/callback/github',
+      'https://admin.revealui.com/api/auth/callback/github',
       's',
       'c',
     );

--- a/apps/admin/src/__tests__/rbac-enforcement.test.ts
+++ b/apps/admin/src/__tests__/rbac-enforcement.test.ts
@@ -80,7 +80,7 @@ describe('Users collection access', () => {
 
   describe('read (admin sees all, non-admin sees only self)', () => {
     // Re-implementing the Users collection read logic inline for testing
-    // (matches apps/cms/src/lib/collections/Users/index.ts)
+    // (matches apps/admin/src/lib/collections/Users/index.ts)
     function usersRead({ req }: { req: { user?: unknown } }) {
       const user = req?.user as { id?: string } | null;
       if (!user?.id) return false;

--- a/apps/admin/src/instrumentation.ts.disabled
+++ b/apps/admin/src/instrumentation.ts.disabled
@@ -35,7 +35,7 @@ export async function register() {
     const __dirname = path.dirname(__filename)
 
     // Load .env file from monorepo root before validation
-    // Next.js automatically loads .env from apps/cms/, but we also need the root .env
+    // Next.js automatically loads .env from apps/admin/, but we also need the root .env
     dotenv.config({ path: path.resolve(__dirname, '../../../.env') })
     // Also load .env.local if it exists (has precedence)
     dotenv.config({ path: path.resolve(__dirname, '../../../.env.local') })

--- a/apps/admin/src/lib/components/UpgradePrompt.tsx
+++ b/apps/admin/src/lib/components/UpgradePrompt.tsx
@@ -1,2 +1,2 @@
-// Consolidated — see apps/cms/src/components/UpgradePrompt.tsx
+// Consolidated — see apps/admin/src/components/UpgradePrompt.tsx
 export { UpgradePrompt } from '../../components/UpgradePrompt';

--- a/apps/api/.env.production.template
+++ b/apps/api/.env.production.template
@@ -54,7 +54,7 @@ STRIPE_WEBHOOK_SECRET=whsec_<your-webhook-signing-secret>
 # IMPORTANT: Vercel stores multi-line PEM as single-line with literal \n.
 #            Paste the key with newlines replaced by \n (the webhook handler
 #            calls .replace(/\\n/g, '\n') to restore them before use).
-# Must match REVEALUI_LICENSE_PUBLIC_KEY set in apps/cms project.
+# Must match REVEALUI_LICENSE_PUBLIC_KEY set in apps/admin project.
 # -----------------------------------------------------------------------------
 REVEALUI_LICENSE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvg...\n-----END PRIVATE KEY-----
 REVEALUI_LICENSE_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\nMIIBIj...\n-----END PUBLIC KEY-----

--- a/apps/api/src/routes/__tests__/billing-ui-accuracy.test.ts
+++ b/apps/api/src/routes/__tests__/billing-ui-accuracy.test.ts
@@ -1,7 +1,7 @@
 /**
  * Billing UI Accuracy Tests (Phase 2.4 — Stripe Go-Live Readiness)
  *
- * Validates that the CMS billing page (apps/cms/src/app/(frontend)/account/billing/page.tsx)
+ * Validates that the CMS billing page (apps/admin/src/app/(frontend)/account/billing/page.tsx)
  * makes API calls that match the actual billing routes, and that hardcoded UI text
  * (tier names, limits, feature descriptions) matches contracts/pricing.ts.
  *

--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -17,7 +17,7 @@ RevealUI Pro adds AI agents, MCP servers, and editor integrations on top of the 
 Pro packages are commercially licensed. An active Pro or Forge subscription, or a perpetual license, is required.
 
 - [View pricing](https://revealui.com/pricing)
-- [Manage your license](https://cms.revealui.com)
+- [Manage your license](https://admin.revealui.com)
 
 ## Installation
 

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -8,7 +8,7 @@ audience: maintainer
 # RevealUI CI/CD Deployment Guide
 
 **Last Updated**: March 2026
-**Status**: Deployment Guide (Production — live at cms.revealui.com and api.revealui.com)
+**Status**: Deployment Guide (Production — live at admin.revealui.com and api.revealui.com)
 
 ---
 
@@ -452,7 +452,7 @@ import tracer from 'dd-trace'
 export async function register() {
   if (process.env.DD_SERVICE) {
     tracer.init({
-      service: 'revealui-cms',
+      service: 'revealui-admin',
       env: process.env.NODE_ENV,
     })
     tracer.use('http')
@@ -463,7 +463,7 @@ export async function register() {
 
 **Environment Variables:**
 ```bash
-DD_SERVICE=revealui-cms
+DD_SERVICE=revealui-admin
 DD_ENV=production
 DD_VERSION=1.0.0
 DD_API_KEY=your-api-key
@@ -1109,7 +1109,7 @@ vercel deploy --prod
 #### Build Individual Apps
 ```bash
 # CMS (Next.js)
-docker build -f apps/admin/Dockerfile -t revealui-cms:latest .
+docker build -f apps/admin/Dockerfile -t revealui-admin:latest .
 
 # Mainframe (Hono SSR + React)
 docker build -f apps/mainframe/Dockerfile -t revealui-mainframe:latest .
@@ -1154,18 +1154,18 @@ docker exec revealui-postgres pg_isready -U revealui
 #### Troubleshooting
 ```bash
 # View container logs
-docker logs revealui-cms
+docker logs revealui-admin
 docker logs revealui-mainframe
 docker logs revealui-postgres
 
 # Inspect image
-docker inspect revealui-cms:latest
+docker inspect revealui-admin:latest
 
 # Check image history
-docker history revealui-cms:latest
+docker history revealui-admin:latest
 
 # Exec into container
-docker exec -it revealui-cms sh
+docker exec -it revealui-admin sh
 docker exec -it revealui-postgres psql -U revealui
 
 # Clean up
@@ -1453,7 +1453,7 @@ docker build --no-cache -f apps/admin/Dockerfile -t test . 2>&1 | grep "Sending 
 
 # Layer Caching Issues
 # Build without cache
-docker build --no-cache -f apps/admin/Dockerfile -t revealui-cms:latest .
+docker build --no-cache -f apps/admin/Dockerfile -t revealui-admin:latest .
 
 # Prune build cache
 docker builder prune
@@ -1473,7 +1473,7 @@ vercel env ls
 
 # Health Check Failures
 # Check application logs
-docker logs revealui-cms
+docker logs revealui-admin
 
 # Test health endpoint locally
 curl -v http://localhost:4000/api/health
@@ -1646,7 +1646,7 @@ Example:
 docker build -f apps/mainframe/Dockerfile -t revealui-mainframe:latest .
 docker build -f apps/docs/Dockerfile -t revealui-docs:latest .
 docker build -f apps/marketing/Dockerfile -t revealui-marketing:latest .
-docker build -f apps/admin/Dockerfile -t revealui-cms:latest .
+docker build -f apps/admin/Dockerfile -t revealui-admin:latest .
 ```
 
 ### Docker Production Deployment Checklist
@@ -1702,7 +1702,7 @@ Before deploying to production:
 docker ps --format "table {{.Names}}\t{{.Status}}"
 
 # View health check logs
-docker inspect revealui-cms | jq '.[0].State.Health'
+docker inspect revealui-admin | jq '.[0].State.Health'
 ```
 
 #### Resource Usage
@@ -1711,19 +1711,19 @@ docker inspect revealui-cms | jq '.[0].State.Health'
 docker stats
 
 # Specific container
-docker stats revealui-cms
+docker stats revealui-admin
 ```
 
 #### Logs
 ```bash
 # View logs
-docker logs revealui-cms
+docker logs revealui-admin
 
 # Follow logs
-docker logs -f revealui-cms
+docker logs -f revealui-admin
 
 # Last 100 lines
-docker logs --tail 100 revealui-cms
+docker logs --tail 100 revealui-admin
 ```
 
 ---
@@ -2510,7 +2510,7 @@ kubectl apply -f k8s/deployments/cms.yaml
 kubectl apply -f k8s/deployments/dashboard.yaml
 
 # Wait for deployments
-kubectl rollout status deployment/revealui-cms -n revealui
+kubectl rollout status deployment/revealui-admin -n revealui
 kubectl rollout status deployment/revealui-dashboard -n revealui
 ```
 
@@ -2741,7 +2741,7 @@ Use the rollback script:
 ./scripts/rollback.sh pause
 
 # Or manually
-kubectl scale deployment/revealui-cms --replicas=0 -n revealui
+kubectl scale deployment/revealui-admin --replicas=0 -n revealui
 kubectl scale deployment/revealui-dashboard --replicas=0 -n revealui
 ```
 
@@ -2752,7 +2752,7 @@ kubectl scale deployment/revealui-dashboard --replicas=0 -n revealui
 ./scripts/rollback.sh resume
 
 # Or manually
-kubectl scale deployment/revealui-cms --replicas=3 -n revealui
+kubectl scale deployment/revealui-admin --replicas=3 -n revealui
 kubectl scale deployment/revealui-dashboard --replicas=2 -n revealui
 ```
 
@@ -2828,7 +2828,7 @@ kubectl describe certificate revealui-tls -n revealui
 kubectl top pods -n revealui
 
 # Increase resource limits
-kubectl set resources deployment/revealui-cms \
+kubectl set resources deployment/revealui-admin \
   --limits=memory=2Gi \
   -n revealui
 ```
@@ -2840,7 +2840,7 @@ kubectl set resources deployment/revealui-cms \
 kubectl get hpa -n revealui
 
 # Manually scale up
-kubectl scale deployment/revealui-cms --replicas=10 -n revealui
+kubectl scale deployment/revealui-admin --replicas=10 -n revealui
 
 # Check database performance
 kubectl exec -n revealui postgres-0 -- psql -U postgres revealui -c \
@@ -2867,8 +2867,8 @@ kubectl exec -it <pod-name> -n revealui -- /bin/sh
 kubectl port-forward -n revealui pod/<pod-name> 3000:3000
 
 # View deployment status
-kubectl rollout status deployment/revealui-cms -n revealui
-kubectl rollout history deployment/revealui-cms -n revealui
+kubectl rollout status deployment/revealui-admin -n revealui
+kubectl rollout history deployment/revealui-admin -n revealui
 
 # Check configuration
 kubectl get configmap revealui-config -n revealui -o yaml
@@ -2895,7 +2895,7 @@ spec:
 
 ```bash
 # Increase connection pool
-kubectl set env deployment/revealui-cms \
+kubectl set env deployment/revealui-admin \
   DATABASE_POOL_SIZE=50 \
   -n revealui
 

--- a/docs/CORE_STABILITY.md
+++ b/docs/CORE_STABILITY.md
@@ -33,7 +33,7 @@ audience: developer
 
 ### Stable — Production-ready
 
-These exports are the load-bearing core of RevealUI. They are covered by unit and integration tests, have been deployed and verified in production (cms.revealui.com, revealui-api.vercel.app), and will not break without a major version bump.
+These exports are the load-bearing core of RevealUI. They are covered by unit and integration tests, have been deployed and verified in production (admin.revealui.com, revealui-api.vercel.app), and will not break without a major version bump.
 
 #### Setup & Instance
 
@@ -226,7 +226,7 @@ import { ... } from '@revealui/core/security'
 
 ## Production Verification Status
 
-This table reflects what has been exercised against production infrastructure (cms.revealui.com, revealui-api.vercel.app, NeonDB production, Electric on Railway).
+This table reflects what has been exercised against production infrastructure (admin.revealui.com, revealui-api.vercel.app, NeonDB production, Electric on Railway).
 
 | Feature | Verified in Production | Notes |
 |---------|----------------------|-------|

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -16,7 +16,7 @@ Forge is best treated as a deployment-level commercial product, distinct from th
 | Component     | Image                                 | Port            |
 | ------------- | ------------------------------------- | --------------- |
 | API (Hono)    | `ghcr.io/revealuistudio/revealui-api` | 3004            |
-| CMS (Next.js) | `ghcr.io/revealuistudio/revealui-cms` | 4000            |
+| Admin (Next.js) | `ghcr.io/revealuistudio/revealui-admin` | 4000            |
 | PostgreSQL 16 | `postgres:16-alpine`                  | 5432 (internal) |
 
 All three services are wired together in `docker-compose.forge.yml` at the root of the repository.
@@ -47,7 +47,7 @@ Forge sits beside, not underneath, the hosted pricing model:
 
 ```bash
 docker pull ghcr.io/revealuistudio/revealui-api:latest
-docker pull ghcr.io/revealuistudio/revealui-cms:latest
+docker pull ghcr.io/revealuistudio/revealui-admin:latest
 ```
 
 > GHCR access is gated by your license key. Log in with the token provided in your Forge welcome email:
@@ -163,7 +163,7 @@ The Next.js admin dashboard (standalone output — no Node.js server required be
 
 ```yaml
 cms:
-  image: ghcr.io/revealuistudio/revealui-cms:latest
+  image: ghcr.io/revealuistudio/revealui-admin:latest
   ports: ["4000:4000"]
   environment:
     DATABASE_URL: postgresql://revealui:${DB_PASSWORD}@db:5432/revealui

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -84,13 +84,13 @@ See `business/BUSINESS_PLAN.md` for full business plan (not superseded — separ
 #### 3.10 Pre-Launch Smoke Checklist (verified 2026-03-30)
 - [x] `GET https://api.revealui.com/openapi.json` → 200 with full spec ✓ OpenAPI 3.0.0, 100+ endpoints
 - [x] `GET https://api.revealui.com/.well-known/agent.json` → 200 ✓ Valid agent card
-- [x] `cms.revealui.com` without session → /login (not landing page) ✓ 307 → /login
-- [x] `revealui.com` "Get Started" → cms.revealui.com/signup ✓
-- [x] `revealui.com` "Log in" → cms.revealui.com/login ✓
-- [x] `cms.revealui.com/posts` → 301 to revealui.com/blog ✓ 308 redirect (permanent, functional)
+- [x] `admin.revealui.com` without session → /login (not landing page) ✓ 307 → /login
+- [x] `revealui.com` "Get Started" → admin.revealui.com/signup ✓
+- [x] `revealui.com` "Log in" → admin.revealui.com/login ✓
+- [x] `admin.revealui.com/posts` → 301 to revealui.com/blog ✓ 308 redirect (permanent, functional)
 - [x] At least 1 blog post visible at revealui.com/blog ✓ "Why I Built RevealUI" (Mar 26, 2026)
 - [x] `BuiltWithRevealUI` badge renders in dark mode in footer — verified via Playwright MCP (2026-03-31)
-- [x] Signup → login page flow — verified: cms.revealui.com → /login redirect, signup form at /signup with Name/Email/Password + OAuth (2026-03-31). Full email verification flow requires manual test.
+- [x] Signup → login page flow — verified: admin.revealui.com → /login redirect, signup form at /signup with Name/Email/Password + OAuth (2026-03-31). Full email verification flow requires manual test.
 - [x] Pricing page loads with live Stripe prices — verified: /api/pricing returns 200, page shows $0/$49/$149/$299 for all 4 tiers (2026-03-31)
 - [x] E2E smoke spec added: `packages/test/src/e2e/smoke-production.spec.ts` (8 tests, @smoke tagged: badge, pricing, auth flow, performance budget, security headers, OAuth hrefs, OpenAPI spec, visual regression)
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1529,7 +1529,7 @@ See **[FORGE.md](./FORGE.md)** for the complete deployment guide, including:
 # Pull images (requires GHCR token from Forge welcome email)
 echo "$GHCR_TOKEN" | docker login ghcr.io -u revealuistudio --password-stdin
 docker pull ghcr.io/revealuistudio/revealui-api:latest
-docker pull ghcr.io/revealuistudio/revealui-cms:latest
+docker pull ghcr.io/revealuistudio/revealui-admin:latest
 
 # Start the stack
 docker compose -f docker-compose.forge.yml --env-file .env.forge up -d

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4480,7 +4480,7 @@ import { ElectricProvider } from "@revealui/sync";
 
 function App() {
   return (
-    <ElectricProvider proxyBaseUrl="https://cms.revealui.com" debug={false}>
+    <ElectricProvider proxyBaseUrl="https://admin.revealui.com" debug={false}>
       <MyApp />
     </ElectricProvider>
   );

--- a/docs/architecture/ADR-004-session-only-auth.md
+++ b/docs/architecture/ADR-004-session-only-auth.md
@@ -32,6 +32,6 @@ JWTs are used only for **license validation** (RS256, asymmetric), not for user 
 ## Consequences
 
 - Every authenticated request hits the database (session lookup). This is acceptable at current scale and can be cached later with PGlite or an in-memory session cache.
-- Cross-subdomain auth works natively via cookie domain (`.revealui.com` covers `cms.revealui.com`, `api.revealui.com`)
+- Cross-subdomain auth works natively via cookie domain (`.revealui.com` covers `admin.revealui.com`, `api.revealui.com`)
 - Session revocation is instant (delete the row)
 - No token refresh flow needed — sessions have a configurable TTL with sliding window

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -346,7 +346,7 @@ await revokeSession(sessionId);
 
 ### Cookie Domain
 
-For cross-subdomain auth (e.g., `cms.revealui.com` and `api.revealui.com`), set the cookie domain to `.revealui.com`. This allows the session cookie to be sent to all subdomains.
+For cross-subdomain auth (e.g., `admin.revealui.com` and `api.revealui.com`), set the cookie domain to `.revealui.com`. This allows the session cookie to be sent to all subdomains.
 
 ---
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -20,7 +20,7 @@ Vercel is the recommended deployment target. RevealUI auto-deploys three service
 
 | App | Vercel Project | Domain |
 |-----|---------------|--------|
-| CMS | `revealui-cms` | cms.yourdomain.com |
+| Admin | `revealui-admin` | admin.yourdomain.com |
 | API | `revealui-api` | api.yourdomain.com |
 | Marketing | `revealui-marketing` | yourdomain.com |
 
@@ -61,8 +61,8 @@ These must be set in every Vercel project:
 ```env
 # Core (required)
 REVEALUI_SECRET=<32+ character random string>
-REVEALUI_PUBLIC_SERVER_URL=https://cms.yourdomain.com
-NEXT_PUBLIC_SERVER_URL=https://cms.yourdomain.com
+REVEALUI_PUBLIC_SERVER_URL=https://admin.yourdomain.com
+NEXT_PUBLIC_SERVER_URL=https://admin.yourdomain.com
 POSTGRES_URL=postgresql://user:pass@host/db?sslmode=require
 
 # Storage (required for media uploads)
@@ -103,7 +103,7 @@ Configure domains in the Vercel dashboard:
 2. Update DNS (CNAME to `cname.vercel-dns.com`)
 3. Update `REVEALUI_PUBLIC_SERVER_URL` to match
 
-For cross-subdomain auth, the session cookie domain should be set to `.yourdomain.com` so it works across `cms.yourdomain.com` and `api.yourdomain.com`.
+For cross-subdomain auth, the session cookie domain should be set to `.yourdomain.com` so it works across `admin.yourdomain.com` and `api.yourdomain.com`.
 
 ---
 
@@ -227,7 +227,7 @@ node dist/index.js
 Use a process manager like PM2 for production:
 
 ```bash
-pm2 start apps/admin/.next/standalone/server.js --name revealui-cms
+pm2 start apps/admin/.next/standalone/server.js --name revealui-admin
 pm2 start apps/api/dist/index.js --name revealui-api
 pm2 save
 pm2 startup
@@ -239,7 +239,7 @@ Place Nginx or Caddy in front of the Node.js processes:
 
 ```nginx
 server {
-    server_name cms.yourdomain.com;
+    server_name admin.yourdomain.com;
 
     location / {
         proxy_pass http://127.0.0.1:4000;

--- a/packages/ai/src/ingestion/cms-indexer.ts
+++ b/packages/ai/src/ingestion/cms-indexer.ts
@@ -5,7 +5,7 @@
  * Wire into CMS collection afterChange hooks — no CMS API calls from here,
  * the event payload carries the document content directly.
  *
- * Usage (in apps/cms/src/lib/ai/indexer.ts):
+ * Usage (in apps/admin/src/lib/ai/indexer.ts):
  *   export const cmsIndexer = new CmsIndexer({ db, ingestionPipeline, enabledCollections: ['posts', 'pages'] })
  *
  * In each CMS collection afterChange hook:

--- a/packages/config/src/ci/github/dependabot.yml.disabled
+++ b/packages/config/src/ci/github/dependabot.yml.disabled
@@ -40,7 +40,7 @@ updates:
 
   # CMS app
   - package-ecosystem: "npm"
-    directory: "/apps/cms"
+    directory: "/apps/admin"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/packages/config/src/revealui.config.ts
+++ b/packages/config/src/revealui.config.ts
@@ -6,7 +6,7 @@
  *
  * ## Usage
  *
- * ### CMS App (apps/cms/revealui.config.ts)
+ * ### Admin App (apps/admin/revealui.config.ts)
  * ```typescript
  * import { getSharedCMSConfig } from '@revealui/config/revealui'
  *
@@ -121,7 +121,7 @@ export const sharedConfig = {
 
 /**
  * Get shared configuration for CMS app
- * Returns base config that can be extended in apps/cms/revealui.config.ts
+ * Returns base config that can be extended in apps/admin/revealui.config.ts
  */
 export function getSharedCMSConfig(): { serverURL: string; secret: string } {
   return {

--- a/packages/contracts/src/__tests__/mocks/payload.ts
+++ b/packages/contracts/src/__tests__/mocks/payload.ts
@@ -1,7 +1,7 @@
 /**
  * Mock RevealUI Types for Isolated Unit Testing
  *
- * These mocks allow tests to run without importing from apps/cms.
+ * These mocks allow tests to run without importing from apps/admin.
  * Use these for unit tests that need to validate type behavior
  * in isolation.
  *

--- a/packages/contracts/src/__tests__/mocks/revealui.ts
+++ b/packages/contracts/src/__tests__/mocks/revealui.ts
@@ -1,7 +1,7 @@
 /**
  * Mock RevealUI Types for Isolated Unit Testing
  *
- * These mocks allow tests to run without importing from apps/cms.
+ * These mocks allow tests to run without importing from apps/admin.
  * Use these for unit tests that need to validate type behavior
  * in isolation.
  *

--- a/packages/harnesses/src/__tests__/workboard-manager.test.ts
+++ b/packages/harnesses/src/__tests__/workboard-manager.test.ts
@@ -211,11 +211,11 @@ describe('WorkboardManager', () => {
 
   describe('updateAgent', () => {
     it('updates specific fields', () => {
-      manager.updateAgent('agent-edit', { task: 'new task', files: 'apps/cms/**' });
+      manager.updateAgent('agent-edit', { task: 'new task', files: 'apps/admin/**' });
       const state = manager.read();
       const row = state.agents.find((a) => a.id === 'agent-edit');
       expect(row?.task).toBe('new task');
-      expect(row?.files).toBe('apps/cms/**');
+      expect(row?.files).toBe('apps/admin/**');
     });
 
     it('is a no-op for unknown agent', () => {

--- a/packages/presentation/src/components/link.tsx
+++ b/packages/presentation/src/components/link.tsx
@@ -3,7 +3,7 @@
  *
  * This is a generic Link component that works with any framework.
  * For framework-specific implementations:
- * - Next.js: Use Next.js Link component (see apps/cms/src/lib/components/Link)
+ * - Next.js: Use Next.js Link component (see apps/admin/src/lib/components/Link)
  * - Other frameworks: Wrap this component with your framework's Link
  *
  * See Catalyst documentation for framework-specific examples:

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -28,7 +28,7 @@ import { ElectricProvider } from '@revealui/sync/provider'
 
 export default function App() {
   return (
-    <ElectricProvider proxyBaseUrl="https://cms.revealui.com">
+    <ElectricProvider proxyBaseUrl="https://admin.revealui.com">
       <YourComponents />
     </ElectricProvider>
   )

--- a/packages/sync/src/provider/index.tsx
+++ b/packages/sync/src/provider/index.tsx
@@ -12,7 +12,7 @@ interface ElectricContextValue {
   /**
    * Base URL prefix for authenticated CMS shape proxy routes.
    * Default '' keeps all hook URLs relative (works for same-origin apps).
-   * Set to 'https://cms.revealui.com' when consuming from a different origin.
+   * Set to 'https://admin.revealui.com' when consuming from a different origin.
    */
   proxyBaseUrl: string;
   debug: boolean;


### PR DESCRIPTION
## Summary
- Replace all `cms.revealui.com` → `admin.revealui.com` (domain deleted)
- Replace all `revealui-cms` → `revealui-admin` (Docker images, service names, Vercel project refs)
- Replace all `apps/cms` → `apps/admin` in code comments, Dockerfiles, env templates
- Fix Dockerfiles that would have broken builds (referencing old `apps/cms/` path)
- Update service worker cache name, dependabot config, deployment guides

32 files changed across apps, packages, and docs.

## Test plan
- [x] Local gate passes (Biome, boundary, security, coverage, version policy)
- [x] No remaining `cms.revealui.com`, `revealui-cms`, or `apps/cms` references in source files
- [x] CHANGELOGs intentionally kept (they document the rename history)
- [x] Generated files (.turbo, .next, dist) will regenerate on next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)