### PR TITLE
fix(api): drop .slice typo on SwaggerUIStandalonePreset

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -816,7 +816,7 @@ const swaggerInitJs = `window.addEventListener('load', function () {
   window.ui = SwaggerUIBundle({
     url: '/openapi.json',
     dom_id: '#swagger-ui',
-    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset.slice],
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
     layout: 'BaseLayout',
     deepLinking: true,
   });


### PR DESCRIPTION
## Summary
- Ports #316 (swagger white-screen hotfix) from `main` back to `test` to keep branches converged.
- Single-line fix: `SwaggerUIStandalonePreset.slice` → `SwaggerUIStandalonePreset` in inline `swagger-init.js`.

## Test plan
- [x] Cherry-pick of `61ec968f` (#316) merge commit
- [ ] CI green on `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)