### PR TITLE
feat(api): add /api/console-auth alias for terminal-auth routes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -831,6 +831,11 @@ app.use('/api/studio-auth/*', noStore);
 app.use('/api/v1/studio-auth/*', noStore);
 app.use('/api/terminal-auth/*', noStore);
 app.use('/api/v1/terminal-auth/*', noStore);
+// console-auth: forward-compat alias for the desktop-client auth routes.
+// Same handler, same rate limits as /api/terminal-auth/*. Lets the Studio
+// DNS cutover target the new path without requiring an internal rename.
+app.use('/api/console-auth/*', noStore);
+app.use('/api/v1/console-auth/*', noStore);
 app.use('/api/api-keys/*', noStore);
 app.use('/api/v1/api-keys/*', noStore);
 app.use('/api/admin/*', noStore);
@@ -885,6 +890,10 @@ app.route('/api/studio-auth', studioAuthRoute);
 app.use('/api/terminal-auth/*', routeLimit('terminal-auth'));
 app.use('/api/v1/terminal-auth/*', routeLimit('terminal-auth'));
 app.route('/api/terminal-auth', terminalAuthRoute);
+// Alias mount (see comment above for console-auth no-store middleware).
+app.use('/api/console-auth/*', routeLimit('terminal-auth'));
+app.use('/api/v1/console-auth/*', routeLimit('terminal-auth'));
+app.route('/api/console-auth', terminalAuthRoute);
 
 // Terminal WebSocket bridge  -  daemon PTY sessions for remote access
 // Auth required: terminal sessions give PTY access to the server


### PR DESCRIPTION
## Summary
Forward-compat alias — mounts the existing \`terminalAuth\` handler at \`/api/console-auth/*\` (and \`/api/v1/console-auth/*\`) alongside the current \`/api/terminal-auth/*\` paths. Shares the same rate-limit key (\`terminal-auth\`) and \`noStore\` middleware.

## Why
Prepares for the RevealUI Studio DNS cutover (\`terminal.revealui.com\` → \`console.revealui.com\`). Studio clients pointing at the new host can hit \`/api/console-auth/*\` immediately once this deploys — no need to block the DNS switch on a broader internal rename.

## Scope
- Additive only. No existing routes change. No tests change.
- Full internal rename of \`terminal-auth.ts\` / tests / \`terminalAuthRoute\` identifier → follow-up after Studio GA.

## Test plan
- [x] \`pnpm --filter api typecheck\` clean
- [x] \`pnpm --filter api test -- terminal-auth\` all 2252 tests pass locally
- [ ] CI gate passes
- [ ] Smoke-test post-merge: \`curl -X POST https://api.revealui.com/api/console-auth/link ...\` returns same shape as \`/api/terminal-auth/link\`

## Merge timing
Not urgent — can merge whenever the DNS cutover PR is staged. Happy to hold as draft if you'd rather bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)