### PR TITLE
docs(master-plan): add §5.17 Hardware-Aware Auto-Config

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -540,6 +540,63 @@ Phase D  -  Agent publisher tools (agent):
 
 **Exit criteria:** Users can browse agents by skill, submit tasks, and receive results without writing code. Agent publishers can list, price, and monitor their agents. Billing works via both Stripe metering and x402 RevealCoin. Task execution is sandboxed with audit trail.
 
+#### 5.17 Hardware-Aware Auto-Config (cross-platform, Suite-wide)
+
+**Origin:** 2026-04-13. WSL repeatedly crashed on a 7.3 GB host because default `.wslconfig` let the VM claim ~6 GB, starving Windows. The fix (memory=4GB, vmIdleTimeout=-1, autoMemoryReclaim off, tuned earlyoom, docker off-by-default) was hand-authored from a crash post-mortem. No new user should have to debug that.
+
+**What it is:** A Suite-wide abstraction that, on first install **and** on demand, scans the host's hardware + platform and applies a tuned, safe-by-default dev configuration. Invoked by the Studio first-run wizard, by the CLI (`revealui system tune`), and by Forge during self-hosted provisioning.
+
+**Detect:**
+- OS / distro / kernel, architecture (x64 / arm64), platform class (native Linux, macOS, Windows, WSL2, Docker, cloud VM)
+- Total RAM, free RAM, CPU core count (physical + logical), swap size, disk size + free space, GPU vendor + VRAM (optional)
+- Existing configs already present (`.wslconfig`, `earlyoom`, Docker autostart, `NODE_OPTIONS`, `PNPM_*`, `TURBO_*`, tmux, shell rc files)
+- Known-bad combinations (e.g. WSL memory ≥ 80% of host RAM, `autoMemoryReclaim=dropcache` on host-pressure systems, Docker autostart on <8 GB host)
+
+**Tune:**
+- **WSL:** `.wslconfig` memory/processors/swap/vmIdleTimeout, networkingMode, kernelCommandLine
+- **Linux host:** `earlyoom` thresholds + `--prefer` list (dev-tool-aware: turbo, biome, vitest, tsc, esbuild), `vm.swappiness`
+- **Container runtimes:** docker + containerd autostart policy (off-by-default on low-RAM hosts; on-demand via `sudo systemctl start docker`)
+- **Node/pnpm/turbo:** `NODE_OPTIONS=--max-old-space-size`, pnpm `child-concurrency`, turbo `--concurrency`, Vitest `poolOptions.threads.maxThreads`
+- **macOS:** file descriptor limits (`launchctl limit maxfiles`), Spotlight exclusions for repo paths
+- **Windows native:** Defender exclusions for repo paths, long-path support
+
+**Surface:**
+- Studio first-run wizard screen: "Tune this machine for RevealUI?" → diff preview → confirm → apply
+- CLI: `revealui system scan` (read-only report), `revealui system tune` (apply with `--dry-run` / `--plan` / `--yes`), `revealui system revert` (restore from timestamped backup)
+- JSON output (`--json`) for agents and for Forge provisioning
+
+**Safety:**
+- Always write a timestamped backup of every file we mutate under `~/.revealui/system-tune/backups/<ts>/`
+- Dry-run default when a config already exists; require `--force` to overwrite user-authored values
+- Never touch shared system services the user didn't opt into; gate privileged changes (e.g. `/etc/default/earlyoom`, `.wslconfig`) behind explicit confirmation
+- Every applied profile carries a version + hostname + hardware-hash header, so reruns know whether they'd be a no-op
+- Ship a machine-readable post-mortem log (`~/.revealui/system-tune/history.jsonl`) so agents can diagnose regressions
+
+**Deliverables (code):**
+- New package `@revealui/system-tune` (or inside `@revealui/setup`) — pure detection + plan generation, no I/O
+- Platform adapters: `adapters/wsl.ts`, `adapters/linux.ts`, `adapters/macos.ts`, `adapters/windows.ts`
+- CLI surface in `@revealui/cli`: `system scan` / `system tune` / `system revert`
+- Studio wizard integration (Tauri): first-run screen + settings-panel entry
+- Forge integration: invoked by self-hosted install script before app boot
+- Tests: snapshot-based detection fixtures (mocked `/proc/meminfo`, `systemctl`, `.wslconfig`, macOS `sysctl`, Windows WMI) + plan-generation unit tests + dry-run integration tests on real WSL / macOS / Linux runners in CI
+
+**Deliverables (docs):**
+- `docs/system-tune/PROFILES.md` — the canonical tuning matrix (host RAM bucket × platform → applied values), with rationale for each value
+- `docs/system-tune/CRASH-POSTMORTEMS.md` — seed entries: WSL 7.3 GB host crash (2026-04-13), host-pressure autoMemoryReclaim, idle-pause clock skew
+
+**When to start:** After Phase 5 ships. Seed profile = the exact 2026-04-13 WSL fix, captured as the "low-RAM WSL2" preset — so the first working baseline is the author's own machine.
+
+- [ ] Extract current WSL fix into a declarative profile (`profiles/wsl-low-ram.json`)
+- [ ] Build detection layer + platform adapters
+- [ ] Build plan generator (pure function: detected state → desired state → diff)
+- [ ] Build CLI (`revealui system scan` / `tune` / `revert`) with dry-run default
+- [ ] Wire into Studio first-run wizard
+- [ ] Wire into Forge self-hosted install script
+- [ ] CI: run `revealui system scan --json` on Ubuntu / macOS / Windows runners and snapshot the detection output
+- [ ] Crash-postmortem doc seeded with the 2026-04-13 incident
+
+**Exit criteria:** A user running `curl | sh` on a brand-new machine — Windows + WSL, bare Linux, macOS M-series, or low-RAM laptop — reaches a working RevealUI dev environment without hand-editing any system config file, and the setup is reproducible + reversible.
+
 ---
 
 ### Phase 6: SOC2 Type II Compliance (post-Phase 5, enterprise prerequisite)


### PR DESCRIPTION
## Summary
- Add Phase 5 item **§5.17 Hardware-Aware Auto-Config** to `docs/MASTER_PLAN.md`.
- Scopes a Suite-wide capability: on first install (Studio wizard, Forge provisioning, or `revealui system tune` CLI), detect platform + RAM/CPU/swap/disk/GPU and apply a tuned, safe-by-default dev config with backup + dry-run + revert.
- Seed profile = the 2026-04-13 WSL crash-fix (memory=4GB, vmIdleTimeout=-1, tuned earlyoom, docker off-by-default on a 7.3 GB host). That exact config was hand-authored from a crash post-mortem; this item ensures no new user has to rediscover it the same way.

## Scope
- **Docs only.** No package, no CLI, no Tauri work in this PR — just the plan entry.
- Defined deliverables: `@revealui/system-tune` pkg (pure detection + plan generation), platform adapters (wsl/linux/macos/windows), `@revealui/cli` surface, Studio first-run wizard screen, Forge install hook, CI snapshot runs on Ubuntu/macOS/Windows.
- Starts after Phase 5 ships.

## Test plan
- [x] Markdown renders (plain section, no special syntax)
- [x] Pre-push gate PASS (secrets scan, biome, audits)
- [ ] CI on this PR green

_Closes not applicable._

🤖 Generated with [Claude Code](https://claude.com/claude-code)