### PR TITLE
fix(deploy): use drizzle-kit migrate for prod, not dev-only script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,10 @@ jobs:
           VERCEL_PROJECT_ID: prj_zk6EQijYXwd9L7BccuBssi436ktM # api
 
       - name: Run migrations
+        # Invokes drizzle-kit migrate inside packages/db (non-interactive,
+        # applies pending migration SQL files against the migrations table).
+        # Do NOT use root `pnpm db:migrate` — that script runs drizzle-kit
+        # generate + push interactively and is a dev-only one-shot script.
         run: |
           set -a
           # shellcheck disable=SC1091
@@ -133,7 +137,7 @@ jobs:
             echo "::error::POSTGRES_URL not found in pulled Vercel env"
             exit 1
           fi
-          pnpm db:migrate
+          pnpm --filter @revealui/db db:migrate
 
   # ---------------------------------------------------------------------------
   # Detect which apps were affected by the merge


### PR DESCRIPTION
Summary: The migrate job in deploy.yml was calling root-level `pnpm db:migrate` which runs scripts/setup/migrations.ts — a one-shot dev script that (1) runs `drizzle-kit generate` (creates migrations from live schema — wrong in prod), (2) runs `drizzle-kit push` (destructive, bypasses migrations table), (3) calls an interactive `confirm()` prompt that hangs in CI until the job timeout. Deploy run 24322793602 (after PR #295 merge) cancelled at 4m47s into Step 2 for this reason.

Fix: invoke `pnpm --filter @revealui/db db:migrate` instead, which runs `drizzle-kit migrate` — the correct non-interactive command that applies pending migration SQL files and exits.

Root cause chain:
- Prior PR #294 unblocked POSTGRES_URL (was reading from a missing GH secret)
- That exposed this second problem: even with the env, the script itself is wrong for CI
- Verified by reading scripts/setup/migrations.ts — headed "CRDT Fixes Migration Script", clearly a one-shot

Test plan:
- CI green on this PR
- After merge test -> main, confirm Deploy run completes with Apply Migrations green
- Verify no new migration files appear in packages/db/migrations/ (that would prove the generate-in-prod bug is gone)