### PR TITLE
docs(auth): fix stale @revealui/auth imports in authentication guide

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -236,23 +236,26 @@ RevealUI includes a server-side password reset flow.
 ### Request a Reset
 
 ```ts
-import { requestPasswordReset } from '@revealui/auth';
+import { generatePasswordResetToken } from '@revealui/auth';
 
-// Generates a time-limited token and returns it
-// Your application is responsible for sending the email
-const result = await requestPasswordReset(email);
+// Generates a time-limited token and returns it.
+// Your application is responsible for sending the email with the reset link.
+const result = await generatePasswordResetToken(email);
 
-if (result.success) {
-  await sendResetEmail(email, result.token);
+if (result.success && result.token && result.tokenId) {
+  // Both tokenId and token are needed to complete the reset
+  await sendResetEmail(email, result.tokenId, result.token);
 }
 ```
 
 ### Complete the Reset
 
 ```ts
-import { resetPassword } from '@revealui/auth';
+import { resetPasswordWithToken } from '@revealui/auth';
 
-const result = await resetPassword(token, newPassword);
+// tokenId identifies the reset row, token is the plain-text secret.
+// Both are delivered in the reset URL, e.g. `?id=<tokenId>&token=<token>`.
+const result = await resetPasswordWithToken(tokenId, token, newPassword);
 
 if (!result.success) {
   // Token expired or invalid, or password does not meet strength requirements
@@ -260,7 +263,7 @@ if (!result.success) {
 }
 ```
 
-Reset tokens are single-use and expire after a configurable duration (default: 1 hour).
+Reset tokens are single-use and expire after 15 minutes.
 
 ---
 
@@ -323,9 +326,11 @@ All endpoints accept and return JSON. Error responses use the format:
 ### Validating a Session
 
 ```ts
-import { validateSession } from '@revealui/auth';
+import { getSession } from '@revealui/auth';
 
-const authSession = await validateSession(sessionToken);
+// Reads the `revealui-session` cookie from the request headers,
+// looks up the matching row, and returns the session + user.
+const authSession = await getSession(request.headers);
 
 if (!authSession) {
   // Session is invalid or expired
@@ -339,9 +344,11 @@ if (!authSession) {
 ### Revoking a Session
 
 ```ts
-import { revokeSession } from '@revealui/auth';
+import { deleteSession } from '@revealui/auth';
 
-await revokeSession(sessionId);
+// Deletes the session associated with the request's cookie.
+// Returns true if a session was deleted, false if none matched.
+await deleteSession(request.headers);
 ```
 
 ### Cookie Domain


### PR DESCRIPTION
## Summary

Replace 4 renamed public exports in `docs/guides/authentication.md` so the
guide matches the real `@revealui/auth` surface. Pre-work for landing the
`docs-import-drift` validator (feat/docs-sample-typecheck, PR #347) as a
hard-fail CI gate once the baseline reaches zero.

## Changes

| Old name | New name | Reason |
|---|---|---|
| `requestPasswordReset` | `generatePasswordResetToken` | Renamed; now returns `tokenId` + `token` (both required to reset) |
| `resetPassword`         | `resetPasswordWithToken`      | Now takes `(tokenId, token, newPassword)` |
| `validateSession`       | `getSession`                  | Reads cookie from `request.headers` (session token is not passed directly) |
| `revokeSession`         | `deleteSession`               | Deletes by `request.headers`, not a session ID |

Also corrected the reset-token expiry note to 15 minutes (matches `TOKEN_EXPIRY_MS` in `packages/auth/src/server/password-reset.ts`).

## Drift impact

Ran the `docs-import-drift` validator (from feat/docs-sample-typecheck) against this branch:

- Before: 225 findings, ~4 in `authentication.md`
- After:  221 findings, 0 in `authentication.md`

The guide no longer references any removed or renamed `@revealui/auth` exports.

## Test plan

- [x] `pnpm validate:docs-imports` reports 0 findings in `authentication.md`
- [x] Pre-push gate passes
- [x] No changes to package code or runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)