### PR TITLE
feat(validate): messaging coverage tracker (§4.19)

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -916,7 +916,7 @@ Holster: "Here is the shared state where coordination happens"
 - [ ] Add a CI check that verifies code samples in docs/ compile against current package exports (extract fenced code blocks, typecheck them)
 - [ ] Add a CI check that verifies CLI `--help` output matches the documented command reference
 - [ ] Add a pre-commit rule: if a public export is renamed or removed, require a corresponding docs/ change in the same commit
-- [ ] Track messaging coverage: percentage of error paths that have user-friendly messages vs raw throws
+- [x] **Messaging coverage tracker** ✅ 2026-04-16 — `scripts/validate/messaging-coverage.ts` (`pnpm validate:messaging`). Counts raw `throw new Error(...)` vs typed `throw new XxxError(...)` across all `packages/*/src` and `apps/*/src` TS/TSX (excluding tests/examples), computes a coverage % (currently **16.27%**, 95/584), and fails CI if coverage regresses more than 0.5pp vs the committed snapshot at `docs/reference/messaging-coverage.snapshot.json`. Ships hard-failing — the floor only moves up from here.
 
 ---
 

--- a/docs/reference/messaging-coverage.snapshot.json
+++ b/docs/reference/messaging-coverage.snapshot.json
@@ -1,0 +1,134 @@
+{
+  "totalThrows": 584,
+  "rawThrows": 489,
+  "typedThrows": 95,
+  "coveragePercent": 16.27,
+  "topRawThrowFiles": [
+    {
+      "file": "apps/api/src/routes/webhooks.ts",
+      "count": 18
+    },
+    {
+      "file": "packages/auth/src/server/oauth.ts",
+      "count": 15
+    },
+    {
+      "file": "packages/security/src/encryption.ts",
+      "count": 15
+    },
+    {
+      "file": "packages/ai/src/skills/loader/vercel-loader.ts",
+      "count": 10
+    },
+    {
+      "file": "packages/ai/src/llm/client.ts",
+      "count": 9
+    },
+    {
+      "file": "packages/core/src/instance/RevealUIInstance.ts",
+      "count": 9
+    },
+    {
+      "file": "packages/ai/src/skills/loader/github-loader.ts",
+      "count": 8
+    },
+    {
+      "file": "packages/cache/src/cdn-config.ts",
+      "count": 8
+    },
+    {
+      "file": "packages/db/src/crypto.ts",
+      "count": 8
+    },
+    {
+      "file": "apps/api/src/routes/agent-tasks.ts",
+      "count": 8
+    },
+    {
+      "file": "packages/core/src/license-encryption.ts",
+      "count": 7
+    },
+    {
+      "file": "apps/admin/src/lib/collections/Products/hooks/beforeChange.ts",
+      "count": 7
+    },
+    {
+      "file": "packages/core/src/collections/operations/update.ts",
+      "count": 6
+    },
+    {
+      "file": "packages/db/src/client/index.ts",
+      "count": 6
+    },
+    {
+      "file": "apps/admin/src/lib/collections/Prices/hooks/beforeChange.ts",
+      "count": 6
+    }
+  ],
+  "typedClassHistogram": [
+    {
+      "name": "DatabaseError",
+      "count": 31
+    },
+    {
+      "name": "ValidationError",
+      "count": 21
+    },
+    {
+      "name": "ScriptError",
+      "count": 14
+    },
+    {
+      "name": "APIError",
+      "count": 10
+    },
+    {
+      "name": "CrossDbReferenceError",
+      "count": 3
+    },
+    {
+      "name": "DatabaseConnectionError",
+      "count": 2
+    },
+    {
+      "name": "DatabaseConstraintError",
+      "count": 2
+    },
+    {
+      "name": "DatabaseOperationError",
+      "count": 2
+    },
+    {
+      "name": "TokenError",
+      "count": 2
+    },
+    {
+      "name": "ConfigValidationError",
+      "count": 2
+    },
+    {
+      "name": "MemoryError",
+      "count": 1
+    },
+    {
+      "name": "MigrationError",
+      "count": 1
+    },
+    {
+      "name": "NotFoundError",
+      "count": 1
+    },
+    {
+      "name": "OAuthAccountConflictError",
+      "count": 1
+    },
+    {
+      "name": "OwnerSlotError",
+      "count": 1
+    },
+    {
+      "name": "CircuitBreakerOpenError",
+      "count": 1
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
-    "validate:versions": "tsx scripts/validate/version-policy.ts"
+    "validate:versions": "tsx scripts/validate/version-policy.ts",
+    "validate:messaging": "tsx scripts/validate/messaging-coverage.ts"
   },
   "type": "module"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,9 @@
     "commander": "^14.0.3",
     "execa": "^9.6.1",
     "jose": "^6.2.2",
-    "ora": "^9.3.0"
+    "ora": "^9.3.0",
+    "semver": "^7.7.4",
+    "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {
     "@revealui/ai": "workspace:^"
@@ -39,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/semver": "^7.7.1",
     "tsup": "^8.5.1",
     "typescript": "catalog:"
   },

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -10,6 +10,7 @@ describe('cli', () => {
     expect(commandNames).toContain('doctor');
     expect(commandNames).toContain('db');
     expect(commandNames).toContain('dev');
+    expect(commandNames).toContain('migrate');
     expect(commandNames).toContain('shell');
   });
 });

--- a/packages/cli/src/__tests__/codemods.test.ts
+++ b/packages/cli/src/__tests__/codemods.test.ts
@@ -1,0 +1,228 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getCodemod,
+  listApplicableCodemods,
+  readInstalledVersion,
+  registry,
+  runCodemods,
+} from '../codemods/index.js';
+import { passwordHasherToAuth } from '../codemods/transforms/password-hasher-to-auth.js';
+
+/**
+ * Build a minimal fixture project on disk so the runner's file discovery,
+ * version detection, and write behavior are exercised end-to-end.
+ */
+async function makeFixture(opts: {
+  securityVersion: string | null;
+  files: Record<string, string>;
+}): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+  const pkg: Record<string, unknown> = {
+    name: 'fixture',
+    version: '0.0.0',
+    dependencies: {},
+  };
+  if (opts.securityVersion) {
+    (pkg.dependencies as Record<string, string>)['@revealui/security'] = opts.securityVersion;
+    const nmDir = path.join(cwd, 'node_modules', '@revealui', 'security');
+    await mkdir(nmDir, { recursive: true });
+    await writeFile(
+      path.join(nmDir, 'package.json'),
+      JSON.stringify({ name: '@revealui/security', version: opts.securityVersion }),
+      'utf8',
+    );
+  }
+  await writeFile(path.join(cwd, 'package.json'), JSON.stringify(pkg), 'utf8');
+  for (const [rel, content] of Object.entries(opts.files)) {
+    const abs = path.join(cwd, rel);
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, content, 'utf8');
+  }
+  return cwd;
+}
+
+describe('codemod registry', () => {
+  it('exposes the password-hasher-to-auth codemod', () => {
+    expect(registry.length).toBeGreaterThan(0);
+    expect(getCodemod('password-hasher-to-auth')).toBeDefined();
+    expect(getCodemod('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('password-hasher-to-auth transform', () => {
+  const api = {
+    filePath: '/fake.ts',
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+
+  it('returns null when the source does not reference PasswordHasher', () => {
+    const source = `import { OAuthClient } from '@revealui/security';\nconst x = 1;\n`;
+    expect(passwordHasherToAuth.transform(source, api)).toBeNull();
+  });
+
+  it('rewrites a sole PasswordHasher import to @revealui/auth', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+const hash = await PasswordHasher.hash('pw');
+const ok = await PasswordHasher.verify('pw', hash);
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).not.toContain("from '@revealui/security'");
+    expect(out).toContain('hashPassword(');
+    expect(out).toContain('verifyPassword(');
+    expect(out).not.toContain('PasswordHasher');
+  });
+
+  it('preserves other named imports from @revealui/security', () => {
+    const source = `import { OAuthClient, PasswordHasher, TwoFactorAuth } from '@revealui/security';
+const h = PasswordHasher.hash('x');
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { OAuthClient, TwoFactorAuth } from '@revealui/security'");
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).toContain('hashPassword(');
+  });
+
+  it('is idempotent — running twice produces the same output', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+await PasswordHasher.hash('pw');
+`;
+    const once = passwordHasherToAuth.transform(source, api);
+    expect(once).not.toBeNull();
+    const twice = passwordHasherToAuth.transform(once as string, api);
+    // After the first pass nothing further needs changing.
+    expect(twice).toBeNull();
+  });
+
+  it('only matches recognized file extensions', () => {
+    expect(passwordHasherToAuth.match?.('/foo.ts')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.tsx')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.js')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.md')).toBe(false);
+  });
+});
+
+describe('readInstalledVersion', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('reads the resolved version from node_modules when present', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.7');
+  });
+
+  it('falls back to the declared range when node_modules is absent', async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+    await writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        dependencies: { '@revealui/security': '^0.2.4' },
+      }),
+      'utf8',
+    );
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.4');
+  });
+
+  it('returns null when the package is not listed at all', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBeNull();
+  });
+});
+
+describe('listApplicableCodemods', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('marks the codemod applicable when installed version is below the target', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(true);
+  });
+
+  it('marks the codemod not applicable when already migrated', async () => {
+    cwd = await makeFixture({ securityVersion: '0.3.0', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('does not satisfy');
+  });
+
+  it('marks the codemod not applicable when the package is absent', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('not installed');
+  });
+});
+
+describe('runCodemods', () => {
+  let cwd: string;
+  const sourceBefore = `import { PasswordHasher } from '@revealui/security';
+export async function login(pw: string) {
+  const h = await PasswordHasher.hash(pw);
+  return await PasswordHasher.verify(pw, h);
+}
+`;
+
+  beforeEach(async () => {
+    cwd = await makeFixture({
+      securityVersion: '0.2.7',
+      files: { 'src/login.ts': sourceBefore },
+    });
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('applies the codemod and rewrites the file', async () => {
+    const result = await runCodemods({ cwd });
+    expect(result.applied).toContain('password-hasher-to-auth');
+    expect(result.changedFiles).toBe(1);
+    expect(result.errored).toBe(0);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(after).toContain('hashPassword(');
+    expect(after).not.toContain('PasswordHasher');
+  });
+
+  it('dry-run reports changes without writing', async () => {
+    const result = await runCodemods({ cwd, dryRun: true });
+    expect(result.changedFiles).toBe(1);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toBe(sourceBefore);
+  });
+
+  it('restricts to a single codemod when `only` is set', async () => {
+    const result = await runCodemods({ cwd, only: 'password-hasher-to-auth' });
+    expect(result.applied).toEqual(['password-hasher-to-auth']);
+  });
+
+  it('reports no-op when no codemod applies', async () => {
+    const freshCwd = await makeFixture({
+      securityVersion: '0.3.0',
+      files: { 'src/login.ts': sourceBefore },
+    });
+    try {
+      const result = await runCodemods({ cwd: freshCwd });
+      expect(result.applied).toEqual([]);
+      expect(result.changedFiles).toBe(0);
+      // Source must be untouched when no codemod applies.
+      expect(await readFile(path.join(freshCwd, 'src/login.ts'), 'utf8')).toBe(sourceBefore);
+    } finally {
+      await rm(freshCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
   runDevUpCommand,
 } from './commands/dev.js';
 import { runDoctorCommand } from './commands/doctor.js';
+import { runMigrateCommand } from './commands/migrate.js';
 import {
   runSystemRevertCommand,
   runSystemScanCommand,
@@ -359,6 +360,16 @@ export function createCli(): Command {
     .description('Revert a previously applied tuning plan from backup')
     .action(async () => {
       await runSystemRevertCommand();
+    });
+
+  program
+    .command('migrate')
+    .description('Apply codemods to migrate your project to newer RevealUI versions')
+    .option('-d, --dry-run', 'Preview changes without writing files', false)
+    .option('--list', 'Show available codemods and applicability without running them', false)
+    .option('--only <name>', 'Run only the codemod with this name')
+    .action(async (options: { dryRun?: boolean; list?: boolean; only?: string }) => {
+      await runMigrateCommand(options);
     });
 
   program

--- a/packages/cli/src/codemods/index.ts
+++ b/packages/cli/src/codemods/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @revealui/cli/codemods — migration transform infrastructure.
+ *
+ * Public entry point. `revealui migrate` consumes this module; authors of
+ * individual codemods place their transforms under `./transforms/` and
+ * register them in `./registry.ts`.
+ */
+
+export { getCodemod, registry } from './registry.js';
+export { listApplicableCodemods, readInstalledVersion, runCodemods } from './runner.js';
+export type {
+  Codemod,
+  CodemodApi,
+  CodemodFileResult,
+  CodemodLogger,
+  CodemodRunResult,
+} from './types.js';

--- a/packages/cli/src/codemods/registry.ts
+++ b/packages/cli/src/codemods/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Codemod registry — central list of every migration transform shipped
+ * with this CLI. New codemods must be added here to be discoverable by
+ * `revealui migrate`.
+ *
+ * Ordering matters: the runner applies codemods in array order when
+ * multiple are applicable in a single run. Keep them in chronological
+ * release order (oldest first) so migrations compose predictably across
+ * multi-version upgrades.
+ */
+
+import { passwordHasherToAuth } from './transforms/password-hasher-to-auth.js';
+import type { Codemod } from './types.js';
+
+export const registry: readonly Codemod[] = [passwordHasherToAuth];
+
+export function getCodemod(name: string): Codemod | undefined {
+  return registry.find((c) => c.name === name);
+}

--- a/packages/cli/src/codemods/runner.ts
+++ b/packages/cli/src/codemods/runner.ts
@@ -1,0 +1,247 @@
+/**
+ * Codemod runner — discovers applicable transforms for a project and
+ * applies them across the source tree.
+ *
+ * Applicability is determined by comparing the installed version of each
+ * codemod's target package (read from the project's `package.json` +
+ * `node_modules`) against the codemod's `fromVersion` range. A codemod
+ * is applicable when the *current* installed version satisfies
+ * `fromVersion` — i.e. the project has not yet migrated.
+ */
+
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import semver from 'semver';
+import { registry } from './registry.js';
+import type { Codemod, CodemodApi, CodemodLogger, CodemodRunResult } from './types.js';
+
+export interface RunOptions {
+  /** Project root — the directory containing the user's package.json. */
+  cwd: string;
+  /** Globs to scan for transformable files (default: src/**\/*.{ts,tsx,js,jsx}). */
+  include?: string[];
+  /** When true, compute changes but do not write. */
+  dryRun?: boolean;
+  /** Restrict the run to a specific codemod by name. */
+  only?: string;
+  /** Logger to receive progress messages. */
+  logger?: CodemodLogger;
+}
+
+const DEFAULT_INCLUDE = ['src/**/*.{ts,tsx,js,jsx,mjs,cjs}'];
+
+const noop = (_: string): void => {
+  /* intentional no-op */
+};
+
+const silentLogger: CodemodLogger = {
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+/**
+ * Read the installed version of `packageName` from the user's project.
+ * Resolution order:
+ *   1. `node_modules/<pkg>/package.json` version (source of truth at runtime)
+ *   2. `package.json` dependencies / devDependencies / peerDependencies
+ *      (stripping leading `^` / `~` / range prefixes).
+ * Returns `null` if the package is not listed at all.
+ */
+export async function readInstalledVersion(
+  cwd: string,
+  packageName: string,
+): Promise<string | null> {
+  // Try node_modules first
+  const installedPkgPath = path.join(cwd, 'node_modules', packageName, 'package.json');
+  try {
+    const raw = await readFile(installedPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as { version?: string };
+    if (parsed.version) return parsed.version;
+  } catch {
+    // fall through
+  }
+
+  // Fall back to the declared range in the user's package.json
+  const userPkgPath = path.join(cwd, 'package.json');
+  try {
+    const raw = await readFile(userPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const declared =
+      parsed.dependencies?.[packageName] ??
+      parsed.devDependencies?.[packageName] ??
+      parsed.peerDependencies?.[packageName];
+    if (!declared) return null;
+    // Extract a concrete version from common range prefixes.
+    const match = declared.match(/(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+    return match ? (match[1] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return codemods that apply to the given project state. A codemod
+ * applies when its `package` is installed AND the installed version
+ * satisfies its `fromVersion` range.
+ */
+export async function listApplicableCodemods(cwd: string): Promise<
+  Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }>
+> {
+  const entries: Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }> = [];
+
+  for (const codemod of registry) {
+    const installedVersion = await readInstalledVersion(cwd, codemod.package);
+    if (installedVersion === null) {
+      entries.push({
+        codemod,
+        installedVersion: null,
+        applicable: false,
+        reason: `${codemod.package} not installed`,
+      });
+      continue;
+    }
+    const coerced = semver.coerce(installedVersion)?.version ?? installedVersion;
+    if (semver.satisfies(coerced, codemod.fromVersion, { includePrerelease: true })) {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: true,
+        reason: `matches ${codemod.fromVersion}`,
+      });
+    } else {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: false,
+        reason: `${coerced} does not satisfy ${codemod.fromVersion}`,
+      });
+    }
+  }
+  return entries;
+}
+
+async function findFiles(cwd: string, patterns: string[]): Promise<string[]> {
+  // Use dynamic import so we don't hard-require `fast-glob` at module load.
+  // tinyglobby is part of the existing dep tree via Vite; fall back to fast-glob.
+  let globber: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+  try {
+    const mod = (await import('tinyglobby')) as {
+      glob: typeof globber;
+    };
+    globber = mod.glob;
+  } catch {
+    const mod = (await import('fast-glob')) as unknown as {
+      default: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+    };
+    globber = mod.default;
+  }
+  return globber(patterns, { cwd, absolute: true });
+}
+
+async function applyCodemodToFile(
+  codemod: Codemod,
+  filePath: string,
+  opts: { dryRun: boolean; logger: CodemodLogger },
+): Promise<{ changed: boolean; error?: Error }> {
+  if (codemod.match && !codemod.match(filePath)) {
+    return { changed: false };
+  }
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isFile()) return { changed: false };
+    const source = await readFile(filePath, 'utf8');
+    const api: CodemodApi = { filePath, logger: opts.logger };
+    const next = codemod.transform(source, api);
+    if (next === null || next === source) return { changed: false };
+    if (!opts.dryRun) {
+      await writeFile(filePath, next, 'utf8');
+    }
+    return { changed: true };
+  } catch (error) {
+    return { changed: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}
+
+/**
+ * Run all applicable codemods against a project. Returns a structured
+ * summary with per-file outcomes.
+ */
+export async function runCodemods(options: RunOptions): Promise<CodemodRunResult> {
+  const logger = options.logger ?? silentLogger;
+  const include = options.include ?? DEFAULT_INCLUDE;
+  const applicable = await listApplicableCodemods(options.cwd);
+
+  const codemods = applicable.filter((a) => a.applicable).map((a) => a.codemod);
+  const filtered = options.only ? codemods.filter((c) => c.name === options.only) : codemods;
+
+  const result: CodemodRunResult = {
+    applied: [],
+    skipped: applicable.filter((a) => !a.applicable).map((a) => `${a.codemod.name} (${a.reason})`),
+    changedFiles: 0,
+    errored: 0,
+    results: [],
+  };
+
+  if (filtered.length === 0) {
+    logger.info('No codemods applicable to this project.');
+    return result;
+  }
+
+  const files = await findFiles(options.cwd, include);
+  logger.info(
+    `Scanning ${files.length} file(s) with ${filtered.length} codemod(s)${options.dryRun ? ' (dry run)' : ''}...`,
+  );
+
+  for (const codemod of filtered) {
+    let changed = 0;
+    for (const file of files) {
+      const outcome = await applyCodemodToFile(codemod, file, {
+        dryRun: options.dryRun ?? false,
+        logger,
+      });
+      if (outcome.error) {
+        result.errored += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'error',
+          error: outcome.error.message,
+        });
+        logger.error(`[${codemod.name}] ${file}: ${outcome.error.message}`);
+      } else if (outcome.changed) {
+        changed += 1;
+        result.changedFiles += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'changed',
+        });
+      } else {
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'unchanged',
+        });
+      }
+    }
+    result.applied.push(codemod.name);
+    logger.info(`[${codemod.name}] ${changed} file(s) changed`);
+  }
+
+  return result;
+}

--- a/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
+++ b/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * Codemod: PasswordHasher (PBKDF2) from @revealui/security → bcrypt-based
+ * hashPassword / verifyPassword from @revealui/auth.
+ *
+ * Shipped alongside @revealui/security 0.3.0 which drops the deprecated
+ * `PasswordHasher` export. See CHANGELOG and .changeset/remove-password-hasher.md.
+ *
+ * Scope: rewrites imports and call sites. Users with PBKDF2 hashes stored
+ * in their database must handle the hash-format migration themselves
+ * (detect `:` separator, re-hash after successful PBKDF2 verification);
+ * that can't be done by a source transform.
+ */
+
+import type { Codemod, CodemodApi } from '../types.js';
+
+const IMPORT_RE = /import\s+\{([^}]*)\}\s+from\s+(['"])@revealui\/security\2/g;
+const CALL_HASH_RE = /\bPasswordHasher\s*\.\s*hash\s*\(/g;
+const CALL_VERIFY_RE = /\bPasswordHasher\s*\.\s*verify\s*\(/g;
+const USES_PASSWORD_HASHER_RE = /\bPasswordHasher\b/;
+
+function rewriteImports(source: string): { source: string; didImport: boolean } {
+  let didImport = false;
+  const rewritten = source.replace(IMPORT_RE, (match, specifiers: string, quote: string) => {
+    // Parse named imports: "{ A, B, PasswordHasher, C as D }"
+    const items = specifiers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const keep: string[] = [];
+    let removedPasswordHasher = false;
+    for (const item of items) {
+      // `PasswordHasher` or `PasswordHasher as X` — drop either form.
+      if (/^PasswordHasher(\s+as\s+\w+)?$/.test(item)) {
+        removedPasswordHasher = true;
+        continue;
+      }
+      keep.push(item);
+    }
+
+    if (!removedPasswordHasher) return match;
+    didImport = true;
+
+    const securityLine =
+      keep.length > 0
+        ? `import { ${keep.join(', ')} } from ${quote}@revealui/security${quote}`
+        : null;
+    const authLine = `import { hashPassword, verifyPassword } from ${quote}@revealui/auth${quote}`;
+
+    return securityLine ? `${securityLine};\n${authLine}` : authLine;
+  });
+
+  return { source: rewritten, didImport };
+}
+
+function rewriteCallSites(source: string): { source: string; didCall: boolean } {
+  let didCall = false;
+  let out = source.replace(CALL_HASH_RE, () => {
+    didCall = true;
+    return 'hashPassword(';
+  });
+  out = out.replace(CALL_VERIFY_RE, () => {
+    didCall = true;
+    return 'verifyPassword(';
+  });
+  return { source: out, didCall };
+}
+
+function transform(source: string, _api: CodemodApi): string | null {
+  if (!USES_PASSWORD_HASHER_RE.test(source)) return null;
+
+  const afterImports = rewriteImports(source);
+  const afterCalls = rewriteCallSites(afterImports.source);
+
+  if (!(afterImports.didImport || afterCalls.didCall)) return null;
+  return afterCalls.source;
+}
+
+export const passwordHasherToAuth: Codemod = {
+  name: 'password-hasher-to-auth',
+  description:
+    'Migrate PasswordHasher (PBKDF2) from @revealui/security to bcrypt-based hashPassword/verifyPassword from @revealui/auth',
+  package: '@revealui/security',
+  fromVersion: '<0.3.0',
+  toVersion: '>=0.3.0',
+  match(filePath) {
+    return /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(filePath);
+  },
+  transform,
+};

--- a/packages/cli/src/codemods/types.ts
+++ b/packages/cli/src/codemods/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Codemod types — shared contract for all RevealUI migration transforms.
+ *
+ * A codemod describes a single breaking change across a version boundary
+ * and knows how to rewrite user source files to match the new API. Codemods
+ * are discovered from a central registry and applied in semver order by
+ * `revealui migrate`.
+ */
+
+/**
+ * API passed to a codemod transform. Kept minimal on purpose — a codemod
+ * that needs a full AST is free to `import { Project } from 'ts-morph'`
+ * (or similar) inside its own implementation. Most public-API renames can
+ * be expressed as straightforward string/regex rewrites over the source.
+ */
+export interface CodemodApi {
+  /** Absolute path of the file currently being transformed. */
+  filePath: string;
+  /** Logger bound to the active `revealui migrate` run. */
+  logger: CodemodLogger;
+}
+
+/** Structured logger surfaced to codemod authors. */
+export interface CodemodLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * A single codemod. One codemod addresses one breaking change, across one
+ * semver boundary. Author as many as the migration requires — ordering is
+ * controlled by `fromVersion`/`toVersion`, not file name.
+ */
+export interface Codemod {
+  /** Stable id, e.g. `password-hasher-to-auth`. Used as the CLI selector. */
+  name: string;
+  /** One-line summary printed by `revealui migrate --list`. */
+  description: string;
+  /**
+   * Semver range (as accepted by `semver.satisfies`) of the *previous*
+   * package version this codemod migrates *from*. Example: `"<0.3.0"`.
+   */
+  fromVersion: string;
+  /**
+   * Semver range the project lands on after this codemod runs. Used to
+   * skip codemods that have already been applied.
+   */
+  toVersion: string;
+  /**
+   * Package the versions refer to. `"@revealui/security"`, `"@revealui/core"`,
+   * etc. — looked up in the user's package.json to decide applicability.
+   */
+  package: string;
+  /**
+   * Optional filter — return false to skip a file without invoking `transform`.
+   * Useful for confining a codemod to `.ts` / `.tsx` only, or to a subtree.
+   */
+  match?(filePath: string): boolean;
+  /**
+   * Transform one file's source. Return the new source string, or `null`
+   * to indicate this file needs no change. Throw for a hard failure — the
+   * runner will catch and report, leaving the file untouched.
+   */
+  transform(source: string, api: CodemodApi): string | null;
+}
+
+/** Outcome per file, reported by the runner. */
+export interface CodemodFileResult {
+  filePath: string;
+  codemod: string;
+  status: 'changed' | 'unchanged' | 'error';
+  error?: string;
+}
+
+/** Aggregate summary returned by `runCodemods`. */
+export interface CodemodRunResult {
+  applied: string[];
+  skipped: string[];
+  changedFiles: number;
+  errored: number;
+  results: CodemodFileResult[];
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,84 @@
+/**
+ * `revealui migrate` — run applicable codemods against the current project.
+ */
+
+import { createLogger } from '@revealui/setup/utils';
+import {
+  type CodemodLogger,
+  type CodemodRunResult,
+  listApplicableCodemods,
+  runCodemods,
+} from '../codemods/index.js';
+
+export interface MigrateOptions {
+  /** Preview changes without writing files. */
+  dryRun?: boolean;
+  /** Print the applicable codemod list and exit. */
+  list?: boolean;
+  /** Restrict the run to a single codemod by name. */
+  only?: string;
+  /** Override the project root (defaults to process.cwd()). */
+  cwd?: string;
+}
+
+const logger = createLogger({ prefix: 'migrate' });
+
+const codemodLogger: CodemodLogger = {
+  info: (m) => logger.info(m),
+  warn: (m) => logger.warn(m),
+  error: (m) => logger.error(m),
+};
+
+export async function runMigrateListCommand(options: MigrateOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const entries = await listApplicableCodemods(cwd);
+  if (entries.length === 0) {
+    logger.info('No codemods are registered.');
+    return;
+  }
+  logger.info(`Codemods available for project at ${cwd}:`);
+  for (const entry of entries) {
+    const marker = entry.applicable ? '✓' : '·';
+    logger.info(
+      `  ${marker} ${entry.codemod.name}  [${entry.codemod.package} ${entry.codemod.fromVersion} → ${entry.codemod.toVersion}]`,
+    );
+    logger.info(`      ${entry.codemod.description}`);
+    logger.info(`      status: ${entry.reason}`);
+  }
+}
+
+export async function runMigrateCommand(options: MigrateOptions = {}): Promise<CodemodRunResult> {
+  const cwd = options.cwd ?? process.cwd();
+  if (options.list) {
+    await runMigrateListCommand({ ...options, cwd });
+    return {
+      applied: [],
+      skipped: [],
+      changedFiles: 0,
+      errored: 0,
+      results: [],
+    };
+  }
+  const result = await runCodemods({
+    cwd,
+    dryRun: options.dryRun,
+    only: options.only,
+    logger: codemodLogger,
+  });
+
+  if (result.applied.length === 0) {
+    logger.info('No applicable codemods. Your project is up to date.');
+    return result;
+  }
+
+  logger.success(
+    `${options.dryRun ? 'Would change' : 'Changed'} ${result.changedFiles} file(s) across ${result.applied.length} codemod(s).`,
+  );
+  if (result.errored > 0) {
+    logger.warn(`${result.errored} file(s) errored — see log above.`);
+  }
+  if (result.skipped.length > 0) {
+    logger.info(`Skipped: ${result.skipped.join(', ')}`);
+  }
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,10 +805,19 @@ importers:
       ora:
         specifier: ^9.3.0
         version: 9.3.0
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.2(@types/node@25.5.2))(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -4821,6 +4830,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -12311,6 +12323,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/tedious@4.0.14':
     dependencies:

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -278,6 +278,11 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
+        name: 'Messaging coverage',
+        command: 'pnpm',
+        args: ['validate:messaging'],
+      },
+      {
         name: 'Pro license validation',
         command: 'pnpm',
         args: ['validate:gitignore'],

--- a/scripts/validate/__tests__/messaging-coverage.test.ts
+++ b/scripts/validate/__tests__/messaging-coverage.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { computeCoverage } from '../messaging-coverage.ts';
+
+describe('computeCoverage', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'msgcov-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content: string): string {
+    const abs = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf8');
+    return abs;
+  }
+
+  it('counts raw vs typed throws', () => {
+    const a = write(
+      'a.ts',
+      `
+      function f() {
+        throw new Error('raw 1');
+        throw new Error('raw 2');
+        throw new ValidationError('typed 1');
+      }
+    `,
+    );
+    const b = write(
+      'b.ts',
+      `
+      function g() {
+        throw new AccessError('typed 2');
+        throw new AccessError('typed 3');
+      }
+    `,
+    );
+    const result = computeCoverage([a, b]);
+    expect(result.rawThrows).toBe(2);
+    expect(result.typedThrows).toBe(3);
+    expect(result.totalThrows).toBe(5);
+    expect(result.coveragePercent).toBe(60);
+  });
+
+  it('does not confuse typed throws for raw throws', () => {
+    const a = write('a.ts', `throw new SpecificError('x');`);
+    const result = computeCoverage([a]);
+    expect(result.rawThrows).toBe(0);
+    expect(result.typedThrows).toBe(1);
+  });
+
+  it('reports 100% when there are no throws', () => {
+    const a = write('a.ts', 'const x = 1;');
+    const result = computeCoverage([a]);
+    expect(result.totalThrows).toBe(0);
+    expect(result.coveragePercent).toBe(100);
+  });
+
+  it('ranks files by raw-throw count', () => {
+    const a = write('a.ts', `throw new Error('1');`);
+    const b = write(
+      'b.ts',
+      `
+      throw new Error('1');
+      throw new Error('2');
+      throw new Error('3');
+    `,
+    );
+    const result = computeCoverage([a, b]);
+    expect(result.topRawThrowFiles[0]?.file).toContain('b.ts');
+    expect(result.topRawThrowFiles[0]?.count).toBe(3);
+    expect(result.topRawThrowFiles[1]?.count).toBe(1);
+  });
+
+  it('captures typed-class histogram', () => {
+    const a = write(
+      'a.ts',
+      `
+      throw new ValidationError('1');
+      throw new ValidationError('2');
+      throw new AccessError('3');
+    `,
+    );
+    const result = computeCoverage([a]);
+    expect(result.typedClassHistogram[0]?.name).toBe('ValidationError');
+    expect(result.typedClassHistogram[0]?.count).toBe(2);
+    expect(result.typedClassHistogram[1]?.name).toBe('AccessError');
+  });
+});
+
+describe('committed baseline snapshot', () => {
+  it('exists and has the expected shape', () => {
+    const snapshotPath = path.resolve(
+      import.meta.dirname,
+      '../../../docs/reference/messaging-coverage.snapshot.json',
+    );
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+    const snap = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    expect(snap).toHaveProperty('totalThrows');
+    expect(snap).toHaveProperty('rawThrows');
+    expect(snap).toHaveProperty('typedThrows');
+    expect(snap).toHaveProperty('coveragePercent');
+    expect(typeof snap.coveragePercent).toBe('number');
+  });
+});

--- a/scripts/validate/messaging-coverage.ts
+++ b/scripts/validate/messaging-coverage.ts
@@ -1,0 +1,234 @@
+/**
+ * Messaging Coverage Tracker
+ *
+ * Computes the ratio of typed-error throws to raw `throw new Error(...)`
+ * across production source files, persists the result to a committed
+ * snapshot, and fails when coverage regresses by more than a small
+ * tolerance.
+ *
+ * "Typed" means the thrown class name isn't the bare `Error` — custom
+ * error classes (`ValidationError`, `AccessError`, `StripeError`, etc.)
+ * carry a display-ready message and usually a discriminant code, so
+ * they are what the plan calls a "user-friendly message." Raw
+ * `throw new Error('...')` leaks an implementation detail to the
+ * user with no contract.
+ *
+ * Usage:
+ *   pnpm validate:messaging          # check coverage vs snapshot
+ *   pnpm validate:messaging --json
+ *   UPDATE=1 pnpm validate:messaging # rebaseline the snapshot
+ *
+ * Exit codes:
+ *   0 = coverage ≥ snapshot − tolerance
+ *   1 = coverage regressed (or UPDATE=1 wrote a new baseline — still 0)
+ *
+ * Scope:
+ * - Scans each workspace's src/ under packages/ and apps/ (.ts / .tsx).
+ * - Skips test files (*.test, *.spec, __tests__/, *.example, *.e2e).
+ * - Skips node_modules, dist, build, .turbo.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const SNAPSHOT_PATH = path.join(ROOT, 'docs/reference/messaging-coverage.snapshot.json');
+const TOLERANCE_PCT = 0.5; // regression tolerance (in percentage points)
+
+const SOURCE_ROOTS = ['packages', 'apps'];
+const EXCLUDE_DIRS = new Set(['node_modules', 'dist', 'build', '.turbo', '__tests__', 'examples']);
+const EXCLUDE_FILE_PATTERNS = [
+  /\.test\.(ts|tsx|js|jsx)$/,
+  /\.spec\.(ts|tsx|js|jsx)$/,
+  /\.example\.(ts|tsx|js|jsx)$/,
+  /\.e2e\.(ts|tsx|js|jsx)$/,
+];
+
+const RAW_THROW = /\bthrow\s+new\s+Error\s*\(/g;
+const TYPED_THROW = /\bthrow\s+new\s+([A-Z][A-Za-z0-9_]*Error)\s*\(/g;
+
+interface CoverageResult {
+  totalThrows: number;
+  rawThrows: number;
+  typedThrows: number;
+  coveragePercent: number;
+  topRawThrowFiles: Array<{ file: string; count: number }>;
+  typedClassHistogram: Array<{ name: string; count: number }>;
+}
+
+function shouldIncludeFile(abs: string): boolean {
+  if (!(abs.endsWith('.ts') || abs.endsWith('.tsx'))) return false;
+  const base = path.basename(abs);
+  for (const pat of EXCLUDE_FILE_PATTERNS) {
+    if (pat.test(base)) return false;
+  }
+  return true;
+}
+
+function walk(dir: string, acc: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDE_DIRS.has(entry.name)) continue;
+      walk(path.join(dir, entry.name), acc);
+    } else if (entry.isFile()) {
+      const full = path.join(dir, entry.name);
+      if (shouldIncludeFile(full)) acc.push(full);
+    }
+  }
+}
+
+function collectFiles(): string[] {
+  const out: string[] = [];
+  for (const rootName of SOURCE_ROOTS) {
+    const rootDir = path.join(ROOT, rootName);
+    if (!fs.existsSync(rootDir)) continue;
+    for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      // Only scan each workspace's src/ — never its dist/ or test dirs.
+      const src = path.join(rootDir, entry.name, 'src');
+      if (fs.existsSync(src)) walk(src, out);
+    }
+  }
+  return out;
+}
+
+export function computeCoverage(files: string[]): CoverageResult {
+  const rawPerFile = new Map<string, number>();
+  const typedClassCounts = new Map<string, number>();
+  let totalRaw = 0;
+  let totalTyped = 0;
+
+  for (const file of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Count typed first — matches `throw new FooError(` and advances the
+    // index past the match, so the raw regex won't double-count.
+    let typedInFile = 0;
+    TYPED_THROW.lastIndex = 0;
+    for (const m of content.matchAll(TYPED_THROW)) {
+      const name = m[1] ?? 'UnknownError';
+      typedClassCounts.set(name, (typedClassCounts.get(name) ?? 0) + 1);
+      typedInFile++;
+    }
+
+    let rawInFile = 0;
+    RAW_THROW.lastIndex = 0;
+    for (const _ of content.matchAll(RAW_THROW)) {
+      rawInFile++;
+    }
+
+    totalRaw += rawInFile;
+    totalTyped += typedInFile;
+    if (rawInFile > 0) rawPerFile.set(file, rawInFile);
+  }
+
+  const totalThrows = totalRaw + totalTyped;
+  const coveragePercent = totalThrows === 0 ? 100 : (totalTyped / totalThrows) * 100;
+
+  const topRawThrowFiles = [...rawPerFile.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([file, count]) => ({ file: path.relative(ROOT, file), count }));
+
+  const typedClassHistogram = [...typedClassCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 20)
+    .map(([name, count]) => ({ name, count }));
+
+  return {
+    totalThrows,
+    rawThrows: totalRaw,
+    typedThrows: totalTyped,
+    coveragePercent: Math.round(coveragePercent * 100) / 100,
+    topRawThrowFiles,
+    typedClassHistogram,
+  };
+}
+
+function readSnapshot(): CoverageResult | null {
+  if (!fs.existsSync(SNAPSHOT_PATH)) return null;
+  return JSON.parse(fs.readFileSync(SNAPSHOT_PATH, 'utf8')) as CoverageResult;
+}
+
+function writeSnapshot(result: CoverageResult): void {
+  fs.mkdirSync(path.dirname(SNAPSHOT_PATH), { recursive: true });
+  fs.writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+}
+
+function main(): void {
+  const jsonOutput = process.argv.includes('--json');
+  const files = collectFiles();
+  const actual = computeCoverage(files);
+
+  if (process.env.UPDATE === '1') {
+    writeSnapshot(actual);
+    console.log(`✓ Wrote snapshot: ${path.relative(ROOT, SNAPSHOT_PATH)}`);
+    console.log(
+      `  ${actual.typedThrows}/${actual.totalThrows} typed throws (${actual.coveragePercent}%)`,
+    );
+    return;
+  }
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(actual, null, 2));
+    return;
+  }
+
+  const expected = readSnapshot();
+  const scanned = files.length;
+  console.log(`· Scanned ${scanned} source file(s)`);
+  console.log(
+    `· Messaging coverage: ${actual.typedThrows}/${actual.totalThrows} typed (${actual.coveragePercent}%)`,
+  );
+
+  if (!expected) {
+    console.error('✗ Snapshot missing. Run `UPDATE=1 pnpm validate:messaging` to create it.');
+    process.exit(1);
+  }
+
+  const delta = actual.coveragePercent - expected.coveragePercent;
+  const deltaStr = `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}pp`;
+  console.log(`· Baseline: ${expected.coveragePercent}%  (delta: ${deltaStr})`);
+
+  if (delta < -TOLERANCE_PCT) {
+    console.error(
+      `✗ Messaging coverage regressed by ${(-delta).toFixed(2)}pp (tolerance ${TOLERANCE_PCT}pp).`,
+    );
+    console.error('  Top files with raw `throw new Error(...)`:');
+    for (const f of actual.topRawThrowFiles.slice(0, 8)) {
+      console.error(`    ${f.file} — ${f.count}`);
+    }
+    console.error('');
+    console.error('  Fix options:');
+    console.error('    (a) replace raw throws with a typed error class (preferred), or');
+    console.error(
+      '    (b) justify the regression and rebaseline with `UPDATE=1 pnpm validate:messaging`',
+    );
+    process.exit(1);
+  }
+
+  if (delta > TOLERANCE_PCT) {
+    console.log('✓ Messaging coverage improved — consider rebaselining the snapshot:');
+    console.log('  UPDATE=1 pnpm validate:messaging');
+  } else {
+    console.log('✓ Messaging coverage within tolerance');
+  }
+}
+
+// Only run when invoked directly (not when imported by tests).
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const selfPath = path.resolve(import.meta.dirname, 'messaging-coverage.ts');
+if (invokedPath === selfPath) {
+  main();
+}


### PR DESCRIPTION
## Summary

Tracks the ratio of typed `throw new XxxError(...)` to raw `throw new Error(...)` across production source, snapshots the baseline, and fails CI on regression.

**Baseline (2026-04-16):** 95/584 typed throws = **16.27%**. Tolerance 0.5pp — the floor only moves up from here.

## How it works

- Scans each workspace's `src/` under `packages/` and `apps/`, `.ts`/`.tsx` only, excluding `*.test` / `*.spec` / `*.example` / `*.e2e` and `__tests__` / `dist` / `examples` dirs.
- Two regexes: `throw new Error(` (raw) and `throw new [A-Z]\w+Error(` (typed). Typed-class histogram is captured so trends by class are visible over time.
- Snapshot at `docs/reference/messaging-coverage.snapshot.json` records totals, top 15 raw-throw offenders, and typed-class top 20.
- `UPDATE=1 pnpm validate:messaging` rebaselines.

## Why raw vs typed?

Raw `throw new Error('<internal message>')` leaks implementation details and has no discriminant — callers can't distinguish what went wrong or surface a clean message to the user. Typed error classes carry display-ready messages plus a code, which is what §4.19 Phase C calls a "user-friendly message."

## Wired as hard-fail

Lands in the CI gate's quality phase (hard-fail, not warn-only). Any PR that adds a raw `throw new Error(...)` without offsetting elsewhere trips the check. Tolerance is 0.5pp so trivial noise doesn't block; real regressions do.

## Top raw-throw hotspots (from the snapshot)

- `apps/api/src/routes/webhooks.ts` — 18
- `packages/auth/src/server/oauth.ts` — 15
- `packages/security/src/encryption.ts` — 15
- `packages/ai/src/skills/loader/vercel-loader.ts` — 10
- `packages/ai/src/llm/client.ts` — 9
- `packages/core/src/instance/RevealUIInstance.ts` — 9
- `packages/ai/src/skills/loader/github-loader.ts` — 8
- `packages/cache/src/cdn-config.ts` — 8
- `packages/db/src/crypto.ts` — 8

These are natural follow-up PRs: each raw throw gets a typed error class and ticks the coverage up.

## Tests

`scripts/validate/__tests__/messaging-coverage.test.ts` — 6 cases: raw/typed counting, no-double-counting of typed as raw, 100% when no throws, file ranking, typed-class histogram, snapshot shape.

## Base branch

Targets `feat/codemod-infra` (#345) for sequencing; will rebase to `test` after the stack merges.

## Test plan

- [ ] `pnpm validate:messaging` reports 16.27% and exits 0
- [ ] Adding a `throw new Error(...)` somewhere + re-running fails
- [ ] `pnpm vitest run scripts/validate/__tests__/messaging-coverage.test.ts` green
- [ ] CI gate shows "Messaging coverage" row in quality phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)