### PR TITLE
feat(api): allow tauri://localhost CORS origin for RevealUI Studio

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -254,6 +254,19 @@ function isVercelPreviewOrigin(origin: string): boolean {
   return origin.endsWith('-revealuistudios-projects.vercel.app');
 }
 
+/**
+ * Check if origin is a trusted desktop-app client (RevealUI Studio).
+ *
+ * Tauri webviews issue requests from `tauri://localhost` (Linux/Windows) or
+ * `https://tauri.localhost` (macOS/Windows HTTPS mode). The Studio app ships
+ * signed binaries and talks to the public API on behalf of authenticated
+ * users, so its origin is allow-listed here rather than via CORS_ORIGIN env
+ * (which is reserved for HTTPS web clients).
+ */
+function isDesktopClientOrigin(origin: string): boolean {
+  return origin === 'tauri://localhost' || origin === 'https://tauri.localhost';
+}
+
 /** Check if origin matches test/dev subdomain: https://(dev|test).(admin.|api.|docs.)?revealui.com */
 function isTestSubdomainOrigin(origin: string): boolean {
   if (!origin.startsWith('https://')) return false;
@@ -278,7 +291,8 @@ app.use('*', async (c, next) => {
     process.env.VERCEL_ENV === 'preview' &&
     (isVercelPreviewOrigin(origin) || isTestSubdomainOrigin(origin));
 
-  const isAllowed = corsOrigins.includes(origin) || isPreviewAllowed;
+  const isAllowed =
+    corsOrigins.includes(origin) || isPreviewAllowed || isDesktopClientOrigin(origin);
 
   if (isAllowed) {
     c.header('Access-Control-Allow-Origin', origin);


### PR DESCRIPTION
## Summary
- Adds `isDesktopClientOrigin()` helper allowing `tauri://localhost` (Linux/Windows) and `https://tauri.localhost` (macOS HTTPS mode) as CORS origins.
- Wired into the manual CORS middleware alongside the existing preview/test-subdomain allow-list.
- Unblocks RevealUI Studio OTP login — Studio was receiving network errors because `api.revealui.com` returned no ACAO header for the Tauri origin.

## Why a code change rather than CORS_ORIGIN env?
`CORS_ORIGIN` is reserved for HTTPS web clients (marketing, admin, etc.). Desktop-app scheme origins don't fit the pattern and warrant an explicit, reviewable allow-list in code — same model as the Vercel preview allow-list.

## Security note
Browsers/webviews control the `Origin` header; an arbitrary website cannot spoof `tauri://localhost`. Only requests from a Tauri webview on the user's machine will carry that origin, and the existing session/auth layer still authenticates the user.

## Test plan
- [ ] CI gate passes (lint/typecheck/tests/build)
- [ ] After merge to `main` + prod deploy: Studio OTP login succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)