### PR TITLE
release: merge test -> main (validator + dev-package hygiene)

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,16 +1,13 @@
 {
   "name": "@revealui/dev",
   "version": "0.1.0",
-  "description": "Zero-config dev environment for RevealUI — Biome, TypeScript, Tailwind, Vite, PostCSS, editor integration, and terminal themes",
+  "private": true,
+  "description": "Internal dev environment for the RevealUI monorepo — Biome, TypeScript, Tailwind, Vite, PostCSS config. Not published to npm; editor configs for external users live in RevealUIStudio/editor-configs (RevCon).",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/RevealUIStudio/revealui.git",
     "directory": "packages/dev"
-  },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
   },
   "keywords": [
     "biome",

--- a/scripts/validate/build-artifacts.ts
+++ b/scripts/validate/build-artifacts.ts
@@ -22,7 +22,6 @@ const ROOT = join(import.meta.dirname, '..', '..');
 
 /** Packages that compile to dist/ and must have .js output */
 const DIST_PACKAGES = [
-  'animations',
   'auth',
   'cache',
   'cli',
@@ -30,7 +29,6 @@ const DIST_PACKAGES = [
   'contracts',
   'core',
   'db',
-  'editors',
   'mcp',
   'openapi',
   'presentation',


### PR DESCRIPTION
## Summary
Second release batch to unblock npm publish:
- fix(scripts): remove deleted \`animations\`/\`editors\` packages from release artifact validator (#292 commits)
- chore(dev): mark \`@revealui/dev\` as private (aligns intent with reality — never published to npm, no external consumers need it)

Release-pipeline follow-up to #289. After this merges, re-dispatching \`release.yml\` will proceed through \`Validate release artifacts\` and publish all 21 package bumps from the original release PR to npm.

## Test plan
- [x] CI on #292 green
- [ ] After merge, dispatch \`release.yml\` — \`Validate release artifacts\` step passes
- [ ] \`pnpm changeset publish\` publishes 21 packages with OIDC provenance