### PR TITLE
fix(api): drop .slice typo on SwaggerUIStandalonePreset

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -816,7 +816,7 @@ const swaggerInitJs = `window.addEventListener('load', function () {
   window.ui = SwaggerUIBundle({
     url: '/openapi.json',
     dom_id: '#swagger-ui',
-    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset.slice],
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
     layout: 'BaseLayout',
     deepLinking: true,
   });


### PR DESCRIPTION
## Summary
- Hotfix for white-screen regression on https://api.revealui.com/docs introduced by #314.
- `swagger-init.js` passed `SwaggerUIStandalonePreset.slice` (the `Array.prototype.slice` function, not a preset) into `SwaggerUIBundle({ presets })`, crashing `combinePlugins` with `Cannot convert undefined or null to object at slice`.
- Single-line fix: drop the bogus `.slice` accessor.

## Test plan
- [x] `pnpm --filter api build` clean
- [x] `node -e "require('./apps/api/dist/index.js')"` boots clean
- [ ] Post-deploy: https://api.revealui.com/docs renders Swagger UI without console errors
- [ ] Port to `test` branch once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)