### PR TITLE
fix(docs): SEO meta tags, source map headers, and doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,9 @@ feature/* ──PR──▶ test ──PR──▶ main
 |---------|---------|
 | @revealui/core | admin engine, REST API, auth, rich text, admin UI, plugins |
 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) |
-| @revealui/db | Drizzle ORM schema (76 tables), dual-DB (Neon + Supabase) |
+| @revealui/db | Drizzle ORM schema (81 tables), dual-DB (Neon + Supabase) |
 | @revealui/auth | Session auth, password reset, rate limiting |
-| @revealui/presentation | 52 native UI components (Tailwind v4, zero external UI deps — only clsx + CVA) |
+| @revealui/presentation | 57 native UI components (Tailwind v4, zero external UI deps — only clsx + CVA) |
 | @revealui/router | Lightweight file-based router with SSR |
 | @revealui/config | Type-safe env config (Zod + lazy Proxy) |
 | @revealui/utils | Logger, DB helpers, validation |
@@ -171,8 +171,8 @@ Schemas are in `packages/db/src/schema/`. Use Drizzle ORM for queries. Dual-data
 - Database tests use PGlite (in-memory PostgreSQL)
 
 ## Build & Security Status
-- 24 workspaces build and typecheck clean
-- 13,700+ tests across 811 test files
+- 30 workspaces build and typecheck clean
+- 20,000+ tests across 1,300+ test files
 - 36 pnpm overrides enforce minimum safe versions for transitive deps
 - React 19.2.4 (CVE-2025-55182 React2Shell patched)
 - Run `pnpm audit:any` and `pnpm audit:console` for current any/console counts (warn-only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,9 @@ revealui/
 │   ├── config/         # Type-safe env config (Zod)
 │   ├── contracts/      # Zod schemas + TypeScript types
 │   ├── core/           # Runtime engine, REST API, plugins
-│   ├── db/             # Drizzle ORM schema (80+ tables, dual-DB)
+│   ├── db/             # Drizzle ORM schema (81 tables, dual-DB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
-│   ├── presentation/   # 58 UI components (Tailwind v4)
+│   ├── presentation/   # 57 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR
 │   ├── setup/          # Environment setup utilities
 │   ├── sync/           # ElectricSQL real-time sync

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You have:
 - **Content management** — define collections in TypeScript, get a full REST API and admin UI instantly
 - **Billing** — Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard** — manage users, content, billing, and settings out of the box
-- **58 UI components** — built with Tailwind CSS v4, zero external UI dependencies
+- **57 UI components** — built with Tailwind CSS v4, zero external UI dependencies
 - **Type-safe throughout** — Zod schemas shared between client, server, and database
 
 No assembly required. No consulting 12 different documentation sites. No decisions about which auth library to use.
@@ -57,7 +57,7 @@ Six principles that give you a tested starting point for every architectural dec
 | Principle | What it means |
 | --- | --- |
 | **Justifiable** | Every default earns its place. No magic, no hidden complexity, no decisions you can't explain to your team. |
-| **Orthogonal** | Clean separation of concerns across 23 packages. Use what you need, replace what you don't. Zero circular dependencies. |
+| **Orthogonal** | Clean separation of concerns across 22 packages. Use what you need, replace what you don't. Zero circular dependencies. |
 | **Sovereign** | Your infrastructure, your data, your rules. Deploy anywhere. Fork anything. No vendor holds your business hostage. |
 | **Hermetic** | Auth doesn't leak into billing. Content doesn't tangle with payments. Sealed boundaries, clean contracts between every layer. |
 | **Unified** | One Zod schema defines the truth. Types, validation, and API flow from database to server to UI with zero drift. |
@@ -146,9 +146,9 @@ Pro packages are source-available under the [Functional Source License (FSL-1.1-
 | ------------------------------------------------------- | ------------------------------------------------- |
 | [`@revealui/core`](packages/core)                       | Runtime engine, REST API, auth, rich text, plugins |
 | [`@revealui/contracts`](packages/contracts)             | Zod schemas + TypeScript types (single source)    |
-| [`@revealui/db`](packages/db)                           | Drizzle ORM schema (80+ tables), dual-DB client   |
+| [`@revealui/db`](packages/db)                           | Drizzle ORM schema (81 tables), dual-DB client     |
 | [`@revealui/auth`](packages/auth)                       | Session auth, password reset, rate limiting       |
-| [`@revealui/presentation`](packages/presentation)       | 58 UI components (Tailwind v4, zero ext deps)     |
+| [`@revealui/presentation`](packages/presentation)       | 57 UI components (Tailwind v4, zero ext deps)     |
 | [`@revealui/openapi`](packages/openapi)                 | OpenAPI route helpers and Swagger generation       |
 | [`@revealui/router`](packages/router)                   | Lightweight file-based router with SSR            |
 | [`@revealui/config`](packages/config)                   | Type-safe environment configuration               |

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -18,7 +18,7 @@ Admin dashboard with content management, account billing, and system monitoring 
 - **Styling**: Tailwind CSS v4
 - **Database**: Drizzle ORM (NeonDB)
 - **Auth**: `@revealui/auth` (bcrypt, sessions, rate limiting)
-- **UI Components**: `@revealui/presentation` (56 native components)
+- **UI Components**: `@revealui/presentation` (57 native components)
 - **Rich Text**: Lexical editor
 - **Payments**: Stripe (checkout, billing portal, webhooks)
 - **Monitoring**: Sentry

--- a/apps/admin/src/seed.ts
+++ b/apps/admin/src/seed.ts
@@ -210,7 +210,7 @@ const sampleContent = {
       title: 'LAUNCH',
       name: 'RevealUI is Open Source',
       description:
-        'The core runtime is MIT-licensed and available on npm. 23 packages, 13,700+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
+        'The core runtime is MIT-licensed and available on npm. 22 packages, 20,000+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
       alt: 'RevealUI open source launch',
     },
     {
@@ -233,8 +233,8 @@ const sampleContent = {
       alt: 'RevealUI banner',
       link: { href: '/getting-started', text: 'Start Building' },
       stats: [
-        { label: 'Packages', value: '23' },
-        { label: 'Tests', value: '13,700+' },
+        { label: 'Packages', value: '22' },
+        { label: 'Tests', value: '20,000+' },
         { label: 'License', value: 'MIT' },
         { label: 'AI Agents', value: 'Pro' },
       ],

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -3,5 +3,14 @@
   "installCommand": "",
   "framework": "nextjs",
   "github": { "silent": true },
-  "relatedProjects": ["prj_zk6EQijYXwd9L7BccuBssi436ktM"]
+  "relatedProjects": ["prj_zk6EQijYXwd9L7BccuBssi436ktM"],
+  "headers": [
+    {
+      "source": "/(.*).map",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
 }

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   platform: 'node',
   bundle: true,
   dts: false,
-  sourcemap: true,
+  sourcemap: false,
   outDir: 'dist',
   // Bundle workspace packages so extensionless ESM imports are resolved at build
   // time rather than failing at runtime in Node.js strict ESM mode.

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -18,6 +18,13 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
       ]
+    },
+    {
+      "source": "/(.*).map",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
     }
   ]
 }

--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -4,7 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RevealUI Documentation</title>
-    <meta name="description" content="Documentation for RevealUI — Business Operating System Software (B.O.S.S.). Build your business, not your boilerplate." />
+    <meta name="description" content="Documentation for RevealUI — the open-source agentic business runtime. Auth, billing, CMS, AI agents, and 52 UI components. Build your business, not your boilerplate." />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="RevealUI Documentation" />
+    <meta property="og:description" content="Documentation for RevealUI — the open-source agentic business runtime. Auth, billing, CMS, AI agents, and 52 UI components." />
+    <meta property="og:url" content="https://docs.revealui.com" />
+    <meta property="og:site_name" content="RevealUI" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="RevealUI Documentation" />
+    <meta name="twitter:description" content="Open-source agentic business runtime. Auth, billing, CMS, AI agents, 52 UI components. Build your business, not your boilerplate." />
+    <!-- SEO -->
+    <link rel="canonical" href="https://docs.revealui.com" />
+    <meta name="keywords" content="revealui, typescript, react, cms, saas, ai agents, open source, business runtime, stripe, authentication" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300..900;1,300..900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.revealui.com/sitemap.xml

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.revealui.com/</loc><priority>1.0</priority></url>
+  <!-- Getting Started -->
+  <url><loc>https://docs.revealui.com/docs/QUICK_START</loc><priority>0.9</priority></url>
+  <url><loc>https://docs.revealui.com/docs/BUILD_YOUR_BUSINESS</loc><priority>0.9</priority></url>
+  <url><loc>https://docs.revealui.com/docs/EXAMPLES</loc><priority>0.8</priority></url>
+  <!-- Tutorials -->
+  <url><loc>https://docs.revealui.com/guides/quick-start</loc><priority>0.9</priority></url>
+  <url><loc>https://docs.revealui.com/guides/authentication</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/guides/collections</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/guides/billing</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/guides/deployment</loc><priority>0.8</priority></url>
+  <!-- Core Guides -->
+  <url><loc>https://docs.revealui.com/docs/ADMIN_GUIDE</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/docs/AUTH</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/docs/DATABASE</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/CI_CD_GUIDE</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/ENVIRONMENT_VARIABLES_GUIDE</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/TESTING</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/TROUBLESHOOTING</loc><priority>0.7</priority></url>
+  <!-- Architecture -->
+  <url><loc>https://docs.revealui.com/docs/ARCHITECTURE</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/PERFORMANCE</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/STANDARDS</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/CORE_STABILITY</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/JOSHUA</loc><priority>0.7</priority></url>
+  <!-- Reference -->
+  <url><loc>https://docs.revealui.com/docs/REFERENCE</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/api/rest-api</loc><priority>0.8</priority></url>
+  <url><loc>https://docs.revealui.com/docs/COMPONENT_CATALOG</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/AI</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/MARKETPLACE</loc><priority>0.7</priority></url>
+  <!-- Pro & Enterprise -->
+  <url><loc>https://docs.revealui.com/docs/PRO</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/FORGE</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/LOCAL_FIRST</loc><priority>0.6</priority></url>
+  <!-- Blog -->
+  <url><loc>https://docs.revealui.com/docs/blog/01-why-we-built-revealui</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/02-http-402-payments</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/03-multi-agent-coordination</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/04-local-first-ai-stack</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/05-five-primitives</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/06-open-source-and-pro</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/07-agent-first-future</loc><priority>0.6</priority></url>
+  <url><loc>https://docs.revealui.com/docs/blog/08-getting-started</loc><priority>0.7</priority></url>
+  <!-- Architecture Decision Records -->
+  <url><loc>https://docs.revealui.com/docs/architecture/ADR-001-agent-first</loc><priority>0.5</priority></url>
+  <url><loc>https://docs.revealui.com/docs/architecture/ADR-002-dual-database</loc><priority>0.5</priority></url>
+  <url><loc>https://docs.revealui.com/docs/architecture/ADR-003-fair-source-licensing</loc><priority>0.5</priority></url>
+  <url><loc>https://docs.revealui.com/docs/architecture/ADR-004-session-only-auth</loc><priority>0.5</priority></url>
+  <url><loc>https://docs.revealui.com/docs/architecture/ADR-005-two-repo-model</loc><priority>0.5</priority></url>
+  <!-- Showcase -->
+  <url><loc>https://docs.revealui.com/showcase</loc><priority>0.7</priority></url>
+  <url><loc>https://docs.revealui.com/showcase/tokens</loc><priority>0.5</priority></url>
+</urlset>

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -22,7 +22,6 @@
   <!-- Architecture -->
   <url><loc>https://docs.revealui.com/docs/ARCHITECTURE</loc><priority>0.7</priority></url>
   <url><loc>https://docs.revealui.com/docs/PERFORMANCE</loc><priority>0.6</priority></url>
-  <url><loc>https://docs.revealui.com/docs/STANDARDS</loc><priority>0.6</priority></url>
   <url><loc>https://docs.revealui.com/docs/CORE_STABILITY</loc><priority>0.6</priority></url>
   <url><loc>https://docs.revealui.com/docs/JOSHUA</loc><priority>0.7</priority></url>
   <!-- Reference -->

--- a/apps/docs/scripts/copy-docs.sh
+++ b/apps/docs/scripts/copy-docs.sh
@@ -23,8 +23,16 @@ if [ -d "$TARGET_DOCS" ]; then
 fi
 
 # Internal-only files that must never be served publicly
+# IMPORTANT: Keep in sync with INTERNAL_DOC_FILES in vite.config.ts
 INTERNAL_FILES=(
+  "MASTER_PLAN.md"
+  "GOVERNANCE.md"
+  "AI-AGENT-RULES.md"
   "AUTOMATION.md"
+  "CI_ENVIRONMENT.md"
+  "PRICE_COLLECTION.md"
+  "PRODUCT_COLLECTION.md"
+  "SECRETS-MANAGEMENT.md"
   "STANDARDS.md"
 )
 

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -11,6 +11,13 @@
     {
       "source": "/assets/(.*)",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/(.*).map",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
     }
   ],
   "rewrites": [

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -14,6 +14,8 @@
     }
   ],
   "rewrites": [
+    { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
+    { "source": "/robots.txt", "destination": "/robots.txt" },
     { "source": "/docs/:path*.md", "destination": "/docs/:path*.md" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -20,6 +20,7 @@ const DEBUG = /\b(docs-copy|\*)\b/.test(process.env.DEBUG ?? '');
  */
 // Files in docs/ that must never be served publicly.
 // These are internal planning, governance, and tooling docs.
+// IMPORTANT: Keep in sync with INTERNAL_FILES in scripts/copy-docs.sh
 const INTERNAL_DOC_FILES = new Set([
   'MASTER_PLAN.md',
   'GOVERNANCE.md',
@@ -29,6 +30,7 @@ const INTERNAL_DOC_FILES = new Set([
   'PRICE_COLLECTION.md',
   'PRODUCT_COLLECTION.md',
   'SECRETS-MANAGEMENT.md',
+  'STANDARDS.md',
 ]);
 
 function docsCopyPlugin() {
@@ -320,7 +322,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    sourcemap: false,
   },
   publicDir: 'public',
   define: {

--- a/apps/marketing/src/app/coming-soon/page.tsx
+++ b/apps/marketing/src/app/coming-soon/page.tsx
@@ -53,7 +53,7 @@ const upcoming: Feature[] = [
   {
     name: 'Perpetual Licenses (Track C)',
     description:
-      'One-time purchase for lifetime access to Pro, Agency, or Forge tier features. No subscription required. Includes 1 year of priority support and updates.',
+      'One-time purchase for lifetime access to Pro, Max, or Forge tier features. No subscription required. Includes 1 year of priority support and updates.',
     status: 'Coming soon',
     category: 'Billing',
   },

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -456,7 +456,7 @@ export default async function PricingPage() {
                 </div>
                 <h3 className="text-base font-semibold text-white">MCP Servers</h3>
                 <p className="mt-2 text-sm text-gray-400">
-                  12 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright,
+                  11 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright,
                   Next.js DevTools, content management, and email. Marketplace discovery coming
                   soon.
                 </p>

--- a/apps/marketing/src/components/EcosystemSection.tsx
+++ b/apps/marketing/src/components/EcosystemSection.tsx
@@ -3,7 +3,7 @@ const projects = [
     name: 'RevealUI',
     tagline: 'The agentic business runtime',
     description:
-      'Users, content, products, payments, and AI agents — five business primitives, pre-wired into one deployable stack. 21 packages on npm, MIT licensed.',
+      'Users, content, products, payments, and AI agents — five business primitives, pre-wired into one deployable stack. 22 packages on npm, MIT licensed.',
     license: 'MIT + Fair Source (Pro)',
     icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',
     iconColor: 'text-emerald-400',
@@ -34,10 +34,20 @@ const projects = [
     tagline: 'Agent-native micropayments (coming soon)',
     description:
       'Solana token for agent-native micropayments. Agents discover capabilities, authenticate, and pay per task — no accounts, no subscriptions. Powered by the x402 payment protocol.',
-    license: 'Coming Soon',
+    license: 'In Development',
     icon: 'M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z',
     iconColor: 'text-violet-400',
-    href: undefined,
+    href: 'https://github.com/RevealUIStudio/revealcoin',
+  },
+  {
+    name: 'Forge',
+    tagline: 'Self-host the full stack',
+    description:
+      'Deploy RevealUI on your own infrastructure. Docker stack, license enforcement, and full data sovereignty. For teams that need to own everything.',
+    license: 'Forge Tier',
+    icon: 'M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z',
+    iconColor: 'text-orange-400',
+    href: 'https://github.com/RevealUIStudio/forge',
   },
 ];
 

--- a/apps/marketing/src/components/SocialProof.tsx
+++ b/apps/marketing/src/components/SocialProof.tsx
@@ -3,8 +3,8 @@ import { Badge } from '@revealui/presentation';
 export function SocialProof() {
   const stats = [
     { value: '5', label: 'problems solved' },
-    { value: '21', label: 'npm packages' },
-    { value: '12', label: 'MCP servers' },
+    { value: '22', label: 'npm packages' },
+    { value: '11', label: 'MCP servers' },
     { value: 'MIT', label: 'licensed' },
   ];
 

--- a/apps/marketing/src/components/__tests__/SocialProof.test.tsx
+++ b/apps/marketing/src/components/__tests__/SocialProof.test.tsx
@@ -26,9 +26,9 @@ describe('SocialProof', () => {
     const html = JSON.stringify(result);
     expect(html).toContain('5');
     expect(html).toContain('problems solved');
-    expect(html).toContain('21');
+    expect(html).toContain('22');
     expect(html).toContain('npm packages');
-    expect(html).toContain('12');
+    expect(html).toContain('11');
     expect(html).toContain('MCP servers');
     expect(html).toContain('MIT');
     expect(html).toContain('licensed');

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -2,5 +2,14 @@
   "buildCommand": "cd ../.. && pnpm --filter marketing run vercel-build",
   "installCommand": "",
   "framework": "nextjs",
-  "relatedProjects": ["prj_zk6EQijYXwd9L7BccuBssi436ktM"]
+  "relatedProjects": ["prj_zk6EQijYXwd9L7BccuBssi436ktM"],
+  "headers": [
+    {
+      "source": "/(.*).map",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
 }

--- a/apps/revealcoin/package.json
+++ b/apps/revealcoin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "revealcoin",
   "version": "0.1.0",
+  "description": "RevealCoin — agent-native micropayment network for the RevealUI ecosystem",
   "private": true,
   "dependencies": {
     "@revealui/contracts": "workspace:*",

--- a/apps/revealcoin/vercel.json
+++ b/apps/revealcoin/vercel.json
@@ -1,5 +1,14 @@
 {
   "buildCommand": "cd ../.. && pnpm --filter revealcoin run vercel-build",
   "installCommand": "",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "headers": [
+    {
+      "source": "/(.*).map",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
 }

--- a/apps/studio/src/__tests__/components/Dashboard.test.tsx
+++ b/apps/studio/src/__tests__/components/Dashboard.test.tsx
@@ -24,6 +24,12 @@ vi.mock('../../lib/billing-api', () => ({
   }),
 }));
 
+// Mock @solana/kit to prevent window reference errors during jsdom teardown
+vi.mock('@solana/kit', () => ({
+  address: vi.fn((s: string) => s),
+  createSolanaRpc: vi.fn(() => ({ getTokenAccountsByOwner: vi.fn() })),
+}));
+
 const mockRefresh = vi.fn().mockResolvedValue(undefined);
 
 const defaultSettings = {

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -53,8 +53,8 @@ Comprehensive guide to AI agent capabilities, configurations, and workflows in t
 
 - **Framework**: RevealUI — Full-stack React 19 + Next.js 16 Admin Framework
 - **Package Count**: 22 packages (17 OSS + 5 Pro)
-- **Test Status**: 811 test files, all packages build and typecheck ✅
-- **Build Status**: All 24 workspaces build successfully ✅
+- **Test Status**: 1,300+ test files, all packages build and typecheck ✅
+- **Build Status**: All 30 workspaces build successfully ✅
 
 ### Commercial Direction
 
@@ -71,9 +71,9 @@ From 2026 onward, automation features should align with:
 packages/
 ├── core/           # Runtime engine (includes types/ and generated/)
 ├── contracts/      # Zod schemas & TypeScript types
-├── db/             # Database (Drizzle ORM, 80+ tables)
+├── db/             # Database (Drizzle ORM, 81 tables)
 ├── auth/           # Authentication system
-├── presentation/   # 58 UI components (Tailwind v4)
+├── presentation/   # 57 UI components (Tailwind v4)
 ├── router/         # File-based router with SSR
 ├── config/         # Type-safe env config (Zod)
 ├── utils/          # Logger, DB helpers, validation

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -158,7 +158,7 @@ tsx scripts/seed-products.ts
 
 ## 4. Add a pricing page
 
-RevealUI ships 58 UI components. Use them to build a pricing page in your frontend app.
+RevealUI ships 57 UI components. Use them to build a pricing page in your frontend app.
 
 In `apps/mainframe/src/pages/pricing.tsx`:
 

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -15,7 +15,7 @@ Brutally honest audit of what RevealUI documentation claims versus what the code
 
 ## Executive Summary
 
-RevealUI's core framework is **real and production-grade** — auth, billing, runtime engine, 58 UI components, 80+ table database, 13,700+ tests. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
+RevealUI's core framework is **real and production-grade** — auth, billing, runtime engine, 57 UI components, 81-table database, 20,000+ tests. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
 
 ---
 
@@ -54,8 +54,8 @@ RevealUI's core framework is **real and production-grade** — auth, billing, ru
 | Stripe checkout/subscriptions/webhooks | 1,100-line webhook handler, 12 event types |
 | Drizzle ORM dual-DB (NeonDB + Supabase) | Schema + queries + boundary enforcement |
 | Biome 2 linting | Pre-commit hooks, CI hard-fail |
-| 13,700+ tests | Vitest + Playwright, passing in CI |
-| MCP servers | 12 server files in packages/mcp/src/servers/ |
+| 20,000+ tests | Vitest + Playwright, passing in CI |
+| MCP servers | 11 server files in packages/mcp/src/servers/ |
 | Content layer | 29 canonical definitions, byte-identical generation |
 
 ### Understated in Documentation (better than claimed)
@@ -192,7 +192,7 @@ _Updated: 2026-03-28 | Commit: e1858051_
 | Pro tier purchasable | ✅ MET | Stripe flow verified (test mode) |
 | All 5 apps deployed | ✅ MET | revealui.com, admin, api, docs all return 200 |
 | CI gate passes | ✅ MET | `pnpm gate:quick` PASS |
-| 13,700+ tests | ✅ MET | 13,700+ tests across 811 test files |
+| 20,000+ tests | ✅ MET | 20,000+ tests across 1,300+ test files |
 | Zero avoidable `any` types | ✅ MET | `pnpm audit:any` = 0 avoidable |
 | Zero production console stmts | ✅ MET | `pnpm audit:console` = 0 |
 | Security audit complete | ✅ MET | Session 133 (2026-03-28) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -38,15 +38,13 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)** — Justifiable, Orthogonal, Sovere
 
 - [Testing](./TESTING.md) — Unit, integration, E2E, component testing
 - [Performance](./PERFORMANCE.md) — API, bundle, turbo optimization, caching strategy
-- [Standards](./STANDARDS.md) — Code style, linting, logging, type system
-- [Automation](./AUTOMATION.md) — AI agents, automation rules, CI conventions
 - [Troubleshooting](./TROUBLESHOOTING.md) — Common issues and solutions
 
 ## Reference
 
 - [Package Reference](./REFERENCE.md) — Core, contracts, DB, config, presentation, utils, router, CLI
 - [Core Stability](./CORE_STABILITY.md) — API stability tiers, production verification status, version policy
-- [Component Catalog](./COMPONENT_CATALOG.md) — 52 native UI components
+- [Component Catalog](./COMPONENT_CATALOG.md) — 57 native UI components
 - [AI](./AI.md) — AI package overview, prompt/response/semantic caching
 - [Pro](./PRO.md) — Studio desktop app, MCP servers, open-model inference, editor integrations, harnesses, services, x402, marketplace, Forge
 

--- a/docs/JOSHUA.md
+++ b/docs/JOSHUA.md
@@ -36,7 +36,7 @@ Every default earns its place. No magic, no hidden complexity, no decisions you 
 Clean separation of concerns. Each package has a single responsibility. No circular dependencies. Use what you need, replace what you don't.
 
 **Evidence:**
-- 23 packages, zero circular deps — enforced by Turborepo dependency graph
+- 22 packages, zero circular deps — enforced by Turborepo dependency graph
 - `@revealui/auth` knows nothing about billing; `@revealui/db` knows nothing about HTTP
 - `@revealui/contracts` is the only package that every other package may depend on (types + schemas)
 - `@revealui/presentation` has zero external UI dependencies (only clsx + CVA)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -102,7 +102,7 @@ Before starting the dev server, initialize the database schema:
 pnpm db:migrate
 ```
 
-This creates all 80+ tables. If you see a connection error, double-check your `POSTGRES_URL` — it must include `?sslmode=require` for NeonDB.
+This creates all 81 tables. If you see a connection error, double-check your `POSTGRES_URL` — it must include `?sslmode=require` for NeonDB.
 
 ---
 
@@ -170,7 +170,7 @@ For more → [Troubleshooting Guide](./TROUBLESHOOTING.md)
 ## Next Steps
 
 - [Full documentation](./INDEX.md)
-- [Component catalog](./COMPONENT_CATALOG.md) — 52 native UI components
+- [Component catalog](./COMPONENT_CATALOG.md) — 57 native UI components
 - [Example projects](./EXAMPLES.md) — blog, SaaS starter, storefront
 - [Deployment guide](./CI_CD_GUIDE.md) — Vercel, environment variables, production checklist
 - [AI agents](./AI.md) — agent orchestration, open-model inference, MCP framework (Pro)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1989,7 +1989,7 @@ See `.env.template` in the repo root for the full list with descriptions.
 
 # @revealui/presentation
 
-52 native UI components for building RevealUI apps. Zero external UI dependencies — only `clsx` and `cva`.
+57 native UI components for building RevealUI apps. Zero external UI dependencies — only `clsx` and `cva`.
 
 ```bash
 npm install @revealui/presentation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ Honest labels for every product in the RevealUI ecosystem. Updated 2026-04-10.
 
 | Product | Maturity | Notes |
 |---------|----------|-------|
-| **RevealUI** (monorepo) | Beta | Deployed, 13,700+ tests, 23 npm packages. No paying users yet. |
+| **RevealUI** (monorepo) | Beta | Deployed, 20,000+ tests, 22 npm packages. No paying users yet. |
 | **Forge** (self-hosted) | Beta | Docker stack complete, license enforcement built. No external customers. |
 | **RevVault** (secrets) | Beta | Rust CLI + desktop app, age-encrypted vault. Not published to crates.io. |
 | **Studio** (desktop) | Alpha | Tauri 2 + React 19, agent coordination UI. No published binaries. |
@@ -45,9 +45,9 @@ Alpha = functional, not deployed/published. Planned = design or schema only.
 - **Auth system** — Session-based auth with bcrypt, RBAC/ABAC, rate limiting, brute-force protection, TOTP 2FA _(infrastructure built, not yet wired into sign-in flow)_, WebAuthn passkeys, magic link recovery, OAuth (GitHub, Google, Vercel) _(note: sessions are not currently bound to IP/UA)_
 - **Content engine** — Schema-first collections, Lexical rich text, media handling, draft/live lifecycle, REST API with OpenAPI spec
 - **Billing stack** — Stripe checkout, subscriptions, webhooks, license keys, billing portal, tier enforcement (free/pro/max/forge)
-- **UI components** — 52 native React 19 components (Tailwind v4, zero external UI deps)
+- **UI components** — 57 native React 19 components (Tailwind v4, zero external UI deps)
 - **Real-time sync** — ElectricSQL integration for editor/client/agent sync _(experimental — basic shape subscriptions, no offline-first)_
-- **Database** — 76+ tables via Drizzle ORM, dual-DB architecture (NeonDB + Supabase)
+- **Database** — 81 tables via Drizzle ORM, dual-DB architecture (NeonDB + Supabase)
 - **CLI** — `npx create-revealui my-app` scaffolds a full project from npm
 - **AI agents** — A2A protocol, CRDT memory, open-model inference, streaming, tool execution
 - **MCP servers** — 5 production servers (Stripe, Neon, Supabase, Vercel, Playwright)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,7 +11,7 @@ Reference guide to testing in the RevealUI monorepo.
 
 ## Overview
 
-RevealUI has **~13,700 test cases across 811 test files**.
+RevealUI has **~20,000 test cases across 1,300+ test files**.
 
 ### Testing Stack
 

--- a/docs/architecture/ADR-002-dual-database.md
+++ b/docs/architecture/ADR-002-dual-database.md
@@ -11,7 +11,7 @@ RevealUI needs both transactional SQL (users, content, billing, auth) and vector
 
 Two PostgreSQL databases, each with a distinct role:
 
-1. **NeonDB** (primary) — All transactional data: users, content, billing, sessions, auth, marketplace. Accessed via Drizzle ORM over HTTP (serverless-compatible). 80+ tables. Schema managed by drizzle-kit migrations.
+1. **NeonDB** (primary) — All transactional data: users, content, billing, sessions, auth, marketplace. Accessed via Drizzle ORM over HTTP (serverless-compatible). 81 tables. Schema managed by drizzle-kit migrations.
 
 2. **Supabase** (vectors/auth) — Vector embeddings for AI memory, semantic search, and agent context. Accessed via the Supabase JS client. Also hosts Supabase Auth for social OAuth flows (GitHub, Google, Vercel) which redirect tokens back to RevealUI's session-based auth.
 

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -70,11 +70,11 @@ Every framework is a set of opinions. Here are ours:
 
 RevealUI launched with:
 
-- **18 npm packages** published to the public registry
-- **80+ database tables** via Drizzle ORM (NeonDB + Supabase)
-- **58 UI components** with zero external dependencies
-- **7 MCP servers** for AI tool access (all MIT)
-- **13,700+ tests** across all packages
+- **22 npm packages** published to the public registry
+- **81 database tables** via Drizzle ORM (NeonDB + Supabase)
+- **57 UI components** with zero external dependencies
+- **11 MCP servers** for AI tool access (all MIT)
+- **20,000+ tests** across all packages
 - **4 GitHub template repos** for different starting points
 
 You can start right now:

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -224,10 +224,10 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 
 Some numbers on what's actually shipped:
 
-- **28 packages** across the monorepo (7 apps, 16 OSS libraries, and 5 Pro packages)
-- **71 database tables** via Drizzle ORM
-- **58 UI components** in the presentation layer (zero external UI dependencies — just Tailwind v4, clsx, and CVA)
-- **13,700+ tests** across all packages
+- **22 packages** across the monorepo (6 apps, 16 OSS libraries, and 5 Pro packages)
+- **81 database tables** via Drizzle ORM
+- **57 UI components** in the presentation layer (zero external UI dependencies — just Tailwind v4, clsx, and CVA)
+- **20,000+ tests** across all packages
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -57,7 +57,7 @@ See [Environment Variables Guide](../ENVIRONMENT_VARIABLES_GUIDE.md) for the ful
 pnpm db:migrate
 ```
 
-This creates all 80+ tables. If you see a connection error, verify that `POSTGRES_URL` includes `?sslmode=require`.
+This creates all 81 tables. If you see a connection error, verify that `POSTGRES_URL` includes `?sslmode=require`.
 
 ---
 

--- a/packages/cache/tsup.config.ts
+++ b/packages/cache/tsup.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   entry: ['src/index.ts', 'src/adapters/index.ts'],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['esm'],
   dts: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   shims: true,
   target: 'node24',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,12 @@
 # @revealui/core
 
-The core runtime engine for RevealUI — collections, admin UI, rich text, security, observability, and plugins.
+[![npm version](https://img.shields.io/npm/v/@revealui/core)](https://www.npmjs.com/package/@revealui/core)
+[![npm downloads](https://img.shields.io/npm/dw/@revealui/core)](https://www.npmjs.com/package/@revealui/core)
+[![license](https://img.shields.io/npm/l/@revealui/core)](https://github.com/RevealUIStudio/revealui/blob/main/LICENSE)
+
+The core runtime engine for [RevealUI](https://revealui.com) — collections, admin UI, rich text, security, observability, and plugins.
+
+Part of the [RevealUI monorepo](https://github.com/RevealUIStudio/revealui) — the open-source agentic business runtime.
 
 ## Features
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -132,7 +132,7 @@ await db.insert(users).values({
 
 ## JOSHUA Alignment
 
-- **Unified**: One schema definition (50 tables) drives types, queries, and migrations across all apps
+- **Unified**: One schema definition (81 tables) drives types, queries, and migrations across all apps
 - **Orthogonal**: Schema files are cleanly separated by domain (cms, users, agents, vector, crdt) with no cross-domain entanglement
 - **Sovereign**: Your database, your schema, your migrations — no hosted schema service in the loop
 

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   ],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   external: ['@electric-sql/pglite'],
 });

--- a/packages/openapi/tsup.config.ts
+++ b/packages/openapi/tsup.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/packages/paywall/tsup.config.ts
+++ b/packages/paywall/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   ],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   external: ['react', 'react/jsx-runtime', 'hono', 'stripe'],
 });

--- a/packages/presentation/README.md
+++ b/packages/presentation/README.md
@@ -1,10 +1,10 @@
 # @revealui/presentation
 
-50+ native UI components for RevealUI — built with React 19, Tailwind CSS v4, and CVA. Zero external UI library dependencies (only clsx + class-variance-authority).
+57 native UI components for RevealUI — built with React 19, Tailwind CSS v4, and CVA. Zero external UI library dependencies (only clsx + class-variance-authority).
 
 ## Features
 
-- **48 Components** — Forms, data display, feedback, navigation, media, and layout
+- **57 Components** — Forms, data display, feedback, navigation, media, and layout
 - **6 Primitives** — Low-level building blocks (Box, Flex, Grid, Heading, Text, Slot)
 - **14 Hooks** — Focus trap, click outside, popover, roving tabindex, scroll lock, and more
 - **Headless + Styled** — Many components ship both unstyled (headless) and styled (CVA) variants
@@ -26,7 +26,7 @@ import { Box, Flex } from '@revealui/presentation/primitives'
 import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 ```
 
-## Components (48)
+## Components (57)
 
 ### Layout
 | Component | Description |

--- a/packages/resilience/tsup.config.ts
+++ b/packages/resilience/tsup.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/packages/router/tsup.config.ts
+++ b/packages/router/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   format: ['esm'],
   dts: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   external: ['react', 'react-dom', 'hono', '@hono/node-server', /^@revealui\//],
   esbuildOptions(options) {

--- a/packages/security/tsup.config.ts
+++ b/packages/security/tsup.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/packages/setup/tsup.config.ts
+++ b/packages/setup/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   format: ['esm'],
   dts: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   shims: true,
   target: 'node24',

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   ],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 });

--- a/scripts/setup/seed.ts
+++ b/scripts/setup/seed.ts
@@ -203,7 +203,7 @@ const sampleContent = {
       title: 'LAUNCH',
       name: 'RevealUI is Open Source',
       description:
-        'The core runtime is MIT-licensed and available on npm. 23 packages, 13,700+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
+        'The core runtime is MIT-licensed and available on npm. 22 packages, 20,000+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
       alt: 'RevealUI open source launch',
     },
     {
@@ -226,8 +226,8 @@ const sampleContent = {
       alt: 'RevealUI banner',
       link: { href: '/getting-started', text: 'Start Building' },
       stats: [
-        { label: 'Packages', value: '23' },
-        { label: 'Tests', value: '13,700+' },
+        { label: 'Packages', value: '22' },
+        { label: 'Tests', value: '20,000+' },
         { label: 'License', value: 'MIT' },
         { label: 'AI Agents', value: 'Pro' },
       ],


### PR DESCRIPTION
## Summary
- Add SEO meta tags (Open Graph, Twitter Card, canonical, keywords) to docs site
- Add `sitemap.xml` and `robots.txt` for search engine crawling
- Disable source maps in production builds and add `.map` security headers
- Sync internal doc exclusion lists and add npm badges to core README
- Correct stale numeric claims and broken doc references across repo
- Fix `@solana/kit` mock in Studio Dashboard test (jsdom teardown)

## Test plan
- [ ] Docs site builds and serves correctly
- [ ] Source map files not exposed in production builds
- [ ] `.map` requests return 404 with security headers
- [ ] Studio test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)