### PR TITLE
docs: generalize founder-specific mount paths + plan hub references

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,8 +1,7 @@
 # RevealUI Master Plan
 
-> **AGENTS:** This is the PUBLIC snapshot. The canonical, up-to-date version is at:
-> `~/projects/revealui-jv/docs/MASTER_PLAN.md`
-> Always read and update the private repo version. This file is synced periodically.
+> **AGENTS:** This is the PUBLIC snapshot. The canonical, up-to-date version lives in the internal planning hub.
+> Always read and update the internal version. This file is synced periodically.
 
 **Last Updated:** 2026-03-30 (Refactored  -  split into MASTER_PLAN + ARCHITECTURE + archive)
 **Status:** Public snapshot  -  canonical version in revealui-jv

--- a/docs/agent-rules/safety.md
+++ b/docs/agent-rules/safety.md
@@ -10,8 +10,8 @@ Rules for protecting sensitive files, credentials, and system paths in the Revea
 
 ## Protected Paths  -  Never Edit
 
-- `/mnt/c/`  -  Windows C: drive (read-only mirror)
-- `/mnt/e/`  -  LTS backup drive (read-only)
+- Windows host mounts (typically `/mnt/c/`)  -  read-only mirror
+- LTS backup drive (typically `/mnt/e/`, configurable via `$LTS_ROOT`)  -  read-only
 - System directories: `/etc/`, `/usr/`, `/var/`
 - Credential directories: `~/.ssh/`, `~/.gnupg/`, `~/.aws/`
 

--- a/docs/security/BACKUP_VERIFICATION.md
+++ b/docs/security/BACKUP_VERIFICATION.md
@@ -27,7 +27,7 @@ Restore drills are conducted quarterly. Each drill validates at least one data s
 | **npm packages** | Published to npm registry | Every release | Indefinite (immutable once published) | npm registry | RevealUI Studio |
 | **Vercel deployments** | Immutable deployment artifacts | Every deploy | 30 days (preview), indefinite (production) | Vercel cloud | Vercel (managed) |
 | **CI/CD configuration** | Git-tracked (`.github/workflows/`) | Every push | Indefinite (full history) | GitHub | RevealUI Studio |
-| **LTS drive mirror** | rsync from WSL | Weekly (manual, `pnpm sync-lts`) | 3 most recent snapshots | External drive (E: / /mnt/e) | RevealUI Studio |
+| **LTS drive mirror** | rsync from WSL | Weekly (manual, `pnpm sync-lts`) | 3 most recent snapshots | External drive mounted at `$LTS_ROOT` | RevealUI Studio |
 
 ### 2.2 What Is Not Backed Up
 
@@ -55,6 +55,8 @@ These items are excluded by design, with justification:
 ## 4. Quarterly Restore Drill Procedure
 
 Each quarter, test at least one data store from the rotation schedule below. Over four quarters, all stores must be tested at least once.
+
+**Path conventions used below:** `$LTS_ROOT` is the operator's LTS mirror mount (set in your environment; the reference operator uses `/mnt/e`). Substitute your own mount point throughout.
 
 ### 4.1 Rotation Schedule
 
@@ -233,7 +235,7 @@ Each quarter, test at least one data store from the rotation schedule below. Ove
 
 1. Copy the RevVault backup from LTS to a temporary location:
    ```bash
-   cp -r /mnt/e/professional/RevealUI/.revvault /tmp/revvault-drill/
+   cp -r $LTS_ROOT/professional/RevealUI/.revvault /tmp/revvault-drill/
    ```
 
 2. List available secrets (without decrypting):
@@ -296,17 +298,17 @@ Each quarter, test at least one data store from the rotation schedule below. Ove
 
 1. Verify the LTS drive is mounted and accessible:
    ```bash
-   ls /mnt/e/professional/RevealUI/
+   ls $LTS_ROOT/professional/RevealUI/
    ```
 
 2. Check the sync timestamp:
    ```bash
-   stat /mnt/e/professional/RevealUI/.git/FETCH_HEAD
+   stat $LTS_ROOT/professional/RevealUI/.git/FETCH_HEAD
    ```
 
 3. Clone from the LTS mirror to a temporary directory:
    ```bash
-   git clone /mnt/e/professional/RevealUI /tmp/lts-restore-drill
+   git clone $LTS_ROOT/professional/RevealUI /tmp/lts-restore-drill
    cd /tmp/lts-restore-drill
    ```
 

--- a/packages/harnesses/src/content/definitions/rules/agent-dispatch.ts
+++ b/packages/harnesses/src/content/definitions/rules/agent-dispatch.ts
@@ -29,7 +29,7 @@ too large or specialized for the current session.
 1. Don't spawn a profile for work that takes under 15 minutes in the current session.
 2. Check the workboard before spawning  -  another agent may already own that area.
 3. Always give spawned agents:
-   - Current phase from \`~/projects/revealui-jv/docs/MASTER_PLAN.md\`
+   - Current phase from the internal planning hub's MASTER_PLAN.md
    - Relevant workboard state
    - The specific task and acceptance criteria
 4. Spawned agents report findings back to the parent. Only the parent updates MASTER_PLAN.md.

--- a/packages/harnesses/src/content/definitions/skills/revealui-safety.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-safety.ts
@@ -23,7 +23,7 @@ Follow these rules for ALL code changes in the RevealUI monorepo.
 
 ## Protected Paths  -  Never Edit
 
-- \`/mnt/c/\`, \`/mnt/e/\`  -  Windows mounts (read-only)
+- Windows host mounts (typically \`/mnt/c/\`) and the LTS backup mount (\`$LTS_ROOT\`, typically \`/mnt/e/\`)  -  read-only
 - System/credential directories: \`/etc/\`, \`~/.ssh/\`, \`~/.gnupg/\`, \`~/.aws/\`
 
 ## Import Boundaries

--- a/scripts/dev-tools/Dismount-WSLDev.ps1
+++ b/scripts/dev-tools/Dismount-WSLDev.ps1
@@ -1,19 +1,23 @@
 <#
 .SYNOPSIS
-    Safely ejects the WSL dev drive (Forge — ext4 USB SSD at /mnt/forge).
+    Safely ejects a WSL dev drive (portable ext4 USB SSD, e.g. Forge).
 
 .DESCRIPTION
-    Stops services that use /mnt/forge, verifies no open file handles,
+    Stops services that use the mount point, verifies no open file handles,
     flushes the filesystem, unmounts inside WSL, then unmounts the physical
     disk from Windows so it is safe to physically disconnect.
 
 .PARAMETER DiskNumber
-    Windows disk number of the Forge drive. If omitted, the script attempts
+    Windows disk number of the dev drive. If omitted, the script attempts
     to auto-detect by matching the disk serial / mount point.
+
+.PARAMETER MountPoint
+    WSL mount point for the dev drive. Defaults to `/mnt/forge`.
 
 .EXAMPLE
     .\Dismount-WSLDev.ps1
     .\Dismount-WSLDev.ps1 -DiskNumber 2
+    .\Dismount-WSLDev.ps1 -MountPoint /mnt/devdrive
 
 .NOTES
     To add to RevealUI.DevEnv module:
@@ -32,7 +36,10 @@
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter()]
-    [int] $DiskNumber = -1
+    [int] $DiskNumber = -1,
+
+    [Parameter()]
+    [string] $MountPoint = '/mnt/forge'
 )
 
 Set-StrictMode -Version Latest
@@ -67,13 +74,13 @@ function Invoke-Wsl {
 }
 
 # ---------------------------------------------------------------------------
-# Step 1: Stop services using /mnt/forge
+# Step 1: Stop services using the dev mount
 # ---------------------------------------------------------------------------
 
-Write-Host "`nDismount-WSLDev: Safe Forge drive eject" -ForegroundColor White
+Write-Host "`nDismount-WSLDev: Safe dev-drive eject ($MountPoint)" -ForegroundColor White
 Write-Host "----------------------------------------" -ForegroundColor DarkGray
 
-Write-Step "Stopping services on /mnt/forge..."
+Write-Step "Stopping services on $MountPoint..."
 
 $services = @(
     @{ name = 'postgres'; cmd = @('sudo', 'systemctl', 'stop', 'postgresql') },
@@ -95,9 +102,9 @@ foreach ($svc in $services) {
 # Step 2: Check for open file handles
 # ---------------------------------------------------------------------------
 
-Write-Step "Checking for open file handles on /mnt/forge..."
+Write-Step "Checking for open file handles on $MountPoint..."
 
-$openFiles = Invoke-Wsl @('lsof', '+D', '/mnt/forge', '-t') 2>$null
+$openFiles = Invoke-Wsl @('lsof', '+D', $MountPoint, '-t') 2>$null
 if ($openFiles -and $openFiles.Trim()) {
     $pids = ($openFiles.Trim() -split "`n") | Where-Object { $_ -match '^\d+$' }
     Write-Warn "$($pids.Count) process(es) still have open handles:"
@@ -113,7 +120,7 @@ if ($openFiles -and $openFiles.Trim()) {
     }
 }
 else {
-    Write-Success "No open file handles on /mnt/forge"
+    Write-Success "No open file handles on $MountPoint"
 }
 
 # ---------------------------------------------------------------------------
@@ -128,10 +135,10 @@ Write-Success "Filesystem synced"
 # Step 4: Unmount inside WSL
 # ---------------------------------------------------------------------------
 
-Write-Step "Unmounting /mnt/forge inside WSL..."
+Write-Step "Unmounting $MountPoint inside WSL..."
 try {
-    Invoke-Wsl @('sudo', 'umount', '/mnt/forge') | Out-Null
-    Write-Success "/mnt/forge unmounted"
+    Invoke-Wsl @('sudo', 'umount', $MountPoint) | Out-Null
+    Write-Success "$MountPoint unmounted"
 }
 catch {
     Write-Warn "umount reported an error (drive may already be unmounted): $_"


### PR DESCRIPTION
## Summary
- Replace hardcoded operator paths (`~/projects/an internal repo/...`, `/mnt/e/professional/...`, `/mnt/forge`) in public docs, rule content, and dev tooling
- Introduce `\$LTS_ROOT` convention for backup-drill + safety-rule paths
- Parameterize `Dismount-WSLDev.ps1` with a `-MountPoint` flag (defaults preserved)
- Reword plan references to a neutral "internal planning hub" description

Contributors and operators can now run the docs/scripts against their own mount layout without editing paths. No behavior change.

## Test plan
- [ ] CI gate passes (lint, typecheck, tests, build)
- [ ] CodeQL clean (no scanner impact — doc + param-default changes)
- [ ] Manual spot check: \`Dismount-WSLDev.ps1 -MountPoint /mnt/custom\` substitutes correctly in \`lsof\` / \`umount\` calls