### PR TITLE
chore(ci): remove obsolete Pro-package stub step

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -123,12 +123,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Stub gitignored Pro packages
-        run: |
-          for pkg in ai harnesses; do
-            [ ! -d "packages/$pkg" ] && mkdir -p "packages/$pkg"
-          done
-
       - name: Pull Vercel environment (preview)
         run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,14 +278,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Stub gitignored Pro packages (directory only — no package.json)
-        run: |
-          for pkg in ai harnesses; do
-            if [ ! -d "packages/$pkg" ]; then
-              mkdir -p "packages/$pkg"
-            fi
-          done
-
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
         env:


### PR DESCRIPTION
## Summary
- Removes the \`Stub gitignored Pro packages\` step from \`deploy.yml\` and \`deploy-test.yml\`.
- Dead code since the Fair Source migration (#192): \`@revealui/ai\` and \`@revealui/harnesses\` are now tracked source under FSL-1.1-MIT, not gitignored.
- The bash short-circuit form (\`[ test ] && cmd\`) silently fails under \`set -e\` when the directory already exists — broke Deploy Test (Preview) run 24325333412.

## Test plan
- [x] Local pre-push gate passed (264s, all 488 unit tests + security + types)
- [ ] CI green on this PR
- [ ] Re-dispatch Deploy Test (Preview) after merge to confirm all 5 apps deploy cleanly