### PR TITLE
docs(system-tune): seed wsl-low-ram profile + 2026-04-13 postmortem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.
 
 ## Current Phase
-**Phase 3  -  Launch Preparation** (docs, OSS prep, marketing, Pro distribution).
+**Phase 5  -  Agent-First Infrastructure** (post-Phase 4). See `docs/MASTER_PLAN.md` for the active 5.x tracks.
 
 ## Stack
 - React 19, Next.js 16, Node 24, TypeScript 6

--- a/docs/system-tune/CRASH-POSTMORTEMS.md
+++ b/docs/system-tune/CRASH-POSTMORTEMS.md
@@ -1,0 +1,56 @@
+# System Tune — Crash Postmortems
+
+Canonical crash/incident log that seeds the `@revealui/system-tune` profile matrix. Every entry here should trace to a concrete profile adjustment in `profiles/*.json` so new users never debug the same class of failure.
+
+---
+
+## 2026-04-13 — WSL 7.3 GB host crash loop
+
+**Host:** Windows 11, 7.3 GB physical RAM, 6 logical cores. WSL2 Ubuntu 24.04.
+**Symptom:** WSL VM crashed three times inside 20 minutes during a multi-package Vitest run. Each crash killed the session mid-command; systemd logged nothing useful because the VM died with the journal.
+
+**Trigger:** Running `pnpm vitest run --reporter=verbose` at the monorepo root. The root vitest config auto-sized workers to 4 and loaded all 862 test files in a single vitest process, pushing RSS past 5 GB.
+
+**Root cause chain:**
+1. Default `.wslconfig` let the VM claim ~80% of host RAM (~6 GB).
+2. Once the VM hit ~5 GB working set, Windows started host-side memory reclaim on the VM.
+3. `[experimental] autoMemoryReclaim=dropcache` made the VM aggressively drop page cache under that pressure, stalling I/O.
+4. `vmIdleTimeout` left idle auto-pause on — paused/resumed VMs saw "time jumped backwards" clock skew, which correlated 1:1 with the crash timestamps.
+5. Net result: host pressure + cache drop + clock skew → VM kill.
+
+**Fix (applied to host `.wslconfig`):**
+- `memory=4GB` (leaves ~3 GB for Windows)
+- `vmIdleTimeout=-1` (disable idle auto-pause)
+- Removed `[experimental] autoMemoryReclaim=dropcache`
+- Kept `networkingMode=nat` (reverted from `mirrored` 2026-03-22 after a separate 0x80072746 WinSock crash class)
+
+**Fix (applied inside VM):**
+- `earlyoom -m 15,8 -s 15,8 --prefer '(turbo|biome|vitest|tsc|esbuild)' -r 10` — kills runaway dev tools before the kernel OOM-killer hits system processes.
+- Docker Desktop autostart disabled; start on demand with `sudo systemctl start docker`.
+
+**Workflow fix (applied to this session):**
+- Replaced root `pnpm vitest run` with serial per-package `pnpm --filter <pkg> test` loop (`/tmp/test-logs/run-all.sh`). One vitest process at a time caps memory at ~1 GB per package, well under the 4 GB WSL cap.
+- Incidentally this also surfaced that root `pnpm vitest run` ignores per-package vitest configs (jsdom env, setup files, etc.), so the 1139 "failures" reported at root level were false alarms. Real failure count: 1 flaky timeout test in `@revealui/ai`, already patched.
+
+**Profile entry:** `profiles/wsl-low-ram.json` captures the exact values above as the `wsl-low-ram` profile. It is the seed baseline for the `@revealui/system-tune` detection+apply pipeline (Phase 5.17).
+
+**Prevention (future work, tracked in master plan 5.17):**
+- `revealui system scan` should detect `hostRamGb <= 8 && platform == wsl2 && wslconfig.memory undefined` and apply this profile before a new user ever hits a test run.
+- Studio first-run wizard should offer to apply it after detecting the same signature.
+- CI snapshot on WSL runner to catch drift if defaults ever regress.
+
+---
+
+## Template for new entries
+
+```
+## YYYY-MM-DD — short title
+
+**Host:** platform, specs.
+**Symptom:** what the user saw.
+**Trigger:** what they ran.
+**Root cause chain:** numbered list from trigger to failure.
+**Fix:** what changed, and where.
+**Profile entry:** which `profiles/*.json` encodes the fix.
+**Prevention:** what `@revealui/system-tune` should do automatically.
+```

--- a/profiles/wsl-low-ram.json
+++ b/profiles/wsl-low-ram.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../docs/system-tune/profile.schema.json",
+  "id": "wsl-low-ram",
+  "version": 1,
+  "name": "WSL2 on low-RAM Windows host",
+  "description": "Tuned for Windows hosts with <=8 GB RAM running WSL2. Leaves enough memory for the host to avoid host-side memory reclaim, which was causing VM crash loops. Seeded from the 2026-04-13 crash post-mortem.",
+  "match": {
+    "platform": "wsl2",
+    "hostRamGb": { "max": 8 }
+  },
+  "apply": {
+    "wslconfig": {
+      "memory": "4GB",
+      "processors": 6,
+      "swap": "6GB",
+      "vmIdleTimeout": -1,
+      "kernelCommandLine": "systemd.firstboot=0",
+      "autoMemoryReclaim": null,
+      "networkingMode": "nat"
+    },
+    "earlyoom": {
+      "mem": "15,8",
+      "swap": "15,8",
+      "prefer": "(turbo|biome|vitest|tsc|esbuild)",
+      "report": 10
+    },
+    "docker": {
+      "autostart": false,
+      "onDemand": true
+    },
+    "node": {
+      "maxOldSpaceSizeMb": 3072
+    },
+    "pnpm": {
+      "childConcurrency": 2
+    },
+    "turbo": {
+      "concurrency": 2
+    },
+    "vitest": {
+      "poolOptions": {
+        "threads": {
+          "maxThreads": 2
+        }
+      }
+    }
+  },
+  "rationale": {
+    "memory": "Host has ~7.3 GB; WSL claiming >=5 GB starves Windows and triggers host-side memory reclaim, which kills the VM. 4 GB leaves ~3 GB headroom.",
+    "vmIdleTimeout": "Idle auto-pause produced 'time jumped backwards' clock skew that correlated 1:1 with mid-session crashes on 2026-04-13. Disabling removes the trigger.",
+    "autoMemoryReclaim": "Experimental 'dropcache' was aggressively dropping VM cache under host pressure, stalling the VM. Removed 2026-04-13.",
+    "networkingMode": "Reverted from 'mirrored' to default 'nat' 2026-03-22 — mirrored mode caused 0x80072746 WinSock crashes.",
+    "earlyoomPrefer": "Kills runaway dev tools (turbo/biome/vitest/tsc/esbuild) before system processes when memory pressure hits 15% / swap 8%.",
+    "dockerAutostart": "Docker Desktop on <8 GB hosts doubles memory pressure even when idle. On-demand start via `sudo systemctl start docker` keeps the cost opt-in.",
+    "concurrency": "Two-worker pools keep parallel vitest/turbo/pnpm runs under the 4 GB cap with headroom for node_modules resolution."
+  },
+  "backups": {
+    "path": "~/.revealui/system-tune/backups/{timestamp}/",
+    "files": [
+      "/mnt/c/Users/{user}/.wslconfig",
+      "/etc/default/earlyoom"
+    ]
+  },
+  "origin": {
+    "incidentDate": "2026-04-13",
+    "postmortem": "docs/system-tune/CRASH-POSTMORTEMS.md#2026-04-13-wsl-73-gb-host-crash-loop"
+  }
+}

--- a/profiles/wsl-low-ram.json
+++ b/profiles/wsl-low-ram.json
@@ -56,10 +56,7 @@
   },
   "backups": {
     "path": "~/.revealui/system-tune/backups/{timestamp}/",
-    "files": [
-      "/mnt/c/Users/{user}/.wslconfig",
-      "/etc/default/earlyoom"
-    ]
+    "files": ["/mnt/c/Users/{user}/.wslconfig", "/etc/default/earlyoom"]
   },
   "origin": {
     "incidentDate": "2026-04-13",


### PR DESCRIPTION
## Summary
- Seeds `profiles/wsl-low-ram.json` — declarative .wslconfig + earlyoom + concurrency profile that resolved the 2026-04-13 crash loop, ready for the 5.17 detection/apply pipeline.
- Adds `docs/system-tune/CRASH-POSTMORTEMS.md` with the incident writeup.
- Bumps CLAUDE.md Current Phase (Phase 3 complete; Phase 5 Agent-First Infrastructure is current).

Completes two 5.17 checklist items:
- profiles/wsl-low-ram.json
- docs/system-tune/CRASH-POSTMORTEMS.md (seeded with 2026-04-13 incident)

Grouping (b) of the backup/test-local-2026-04-13 split; grouping (a) landed as #321, (c) follows.

## Test plan
- [ ] CI green (Build, Typecheck, Quality, Security Gate)
- [ ] Verify profile JSON parses (no schema yet — 5.17 pipeline will add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)