### PR TITLE
feat(harnesses): native terminal layer 1 — ClaudeCode PTY backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
       "@swc/core",
       "@tailwindcss/oxide",
       "esbuild",
+      "node-pty",
       "sharp",
       "unrs-resolver"
     ],

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -14,11 +14,12 @@
   "dependencies": {
     "@electric-sql/pglite": "^0.4.3",
     "@revealui/core": "workspace:*",
+    "node-pty": "^1.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
     "@revealui/dev": "workspace:*",
+    "@types/node": "^25.5.2",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.3"

--- a/packages/harnesses/src/server/rpc-server.ts
+++ b/packages/harnesses/src/server/rpc-server.ts
@@ -66,6 +66,8 @@ const ERR_INTERNAL = -32603;
  *   agent.stop                → { ok: true }
  *   agent.list                → AgentSessionInfo[]
  *   agent.remove              → { ok: true }
+ *   agent.input               → { ok: true }
+ *   agent.resize              → { ok: true }
  *   inference.ollama.status   → OllamaStatus
  *   inference.ollama.models   → OllamaModel[]
  *   inference.ollama.pull     → ModelPullResult
@@ -564,7 +566,17 @@ export class RpcServer {
         if (!(name && backend && model && prompt)) {
           return this.missingParam(id, 'name, backend, model, prompt');
         }
-        const sessionId = this.spawner.spawn(name, backend as 'Snap' | 'Ollama', model, prompt);
+        const sessionId = this.spawner.spawn(
+          name,
+          backend as 'Snap' | 'Ollama' | 'ClaudeCode',
+          model,
+          prompt,
+          {
+            cwd: p.cwd as string | undefined,
+            cols: p.cols as number | undefined,
+            rows: p.rows as number | undefined,
+          },
+        );
         return { jsonrpc: '2.0', id, result: { sessionId } };
       }
 
@@ -586,6 +598,25 @@ export class RpcServer {
         const sessionId = p.sessionId as string | undefined;
         if (!sessionId) return this.missingParam(id, 'sessionId');
         this.spawner.remove(sessionId);
+        return { jsonrpc: '2.0', id, result: { ok: true } };
+      }
+
+      case 'agent.input': {
+        if (!this.spawner) return this.noService(id, 'spawner');
+        const sessionId = p.sessionId as string | undefined;
+        const data = p.data as string | undefined;
+        if (!(sessionId && data !== undefined)) return this.missingParam(id, 'sessionId, data');
+        this.spawner.write(sessionId, data);
+        return { jsonrpc: '2.0', id, result: { ok: true } };
+      }
+
+      case 'agent.resize': {
+        if (!this.spawner) return this.noService(id, 'spawner');
+        const sessionId = p.sessionId as string | undefined;
+        const cols = p.cols as number | undefined;
+        const rows = p.rows as number | undefined;
+        if (!(sessionId && cols && rows)) return this.missingParam(id, 'sessionId, cols, rows');
+        this.spawner.resize(sessionId, cols, rows);
         return { jsonrpc: '2.0', id, result: { ok: true } };
       }
 

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events';
 
 // ── Types ───────────────────────────────────────────────────────────
 
-export type AgentBackend = 'Snap' | 'Ollama';
+export type AgentBackend = 'Snap' | 'Ollama' | 'ClaudeCode';
 
 export interface AgentSessionInfo {
   id: string;
@@ -14,17 +14,31 @@ export interface AgentSessionInfo {
   prompt: string;
   status: 'running' | 'stopped' | 'errored';
   pid: number | null;
+  /** Whether this session is a PTY (interactive terminal). */
+  isPty: boolean;
 }
 
 export interface AgentOutputEvent {
   sessionId: string;
-  stream: 'stdout' | 'stderr';
-  line: string;
+  stream: 'stdout' | 'stderr' | 'pty';
+  data: string;
 }
 
 export interface AgentExitEvent {
   sessionId: string;
   code: number | null;
+}
+
+/** node-pty IPty interface (dynamically imported to keep it optional). */
+interface IPty {
+  pid: number;
+  cols: number;
+  rows: number;
+  onData: (handler: (data: string) => void) => { dispose: () => void };
+  onExit: (handler: (e: { exitCode: number; signal?: number }) => void) => { dispose: () => void };
+  write: (data: string) => void;
+  resize: (cols: number, rows: number) => void;
+  kill: (signal?: string) => void;
 }
 
 // ── Configuration ───────────────────────────────────────────────────
@@ -48,7 +62,8 @@ interface AgentProcess {
   model: string;
   backend: AgentBackend;
   prompt: string;
-  child: ChildProcess;
+  child: ChildProcess | null;
+  pty: IPty | null;
   status: 'running' | 'stopped' | 'errored';
 }
 
@@ -69,12 +84,23 @@ export class SpawnerService extends EventEmitter {
   }
 
   /** Spawn a new agent process. Returns the session ID. */
-  spawn(name: string, backend: AgentBackend, model: string, prompt: string): string {
+  spawn(
+    name: string,
+    backend: AgentBackend,
+    model: string,
+    prompt: string,
+    options?: { cwd?: string; cols?: number; rows?: number },
+  ): string {
     if (this.sessions.size >= this.config.maxSessions) {
       throw new Error(`Max sessions (${this.config.maxSessions}) reached`);
     }
 
     const sessionId = randomUUID();
+
+    if (backend === 'ClaudeCode') {
+      return this.spawnPty(sessionId, name, model, prompt, options);
+    }
+
     let child: ChildProcess;
 
     switch (backend) {
@@ -108,26 +134,30 @@ export class SpawnerService extends EventEmitter {
       }
     }
 
-    const proc: AgentProcess = { name, model, backend, prompt, child, status: 'running' };
+    const proc: AgentProcess = {
+      name,
+      model,
+      backend,
+      prompt,
+      child,
+      pty: null,
+      status: 'running',
+    };
     this.sessions.set(sessionId, proc);
 
     // Stream stdout
     child.stdout?.on('data', (chunk: Buffer) => {
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.length > 0) {
-          this.emit('output', { sessionId, stream: 'stdout', line } satisfies AgentOutputEvent);
-        }
+      const data = chunk.toString();
+      if (data.length > 0) {
+        this.emit('output', { sessionId, stream: 'stdout', data } satisfies AgentOutputEvent);
       }
     });
 
     // Stream stderr
     child.stderr?.on('data', (chunk: Buffer) => {
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.length > 0) {
-          this.emit('output', { sessionId, stream: 'stderr', line } satisfies AgentOutputEvent);
-        }
+      const data = chunk.toString();
+      if (data.length > 0) {
+        this.emit('output', { sessionId, stream: 'stderr', data } satisfies AgentOutputEvent);
       }
     });
 
@@ -145,12 +175,97 @@ export class SpawnerService extends EventEmitter {
     return sessionId;
   }
 
+  /**
+   * Spawn a ClaudeCode process with PTY support (interactive terminal).
+   * Uses node-pty (dynamically imported) so the harness still works without it.
+   */
+  private spawnPty(
+    sessionId: string,
+    name: string,
+    model: string,
+    prompt: string,
+    options?: { cwd?: string; cols?: number; rows?: number },
+  ): string {
+    // node-pty is dynamically required — it's optional and native
+    let ptyModule: { spawn: (file: string, args: string[], opts: unknown) => IPty };
+    try {
+      // biome-ignore lint/style/noCommaOperator: dynamic require for optional native module
+      ptyModule = require('node-pty');
+    } catch {
+      throw new Error(
+        'node-pty is not installed. Run: pnpm add node-pty --filter @revealui/harnesses',
+      );
+    }
+
+    const cols = options?.cols ?? 120;
+    const rows = options?.rows ?? 30;
+    const cwd = options?.cwd ?? process.cwd();
+
+    const pty = ptyModule.spawn('claude', [], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd,
+      env: {
+        ...process.env,
+        CLAUDE_AGENT_ROLE: name,
+        TERM: 'xterm-256color',
+      },
+    });
+
+    const proc: AgentProcess = {
+      name,
+      model,
+      backend: 'ClaudeCode',
+      prompt,
+      child: null,
+      pty,
+      status: 'running',
+    };
+    this.sessions.set(sessionId, proc);
+
+    // Stream PTY output
+    pty.onData((data: string) => {
+      this.emit('output', { sessionId, stream: 'pty', data } satisfies AgentOutputEvent);
+    });
+
+    // Handle PTY exit
+    pty.onExit(({ exitCode }: { exitCode: number }) => {
+      proc.status = exitCode === 0 ? 'stopped' : 'errored';
+      this.emit('exit', { sessionId, code: exitCode } satisfies AgentExitEvent);
+    });
+
+    return sessionId;
+  }
+
+  /** Write input data to a session's PTY. Only works for PTY sessions. */
+  write(sessionId: string, data: string): void {
+    const proc = this.sessions.get(sessionId);
+    if (!proc) throw new Error(`No agent session: ${sessionId}`);
+    if (!proc.pty) throw new Error('Session is not a PTY — use ClaudeCode backend');
+    if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
+    proc.pty.write(data);
+  }
+
+  /** Resize a session's PTY terminal. Only works for PTY sessions. */
+  resize(sessionId: string, cols: number, rows: number): void {
+    const proc = this.sessions.get(sessionId);
+    if (!proc) throw new Error(`No agent session: ${sessionId}`);
+    if (!proc.pty) throw new Error('Session is not a PTY — use ClaudeCode backend');
+    if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
+    proc.pty.resize(cols, rows);
+  }
+
   /** Stop a running agent by killing its process. */
   stop(sessionId: string): void {
     const proc = this.sessions.get(sessionId);
     if (!proc) throw new Error(`No agent session: ${sessionId}`);
     if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
-    proc.child.kill('SIGTERM');
+    if (proc.pty) {
+      proc.pty.kill();
+    } else if (proc.child) {
+      proc.child.kill('SIGTERM');
+    }
     proc.status = 'stopped';
   }
 
@@ -165,7 +280,8 @@ export class SpawnerService extends EventEmitter {
         backend: proc.backend,
         prompt: proc.prompt,
         status: proc.status,
-        pid: proc.child.pid ?? null,
+        pid: proc.pty?.pid ?? proc.child?.pid ?? null,
+        isPty: proc.pty !== null,
       });
     }
     return result;
@@ -183,7 +299,11 @@ export class SpawnerService extends EventEmitter {
   stopAll(): void {
     for (const [, proc] of this.sessions) {
       if (proc.status === 'running') {
-        proc.child.kill('SIGTERM');
+        if (proc.pty) {
+          proc.pty.kill();
+        } else if (proc.child) {
+          proc.child.kill('SIGTERM');
+        }
         proc.status = 'stopped';
       }
     }

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -189,7 +189,6 @@ export class SpawnerService extends EventEmitter {
     // node-pty is dynamically required — it's optional and native
     let ptyModule: { spawn: (file: string, args: string[], opts: unknown) => IPty };
     try {
-      // biome-ignore lint/style/noCommaOperator: dynamic require for optional native module
       ptyModule = require('node-pty');
     } catch {
       throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,6 +1162,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -7830,6 +7833,9 @@ packages:
       sass:
         optional: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -7860,6 +7866,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -16419,6 +16428,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-addon-api@7.1.1: {}
+
   node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
@@ -16432,6 +16443,10 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
## Summary

- Extend SpawnerService with `ClaudeCode` backend that spawns Claude Code processes via `node-pty` (interactive PTY terminal, not pipe)
- Daemon assigns identity at spawn time via `CLAUDE_AGENT_ROLE` env var — replaces the 6-tier detection cascade for daemon-managed sessions
- New RPC methods: `agent.input` (write to PTY), `agent.resize` (resize terminal dimensions)
- PTY output emitted as `'pty'` stream events (raw terminal data for xterm.js rendering)
- `node-pty` dynamically imported — harness still works without it for non-PTY backends (Snap, Ollama)
- Added `node-pty` to `onlyBuiltDependencies` in root package.json

This is Layer 1 of the Native Terminal architecture (design doc: `docs/NATIVE_TERMINAL.md`). Next layers: Studio terminal panes (xterm.js), WebSocket bridge, SSH terminal proxy.

## Test plan

- [x] 252/252 harness tests pass
- [x] Typecheck clean
- [x] Pre-push gate passes (all 10 quality checks green)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)