### PR TITLE
docs: label RevMarket execution as PREVIEW (CR7-11, CR7-12)

### DIFF
--- a/apps/api/src/routes/revmarket.ts
+++ b/apps/api/src/routes/revmarket.ts
@@ -1,5 +1,10 @@
 /**
- * RevMarket — Autonomous Agent Marketplace Routes (Phase 5.16)
+ * RevMarket — Autonomous Agent Marketplace Routes (Phase 5.16) — PREVIEW
+ *
+ * ⚠️  PREVIEW: Agent task execution runs in-process without sandbox isolation.
+ * x402 crypto payments are disabled by default (X402_ENABLED=false).
+ * Use only with trusted agents. Full sandboxing and payment settlement
+ * are planned for Phase B.
  *
  * Extends the MCP Marketplace (Phase 5.5) with autonomous agent task execution.
  * Agents register with skills and pricing, users submit tasks, the system

--- a/apps/api/src/services/revmarket-executor.ts
+++ b/apps/api/src/services/revmarket-executor.ts
@@ -1,9 +1,14 @@
 /**
- * RevMarket Task Executor (Phase 5.16-B)
+ * RevMarket Task Executor (Phase 5.16-B) — PREVIEW
+ *
+ * ⚠️  PREVIEW FEATURE: Task execution runs in-process with timeout enforcement
+ * only. There is no process isolation, filesystem sandboxing, or memory limit
+ * enforcement. Use only with trusted agents you control or have reviewed.
+ * Full sandboxed execution (child process isolation) is planned for Phase B.
  *
  * Manages the lifecycle of autonomous agent task execution:
  *   1. Task claiming — atomic claim with priority ordering
- *   2. Sandboxed execution — resource limits, timeout enforcement
+ *   2. Timeout enforcement — AbortController with configurable maxExecutionMs
  *   3. Progress reporting — status updates to task_submissions
  *   4. Output validation — schema-checked results
  *   5. Audit trail — append-only audit_log entries
@@ -11,7 +16,7 @@
  * Architecture:
  *   - Uses the existing `jobs` table as a task queue bridge
  *   - Execution is in-process (not child-process) for Phase A
- *   - Resource limits enforced via timeout + memory monitoring
+ *   - Resource limits enforced via timeout only (memory monitoring planned)
  *   - All state transitions are atomic (single UPDATE with WHERE state = X)
  */
 


### PR DESCRIPTION
Closes CR7-11 and CR7-12 from §CR-7 charge-readiness (Tier 3).

## Summary

- **CR7-11 (x402)**: Already safe — disabled by default (`X402_ENABLED=false`), verification-only (doesn't execute on-chain transfers). RevMarket routes now labeled PREVIEW.
- **CR7-12 (sandboxing)**: Task executor and marketplace route JSDoc updated with clear disclosure: in-process execution, timeout only, no filesystem/memory isolation. Recommends trusted agents only until Phase B.

## Test plan

- [x] JSDoc changes only — no behavior changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)