### PR TITLE
feat(setup): hardware-aware system-tune (5.17)

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -585,14 +585,14 @@ Phase D  -  Agent publisher tools (agent):
 
 **When to start:** After Phase 5 ships. Seed profile = the exact 2026-04-13 WSL fix, captured as the "low-RAM WSL2" preset — so the first working baseline is the author's own machine.
 
-- [ ] Extract current WSL fix into a declarative profile (`profiles/wsl-low-ram.json`)
-- [ ] Build detection layer + platform adapters
-- [ ] Build plan generator (pure function: detected state → desired state → diff)
-- [ ] Build CLI (`revealui system scan` / `tune` / `revert`) with dry-run default
+- [x] Extract current WSL fix into a declarative profile (`profiles/wsl-low-ram.json`) (2026-04-15)
+- [x] Build detection layer + platform adapters (2026-04-15)
+- [x] Build plan generator (pure function: detected state → desired state → diff) (2026-04-15)
+- [x] Build CLI (`revealui system scan` / `tune` / `revert`) with dry-run default (2026-04-15)
 - [ ] Wire into Studio first-run wizard
 - [ ] Wire into Forge self-hosted install script
 - [ ] CI: run `revealui system scan --json` on Ubuntu / macOS / Windows runners and snapshot the detection output
-- [ ] Crash-postmortem doc seeded with the 2026-04-13 incident
+- [x] Crash-postmortem doc seeded with the 2026-04-13 incident (2026-04-15)
 
 **Exit criteria:** A user running `curl | sh` on a brand-new machine — Windows + WSL, bare Linux, macOS M-series, or low-RAM laptop — reaches a working RevealUI dev environment without hand-editing any system config file, and the setup is reproducible + reversible.
 

--- a/docs/system-tune/PROFILES.md
+++ b/docs/system-tune/PROFILES.md
@@ -1,0 +1,39 @@
+# System Tune Profiles
+
+Tuning profiles map a (platform, RAM bucket) pair to a set of safe defaults.
+Each profile is a JSON file in `packages/setup/src/system-tune/profiles/`.
+
+## Profile Matrix
+
+| Profile ID | Platform | RAM Range | Key Settings |
+|-----------|----------|-----------|--------------|
+| `wsl-low-ram` | WSL2 | ≤ 8 GB | memory=4GB, processors=2, swap=2GB, vmIdleTimeout=-1, earlyoom, Docker off |
+
+## WSL Low-RAM (seed profile)
+
+**ID:** `wsl-low-ram`
+**File:** `packages/setup/src/system-tune/profiles/wsl-low-ram.json`
+
+### Rationale
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `memory=4GB` | Hard cap | On a 7.3 GB host, the default ~6 GB allocation starves Windows (explorer, antimalware, Terminal). 4 GB gives WSL enough for Node 24 + turbo builds while leaving ~3 GB for Windows. |
+| `processors=2` | 2 logical | Limits CPU contention. On a 4-core host, 2 cores for WSL keeps the host responsive. |
+| `swap=2GB` | 2 GB | Provides overflow for memory spikes during `pnpm install` or parallel builds. |
+| `vmIdleTimeout=-1` | Never idle | Disables idle shutdown to prevent clock-skew bugs and `git` timestamp drift when the VM resumes. |
+| `autoMemoryReclaim=disabled` | Off | `dropcache` reclaim on host-pressure systems causes I/O stalls and OOM-like symptoms. Off is safer on low-RAM hosts. |
+| `networkingMode=mirrored` | Mirrored | Shares the host network stack — simplifies port forwarding for dev servers. |
+| `NODE_OPTIONS --max-old-space-size=2048` | 2 GB | Prevents Node from claiming all available RAM during TypeScript compilation or Vitest runs. |
+| `pnpm child-concurrency=2` | 2 | Limits parallel package installs to avoid memory spikes. |
+| `turbo concurrency=2` | 2 | Limits parallel task execution in Turborepo. |
+| `vitest maxThreads=2` | 2 | Prevents Vitest from spawning too many worker threads. |
+| `earlyoom` | 5% mem, 10% swap | Kills memory hogs before the kernel OOM killer freezes the system. Prefers dev tools (turbo, biome, vitest, tsc, esbuild). |
+| `Docker autostart=false` | Off | Docker daemon + containerd use ~200-400 MB at idle. On-demand via `sudo systemctl start docker`. |
+
+## Adding New Profiles
+
+1. Create a JSON file in `packages/setup/src/system-tune/profiles/`
+2. Follow the `TuneProfile` schema (see `types.ts`)
+3. Import and add to the `PROFILES` array in `profiles.ts` (most specific first)
+4. Document the profile in this file with a rationale table

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,11 @@ import {
   runDevUpCommand,
 } from './commands/dev.js';
 import { runDoctorCommand } from './commands/doctor.js';
+import {
+  runSystemRevertCommand,
+  runSystemScanCommand,
+  runSystemTuneCommand,
+} from './commands/system.js';
 import { runTerminalInstallCommand, runTerminalListCommand } from './commands/terminal.js';
 
 const cliRequire = createRequire(import.meta.url);
@@ -325,6 +330,35 @@ export function createCli(): Command {
     .option('--json', 'Output machine-readable JSON', false)
     .action(async (options: { json?: boolean }) => {
       await runTerminalListCommand(options);
+    });
+
+  const system = program
+    .command('system')
+    .description('Hardware-aware system tuning for RevealUI development');
+
+  system
+    .command('scan')
+    .description('Read-only scan of host hardware and platform')
+    .option('--json', 'Output machine-readable JSON', false)
+    .action(async (options: { json?: boolean }) => {
+      await runSystemScanCommand(options);
+    });
+
+  system
+    .command('tune')
+    .description('Generate and apply a tuning plan for this machine')
+    .option('--json', 'Output machine-readable JSON plan', false)
+    .option('--dry-run', 'Show the plan without applying changes', false)
+    .option('-y, --yes', 'Apply without confirmation', false)
+    .action(async (options: { json?: boolean; dryRun?: boolean; yes?: boolean }) => {
+      await runSystemTuneCommand(options);
+    });
+
+  system
+    .command('revert')
+    .description('Revert a previously applied tuning plan from backup')
+    .action(async () => {
+      await runSystemRevertCommand();
     });
 
   program

--- a/packages/cli/src/commands/system.ts
+++ b/packages/cli/src/commands/system.ts
@@ -1,0 +1,162 @@
+/**
+ * CLI Commands: system scan / system tune / system revert
+ *
+ * Hardware-aware auto-config for RevealUI development environments.
+ */
+
+import type { PlanAction, TunePlan } from '@revealui/setup/system-tune';
+import { detectSystem, generateAutoplan, matchProfile } from '@revealui/setup/system-tune';
+import { createLogger } from '@revealui/setup/utils';
+
+const logger = createLogger({ prefix: 'System' });
+
+// =============================================================================
+// Formatting
+// =============================================================================
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  return `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+function formatAction(action: PlanAction, index: number): string {
+  const lines = [`  ${index + 1}. ${action.description}`, `     Target: ${action.target}`];
+  if (action.current) lines.push(`     Current: ${action.current}`);
+  lines.push(`     Desired: ${action.desired}`);
+  if (action.privileged) lines.push(`     ⚠ Requires elevated privileges (sudo)`);
+  return lines.join('\n');
+}
+
+function formatPlan(plan: TunePlan): string {
+  const lines = [
+    '',
+    '════════════════════════════════════════════════',
+    '  RevealUI System Tune Plan',
+    '════════════════════════════════════════════════',
+    '',
+    `  Profile: ${plan.profileId}`,
+    `  Platform: ${plan.system.platformClass}`,
+    `  RAM: ${formatBytes(plan.system.memory.totalBytes)} total, ${formatBytes(plan.system.memory.freeBytes)} free`,
+    `  CPU: ${plan.system.cpu.logicalCores} cores (${plan.system.cpu.physicalCores} physical)`,
+    `  Disk: ${formatBytes(plan.system.disk.freeBytes)} free of ${formatBytes(plan.system.disk.totalBytes)}`,
+    '',
+  ];
+
+  if (plan.isNoop) {
+    lines.push('  ✓ System is already tuned — no changes needed.');
+  } else {
+    lines.push(`  ${plan.actions.length} action(s):`);
+    lines.push('');
+    for (let i = 0; i < plan.actions.length; i++) {
+      lines.push(formatAction(plan.actions[i], i));
+      lines.push('');
+    }
+  }
+
+  lines.push('════════════════════════════════════════════════');
+  return lines.join('\n');
+}
+
+function formatScanReport(system: ReturnType<typeof detectSystem>): string {
+  const lines = [
+    '',
+    `  Platform:   ${system.platformClass}`,
+    `  OS:         ${system.os.distro ?? `${system.os.platform} ${system.os.release}`}`,
+    `  Arch:       ${system.os.arch}`,
+    `  RAM:        ${formatBytes(system.memory.totalBytes)} total, ${formatBytes(system.memory.freeBytes)} free`,
+    `  Swap:       ${formatBytes(system.memory.swapTotalBytes)} total`,
+    `  CPU:        ${system.cpu.model}`,
+    `  Cores:      ${system.cpu.logicalCores} logical, ${system.cpu.physicalCores} physical`,
+    `  Disk:       ${formatBytes(system.disk.freeBytes)} free of ${formatBytes(system.disk.totalBytes)}`,
+    '',
+    '  Existing configs:',
+    `    .wslconfig:    ${system.existingConfigs.wslconfig ? 'found' : 'not found'}`,
+    `    earlyoom:      ${system.existingConfigs.earlyoom ? 'enabled' : 'not enabled'}`,
+    `    Docker auto:   ${system.existingConfigs.dockerAutostart ? 'enabled' : 'disabled'}`,
+    `    NODE_OPTIONS:  ${system.existingConfigs.nodeOptions ?? '(not set)'}`,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+// =============================================================================
+// Commands
+// =============================================================================
+
+export interface SystemScanOptions {
+  json?: boolean;
+}
+
+/** Read-only system scan — report hardware and platform detection. */
+export async function runSystemScanCommand(options: SystemScanOptions): Promise<void> {
+  const system = detectSystem();
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(system, null, 2)}\n`);
+    return;
+  }
+
+  logger.header('System Scan');
+  process.stdout.write(`${formatScanReport(system)}\n`);
+
+  const profile = matchProfile(system);
+  if (profile) {
+    process.stdout.write(`  Matching profile: ${profile.name} (${profile.id})\n`);
+    process.stdout.write(`  Run 'revealui system tune' to apply.\n`);
+  } else {
+    process.stdout.write('  No matching profile — system looks well-configured.\n');
+  }
+}
+
+export interface SystemTuneOptions {
+  json?: boolean;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/** Generate and optionally apply a tuning plan. */
+export async function runSystemTuneCommand(options: SystemTuneOptions): Promise<void> {
+  const system = detectSystem();
+  const plan = generateAutoplan(system);
+
+  if (!plan) {
+    if (options.json) {
+      process.stdout.write(
+        `${JSON.stringify({ status: 'no-match', message: 'No matching profile' })}\n`,
+      );
+      return;
+    }
+    logger.info(
+      'No matching tuning profile for this system. Run `revealui system scan` for details.',
+    );
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${formatPlan(plan)}\n`);
+
+  if (plan.isNoop) return;
+
+  if (options.dryRun) {
+    process.stdout.write('  (dry-run mode — no changes applied)\n');
+    return;
+  }
+
+  // Apply is not yet implemented — this is the detection + plan phase
+  logger.info('Automatic apply is not yet implemented.');
+  logger.info('Apply the changes above manually, or re-run with --json to pipe to automation.');
+}
+
+/** Revert a previously applied tuning plan from backup. */
+export async function runSystemRevertCommand(): Promise<void> {
+  // Placeholder — revert requires the apply phase to have stored backups
+  logger.info('System revert is not yet implemented.');
+  logger.info(
+    'Backups will be stored in ~/.revealui/system-tune/backups/ once apply is available.',
+  );
+}

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -54,6 +54,10 @@
     "./bootstrap": {
       "types": "./dist/bootstrap/index.d.ts",
       "import": "./dist/bootstrap/index.js"
+    },
+    "./system-tune": {
+      "types": "./dist/system-tune/index.d.ts",
+      "import": "./dist/system-tune/index.js"
     }
   },
   "files": [

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -12,6 +12,8 @@
 export * from './bootstrap/index.js';
 // Environment setup
 export * from './environment/index.js';
+// System Tune (hardware-aware auto-config)
+export * from './system-tune/index.js';
 // Utilities
 export * from './utils/index.js';
 // Validators

--- a/packages/setup/src/system-tune/detect.ts
+++ b/packages/setup/src/system-tune/detect.ts
@@ -1,0 +1,243 @@
+/**
+ * System Detection Layer
+ *
+ * Scans the host's hardware and platform to produce a SystemInfo snapshot.
+ * This is the "read" side — no mutations, only observation.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { arch, cpus, freemem, homedir, platform, release, totalmem } from 'node:os';
+import { join } from 'node:path';
+import type { PlatformClass, SystemInfo } from './types.js';
+
+// =============================================================================
+// Platform Detection
+// =============================================================================
+
+function detectPlatformClass(): PlatformClass {
+  const p = platform();
+
+  if (p === 'linux') {
+    // Check for WSL2
+    try {
+      const procVersion = readFileSync('/proc/version', 'utf8').toLowerCase();
+      if (procVersion.includes('microsoft') || procVersion.includes('wsl')) {
+        return 'wsl2';
+      }
+    } catch {
+      // Not available — continue
+    }
+
+    // Check for Docker/container
+    try {
+      if (existsSync('/.dockerenv')) return 'docker';
+      const cgroup = readFileSync('/proc/1/cgroup', 'utf8');
+      if (cgroup.includes('docker') || cgroup.includes('containerd')) return 'docker';
+    } catch {
+      // Not available — continue
+    }
+
+    // Check for cloud VM (common indicators)
+    try {
+      const dmiProduct = readFileSync('/sys/class/dmi/id/product_name', 'utf8')
+        .trim()
+        .toLowerCase();
+      if (
+        dmiProduct.includes('virtual') ||
+        dmiProduct.includes('kvm') ||
+        dmiProduct.includes('xen') ||
+        dmiProduct.includes('hvm')
+      ) {
+        return 'cloud-vm';
+      }
+    } catch {
+      // Not available — bare metal or restricted
+    }
+
+    return 'linux';
+  }
+
+  if (p === 'darwin') return 'macos';
+  if (p === 'win32') return 'windows';
+  return 'unknown';
+}
+
+function detectDistro(): string | undefined {
+  try {
+    const osRelease = readFileSync('/etc/os-release', 'utf8');
+    const match = osRelease.match(/^PRETTY_NAME="?([^"\n]+)"?/m);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+// =============================================================================
+// Memory Detection
+// =============================================================================
+
+function detectMemory(): SystemInfo['memory'] {
+  const p = platform();
+
+  if (p === 'linux') {
+    try {
+      const meminfo = readFileSync('/proc/meminfo', 'utf8');
+      const parse = (key: string): number => {
+        const match = meminfo.match(new RegExp(`^${key}:\\s+(\\d+)`, 'm'));
+        return match ? Number.parseInt(match[1], 10) * 1024 : 0; // kB → bytes
+      };
+      return {
+        totalBytes: parse('MemTotal'),
+        freeBytes: parse('MemAvailable') || parse('MemFree'),
+        swapTotalBytes: parse('SwapTotal'),
+        swapFreeBytes: parse('SwapFree'),
+      };
+    } catch {
+      // Fallback to Node.js APIs
+    }
+  }
+
+  return {
+    totalBytes: totalmem(),
+    freeBytes: freemem(),
+    swapTotalBytes: 0,
+    swapFreeBytes: 0,
+  };
+}
+
+// =============================================================================
+// CPU Detection
+// =============================================================================
+
+function detectCpu(): SystemInfo['cpu'] {
+  const cores = cpus();
+  const model = cores[0]?.model ?? 'unknown';
+  const logicalCores = cores.length;
+
+  // Physical cores: try platform-specific detection
+  let physicalCores = logicalCores;
+  const p = platform();
+  if (p === 'linux') {
+    try {
+      const output = execSync('grep "^cpu cores" /proc/cpuinfo | head -1', {
+        encoding: 'utf8',
+        timeout: 2000,
+      });
+      const match = output.match(/:\s*(\d+)/);
+      if (match) physicalCores = Number.parseInt(match[1], 10);
+    } catch {
+      // Fallback — use logical as estimate
+    }
+  } else if (p === 'darwin') {
+    try {
+      const output = execSync('sysctl -n hw.physicalcpu', { encoding: 'utf8', timeout: 2000 });
+      physicalCores = Number.parseInt(output.trim(), 10) || logicalCores;
+    } catch {
+      // Fallback
+    }
+  }
+
+  return { model, physicalCores, logicalCores };
+}
+
+// =============================================================================
+// Disk Detection
+// =============================================================================
+
+function detectDisk(): SystemInfo['disk'] {
+  const p = platform();
+  const target = process.cwd();
+
+  if (p === 'linux' || p === 'darwin') {
+    try {
+      const output = execSync(`df -B1 "${target}" | tail -1`, { encoding: 'utf8', timeout: 2000 });
+      const parts = output.trim().split(/\s+/);
+      // df -B1 columns: Filesystem 1B-blocks Used Available Use% Mounted
+      if (parts.length >= 4) {
+        return {
+          totalBytes: Number.parseInt(parts[1], 10) || 0,
+          freeBytes: Number.parseInt(parts[3], 10) || 0,
+        };
+      }
+    } catch {
+      // Fallback
+    }
+  }
+
+  return { totalBytes: 0, freeBytes: 0 };
+}
+
+// =============================================================================
+// Existing Config Detection
+// =============================================================================
+
+function detectExistingConfigs(): SystemInfo['existingConfigs'] {
+  const home = homedir();
+
+  // .wslconfig (Windows-side, but accessible from WSL via /mnt/c/Users/<user>/)
+  let wslconfig = false;
+  try {
+    // In WSL, check the Windows-side .wslconfig
+    const windowsUser = execSync('cmd.exe /c "echo %USERPROFILE%" 2>/dev/null', {
+      encoding: 'utf8',
+      timeout: 3000,
+    }).trim();
+    const wslPath = windowsUser
+      .replace(/\\/g, '/')
+      .replace(/^([A-Z]):/i, (_, d: string) => `/mnt/${d.toLowerCase()}`);
+    wslconfig = existsSync(join(wslPath, '.wslconfig'));
+  } catch {
+    wslconfig = existsSync(join(home, '.wslconfig'));
+  }
+
+  // earlyoom
+  let earlyoom = false;
+  try {
+    const result = execSync('systemctl is-enabled earlyoom 2>/dev/null', {
+      encoding: 'utf8',
+      timeout: 2000,
+    });
+    earlyoom = result.trim() === 'enabled';
+  } catch {
+    earlyoom = false;
+  }
+
+  // Docker autostart
+  let dockerAutostart = false;
+  try {
+    const result = execSync('systemctl is-enabled docker 2>/dev/null', {
+      encoding: 'utf8',
+      timeout: 2000,
+    });
+    dockerAutostart = result.trim() === 'enabled';
+  } catch {
+    dockerAutostart = false;
+  }
+
+  // NODE_OPTIONS
+  const nodeOptions = process.env.NODE_OPTIONS ?? null;
+
+  return { wslconfig, earlyoom, dockerAutostart, nodeOptions };
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/** Scan the current host and return a SystemInfo snapshot. */
+export function detectSystem(): SystemInfo {
+  return {
+    os: {
+      platform: platform(),
+      release: release(),
+      arch: arch(),
+      distro: detectDistro(),
+    },
+    platformClass: detectPlatformClass(),
+    memory: detectMemory(),
+    cpu: detectCpu(),
+    disk: detectDisk(),
+    existingConfigs: detectExistingConfigs(),
+  };
+}

--- a/packages/setup/src/system-tune/index.ts
+++ b/packages/setup/src/system-tune/index.ts
@@ -1,0 +1,19 @@
+/**
+ * System Tune — Hardware-Aware Auto-Config
+ *
+ * Detects host hardware/platform and generates a tuning plan.
+ * Pure detection + plan generation; CLI surface lives in @revealui/cli.
+ */
+
+export { detectSystem } from './detect.js';
+export { generateAutoplan, generatePlan, matchProfile } from './plan.js';
+export { PROFILES } from './profiles.js';
+export type {
+  PlanAction,
+  PlatformClass,
+  SystemInfo,
+  TunePlan,
+  TuneProfile,
+  TuneValues,
+  WslConfigTune,
+} from './types.js';

--- a/packages/setup/src/system-tune/plan.ts
+++ b/packages/setup/src/system-tune/plan.ts
@@ -1,0 +1,184 @@
+/**
+ * Plan Generator
+ *
+ * Pure function: (detected system state, profile) → plan of actions.
+ * No I/O — only computes the diff between current and desired state.
+ */
+
+import { PROFILES } from './profiles.js';
+import type { PlanAction, SystemInfo, TunePlan, TuneProfile } from './types.js';
+
+// =============================================================================
+// Profile Matching
+// =============================================================================
+
+/** Find the best matching profile for the detected system. */
+export function matchProfile(system: SystemInfo): TuneProfile | null {
+  const ramGb = system.memory.totalBytes / (1024 * 1024 * 1024);
+
+  for (const profile of PROFILES) {
+    if (profile.match.platform !== system.platformClass) continue;
+    if (profile.match.maxHostRamGb !== undefined && ramGb > profile.match.maxHostRamGb) continue;
+    if (profile.match.minHostRamGb !== undefined && ramGb < profile.match.minHostRamGb) continue;
+    return profile;
+  }
+
+  return null;
+}
+
+// =============================================================================
+// Action Generation
+// =============================================================================
+
+function generateWslActions(profile: TuneProfile, system: SystemInfo): PlanAction[] {
+  const actions: PlanAction[] = [];
+  const wsl = profile.tune.wslconfig;
+  if (!wsl) return actions;
+
+  const entries: Array<[string, string]> = [];
+  if (wsl.memory) entries.push(['memory', wsl.memory]);
+  if (wsl.processors !== undefined) entries.push(['processors', String(wsl.processors)]);
+  if (wsl.swap) entries.push(['swap', wsl.swap]);
+  if (wsl.vmIdleTimeout !== undefined) entries.push(['vmIdleTimeout', String(wsl.vmIdleTimeout)]);
+  if (wsl.autoMemoryReclaim) entries.push(['autoMemoryReclaim', wsl.autoMemoryReclaim]);
+  if (wsl.networkingMode) entries.push(['networkingMode', wsl.networkingMode]);
+
+  if (entries.length > 0) {
+    const desired = entries.map(([k, v]) => `${k}=${v}`).join(', ');
+    actions.push({
+      target: '.wslconfig [wsl2]',
+      current: system.existingConfigs.wslconfig ? '(exists, values unknown)' : null,
+      desired,
+      privileged: false,
+      description: `Set WSL2 config: ${desired}`,
+    });
+  }
+
+  return actions;
+}
+
+function generateNodeActions(profile: TuneProfile, system: SystemInfo): PlanAction[] {
+  const actions: PlanAction[] = [];
+  const node = profile.tune.node;
+  if (!node?.maxOldSpaceSize) return actions;
+
+  const desired = `--max-old-space-size=${node.maxOldSpaceSize}`;
+  const current = system.existingConfigs.nodeOptions;
+  const alreadySet = current?.includes('max-old-space-size') ?? false;
+
+  if (!alreadySet) {
+    actions.push({
+      target: 'NODE_OPTIONS',
+      current,
+      desired: current ? `${current} ${desired}` : desired,
+      privileged: false,
+      description: `Add ${desired} to NODE_OPTIONS in shell profile`,
+    });
+  }
+
+  return actions;
+}
+
+function generateEarlyoomActions(profile: TuneProfile, system: SystemInfo): PlanAction[] {
+  const actions: PlanAction[] = [];
+  const oom = profile.tune.earlyoom;
+  if (!oom?.enabled) return actions;
+
+  if (!system.existingConfigs.earlyoom) {
+    const args = [`-m ${oom.memThreshold ?? 5}`, `-s ${oom.swapThreshold ?? 10}`];
+    if (oom.prefer) args.push(`--prefer '${oom.prefer}'`);
+
+    actions.push({
+      target: '/etc/default/earlyoom',
+      current: null,
+      desired: `EARLYOOM_ARGS="${args.join(' ')}"`,
+      privileged: true,
+      description: `Install and configure earlyoom (kill memory hogs before OOM killer)`,
+    });
+  }
+
+  return actions;
+}
+
+function generateDockerActions(profile: TuneProfile, system: SystemInfo): PlanAction[] {
+  const actions: PlanAction[] = [];
+  const docker = profile.tune.docker;
+  if (docker === undefined) return actions;
+
+  if (!docker.autostart && system.existingConfigs.dockerAutostart) {
+    actions.push({
+      target: 'systemctl docker',
+      current: 'enabled (autostart)',
+      desired: 'disabled (on-demand via sudo systemctl start docker)',
+      privileged: true,
+      description: 'Disable Docker autostart to save ~200-400 MB RAM on boot',
+    });
+  }
+
+  return actions;
+}
+
+function generateConcurrencyActions(profile: TuneProfile): PlanAction[] {
+  const actions: PlanAction[] = [];
+
+  if (profile.tune.pnpm?.childConcurrency) {
+    actions.push({
+      target: '.npmrc or pnpm config',
+      current: null,
+      desired: `child-concurrency=${profile.tune.pnpm.childConcurrency}`,
+      privileged: false,
+      description: `Limit pnpm child concurrency to ${profile.tune.pnpm.childConcurrency}`,
+    });
+  }
+
+  if (profile.tune.turbo?.concurrency) {
+    actions.push({
+      target: 'turbo.json or TURBO_CONCURRENCY',
+      current: null,
+      desired: `concurrency=${profile.tune.turbo.concurrency}`,
+      privileged: false,
+      description: `Limit Turbo concurrency to ${profile.tune.turbo.concurrency}`,
+    });
+  }
+
+  if (profile.tune.vitest?.maxThreads) {
+    actions.push({
+      target: 'vitest.config poolOptions.threads.maxThreads',
+      current: null,
+      desired: `maxThreads=${profile.tune.vitest.maxThreads}`,
+      privileged: false,
+      description: `Limit Vitest threads to ${profile.tune.vitest.maxThreads}`,
+    });
+  }
+
+  return actions;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/** Generate a tuning plan from detected system state and a profile. */
+export function generatePlan(system: SystemInfo, profile: TuneProfile): TunePlan {
+  const actions: PlanAction[] = [
+    ...generateWslActions(profile, system),
+    ...generateNodeActions(profile, system),
+    ...generateEarlyoomActions(profile, system),
+    ...generateDockerActions(profile, system),
+    ...generateConcurrencyActions(profile),
+  ];
+
+  return {
+    profileId: profile.id,
+    system,
+    actions,
+    isNoop: actions.length === 0,
+  };
+}
+
+/** Detect system, find matching profile, and generate plan. */
+export function generateAutoplan(system: SystemInfo): TunePlan | null {
+  const profile = matchProfile(system);
+  if (!profile) return null;
+  return generatePlan(system, profile);
+}

--- a/packages/setup/src/system-tune/profiles.ts
+++ b/packages/setup/src/system-tune/profiles.ts
@@ -1,0 +1,12 @@
+/**
+ * Built-in Tuning Profiles
+ *
+ * Profiles are ordered by specificity — the first match wins.
+ * Add new profiles here, most specific first.
+ */
+
+// Seed profile: the exact 2026-04-13 WSL fix
+import wslLowRam from './profiles/wsl-low-ram.json' with { type: 'json' };
+import type { TuneProfile } from './types.js';
+
+export const PROFILES: TuneProfile[] = [wslLowRam as TuneProfile];

--- a/packages/setup/src/system-tune/profiles/wsl-low-ram.json
+++ b/packages/setup/src/system-tune/profiles/wsl-low-ram.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../profile-schema.json",
+  "id": "wsl-low-ram",
+  "name": "WSL2 Low-RAM Host",
+  "description": "Safe defaults for WSL2 on hosts with ≤8 GB RAM. Prevents the VM from starving Windows by capping memory, disabling aggressive reclaim, and keeping Docker off by default.",
+  "version": "0.1.0",
+  "origin": "2026-04-13 crash postmortem: WSL on 7.3 GB host claimed ~6 GB, starving Windows. Hand-authored fix captured as seed profile.",
+  "match": {
+    "platform": "wsl2",
+    "maxHostRamGb": 8
+  },
+  "tune": {
+    "wslconfig": {
+      "memory": "4GB",
+      "processors": 2,
+      "swap": "2GB",
+      "vmIdleTimeout": -1,
+      "autoMemoryReclaim": "disabled",
+      "networkingMode": "mirrored"
+    },
+    "node": {
+      "maxOldSpaceSize": 2048
+    },
+    "pnpm": {
+      "childConcurrency": 2
+    },
+    "turbo": {
+      "concurrency": 2
+    },
+    "vitest": {
+      "maxThreads": 2
+    },
+    "earlyoom": {
+      "enabled": true,
+      "memThreshold": 5,
+      "swapThreshold": 10,
+      "prefer": "turbo|biome|vitest|tsc|esbuild"
+    },
+    "docker": {
+      "autostart": false
+    }
+  }
+}

--- a/packages/setup/src/system-tune/types.ts
+++ b/packages/setup/src/system-tune/types.ts
@@ -1,0 +1,127 @@
+/**
+ * System Tune Types
+ *
+ * Shared types for hardware detection, tuning profiles, and plan generation.
+ */
+
+// =============================================================================
+// Platform Detection
+// =============================================================================
+
+export type PlatformClass =
+  | 'wsl2'
+  | 'linux'
+  | 'macos'
+  | 'windows'
+  | 'docker'
+  | 'cloud-vm'
+  | 'unknown';
+
+export interface SystemInfo {
+  /** OS/distro/kernel identification */
+  os: {
+    platform: NodeJS.Platform;
+    release: string;
+    arch: string;
+    distro?: string;
+  };
+  /** Detected platform class */
+  platformClass: PlatformClass;
+  /** Memory in bytes */
+  memory: {
+    totalBytes: number;
+    freeBytes: number;
+    swapTotalBytes: number;
+    swapFreeBytes: number;
+  };
+  /** CPU info */
+  cpu: {
+    model: string;
+    physicalCores: number;
+    logicalCores: number;
+  };
+  /** Disk info for the working directory */
+  disk: {
+    totalBytes: number;
+    freeBytes: number;
+  };
+  /** Existing configs already present */
+  existingConfigs: {
+    wslconfig: boolean;
+    earlyoom: boolean;
+    dockerAutostart: boolean;
+    nodeOptions: string | null;
+  };
+}
+
+// =============================================================================
+// Tuning Profile
+// =============================================================================
+
+export interface WslConfigTune {
+  memory?: string;
+  processors?: number;
+  swap?: string;
+  vmIdleTimeout?: number;
+  autoMemoryReclaim?: string;
+  networkingMode?: string;
+}
+
+export interface TuneValues {
+  wslconfig?: WslConfigTune;
+  node?: { maxOldSpaceSize?: number };
+  pnpm?: { childConcurrency?: number };
+  turbo?: { concurrency?: number };
+  vitest?: { maxThreads?: number };
+  earlyoom?: {
+    enabled?: boolean;
+    memThreshold?: number;
+    swapThreshold?: number;
+    prefer?: string;
+  };
+  docker?: { autostart?: boolean };
+  macos?: { maxFiles?: number; spotlightExclusions?: string[] };
+  windows?: { defenderExclusions?: string[]; longPaths?: boolean };
+}
+
+export interface TuneProfile {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  origin?: string;
+  match: {
+    platform: PlatformClass;
+    maxHostRamGb?: number;
+    minHostRamGb?: number;
+  };
+  tune: TuneValues;
+}
+
+// =============================================================================
+// Plan
+// =============================================================================
+
+export interface PlanAction {
+  /** What file or setting is being changed */
+  target: string;
+  /** What the current value is (null if not set) */
+  current: string | null;
+  /** What the new value will be */
+  desired: string;
+  /** Whether this requires elevated privileges */
+  privileged: boolean;
+  /** Human-readable description */
+  description: string;
+}
+
+export interface TunePlan {
+  /** Profile that generated this plan */
+  profileId: string;
+  /** Detected system info */
+  system: SystemInfo;
+  /** Actions to take */
+  actions: PlanAction[];
+  /** Whether all actions are no-ops (system already tuned) */
+  isNoop: boolean;
+}

--- a/packages/setup/tsup.config.ts
+++ b/packages/setup/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'utils/index': 'src/utils/index.ts',
     'validators/index': 'src/validators/index.ts',
     'bootstrap/index': 'src/bootstrap/index.ts',
+    'system-tune/index': 'src/system-tune/index.ts',
   },
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Closes the code deliverables for **Phase 5.17 — Hardware-Aware Auto-Config**:

- **`@revealui/setup/system-tune`** module: type definitions, hardware/platform detection, profile matching, plan generation
- **Seed profile** `wsl-low-ram.json`: captures the 2026-04-13 WSL crash fix (memory=4GB, processors=2, swap=2GB, vmIdleTimeout=-1, earlyoom, Docker off)
- **CLI surface**: `revealui system scan` (read-only report), `system tune` (generate plan, `--dry-run`/`--json`), `system revert` (placeholder)
- **Docs**: `PROFILES.md` rationale matrix, `CRASH-POSTMORTEMS.md` with the 2026-04-13 incident

### What's NOT in this PR (future work)
- Apply phase (writing `.wslconfig`, enabling earlyoom, etc.)
- Studio first-run wizard integration
- Forge self-hosted install script integration
- CI snapshot tests on Ubuntu/macOS/Windows runners

## Test plan
- [ ] `revealui system scan` outputs hardware info on WSL2
- [ ] `revealui system scan --json` outputs valid JSON
- [ ] `revealui system tune --dry-run` shows the wsl-low-ram plan
- [ ] `revealui system tune --json` outputs valid JSON plan
- [ ] TypeScript compiles clean (`pnpm typecheck:all`)
- [ ] Full CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)