### PR TITLE
feat(openapi): native Zod→OpenAPI scaffold — extension, registry, converter

### DIFF
--- a/packages/openapi/src/__tests__/native.test.ts
+++ b/packages/openapi/src/__tests__/native.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Native OpenAPI Implementation Tests
+ *
+ * Tests for the zero-dependency Zod → OpenAPI pipeline:
+ * - Zod extension (.openapi() metadata)
+ * - Registry (route/schema collection)
+ * - Zod → JSON Schema converter
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { NativeOpenAPIRegistry } from '../native/registry.js';
+import {
+  extendZodWithOpenApi,
+  getOpenApiMetadata,
+  setOpenApiMetadata,
+} from '../native/zod-extension.js';
+import { zodToJsonSchema } from '../native/zod-to-schema.js';
+
+// Extend Zod once for all tests
+extendZodWithOpenApi(z);
+
+// =============================================================================
+// Zod Extension
+// =============================================================================
+
+describe('Zod Extension', () => {
+  it('adds .openapi() method to Zod schemas', () => {
+    const schema = z.string().openapi({ description: 'A name' });
+    const meta = getOpenApiMetadata(schema);
+    expect(meta?.description).toBe('A name');
+  });
+
+  it('supports multiple metadata fields', () => {
+    const schema = z.number().openapi({
+      description: 'User age',
+      example: 25,
+      deprecated: true,
+      format: 'int32',
+    });
+    const meta = getOpenApiMetadata(schema);
+    expect(meta?.example).toBe(25);
+    expect(meta?.deprecated).toBe(true);
+    expect(meta?.format).toBe('int32');
+  });
+
+  it('supports refId for $ref generation', () => {
+    const schema = z.object({ id: z.string() }).openapi({ refId: 'User' });
+    const meta = getOpenApiMetadata(schema);
+    expect(meta?.refId).toBe('User');
+  });
+
+  it('returns undefined for schemas without metadata', () => {
+    const schema = z.string();
+    expect(getOpenApiMetadata(schema)).toBeUndefined();
+  });
+
+  it('setOpenApiMetadata works directly', () => {
+    const schema = z.boolean();
+    setOpenApiMetadata(schema, { description: 'Active flag' });
+    expect(getOpenApiMetadata(schema)?.description).toBe('Active flag');
+  });
+
+  it('extendZodWithOpenApi is idempotent', () => {
+    // Should not throw or duplicate
+    extendZodWithOpenApi(z);
+    extendZodWithOpenApi(z);
+    const schema = z.string().openapi({ description: 'test' });
+    expect(getOpenApiMetadata(schema)?.description).toBe('test');
+  });
+});
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+describe('NativeOpenAPIRegistry', () => {
+  it('starts with empty definitions', () => {
+    const registry = new NativeOpenAPIRegistry();
+    expect(registry.definitions).toHaveLength(0);
+  });
+
+  it('registerPath adds a route definition', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.registerPath({
+      method: 'get',
+      path: '/users',
+      responses: { 200: { description: 'Success' } },
+    });
+    expect(registry.definitions).toHaveLength(1);
+    expect(registry.definitions[0].type).toBe('route');
+  });
+
+  it('register adds a schema definition', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.register('User', z.object({ id: z.string() }));
+    expect(registry.definitions).toHaveLength(1);
+    expect(registry.definitions[0].type).toBe('schema');
+  });
+
+  it('registerComponent adds a component definition', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.registerComponent('securitySchemes', 'BearerAuth', {
+      type: 'http',
+      scheme: 'bearer',
+    });
+    expect(registry.definitions).toHaveLength(1);
+    expect(registry.definitions[0].type).toBe('component');
+  });
+
+  it('registerWebhook adds a webhook definition', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.registerWebhook({
+      method: 'post',
+      path: '/webhooks/order',
+      responses: { 200: { description: 'Received' } },
+    });
+    expect(registry.definitions).toHaveLength(1);
+    expect(registry.definitions[0].type).toBe('webhook');
+  });
+
+  it('registerParameter adds a parameter definition', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.registerParameter('PageParam', z.number().int().min(1));
+    expect(registry.definitions).toHaveLength(1);
+    expect(registry.definitions[0].type).toBe('parameter');
+  });
+
+  it('accumulates multiple definitions', () => {
+    const registry = new NativeOpenAPIRegistry();
+    registry.registerPath({ method: 'get', path: '/a', responses: {} });
+    registry.registerPath({ method: 'post', path: '/b', responses: {} });
+    registry.register('Schema1', z.string());
+    expect(registry.definitions).toHaveLength(3);
+  });
+});
+
+// =============================================================================
+// Zod → JSON Schema Converter
+// =============================================================================
+
+describe('zodToJsonSchema', () => {
+  describe('primitives', () => {
+    it('converts z.string()', () => {
+      expect(zodToJsonSchema(z.string())).toEqual({ type: 'string' });
+    });
+
+    it('converts z.number()', () => {
+      expect(zodToJsonSchema(z.number())).toEqual({ type: 'number' });
+    });
+
+    it('converts z.boolean()', () => {
+      expect(zodToJsonSchema(z.boolean())).toEqual({ type: 'boolean' });
+    });
+
+    it('converts z.null()', () => {
+      expect(zodToJsonSchema(z.null())).toEqual({ type: 'null' });
+    });
+
+    it('converts z.date() to string format date-time', () => {
+      expect(zodToJsonSchema(z.date())).toEqual({ type: 'string', format: 'date-time' });
+    });
+
+    it('converts z.bigint() to integer format int64', () => {
+      expect(zodToJsonSchema(z.bigint())).toEqual({ type: 'integer', format: 'int64' });
+    });
+  });
+
+  describe('string constraints', () => {
+    it('min/max length', () => {
+      const schema = z.string().min(3).max(50);
+      const result = zodToJsonSchema(schema);
+      expect(result.minLength).toBe(3);
+      expect(result.maxLength).toBe(50);
+    });
+
+    it('email format', () => {
+      expect(zodToJsonSchema(z.string().email())).toMatchObject({ format: 'email' });
+    });
+
+    it('url format', () => {
+      expect(zodToJsonSchema(z.string().url())).toMatchObject({ format: 'uri' });
+    });
+
+    it('uuid format', () => {
+      expect(zodToJsonSchema(z.string().uuid())).toMatchObject({ format: 'uuid' });
+    });
+
+    it('datetime format', () => {
+      expect(zodToJsonSchema(z.string().datetime())).toMatchObject({ format: 'date-time' });
+    });
+  });
+
+  describe('number constraints', () => {
+    it('integer', () => {
+      expect(zodToJsonSchema(z.number().int())).toMatchObject({ type: 'integer' });
+    });
+
+    it('min/max', () => {
+      const result = zodToJsonSchema(z.number().min(0).max(100));
+      expect(result.minimum).toBe(0);
+      expect(result.maximum).toBe(100);
+    });
+
+    it('multipleOf', () => {
+      expect(zodToJsonSchema(z.number().multipleOf(5))).toMatchObject({ multipleOf: 5 });
+    });
+  });
+
+  describe('literals and enums', () => {
+    it('string literal', () => {
+      expect(zodToJsonSchema(z.literal('active'))).toEqual({ type: 'string', const: 'active' });
+    });
+
+    it('number literal', () => {
+      expect(zodToJsonSchema(z.literal(42))).toEqual({ type: 'number', const: 42 });
+    });
+
+    it('boolean literal', () => {
+      expect(zodToJsonSchema(z.literal(true))).toEqual({ type: 'boolean', const: true });
+    });
+
+    it('z.enum()', () => {
+      const result = zodToJsonSchema(z.enum(['active', 'inactive', 'pending']));
+      expect(result.type).toBe('string');
+      expect(result.enum).toEqual(['active', 'inactive', 'pending']);
+    });
+  });
+
+  describe('arrays', () => {
+    it('basic array', () => {
+      const result = zodToJsonSchema(z.array(z.string()));
+      expect(result.type).toBe('array');
+      expect(result.items).toEqual({ type: 'string' });
+    });
+
+    it('min/max items', () => {
+      const result = zodToJsonSchema(z.array(z.number()).min(1).max(10));
+      expect(result.minItems).toBe(1);
+      expect(result.maxItems).toBe(10);
+    });
+  });
+
+  describe('objects', () => {
+    it('simple object', () => {
+      const schema = z.object({ name: z.string(), age: z.number() });
+      const result = zodToJsonSchema(schema);
+      expect(result.type).toBe('object');
+      expect(result.properties?.name).toEqual({ type: 'string' });
+      expect(result.properties?.age).toEqual({ type: 'number' });
+      expect(result.required).toEqual(['name', 'age']);
+    });
+
+    it('optional fields are not required', () => {
+      const schema = z.object({ name: z.string(), bio: z.string().optional() });
+      const result = zodToJsonSchema(schema);
+      expect(result.required).toEqual(['name']);
+    });
+
+    it('fields with defaults are not required', () => {
+      const schema = z.object({ role: z.string().default('viewer') });
+      const result = zodToJsonSchema(schema);
+      expect(result.required).toBeUndefined();
+      expect(result.properties?.role?.default).toBe('viewer');
+    });
+  });
+
+  describe('unions and intersections', () => {
+    it('z.union() produces oneOf', () => {
+      const schema = z.union([z.string(), z.number()]);
+      const result = zodToJsonSchema(schema);
+      expect(result.oneOf).toHaveLength(2);
+      expect(result.oneOf?.[0]).toEqual({ type: 'string' });
+      expect(result.oneOf?.[1]).toEqual({ type: 'number' });
+    });
+
+    it('z.intersection() produces allOf', () => {
+      const schema = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }));
+      const result = zodToJsonSchema(schema);
+      expect(result.allOf).toHaveLength(2);
+    });
+  });
+
+  describe('nullable and optional', () => {
+    it('nullable adds nullable: true', () => {
+      const result = zodToJsonSchema(z.string().nullable());
+      expect(result.nullable).toBe(true);
+      expect(result.type).toBe('string');
+    });
+
+    it('optional unwraps to inner type', () => {
+      const result = zodToJsonSchema(z.string().optional());
+      expect(result.type).toBe('string');
+    });
+  });
+
+  describe('records', () => {
+    it('z.record() produces object with additionalProperties', () => {
+      const result = zodToJsonSchema(z.record(z.string(), z.number()));
+      expect(result.type).toBe('object');
+      expect(result.additionalProperties).toEqual({ type: 'number' });
+    });
+  });
+
+  describe('OpenAPI metadata integration', () => {
+    it('applies description from .openapi()', () => {
+      const schema = z.string().openapi({ description: 'User email' });
+      const result = zodToJsonSchema(schema);
+      expect(result.description).toBe('User email');
+    });
+
+    it('applies format override from .openapi()', () => {
+      const schema = z.string().openapi({ format: 'password' });
+      const result = zodToJsonSchema(schema);
+      expect(result.format).toBe('password');
+    });
+
+    it('applies example from .openapi()', () => {
+      const schema = z.number().openapi({ example: 42 });
+      const result = zodToJsonSchema(schema);
+      expect(result.example).toBe(42);
+    });
+
+    it('applies Zod .describe() as fallback description', () => {
+      const schema = z.string().describe('A test field');
+      const result = zodToJsonSchema(schema);
+      expect(result.description).toBe('A test field');
+    });
+  });
+
+  describe('effects and wrappers', () => {
+    it('z.coerce.number() unwraps to number', () => {
+      const result = zodToJsonSchema(z.coerce.number());
+      expect(result.type).toBe('number');
+    });
+
+    it('z.string().default() includes default value', () => {
+      const result = zodToJsonSchema(z.string().default('hello'));
+      expect(result.type).toBe('string');
+      expect(result.default).toBe('hello');
+    });
+  });
+});

--- a/packages/openapi/src/native/index.ts
+++ b/packages/openapi/src/native/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Native OpenAPI implementation — zero external dependencies.
+ *
+ * Replaces @asteasolutions/zod-to-openapi with native Zod → OpenAPI conversion.
+ * Status: Phase A — Zod extension, registry, and schema converter implemented.
+ * The document generator (Phase B) will complete the replacement.
+ */
+
+export {
+  type ComponentDefinition,
+  NativeOpenAPIRegistry,
+  type ParameterDefinition,
+  type RegistryDefinition,
+  type RouteDefinition,
+  type SchemaDefinition,
+  type WebhookDefinition,
+} from './registry.js';
+export {
+  extendZodWithOpenApi,
+  getOpenApiMetadata,
+  type OpenAPIMetadata,
+  setOpenApiMetadata,
+} from './zod-extension.js';
+export { type JSONSchema, zodToJsonSchema } from './zod-to-schema.js';

--- a/packages/openapi/src/native/registry.ts
+++ b/packages/openapi/src/native/registry.ts
@@ -1,0 +1,138 @@
+/**
+ * Native OpenAPI Registry
+ *
+ * Collects route definitions, schema components, webhooks, and parameters
+ * for OpenAPI document generation. Replaces the OpenAPIRegistry from
+ * @asteasolutions/zod-to-openapi.
+ *
+ * Usage:
+ *   const registry = new NativeOpenAPIRegistry();
+ *   registry.registerPath({ method: 'get', path: '/users', ... });
+ *   const doc = generator.generateDocument(registry.definitions, config);
+ */
+
+import type { z } from 'zod';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface RouteDefinition {
+  type: 'route';
+  route: {
+    method: string;
+    path: string;
+    summary?: string;
+    description?: string;
+    tags?: string[];
+    operationId?: string;
+    deprecated?: boolean;
+    request?: {
+      params?: z.ZodTypeAny;
+      query?: z.ZodTypeAny;
+      headers?: z.ZodTypeAny;
+      cookies?: z.ZodTypeAny;
+      body?: {
+        content: Record<string, { schema: z.ZodTypeAny }>;
+        required?: boolean;
+        description?: string;
+      };
+    };
+    responses: Record<
+      string,
+      {
+        description: string;
+        content?: Record<string, { schema: z.ZodTypeAny }>;
+        headers?: Record<string, { schema: z.ZodTypeAny }>;
+      }
+    >;
+    security?: Array<Record<string, string[]>>;
+  };
+}
+
+export interface SchemaDefinition {
+  type: 'schema';
+  schema: z.ZodTypeAny;
+  refId: string;
+}
+
+export interface ComponentDefinition {
+  type: 'component';
+  componentType: 'schemas' | 'responses' | 'parameters' | 'headers' | 'securitySchemes';
+  name: string;
+  component: unknown;
+}
+
+export interface WebhookDefinition {
+  type: 'webhook';
+  webhook: {
+    method: string;
+    path: string;
+    description?: string;
+    request?: RouteDefinition['route']['request'];
+    responses: RouteDefinition['route']['responses'];
+  };
+}
+
+export interface ParameterDefinition {
+  type: 'parameter';
+  refId: string;
+  schema: z.ZodTypeAny;
+}
+
+export type RegistryDefinition =
+  | RouteDefinition
+  | SchemaDefinition
+  | ComponentDefinition
+  | WebhookDefinition
+  | ParameterDefinition;
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+/**
+ * Collects OpenAPI definitions for document generation.
+ */
+export class NativeOpenAPIRegistry {
+  definitions: RegistryDefinition[] = [];
+
+  /**
+   * Register a route (path + method + request/response schemas).
+   */
+  registerPath(route: RouteDefinition['route']): void {
+    this.definitions.push({ type: 'route', route });
+  }
+
+  /**
+   * Register a reusable Zod schema as a named component.
+   */
+  register(refId: string, schema: z.ZodTypeAny): void {
+    this.definitions.push({ type: 'schema', schema, refId });
+  }
+
+  /**
+   * Register a component (schema, response, parameter, header, or security scheme).
+   */
+  registerComponent(
+    componentType: ComponentDefinition['componentType'],
+    name: string,
+    component: unknown,
+  ): void {
+    this.definitions.push({ type: 'component', componentType, name, component });
+  }
+
+  /**
+   * Register a webhook definition.
+   */
+  registerWebhook(webhook: WebhookDefinition['webhook']): void {
+    this.definitions.push({ type: 'webhook', webhook });
+  }
+
+  /**
+   * Register a parameter schema for reuse via $ref.
+   */
+  registerParameter(refId: string, schema: z.ZodTypeAny): void {
+    this.definitions.push({ type: 'parameter', refId, schema });
+  }
+}

--- a/packages/openapi/src/native/zod-extension.ts
+++ b/packages/openapi/src/native/zod-extension.ts
@@ -1,0 +1,104 @@
+/**
+ * Native Zod → OpenAPI Extension
+ *
+ * Adds `.openapi()` method to Zod schemas for attaching OpenAPI metadata
+ * (description, example, deprecated, etc.) without requiring
+ * @asteasolutions/zod-to-openapi.
+ *
+ * Usage:
+ *   extendZodWithOpenApi(z);
+ *   const schema = z.string().openapi({ description: 'User name', example: 'Alice' });
+ */
+
+import type { z as zod } from 'zod';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface OpenAPIMetadata {
+  /** OpenAPI description */
+  description?: string;
+  /** Example value */
+  example?: unknown;
+  /** Multiple examples */
+  examples?: unknown[];
+  /** Mark as deprecated */
+  deprecated?: boolean;
+  /** Reference ID for schema reuse ($ref) */
+  refId?: string;
+  /** OpenAPI format (e.g., 'email', 'uri', 'date-time') */
+  format?: string;
+  /** Default value */
+  default?: unknown;
+  /** Title for the schema */
+  title?: string;
+  /** OpenAPI parameter metadata */
+  param?: {
+    name?: string;
+    in?: 'query' | 'header' | 'path' | 'cookie';
+    required?: boolean;
+    description?: string;
+  };
+  /** Additional OpenAPI properties */
+  [key: string]: unknown;
+}
+
+// Symbol used to store metadata on Zod schema instances
+const OPENAPI_METADATA = Symbol.for('revealui:openapi-metadata');
+
+// =============================================================================
+// Metadata Storage
+// =============================================================================
+
+/**
+ * Get OpenAPI metadata from a Zod schema.
+ * Returns undefined if no metadata has been attached.
+ */
+export function getOpenApiMetadata(schema: zod.ZodTypeAny): OpenAPIMetadata | undefined {
+  return (schema as unknown as Record<symbol, unknown>)[OPENAPI_METADATA] as
+    | OpenAPIMetadata
+    | undefined;
+}
+
+/**
+ * Set OpenAPI metadata on a Zod schema.
+ */
+export function setOpenApiMetadata(schema: zod.ZodTypeAny, metadata: OpenAPIMetadata): void {
+  (schema as unknown as Record<symbol, unknown>)[OPENAPI_METADATA] = metadata;
+}
+
+// =============================================================================
+// Zod Extension
+// =============================================================================
+
+/**
+ * Extends Zod with `.openapi()` method for attaching OpenAPI metadata.
+ *
+ * Call once at application startup:
+ *   import { z } from 'zod';
+ *   import { extendZodWithOpenApi } from '@revealui/openapi/native';
+ *   extendZodWithOpenApi(z);
+ */
+export function extendZodWithOpenApi(zod: typeof import('zod').z): void {
+  if ('openapi' in zod.ZodType.prototype) {
+    return; // Already extended
+  }
+
+  // Add .openapi() method to all Zod types
+  zod.ZodType.prototype.openapi = function (metadata: OpenAPIMetadata) {
+    const clone = this.describe(metadata.description ?? '');
+    (clone as Record<symbol, unknown>)[OPENAPI_METADATA] = {
+      ...getOpenApiMetadata(this),
+      ...metadata,
+    };
+    return clone;
+  };
+}
+
+// Type augmentation for TypeScript
+declare module 'zod' {
+  interface ZodType {
+    openapi(metadata: OpenAPIMetadata): this;
+  }
+}

--- a/packages/openapi/src/native/zod-to-schema.ts
+++ b/packages/openapi/src/native/zod-to-schema.ts
@@ -1,0 +1,412 @@
+/**
+ * Native Zod → JSON Schema Converter
+ *
+ * Converts Zod schemas to JSON Schema (OpenAPI 3.0 compatible subset).
+ * Replaces the schema conversion logic from @asteasolutions/zod-to-openapi.
+ *
+ * Supports: string, number, integer, boolean, null, array, object, enum,
+ * union, literal, optional, nullable, default, describe, and common
+ * validation constraints (min, max, email, url, uuid, regex, etc.).
+ */
+
+import type { z } from 'zod';
+import { getOpenApiMetadata } from './zod-extension.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface JSONSchema {
+  type?: string | string[];
+  format?: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  const?: unknown;
+  items?: JSONSchema;
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  additionalProperties?: boolean | JSONSchema;
+  oneOf?: JSONSchema[];
+  anyOf?: JSONSchema[];
+  allOf?: JSONSchema[];
+  not?: JSONSchema;
+  $ref?: string;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  multipleOf?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  minProperties?: number;
+  maxProperties?: number;
+  nullable?: boolean;
+  deprecated?: boolean;
+  example?: unknown;
+  examples?: unknown[];
+  [key: string]: unknown;
+}
+
+interface ConversionContext {
+  /** Track schemas seen to prevent infinite recursion */
+  seen: WeakSet<object>;
+  /** Named schemas for $ref generation */
+  components: Map<string, JSONSchema>;
+}
+
+// =============================================================================
+// Converter
+// =============================================================================
+
+/**
+ * Convert a Zod schema to JSON Schema.
+ */
+export function zodToJsonSchema(schema: z.ZodTypeAny, ctx?: ConversionContext): JSONSchema {
+  const context = ctx ?? { seen: new WeakSet(), components: new Map() };
+
+  // Prevent infinite recursion on circular schemas
+  if (context.seen.has(schema)) {
+    return {};
+  }
+  context.seen.add(schema);
+
+  // Check for OpenAPI metadata (refId → $ref)
+  const metadata = getOpenApiMetadata(schema);
+  if (metadata?.refId && ctx) {
+    // Register as component and return $ref
+    const refSchema = convertType(schema, context);
+    context.components.set(metadata.refId, refSchema);
+    return { $ref: `#/components/schemas/${metadata.refId}` };
+  }
+
+  const result = convertType(schema, context);
+
+  // Apply OpenAPI metadata overrides
+  if (metadata) {
+    if (metadata.description) result.description = metadata.description;
+    if (metadata.example !== undefined) result.example = metadata.example;
+    if (metadata.format) result.format = metadata.format;
+    if (metadata.title) result.title = metadata.title;
+    if (metadata.deprecated) result.deprecated = metadata.deprecated;
+    if (metadata.default !== undefined) result.default = metadata.default;
+  }
+
+  // Apply Zod description
+  if (schema.description && !result.description) {
+    result.description = schema.description;
+  }
+
+  return result;
+}
+
+/**
+ * Zod v4 uses `schema._def.type` (e.g., 'string', 'number', 'object')
+ * and stores checks in `check._zod.def` with properties like
+ * `{ check: 'min_length', minimum: 3 }`.
+ */
+function convertType(schema: z.ZodTypeAny, ctx: ConversionContext): JSONSchema {
+  const def = schema._def as unknown as Record<string, unknown>;
+  const type = def.type as string;
+
+  switch (type) {
+    case 'string':
+      return convertString(def);
+    case 'number':
+      return convertNumber(def);
+    case 'boolean':
+      return { type: 'boolean' };
+    case 'null':
+      return { type: 'null' };
+    case 'undefined':
+    case 'void':
+    case 'any':
+    case 'unknown':
+      return {};
+    case 'never':
+      return { not: {} };
+    case 'literal':
+      return convertLiteral(def);
+    case 'enum':
+      return convertEnum(def);
+    case 'array':
+      return convertArray(def, ctx);
+    case 'object':
+      return convertObject(def, ctx);
+    case 'union':
+      return convertUnion(def, ctx);
+    case 'intersection':
+      return convertIntersection(def, ctx);
+    case 'tuple':
+      return convertTuple(def, ctx);
+    case 'record':
+      return convertRecord(def, ctx);
+    case 'optional':
+      return zodToJsonSchema(def.innerType as z.ZodTypeAny, ctx);
+    case 'nullable':
+      return convertNullable(def, ctx);
+    case 'default':
+      return convertDefault(def, ctx);
+    case 'pipe':
+      return zodToJsonSchema(def.in as z.ZodTypeAny, ctx);
+    case 'lazy':
+      return zodToJsonSchema((def.getter as () => z.ZodTypeAny)(), ctx);
+    case 'branded':
+      return zodToJsonSchema(def.type as z.ZodTypeAny, ctx);
+    case 'catch':
+      return zodToJsonSchema(def.innerType as z.ZodTypeAny, ctx);
+    case 'readonly':
+      return zodToJsonSchema(def.innerType as z.ZodTypeAny, ctx);
+    case 'date':
+      return { type: 'string', format: 'date-time' };
+    case 'bigint':
+      return { type: 'integer', format: 'int64' };
+    case 'symbol':
+      return { type: 'string' };
+    case 'nan':
+      return { type: 'number' };
+    default:
+      return {};
+  }
+}
+
+// =============================================================================
+// Type-specific converters
+// =============================================================================
+
+/** Extract Zod v4 check def: stored in `check._zod.def` */
+function getCheckDef(check: unknown): Record<string, unknown> {
+  const c = check as { _zod?: { def?: Record<string, unknown> } };
+  return c?._zod?.def ?? {};
+}
+
+function convertString(def: Record<string, unknown>): JSONSchema {
+  const result: JSONSchema = { type: 'string' };
+  const checks = (def.checks as unknown[]) ?? [];
+
+  for (const check of checks) {
+    const cd = getCheckDef(check);
+    switch (cd.check) {
+      case 'min_length':
+        result.minLength = cd.minimum as number;
+        break;
+      case 'max_length':
+        result.maxLength = cd.maximum as number;
+        break;
+      case 'length':
+        result.minLength = cd.length as number;
+        result.maxLength = cd.length as number;
+        break;
+      case 'string_format':
+        switch (cd.format) {
+          case 'email':
+            result.format = 'email';
+            break;
+          case 'url':
+          case 'uri':
+            result.format = 'uri';
+            break;
+          case 'uuid':
+            result.format = 'uuid';
+            break;
+          case 'cuid':
+            result.format = 'cuid';
+            break;
+          case 'datetime':
+            result.format = 'date-time';
+            break;
+          case 'date':
+            result.format = 'date';
+            break;
+          case 'time':
+            result.format = 'time';
+            break;
+          case 'ip':
+          case 'ipv4':
+            result.format = 'ipv4';
+            break;
+          case 'ipv6':
+            result.format = 'ipv6';
+            break;
+        }
+        break;
+      case 'pattern':
+        result.pattern = String(cd.pattern);
+        break;
+      case 'starts_with':
+        result.pattern = `^${escapeForPattern(String(cd.prefix))}`;
+        break;
+      case 'ends_with':
+        result.pattern = `${escapeForPattern(String(cd.suffix))}$`;
+        break;
+      case 'includes':
+        result.pattern = escapeForPattern(String(cd.includes));
+        break;
+    }
+  }
+
+  return result;
+}
+
+function convertNumber(def: Record<string, unknown>): JSONSchema {
+  const checks = (def.checks as unknown[]) ?? [];
+  let isInt = false;
+  const result: JSONSchema = { type: 'number' };
+
+  for (const check of checks) {
+    const cd = getCheckDef(check);
+    switch (cd.check) {
+      case 'greater_than':
+        if (cd.inclusive === false) {
+          result.exclusiveMinimum = cd.value as number;
+        } else {
+          result.minimum = cd.value as number;
+        }
+        break;
+      case 'less_than':
+        if (cd.inclusive === false) {
+          result.exclusiveMaximum = cd.value as number;
+        } else {
+          result.maximum = cd.value as number;
+        }
+        break;
+      case 'multiple_of':
+        result.multipleOf = cd.value as number;
+        break;
+      case 'number_format':
+        if (cd.format === 'safeint') isInt = true;
+        break;
+    }
+  }
+
+  if (isInt) result.type = 'integer';
+  return result;
+}
+
+function convertLiteral(def: Record<string, unknown>): JSONSchema {
+  // Zod v4 stores literal values in `def.values` as an array
+  const values = def.values as unknown[];
+  if (!values || values.length === 0) return {};
+  const value = values[0];
+  if (typeof value === 'string') return { type: 'string', const: value };
+  if (typeof value === 'number') return { type: 'number', const: value };
+  if (typeof value === 'boolean') return { type: 'boolean', const: value };
+  if (value === null) return { type: 'null' };
+  return { const: value };
+}
+
+function convertEnum(def: Record<string, unknown>): JSONSchema {
+  // Zod v4 stores enum entries as `{ a: 'a', b: 'b' }`
+  const entries = def.entries as Record<string, string>;
+  return { type: 'string', enum: Object.values(entries) };
+}
+
+function convertArray(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  // Zod v4 uses `def.element` for array item type
+  const result: JSONSchema = {
+    type: 'array',
+    items: zodToJsonSchema(def.element as z.ZodTypeAny, ctx),
+  };
+
+  // Check for min/max length in checks
+  const checks = (def.checks as unknown[]) ?? [];
+  for (const check of checks) {
+    const cd = getCheckDef(check);
+    if (cd.check === 'min_length') result.minItems = cd.minimum as number;
+    if (cd.check === 'max_length') result.maxItems = cd.maximum as number;
+  }
+
+  return result;
+}
+
+function convertObject(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  const shape = def.shape as Record<string, z.ZodTypeAny>;
+
+  const properties: Record<string, JSONSchema> = {};
+  const required: string[] = [];
+
+  for (const [key, value] of Object.entries(shape)) {
+    properties[key] = zodToJsonSchema(value, ctx);
+
+    if (!isOptional(value)) {
+      required.push(key);
+    }
+  }
+
+  const result: JSONSchema = { type: 'object', properties };
+  if (required.length > 0) result.required = required;
+
+  return result;
+}
+
+function convertUnion(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  const options = (def.options as z.ZodTypeAny[]) ?? [];
+  return {
+    oneOf: options.map((opt) => zodToJsonSchema(opt, ctx)),
+  };
+}
+
+function convertIntersection(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  return {
+    allOf: [
+      zodToJsonSchema(def.left as z.ZodTypeAny, ctx),
+      zodToJsonSchema(def.right as z.ZodTypeAny, ctx),
+    ],
+  };
+}
+
+function convertTuple(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  const items = (def.items as z.ZodTypeAny[]) ?? [];
+  return {
+    type: 'array',
+    items: { oneOf: items.map((item) => zodToJsonSchema(item, ctx)) },
+    minItems: items.length,
+    maxItems: items.length,
+  };
+}
+
+function convertRecord(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  return {
+    type: 'object',
+    additionalProperties: zodToJsonSchema(def.valueType as z.ZodTypeAny, ctx),
+  };
+}
+
+function convertNullable(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  const inner = zodToJsonSchema(def.innerType as z.ZodTypeAny, ctx);
+  return { ...inner, nullable: true };
+}
+
+function convertDefault(def: Record<string, unknown>, ctx: ConversionContext): JSONSchema {
+  const inner = zodToJsonSchema(def.innerType as z.ZodTypeAny, ctx);
+  const defaultValue =
+    typeof def.defaultValue === 'function'
+      ? (def.defaultValue as () => unknown)()
+      : def.defaultValue;
+  return { ...inner, default: defaultValue };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function isOptional(schema: z.ZodTypeAny): boolean {
+  const def = schema._def as unknown as Record<string, unknown>;
+  const type = def.type as string;
+  if (type === 'optional') return true;
+  if (type === 'default') return true;
+  if (type === 'nullable') {
+    return isOptional(def.innerType as z.ZodTypeAny);
+  }
+  return false;
+}
+
+// regex-ok: escaping user input for safe inclusion in a JSON Schema pattern
+function escapeForPattern(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
Phase A of replacing `@asteasolutions/zod-to-openapi` with a zero-dependency native implementation.

## Summary

- **Zod extension**: `.openapi()` method via Symbol storage (description, example, format, refId, deprecated, param metadata)
- **NativeOpenAPIRegistry**: Route/schema/component/webhook/parameter collection matching the external library's API
- **zodToJsonSchema**: Zod v4 → JSON Schema converter supporting 20+ type kinds plus validation constraints
- **47 tests** covering all converter paths, metadata integration, registry operations

## What's left (Phase B)

The document generator — takes registry definitions + config and produces a valid OpenAPI 3.0/3.1 document. Once that's done, the `@asteasolutions/zod-to-openapi` dependency can be removed.

## Test plan

- [x] 47 native tests pass
- [x] Existing 20 openapi-hono tests still pass
- [x] Biome lint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)