### PR TITLE
fix(docker): add missing workspace deps and turbo build ordering

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -14,6 +14,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY .npmrc* ./
 
 # Copy all workspace package.json files for dependency resolution
+COPY packages/ai/package.json ./packages/ai/
 COPY packages/auth/package.json ./packages/auth/
 COPY packages/cache/package.json ./packages/cache/
 COPY packages/config/package.json ./packages/config/
@@ -21,9 +22,12 @@ COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/core/package.json ./packages/core/
 COPY packages/db/package.json ./packages/db/
 COPY packages/dev/package.json ./packages/dev/
+COPY packages/paywall/package.json ./packages/paywall/
 COPY packages/presentation/package.json ./packages/presentation/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json ./packages/security/
+COPY packages/services/package.json ./packages/services/
+COPY packages/setup/package.json ./packages/setup/
 COPY packages/sync/package.json ./packages/sync/
 COPY packages/utils/package.json ./packages/utils/
 COPY apps/admin/package.json ./apps/admin/
@@ -49,7 +53,7 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter admin run build
+RUN pnpm turbo run build --filter=admin...
 
 # Runner stage
 FROM base AS runner

--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -14,7 +14,9 @@ WORKDIR /app
 FROM base AS deps
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY packages/ai/package.json            ./packages/ai/
 COPY packages/auth/package.json          ./packages/auth/
+COPY packages/cache/package.json         ./packages/cache/
 COPY packages/cli/package.json           ./packages/cli/
 COPY packages/config/package.json        ./packages/config/
 COPY packages/contracts/package.json     ./packages/contracts/
@@ -22,13 +24,17 @@ COPY packages/core/package.json          ./packages/core/
 COPY packages/create-revealui/package.json ./packages/create-revealui/
 COPY packages/db/package.json            ./packages/db/
 COPY packages/dev/package.json           ./packages/dev/
+COPY packages/paywall/package.json       ./packages/paywall/
 COPY packages/presentation/package.json  ./packages/presentation/
+COPY packages/resilience/package.json    ./packages/resilience/
 COPY packages/router/package.json        ./packages/router/
+COPY packages/security/package.json      ./packages/security/
+COPY packages/services/package.json      ./packages/services/
 COPY packages/setup/package.json         ./packages/setup/
 COPY packages/sync/package.json          ./packages/sync/
 COPY packages/test/package.json          ./packages/test/
 COPY packages/utils/package.json         ./packages/utils/
-COPY apps/admin/package.json               ./apps/admin/
+COPY apps/admin/package.json             ./apps/admin/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile --filter admin...
@@ -48,7 +54,7 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter admin run build
+RUN pnpm turbo run build --filter=admin...
 
 # ---------------------------------------------------------------------------
 # Runtime stage — minimal image, production only

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,15 +14,18 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY .npmrc* ./
 
 # Copy workspace package.json files needed by api
+COPY packages/ai/package.json ./packages/ai/
 COPY packages/auth/package.json ./packages/auth/
 COPY packages/cache/package.json ./packages/cache/
 COPY packages/config/package.json ./packages/config/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/core/package.json ./packages/core/
 COPY packages/db/package.json ./packages/db/
+COPY packages/dev/package.json ./packages/dev/
 COPY packages/openapi/package.json ./packages/openapi/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json ./packages/security/
+COPY packages/services/package.json ./packages/services/
 COPY packages/utils/package.json ./packages/utils/
 COPY apps/api/package.json ./apps/api/
 
@@ -46,7 +49,7 @@ COPY apps/api ./apps/api
 ENV NODE_ENV=production
 ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter api run build
+RUN pnpm turbo run build --filter=api...
 
 # Create a self-contained deploy directory with only production deps
 # pnpm deploy resolves hoisted packages into a flat node_modules

--- a/apps/api/Dockerfile.forge
+++ b/apps/api/Dockerfile.forge
@@ -12,11 +12,19 @@ WORKDIR /app
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY packages/ai/package.json         ./packages/ai/
 COPY packages/auth/package.json       ./packages/auth/
+COPY packages/cache/package.json      ./packages/cache/
 COPY packages/config/package.json     ./packages/config/
 COPY packages/contracts/package.json  ./packages/contracts/
 COPY packages/core/package.json       ./packages/core/
 COPY packages/db/package.json         ./packages/db/
+COPY packages/dev/package.json        ./packages/dev/
+COPY packages/openapi/package.json    ./packages/openapi/
+COPY packages/resilience/package.json ./packages/resilience/
+COPY packages/security/package.json   ./packages/security/
+COPY packages/services/package.json   ./packages/services/
+COPY packages/utils/package.json      ./packages/utils/
 COPY apps/api/package.json            ./apps/api/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
@@ -28,8 +36,9 @@ COPY packages ./packages
 COPY apps/api  ./apps/api
 
 ENV NODE_ENV=production
+ENV SKIP_ENV_VALIDATION=true
 
-RUN pnpm --filter api run build
+RUN pnpm turbo run build --filter=api...
 
 # ---------------------------------------------------------------------------
 # Runtime stage — minimal image, production only


### PR DESCRIPTION
## Summary

- Add all missing transitive workspace `package.json` COPYs to all four Dockerfiles (API + Admin, regular + Forge) so `pnpm install --filter <app>...` can resolve the full workspace graph
- Add `SKIP_ENV_VALIDATION=true` to API Dockerfile.forge (was missing, causing config validation failure at import time)
- Replace `pnpm --filter <app> run build` with `pnpm turbo run build --filter=<app>...` to build workspace dependencies in correct topological order via turbo's `^build` pipeline

Fixes the `Build & Push Forge Docker Images` workflow failure where the API build errored with 220 unresolved workspace imports (`@revealui/openapi`, `@revealui/core`, `@revealui/db`, etc.) because their `dist/` directories didn't exist.

## Test plan

- [ ] Re-run `Build & Push Forge Docker Images` workflow after merge
- [ ] Verify API image builds successfully (no unresolved workspace imports)
- [ ] Verify Admin image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)