### PR TITLE
fix(studio): add unmount guards to 7 polling hooks (CI flake fix)

### DIFF
--- a/apps/studio/src/hooks/use-apps.ts
+++ b/apps/studio/src/hooks/use-apps.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { listApps, startApp, stopApp } from '../lib/invoke';
 import type { AppStatus } from '../types';
 
@@ -25,24 +25,31 @@ export function useApps() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [operating, setOperating] = useState<Record<string, boolean>>({});
+  const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
     try {
       const result = await listApps();
+      if (!mountedRef.current) return;
       setApps(result);
       setLoading(false);
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     refresh();
     const id = setInterval(() => {
       if (!document.hidden) refresh();
     }, 5_000);
-    return () => clearInterval(id);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
   }, [refresh]);
 
   const start = useCallback(async (name: string) => {

--- a/apps/studio/src/hooks/use-health.ts
+++ b/apps/studio/src/hooks/use-health.ts
@@ -5,7 +5,7 @@
  * along with individual check results. Polls on the settings interval.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { HealthResponse } from '../lib/health-api';
 import { fetchHealth } from '../lib/health-api';
 import { useSettingsContext } from './use-settings';
@@ -23,9 +23,11 @@ export function useHealth(): HealthState {
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [reachable, setReachable] = useState(true);
   const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
 
-  async function poll() {
+  const poll = useCallback(async () => {
     const result = await fetchHealth(settings.apiUrl);
+    if (!mountedRef.current) return;
     if (result) {
       setHealth(result);
       setReachable(true);
@@ -33,20 +35,23 @@ export function useHealth(): HealthState {
       setReachable(false);
     }
     setLoading(false);
-  }
+  }, [settings.apiUrl]);
 
-  function refresh() {
+  const refresh = useCallback(() => {
     setLoading(true);
     poll();
-  }
+  }, [poll]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-poll when apiUrl or interval changes
   useEffect(() => {
+    mountedRef.current = true;
     poll();
 
     const interval = setInterval(poll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
-  }, [settings.apiUrl, settings.pollingIntervalMs]);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [poll, settings.pollingIntervalMs]);
 
   return { health, reachable, loading, refresh };
 }

--- a/apps/studio/src/hooks/use-inference.ts
+++ b/apps/studio/src/hooks/use-inference.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   inferenceOllamaDelete,
   inferenceOllamaModels,
@@ -20,6 +20,7 @@ export function useInference() {
   const [error, setError] = useState<string | null>(null);
   const [pulling, setPulling] = useState(false);
   const [installingSnap, setInstallingSnap] = useState<string | null>(null);
+  const mountedRef = useRef(true);
 
   async function refresh(): Promise<void> {
     try {
@@ -27,11 +28,13 @@ export function useInference() {
         inferenceOllamaStatus(),
         inferenceSnapList(),
       ]);
+      if (!mountedRef.current) return;
       setOllama(ollamaResult);
       setSnaps(snapList);
 
       if (ollamaResult.running) {
         const modelList = await inferenceOllamaModels();
+        if (!mountedRef.current) return;
         setModels(modelList);
       } else {
         setModels([]);
@@ -39,6 +42,7 @@ export function useInference() {
 
       setLoading(false);
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);
     }
@@ -46,11 +50,15 @@ export function useInference() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refresh is stable, run on mount only
   useEffect(() => {
+    mountedRef.current = true;
     refresh();
     const id = setInterval(() => {
       if (!document.hidden) refresh();
     }, 30_000);
-    return () => clearInterval(id);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
   }, []);
 
   async function startOllama(): Promise<void> {

--- a/apps/studio/src/hooks/use-rvui-balance.ts
+++ b/apps/studio/src/hooks/use-rvui-balance.ts
@@ -40,6 +40,7 @@ export function useRvuiBalance(): RvuiBalanceState {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
 
   const walletAddress = settings.solanaWalletAddress;
   const network = settings.solanaNetwork;
@@ -71,6 +72,8 @@ export function useRvuiBalance(): RvuiBalanceState {
         )
         .send();
 
+      if (!mountedRef.current) return;
+
       if (response.value.length === 0) {
         setBalance('0');
         setUiAmount(0);
@@ -91,15 +94,18 @@ export function useRvuiBalance(): RvuiBalanceState {
         );
       }
     } catch (err) {
+      if (!mountedRef.current) return;
       const msg = err instanceof Error ? err.message : 'Failed to fetch RVUI balance';
       setError(msg);
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }, [walletAddress, network]);
 
   // Initial fetch + polling
   useEffect(() => {
+    mountedRef.current = true;
+
     if (!configured) {
       setBalance(null);
       setUiAmount(0);
@@ -114,6 +120,7 @@ export function useRvuiBalance(): RvuiBalanceState {
     }, POLL_INTERVAL_MS);
 
     return () => {
+      mountedRef.current = false;
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, [configured, fetchBalance]);

--- a/apps/studio/src/hooks/use-status.ts
+++ b/apps/studio/src/hooks/use-status.ts
@@ -1,4 +1,4 @@
-import { createContext, use, useCallback, useEffect, useState } from 'react';
+import { createContext, use, useCallback, useEffect, useRef, useState } from 'react';
 
 const STATUS_POLL_INTERVAL_MS = 30_000;
 
@@ -31,13 +31,16 @@ export function useStatus() {
     loading: true,
     error: null,
   });
+  const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
     setState((prev) => ({ ...prev, loading: true, error: null }));
     try {
       const [system, mount] = await Promise.all([getSystemStatus(), getMountStatus()]);
+      if (!mountedRef.current) return;
       setState({ system, mount, loading: false, error: null });
     } catch (err) {
+      if (!mountedRef.current) return;
       setState((prev) => ({
         ...prev,
         loading: false,
@@ -47,9 +50,13 @@ export function useStatus() {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     refresh();
     const interval = setInterval(refresh, STATUS_POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
   }, [refresh]);
 
   return { ...state, refresh };

--- a/apps/studio/src/hooks/use-subscription.ts
+++ b/apps/studio/src/hooks/use-subscription.ts
@@ -28,6 +28,7 @@ export function useSubscription(): SubscriptionState {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const refreshRef = useRef(0);
+  const mountedRef = useRef(true);
 
   function refresh() {
     refreshRef.current += 1;
@@ -48,26 +49,32 @@ export function useSubscription(): SubscriptionState {
         fetchSubscription(settings.apiUrl, token),
         fetchUsage(settings.apiUrl, token),
       ]);
+      if (!mountedRef.current) return;
       setSubscription(sub);
       setUsage(usg);
       setError(null);
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(err instanceof Error ? err.message : 'Failed to fetch billing data');
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }
 
   // Fetch on mount and on interval
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-fetch when auth step or apiUrl changes
   useEffect(() => {
+    mountedRef.current = true;
     if (step !== 'authenticated') return;
 
     setLoading(true);
     fetchAll();
 
     const interval = setInterval(fetchAll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
   }, [step, settings.apiUrl, settings.pollingIntervalMs]);
 
   return { subscription, usage, loading, error, refresh };

--- a/apps/studio/src/hooks/use-tunnel.ts
+++ b/apps/studio/src/hooks/use-tunnel.ts
@@ -20,12 +20,15 @@ export function useTunnel() {
   });
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
 
   const fetchStatus = useCallback(async () => {
     try {
       const status = await getTailscaleStatus();
+      if (!mountedRef.current) return;
       setState((prev) => ({ ...prev, status, loading: false, error: null }));
     } catch (err) {
+      if (!mountedRef.current) return;
       setState((prev) => ({
         ...prev,
         loading: false,
@@ -36,9 +39,11 @@ export function useTunnel() {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     fetchStatus();
     intervalRef.current = setInterval(fetchStatus, POLL_INTERVAL_MS);
     return () => {
+      mountedRef.current = false;
       if (intervalRef.current !== null) {
         clearInterval(intervalRef.current);
       }


### PR DESCRIPTION
## Summary
Fixes the recurring Studio CI flake that caused ~5 re-runs this session.

**Root cause**: 7 hooks with `setInterval`-based polling call `setState` after jsdom teardown when an in-flight `fetchHealth`/`listApps`/etc. completes after the component unmounts. Vitest catches these as "unhandled rejections" (`window is not defined`) and fails the run even though all tests pass.

**Fix**: Added `mountedRef` guard to all 7 hooks: `use-health`, `use-apps`, `use-inference`, `use-rvui-balance`, `use-status`, `use-subscription`, `use-tunnel`. The guard checks `mountedRef.current` after every await before calling setState, and sets it to false in the cleanup function.

## Test plan
- [ ] All 506 Studio tests pass locally
- [ ] CI no longer produces "Vitest caught N unhandled errors" for Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)