### PR TITLE
fix(db): add CREATE EXTENSION vector to baseline migration

### DIFF
--- a/packages/db/migrations/0000_init.sql
+++ b/packages/db/migrations/0000_init.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
 CREATE TABLE "agent_actions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"version" integer DEFAULT 1 NOT NULL,


### PR DESCRIPTION
## Summary
- \`0000_init.sql\` uses \`vector(768)\` on 3 tables but never declared \`CREATE EXTENSION vector\`.
- The live Neon DB had the extension installed out-of-band pre-consolidation, so old migrations worked by accident.
- After the prod DB wipe (DROP SCHEMA public CASCADE), the extension went with it — prod deploy run 24328645980 failed on the first \`vector(768)\` reference. Transaction rolled back cleanly, DB remains empty.
- Adds \`CREATE EXTENSION IF NOT EXISTS vector;\` at the top. Self-contained against any fresh Postgres with pgvector available (Neon, Supabase, PGlite + vector plugin).

## Why this slipped past CI
- PGlite tests that exercise the migration pass with or without the CREATE EXTENSION (PGlite's vector plugin registers the type implicitly).
- Only a "fresh Postgres without vector" scenario surfaces it, and we never had one in CI until now.

## Test plan
- [x] \`pnpm --filter @revealui/auth test\` — 488 pass (oauth-pglite exercises this migration)
- [ ] CI green on this PR
- [ ] After promotion to main: \`Apply Migrations\` step succeeds on prod Neon DB
- [ ] All 5 apps deploy