### PR TITLE
feat(studio): native terminal layer 2 — agent terminal pane

### DIFF
--- a/apps/studio/src-tauri/src/commands/spawner.rs
+++ b/apps/studio/src-tauri/src/commands/spawner.rs
@@ -44,3 +44,31 @@ pub fn agent_remove(
     crate::spawner::remove(&session_id, state.sessions.clone())
         .map_err(|e| StudioError::Process(e))
 }
+
+/// Write input data to a daemon PTY session (agent.input RPC).
+#[tauri::command]
+pub async fn agent_input(session_id: String, data: String) -> Result<(), StudioError> {
+    crate::harness::rpc_call(
+        "agent.input",
+        serde_json::json!({ "sessionId": session_id, "data": data }),
+    )
+    .await
+    .map_err(|e| StudioError::Other(e))?;
+    Ok(())
+}
+
+/// Resize a daemon PTY session's terminal (agent.resize RPC).
+#[tauri::command]
+pub async fn agent_resize(
+    session_id: String,
+    cols: u32,
+    rows: u32,
+) -> Result<(), StudioError> {
+    crate::harness::rpc_call(
+        "agent.resize",
+        serde_json::json!({ "sessionId": session_id, "cols": cols, "rows": rows }),
+    )
+    .await
+    .map_err(|e| StudioError::Other(e))?;
+    Ok(())
+}

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -144,6 +144,8 @@ pub fn run() {
             spawner_cmds::agent_stop,
             spawner_cmds::agent_list,
             spawner_cmds::agent_remove,
+            spawner_cmds::agent_input,
+            spawner_cmds::agent_resize,
             inference_cmds::inference_ollama_status,
             inference_cmds::inference_ollama_models,
             inference_cmds::inference_ollama_pull,

--- a/apps/studio/src/components/agent/AgentTerminalPane.tsx
+++ b/apps/studio/src/components/agent/AgentTerminalPane.tsx
@@ -1,0 +1,219 @@
+/**
+ * AgentTerminalPane — embedded terminal for daemon-managed Claude Code sessions.
+ *
+ * Left sidebar: list of active PTY sessions + "New Agent" button.
+ * Main area: xterm.js terminal connected to the selected session via
+ * agent.input (keystrokes) and agent:output (PTY data) events.
+ */
+
+import type { Terminal } from '@xterm/xterm';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { agentInput, agentList, agentResize, agentSpawn, agentStop } from '../../lib/invoke';
+import type { AgentSessionInfo } from '../../types';
+import Button from '../ui/Button';
+import StatusDot from '../ui/StatusDot';
+import TerminalView from '../terminal/TerminalView';
+
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+export default function AgentTerminalPane() {
+  const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
+  const [activeSession, setActiveSession] = useState<string | null>(null);
+  const [spawning, setSpawning] = useState(false);
+  const terminalRef = useRef<Terminal | null>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
+
+  // Poll sessions
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const list = await agentList();
+        if (!cancelled) setSessions(list);
+      } catch {
+        // daemon unreachable
+      }
+    }
+
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  // Subscribe to PTY output events for the active session
+  useEffect(() => {
+    if (!activeSession) return;
+
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+
+    // Clear terminal when switching sessions
+    terminal.clear();
+    terminal.writeln(`\x1b[1;33mAttached to ${activeSession}\x1b[0m`);
+    terminal.writeln('');
+
+    // Listen for output events from Tauri
+    if (isTauri()) {
+      let cleanup: (() => void) | null = null;
+      import('@tauri-apps/api/event').then(({ listen }) => {
+        listen<{ sessionId: string; stream: string; data: string }>('agent:output', (event) => {
+          if (event.payload.sessionId === activeSession) {
+            terminalRef.current?.write(event.payload.data);
+          }
+        }).then((unlisten) => {
+          cleanup = unlisten;
+          unlistenRef.current = unlisten;
+        });
+      });
+
+      return () => {
+        cleanup?.();
+        unlistenRef.current = null;
+      };
+    }
+
+    // Browser fallback: no streaming, just show status
+    terminal.writeln('\x1b[90m(Browser mode — PTY streaming requires Tauri desktop)\x1b[0m');
+    return undefined;
+  }, [activeSession]);
+
+  const handleData = useCallback(
+    (data: string) => {
+      if (activeSession) {
+        agentInput(activeSession, data).catch(() => {
+          // session may have ended
+        });
+      }
+    },
+    [activeSession],
+  );
+
+  const handleResize = useCallback(
+    (cols: number, rows: number) => {
+      if (activeSession) {
+        agentResize(activeSession, cols, rows).catch(() => {
+          // session may have ended
+        });
+      }
+    },
+    [activeSession],
+  );
+
+  async function spawnAgent() {
+    setSpawning(true);
+    try {
+      const cols = terminalRef.current?.cols ?? 120;
+      const rows = terminalRef.current?.rows ?? 30;
+      const sessionId = await agentSpawn(
+        `agent-${Date.now().toString(36)}`,
+        'ClaudeCode',
+        'claude-opus-4-6',
+        '',
+        { cols, rows },
+      );
+      setActiveSession(sessionId);
+      // Refresh session list
+      const list = await agentList();
+      setSessions(list);
+    } catch (err) {
+      terminalRef.current?.writeln(
+        `\x1b[31mFailed to spawn: ${err instanceof Error ? err.message : String(err)}\x1b[0m`,
+      );
+    } finally {
+      setSpawning(false);
+    }
+  }
+
+  async function stopSession(sessionId: string) {
+    try {
+      await agentStop(sessionId);
+      if (activeSession === sessionId) setActiveSession(null);
+      const list = await agentList();
+      setSessions(list);
+    } catch {
+      // already stopped
+    }
+  }
+
+  const ptyCount = sessions.filter((s) => s.isPty && s.status === 'running').length;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden md:flex-row">
+      {/* Sidebar — session list */}
+      <div className="flex w-full flex-col border-b border-neutral-800 md:w-56 md:border-r md:border-b-0">
+        <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
+          <span className="text-sm font-medium text-neutral-300">
+            Agents {ptyCount > 0 && `(${ptyCount})`}
+          </span>
+          <Button size="sm" onClick={spawnAgent} disabled={spawning}>
+            {spawning ? '...' : '+ New'}
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {sessions.length === 0 && (
+            <p className="px-3 py-4 text-xs text-neutral-500">
+              No agent sessions. Click "+ New" to spawn a Claude Code agent.
+            </p>
+          )}
+          {sessions.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setActiveSession(s.id)}
+              className={`flex w-full items-center gap-2 border-b border-neutral-800/50 px-3 py-2 text-left text-sm transition-colors hover:bg-neutral-800/50 ${
+                activeSession === s.id ? 'bg-neutral-800' : ''
+              }`}
+            >
+              <StatusDot
+                status={s.status === 'running' ? 'ok' : s.status === 'errored' ? 'error' : 'off'}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-neutral-200">{s.name}</div>
+                <div className="truncate text-xs text-neutral-500">
+                  {s.backend} · {s.status}
+                  {s.isPty && ' · PTY'}
+                </div>
+              </div>
+              {s.status === 'running' && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    stopSession(s.id);
+                  }}
+                  className="rounded px-1 text-xs text-neutral-500 hover:bg-red-900/30 hover:text-red-400"
+                  title="Stop"
+                >
+                  ■
+                </button>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Main area — terminal */}
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {activeSession ? (
+          <TerminalView onData={handleData} onResize={handleResize} terminalRef={terminalRef} />
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-neutral-500">
+            <div className="text-center">
+              <p className="text-lg">No session selected</p>
+              <p className="mt-1 text-sm">
+                Select a session from the sidebar or spawn a new agent.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/components/agent/AgentTerminalPane.tsx
+++ b/apps/studio/src/components/agent/AgentTerminalPane.tsx
@@ -10,9 +10,9 @@ import type { Terminal } from '@xterm/xterm';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { agentInput, agentList, agentResize, agentSpawn, agentStop } from '../../lib/invoke';
 import type { AgentSessionInfo } from '../../types';
+import TerminalView from '../terminal/TerminalView';
 import Button from '../ui/Button';
 import StatusDot from '../ui/StatusDot';
-import TerminalView from '../terminal/TerminalView';
 
 function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -180,6 +180,8 @@ const MOCK_DATA: Record<string, unknown> = {
   agent_stop: undefined,
   agent_list: [] satisfies AgentSessionInfo[],
   agent_remove: undefined,
+  agent_input: undefined,
+  agent_resize: undefined,
   inference_ollama_status: {
     installed: false,
     running: false,
@@ -346,6 +348,8 @@ const HARNESS_RPC_MAP: Record<string, string> = {
   agent_stop: 'agent.stop',
   agent_list: 'agent.list',
   agent_remove: 'agent.remove',
+  agent_input: 'agent.input',
+  agent_resize: 'agent.resize',
   // Inference engine management
   inference_ollama_status: 'inference.ollama.status',
   inference_ollama_models: 'inference.ollama.models',
@@ -708,8 +712,17 @@ export function agentSpawn(
   backend: AgentBackend,
   model: string,
   prompt: string,
+  options?: { cwd?: string; cols?: number; rows?: number },
 ): Promise<string> {
-  return invoke<string>('agent_spawn', { name, backend, model, prompt });
+  return invoke<string>('agent_spawn', {
+    name,
+    backend,
+    model,
+    prompt,
+    cwd: options?.cwd ?? null,
+    cols: options?.cols ?? null,
+    rows: options?.rows ?? null,
+  });
 }
 
 export function agentStop(sessionId: string): Promise<void> {
@@ -722,6 +735,14 @@ export function agentList(): Promise<AgentSessionInfo[]> {
 
 export function agentRemove(sessionId: string): Promise<void> {
   return invoke<void>('agent_remove', { sessionId });
+}
+
+export function agentInput(sessionId: string, data: string): Promise<void> {
+  return invoke<void>('agent_input', { sessionId, data });
+}
+
+export function agentResize(sessionId: string, cols: number, rows: number): Promise<void> {
+  return invoke<void>('agent_resize', { sessionId, cols, rows });
 }
 
 // ── Local Inference ─────────────────────────────────────────────────────────

--- a/apps/studio/src/types.ts
+++ b/apps/studio/src/types.ts
@@ -87,7 +87,7 @@ export interface AgentSession {
 // ── Agent Spawner ──────────────────────────────────────────────────────────
 
 /** Inference backend for spawned agents */
-export type AgentBackend = 'Snap' | 'Ollama';
+export type AgentBackend = 'Snap' | 'Ollama' | 'ClaudeCode';
 
 /** Snapshot of a spawned agent session */
 export interface AgentSessionInfo {
@@ -98,12 +98,14 @@ export interface AgentSessionInfo {
   prompt: string;
   status: 'running' | 'stopped' | 'errored';
   pid: number | null;
+  /** Whether this session is a PTY (interactive terminal). */
+  isPty: boolean;
 }
 
 /** Streamed output from an agent process */
 export interface AgentOutputEvent {
   session_id: string;
-  stream: 'stdout' | 'stderr';
+  stream: 'stdout' | 'stderr' | 'pty';
   line: string;
 }
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
       "@swc/core",
       "@tailwindcss/oxide",
       "esbuild",
+      "node-pty",
       "sharp",
       "unrs-resolver"
     ],

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -14,11 +14,12 @@
   "dependencies": {
     "@electric-sql/pglite": "^0.4.3",
     "@revealui/core": "workspace:*",
+    "node-pty": "^1.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
     "@revealui/dev": "workspace:*",
+    "@types/node": "^25.5.2",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.3"

--- a/packages/harnesses/src/server/rpc-server.ts
+++ b/packages/harnesses/src/server/rpc-server.ts
@@ -66,6 +66,8 @@ const ERR_INTERNAL = -32603;
  *   agent.stop                → { ok: true }
  *   agent.list                → AgentSessionInfo[]
  *   agent.remove              → { ok: true }
+ *   agent.input               → { ok: true }
+ *   agent.resize              → { ok: true }
  *   inference.ollama.status   → OllamaStatus
  *   inference.ollama.models   → OllamaModel[]
  *   inference.ollama.pull     → ModelPullResult
@@ -564,7 +566,17 @@ export class RpcServer {
         if (!(name && backend && model && prompt)) {
           return this.missingParam(id, 'name, backend, model, prompt');
         }
-        const sessionId = this.spawner.spawn(name, backend as 'Snap' | 'Ollama', model, prompt);
+        const sessionId = this.spawner.spawn(
+          name,
+          backend as 'Snap' | 'Ollama' | 'ClaudeCode',
+          model,
+          prompt,
+          {
+            cwd: p.cwd as string | undefined,
+            cols: p.cols as number | undefined,
+            rows: p.rows as number | undefined,
+          },
+        );
         return { jsonrpc: '2.0', id, result: { sessionId } };
       }
 
@@ -586,6 +598,25 @@ export class RpcServer {
         const sessionId = p.sessionId as string | undefined;
         if (!sessionId) return this.missingParam(id, 'sessionId');
         this.spawner.remove(sessionId);
+        return { jsonrpc: '2.0', id, result: { ok: true } };
+      }
+
+      case 'agent.input': {
+        if (!this.spawner) return this.noService(id, 'spawner');
+        const sessionId = p.sessionId as string | undefined;
+        const data = p.data as string | undefined;
+        if (!(sessionId && data !== undefined)) return this.missingParam(id, 'sessionId, data');
+        this.spawner.write(sessionId, data);
+        return { jsonrpc: '2.0', id, result: { ok: true } };
+      }
+
+      case 'agent.resize': {
+        if (!this.spawner) return this.noService(id, 'spawner');
+        const sessionId = p.sessionId as string | undefined;
+        const cols = p.cols as number | undefined;
+        const rows = p.rows as number | undefined;
+        if (!(sessionId && cols && rows)) return this.missingParam(id, 'sessionId, cols, rows');
+        this.spawner.resize(sessionId, cols, rows);
         return { jsonrpc: '2.0', id, result: { ok: true } };
       }
 

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events';
 
 // ── Types ───────────────────────────────────────────────────────────
 
-export type AgentBackend = 'Snap' | 'Ollama';
+export type AgentBackend = 'Snap' | 'Ollama' | 'ClaudeCode';
 
 export interface AgentSessionInfo {
   id: string;
@@ -14,17 +14,31 @@ export interface AgentSessionInfo {
   prompt: string;
   status: 'running' | 'stopped' | 'errored';
   pid: number | null;
+  /** Whether this session is a PTY (interactive terminal). */
+  isPty: boolean;
 }
 
 export interface AgentOutputEvent {
   sessionId: string;
-  stream: 'stdout' | 'stderr';
-  line: string;
+  stream: 'stdout' | 'stderr' | 'pty';
+  data: string;
 }
 
 export interface AgentExitEvent {
   sessionId: string;
   code: number | null;
+}
+
+/** node-pty IPty interface (dynamically imported to keep it optional). */
+interface IPty {
+  pid: number;
+  cols: number;
+  rows: number;
+  onData: (handler: (data: string) => void) => { dispose: () => void };
+  onExit: (handler: (e: { exitCode: number; signal?: number }) => void) => { dispose: () => void };
+  write: (data: string) => void;
+  resize: (cols: number, rows: number) => void;
+  kill: (signal?: string) => void;
 }
 
 // ── Configuration ───────────────────────────────────────────────────
@@ -48,7 +62,8 @@ interface AgentProcess {
   model: string;
   backend: AgentBackend;
   prompt: string;
-  child: ChildProcess;
+  child: ChildProcess | null;
+  pty: IPty | null;
   status: 'running' | 'stopped' | 'errored';
 }
 
@@ -69,12 +84,23 @@ export class SpawnerService extends EventEmitter {
   }
 
   /** Spawn a new agent process. Returns the session ID. */
-  spawn(name: string, backend: AgentBackend, model: string, prompt: string): string {
+  spawn(
+    name: string,
+    backend: AgentBackend,
+    model: string,
+    prompt: string,
+    options?: { cwd?: string; cols?: number; rows?: number },
+  ): string {
     if (this.sessions.size >= this.config.maxSessions) {
       throw new Error(`Max sessions (${this.config.maxSessions}) reached`);
     }
 
     const sessionId = randomUUID();
+
+    if (backend === 'ClaudeCode') {
+      return this.spawnPty(sessionId, name, model, prompt, options);
+    }
+
     let child: ChildProcess;
 
     switch (backend) {
@@ -108,26 +134,30 @@ export class SpawnerService extends EventEmitter {
       }
     }
 
-    const proc: AgentProcess = { name, model, backend, prompt, child, status: 'running' };
+    const proc: AgentProcess = {
+      name,
+      model,
+      backend,
+      prompt,
+      child,
+      pty: null,
+      status: 'running',
+    };
     this.sessions.set(sessionId, proc);
 
     // Stream stdout
     child.stdout?.on('data', (chunk: Buffer) => {
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.length > 0) {
-          this.emit('output', { sessionId, stream: 'stdout', line } satisfies AgentOutputEvent);
-        }
+      const data = chunk.toString();
+      if (data.length > 0) {
+        this.emit('output', { sessionId, stream: 'stdout', data } satisfies AgentOutputEvent);
       }
     });
 
     // Stream stderr
     child.stderr?.on('data', (chunk: Buffer) => {
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.length > 0) {
-          this.emit('output', { sessionId, stream: 'stderr', line } satisfies AgentOutputEvent);
-        }
+      const data = chunk.toString();
+      if (data.length > 0) {
+        this.emit('output', { sessionId, stream: 'stderr', data } satisfies AgentOutputEvent);
       }
     });
 
@@ -145,12 +175,97 @@ export class SpawnerService extends EventEmitter {
     return sessionId;
   }
 
+  /**
+   * Spawn a ClaudeCode process with PTY support (interactive terminal).
+   * Uses node-pty (dynamically imported) so the harness still works without it.
+   */
+  private spawnPty(
+    sessionId: string,
+    name: string,
+    model: string,
+    prompt: string,
+    options?: { cwd?: string; cols?: number; rows?: number },
+  ): string {
+    // node-pty is dynamically required — it's optional and native
+    let ptyModule: { spawn: (file: string, args: string[], opts: unknown) => IPty };
+    try {
+      // biome-ignore lint/style/noCommaOperator: dynamic require for optional native module
+      ptyModule = require('node-pty');
+    } catch {
+      throw new Error(
+        'node-pty is not installed. Run: pnpm add node-pty --filter @revealui/harnesses',
+      );
+    }
+
+    const cols = options?.cols ?? 120;
+    const rows = options?.rows ?? 30;
+    const cwd = options?.cwd ?? process.cwd();
+
+    const pty = ptyModule.spawn('claude', [], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd,
+      env: {
+        ...process.env,
+        CLAUDE_AGENT_ROLE: name,
+        TERM: 'xterm-256color',
+      },
+    });
+
+    const proc: AgentProcess = {
+      name,
+      model,
+      backend: 'ClaudeCode',
+      prompt,
+      child: null,
+      pty,
+      status: 'running',
+    };
+    this.sessions.set(sessionId, proc);
+
+    // Stream PTY output
+    pty.onData((data: string) => {
+      this.emit('output', { sessionId, stream: 'pty', data } satisfies AgentOutputEvent);
+    });
+
+    // Handle PTY exit
+    pty.onExit(({ exitCode }: { exitCode: number }) => {
+      proc.status = exitCode === 0 ? 'stopped' : 'errored';
+      this.emit('exit', { sessionId, code: exitCode } satisfies AgentExitEvent);
+    });
+
+    return sessionId;
+  }
+
+  /** Write input data to a session's PTY. Only works for PTY sessions. */
+  write(sessionId: string, data: string): void {
+    const proc = this.sessions.get(sessionId);
+    if (!proc) throw new Error(`No agent session: ${sessionId}`);
+    if (!proc.pty) throw new Error('Session is not a PTY — use ClaudeCode backend');
+    if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
+    proc.pty.write(data);
+  }
+
+  /** Resize a session's PTY terminal. Only works for PTY sessions. */
+  resize(sessionId: string, cols: number, rows: number): void {
+    const proc = this.sessions.get(sessionId);
+    if (!proc) throw new Error(`No agent session: ${sessionId}`);
+    if (!proc.pty) throw new Error('Session is not a PTY — use ClaudeCode backend');
+    if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
+    proc.pty.resize(cols, rows);
+  }
+
   /** Stop a running agent by killing its process. */
   stop(sessionId: string): void {
     const proc = this.sessions.get(sessionId);
     if (!proc) throw new Error(`No agent session: ${sessionId}`);
     if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
-    proc.child.kill('SIGTERM');
+    if (proc.pty) {
+      proc.pty.kill();
+    } else if (proc.child) {
+      proc.child.kill('SIGTERM');
+    }
     proc.status = 'stopped';
   }
 
@@ -165,7 +280,8 @@ export class SpawnerService extends EventEmitter {
         backend: proc.backend,
         prompt: proc.prompt,
         status: proc.status,
-        pid: proc.child.pid ?? null,
+        pid: proc.pty?.pid ?? proc.child?.pid ?? null,
+        isPty: proc.pty !== null,
       });
     }
     return result;
@@ -183,7 +299,11 @@ export class SpawnerService extends EventEmitter {
   stopAll(): void {
     for (const [, proc] of this.sessions) {
       if (proc.status === 'running') {
-        proc.child.kill('SIGTERM');
+        if (proc.pty) {
+          proc.pty.kill();
+        } else if (proc.child) {
+          proc.child.kill('SIGTERM');
+        }
         proc.status = 'stopped';
       }
     }

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -189,7 +189,6 @@ export class SpawnerService extends EventEmitter {
     // node-pty is dynamically required — it's optional and native
     let ptyModule: { spawn: (file: string, args: string[], opts: unknown) => IPty };
     try {
-      // biome-ignore lint/style/noCommaOperator: dynamic require for optional native module
       ptyModule = require('node-pty');
     } catch {
       throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,6 +1162,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -7830,6 +7833,9 @@ packages:
       sass:
         optional: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -7860,6 +7866,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -16419,6 +16428,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-addon-api@7.1.1: {}
+
   node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
@@ -16432,6 +16443,10 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.37: {}
 


### PR DESCRIPTION
## Summary

- New `AgentTerminalPane` component: left sidebar with session list + "New Agent" spawn button, main area with xterm.js terminal connected to daemon PTY sessions
- Reuses existing `TerminalView` component (same theme, font, fit behavior)
- `agentInput` / `agentResize` invoke wrappers with RPC map entries for browser-mode daemon access
- Tauri commands: `agent_input` (delegates to daemon `agent.input` RPC), `agent_resize` (delegates to daemon `agent.resize` RPC)
- Updated `AgentSessionInfo` type: added `isPty` field, `ClaudeCode` backend variant, `'pty'` stream type
- Listens for `agent:output` Tauri events to stream PTY data to xterm.js

This is Layer 2 of the Native Terminal architecture. Requires Layer 1 (PR #254) for daemon-side PTY support.

## Test plan

- [x] Studio typecheck clean (`pnpm --filter studio typecheck`)
- [x] Harnesses typecheck clean
- [x] Pre-push gate passes (all 10 quality checks green)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)