### PR TITLE
release: vector extension fix for baseline migration

### DIFF
--- a/packages/db/migrations/0000_init.sql
+++ b/packages/db/migrations/0000_init.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
 CREATE TABLE "agent_actions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"version" integer DEFAULT 1 NOT NULL,


### PR DESCRIPTION
## Summary

Follow-up to PR #299. Adds \`CREATE EXTENSION IF NOT EXISTS vector;\` to \`0000_init.sql\` so the baseline can apply against a fresh Neon prod DB.

### Context
- PR #299 merged the DB baseline reset into main.
- On auto-deploy, \`drizzle-kit migrate\` failed on \`vector(768)\` references (prod DB had been wiped, and the vector extension had been installed out-of-band pre-consolidation).
- Transaction rolled back cleanly — prod DB still empty, safe to retry.
- This PR makes the baseline self-contained.

### Test plan
- [ ] CI green on this PR (full gate + integration + E2E + visual)
- [ ] On merge: deploy.yml's Apply Migrations step succeeds this time
- [ ] All 5 Vercel apps deploy
- [ ] Manual smoke: prod sites load, auth works