### PR TITLE
chore(security): remove deprecated PasswordHasher (PBKDF2)

### DIFF
--- a/.changeset/remove-password-hasher.md
+++ b/.changeset/remove-password-hasher.md
@@ -1,0 +1,23 @@
+---
+'@revealui/security': minor
+---
+
+Remove deprecated `PasswordHasher` (PBKDF2) from `@revealui/security`.
+
+**Why:** PBKDF2 is less resistant to GPU brute-force attacks than bcrypt. `@revealui/auth` has shipped bcrypt-based password hashing (12 rounds) as the canonical implementation for several releases, and `@revealui/security`'s `PasswordHasher` has been marked `@deprecated` since its introduction. No internal callers remain in this monorepo.
+
+**Migration:** Replace `PasswordHasher` from `@revealui/security` with the bcrypt-based utilities exported from `@revealui/auth`.
+
+```ts
+// Before
+import { PasswordHasher } from '@revealui/security';
+const hash = await PasswordHasher.hash(password);
+const ok = await PasswordHasher.verify(password, hash);
+
+// After
+import { hashPassword, verifyPassword } from '@revealui/auth';
+const hash = await hashPassword(password);
+const ok = await verifyPassword(password, hash);
+```
+
+Hashes produced by the old PBKDF2 implementation (`salt:hash` hex format) are not verifiable by bcrypt and must be re-hashed at next login. If you have production users with PBKDF2 hashes, detect the format on login (`hash.includes(':')`) and re-hash with bcrypt after successful PBKDF2 verification.

--- a/packages/security/src/__tests__/auth.test.ts
+++ b/packages/security/src/__tests__/auth.test.ts
@@ -1,11 +1,11 @@
 /**
  * Authentication Utilities Tests
  *
- * Covers: OAuthClient, PasswordHasher, TwoFactorAuth (TOTP).
+ * Covers: OAuthClient, TwoFactorAuth (TOTP).
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { OAuthClient, PasswordHasher, TwoFactorAuth } from '../auth.js';
+import { OAuthClient, TwoFactorAuth } from '../auth.js';
 
 // =============================================================================
 // OAuthClient
@@ -118,46 +118,6 @@ describe('OAuthClient', () => {
     expect(result.email).toBe('user@example.com');
 
     vi.restoreAllMocks();
-  });
-});
-
-// =============================================================================
-// PasswordHasher (PBKDF2)
-// =============================================================================
-
-describe('PasswordHasher', () => {
-  it('hashes a password and produces salt:hash format', async () => {
-    const hashed = await PasswordHasher.hash('mypassword');
-    expect(hashed).toContain(':');
-
-    const [salt, hash] = hashed.split(':');
-    expect(salt).toBeDefined();
-    expect(hash).toBeDefined();
-    expect(salt!.length).toBe(32); // 16 bytes hex
-    expect(hash!.length).toBe(128); // 64 bytes hex
-  });
-
-  it('verifies correct password', async () => {
-    const hashed = await PasswordHasher.hash('correct-password');
-    const valid = await PasswordHasher.verify('correct-password', hashed);
-    expect(valid).toBe(true);
-  });
-
-  it('rejects wrong password', async () => {
-    const hashed = await PasswordHasher.hash('correct-password');
-    const valid = await PasswordHasher.verify('wrong-password', hashed);
-    expect(valid).toBe(false);
-  });
-
-  it('produces different hashes for same password (random salt)', async () => {
-    const hash1 = await PasswordHasher.hash('same-password');
-    const hash2 = await PasswordHasher.hash('same-password');
-    expect(hash1).not.toBe(hash2);
-  });
-
-  it('rejects malformed hash (no colon)', async () => {
-    const valid = await PasswordHasher.verify('password', 'nocolonhere');
-    expect(valid).toBe(false);
   });
 });
 

--- a/packages/security/src/__tests__/security.test.ts
+++ b/packages/security/src/__tests__/security.test.ts
@@ -4,35 +4,12 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuditSystem, InMemoryAuditStorage } from '../audit';
-import { PasswordHasher, TwoFactorAuth } from '../auth';
+import { TwoFactorAuth } from '../auth';
 import { AuthorizationSystem, PolicyBuilder } from '../authorization';
 import { DataMasking, EncryptionSystem, TokenGenerator } from '../encryption';
 import { ConsentManager, DataAnonymization, DataExportSystem } from '../gdpr';
 import { InMemoryGDPRStorage } from '../gdpr-storage';
 import { CORSManager, SecurityHeaders, SecurityPresets } from '../headers';
-
-describe('PasswordHasher', () => {
-  it('should hash and verify passwords', async () => {
-    const hash = await PasswordHasher.hash('my-secure-password');
-
-    expect(hash).toContain(':');
-    expect(await PasswordHasher.verify('my-secure-password', hash)).toBe(true);
-    expect(await PasswordHasher.verify('wrong-password', hash)).toBe(false);
-  });
-
-  it('should produce different hashes for same password (random salt)', async () => {
-    const hash1 = await PasswordHasher.hash('same-password');
-    const hash2 = await PasswordHasher.hash('same-password');
-
-    expect(hash1).not.toBe(hash2);
-    expect(await PasswordHasher.verify('same-password', hash1)).toBe(true);
-    expect(await PasswordHasher.verify('same-password', hash2)).toBe(true);
-  });
-
-  it('should reject malformed hashes', async () => {
-    expect(await PasswordHasher.verify('password', 'no-colon-here')).toBe(false);
-  });
-});
 
 describe('TwoFactorAuth', () => {
   it('should generate a base32 secret', () => {

--- a/packages/security/src/auth.ts
+++ b/packages/security/src/auth.ts
@@ -166,67 +166,6 @@ export class OAuthClient {
 }
 
 /**
- * Password hashing utilities
- *
- * Uses PBKDF2 with a random salt for secure password hashing.
- *
- * @deprecated Use `@revealui/auth` instead  -  it uses bcrypt which is more
- * resistant to GPU brute-force attacks. This PBKDF2 implementation will be
- * removed in a future major version.
- */
-
-const PH_ITERATIONS = 100000;
-const PH_KEY_LENGTH = 64;
-const PH_DIGEST = 'sha512';
-
-/**
- * Hash password with PBKDF2 and random salt
- */
-async function hashPassword(password: string): Promise<string> {
-  const { pbkdf2, randomBytes: rb } = await import('node:crypto');
-  const salt = rb(16).toString('hex');
-
-  return new Promise((resolve, reject) => {
-    pbkdf2(password, salt, PH_ITERATIONS, PH_KEY_LENGTH, PH_DIGEST, (err, derivedKey) => {
-      if (err) reject(err);
-      else resolve(`${salt}:${derivedKey.toString('hex')}`);
-    });
-  });
-}
-
-/**
- * Verify password against stored hash
- */
-async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
-  const { pbkdf2, timingSafeEqual: tse } = await import('node:crypto');
-  const [salt, hash] = storedHash.split(':');
-
-  if (!(salt && hash)) {
-    return false;
-  }
-
-  return new Promise((resolve, reject) => {
-    pbkdf2(password, salt, PH_ITERATIONS, PH_KEY_LENGTH, PH_DIGEST, (err, derivedKey) => {
-      if (err) reject(err);
-      else {
-        const derived = Buffer.from(derivedKey.toString('hex'), 'utf-8');
-        const expected = Buffer.from(hash, 'utf-8');
-        if (derived.length !== expected.length) {
-          resolve(false);
-        } else {
-          resolve(tse(derived, expected));
-        }
-      }
-    });
-  });
-}
-
-export const PasswordHasher = {
-  hash: hashPassword,
-  verify: verifyPassword,
-} as const;
-
-/**
  * Two-factor authentication
  */
 

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -47,7 +47,6 @@ export type {
 export {
   OAuthClient,
   OAuthProviders,
-  PasswordHasher,
   TwoFactorAuth,
 } from './auth.js';
 export type {


### PR DESCRIPTION
## Summary

Removes the last meaningful `@deprecated` marker in the codebase. `@revealui/auth` has shipped bcrypt-based password hashing as the canonical implementation for several releases; this PBKDF2 variant was kept as a deprecated shim for internal callers that no longer exist.

- Drops `PasswordHasher`, `hashPassword`, `verifyPassword` + PBKDF2 constants from `packages/security/src/auth.ts`
- Drops `PasswordHasher` from `packages/security/src/index.ts` barrel
- Removes the `PasswordHasher` test blocks from `auth.test.ts` and `security.test.ts` (both only exercised the removed code)
- Changeset: minor bump for `@revealui/security` (0.x breaking change per SemVer 0.x semantics)

## Migration path (documented in changeset)

```ts
// Before
import { PasswordHasher } from '@revealui/security';
const hash = await PasswordHasher.hash(password);

// After
import { hashPassword, verifyPassword } from '@revealui/auth';
const hash = await hashPassword(password);
```

PBKDF2 hashes (`salt:hash` hex) are not bcrypt-verifiable; production callers must detect the format on login and re-hash after successful PBKDF2 verification.

## Test plan
- [x] `pnpm --filter @revealui/security typecheck` — green
- [x] `pnpm --filter @revealui/security test` — 614/614 green
- [x] Pre-push gate PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)