### PR TITLE
feat(validate): docs import drift detector (§4.19, warn-only)

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -913,7 +913,7 @@ Holster: "Here is the shared state where coordination happens"
 ### Phase C: Automated Drift Detection
 
 - [x] **Claim/count drift detector** ✅ 2026-04-15 — `scripts/validate/claim-drift.ts` (`pnpm validate:claims`). Counts real packages/apps/workspaces/tests/UI components/MCP servers and fails if docs, marketing, or READMEs claim a different number. First run found 35 mismatches across docs/marketing — all corrected.
-- [ ] Add a CI check that verifies code samples in docs/ compile against current package exports (extract fenced code blocks, typecheck them)
+- [x] **Docs import drift detector** ✅ 2026-04-16 — `scripts/validate/docs-import-drift.ts` (`pnpm validate:docs-imports`). Extracts every `ts`/`tsx`/`typescript` code fence in `docs/`, parses `@revealui/*` imports, and checks each named import against the package's built `.d.ts` exports. Ships in the CI gate as **warn-only** — initial scan found ~225 stale imports, will flip to hard-fail once the backlog is drained. Doesn't do full tsc-style typechecking; focuses on the drift class that matters (removed/renamed public API names).
 - [ ] Add a CI check that verifies CLI `--help` output matches the documented command reference
 - [ ] Add a pre-commit rule: if a public export is renamed or removed, require a corresponding docs/ change in the same commit
 - [ ] Track messaging coverage: percentage of error paths that have user-friendly messages vs raw throws

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
-    "validate:versions": "tsx scripts/validate/version-policy.ts"
+    "validate:versions": "tsx scripts/validate/version-policy.ts",
+    "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts"
   },
   "type": "module"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,9 @@
     "commander": "^14.0.3",
     "execa": "^9.6.1",
     "jose": "^6.2.2",
-    "ora": "^9.3.0"
+    "ora": "^9.3.0",
+    "semver": "^7.7.4",
+    "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {
     "@revealui/ai": "workspace:^"
@@ -39,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/semver": "^7.7.1",
     "tsup": "^8.5.1",
     "typescript": "catalog:"
   },

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -10,6 +10,7 @@ describe('cli', () => {
     expect(commandNames).toContain('doctor');
     expect(commandNames).toContain('db');
     expect(commandNames).toContain('dev');
+    expect(commandNames).toContain('migrate');
     expect(commandNames).toContain('shell');
   });
 });

--- a/packages/cli/src/__tests__/codemods.test.ts
+++ b/packages/cli/src/__tests__/codemods.test.ts
@@ -1,0 +1,228 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getCodemod,
+  listApplicableCodemods,
+  readInstalledVersion,
+  registry,
+  runCodemods,
+} from '../codemods/index.js';
+import { passwordHasherToAuth } from '../codemods/transforms/password-hasher-to-auth.js';
+
+/**
+ * Build a minimal fixture project on disk so the runner's file discovery,
+ * version detection, and write behavior are exercised end-to-end.
+ */
+async function makeFixture(opts: {
+  securityVersion: string | null;
+  files: Record<string, string>;
+}): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+  const pkg: Record<string, unknown> = {
+    name: 'fixture',
+    version: '0.0.0',
+    dependencies: {},
+  };
+  if (opts.securityVersion) {
+    (pkg.dependencies as Record<string, string>)['@revealui/security'] = opts.securityVersion;
+    const nmDir = path.join(cwd, 'node_modules', '@revealui', 'security');
+    await mkdir(nmDir, { recursive: true });
+    await writeFile(
+      path.join(nmDir, 'package.json'),
+      JSON.stringify({ name: '@revealui/security', version: opts.securityVersion }),
+      'utf8',
+    );
+  }
+  await writeFile(path.join(cwd, 'package.json'), JSON.stringify(pkg), 'utf8');
+  for (const [rel, content] of Object.entries(opts.files)) {
+    const abs = path.join(cwd, rel);
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, content, 'utf8');
+  }
+  return cwd;
+}
+
+describe('codemod registry', () => {
+  it('exposes the password-hasher-to-auth codemod', () => {
+    expect(registry.length).toBeGreaterThan(0);
+    expect(getCodemod('password-hasher-to-auth')).toBeDefined();
+    expect(getCodemod('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('password-hasher-to-auth transform', () => {
+  const api = {
+    filePath: '/fake.ts',
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+
+  it('returns null when the source does not reference PasswordHasher', () => {
+    const source = `import { OAuthClient } from '@revealui/security';\nconst x = 1;\n`;
+    expect(passwordHasherToAuth.transform(source, api)).toBeNull();
+  });
+
+  it('rewrites a sole PasswordHasher import to @revealui/auth', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+const hash = await PasswordHasher.hash('pw');
+const ok = await PasswordHasher.verify('pw', hash);
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).not.toContain("from '@revealui/security'");
+    expect(out).toContain('hashPassword(');
+    expect(out).toContain('verifyPassword(');
+    expect(out).not.toContain('PasswordHasher');
+  });
+
+  it('preserves other named imports from @revealui/security', () => {
+    const source = `import { OAuthClient, PasswordHasher, TwoFactorAuth } from '@revealui/security';
+const h = PasswordHasher.hash('x');
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { OAuthClient, TwoFactorAuth } from '@revealui/security'");
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).toContain('hashPassword(');
+  });
+
+  it('is idempotent — running twice produces the same output', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+await PasswordHasher.hash('pw');
+`;
+    const once = passwordHasherToAuth.transform(source, api);
+    expect(once).not.toBeNull();
+    const twice = passwordHasherToAuth.transform(once as string, api);
+    // After the first pass nothing further needs changing.
+    expect(twice).toBeNull();
+  });
+
+  it('only matches recognized file extensions', () => {
+    expect(passwordHasherToAuth.match?.('/foo.ts')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.tsx')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.js')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.md')).toBe(false);
+  });
+});
+
+describe('readInstalledVersion', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('reads the resolved version from node_modules when present', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.7');
+  });
+
+  it('falls back to the declared range when node_modules is absent', async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+    await writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        dependencies: { '@revealui/security': '^0.2.4' },
+      }),
+      'utf8',
+    );
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.4');
+  });
+
+  it('returns null when the package is not listed at all', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBeNull();
+  });
+});
+
+describe('listApplicableCodemods', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('marks the codemod applicable when installed version is below the target', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(true);
+  });
+
+  it('marks the codemod not applicable when already migrated', async () => {
+    cwd = await makeFixture({ securityVersion: '0.3.0', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('does not satisfy');
+  });
+
+  it('marks the codemod not applicable when the package is absent', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('not installed');
+  });
+});
+
+describe('runCodemods', () => {
+  let cwd: string;
+  const sourceBefore = `import { PasswordHasher } from '@revealui/security';
+export async function login(pw: string) {
+  const h = await PasswordHasher.hash(pw);
+  return await PasswordHasher.verify(pw, h);
+}
+`;
+
+  beforeEach(async () => {
+    cwd = await makeFixture({
+      securityVersion: '0.2.7',
+      files: { 'src/login.ts': sourceBefore },
+    });
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('applies the codemod and rewrites the file', async () => {
+    const result = await runCodemods({ cwd });
+    expect(result.applied).toContain('password-hasher-to-auth');
+    expect(result.changedFiles).toBe(1);
+    expect(result.errored).toBe(0);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(after).toContain('hashPassword(');
+    expect(after).not.toContain('PasswordHasher');
+  });
+
+  it('dry-run reports changes without writing', async () => {
+    const result = await runCodemods({ cwd, dryRun: true });
+    expect(result.changedFiles).toBe(1);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toBe(sourceBefore);
+  });
+
+  it('restricts to a single codemod when `only` is set', async () => {
+    const result = await runCodemods({ cwd, only: 'password-hasher-to-auth' });
+    expect(result.applied).toEqual(['password-hasher-to-auth']);
+  });
+
+  it('reports no-op when no codemod applies', async () => {
+    const freshCwd = await makeFixture({
+      securityVersion: '0.3.0',
+      files: { 'src/login.ts': sourceBefore },
+    });
+    try {
+      const result = await runCodemods({ cwd: freshCwd });
+      expect(result.applied).toEqual([]);
+      expect(result.changedFiles).toBe(0);
+      // Source must be untouched when no codemod applies.
+      expect(await readFile(path.join(freshCwd, 'src/login.ts'), 'utf8')).toBe(sourceBefore);
+    } finally {
+      await rm(freshCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
   runDevUpCommand,
 } from './commands/dev.js';
 import { runDoctorCommand } from './commands/doctor.js';
+import { runMigrateCommand } from './commands/migrate.js';
 import {
   runSystemRevertCommand,
   runSystemScanCommand,
@@ -359,6 +360,16 @@ export function createCli(): Command {
     .description('Revert a previously applied tuning plan from backup')
     .action(async () => {
       await runSystemRevertCommand();
+    });
+
+  program
+    .command('migrate')
+    .description('Apply codemods to migrate your project to newer RevealUI versions')
+    .option('-d, --dry-run', 'Preview changes without writing files', false)
+    .option('--list', 'Show available codemods and applicability without running them', false)
+    .option('--only <name>', 'Run only the codemod with this name')
+    .action(async (options: { dryRun?: boolean; list?: boolean; only?: string }) => {
+      await runMigrateCommand(options);
     });
 
   program

--- a/packages/cli/src/codemods/index.ts
+++ b/packages/cli/src/codemods/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @revealui/cli/codemods — migration transform infrastructure.
+ *
+ * Public entry point. `revealui migrate` consumes this module; authors of
+ * individual codemods place their transforms under `./transforms/` and
+ * register them in `./registry.ts`.
+ */
+
+export { getCodemod, registry } from './registry.js';
+export { listApplicableCodemods, readInstalledVersion, runCodemods } from './runner.js';
+export type {
+  Codemod,
+  CodemodApi,
+  CodemodFileResult,
+  CodemodLogger,
+  CodemodRunResult,
+} from './types.js';

--- a/packages/cli/src/codemods/registry.ts
+++ b/packages/cli/src/codemods/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Codemod registry — central list of every migration transform shipped
+ * with this CLI. New codemods must be added here to be discoverable by
+ * `revealui migrate`.
+ *
+ * Ordering matters: the runner applies codemods in array order when
+ * multiple are applicable in a single run. Keep them in chronological
+ * release order (oldest first) so migrations compose predictably across
+ * multi-version upgrades.
+ */
+
+import { passwordHasherToAuth } from './transforms/password-hasher-to-auth.js';
+import type { Codemod } from './types.js';
+
+export const registry: readonly Codemod[] = [passwordHasherToAuth];
+
+export function getCodemod(name: string): Codemod | undefined {
+  return registry.find((c) => c.name === name);
+}

--- a/packages/cli/src/codemods/runner.ts
+++ b/packages/cli/src/codemods/runner.ts
@@ -1,0 +1,247 @@
+/**
+ * Codemod runner — discovers applicable transforms for a project and
+ * applies them across the source tree.
+ *
+ * Applicability is determined by comparing the installed version of each
+ * codemod's target package (read from the project's `package.json` +
+ * `node_modules`) against the codemod's `fromVersion` range. A codemod
+ * is applicable when the *current* installed version satisfies
+ * `fromVersion` — i.e. the project has not yet migrated.
+ */
+
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import semver from 'semver';
+import { registry } from './registry.js';
+import type { Codemod, CodemodApi, CodemodLogger, CodemodRunResult } from './types.js';
+
+export interface RunOptions {
+  /** Project root — the directory containing the user's package.json. */
+  cwd: string;
+  /** Globs to scan for transformable files (default: src/**\/*.{ts,tsx,js,jsx}). */
+  include?: string[];
+  /** When true, compute changes but do not write. */
+  dryRun?: boolean;
+  /** Restrict the run to a specific codemod by name. */
+  only?: string;
+  /** Logger to receive progress messages. */
+  logger?: CodemodLogger;
+}
+
+const DEFAULT_INCLUDE = ['src/**/*.{ts,tsx,js,jsx,mjs,cjs}'];
+
+const noop = (_: string): void => {
+  /* intentional no-op */
+};
+
+const silentLogger: CodemodLogger = {
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+/**
+ * Read the installed version of `packageName` from the user's project.
+ * Resolution order:
+ *   1. `node_modules/<pkg>/package.json` version (source of truth at runtime)
+ *   2. `package.json` dependencies / devDependencies / peerDependencies
+ *      (stripping leading `^` / `~` / range prefixes).
+ * Returns `null` if the package is not listed at all.
+ */
+export async function readInstalledVersion(
+  cwd: string,
+  packageName: string,
+): Promise<string | null> {
+  // Try node_modules first
+  const installedPkgPath = path.join(cwd, 'node_modules', packageName, 'package.json');
+  try {
+    const raw = await readFile(installedPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as { version?: string };
+    if (parsed.version) return parsed.version;
+  } catch {
+    // fall through
+  }
+
+  // Fall back to the declared range in the user's package.json
+  const userPkgPath = path.join(cwd, 'package.json');
+  try {
+    const raw = await readFile(userPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const declared =
+      parsed.dependencies?.[packageName] ??
+      parsed.devDependencies?.[packageName] ??
+      parsed.peerDependencies?.[packageName];
+    if (!declared) return null;
+    // Extract a concrete version from common range prefixes.
+    const match = declared.match(/(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+    return match ? (match[1] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return codemods that apply to the given project state. A codemod
+ * applies when its `package` is installed AND the installed version
+ * satisfies its `fromVersion` range.
+ */
+export async function listApplicableCodemods(cwd: string): Promise<
+  Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }>
+> {
+  const entries: Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }> = [];
+
+  for (const codemod of registry) {
+    const installedVersion = await readInstalledVersion(cwd, codemod.package);
+    if (installedVersion === null) {
+      entries.push({
+        codemod,
+        installedVersion: null,
+        applicable: false,
+        reason: `${codemod.package} not installed`,
+      });
+      continue;
+    }
+    const coerced = semver.coerce(installedVersion)?.version ?? installedVersion;
+    if (semver.satisfies(coerced, codemod.fromVersion, { includePrerelease: true })) {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: true,
+        reason: `matches ${codemod.fromVersion}`,
+      });
+    } else {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: false,
+        reason: `${coerced} does not satisfy ${codemod.fromVersion}`,
+      });
+    }
+  }
+  return entries;
+}
+
+async function findFiles(cwd: string, patterns: string[]): Promise<string[]> {
+  // Use dynamic import so we don't hard-require `fast-glob` at module load.
+  // tinyglobby is part of the existing dep tree via Vite; fall back to fast-glob.
+  let globber: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+  try {
+    const mod = (await import('tinyglobby')) as {
+      glob: typeof globber;
+    };
+    globber = mod.glob;
+  } catch {
+    const mod = (await import('fast-glob')) as unknown as {
+      default: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+    };
+    globber = mod.default;
+  }
+  return globber(patterns, { cwd, absolute: true });
+}
+
+async function applyCodemodToFile(
+  codemod: Codemod,
+  filePath: string,
+  opts: { dryRun: boolean; logger: CodemodLogger },
+): Promise<{ changed: boolean; error?: Error }> {
+  if (codemod.match && !codemod.match(filePath)) {
+    return { changed: false };
+  }
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isFile()) return { changed: false };
+    const source = await readFile(filePath, 'utf8');
+    const api: CodemodApi = { filePath, logger: opts.logger };
+    const next = codemod.transform(source, api);
+    if (next === null || next === source) return { changed: false };
+    if (!opts.dryRun) {
+      await writeFile(filePath, next, 'utf8');
+    }
+    return { changed: true };
+  } catch (error) {
+    return { changed: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}
+
+/**
+ * Run all applicable codemods against a project. Returns a structured
+ * summary with per-file outcomes.
+ */
+export async function runCodemods(options: RunOptions): Promise<CodemodRunResult> {
+  const logger = options.logger ?? silentLogger;
+  const include = options.include ?? DEFAULT_INCLUDE;
+  const applicable = await listApplicableCodemods(options.cwd);
+
+  const codemods = applicable.filter((a) => a.applicable).map((a) => a.codemod);
+  const filtered = options.only ? codemods.filter((c) => c.name === options.only) : codemods;
+
+  const result: CodemodRunResult = {
+    applied: [],
+    skipped: applicable.filter((a) => !a.applicable).map((a) => `${a.codemod.name} (${a.reason})`),
+    changedFiles: 0,
+    errored: 0,
+    results: [],
+  };
+
+  if (filtered.length === 0) {
+    logger.info('No codemods applicable to this project.');
+    return result;
+  }
+
+  const files = await findFiles(options.cwd, include);
+  logger.info(
+    `Scanning ${files.length} file(s) with ${filtered.length} codemod(s)${options.dryRun ? ' (dry run)' : ''}...`,
+  );
+
+  for (const codemod of filtered) {
+    let changed = 0;
+    for (const file of files) {
+      const outcome = await applyCodemodToFile(codemod, file, {
+        dryRun: options.dryRun ?? false,
+        logger,
+      });
+      if (outcome.error) {
+        result.errored += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'error',
+          error: outcome.error.message,
+        });
+        logger.error(`[${codemod.name}] ${file}: ${outcome.error.message}`);
+      } else if (outcome.changed) {
+        changed += 1;
+        result.changedFiles += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'changed',
+        });
+      } else {
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'unchanged',
+        });
+      }
+    }
+    result.applied.push(codemod.name);
+    logger.info(`[${codemod.name}] ${changed} file(s) changed`);
+  }
+
+  return result;
+}

--- a/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
+++ b/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * Codemod: PasswordHasher (PBKDF2) from @revealui/security → bcrypt-based
+ * hashPassword / verifyPassword from @revealui/auth.
+ *
+ * Shipped alongside @revealui/security 0.3.0 which drops the deprecated
+ * `PasswordHasher` export. See CHANGELOG and .changeset/remove-password-hasher.md.
+ *
+ * Scope: rewrites imports and call sites. Users with PBKDF2 hashes stored
+ * in their database must handle the hash-format migration themselves
+ * (detect `:` separator, re-hash after successful PBKDF2 verification);
+ * that can't be done by a source transform.
+ */
+
+import type { Codemod, CodemodApi } from '../types.js';
+
+const IMPORT_RE = /import\s+\{([^}]*)\}\s+from\s+(['"])@revealui\/security\2/g;
+const CALL_HASH_RE = /\bPasswordHasher\s*\.\s*hash\s*\(/g;
+const CALL_VERIFY_RE = /\bPasswordHasher\s*\.\s*verify\s*\(/g;
+const USES_PASSWORD_HASHER_RE = /\bPasswordHasher\b/;
+
+function rewriteImports(source: string): { source: string; didImport: boolean } {
+  let didImport = false;
+  const rewritten = source.replace(IMPORT_RE, (match, specifiers: string, quote: string) => {
+    // Parse named imports: "{ A, B, PasswordHasher, C as D }"
+    const items = specifiers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const keep: string[] = [];
+    let removedPasswordHasher = false;
+    for (const item of items) {
+      // `PasswordHasher` or `PasswordHasher as X` — drop either form.
+      if (/^PasswordHasher(\s+as\s+\w+)?$/.test(item)) {
+        removedPasswordHasher = true;
+        continue;
+      }
+      keep.push(item);
+    }
+
+    if (!removedPasswordHasher) return match;
+    didImport = true;
+
+    const securityLine =
+      keep.length > 0
+        ? `import { ${keep.join(', ')} } from ${quote}@revealui/security${quote}`
+        : null;
+    const authLine = `import { hashPassword, verifyPassword } from ${quote}@revealui/auth${quote}`;
+
+    return securityLine ? `${securityLine};\n${authLine}` : authLine;
+  });
+
+  return { source: rewritten, didImport };
+}
+
+function rewriteCallSites(source: string): { source: string; didCall: boolean } {
+  let didCall = false;
+  let out = source.replace(CALL_HASH_RE, () => {
+    didCall = true;
+    return 'hashPassword(';
+  });
+  out = out.replace(CALL_VERIFY_RE, () => {
+    didCall = true;
+    return 'verifyPassword(';
+  });
+  return { source: out, didCall };
+}
+
+function transform(source: string, _api: CodemodApi): string | null {
+  if (!USES_PASSWORD_HASHER_RE.test(source)) return null;
+
+  const afterImports = rewriteImports(source);
+  const afterCalls = rewriteCallSites(afterImports.source);
+
+  if (!(afterImports.didImport || afterCalls.didCall)) return null;
+  return afterCalls.source;
+}
+
+export const passwordHasherToAuth: Codemod = {
+  name: 'password-hasher-to-auth',
+  description:
+    'Migrate PasswordHasher (PBKDF2) from @revealui/security to bcrypt-based hashPassword/verifyPassword from @revealui/auth',
+  package: '@revealui/security',
+  fromVersion: '<0.3.0',
+  toVersion: '>=0.3.0',
+  match(filePath) {
+    return /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(filePath);
+  },
+  transform,
+};

--- a/packages/cli/src/codemods/types.ts
+++ b/packages/cli/src/codemods/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Codemod types — shared contract for all RevealUI migration transforms.
+ *
+ * A codemod describes a single breaking change across a version boundary
+ * and knows how to rewrite user source files to match the new API. Codemods
+ * are discovered from a central registry and applied in semver order by
+ * `revealui migrate`.
+ */
+
+/**
+ * API passed to a codemod transform. Kept minimal on purpose — a codemod
+ * that needs a full AST is free to `import { Project } from 'ts-morph'`
+ * (or similar) inside its own implementation. Most public-API renames can
+ * be expressed as straightforward string/regex rewrites over the source.
+ */
+export interface CodemodApi {
+  /** Absolute path of the file currently being transformed. */
+  filePath: string;
+  /** Logger bound to the active `revealui migrate` run. */
+  logger: CodemodLogger;
+}
+
+/** Structured logger surfaced to codemod authors. */
+export interface CodemodLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * A single codemod. One codemod addresses one breaking change, across one
+ * semver boundary. Author as many as the migration requires — ordering is
+ * controlled by `fromVersion`/`toVersion`, not file name.
+ */
+export interface Codemod {
+  /** Stable id, e.g. `password-hasher-to-auth`. Used as the CLI selector. */
+  name: string;
+  /** One-line summary printed by `revealui migrate --list`. */
+  description: string;
+  /**
+   * Semver range (as accepted by `semver.satisfies`) of the *previous*
+   * package version this codemod migrates *from*. Example: `"<0.3.0"`.
+   */
+  fromVersion: string;
+  /**
+   * Semver range the project lands on after this codemod runs. Used to
+   * skip codemods that have already been applied.
+   */
+  toVersion: string;
+  /**
+   * Package the versions refer to. `"@revealui/security"`, `"@revealui/core"`,
+   * etc. — looked up in the user's package.json to decide applicability.
+   */
+  package: string;
+  /**
+   * Optional filter — return false to skip a file without invoking `transform`.
+   * Useful for confining a codemod to `.ts` / `.tsx` only, or to a subtree.
+   */
+  match?(filePath: string): boolean;
+  /**
+   * Transform one file's source. Return the new source string, or `null`
+   * to indicate this file needs no change. Throw for a hard failure — the
+   * runner will catch and report, leaving the file untouched.
+   */
+  transform(source: string, api: CodemodApi): string | null;
+}
+
+/** Outcome per file, reported by the runner. */
+export interface CodemodFileResult {
+  filePath: string;
+  codemod: string;
+  status: 'changed' | 'unchanged' | 'error';
+  error?: string;
+}
+
+/** Aggregate summary returned by `runCodemods`. */
+export interface CodemodRunResult {
+  applied: string[];
+  skipped: string[];
+  changedFiles: number;
+  errored: number;
+  results: CodemodFileResult[];
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,84 @@
+/**
+ * `revealui migrate` — run applicable codemods against the current project.
+ */
+
+import { createLogger } from '@revealui/setup/utils';
+import {
+  type CodemodLogger,
+  type CodemodRunResult,
+  listApplicableCodemods,
+  runCodemods,
+} from '../codemods/index.js';
+
+export interface MigrateOptions {
+  /** Preview changes without writing files. */
+  dryRun?: boolean;
+  /** Print the applicable codemod list and exit. */
+  list?: boolean;
+  /** Restrict the run to a single codemod by name. */
+  only?: string;
+  /** Override the project root (defaults to process.cwd()). */
+  cwd?: string;
+}
+
+const logger = createLogger({ prefix: 'migrate' });
+
+const codemodLogger: CodemodLogger = {
+  info: (m) => logger.info(m),
+  warn: (m) => logger.warn(m),
+  error: (m) => logger.error(m),
+};
+
+export async function runMigrateListCommand(options: MigrateOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const entries = await listApplicableCodemods(cwd);
+  if (entries.length === 0) {
+    logger.info('No codemods are registered.');
+    return;
+  }
+  logger.info(`Codemods available for project at ${cwd}:`);
+  for (const entry of entries) {
+    const marker = entry.applicable ? '✓' : '·';
+    logger.info(
+      `  ${marker} ${entry.codemod.name}  [${entry.codemod.package} ${entry.codemod.fromVersion} → ${entry.codemod.toVersion}]`,
+    );
+    logger.info(`      ${entry.codemod.description}`);
+    logger.info(`      status: ${entry.reason}`);
+  }
+}
+
+export async function runMigrateCommand(options: MigrateOptions = {}): Promise<CodemodRunResult> {
+  const cwd = options.cwd ?? process.cwd();
+  if (options.list) {
+    await runMigrateListCommand({ ...options, cwd });
+    return {
+      applied: [],
+      skipped: [],
+      changedFiles: 0,
+      errored: 0,
+      results: [],
+    };
+  }
+  const result = await runCodemods({
+    cwd,
+    dryRun: options.dryRun,
+    only: options.only,
+    logger: codemodLogger,
+  });
+
+  if (result.applied.length === 0) {
+    logger.info('No applicable codemods. Your project is up to date.');
+    return result;
+  }
+
+  logger.success(
+    `${options.dryRun ? 'Would change' : 'Changed'} ${result.changedFiles} file(s) across ${result.applied.length} codemod(s).`,
+  );
+  if (result.errored > 0) {
+    logger.warn(`${result.errored} file(s) errored — see log above.`);
+  }
+  if (result.skipped.length > 0) {
+    logger.info(`Skipped: ${result.skipped.join(', ')}`);
+  }
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,10 +805,19 @@ importers:
       ora:
         specifier: ^9.3.0
         version: 9.3.0
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.2(@types/node@25.5.2))(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -4821,6 +4830,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -12311,6 +12323,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/tedious@4.0.14':
     dependencies:

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -278,6 +278,12 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
+        name: 'Docs import drift',
+        command: 'pnpm',
+        args: ['validate:docs-imports', '--warn'],
+        warnOnly: true,
+      },
+      {
         name: 'Pro license validation',
         command: 'pnpm',
         args: ['validate:gitignore'],

--- a/scripts/validate/__tests__/docs-import-drift.test.ts
+++ b/scripts/validate/__tests__/docs-import-drift.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractFences,
+  loadExportsFromDts,
+  moduleSubpath,
+  parseImports,
+} from '../docs-import-drift.ts';
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+
+describe('extractFences', () => {
+  it('pulls out ts/tsx/typescript fences with line numbers', () => {
+    const md = [
+      'Some prose',
+      '```ts',
+      'const a = 1;',
+      '```',
+      'More prose',
+      '```tsx',
+      'const b = 2;',
+      '```',
+      '```bash',
+      'ignored',
+      '```',
+      '```typescript',
+      'const c = 3;',
+      '```',
+    ].join('\n');
+    const fences = extractFences(md);
+    expect(fences.map((f) => f.code.trim())).toEqual([
+      'const a = 1;',
+      'const b = 2;',
+      'const c = 3;',
+    ]);
+    expect(fences[0]?.startLine).toBe(3);
+  });
+
+  it('accepts trailing metadata on the fence line', () => {
+    const md = ['```ts title="example.ts"', 'const x = 1;', '```'].join('\n');
+    expect(extractFences(md)).toHaveLength(1);
+  });
+});
+
+describe('parseImports', () => {
+  it('extracts @revealui named imports with correct line offset', () => {
+    const code = [
+      "import { a } from 'react';",
+      "import { hashPassword, verifyPassword } from '@revealui/auth';",
+      "import { createLogger } from '@revealui/setup/utils';",
+    ].join('\n');
+    const refs = parseImports(code, 'fake.md', 10);
+    expect(refs).toHaveLength(2);
+    expect(refs[0]?.module).toBe('@revealui/auth');
+    expect(refs[0]?.names).toEqual(['hashPassword', 'verifyPassword']);
+    expect(refs[0]?.line).toBe(11);
+    expect(refs[1]?.module).toBe('@revealui/setup/utils');
+  });
+
+  it('ignores namespace imports', () => {
+    const code = "import * as x from '@revealui/core';";
+    expect(parseImports(code, 'fake.md', 0)).toEqual([]);
+  });
+
+  it('captures default + named combined imports', () => {
+    const code = "import def, { named } from '@revealui/core';";
+    const refs = parseImports(code, 'fake.md', 0);
+    expect(refs[0]?.hasDefault).toBe(true);
+    expect(refs[0]?.names).toEqual(['default', 'named']);
+  });
+});
+
+describe('moduleSubpath', () => {
+  it('splits module specifier into package + subpath', () => {
+    expect(moduleSubpath('@revealui/core')).toEqual({ pkg: '@revealui/core', subpath: '.' });
+    expect(moduleSubpath('@revealui/core/utils')).toEqual({
+      pkg: '@revealui/core',
+      subpath: './utils',
+    });
+    expect(moduleSubpath('@revealui/db/schema/posts')).toEqual({
+      pkg: '@revealui/db',
+      subpath: './schema/posts',
+    });
+  });
+});
+
+describe('loadExportsFromDts — against real workspace', () => {
+  const securityDts = path.join(ROOT, 'packages/security/dist/index.d.ts');
+
+  it('loads a real dist .d.ts and extracts a non-trivial set of exports', () => {
+    // Skip if dist hasn't been built (e.g. fresh clone).
+    if (!fs.existsSync(securityDts)) return;
+    const names = loadExportsFromDts(securityDts);
+    expect(names.size).toBeGreaterThan(10);
+    // AuditSystem is a stable public export that should persist across refactors.
+    expect(names.has('AuditSystem')).toBe(true);
+  });
+});

--- a/scripts/validate/docs-import-drift.ts
+++ b/scripts/validate/docs-import-drift.ts
@@ -1,0 +1,397 @@
+/**
+ * Docs Import Drift Detector
+ *
+ * Extracts TypeScript/TSX code fences from `docs/**` and verifies that
+ * every `import { X } from '@revealui/pkg'` names an identifier that
+ * the current workspace package actually exports. Catches the most
+ * common class of doc drift — samples that reference removed or
+ * renamed public API — without running the full TypeScript compiler.
+ *
+ * Usage:
+ *   pnpm validate:docs-imports
+ *   pnpm validate:docs-imports --json
+ *   pnpm validate:docs-imports --warn  # never exit nonzero (CI default)
+ *
+ * Exit codes:
+ *   0 = every doc import matches a real workspace export (or --warn)
+ *   1 = drift detected (list printed)
+ *
+ * NOTE: the initial scan (2026-04-16) reports ~225 findings against
+ * existing docs. The check ships in CI as warn-only until that backlog
+ * is drained. Once findings approach zero, flip the gate entry to hard-fail.
+ *
+ * Design notes:
+ * - Only validates workspace `@revealui/*` imports. Third-party imports
+ *   (react, zod, commander, etc.) are out of scope — they have their
+ *   own versioning.
+ * - Reads the package's built `.d.ts` (from its `exports["."]["types"]`
+ *   entry) to build the export manifest. This is the same surface users
+ *   actually see; if the .d.ts isn't built the check is skipped (warn).
+ * - Subpath imports (`@revealui/core/utils/deep-clone`) check against
+ *   the matching `exports["./utils/deep-clone"]` entry when declared.
+ * - Side-effect imports (`import '@revealui/pkg';`) are ignored.
+ * - Default imports (`import foo from ...`) are accepted as long as the
+ *   module has a default export.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const DOCS_DIR = path.join(ROOT, 'docs');
+const PACKAGES_DIR = path.join(ROOT, 'packages');
+
+interface ImportRef {
+  file: string;
+  line: number;
+  module: string;
+  /** Named imports in this statement; `default` sentinel for default imports. */
+  names: string[];
+  /** True when any name was a default import. */
+  hasDefault: boolean;
+}
+
+interface PackageExports {
+  /** Map of subpath (".", "./utils", etc.) → resolved absolute .d.ts path. */
+  subpaths: Map<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Fence extraction
+// ---------------------------------------------------------------------------
+
+const FENCE_RE = /^```(ts|tsx|typescript)(?:\s+[^\n]*)?$/;
+const FENCE_CLOSE = '```';
+
+function extractFences(markdown: string): Array<{ startLine: number; code: string }> {
+  const out: Array<{ startLine: number; code: string }> = [];
+  const lines = markdown.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line && FENCE_RE.test(line)) {
+      // Line number of the first line *inside* the fence, 1-indexed.
+      // Combined with the 0-indexed per-snippet offset from ts.SourceFile,
+      // this yields the real file line of the import.
+      const startLine = i + 2;
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && lines[i] !== FENCE_CLOSE) {
+        buf.push(lines[i] as string);
+        i++;
+      }
+      out.push({ startLine, code: buf.join('\n') });
+    }
+    i++;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Import parsing
+// ---------------------------------------------------------------------------
+
+function parseImports(code: string, file: string, baseLine: number): ImportRef[] {
+  const sf = ts.createSourceFile('snippet.ts', code, ts.ScriptTarget.Latest, true);
+  const refs: ImportRef[] = [];
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const module = stmt.moduleSpecifier.text;
+    if (!module.startsWith('@revealui/')) continue;
+
+    const names: string[] = [];
+    let hasDefault = false;
+    const clause = stmt.importClause;
+    if (clause) {
+      if (clause.name) {
+        hasDefault = true;
+        names.push('default');
+      }
+      if (clause.namedBindings) {
+        if (ts.isNamespaceImport(clause.namedBindings)) {
+          // `import * as X from '...'` — treat as wildcard, no per-name check.
+          continue;
+        }
+        if (ts.isNamedImports(clause.namedBindings)) {
+          for (const el of clause.namedBindings.elements) {
+            // Prefer the original export name (`propertyName`) when aliased.
+            names.push((el.propertyName ?? el.name).text);
+          }
+        }
+      }
+    }
+
+    if (names.length === 0) continue; // side-effect import
+
+    const { line } = sf.getLineAndCharacterOfPosition(stmt.getStart(sf));
+    refs.push({
+      file,
+      line: baseLine + line,
+      module,
+      names,
+      hasDefault,
+    });
+  }
+  return refs;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace export manifest
+// ---------------------------------------------------------------------------
+
+const pkgCache = new Map<string, PackageExports | null>();
+
+function loadPackageExports(pkgName: string): PackageExports | null {
+  if (pkgCache.has(pkgName)) return pkgCache.get(pkgName) ?? null;
+
+  // @revealui/security → packages/security
+  const short = pkgName.replace(/^@revealui\//, '');
+  const pkgDir = path.join(PACKAGES_DIR, short);
+  const pkgJsonPath = path.join(pkgDir, 'package.json');
+  if (!fs.existsSync(pkgJsonPath)) {
+    pkgCache.set(pkgName, null);
+    return null;
+  }
+
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')) as {
+    exports?: Record<string, { types?: string; import?: string } | string>;
+    types?: string;
+    main?: string;
+  };
+
+  const subpaths = new Map<string, string>();
+
+  if (pkgJson.exports && typeof pkgJson.exports === 'object') {
+    for (const [subpath, target] of Object.entries(pkgJson.exports)) {
+      let typesPath: string | undefined;
+      if (typeof target === 'string') typesPath = target;
+      else typesPath = target.types ?? target.import;
+      if (!typesPath) continue;
+      const abs = path.resolve(pkgDir, typesPath);
+      if (fs.existsSync(abs)) subpaths.set(subpath, abs);
+    }
+  } else if (pkgJson.types) {
+    const abs = path.resolve(pkgDir, pkgJson.types);
+    if (fs.existsSync(abs)) subpaths.set('.', abs);
+  }
+
+  const result: PackageExports = { subpaths };
+  pkgCache.set(pkgName, result);
+  return result;
+}
+
+function moduleSubpath(module: string): { pkg: string; subpath: string } {
+  // @revealui/core → pkg=@revealui/core, sub=.
+  // @revealui/core/utils → pkg=@revealui/core, sub=./utils
+  const parts = module.split('/');
+  const pkg = `${parts[0]}/${parts[1]}`;
+  const rest = parts.slice(2).join('/');
+  return { pkg, subpath: rest ? `./${rest}` : '.' };
+}
+
+const exportCache = new Map<string, Set<string>>();
+
+function loadExportsFromDts(dtsPath: string): Set<string> {
+  const cached = exportCache.get(dtsPath);
+  if (cached) return cached;
+
+  const source = fs.readFileSync(dtsPath, 'utf8');
+  const sf = ts.createSourceFile(dtsPath, source, ts.ScriptTarget.Latest, true);
+  const names = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isExportDeclaration(node)) {
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        // export { A, B as C } from '...'
+        for (const el of node.exportClause.elements) {
+          names.add(el.name.text);
+        }
+      } else if (
+        node.moduleSpecifier &&
+        ts.isStringLiteral(node.moduleSpecifier) &&
+        !node.exportClause
+      ) {
+        // Re-export: `export * from './foo'` — follow transitively.
+        const spec = node.moduleSpecifier.text;
+        if (spec.startsWith('.')) {
+          // Normalise: emitted .d.ts files reference `./foo.js` — strip the
+          // extension so we can check for `./foo.d.ts` / `./foo/index.d.ts`.
+          const stripped = spec.replace(/\.(js|mjs|cjs|ts|tsx)$/, '');
+          const candidates = [
+            path.resolve(path.dirname(dtsPath), `${stripped}.d.ts`),
+            path.resolve(path.dirname(dtsPath), stripped, 'index.d.ts'),
+          ];
+          for (const c of candidates) {
+            if (fs.existsSync(c)) {
+              for (const n of loadExportsFromDts(c)) names.add(n);
+              break;
+            }
+          }
+        }
+      }
+    } else if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      if (node.name) names.add(node.name.text);
+      if (node.modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)) {
+        names.add('default');
+      }
+    } else if (
+      ts.isVariableStatement(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of node.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) names.add(decl.name.text);
+      }
+    } else if (ts.isExportAssignment(node)) {
+      names.add('default');
+    }
+  };
+
+  ts.forEachChild(sf, visit);
+  exportCache.set(dtsPath, names);
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function walkDocs(dir: string, acc: string[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkDocs(full, acc);
+    else if (entry.isFile() && entry.name.endsWith('.md')) acc.push(full);
+  }
+}
+
+interface Finding {
+  file: string;
+  line: number;
+  module: string;
+  missing: string;
+  reason: 'unknown-package' | 'no-dts' | 'unknown-subpath' | 'not-exported';
+}
+
+function main(): void {
+  const jsonOutput = process.argv.includes('--json');
+  const warnOnly = process.argv.includes('--warn');
+  const files: string[] = [];
+  walkDocs(DOCS_DIR, files);
+
+  const findings: Finding[] = [];
+  const skippedNoDts = new Set<string>();
+
+  for (const file of files) {
+    const md = fs.readFileSync(file, 'utf8');
+    const fences = extractFences(md);
+    for (const { startLine, code } of fences) {
+      const refs = parseImports(code, file, startLine);
+      for (const ref of refs) {
+        const { pkg, subpath } = moduleSubpath(ref.module);
+        const exp = loadPackageExports(pkg);
+        if (!exp) {
+          for (const n of ref.names) {
+            findings.push({
+              file: ref.file,
+              line: ref.line,
+              module: ref.module,
+              missing: n,
+              reason: 'unknown-package',
+            });
+          }
+          continue;
+        }
+        const dts = exp.subpaths.get(subpath);
+        if (!dts) {
+          // Subpath not declared in exports — count as drift (user can't import this).
+          for (const n of ref.names) {
+            findings.push({
+              file: ref.file,
+              line: ref.line,
+              module: ref.module,
+              missing: n,
+              reason: 'unknown-subpath',
+            });
+          }
+          continue;
+        }
+        if (!fs.existsSync(dts)) {
+          skippedNoDts.add(pkg);
+          continue;
+        }
+        const names = loadExportsFromDts(dts);
+        for (const n of ref.names) {
+          if (!names.has(n)) {
+            findings.push({
+              file: ref.file,
+              line: ref.line,
+              module: ref.module,
+              missing: n,
+              reason: 'not-exported',
+            });
+          }
+        }
+      }
+    }
+  }
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        {
+          findings,
+          skippedNoDts: [...skippedNoDts],
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    if (skippedNoDts.size > 0) {
+      console.log(
+        `· Skipped ${skippedNoDts.size} package(s) with no built .d.ts: ${[...skippedNoDts].join(', ')}`,
+      );
+      console.log('  (run `pnpm build` to include them)');
+    }
+    if (findings.length === 0) {
+      console.log(
+        `✓ Every @revealui/* import in docs/ resolves to a current export (${files.length} files scanned)`,
+      );
+      return;
+    }
+    console.error(`✗ ${findings.length} doc import(s) reference missing exports:`);
+    for (const f of findings) {
+      const rel = path.relative(ROOT, f.file);
+      console.error(
+        `  ${rel}:${f.line} — import { ${f.missing} } from '${f.module}' [${f.reason}]`,
+      );
+    }
+    console.error('');
+    console.error('  Each of these is a stale doc sample. Either:');
+    console.error('    (a) update the doc to reference the current export, or');
+    console.error('    (b) ship a codemod if this was a recent rename (see §4.18 Phase B).');
+    if (warnOnly) {
+      console.error('');
+      console.error('  (running with --warn: not failing the build)');
+    }
+  }
+
+  if (findings.length > 0 && !warnOnly) process.exit(1);
+}
+
+// Only run when invoked directly (not when imported by tests).
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const selfPath = path.resolve(import.meta.dirname, 'docs-import-drift.ts');
+if (invokedPath === selfPath) {
+  main();
+}
+
+export { extractFences, loadExportsFromDts, moduleSubpath, parseImports };


### PR DESCRIPTION
## Summary

Adds `pnpm validate:docs-imports`, a drift detector for `docs/**` that catches the highest-value class of doc staleness: `import { X } from '@revealui/pkg'` references pointing at removed or renamed public API.

## How it works

- Walks `docs/**/*.md`, extracts every `ts`/`tsx`/`typescript` fenced block.
- Uses `ts.createSourceFile` to parse imports. Only `@revealui/*` specifiers are considered.
- For each workspace package, reads the `exports["."]["types"]` entry from its `package.json` and walks the `.d.ts` to build an export manifest (transitively follows `export * from './foo'`).
- Reports `file:line` when a named import isn't in the manifest.

## Why not full tsc?

Full typechecking the 847 code fences in `docs/` is out of scope for one PR and produces mostly noise (incomplete samples, pseudocode). The import-name check is cheap, deterministic, and catches the exact class of drift the plan cares about — e.g. `@revealui/security.PasswordHasher` → `@revealui/auth.hashPassword` renames from PR #344.

## Rollout

**Initial scan: 225 findings across existing docs.** Landing as **warn-only** in the CI gate so the infrastructure ships without blocking PRs. Backlog will be drained in follow-up doc PRs. When findings hit zero, flip `warnOnly: true` to `false` in `ci-gate.ts`.

Breakdown:
- 185 `not-exported` — imported name no longer in the package surface
- 155 `unknown-subpath` — deep import path not declared in the package's `exports` map
- 9 `unknown-package` — module not a workspace package

## Tests

`scripts/validate/__tests__/docs-import-drift.test.ts` — 7 cases covering fence extraction, import parsing (named / default+named / namespace / line offsets), module-subpath split, and real workspace `.d.ts` walk.

## Base branch

Targets `feat/codemod-infra` (#345) for sequencing; will rebase to `test` after the stack merges.

## Test plan

- [ ] `pnpm validate:docs-imports` prints the 225 findings and exits 1
- [ ] `pnpm validate:docs-imports --warn` prints the same list and exits 0
- [ ] `pnpm vitest run scripts/validate/__tests__/docs-import-drift.test.ts` green
- [ ] CI gate shows "Docs import drift" row in quality phase (warn-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)