### PR TITLE
feat: charge-readiness Phase A — pagination, Sentry, sidebar nav

### DIFF
--- a/apps/admin/src/app/(backend)/admin/layout.tsx
+++ b/apps/admin/src/app/(backend)/admin/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import {
   Sidebar,
   SidebarBody,
@@ -9,10 +8,11 @@ import {
   SidebarHeading,
   SidebarItem,
   SidebarLabel,
+  SidebarLayout,
   SidebarSection,
   SidebarSpacer,
 } from '@revealui/presentation/client';
-import { SidebarLayout } from '@revealui/presentation/client';
+import { usePathname } from 'next/navigation';
 
 interface NavItem {
   href: string;

--- a/apps/admin/src/app/(backend)/admin/layout.tsx
+++ b/apps/admin/src/app/(backend)/admin/layout.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import {
+  Sidebar,
+  SidebarBody,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarHeading,
+  SidebarItem,
+  SidebarLabel,
+  SidebarSection,
+  SidebarSpacer,
+} from '@revealui/presentation/client';
+import { SidebarLayout } from '@revealui/presentation/client';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+function NavIcon({ d }: { d: string }) {
+  return (
+    <svg data-slot="icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d={d} clipRule="evenodd" />
+    </svg>
+  );
+}
+
+const contentItems: NavItem[] = [
+  {
+    href: '/admin',
+    label: 'Dashboard',
+    icon: (
+      <NavIcon d="M10.707 2.293a1 1 0 0 0-1.414 0l-7 7a1 1 0 0 0 1.414 1.414L4 10.414V17a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-6.586l.293.293a1 1 0 0 0 1.414-1.414l-7-7Z" />
+    ),
+  },
+  {
+    href: '/admin/chat',
+    label: 'Chat',
+    icon: (
+      <NavIcon d="M3.43 2.524A41.29 41.29 0 0 1 10 2c2.236 0 4.43.18 6.57.524 1.437.231 2.43 1.49 2.43 2.902v5.148c0 1.413-.993 2.67-2.43 2.902a41.202 41.202 0 0 1-3.55.414c-.28.02-.521.18-.643.413l-1.712 3.293a.75.75 0 0 1-1.33 0l-1.713-3.293a.783.783 0 0 0-.642-.413 41.202 41.202 0 0 1-3.551-.414C1.993 13.245 1 11.986 1 10.574V5.426c0-1.413.993-2.67 2.43-2.902Z" />
+    ),
+  },
+  {
+    href: '/admin/marketplace',
+    label: 'Marketplace',
+    icon: (
+      <NavIcon d="M4 4a2 2 0 0 0-2 2v1h16V6a2 2 0 0 0-2-2H4ZM18 9H2v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9ZM4 13a1 1 0 0 1 1-1h1a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Zm5-1a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2H9Z" />
+    ),
+  },
+];
+
+const aiItems: NavItem[] = [
+  {
+    href: '/admin/agents',
+    label: 'Agents',
+    icon: (
+      <NavIcon d="M13.024 9.25c.47 0 .827-.433.637-.863a4 4 0 0 0-7.322 0c-.19.43.168.863.637.863h6.048ZM7.5 6.5a2.5 2.5 0 1 1 5 0 2.5 2.5 0 0 1-5 0ZM3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3Zm8.5.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5Zm.5-3.5a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5Z" />
+    ),
+  },
+  {
+    href: '/admin/agent-tasks',
+    label: 'Agent Tasks',
+    icon: (
+      <NavIcon d="M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 0 1 .628.74v2.288a2.25 2.25 0 0 1-.659 1.59l-4.682 4.683a2.25 2.25 0 0 0-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 0 1 8 18.25v-5.757a2.25 2.25 0 0 0-.659-1.591L2.659 6.22A2.25 2.25 0 0 1 2 4.629V2.34a.75.75 0 0 1 .628-.74Z" />
+    ),
+  },
+];
+
+const operationsItems: NavItem[] = [
+  {
+    href: '/admin/monitoring',
+    label: 'Monitoring',
+    icon: (
+      <NavIcon d="M12.577 4.878a.75.75 0 0 1 .919-.53l4.78 1.281a.75.75 0 0 1 .531.919l-1.281 4.78a.75.75 0 0 1-1.449-.388l.81-3.022a19.407 19.407 0 0 0-5.594 5.203.75.75 0 0 1-1.139.093L7 10.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06l5.25-5.25a.75.75 0 0 1 1.06 0l3.082 3.083a20.903 20.903 0 0 1 5.495-4.876l-3.042.815a.75.75 0 0 1-.388-1.449Z" />
+    ),
+  },
+  {
+    href: '/admin/revenue',
+    label: 'Revenue',
+    icon: (
+      <NavIcon d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.798 7.45c.512-.67 1.135-.95 1.702-.95s1.19.28 1.702.95a.75.75 0 0 0 1.192-.91C12.637 5.55 11.596 5 10.5 5s-2.137.55-2.894 1.54A5.205 5.205 0 0 0 6.5 10c0 1.519.474 2.77 1.106 3.46.757.99 1.798 1.54 2.894 1.54s2.137-.55 2.894-1.54a.75.75 0 0 0-1.192-.91c-.512.67-1.135.95-1.702.95s-1.19-.28-1.702-.95A3.505 3.505 0 0 1 8 10c0-.97.266-1.86.798-2.55Z" />
+    ),
+  },
+  {
+    href: '/admin/logs',
+    label: 'Logs',
+    icon: (
+      <NavIcon d="M4.5 2A1.5 1.5 0 0 0 3 3.5v13A1.5 1.5 0 0 0 4.5 18h11a1.5 1.5 0 0 0 1.5-1.5V7.621a1.5 1.5 0 0 0-.44-1.06l-4.12-4.122A1.5 1.5 0 0 0 11.378 2H4.5ZM7 11a.75.75 0 0 0 0 1.5h6A.75.75 0 0 0 13 11H7Zm0 3a.75.75 0 0 0 0 1.5h6A.75.75 0 0 0 13 14H7Zm.75-6.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1-.75-.75Z" />
+    ),
+  },
+  {
+    href: '/admin/errors',
+    label: 'Errors',
+    icon: (
+      <NavIcon d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" />
+    ),
+  },
+  {
+    href: '/admin/audit',
+    label: 'Audit Trail',
+    icon: (
+      <NavIcon d="M10 1a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 1ZM5.05 3.636a.75.75 0 0 1 0 1.06l-1.06 1.06a.75.75 0 0 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0ZM14.95 3.636a.75.75 0 0 1 1.06 0l1.06 1.06a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06ZM10 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6Zm-6.25 3a.75.75 0 0 1-.75-.75h-1.5a.75.75 0 0 1 0 1.5H3a.75.75 0 0 1 .75-.75Zm14 0a.75.75 0 0 1-.75-.75h-1.5a.75.75 0 0 1 0 1.5H17a.75.75 0 0 1 .75-.75Zm-11.7 4.95a.75.75 0 0 1 0 1.06l-1.06 1.06a.75.75 0 0 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm9.9 0a.75.75 0 0 1 1.06 0l1.06 1.06a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06ZM10 15a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 15Z" />
+    ),
+  },
+  {
+    href: '/admin/webhooks',
+    label: 'Webhooks',
+    icon: (
+      <NavIcon d="M4.632 3.533A2 2 0 0 1 6.577 2h6.846a2 2 0 0 1 1.945 1.533l1.976 8.234A3.489 3.489 0 0 0 16 11.5H4c-.476 0-.93.095-1.344.267l1.976-8.234ZM4 13a2 2 0 1 0 0 4h12a2 2 0 1 0 0-4H4Zm11.5 2a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0Zm-2 0a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0Z" />
+    ),
+  },
+  {
+    href: '/admin/refunds',
+    label: 'Refunds',
+    icon: (
+      <NavIcon d="M13.024 2a.75.75 0 0 1 .743.648l.034.402c.164 1.922.407 3.477 1.712 3.95.14.051.27.116.386.196A.75.75 0 0 1 15.5 8H4.5a.75.75 0 0 1-.399-.804c.116-.08.246-.145.386-.196 1.305-.473 1.548-2.028 1.712-3.95L6.233 2.648A.75.75 0 0 1 6.976 2h6.048ZM3.5 9.5a1 1 0 0 0-1 1v.5a4 4 0 0 0 4 4h.528a1.5 1.5 0 0 1 .972.358l1.5 1.273 1.5-1.273A1.5 1.5 0 0 1 12 15h.528a4 4 0 0 0 4-4v-.5a1 1 0 0 0-1-1h-12Z" />
+    ),
+  },
+];
+
+const bottomItems: NavItem[] = [
+  {
+    href: '/admin/upgrade',
+    label: 'Upgrade',
+    icon: (
+      <NavIcon d="M10.75 10.818v2.614A3.13 3.13 0 0 0 11.888 17a3.13 3.13 0 0 0 2.529-1.279l2.387-3.29a.25.25 0 0 0-.203-.393h-2.35l1.108-4.432a.25.25 0 0 0-.44-.205L10.75 10.818ZM7.556 5.088a.25.25 0 0 0-.44.205l1.109 4.432H5.874a.25.25 0 0 0-.203.393l2.387 3.29A3.13 3.13 0 0 0 10.587 17c.403-.5.652-1.134.652-1.825v-4.357L7.556 5.088Z" />
+    ),
+  },
+  {
+    href: '/admin/settings',
+    label: 'Settings',
+    icon: (
+      <NavIcon d="M8 10a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm2-5.5A1.5 1.5 0 0 1 11.5 6c0 .587.268 1.089.689 1.24a4.98 4.98 0 0 1 1.271.733c.403.29.94.284 1.365.026A1.5 1.5 0 0 1 17.5 9.5c0 .587-.268 1.089-.689 1.24a4.98 4.98 0 0 0 0 2.52c.421.151.689.653.689 1.24a1.5 1.5 0 0 1-2.675 1.001c-.425-.258-.962-.264-1.365.026a4.98 4.98 0 0 1-1.271.733c-.421.151-.689.653-.689 1.24A1.5 1.5 0 0 1 10 19.5a1.5 1.5 0 0 1-1.5-1.5c0-.587-.268-1.089-.689-1.24a4.98 4.98 0 0 1-1.271-.733c-.403-.29-.94-.284-1.365-.026A1.5 1.5 0 0 1 2.5 14.5c0-.587.268-1.089.689-1.24a4.98 4.98 0 0 0 0-2.52C2.768 10.589 2.5 10.087 2.5 9.5A1.5 1.5 0 0 1 5.175 8.499c.425.258.962.264 1.365-.026a4.98 4.98 0 0 1 1.271-.733C8.232 7.589 8.5 7.087 8.5 6.5A1.5 1.5 0 0 1 10 5Z" />
+    ),
+  },
+];
+
+function AdminSidebarContent() {
+  const pathname = usePathname();
+
+  const isCurrent = (href: string) => {
+    if (href === '/admin') return pathname === '/admin';
+    return pathname.startsWith(href);
+  };
+
+  return (
+    <Sidebar>
+      <SidebarHeader>
+        <SidebarSection>
+          <SidebarItem href="/admin" current={isCurrent('/admin')}>
+            <span className="text-lg font-bold text-white">RevealUI</span>
+          </SidebarItem>
+        </SidebarSection>
+      </SidebarHeader>
+      <SidebarBody>
+        <SidebarSection>
+          <SidebarHeading>Content</SidebarHeading>
+          {contentItems.map((item) => (
+            <SidebarItem key={item.href} href={item.href} current={isCurrent(item.href)}>
+              {item.icon}
+              <SidebarLabel>{item.label}</SidebarLabel>
+            </SidebarItem>
+          ))}
+        </SidebarSection>
+        <SidebarSection>
+          <SidebarHeading>AI</SidebarHeading>
+          {aiItems.map((item) => (
+            <SidebarItem key={item.href} href={item.href} current={isCurrent(item.href)}>
+              {item.icon}
+              <SidebarLabel>{item.label}</SidebarLabel>
+            </SidebarItem>
+          ))}
+        </SidebarSection>
+        <SidebarSection>
+          <SidebarHeading>Operations</SidebarHeading>
+          {operationsItems.map((item) => (
+            <SidebarItem key={item.href} href={item.href} current={isCurrent(item.href)}>
+              {item.icon}
+              <SidebarLabel>{item.label}</SidebarLabel>
+            </SidebarItem>
+          ))}
+        </SidebarSection>
+        <SidebarSpacer />
+        <SidebarSection>
+          {bottomItems.map((item) => (
+            <SidebarItem key={item.href} href={item.href} current={isCurrent(item.href)}>
+              {item.icon}
+              <SidebarLabel>{item.label}</SidebarLabel>
+            </SidebarItem>
+          ))}
+        </SidebarSection>
+      </SidebarBody>
+      <SidebarFooter>
+        <p className="text-xs text-zinc-500">RevealUI Admin</p>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarLayout navbar={<span />} sidebar={<AdminSidebarContent />}>
+      {children}
+    </SidebarLayout>
+  );
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
     "@revealui/openapi": "workspace:*",
+    "@sentry/node": "^10.48.0",
     "@vercel/blob": "^2.3.3",
     "drizzle-orm": "catalog:",
     "hono": "4.12.12",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,8 +11,8 @@ if (process.env.SENTRY_DSN) {
       if (process.env.NODE_ENV !== 'production') return null;
       // Strip sensitive headers
       if (event.request?.headers) {
-        delete event.request.headers.cookie;
-        delete event.request.headers.authorization;
+        event.request.headers.cookie = undefined;
+        event.request.headers.authorization = undefined;
       }
       return event;
     },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,24 @@
+import * as Sentry from '@sentry/node';
+
+// Initialize Sentry before all other imports for proper instrumentation
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV ?? 'production',
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+    beforeSend(event) {
+      // Don't send events in non-production environments
+      if (process.env.NODE_ENV !== 'production') return null;
+      // Strip sensitive headers
+      if (event.request?.headers) {
+        delete event.request.headers.cookie;
+        delete event.request.headers.authorization;
+      }
+      return event;
+    },
+  });
+}
+
 import { serve } from '@hono/node-server';
 import { swaggerUI } from '@hono/swagger-ui';
 import { initializeLicense } from '@revealui/core/license';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,8 +11,8 @@ if (process.env.SENTRY_DSN) {
       if (process.env.NODE_ENV !== 'production') return null;
       // Strip sensitive headers
       if (event.request?.headers) {
-        event.request.headers.cookie = undefined;
-        event.request.headers.authorization = undefined;
+        const { cookie: _, authorization: __, ...safe } = event.request.headers;
+        event.request.headers = safe;
       }
       return event;
     },

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { errorEvents } from '@revealui/db/schema';
@@ -53,6 +54,7 @@ export const errorHandler: ErrorHandler = (err, c) => {
   if (err instanceof HTTPException) {
     // Only persist 5xx server errors — 4xx are client mistakes, not bugs
     if (err.status >= 500) {
+      Sentry.captureException(err, { extra: { requestId, url } });
       persistError('error', err.message, err.stack, requestId, url);
     }
     return c.json(
@@ -89,7 +91,8 @@ export const errorHandler: ErrorHandler = (err, c) => {
     );
   }
 
-  // Unhandled server error — persist
+  // Unhandled server error — persist and report to Sentry
+  Sentry.captureException(error, { extra: { requestId, url } });
   persistError('error', error.message, error.stack, requestId, url);
 
   return c.json(

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,7 +1,7 @@
-import * as Sentry from '@sentry/node';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { errorEvents } from '@revealui/db/schema';
+import * as Sentry from '@sentry/node';
 import type { ErrorHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 

--- a/apps/api/src/routes/__tests__/content.test.ts
+++ b/apps/api/src/routes/__tests__/content.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockPostQueries, mockMediaQueries, mockSiteQueries, mockPageQueries } = vi.hoisted(() => ({
   mockPostQueries: {
     getAllPosts: vi.fn(),
+    countPosts: vi.fn(),
     createPost: vi.fn(),
     getPostById: vi.fn(),
     getPostBySlug: vi.fn(),
@@ -26,12 +27,14 @@ const { mockPostQueries, mockMediaQueries, mockSiteQueries, mockPageQueries } = 
   },
   mockMediaQueries: {
     getAllMedia: vi.fn(),
+    countMedia: vi.fn(),
     getMediaById: vi.fn(),
     updateMedia: vi.fn(),
     deleteMedia: vi.fn(),
   },
   mockSiteQueries: {
     getAllSites: vi.fn(),
+    countSites: vi.fn(),
     createSite: vi.fn(),
     getSiteById: vi.fn(),
     updateSite: vi.fn(),
@@ -169,6 +172,7 @@ describe('GET /posts — list posts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPostQueries.getAllPosts.mockResolvedValue([]);
+    mockPostQueries.countPosts.mockResolvedValue(0);
   });
 
   it('returns 200 with published posts for unauthenticated requests (public read)', async () => {
@@ -497,6 +501,7 @@ describe('GET /media — list media', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMediaQueries.getAllMedia.mockResolvedValue([]);
+    mockMediaQueries.countMedia.mockResolvedValue(0);
   });
 
   it('returns 401 without authentication', async () => {
@@ -622,6 +627,7 @@ describe('GET /sites — list sites', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSiteQueries.getAllSites.mockResolvedValue([]);
+    mockSiteQueries.countSites.mockResolvedValue(0);
   });
 
   it('returns 401 without authentication', async () => {

--- a/apps/api/src/routes/__tests__/orders.test.ts
+++ b/apps/api/src/routes/__tests__/orders.test.ts
@@ -23,6 +23,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockOrderQueries } = vi.hoisted(() => ({
   mockOrderQueries: {
     getAllOrders: vi.fn(),
+    countOrders: vi.fn(),
     createOrder: vi.fn(),
     getOrderById: vi.fn(),
     updateOrder: vi.fn(),
@@ -106,6 +107,7 @@ describe('GET /orders — list orders', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockOrderQueries.getAllOrders.mockResolvedValue([]);
+    mockOrderQueries.countOrders.mockResolvedValue(0);
   });
 
   it('admin sees all orders (no customerId filter)', async () => {

--- a/apps/api/src/routes/__tests__/products.test.ts
+++ b/apps/api/src/routes/__tests__/products.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockProductQueries } = vi.hoisted(() => ({
   mockProductQueries: {
     getAllProducts: vi.fn(),
+    countProducts: vi.fn(),
     createProduct: vi.fn(),
     getProductById: vi.fn(),
     updateProduct: vi.fn(),
@@ -92,6 +93,7 @@ describe('GET /products — list products', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProductQueries.getAllProducts.mockResolvedValue([]);
+    mockProductQueries.countProducts.mockResolvedValue(0);
   });
 
   it('returns 200 with published-only filter for unauthenticated requests', async () => {

--- a/apps/api/src/routes/__tests__/search.test.ts
+++ b/apps/api/src/routes/__tests__/search.test.ts
@@ -166,7 +166,7 @@ describe('GET /search — type=posts', () => {
   it('queries only the posts table (one select call)', async () => {
     setupChain([]);
     await createApp().request('/search?q=hello&type=posts');
-    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -187,7 +187,7 @@ describe('GET /search — type=pages', () => {
   it('queries only the pages table (one select call)', async () => {
     setupChain([]);
     await createApp().request('/search?q=hello&type=pages');
-    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -207,7 +207,7 @@ describe('GET /search — type=all', () => {
   it('queries both posts and pages tables', async () => {
     setupDualChain([], []);
     await createApp().request('/search?q=hello&type=all');
-    expect(mockDb.select).toHaveBeenCalledTimes(2);
+    expect(mockDb.select).toHaveBeenCalledTimes(4);
   });
 
   it('merges results from both tables', async () => {
@@ -297,7 +297,8 @@ describe('GET /search — response shape', () => {
       query: 'test',
       type: 'posts',
       results: expect.any(Array),
-      count: expect.any(Number),
+      totalDocs: expect.any(Number),
+      totalPages: expect.any(Number),
       limit: expect.any(Number),
       offset: expect.any(Number),
     });
@@ -315,7 +316,7 @@ describe('GET /search — response shape', () => {
     const res = await createApp().request('/search?q=notfound&type=posts');
     const body = await parseBody(res);
     expect(body.results).toHaveLength(0);
-    expect(body.count).toBe(0);
+    expect(body.totalDocs).toBe(0);
   });
 
   it('result items include id, title, slug, status, type, rank fields', async () => {

--- a/apps/api/src/routes/content/media.ts
+++ b/apps/api/src/routes/content/media.ts
@@ -167,7 +167,14 @@ app.openapi(
       200: {
         content: {
           'application/json': {
-            schema: z.object({ success: z.literal(true), data: z.array(MediaSchema) }),
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(MediaSchema),
+              totalDocs: z.number(),
+              totalPages: z.number(),
+              limit: z.number(),
+              offset: z.number(),
+            }),
           },
         },
         description: 'Media list',
@@ -181,8 +188,22 @@ app.openapi(
     const { mimeType, limit, offset } = c.req.valid('query');
     // Non-admin users only see their own uploads (R5-C5 multi-tenancy fix)
     const uploadedBy = user.role === 'admin' ? undefined : user.id;
-    const data = await mediaQueries.getAllMedia(db, { mimeType, uploadedBy, limit, offset });
-    return c.json({ success: true as const, data }, 200);
+    const filterOpts = { mimeType, uploadedBy };
+    const [data, totalDocs] = await Promise.all([
+      mediaQueries.getAllMedia(db, { ...filterOpts, limit, offset }),
+      mediaQueries.countMedia(db, filterOpts),
+    ]);
+    return c.json(
+      {
+        success: true as const,
+        data,
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
+        limit,
+        offset,
+      },
+      200,
+    );
   },
 );
 

--- a/apps/api/src/routes/content/orders.ts
+++ b/apps/api/src/routes/content/orders.ts
@@ -88,7 +88,14 @@ app.openapi(
       200: {
         content: {
           'application/json': {
-            schema: z.object({ success: z.literal(true), data: z.array(OrderSchema) }),
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(OrderSchema),
+              totalDocs: z.number(),
+              totalPages: z.number(),
+              limit: z.number(),
+              offset: z.number(),
+            }),
           },
         },
         description: 'Order list',
@@ -104,8 +111,22 @@ app.openapi(
 
     // Admin sees all orders; non-admin sees only their own
     const customerId = user.role === 'admin' ? undefined : user.id;
-    const data = await orderQueries.getAllOrders(db, { customerId, status, limit, offset });
-    return c.json({ success: true as const, data: data.map(serializeOrder) }, 200);
+    const filterOpts = { customerId, status };
+    const [data, totalDocs] = await Promise.all([
+      orderQueries.getAllOrders(db, { ...filterOpts, limit, offset }),
+      orderQueries.countOrders(db, filterOpts),
+    ]);
+    return c.json(
+      {
+        success: true as const,
+        data: data.map(serializeOrder),
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
+        limit,
+        offset,
+      },
+      200,
+    );
   },
 );
 

--- a/apps/api/src/routes/content/posts.ts
+++ b/apps/api/src/routes/content/posts.ts
@@ -92,7 +92,14 @@ app.openapi(
       200: {
         content: {
           'application/json': {
-            schema: z.object({ success: z.literal(true), data: z.array(PostSchema) }),
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(PostSchema),
+              totalDocs: z.number(),
+              totalPages: z.number(),
+              limit: z.number(),
+              offset: z.number(),
+            }),
           },
         },
         description: 'Post list',
@@ -105,18 +112,41 @@ app.openapi(
     const { status, authorId, limit, offset } = c.req.valid('query');
     if (!user) {
       // Public access: only published posts, no author filtering
-      const data = await postQueries.getAllPosts(db, { status: 'published', limit, offset });
-      return c.json({ success: true as const, data: data.map(serializePost) }, 200);
+      const filterOpts = { status: 'published' as const };
+      const [data, totalDocs] = await Promise.all([
+        postQueries.getAllPosts(db, { ...filterOpts, limit, offset }),
+        postQueries.countPosts(db, filterOpts),
+      ]);
+      return c.json(
+        {
+          success: true as const,
+          data: data.map(serializePost),
+          totalDocs,
+          totalPages: Math.ceil(totalDocs / limit),
+          limit,
+          offset,
+        },
+        200,
+      );
     }
     // Non-admin users can only read their own posts
     const effectiveAuthorId = user.role === 'admin' ? authorId : user.id;
-    const data = await postQueries.getAllPosts(db, {
-      status,
-      authorId: effectiveAuthorId,
-      limit,
-      offset,
-    });
-    return c.json({ success: true as const, data: data.map(serializePost) }, 200);
+    const filterOpts = { status, authorId: effectiveAuthorId };
+    const [data, totalDocs] = await Promise.all([
+      postQueries.getAllPosts(db, { ...filterOpts, limit, offset }),
+      postQueries.countPosts(db, filterOpts),
+    ]);
+    return c.json(
+      {
+        success: true as const,
+        data: data.map(serializePost),
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
+        limit,
+        offset,
+      },
+      200,
+    );
   },
 );
 

--- a/apps/api/src/routes/content/products.ts
+++ b/apps/api/src/routes/content/products.ts
@@ -93,7 +93,14 @@ app.openapi(
       200: {
         content: {
           'application/json': {
-            schema: z.object({ success: z.literal(true), data: z.array(ProductSchema) }),
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(ProductSchema),
+              totalDocs: z.number(),
+              totalPages: z.number(),
+              limit: z.number(),
+              offset: z.number(),
+            }),
           },
         },
         description: 'Product list',
@@ -107,22 +114,42 @@ app.openapi(
 
     if (!user) {
       // Public access: only published products
-      const data = await productQueries.getAllProducts(db, {
-        status: 'published',
-        limit,
-        offset,
-      });
-      return c.json({ success: true as const, data: data.map(serializeProduct) }, 200);
+      const filterOpts = { status: 'published' as const };
+      const [data, totalDocs] = await Promise.all([
+        productQueries.getAllProducts(db, { ...filterOpts, limit, offset }),
+        productQueries.countProducts(db, filterOpts),
+      ]);
+      return c.json(
+        {
+          success: true as const,
+          data: data.map(serializeProduct),
+          totalDocs,
+          totalPages: Math.ceil(totalDocs / limit),
+          limit,
+          offset,
+        },
+        200,
+      );
     }
 
     // Admin sees all; non-admin sees only published
     const effectiveStatus = user.role === 'admin' ? status : 'published';
-    const data = await productQueries.getAllProducts(db, {
-      status: effectiveStatus,
-      limit,
-      offset,
-    });
-    return c.json({ success: true as const, data: data.map(serializeProduct) }, 200);
+    const filterOpts = { status: effectiveStatus };
+    const [data, totalDocs] = await Promise.all([
+      productQueries.getAllProducts(db, { ...filterOpts, limit, offset }),
+      productQueries.countProducts(db, filterOpts),
+    ]);
+    return c.json(
+      {
+        success: true as const,
+        data: data.map(serializeProduct),
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
+        limit,
+        offset,
+      },
+      200,
+    );
   },
 );
 

--- a/apps/api/src/routes/content/search.ts
+++ b/apps/api/src/routes/content/search.ts
@@ -10,7 +10,7 @@
 import { getClient } from '@revealui/db/client';
 import { pages, posts } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
 import type { ContentVariables } from './index.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
@@ -43,7 +43,8 @@ const SearchResponse = z.object({
   query: z.string(),
   type: z.enum(['posts', 'pages', 'all']),
   results: z.array(SearchResultItem),
-  count: z.number(),
+  totalDocs: z.number(),
+  totalPages: z.number(),
   limit: z.number(),
   offset: z.number(),
 });
@@ -92,44 +93,55 @@ app.openapi(
 
     // plainto_tsquery is safe against injection — it treats input as plain text
     const tsquery = sql`plainto_tsquery('english', ${q})`;
+    let totalDocs = 0;
 
     if (type === 'posts' || type === 'all') {
-      const postResults = await db
-        .select({
-          id: posts.id,
-          title: posts.title,
-          slug: posts.slug,
-          status: posts.status,
-          createdAt: posts.createdAt,
-          rank: sql<number>`ts_rank(search_vector, ${tsquery})`,
-        })
-        .from(posts)
-        .where(and(sql`search_vector @@ ${tsquery}`, eq(posts.status, 'published')))
-        .orderBy(desc(sql`ts_rank(search_vector, ${tsquery})`))
-        .limit(limit)
-        .offset(offset);
+      const postWhere = and(sql`search_vector @@ ${tsquery}`, eq(posts.status, 'published'));
+      const [postResults, postCount] = await Promise.all([
+        db
+          .select({
+            id: posts.id,
+            title: posts.title,
+            slug: posts.slug,
+            status: posts.status,
+            createdAt: posts.createdAt,
+            rank: sql<number>`ts_rank(search_vector, ${tsquery})`,
+          })
+          .from(posts)
+          .where(postWhere)
+          .orderBy(desc(sql`ts_rank(search_vector, ${tsquery})`))
+          .limit(limit)
+          .offset(offset),
+        db.select({ total: count() }).from(posts).where(postWhere),
+      ]);
 
+      totalDocs += postCount[0]?.total ?? 0;
       for (const r of postResults) {
         results.push({ ...r, type: 'post' });
       }
     }
 
     if (type === 'pages' || type === 'all') {
-      const pageResults = await db
-        .select({
-          id: pages.id,
-          title: pages.title,
-          slug: pages.slug,
-          status: pages.status,
-          createdAt: pages.createdAt,
-          rank: sql<number>`ts_rank(search_vector, ${tsquery})`,
-        })
-        .from(pages)
-        .where(and(sql`search_vector @@ ${tsquery}`, eq(pages.status, 'published')))
-        .orderBy(desc(sql`ts_rank(search_vector, ${tsquery})`))
-        .limit(limit)
-        .offset(offset);
+      const pageWhere = and(sql`search_vector @@ ${tsquery}`, eq(pages.status, 'published'));
+      const [pageResults, pageCount] = await Promise.all([
+        db
+          .select({
+            id: pages.id,
+            title: pages.title,
+            slug: pages.slug,
+            status: pages.status,
+            createdAt: pages.createdAt,
+            rank: sql<number>`ts_rank(search_vector, ${tsquery})`,
+          })
+          .from(pages)
+          .where(pageWhere)
+          .orderBy(desc(sql`ts_rank(search_vector, ${tsquery})`))
+          .limit(limit)
+          .offset(offset),
+        db.select({ total: count() }).from(pages).where(pageWhere),
+      ]);
 
+      totalDocs += pageCount[0]?.total ?? 0;
       for (const r of pageResults) {
         results.push({ ...r, type: 'page' });
       }
@@ -148,7 +160,8 @@ app.openapi(
           ...r,
           createdAt: r.createdAt?.toISOString() ?? null,
         })),
-        count: sliced.length,
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
         limit,
         offset,
       },

--- a/apps/api/src/routes/content/sites.ts
+++ b/apps/api/src/routes/content/sites.ts
@@ -82,7 +82,14 @@ app.openapi(
       200: {
         content: {
           'application/json': {
-            schema: z.object({ success: z.literal(true), data: z.array(SiteSchema) }),
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(SiteSchema),
+              totalDocs: z.number(),
+              totalPages: z.number(),
+              limit: z.number(),
+              offset: z.number(),
+            }),
           },
         },
         description: 'Site list',
@@ -94,8 +101,22 @@ app.openapi(
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
     const { status, limit, offset } = c.req.valid('query');
-    const data = await siteQueries.getAllSites(db, { ownerId: user.id, status, limit, offset });
-    return c.json({ success: true as const, data: data.map(serializeSite) }, 200);
+    const filterOpts = { ownerId: user.id, status };
+    const [data, totalDocs] = await Promise.all([
+      siteQueries.getAllSites(db, { ...filterOpts, limit, offset }),
+      siteQueries.countSites(db, filterOpts),
+    ]);
+    return c.json(
+      {
+        success: true as const,
+        data: data.map(serializeSite),
+        totalDocs,
+        totalPages: Math.ceil(totalDocs / limit),
+        limit,
+        offset,
+      },
+      200,
+    );
   },
 );
 

--- a/packages/db/src/queries/media.ts
+++ b/packages/db/src/queries/media.ts
@@ -2,9 +2,27 @@
  * Media database queries
  */
 
-import { and, desc, eq, isNull, like } from 'drizzle-orm';
+import { and, count, desc, eq, isNull, like } from 'drizzle-orm';
 import type { Database } from '../client/index.js';
 import { media } from '../schema/admin.js';
+
+/** Count media matching filters (for pagination) */
+export async function countMedia(
+  db: Database,
+  options: { mimeType?: string; uploadedBy?: string } = {},
+) {
+  const { mimeType, uploadedBy } = options;
+  const conditions = [
+    isNull(media.deletedAt),
+    ...(mimeType ? [like(media.mimeType, `${mimeType}%`)] : []),
+    ...(uploadedBy ? [eq(media.uploadedBy, uploadedBy)] : []),
+  ];
+  const result = await db
+    .select({ total: count() })
+    .from(media)
+    .where(and(...conditions));
+  return result[0]?.total ?? 0;
+}
 
 export async function getAllMedia(
   db: Database,

--- a/packages/db/src/queries/orders.ts
+++ b/packages/db/src/queries/orders.ts
@@ -2,9 +2,26 @@
  * Order database queries
  */
 
-import { and, desc, eq } from 'drizzle-orm';
+import { and, count, desc, eq } from 'drizzle-orm';
 import type { Database } from '../client/index.js';
 import { orders } from '../schema/products.js';
+
+/** Count orders matching filters (for pagination) */
+export async function countOrders(
+  db: Database,
+  options: { customerId?: string; status?: string } = {},
+) {
+  const { customerId, status } = options;
+  const conditions = [
+    ...(customerId ? [eq(orders.customerId, customerId)] : []),
+    ...(status ? [eq(orders.status, status)] : []),
+  ];
+  const result = await db
+    .select({ total: count() })
+    .from(orders)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+  return result[0]?.total ?? 0;
+}
 
 export async function getAllOrders(
   db: Database,

--- a/packages/db/src/queries/posts.ts
+++ b/packages/db/src/queries/posts.ts
@@ -2,10 +2,28 @@
  * Post database queries
  */
 
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, count, desc, eq, isNull } from 'drizzle-orm';
 import type { Database } from '../client/index.js';
 import { posts } from '../schema/admin.js';
 import { users } from '../schema/users.js';
+
+/** Count posts matching filters (for pagination) */
+export async function countPosts(
+  db: Database,
+  options: { status?: string; authorId?: string } = {},
+) {
+  const { status, authorId } = options;
+  const conditions = [
+    isNull(posts.deletedAt),
+    ...(status ? [eq(posts.status, status)] : []),
+    ...(authorId ? [eq(posts.authorId, authorId)] : []),
+  ];
+  const result = await db
+    .select({ total: count() })
+    .from(posts)
+    .where(and(...conditions));
+  return result[0]?.total ?? 0;
+}
 
 export async function getAllPosts(
   db: Database,

--- a/packages/db/src/queries/products.ts
+++ b/packages/db/src/queries/products.ts
@@ -2,9 +2,27 @@
  * Product database queries
  */
 
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, count, desc, eq, isNull } from 'drizzle-orm';
 import type { Database } from '../client/index.js';
 import { products } from '../schema/products.js';
+
+/** Count products matching filters (for pagination) */
+export async function countProducts(
+  db: Database,
+  options: { status?: string; ownerId?: string } = {},
+) {
+  const { status, ownerId } = options;
+  const conditions = [
+    isNull(products.deletedAt),
+    ...(status ? [eq(products.status, status)] : []),
+    ...(ownerId ? [eq(products.ownerId, ownerId)] : []),
+  ];
+  const result = await db
+    .select({ total: count() })
+    .from(products)
+    .where(and(...conditions));
+  return result[0]?.total ?? 0;
+}
 
 export async function getAllProducts(
   db: Database,

--- a/packages/db/src/queries/sites.ts
+++ b/packages/db/src/queries/sites.ts
@@ -2,12 +2,30 @@
  * Site database queries
  */
 
-import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, count, desc, eq, isNull, sql } from 'drizzle-orm';
 import type { Database } from '../client/index.js';
 import { sites } from '../schema/sites.js';
 
 /** Condition that excludes soft-deleted sites */
 const notDeleted = isNull(sites.deletedAt);
+
+/** Count sites matching filters (for pagination) */
+export async function countSites(
+  db: Database,
+  options: { ownerId?: string; status?: string; includeDeleted?: boolean } = {},
+) {
+  const { ownerId, status, includeDeleted = false } = options;
+  const conditions = [
+    ...(includeDeleted ? [] : [notDeleted]),
+    ...(ownerId ? [eq(sites.ownerId, ownerId)] : []),
+    ...(status ? [eq(sites.status, status)] : []),
+  ];
+  const result = await db
+    .select({ total: count() })
+    .from(sites)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+  return result[0]?.total ?? 0;
+}
 
 export async function getAllSites(
   db: Database,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@revealui/services':
         specifier: workspace:^
         version: link:../../packages/services
+      '@sentry/node':
+        specifier: ^10.48.0
+        version: 10.48.0
       '@vercel/blob':
         specifier: ^2.3.3
         version: 2.3.3
@@ -3816,6 +3819,10 @@ packages:
     resolution: {integrity: sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==}
     engines: {node: '>=18'}
 
+  '@sentry/core@10.48.0':
+    resolution: {integrity: sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==}
+    engines: {node: '>=18'}
+
   '@sentry/core@7.120.4':
     resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
     engines: {node: '>=8'}
@@ -3860,8 +3867,42 @@ packages:
       '@opentelemetry/semantic-conventions':
         optional: true
 
+  '@sentry/node-core@10.48.0':
+    resolution: {integrity: sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/context-async-hooks':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
   '@sentry/node@10.47.0':
     resolution: {integrity: sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==}
+    engines: {node: '>=18'}
+
+  '@sentry/node@10.48.0':
+    resolution: {integrity: sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==}
     engines: {node: '>=18'}
 
   '@sentry/node@7.120.4':
@@ -3870,6 +3911,16 @@ packages:
 
   '@sentry/opentelemetry@10.47.0':
     resolution: {integrity: sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/opentelemetry@10.48.0':
+    resolution: {integrity: sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -11896,6 +11947,8 @@ snapshots:
 
   '@sentry/core@10.47.0': {}
 
+  '@sentry/core@10.48.0': {}
+
   '@sentry/core@7.120.4':
     dependencies:
       '@sentry/types': 7.120.4
@@ -11948,6 +12001,20 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@sentry/node-core@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.48.0
+      '@sentry/opentelemetry': 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@sentry/node@10.47.0':
     dependencies:
       '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
@@ -11989,6 +12056,46 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
+  '@sentry/node@10.48.0':
+    dependencies:
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.48.0
+      '@sentry/node-core': 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
   '@sentry/node@7.120.4':
     dependencies:
       '@sentry-internal/tracing': 7.120.4
@@ -12005,6 +12112,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.47.0
+
+  '@sentry/opentelemetry@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.48.0
 
   '@sentry/react@10.47.0(react@19.2.5)':
     dependencies:
@@ -13334,7 +13450,7 @@ snapshots:
 
   '@types/pg-pool@2.0.7':
     dependencies:
-      '@types/pg': 8.15.6
+      '@types/pg': 8.20.0
 
   '@types/pg@8.15.6':
     dependencies:


### PR DESCRIPTION
Closes Phase A charge-blockers from the charge-readiness assessment.

## Summary

- **A4: Pagination totals** — Add `totalDocs` and `totalPages` to all collection list endpoints (posts, sites, media, products, orders, search). Each endpoint now runs a parallel COUNT query so clients can render proper pagination controls.
- **A5: Sentry for API** — Add `@sentry/node` to the Hono API app. Initialized at startup, captures all 5xx errors with request context. Sensitive headers stripped. Only active when `SENTRY_DSN` is set.
- **A1: Admin sidebar navigation** — Add persistent sidebar to all `/admin/*` pages using `SidebarLayout` from `@revealui/presentation`. Organized into Content, AI, and Operations sections with SVG icons and active-state highlighting. Mobile gets a hamburger drawer; desktop gets a fixed sidebar.

## Test plan

- [x] API: 2252/2252 tests pass (pagination assertions updated)
- [x] DB: 943/943 tests pass (new count functions)
- [x] Admin: 1521/1521 tests pass (sidebar layout)
- [x] Typecheck: clean across api + admin + db
- [x] Gate: PASS (Biome, security, boundary, coverage)
- [ ] Visual: verify sidebar renders on `/admin` in dev
- [ ] Verify Sentry events arrive when `SENTRY_DSN` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)