### PR TITLE
fix(harnesses): validate MCP server names (CodeQL alert #300)

### DIFF
--- a/packages/harnesses/src/__tests__/config-normalizer.test.ts
+++ b/packages/harnesses/src/__tests__/config-normalizer.test.ts
@@ -85,6 +85,38 @@ describe('vaughnConfigToClaudeSettings', () => {
     expect(settings.env).toBeUndefined();
     expect(settings.mcpServers).toBeUndefined();
   });
+
+  it('drops MCP servers with unsafe names (prototype-pollution vectors)', () => {
+    const config = createTestConfig({
+      environment: {
+        variables: {},
+        mcpServers: [
+          { name: '__proto__', command: 'npx' },
+          { name: 'constructor', command: 'npx' },
+          { name: 'prototype', command: 'npx' },
+          { name: '', command: 'npx' },
+          { name: '../escape', command: 'npx' },
+          { name: 'has spaces', command: 'npx' },
+          { name: 'github', command: 'npx' }, // safe — should survive
+        ],
+      },
+    });
+    const settings = vaughnConfigToClaudeSettings(config);
+    expect(Object.keys(settings.mcpServers ?? {})).toEqual(['github']);
+    // Confirm no prototype pollution: Object.prototype remains untouched
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('omits mcpServers entirely when all names are unsafe', () => {
+    const config = createTestConfig({
+      environment: {
+        variables: {},
+        mcpServers: [{ name: '__proto__', command: 'npx' }],
+      },
+    });
+    const settings = vaughnConfigToClaudeSettings(config);
+    expect(settings.mcpServers).toBeUndefined();
+  });
 });
 
 describe('claudeSettingsToVaughnConfig', () => {
@@ -113,6 +145,19 @@ describe('claudeSettingsToVaughnConfig', () => {
     const config = claudeSettingsToVaughnConfig({});
     expect(config.environment?.variables).toEqual({});
     expect(config.environment?.mcpServers).toEqual([]);
+  });
+
+  it('filters out MCP server entries with unsafe keys from external JSON', () => {
+    const settings = {
+      mcpServers: {
+        __proto__: { command: 'evil' },
+        constructor: { command: 'evil' },
+        github: { command: 'npx' },
+      } as Record<string, { command: string }>,
+    };
+    const config = claudeSettingsToVaughnConfig(settings);
+    expect(config.environment?.mcpServers).toHaveLength(1);
+    expect(config.environment?.mcpServers[0].name).toBe('github');
   });
 
   it('round-trips permissions through Claude settings', () => {

--- a/packages/harnesses/src/vaughn/config-normalizer.ts
+++ b/packages/harnesses/src/vaughn/config-normalizer.ts
@@ -14,6 +14,42 @@ export interface ConfigGenerationResult {
   files: Map<string, string>;
 }
 
+// -- Key-safety barrier ---------------------------------------------------------
+
+/**
+ * MCP server names are used as object keys in the emitted Claude Code
+ * settings.json. To prevent prototype-pollution vectors and satisfy the
+ * CodeQL `js/remote-property-injection` sink, names must:
+ *   1. match a strict allowlist pattern (leading alphanumeric + up to 63 more
+ *      ASCII letters/digits/underscores/hyphens), and
+ *   2. not collide with any `Object.prototype` member name (`constructor`,
+ *      `prototype`, `toString`, …).
+ * The regex alone rejects `__proto__` and non-identifier characters; the
+ * denylist closes the gap on plain-word property collisions like
+ * `constructor`.
+ */
+const MCP_SERVER_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+const FORBIDDEN_MCP_SERVER_NAMES: ReadonlySet<string> = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'toString',
+  'valueOf',
+]);
+
+export function isSafeMcpServerName(name: unknown): name is string {
+  return (
+    typeof name === 'string' &&
+    MCP_SERVER_NAME_PATTERN.test(name) &&
+    !FORBIDDEN_MCP_SERVER_NAMES.has(name)
+  );
+}
+
 // -- Claude Code settings.json <-> VaughnConfig ---------------------------------
 
 /** Subset of Claude Code settings.json we read/write. */
@@ -45,17 +81,19 @@ export function vaughnConfigToClaudeSettings(config: VaughnConfig): ClaudeCodeSe
   }
 
   if (config.environment.mcpServers.length > 0) {
-    const servers = new Map<string, NonNullable<ClaudeCodeSettings['mcpServers']>[string]>();
+    const servers: NonNullable<ClaudeCodeSettings['mcpServers']> = {};
     for (const server of config.environment.mcpServers) {
-      servers.set(server.name, {
+      // Allowlist-validated name; regex barrier excludes __proto__, constructor, etc.
+      if (!isSafeMcpServerName(server.name)) continue;
+      servers[server.name] = {
         command: server.command,
         ...(server.args && { args: server.args }),
         ...(server.env && { env: server.env }),
-      });
+      };
     }
-    settings.mcpServers = Object.fromEntries(servers) as NonNullable<
-      ClaudeCodeSettings['mcpServers']
-    >;
+    if (Object.keys(servers).length > 0) {
+      settings.mcpServers = servers;
+    }
   }
 
   return settings;
@@ -72,13 +110,17 @@ export function claudeSettingsToVaughnConfig(settings: ClaudeCodeSettings): Part
     };
   }
 
+  // External settings.json is untrusted input — drop entries whose keys don't
+  // match our allowlist so malicious names can't round-trip through the adapter.
   const mcpServers = settings.mcpServers
-    ? Object.entries(settings.mcpServers).map(([name, server]) => ({
-        name,
-        command: server.command,
-        ...(server.args && { args: server.args }),
-        ...(server.env && { env: server.env }),
-      }))
+    ? Object.entries(settings.mcpServers)
+        .filter(([name]) => isSafeMcpServerName(name))
+        .map(([name, server]) => ({
+          name,
+          command: server.command,
+          ...(server.args && { args: server.args }),
+          ...(server.env && { env: server.env }),
+        }))
     : [];
 
   config.environment = {


### PR DESCRIPTION
## Summary
- Resolve CodeQL alert #300 (`js/remote-property-injection`, HIGH) in `packages/harnesses/src/vaughn/config-normalizer.ts`
- Replace cosmetic Map + Object.fromEntries with real sanitization barrier: allowlist regex `/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/` + explicit `Object.prototype` denylist (`constructor`, `prototype`, `toString`, ...)
- Apply in **both** directions: serialize (config → settings.json) and parse (settings.json → config)
- Export `isSafeMcpServerName` for reuse

## Why the previous fixes didn't work
Commits `c1f22252` and `357a22ba` attempted to silence the alert with `Object.create(null)` and Map detours, but CodeQL's taint tracker saw the keys flow back into a plain object via `Object.fromEntries`. The allowlist regex is the first sanitizer the tracker actually recognizes — and unlike the Map dance, it genuinely prevents prototype pollution.

## Test plan
- [x] `pnpm --filter @revealui/harnesses test` — 256/256 pass (3 new cases: prototype-pollution vectors in both directions, empty-after-filter)
- [x] `pnpm --filter @revealui/harnesses typecheck` — clean
- [x] Biome — clean
- [ ] CI CodeQL scan reports 0 open alerts on this branch → unblocks PR #289 (test → main)