### PR TITLE
fix(admin): use runtime env vars in collection preview URLs

### DIFF
--- a/apps/admin/src/lib/collections/Prices/index.ts
+++ b/apps/admin/src/lib/collections/Prices/index.ts
@@ -38,9 +38,9 @@ const Prices: RevealCollectionConfig<Price> = {
     useAsTitle: 'title',
     defaultColumns: ['title', 'stripePriceID', '_status'],
     preview: (doc: Record<string, unknown>) => {
-      return `${import.meta.env.REVEALUI_PUBLIC_SERVER_URL}/api/preview?url=${encodeURIComponent(
-        `${import.meta.env.REVEALUI_PUBLIC_SERVER_URL}/prices/${doc.slug}`,
-      )}&secret=${import.meta.env.REVEALUI_DRAFT_SECRET}`;
+      // process.env (not import.meta.env) so the value is read at runtime, not inlined at build time
+      const serverUrl = process.env.REVEALUI_PUBLIC_SERVER_URL || 'http://localhost:4000';
+      return `${serverUrl}/next/preview?path=${encodeURIComponent(`/prices/${doc.slug}`)}`;
     },
   },
   hooks: {

--- a/apps/admin/src/lib/collections/Products/index.ts
+++ b/apps/admin/src/lib/collections/Products/index.ts
@@ -18,9 +18,9 @@ const Products: RevealCollectionConfig<Product> = {
     defaultColumns: ['title', 'stripeProductID', '_status'],
     preview: (doc: Record<string, unknown>) => {
       // Use the cookie-based JWT preview route — no secret in the URL
-      return `${import.meta.env.REVEALUI_PUBLIC_SERVER_URL}/next/preview?path=${encodeURIComponent(
-        `/products/${doc.slug}`,
-      )}`;
+      // process.env (not import.meta.env) so the value is read at runtime, not inlined at build time
+      const serverUrl = process.env.REVEALUI_PUBLIC_SERVER_URL || 'http://localhost:4000';
+      return `${serverUrl}/next/preview?path=${encodeURIComponent(`/products/${doc.slug}`)}`;
     },
   },
   hooks: {


### PR DESCRIPTION
## Summary

- Replace `import.meta.env.REVEALUI_PUBLIC_SERVER_URL` with `process.env.REVEALUI_PUBLIC_SERVER_URL` in Products and Prices collection preview callbacks
- `import.meta.env` gets inlined by Vite/Turbopack at **build time** — if the var isn't set during build, the preview URL is permanently baked in as `undefined`
- `process.env` is read at **runtime**, which is correct since preview callbacks execute in the admin UI, not during SSG
- Also fixes Prices preview to use cookie-based JWT route (matching Products) instead of leaking `REVEALUI_DRAFT_SECRET` in the URL

This closes the "admin build env timing" item that was blocking the A grade assessment.

## Test plan

- [x] `SKIP_ENV_VALIDATION=true pnpm --filter admin build` succeeds
- [x] Zero `import.meta.env.REVEALUI_PUBLIC_SERVER_URL` references in `.next/**/*.js` build output
- [x] Pre-push gate passes (all 10 quality checks green)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)