### PR TITLE
fix(ai): bump flaky test-runner timeout budget

### DIFF
--- a/packages/ai/src/__tests__/tools/coding/test-runner.test.ts
+++ b/packages/ai/src/__tests__/tools/coding/test-runner.test.ts
@@ -140,12 +140,12 @@ describe('test_runner tool', () => {
       }),
     );
 
-    const result = await testRunnerTool.execute({ timeout: 1500 });
+    const result = await testRunnerTool.execute({ timeout: 4000 });
     expect(result.success).toBe(false);
     expect(result.error).toContain('timed out');
     rmSync(join(ROOT, 'block.js'), { force: true });
     rmSync(join(ROOT, 'pnpm-workspace.yaml'), { force: true });
-  }, 15_000);
+  }, 20_000);
 
   it('always includes data even on timeout', async () => {
     writeFileSync(


### PR DESCRIPTION
## Summary
- Bumps tool timeout from 1500ms → 4000ms and vitest budget to 20s on the `reports timeout when command exceeds limit` test.
- Low-RAM hosts can finish `node block.js` (or return the tool) inside the old 1500ms window, flipping `result.success` to `true` and failing the assertion. The new budget gives pnpm bootstrap enough headroom to deterministically hit the timeout path.

Grouping (c) of the backup/test-local-2026-04-13 split. Grouping (a) landed as #321, (b) is open as #324 (biome fix on profiles/wsl-low-ram.json folded into #324).

## Test plan
- [ ] CI green — `packages/ai` tests deterministic across runs
- [ ] No flakes on low-RAM runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)