### PR TITLE
docs: honest labeling — editor disclosure + maturity labels (CR7-15, CR7-16)

### DIFF
--- a/apps/marketing/src/components/SocialProof.tsx
+++ b/apps/marketing/src/components/SocialProof.tsx
@@ -23,7 +23,7 @@ export function SocialProof() {
     {
       title: 'Content Engine',
       description:
-        'Schema-first collections with rich text (Lexical), media, relationships, and lifecycle hooks. Define once, query everywhere via REST API.',
+        'Schema-first collections with Lexical-powered rich text fields, media, relationships, and lifecycle hooks. Define once, query everywhere via REST API.',
       icon: 'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
       iconColor: 'text-blue-400',
     },

--- a/apps/marketing/src/components/ValueProposition.tsx
+++ b/apps/marketing/src/components/ValueProposition.tsx
@@ -13,7 +13,7 @@ export function ValueProposition() {
     {
       title: 'Content + Admin, Done',
       description:
-        'Schema-first collections, rich text editor, media management, and a full admin dashboard — works out of the box. Define your data, get a REST API and admin UI for free.',
+        'Schema-first collections with Lexical rich text fields, media management, and a full admin dashboard — works out of the box. Define your data, get a REST API and admin UI for free.',
       icon: 'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
       accent: 'bg-emerald-600',
       href: 'https://docs.revealui.com/docs/REFERENCE',

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,30 @@ audience: developer
 
 This roadmap reflects our current priorities and planned direction. It is updated regularly and may shift based on community feedback and business needs.
 
-**Last updated:** 2026-04-05
+**Last updated:** 2026-04-10
+
+---
+
+## Suite Product Maturity
+
+Honest labels for every product in the RevealUI ecosystem. Updated 2026-04-10.
+
+| Product | Maturity | Notes |
+|---------|----------|-------|
+| **RevealUI** (monorepo) | Beta | Deployed, 13,700+ tests, 23 npm packages. No paying users yet. |
+| **Forge** (self-hosted) | Beta | Docker stack complete, license enforcement built. No external customers. |
+| **RevVault** (secrets) | Beta | Rust CLI + desktop app, age-encrypted vault. Not published to crates.io. |
+| **Studio** (desktop) | Alpha | Tauri 2 + React 19, agent coordination UI. No published binaries. |
+| **Terminal** (TUI) | Alpha | Go SSH server + Bubble Tea. Functional, not deployed. |
+| **RevCon** (configs) | Alpha | Editor config sync tooling. Functional, undocumented. |
+| **RevealCoin** (token) | Alpha | Solana devnet proof-of-concept. Not on mainnet. |
+| **RevSkills** (skills) | Alpha | 6 Claude Code skills on GitHub. No tests. |
+| **RevDev** (dev tools) | Planned | Harness infrastructure exists. Not a standalone product yet. |
+| **RevMarket** (marketplace) | Planned | Database schema defined. No API routes or UI. |
+| **RevKit** (templates) | Planned | Design documented. Stub implementation. |
+
+**Labels:** Production = real users + stable API. Beta = feature-complete, deployed, pre-users.
+Alpha = functional, not deployed/published. Planned = design or schema only.
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,7 +6,7 @@ The core runtime engine for RevealUI — collections, admin UI, rich text, secur
 
 - **Collections & CRUD** — Define content types with field hooks, access control, and validation
 - **Admin Dashboard** — Ready-to-use React admin UI (collection browser, document editor, global forms)
-- **Rich Text** — Lexical-based editor with 20+ features (bold, headings, lists, links, images, blocks)
+- **Rich Text Fields** — Lexical-powered content fields in the admin editor (bold, headings, lists, links, images, blocks)
 - **Security** — CORS, CSP, HSTS, RBAC/ABAC policy engine, encryption (AES-256-GCM), audit logging
 - **GDPR Compliance** — Consent management, data export, deletion, anonymization, breach reporting
 - **Observability** — Structured logging, process health monitoring, alert system, graceful shutdown
@@ -78,15 +78,15 @@ function App() {
 }
 ```
 
-### Rich Text
+### Rich Text Fields
+
+Rich text editing is available as a field type in the admin dashboard.
+Define a `richText` field in your collection schema — the admin UI renders
+a Lexical editor automatically. Not a standalone component.
 
 ```typescript
-import { RichTextEditor, BoldFeature, HeadingFeature, ListFeature } from '@revealui/core/richtext/client'
-
-<RichTextEditor
-  features={[BoldFeature(), HeadingFeature(), ListFeature()]}
-  onChange={(json) => console.log(json)}
-/>
+// In your collection definition:
+defineField({ name: 'body', type: 'richText' })
 ```
 
 ### Feature Gating


### PR DESCRIPTION
Closes CR7-15 and CR7-16 from §CR-7 charge-readiness.

## Summary

- **CR7-15**: Marketing and core/README now say "rich text fields" instead of "rich text editor" — Lexical powers admin content fields, not a standalone reusable component. Removed misleading `RichTextEditor` code example from core/README.
- **CR7-16**: Added Suite Product Maturity table to `docs/ROADMAP.md` with honest labels for all 11 products (Beta / Alpha / Planned)

## Test plan

- [x] No code changes — text/docs only
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)