### PR TITLE
fix(api): allow vercel.live in CSP for Toolbar/feedback widget

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -216,19 +216,20 @@ logger.info('CORS origins loaded', { origins: corsOrigins, count: corsOrigins.le
 // Vercel Live (preview/prod Toolbar) needs vercel.live in CSP for feedback widget.
 const strict = SecurityPresets.strict();
 const strictCsp = strict.contentSecurityPolicy;
-const strictWithVercelLive = {
-  ...strict,
-  contentSecurityPolicy: strictCsp
+const strictWithVercelLive =
+  strictCsp && typeof strictCsp === 'object'
     ? {
-        ...strictCsp,
-        scriptSrc: [...(strictCsp.scriptSrc ?? []), 'https://vercel.live'],
-        styleSrc: [...(strictCsp.styleSrc ?? []), 'https://vercel.live'],
-        imgSrc: [...(strictCsp.imgSrc ?? []), 'https://vercel.live'],
-        connectSrc: [...(strictCsp.connectSrc ?? []), 'https://vercel.live', 'wss://vercel.live'],
-        frameSrc: ['https://vercel.live'],
+        ...strict,
+        contentSecurityPolicy: {
+          ...strictCsp,
+          scriptSrc: [...(strictCsp.scriptSrc ?? []), 'https://vercel.live'],
+          styleSrc: [...(strictCsp.styleSrc ?? []), 'https://vercel.live'],
+          imgSrc: [...(strictCsp.imgSrc ?? []), 'https://vercel.live'],
+          connectSrc: [...(strictCsp.connectSrc ?? []), 'https://vercel.live', 'wss://vercel.live'],
+          frameSrc: ['https://vercel.live'],
+        },
       }
-    : undefined,
-};
+    : strict;
 const securityPreset =
   process.env.NODE_ENV?.trim() === 'production'
     ? strictWithVercelLive

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -213,9 +213,25 @@ const corsOrigins = getCorsOrigins();
 logger.info('CORS origins loaded', { origins: corsOrigins, count: corsOrigins.length });
 
 // Security headers (environment-appropriate preset)
+// Vercel Live (preview/prod Toolbar) needs vercel.live in CSP for feedback widget.
+const strict = SecurityPresets.strict();
+const strictCsp = strict.contentSecurityPolicy;
+const strictWithVercelLive = {
+  ...strict,
+  contentSecurityPolicy: strictCsp
+    ? {
+        ...strictCsp,
+        scriptSrc: [...(strictCsp.scriptSrc ?? []), 'https://vercel.live'],
+        styleSrc: [...(strictCsp.styleSrc ?? []), 'https://vercel.live'],
+        imgSrc: [...(strictCsp.imgSrc ?? []), 'https://vercel.live'],
+        connectSrc: [...(strictCsp.connectSrc ?? []), 'https://vercel.live', 'wss://vercel.live'],
+        frameSrc: ['https://vercel.live'],
+      }
+    : undefined,
+};
 const securityPreset =
   process.env.NODE_ENV?.trim() === 'production'
-    ? SecurityPresets.strict()
+    ? strictWithVercelLive
     : SecurityPresets.development();
 const securityHeaders = new SecurityHeaders(securityPreset);
 


### PR DESCRIPTION
## Summary
- Unblocks Vercel Live feedback widget on https://api.revealui.com/docs by adding `https://vercel.live` (+ `wss://vercel.live`) to `script-src`, `style-src`, `img-src`, `connect-src`, and `frame-src`.
- Scoped to the API's production preset only — does not modify the shared `SecurityPresets.strict` default, so other apps are unaffected.

## Test plan
- [x] `pnpm --filter api build` clean
- [ ] After deploy: https://api.revealui.com/docs shows no feedback.js CSP violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)