### PR TITLE
feat(validate): export → docs guard (§4.19, warn-only)

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -915,7 +915,7 @@ Holster: "Here is the shared state where coordination happens"
 - [x] **Claim/count drift detector** ✅ 2026-04-15 — `scripts/validate/claim-drift.ts` (`pnpm validate:claims`). Counts real packages/apps/workspaces/tests/UI components/MCP servers and fails if docs, marketing, or READMEs claim a different number. First run found 35 mismatches across docs/marketing — all corrected.
 - [ ] Add a CI check that verifies code samples in docs/ compile against current package exports (extract fenced code blocks, typecheck them)
 - [ ] Add a CI check that verifies CLI `--help` output matches the documented command reference
-- [ ] Add a pre-commit rule: if a public export is renamed or removed, require a corresponding docs/ change in the same commit
+- [x] **Export → docs guard** ✅ 2026-04-16 — `scripts/validate/export-docs-guard.ts` (`pnpm validate:export-docs`). For every `packages/*/src/index.ts` barrel that changes between `origin/test` and HEAD, parses the before/after with the TS compiler and flags any removed named export that isn't paired with a change under `docs/`. Runs in the CI gate as warn-only initially; promote to hard-fail once workflow is proven. Not pre-commit — the check needs the base ref, which is cleaner in pre-push / CI.
 - [ ] Track messaging coverage: percentage of error paths that have user-friendly messages vs raw throws
 
 ---

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
-    "validate:versions": "tsx scripts/validate/version-policy.ts"
+    "validate:versions": "tsx scripts/validate/version-policy.ts",
+    "validate:export-docs": "tsx scripts/validate/export-docs-guard.ts"
   },
   "type": "module"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,9 @@
     "commander": "^14.0.3",
     "execa": "^9.6.1",
     "jose": "^6.2.2",
-    "ora": "^9.3.0"
+    "ora": "^9.3.0",
+    "semver": "^7.7.4",
+    "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {
     "@revealui/ai": "workspace:^"
@@ -39,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/semver": "^7.7.1",
     "tsup": "^8.5.1",
     "typescript": "catalog:"
   },

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -10,6 +10,7 @@ describe('cli', () => {
     expect(commandNames).toContain('doctor');
     expect(commandNames).toContain('db');
     expect(commandNames).toContain('dev');
+    expect(commandNames).toContain('migrate');
     expect(commandNames).toContain('shell');
   });
 });

--- a/packages/cli/src/__tests__/codemods.test.ts
+++ b/packages/cli/src/__tests__/codemods.test.ts
@@ -1,0 +1,228 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getCodemod,
+  listApplicableCodemods,
+  readInstalledVersion,
+  registry,
+  runCodemods,
+} from '../codemods/index.js';
+import { passwordHasherToAuth } from '../codemods/transforms/password-hasher-to-auth.js';
+
+/**
+ * Build a minimal fixture project on disk so the runner's file discovery,
+ * version detection, and write behavior are exercised end-to-end.
+ */
+async function makeFixture(opts: {
+  securityVersion: string | null;
+  files: Record<string, string>;
+}): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+  const pkg: Record<string, unknown> = {
+    name: 'fixture',
+    version: '0.0.0',
+    dependencies: {},
+  };
+  if (opts.securityVersion) {
+    (pkg.dependencies as Record<string, string>)['@revealui/security'] = opts.securityVersion;
+    const nmDir = path.join(cwd, 'node_modules', '@revealui', 'security');
+    await mkdir(nmDir, { recursive: true });
+    await writeFile(
+      path.join(nmDir, 'package.json'),
+      JSON.stringify({ name: '@revealui/security', version: opts.securityVersion }),
+      'utf8',
+    );
+  }
+  await writeFile(path.join(cwd, 'package.json'), JSON.stringify(pkg), 'utf8');
+  for (const [rel, content] of Object.entries(opts.files)) {
+    const abs = path.join(cwd, rel);
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, content, 'utf8');
+  }
+  return cwd;
+}
+
+describe('codemod registry', () => {
+  it('exposes the password-hasher-to-auth codemod', () => {
+    expect(registry.length).toBeGreaterThan(0);
+    expect(getCodemod('password-hasher-to-auth')).toBeDefined();
+    expect(getCodemod('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('password-hasher-to-auth transform', () => {
+  const api = {
+    filePath: '/fake.ts',
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+
+  it('returns null when the source does not reference PasswordHasher', () => {
+    const source = `import { OAuthClient } from '@revealui/security';\nconst x = 1;\n`;
+    expect(passwordHasherToAuth.transform(source, api)).toBeNull();
+  });
+
+  it('rewrites a sole PasswordHasher import to @revealui/auth', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+const hash = await PasswordHasher.hash('pw');
+const ok = await PasswordHasher.verify('pw', hash);
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).not.toContain("from '@revealui/security'");
+    expect(out).toContain('hashPassword(');
+    expect(out).toContain('verifyPassword(');
+    expect(out).not.toContain('PasswordHasher');
+  });
+
+  it('preserves other named imports from @revealui/security', () => {
+    const source = `import { OAuthClient, PasswordHasher, TwoFactorAuth } from '@revealui/security';
+const h = PasswordHasher.hash('x');
+`;
+    const out = passwordHasherToAuth.transform(source, api);
+    expect(out).not.toBeNull();
+    expect(out).toContain("import { OAuthClient, TwoFactorAuth } from '@revealui/security'");
+    expect(out).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(out).toContain('hashPassword(');
+  });
+
+  it('is idempotent — running twice produces the same output', () => {
+    const source = `import { PasswordHasher } from '@revealui/security';
+await PasswordHasher.hash('pw');
+`;
+    const once = passwordHasherToAuth.transform(source, api);
+    expect(once).not.toBeNull();
+    const twice = passwordHasherToAuth.transform(once as string, api);
+    // After the first pass nothing further needs changing.
+    expect(twice).toBeNull();
+  });
+
+  it('only matches recognized file extensions', () => {
+    expect(passwordHasherToAuth.match?.('/foo.ts')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.tsx')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.js')).toBe(true);
+    expect(passwordHasherToAuth.match?.('/foo.md')).toBe(false);
+  });
+});
+
+describe('readInstalledVersion', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('reads the resolved version from node_modules when present', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.7');
+  });
+
+  it('falls back to the declared range when node_modules is absent', async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'revealui-codemod-'));
+    await writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        dependencies: { '@revealui/security': '^0.2.4' },
+      }),
+      'utf8',
+    );
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBe('0.2.4');
+  });
+
+  it('returns null when the package is not listed at all', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    expect(await readInstalledVersion(cwd, '@revealui/security')).toBeNull();
+  });
+});
+
+describe('listApplicableCodemods', () => {
+  let cwd: string;
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('marks the codemod applicable when installed version is below the target', async () => {
+    cwd = await makeFixture({ securityVersion: '0.2.7', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(true);
+  });
+
+  it('marks the codemod not applicable when already migrated', async () => {
+    cwd = await makeFixture({ securityVersion: '0.3.0', files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('does not satisfy');
+  });
+
+  it('marks the codemod not applicable when the package is absent', async () => {
+    cwd = await makeFixture({ securityVersion: null, files: {} });
+    const applicable = await listApplicableCodemods(cwd);
+    const entry = applicable.find((a) => a.codemod.name === 'password-hasher-to-auth');
+    expect(entry?.applicable).toBe(false);
+    expect(entry?.reason).toContain('not installed');
+  });
+});
+
+describe('runCodemods', () => {
+  let cwd: string;
+  const sourceBefore = `import { PasswordHasher } from '@revealui/security';
+export async function login(pw: string) {
+  const h = await PasswordHasher.hash(pw);
+  return await PasswordHasher.verify(pw, h);
+}
+`;
+
+  beforeEach(async () => {
+    cwd = await makeFixture({
+      securityVersion: '0.2.7',
+      files: { 'src/login.ts': sourceBefore },
+    });
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('applies the codemod and rewrites the file', async () => {
+    const result = await runCodemods({ cwd });
+    expect(result.applied).toContain('password-hasher-to-auth');
+    expect(result.changedFiles).toBe(1);
+    expect(result.errored).toBe(0);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toContain("import { hashPassword, verifyPassword } from '@revealui/auth'");
+    expect(after).toContain('hashPassword(');
+    expect(after).not.toContain('PasswordHasher');
+  });
+
+  it('dry-run reports changes without writing', async () => {
+    const result = await runCodemods({ cwd, dryRun: true });
+    expect(result.changedFiles).toBe(1);
+    const after = await readFile(path.join(cwd, 'src/login.ts'), 'utf8');
+    expect(after).toBe(sourceBefore);
+  });
+
+  it('restricts to a single codemod when `only` is set', async () => {
+    const result = await runCodemods({ cwd, only: 'password-hasher-to-auth' });
+    expect(result.applied).toEqual(['password-hasher-to-auth']);
+  });
+
+  it('reports no-op when no codemod applies', async () => {
+    const freshCwd = await makeFixture({
+      securityVersion: '0.3.0',
+      files: { 'src/login.ts': sourceBefore },
+    });
+    try {
+      const result = await runCodemods({ cwd: freshCwd });
+      expect(result.applied).toEqual([]);
+      expect(result.changedFiles).toBe(0);
+      // Source must be untouched when no codemod applies.
+      expect(await readFile(path.join(freshCwd, 'src/login.ts'), 'utf8')).toBe(sourceBefore);
+    } finally {
+      await rm(freshCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
   runDevUpCommand,
 } from './commands/dev.js';
 import { runDoctorCommand } from './commands/doctor.js';
+import { runMigrateCommand } from './commands/migrate.js';
 import {
   runSystemRevertCommand,
   runSystemScanCommand,
@@ -359,6 +360,16 @@ export function createCli(): Command {
     .description('Revert a previously applied tuning plan from backup')
     .action(async () => {
       await runSystemRevertCommand();
+    });
+
+  program
+    .command('migrate')
+    .description('Apply codemods to migrate your project to newer RevealUI versions')
+    .option('-d, --dry-run', 'Preview changes without writing files', false)
+    .option('--list', 'Show available codemods and applicability without running them', false)
+    .option('--only <name>', 'Run only the codemod with this name')
+    .action(async (options: { dryRun?: boolean; list?: boolean; only?: string }) => {
+      await runMigrateCommand(options);
     });
 
   program

--- a/packages/cli/src/codemods/index.ts
+++ b/packages/cli/src/codemods/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @revealui/cli/codemods — migration transform infrastructure.
+ *
+ * Public entry point. `revealui migrate` consumes this module; authors of
+ * individual codemods place their transforms under `./transforms/` and
+ * register them in `./registry.ts`.
+ */
+
+export { getCodemod, registry } from './registry.js';
+export { listApplicableCodemods, readInstalledVersion, runCodemods } from './runner.js';
+export type {
+  Codemod,
+  CodemodApi,
+  CodemodFileResult,
+  CodemodLogger,
+  CodemodRunResult,
+} from './types.js';

--- a/packages/cli/src/codemods/registry.ts
+++ b/packages/cli/src/codemods/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Codemod registry — central list of every migration transform shipped
+ * with this CLI. New codemods must be added here to be discoverable by
+ * `revealui migrate`.
+ *
+ * Ordering matters: the runner applies codemods in array order when
+ * multiple are applicable in a single run. Keep them in chronological
+ * release order (oldest first) so migrations compose predictably across
+ * multi-version upgrades.
+ */
+
+import { passwordHasherToAuth } from './transforms/password-hasher-to-auth.js';
+import type { Codemod } from './types.js';
+
+export const registry: readonly Codemod[] = [passwordHasherToAuth];
+
+export function getCodemod(name: string): Codemod | undefined {
+  return registry.find((c) => c.name === name);
+}

--- a/packages/cli/src/codemods/runner.ts
+++ b/packages/cli/src/codemods/runner.ts
@@ -1,0 +1,247 @@
+/**
+ * Codemod runner — discovers applicable transforms for a project and
+ * applies them across the source tree.
+ *
+ * Applicability is determined by comparing the installed version of each
+ * codemod's target package (read from the project's `package.json` +
+ * `node_modules`) against the codemod's `fromVersion` range. A codemod
+ * is applicable when the *current* installed version satisfies
+ * `fromVersion` — i.e. the project has not yet migrated.
+ */
+
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import semver from 'semver';
+import { registry } from './registry.js';
+import type { Codemod, CodemodApi, CodemodLogger, CodemodRunResult } from './types.js';
+
+export interface RunOptions {
+  /** Project root — the directory containing the user's package.json. */
+  cwd: string;
+  /** Globs to scan for transformable files (default: src/**\/*.{ts,tsx,js,jsx}). */
+  include?: string[];
+  /** When true, compute changes but do not write. */
+  dryRun?: boolean;
+  /** Restrict the run to a specific codemod by name. */
+  only?: string;
+  /** Logger to receive progress messages. */
+  logger?: CodemodLogger;
+}
+
+const DEFAULT_INCLUDE = ['src/**/*.{ts,tsx,js,jsx,mjs,cjs}'];
+
+const noop = (_: string): void => {
+  /* intentional no-op */
+};
+
+const silentLogger: CodemodLogger = {
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+/**
+ * Read the installed version of `packageName` from the user's project.
+ * Resolution order:
+ *   1. `node_modules/<pkg>/package.json` version (source of truth at runtime)
+ *   2. `package.json` dependencies / devDependencies / peerDependencies
+ *      (stripping leading `^` / `~` / range prefixes).
+ * Returns `null` if the package is not listed at all.
+ */
+export async function readInstalledVersion(
+  cwd: string,
+  packageName: string,
+): Promise<string | null> {
+  // Try node_modules first
+  const installedPkgPath = path.join(cwd, 'node_modules', packageName, 'package.json');
+  try {
+    const raw = await readFile(installedPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as { version?: string };
+    if (parsed.version) return parsed.version;
+  } catch {
+    // fall through
+  }
+
+  // Fall back to the declared range in the user's package.json
+  const userPkgPath = path.join(cwd, 'package.json');
+  try {
+    const raw = await readFile(userPkgPath, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const declared =
+      parsed.dependencies?.[packageName] ??
+      parsed.devDependencies?.[packageName] ??
+      parsed.peerDependencies?.[packageName];
+    if (!declared) return null;
+    // Extract a concrete version from common range prefixes.
+    const match = declared.match(/(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+    return match ? (match[1] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return codemods that apply to the given project state. A codemod
+ * applies when its `package` is installed AND the installed version
+ * satisfies its `fromVersion` range.
+ */
+export async function listApplicableCodemods(cwd: string): Promise<
+  Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }>
+> {
+  const entries: Array<{
+    codemod: Codemod;
+    installedVersion: string | null;
+    applicable: boolean;
+    reason: string;
+  }> = [];
+
+  for (const codemod of registry) {
+    const installedVersion = await readInstalledVersion(cwd, codemod.package);
+    if (installedVersion === null) {
+      entries.push({
+        codemod,
+        installedVersion: null,
+        applicable: false,
+        reason: `${codemod.package} not installed`,
+      });
+      continue;
+    }
+    const coerced = semver.coerce(installedVersion)?.version ?? installedVersion;
+    if (semver.satisfies(coerced, codemod.fromVersion, { includePrerelease: true })) {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: true,
+        reason: `matches ${codemod.fromVersion}`,
+      });
+    } else {
+      entries.push({
+        codemod,
+        installedVersion: coerced,
+        applicable: false,
+        reason: `${coerced} does not satisfy ${codemod.fromVersion}`,
+      });
+    }
+  }
+  return entries;
+}
+
+async function findFiles(cwd: string, patterns: string[]): Promise<string[]> {
+  // Use dynamic import so we don't hard-require `fast-glob` at module load.
+  // tinyglobby is part of the existing dep tree via Vite; fall back to fast-glob.
+  let globber: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+  try {
+    const mod = (await import('tinyglobby')) as {
+      glob: typeof globber;
+    };
+    globber = mod.glob;
+  } catch {
+    const mod = (await import('fast-glob')) as unknown as {
+      default: (patterns: string[], opts: { cwd: string; absolute: boolean }) => Promise<string[]>;
+    };
+    globber = mod.default;
+  }
+  return globber(patterns, { cwd, absolute: true });
+}
+
+async function applyCodemodToFile(
+  codemod: Codemod,
+  filePath: string,
+  opts: { dryRun: boolean; logger: CodemodLogger },
+): Promise<{ changed: boolean; error?: Error }> {
+  if (codemod.match && !codemod.match(filePath)) {
+    return { changed: false };
+  }
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isFile()) return { changed: false };
+    const source = await readFile(filePath, 'utf8');
+    const api: CodemodApi = { filePath, logger: opts.logger };
+    const next = codemod.transform(source, api);
+    if (next === null || next === source) return { changed: false };
+    if (!opts.dryRun) {
+      await writeFile(filePath, next, 'utf8');
+    }
+    return { changed: true };
+  } catch (error) {
+    return { changed: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}
+
+/**
+ * Run all applicable codemods against a project. Returns a structured
+ * summary with per-file outcomes.
+ */
+export async function runCodemods(options: RunOptions): Promise<CodemodRunResult> {
+  const logger = options.logger ?? silentLogger;
+  const include = options.include ?? DEFAULT_INCLUDE;
+  const applicable = await listApplicableCodemods(options.cwd);
+
+  const codemods = applicable.filter((a) => a.applicable).map((a) => a.codemod);
+  const filtered = options.only ? codemods.filter((c) => c.name === options.only) : codemods;
+
+  const result: CodemodRunResult = {
+    applied: [],
+    skipped: applicable.filter((a) => !a.applicable).map((a) => `${a.codemod.name} (${a.reason})`),
+    changedFiles: 0,
+    errored: 0,
+    results: [],
+  };
+
+  if (filtered.length === 0) {
+    logger.info('No codemods applicable to this project.');
+    return result;
+  }
+
+  const files = await findFiles(options.cwd, include);
+  logger.info(
+    `Scanning ${files.length} file(s) with ${filtered.length} codemod(s)${options.dryRun ? ' (dry run)' : ''}...`,
+  );
+
+  for (const codemod of filtered) {
+    let changed = 0;
+    for (const file of files) {
+      const outcome = await applyCodemodToFile(codemod, file, {
+        dryRun: options.dryRun ?? false,
+        logger,
+      });
+      if (outcome.error) {
+        result.errored += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'error',
+          error: outcome.error.message,
+        });
+        logger.error(`[${codemod.name}] ${file}: ${outcome.error.message}`);
+      } else if (outcome.changed) {
+        changed += 1;
+        result.changedFiles += 1;
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'changed',
+        });
+      } else {
+        result.results.push({
+          filePath: file,
+          codemod: codemod.name,
+          status: 'unchanged',
+        });
+      }
+    }
+    result.applied.push(codemod.name);
+    logger.info(`[${codemod.name}] ${changed} file(s) changed`);
+  }
+
+  return result;
+}

--- a/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
+++ b/packages/cli/src/codemods/transforms/password-hasher-to-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * Codemod: PasswordHasher (PBKDF2) from @revealui/security → bcrypt-based
+ * hashPassword / verifyPassword from @revealui/auth.
+ *
+ * Shipped alongside @revealui/security 0.3.0 which drops the deprecated
+ * `PasswordHasher` export. See CHANGELOG and .changeset/remove-password-hasher.md.
+ *
+ * Scope: rewrites imports and call sites. Users with PBKDF2 hashes stored
+ * in their database must handle the hash-format migration themselves
+ * (detect `:` separator, re-hash after successful PBKDF2 verification);
+ * that can't be done by a source transform.
+ */
+
+import type { Codemod, CodemodApi } from '../types.js';
+
+const IMPORT_RE = /import\s+\{([^}]*)\}\s+from\s+(['"])@revealui\/security\2/g;
+const CALL_HASH_RE = /\bPasswordHasher\s*\.\s*hash\s*\(/g;
+const CALL_VERIFY_RE = /\bPasswordHasher\s*\.\s*verify\s*\(/g;
+const USES_PASSWORD_HASHER_RE = /\bPasswordHasher\b/;
+
+function rewriteImports(source: string): { source: string; didImport: boolean } {
+  let didImport = false;
+  const rewritten = source.replace(IMPORT_RE, (match, specifiers: string, quote: string) => {
+    // Parse named imports: "{ A, B, PasswordHasher, C as D }"
+    const items = specifiers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const keep: string[] = [];
+    let removedPasswordHasher = false;
+    for (const item of items) {
+      // `PasswordHasher` or `PasswordHasher as X` — drop either form.
+      if (/^PasswordHasher(\s+as\s+\w+)?$/.test(item)) {
+        removedPasswordHasher = true;
+        continue;
+      }
+      keep.push(item);
+    }
+
+    if (!removedPasswordHasher) return match;
+    didImport = true;
+
+    const securityLine =
+      keep.length > 0
+        ? `import { ${keep.join(', ')} } from ${quote}@revealui/security${quote}`
+        : null;
+    const authLine = `import { hashPassword, verifyPassword } from ${quote}@revealui/auth${quote}`;
+
+    return securityLine ? `${securityLine};\n${authLine}` : authLine;
+  });
+
+  return { source: rewritten, didImport };
+}
+
+function rewriteCallSites(source: string): { source: string; didCall: boolean } {
+  let didCall = false;
+  let out = source.replace(CALL_HASH_RE, () => {
+    didCall = true;
+    return 'hashPassword(';
+  });
+  out = out.replace(CALL_VERIFY_RE, () => {
+    didCall = true;
+    return 'verifyPassword(';
+  });
+  return { source: out, didCall };
+}
+
+function transform(source: string, _api: CodemodApi): string | null {
+  if (!USES_PASSWORD_HASHER_RE.test(source)) return null;
+
+  const afterImports = rewriteImports(source);
+  const afterCalls = rewriteCallSites(afterImports.source);
+
+  if (!(afterImports.didImport || afterCalls.didCall)) return null;
+  return afterCalls.source;
+}
+
+export const passwordHasherToAuth: Codemod = {
+  name: 'password-hasher-to-auth',
+  description:
+    'Migrate PasswordHasher (PBKDF2) from @revealui/security to bcrypt-based hashPassword/verifyPassword from @revealui/auth',
+  package: '@revealui/security',
+  fromVersion: '<0.3.0',
+  toVersion: '>=0.3.0',
+  match(filePath) {
+    return /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(filePath);
+  },
+  transform,
+};

--- a/packages/cli/src/codemods/types.ts
+++ b/packages/cli/src/codemods/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Codemod types — shared contract for all RevealUI migration transforms.
+ *
+ * A codemod describes a single breaking change across a version boundary
+ * and knows how to rewrite user source files to match the new API. Codemods
+ * are discovered from a central registry and applied in semver order by
+ * `revealui migrate`.
+ */
+
+/**
+ * API passed to a codemod transform. Kept minimal on purpose — a codemod
+ * that needs a full AST is free to `import { Project } from 'ts-morph'`
+ * (or similar) inside its own implementation. Most public-API renames can
+ * be expressed as straightforward string/regex rewrites over the source.
+ */
+export interface CodemodApi {
+  /** Absolute path of the file currently being transformed. */
+  filePath: string;
+  /** Logger bound to the active `revealui migrate` run. */
+  logger: CodemodLogger;
+}
+
+/** Structured logger surfaced to codemod authors. */
+export interface CodemodLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * A single codemod. One codemod addresses one breaking change, across one
+ * semver boundary. Author as many as the migration requires — ordering is
+ * controlled by `fromVersion`/`toVersion`, not file name.
+ */
+export interface Codemod {
+  /** Stable id, e.g. `password-hasher-to-auth`. Used as the CLI selector. */
+  name: string;
+  /** One-line summary printed by `revealui migrate --list`. */
+  description: string;
+  /**
+   * Semver range (as accepted by `semver.satisfies`) of the *previous*
+   * package version this codemod migrates *from*. Example: `"<0.3.0"`.
+   */
+  fromVersion: string;
+  /**
+   * Semver range the project lands on after this codemod runs. Used to
+   * skip codemods that have already been applied.
+   */
+  toVersion: string;
+  /**
+   * Package the versions refer to. `"@revealui/security"`, `"@revealui/core"`,
+   * etc. — looked up in the user's package.json to decide applicability.
+   */
+  package: string;
+  /**
+   * Optional filter — return false to skip a file without invoking `transform`.
+   * Useful for confining a codemod to `.ts` / `.tsx` only, or to a subtree.
+   */
+  match?(filePath: string): boolean;
+  /**
+   * Transform one file's source. Return the new source string, or `null`
+   * to indicate this file needs no change. Throw for a hard failure — the
+   * runner will catch and report, leaving the file untouched.
+   */
+  transform(source: string, api: CodemodApi): string | null;
+}
+
+/** Outcome per file, reported by the runner. */
+export interface CodemodFileResult {
+  filePath: string;
+  codemod: string;
+  status: 'changed' | 'unchanged' | 'error';
+  error?: string;
+}
+
+/** Aggregate summary returned by `runCodemods`. */
+export interface CodemodRunResult {
+  applied: string[];
+  skipped: string[];
+  changedFiles: number;
+  errored: number;
+  results: CodemodFileResult[];
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,84 @@
+/**
+ * `revealui migrate` — run applicable codemods against the current project.
+ */
+
+import { createLogger } from '@revealui/setup/utils';
+import {
+  type CodemodLogger,
+  type CodemodRunResult,
+  listApplicableCodemods,
+  runCodemods,
+} from '../codemods/index.js';
+
+export interface MigrateOptions {
+  /** Preview changes without writing files. */
+  dryRun?: boolean;
+  /** Print the applicable codemod list and exit. */
+  list?: boolean;
+  /** Restrict the run to a single codemod by name. */
+  only?: string;
+  /** Override the project root (defaults to process.cwd()). */
+  cwd?: string;
+}
+
+const logger = createLogger({ prefix: 'migrate' });
+
+const codemodLogger: CodemodLogger = {
+  info: (m) => logger.info(m),
+  warn: (m) => logger.warn(m),
+  error: (m) => logger.error(m),
+};
+
+export async function runMigrateListCommand(options: MigrateOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const entries = await listApplicableCodemods(cwd);
+  if (entries.length === 0) {
+    logger.info('No codemods are registered.');
+    return;
+  }
+  logger.info(`Codemods available for project at ${cwd}:`);
+  for (const entry of entries) {
+    const marker = entry.applicable ? '✓' : '·';
+    logger.info(
+      `  ${marker} ${entry.codemod.name}  [${entry.codemod.package} ${entry.codemod.fromVersion} → ${entry.codemod.toVersion}]`,
+    );
+    logger.info(`      ${entry.codemod.description}`);
+    logger.info(`      status: ${entry.reason}`);
+  }
+}
+
+export async function runMigrateCommand(options: MigrateOptions = {}): Promise<CodemodRunResult> {
+  const cwd = options.cwd ?? process.cwd();
+  if (options.list) {
+    await runMigrateListCommand({ ...options, cwd });
+    return {
+      applied: [],
+      skipped: [],
+      changedFiles: 0,
+      errored: 0,
+      results: [],
+    };
+  }
+  const result = await runCodemods({
+    cwd,
+    dryRun: options.dryRun,
+    only: options.only,
+    logger: codemodLogger,
+  });
+
+  if (result.applied.length === 0) {
+    logger.info('No applicable codemods. Your project is up to date.');
+    return result;
+  }
+
+  logger.success(
+    `${options.dryRun ? 'Would change' : 'Changed'} ${result.changedFiles} file(s) across ${result.applied.length} codemod(s).`,
+  );
+  if (result.errored > 0) {
+    logger.warn(`${result.errored} file(s) errored — see log above.`);
+  }
+  if (result.skipped.length > 0) {
+    logger.info(`Skipped: ${result.skipped.join(', ')}`);
+  }
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,10 +805,19 @@ importers:
       ora:
         specifier: ^9.3.0
         version: 9.3.0
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.2(@types/node@25.5.2))(@swc/core@1.15.21(@swc/helpers@0.5.20))(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -4821,6 +4830,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -12311,6 +12323,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/tedious@4.0.14':
     dependencies:

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -278,6 +278,12 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
+        name: 'Export → docs guard',
+        command: 'pnpm',
+        args: ['validate:export-docs'],
+        warnOnly: true,
+      },
+      {
         name: 'Pro license validation',
         command: 'pnpm',
         args: ['validate:gitignore'],

--- a/scripts/validate/__tests__/export-docs-guard.test.ts
+++ b/scripts/validate/__tests__/export-docs-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { extractExports } from '../export-docs-guard.ts';
+
+describe('extractExports', () => {
+  it('finds named re-exports', () => {
+    const src = `export { Foo, Bar as Baz } from './a';`;
+    const names = extractExports(src);
+    expect(names.has('Foo')).toBe(true);
+    expect(names.has('Baz')).toBe(true);
+    expect(names.has('Bar')).toBe(false);
+  });
+
+  it('finds export function / class / type / interface / enum', () => {
+    const src = `
+      export function a() {}
+      export class B {}
+      export type C = number;
+      export interface D {}
+      export enum E {}
+    `;
+    const names = extractExports(src);
+    expect([...names].sort()).toEqual(['B', 'C', 'D', 'E', 'a']);
+  });
+
+  it('finds multi-declarator export const', () => {
+    const src = `export const x = 1, y = 2;`;
+    const names = extractExports(src);
+    expect(names.has('x')).toBe(true);
+    expect(names.has('y')).toBe(true);
+  });
+
+  it('ignores star re-exports (intentional — only explicit named removals trip the guard)', () => {
+    const src = `export * from './barrel';`;
+    const names = extractExports(src);
+    expect(names.size).toBe(0);
+  });
+
+  it('ignores non-exported declarations', () => {
+    const src = `
+      function hidden() {}
+      const local = 1;
+      export const visible = 2;
+    `;
+    const names = extractExports(src);
+    expect(names.has('hidden')).toBe(false);
+    expect(names.has('local')).toBe(false);
+    expect(names.has('visible')).toBe(true);
+  });
+
+  it('detects set difference = removed exports', () => {
+    const before = extractExports(`
+      export { A, B, C } from './lib';
+      export function D() {}
+    `);
+    const after = extractExports(`
+      export { A, C } from './lib';
+      export function D() {}
+    `);
+    const removed = [...before].filter((n) => !after.has(n));
+    expect(removed).toEqual(['B']);
+  });
+});

--- a/scripts/validate/export-docs-guard.ts
+++ b/scripts/validate/export-docs-guard.ts
@@ -1,0 +1,216 @@
+/**
+ * Export → Docs Guard
+ *
+ * When a PR changes any `packages/*\/src/index.ts` barrel in a way that
+ * REMOVES an exported name, require a corresponding change somewhere
+ * under `docs/` in the same diff. This is the "public API rename or
+ * removal must ship with a docs update" rule from MASTER_PLAN §4.19
+ * Phase C.
+ *
+ * Usage:
+ *   pnpm validate:export-docs                  # default base: origin/test
+ *   pnpm validate:export-docs --base <ref>
+ *   pnpm validate:export-docs --json
+ *
+ * Exit codes:
+ *   0 = no export removals, OR removals are paired with docs changes
+ *   1 = exports removed without any docs/ changes in the same diff
+ *
+ * Design notes:
+ * - Compares the barrel at `<base>` vs working tree using
+ *   `git show <base>:<file>`, not the staged index. This is the behavior
+ *   you want for a pre-push / CI check — the base is the thing you're
+ *   merging INTO.
+ * - Parses exports with the TS compiler (`export { ... }`, `export function`,
+ *   `export const`, `export class`, etc.) so cosmetic reformats don't
+ *   trigger false positives.
+ * - Intentionally scoped to top-level barrels. Deep reorganisations
+ *   inside a package are the package author's concern; the user-facing
+ *   contract is what leaves via index.ts.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+
+interface GuardResult {
+  base: string;
+  changedBarrels: string[];
+  removedByFile: Record<string, string[]>;
+  hasDocsChange: boolean;
+  docsChangedFiles: string[];
+  verdict: 'pass' | 'fail';
+}
+
+function git(args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const e = err as { stderr?: Buffer | string };
+    const stderr = typeof e.stderr === 'string' ? e.stderr : (e.stderr?.toString('utf8') ?? '');
+    throw new Error(`git ${args.join(' ')} failed: ${stderr.trim()}`);
+  }
+}
+
+function resolveBase(explicit: string | undefined): string {
+  if (explicit) return explicit;
+  // Prefer origin/test (the repo's PR target); fall back to origin/main.
+  for (const candidate of ['origin/test', 'origin/main']) {
+    try {
+      git(['rev-parse', '--verify', candidate]);
+      return candidate;
+    } catch {
+      /* try next */
+    }
+  }
+  throw new Error('No base ref available (origin/test or origin/main).');
+}
+
+function listChangedFiles(base: string): string[] {
+  const out = git(['diff', '--name-only', `${base}...HEAD`]);
+  return out.split('\n').filter(Boolean);
+}
+
+function readAtRef(ref: string, file: string): string | null {
+  try {
+    return git(['show', `${ref}:${file}`]);
+  } catch {
+    // Missing at base = newly added file, not a removal candidate.
+    return null;
+  }
+}
+
+export function extractExports(source: string): Set<string> {
+  const sf = ts.createSourceFile('barrel.ts', source, ts.ScriptTarget.Latest, true);
+  const names = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isExportDeclaration(node)) {
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const el of node.exportClause.elements) {
+          names.add(el.name.text);
+        }
+      }
+      // `export * from './foo'` — we don't resolve the target here. That
+      // means star-re-export removals are invisible to the guard, which
+      // is a conservative choice: the guard only fires on *explicit*
+      // named removals, which are the ones a user can observe directly.
+    } else if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      if (node.name) names.add(node.name.text);
+    } else if (
+      ts.isVariableStatement(node) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of node.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) names.add(decl.name.text);
+      }
+    }
+  };
+
+  ts.forEachChild(sf, visit);
+  return names;
+}
+
+function main(): GuardResult {
+  const args = process.argv.slice(2);
+  const baseArgIdx = args.indexOf('--base');
+  const explicitBase = baseArgIdx >= 0 ? args[baseArgIdx + 1] : undefined;
+  const jsonOutput = args.includes('--json');
+  const base = resolveBase(explicitBase);
+
+  const changed = listChangedFiles(base);
+
+  // Only top-level package barrels — the user-facing contract surface.
+  const barrelRe = /^packages\/[^/]+\/src\/index\.ts$/;
+  const changedBarrels = changed.filter((f) => barrelRe.test(f));
+  const docsChangedFiles = changed.filter((f) => f.startsWith('docs/'));
+
+  const removedByFile: Record<string, string[]> = {};
+
+  for (const barrel of changedBarrels) {
+    const before = readAtRef(base, barrel);
+    const afterAbs = path.join(ROOT, barrel);
+    if (!fs.existsSync(afterAbs)) continue; // barrel deleted — separate concern
+    const after = fs.readFileSync(afterAbs, 'utf8');
+
+    const beforeSet = before ? extractExports(before) : new Set<string>();
+    const afterSet = extractExports(after);
+
+    const removed: string[] = [];
+    for (const name of beforeSet) {
+      if (!afterSet.has(name)) removed.push(name);
+    }
+    if (removed.length > 0) {
+      removed.sort();
+      removedByFile[barrel] = removed;
+    }
+  }
+
+  const hasRemovals = Object.keys(removedByFile).length > 0;
+  const verdict: 'pass' | 'fail' = hasRemovals && docsChangedFiles.length === 0 ? 'fail' : 'pass';
+
+  const result: GuardResult = {
+    base,
+    changedBarrels,
+    removedByFile,
+    hasDocsChange: docsChangedFiles.length > 0,
+    docsChangedFiles,
+    verdict,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`· Base: ${base}`);
+    console.log(`· Changed barrels: ${changedBarrels.length}`);
+    console.log(`· Docs files changed: ${docsChangedFiles.length}`);
+
+    if (!hasRemovals) {
+      console.log('✓ No public exports removed — guard inactive.');
+    } else if (docsChangedFiles.length > 0) {
+      console.log('✓ Exports removed, docs change detected — guard satisfied.');
+      for (const [file, names] of Object.entries(removedByFile)) {
+        console.log(`    ${file}: -${names.join(', -')}`);
+      }
+    } else {
+      console.error('✗ Public exports removed without any docs/ changes in this diff:');
+      for (const [file, names] of Object.entries(removedByFile)) {
+        console.error(`    ${file}: -${names.join(', -')}`);
+      }
+      console.error('');
+      console.error('  Rename or removal of a public export is a user-visible contract');
+      console.error('  change. Update at least one file under `docs/` in the same diff:');
+      console.error('    - migration note / CHANGELOG entry');
+      console.error('    - guide or reference page that mentioned the removed symbol');
+      console.error('    - `docs/reference/cli-help.snapshot.json` if this was a CLI change');
+      console.error('');
+      console.error('  If the removal is genuinely doc-irrelevant (e.g. a symbol that');
+      console.error('  was never documented), commit with `--no-verify` and explain why');
+      console.error('  in the PR description.');
+    }
+  }
+
+  if (verdict === 'fail') process.exit(1);
+  return result;
+}
+
+// Only run when invoked directly (not when imported by tests).
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const selfPath = path.resolve(import.meta.dirname, 'export-docs-guard.ts');
+if (invokedPath === selfPath) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds `pnpm validate:export-docs`, a guard that fires when a PR removes a named export from any `packages/*/src/index.ts` barrel without touching anything under `docs/`.

Public API removals are a user-visible contract change. The plan says they "require a corresponding docs/ change in the same commit" (MASTER_PLAN §4.19 Phase C). This check enforces that at PR-time.

## How it works

- Resolves a base ref (default `origin/test`, with `origin/main` fallback; `--base <ref>` to override).
- `git diff --name-only <base>...HEAD` to find changed barrels and any `docs/` changes in the diff.
- For each changed barrel: `git show <base>:<file>` vs working tree, extract exported names with the TS compiler (handles `export { ... }`, `export function/class/type/interface/enum`, `export const`), compute set difference.
- If `removed.size > 0 && docsChanged === 0` → fail.
- Star re-exports (`export * from './foo'`) are intentionally ignored — only explicit named removals trip the guard.

## Rollout

Wired as **warn-only** in the CI gate's quality phase. Promote to hard-fail once the workflow is proven. Pre-commit was rejected because the base ref needs to be remote-aware, which is cleaner in pre-push / CI than in a local hook.

## Tests

`scripts/validate/__tests__/export-docs-guard.test.ts` — 6 cases covering the AST extractor: named re-exports (+ `as` aliases), function/class/type/interface/enum, multi-declarator const, star-re-export ignored, non-exports excluded, set-difference computation.

## Base branch

Targets `feat/codemod-infra` (#345) for sequencing; will rebase to `test` after the stack merges.

## Test plan

- [ ] `pnpm validate:export-docs` passes (no barrels changed vs origin/test)
- [ ] Manual smoke: delete an export from some barrel, re-run — should fail
- [ ] `pnpm vitest run scripts/validate/__tests__/export-docs-guard.test.ts` green
- [ ] CI gate shows "Export → docs guard" row in quality phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)