### PR TITLE
feat(cache): browser PGlite cache + offline mutation queue (Phase 5 Cache E)

### DIFF
--- a/apps/admin/public/sw.js
+++ b/apps/admin/public/sw.js
@@ -1,6 +1,7 @@
 // @ts-nocheck  -  plain JavaScript service worker (not processed by TypeScript)
 
-var CACHE_NAME = 'revealui-admin-v1';
+var CACHE_NAME = 'revealui-admin-v2';
+var MUTATION_STORE = 'revealui-offline-mutations';
 
 var PRE_CACHE_URLS = ['/', '/admin', '/login'];
 
@@ -66,7 +67,32 @@ function isNavigationRequest(request) {
 self.addEventListener('fetch', (event) => {
   var request = event.request;
 
-  // Only handle GET requests  -  mutations go straight to the network.
+  // Queue offline mutations (POST/PUT/PATCH/DELETE to /api/) for replay on reconnect.
+  if (request.method !== 'GET' && isApiRequest(request.url)) {
+    event.respondWith(
+      fetch(request.clone()).catch(async () => {
+        // Network unavailable: queue the mutation for later replay
+        var body = await request.clone().text();
+        var mutation = {
+          url: request.url,
+          method: request.method,
+          headers: Object.fromEntries(request.headers.entries()),
+          body: body,
+          timestamp: Date.now(),
+        };
+        var db = await openMutationStore();
+        var tx = db.transaction(MUTATION_STORE, 'readwrite');
+        tx.objectStore(MUTATION_STORE).add(mutation);
+        return new Response(JSON.stringify({ queued: true }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+    return;
+  }
+
+  // Only handle GET requests for caching strategies.
   if (request.method !== 'GET') {
     return;
   }
@@ -121,5 +147,74 @@ self.addEventListener('fetch', (event) => {
         .catch(() => caches.match('/')),
     );
     return;
+  }
+});
+
+// ---------- Offline Mutation Store (IndexedDB) ----------
+
+function openMutationStore() {
+  return new Promise((resolve, reject) => {
+    var request = indexedDB.open('revealui-sw', 1);
+    request.onupgradeneeded = () => {
+      var db = request.result;
+      if (!db.objectStoreNames.contains(MUTATION_STORE)) {
+        db.createObjectStore(MUTATION_STORE, { autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+}
+
+// ---------- Flush Offline Mutations on Reconnect ----------
+
+async function flushMutations() {
+  try {
+    const db = await openMutationStore();
+    const tx = db.transaction(MUTATION_STORE, 'readonly');
+    const store = tx.objectStore(MUTATION_STORE);
+
+    const allKeys = await new Promise((resolve, reject) => {
+      const req = store.getAllKeys();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+
+    const allMutations = await new Promise((resolve, reject) => {
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+
+    // Replay mutations in order (FIFO)
+    for (let i = 0; i < allMutations.length; i++) {
+      const mutation = allMutations[i];
+      try {
+        await fetch(mutation.url, {
+          method: mutation.method,
+          headers: mutation.headers,
+          body: mutation.body || undefined,
+        });
+        // Remove successfully replayed mutation
+        const deleteTx = db.transaction(MUTATION_STORE, 'readwrite');
+        deleteTx.objectStore(MUTATION_STORE).delete(allKeys[i]);
+      } catch (_err) {
+        // Network still down or server error: stop replaying, try again later
+        break;
+      }
+    }
+  } catch (_err) {
+    // IndexedDB not available: nothing to flush
+  }
+}
+
+// Flush queued mutations when the browser comes back online
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'FLUSH_MUTATIONS') {
+    flushMutations();
   }
 });

--- a/packages/ai/src/memory/preferences/user-preferences-manager.ts
+++ b/packages/ai/src/memory/preferences/user-preferences-manager.ts
@@ -164,9 +164,9 @@ export class UserPreferencesManager {
     const parentKeys = keys.slice(0, -1);
 
     // Guard against prototype pollution
-    const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+    const ForbiddenKeys = new Set(['__proto__', 'constructor', 'prototype']);
     for (const k of keys) {
-      if (FORBIDDEN_KEYS.has(k)) {
+      if (ForbiddenKeys.has(k)) {
         throw new ValidationError(`Forbidden preference key segment: "${k}"`);
       }
     }

--- a/packages/cache/src/adapters/browser.ts
+++ b/packages/cache/src/adapters/browser.ts
@@ -1,0 +1,48 @@
+/**
+ * Browser PGlite Cache Store
+ *
+ * Creates a PGlite WASM instance in the browser backed by IndexedDB,
+ * then wraps it with PGliteCacheStore for SQL-powered client-side caching.
+ *
+ * Benefits over localStorage:
+ * - SQL queries for filtering cached data
+ * - Tag-based and prefix-based invalidation
+ * - IndexedDB storage (much larger than localStorage's ~5MB)
+ * - Shared CacheStore interface with server-side cache
+ *
+ * Usage:
+ *   const cache = await createBrowserCache();
+ *   await cache.set('posts:123', postData, 3600, ['posts']);
+ *   const data = await cache.get('posts:123');
+ *   await cache.close(); // on unmount
+ */
+
+import { PGliteCacheStore } from './pglite.js';
+import type { CacheStore } from './types.js';
+
+interface BrowserCacheOptions {
+  /** IndexedDB database name for persistence (default: 'revealui-cache') */
+  dbName?: string;
+}
+
+/**
+ * Create a browser-compatible PGlite cache store.
+ *
+ * Dynamically imports @electric-sql/pglite (WASM) to avoid bundling
+ * it in server builds. The PGlite instance uses IndexedDB for persistence
+ * so cached data survives page reloads.
+ */
+export async function createBrowserCache(options?: BrowserCacheOptions): Promise<CacheStore> {
+  const dbName = options?.dbName ?? 'revealui-cache';
+
+  // Dynamic import to avoid bundling PGlite WASM in server builds
+  const { PGlite } = await import('@electric-sql/pglite');
+
+  const db = new PGlite(`idb://${dbName}`);
+  await db.waitReady;
+
+  return new PGliteCacheStore({
+    db,
+    closeOnDestroy: true,
+  });
+}

--- a/packages/cache/src/adapters/index.ts
+++ b/packages/cache/src/adapters/index.ts
@@ -4,8 +4,12 @@
  * Pluggable backends for the RevealUI caching layer:
  * - InMemoryCacheStore: Map-backed, zero-dep, single-instance
  * - PGliteCacheStore: PostgreSQL-backed via PGlite, supports distributed invalidation
+ * - createBrowserCache: PGlite WASM + IndexedDB for offline-first browser caching
+ * - useBrowserCache: React hook for singleton browser cache access
  */
 
+export { createBrowserCache } from './browser.js';
 export { InMemoryCacheStore } from './memory.js';
 export { PGliteCacheStore } from './pglite.js';
 export type { CacheEntry, CacheStore } from './types.js';
+export { useBrowserCache } from './use-browser-cache.js';

--- a/packages/cache/src/adapters/use-browser-cache.ts
+++ b/packages/cache/src/adapters/use-browser-cache.ts
@@ -1,0 +1,93 @@
+'use client';
+
+/**
+ * React hook for browser-side PGlite cache.
+ *
+ * Provides a singleton CacheStore instance backed by PGlite WASM + IndexedDB.
+ * The cache is created lazily on first access and shared across all components.
+ * Handles cleanup on unmount of the last consumer.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { CacheStore } from './types.js';
+
+// Singleton state shared across all hook instances
+let sharedCache: CacheStore | null = null;
+let initPromise: Promise<CacheStore> | null = null;
+let refCount = 0;
+
+async function getOrCreateCache(): Promise<CacheStore> {
+  if (sharedCache) return sharedCache;
+  if (initPromise) return initPromise;
+
+  initPromise = import('./browser.js').then(async (mod) => {
+    const cache = await mod.createBrowserCache();
+    sharedCache = cache;
+    return cache;
+  });
+
+  return initPromise;
+}
+
+interface UseBrowserCacheResult {
+  /** The PGlite-backed CacheStore instance. Null while initializing. */
+  cache: CacheStore | null;
+  /** Whether the cache is still being initialized. */
+  loading: boolean;
+  /** Initialization error, if any. */
+  error: Error | null;
+}
+
+/**
+ * Access the browser-side PGlite cache store.
+ *
+ * Returns a shared singleton CacheStore. Multiple components can
+ * use this hook without creating duplicate PGlite instances.
+ *
+ * Example:
+ *   const { cache, loading } = useBrowserCache();
+ *   if (!loading && cache) {
+ *     const data = await cache.get('posts:recent');
+ *   }
+ */
+export function useBrowserCache(): UseBrowserCacheResult {
+  const [cache, setCache] = useState<CacheStore | null>(sharedCache);
+  const [loading, setLoading] = useState(!sharedCache);
+  const [error, setError] = useState<Error | null>(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    refCount++;
+
+    if (!sharedCache) {
+      getOrCreateCache()
+        .then((c) => {
+          if (mounted.current) {
+            setCache(c);
+            setLoading(false);
+          }
+        })
+        .catch((err) => {
+          if (mounted.current) {
+            setError(err instanceof Error ? err : new Error(String(err)));
+            setLoading(false);
+          }
+        });
+    }
+
+    return () => {
+      mounted.current = false;
+      refCount--;
+
+      // Close the cache when no components are using it
+      if (refCount === 0 && sharedCache) {
+        sharedCache.close().catch(() => {});
+        sharedCache = null;
+        initPromise = null;
+      }
+    };
+  }, []);
+
+  return { cache, loading, error };
+}

--- a/packages/cache/tsup.config.ts
+++ b/packages/cache/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   dts: true,
   sourcemap: false,
   clean: true,
+  external: ['react', '@electric-sql/pglite'],
 });


### PR DESCRIPTION
## Summary
First deliverable of Phase 5 Cache E (PGlite browser + offline-first):

### Browser PGlite cache adapter
- \`createBrowserCache()\`: PGlite WASM + IndexedDB persistence, same \`CacheStore\` interface as server-side (SQL queries, tag-based invalidation, prefix deletion)
- \`useBrowserCache()\`: React hook with singleton management, reference counting, automatic cleanup

### Service worker offline mutations
- POST/PUT/PATCH/DELETE to \`/api/*\` queued in IndexedDB when offline
- Returns 202 with \`{ queued: true }\` to client
- FIFO replay on reconnect via \`FLUSH_MUTATIONS\` message
- Failed replays stop and retry on next online event

### Remaining Phase E items (future PRs)
- ElectricSQL shape subscription resilience
- Conflict resolution middleware
- \`useOfflineCache\` upgrade from localStorage to PGlite

## Test plan
- [ ] Cache package typechecks clean
- [ ] Browser cache creates PGlite instance with IndexedDB persistence
- [ ] Service worker queues mutations offline and replays on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)