### PR TITLE
fix(docker): remove stale patches dir reference

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -14,7 +14,6 @@ WORKDIR /app
 FROM base AS deps
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY patches ./patches
 COPY packages/auth/package.json          ./packages/auth/
 COPY packages/cli/package.json           ./packages/cli/
 COPY packages/config/package.json        ./packages/config/

--- a/apps/api/Dockerfile.forge
+++ b/apps/api/Dockerfile.forge
@@ -12,7 +12,6 @@ WORKDIR /app
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY patches ./patches
 COPY packages/auth/package.json       ./packages/auth/
 COPY packages/config/package.json     ./packages/config/
 COPY packages/contracts/package.json  ./packages/contracts/


### PR DESCRIPTION
## Summary

- Remove `COPY patches ./patches` from both `Dockerfile.forge` files (admin + api)
- `patchedDependencies` is empty in package.json and no `patches/` directory exists
- This was causing the Docker build workflow to fail

## Test plan

- [x] Pre-push gate passes
- [ ] CI passes
- [ ] Docker workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)