### PR TITLE
feat(core): expose api/* + monitoring/query-monitor as public subpaths

### DIFF
--- a/.changeset/core-api-monitoring-subpaths.md
+++ b/.changeset/core-api-monitoring-subpaths.md
@@ -1,0 +1,15 @@
+---
+'@revealui/core': minor
+---
+
+Expose five previously internal-but-documented modules as public subpath imports:
+
+- `@revealui/core/api/compression` — response compression middleware + presets
+- `@revealui/core/api/payload-optimization` — cursor pagination, field selection, response shaping
+- `@revealui/core/api/rate-limit` — sliding-window rate limiter + presets (per-IP, per-user, per-API-key)
+- `@revealui/core/api/response-cache` — HTTP cache middleware, ETag, tag-based invalidation
+- `@revealui/core/monitoring/query-monitor` — `monitorQuery` DB performance wrapper
+
+Each module has existed in source (`packages/core/src/api/*.ts`, `monitoring/query-monitor.ts`) with full unit test coverage but was not listed in `package.json#exports`, so `docs/PERFORMANCE.md` examples like `import { compressResponse } from '@revealui/core/api/compression'` would fail at the module resolver. No code changes — this is purely an exports-map addition.
+
+Drops `docs-import-drift` findings by 35 (225 → 190).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -169,6 +169,22 @@
       "types": "./dist/api/rest.d.ts",
       "import": "./dist/api/rest.js"
     },
+    "./api/compression": {
+      "types": "./dist/api/compression.d.ts",
+      "import": "./dist/api/compression.js"
+    },
+    "./api/payload-optimization": {
+      "types": "./dist/api/payload-optimization.d.ts",
+      "import": "./dist/api/payload-optimization.js"
+    },
+    "./api/rate-limit": {
+      "types": "./dist/api/rate-limit.d.ts",
+      "import": "./dist/api/rate-limit.js"
+    },
+    "./api/response-cache": {
+      "types": "./dist/api/response-cache.d.ts",
+      "import": "./dist/api/response-cache.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
@@ -240,6 +256,10 @@
     "./monitoring/process-registry": {
       "types": "./dist/monitoring/process-registry.d.ts",
       "import": "./dist/monitoring/process-registry.js"
+    },
+    "./monitoring/query-monitor": {
+      "types": "./dist/monitoring/query-monitor.d.ts",
+      "import": "./dist/monitoring/query-monitor.js"
     },
     "./utils/error-responses": {
       "types": "./dist/utils/error-responses.d.ts",


### PR DESCRIPTION
## Summary

Add five subpath exports to `packages/core/package.json` that match modules already present in the source tree, fully tested, and documented — but blocked at the module resolver because they weren't in the exports map.

New subpaths:

| Subpath | Purpose | Source |
|---|---|---|
| `./api/compression` | Response compression middleware + presets | `src/api/compression.ts` |
| `./api/payload-optimization` | Cursor pagination, field selection, response shaping | `src/api/payload-optimization.ts` |
| `./api/rate-limit` | Sliding-window rate limiter + presets | `src/api/rate-limit.ts` |
| `./api/response-cache` | HTTP cache middleware, ETag, tag invalidation | `src/api/response-cache.ts` |
| `./monitoring/query-monitor` | `monitorQuery` DB performance wrapper | `src/monitoring/query-monitor.ts` |

All five modules:
- Exist in source with 300-500 LOC each
- Have matching unit test files in `__tests__/`
- Have existing dist artifacts (`*.d.ts` + `*.js`)
- Are referenced as public API in `docs/PERFORMANCE.md` and `docs/REFERENCE.md`

This is a purely additive change to the exports map — no code, no runtime behavior changes.

## Validator impact

Re-ran `scripts/validate/docs-import-drift.ts` (from feat/docs-sample-typecheck) against this branch:

| File | Before | After | Delta |
|---|---|---|---|
| Total | 225 | 190 | -35 |
| PERFORMANCE.md | 83 | 55 | -28 |
| REFERENCE.md | 27 | 25 | -2 |
| DATABASE.md | 16 | 11 | -5 |

(Remaining PERFORMANCE.md findings are all in sections for modules that have moved to `@revealui/cache` or been removed — will be addressed in separate doc-rewrite PRs.)

## Changeset

`@revealui/core` minor bump — adding public subpath exports expands the contract.

## Test plan

- [x] `pnpm --filter @revealui/core typecheck` clean
- [x] `pnpm validate:catalog` passes
- [x] `pnpm validate:versions` passes
- [x] Pre-push gate passes
- [x] Dist artifacts for all five subpaths verified on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)