### PR TITLE
fix(ai): expose caching + orchestration + skills-registry subpaths

### DIFF
--- a/.changeset/ai-llm-orchestration-subpaths.md
+++ b/.changeset/ai-llm-orchestration-subpaths.md
@@ -1,0 +1,13 @@
+---
+'@revealui/ai': minor
+---
+
+Add subpath exports for AI caching, orchestration, and skills registry helpers:
+
+- `@revealui/ai/llm/cache-utils` — `withCache`, `cacheableSystemPrompt`, and related prompt-caching helpers
+- `@revealui/ai/llm/response-cache` — `getGlobalResponseCache`, `calculateResponseCacheSavings`
+- `@revealui/ai/llm/semantic-cache` — `getGlobalSemanticCache`, `calculateSemanticCacheSavings`
+- `@revealui/ai/orchestration/runtime` — non-streaming agent runtime (complement to the existing `./orchestration/streaming-runtime`)
+- `@revealui/ai/skills/registry` — `globalSkillRegistry`, `SkillRegistry`, `SkillStorageConfig`
+
+Docs under `docs/ai/PROMPT_CACHING.md`, `docs/ai/RESPONSE_CACHING.md`, and `docs/ai/SEMANTIC_CACHING.md` reference these paths; they previously resolved only via deep relative paths.

--- a/docs/ai/PROMPT_CACHING.md
+++ b/docs/ai/PROMPT_CACHING.md
@@ -154,9 +154,9 @@ response = await client.chat(messages, { enableCache: true })
 ### Pattern 4: Skills/Resources
 
 ```typescript
-import { loadSkill } from '@revealui/ai/skills/registry'
+import { globalSkillRegistry } from '@revealui/ai/skills/registry'
 
-const skill = await skillRegistry.loadSkill('typescript-expert')
+const skill = await globalSkillRegistry.loadSkill('typescript-expert')
 
 // Skill instructions + resources (~5000 tokens)
 const messages = [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -83,6 +83,14 @@
       "types": "./dist/skills/index.d.ts",
       "import": "./dist/skills/index.js"
     },
+    "./skills/registry": {
+      "types": "./dist/skills/registry/index.d.ts",
+      "import": "./dist/skills/registry/index.js"
+    },
+    "./llm/cache-utils": {
+      "types": "./dist/llm/cache-utils.d.ts",
+      "import": "./dist/llm/cache-utils.js"
+    },
     "./llm/client": {
       "types": "./dist/llm/client.d.ts",
       "import": "./dist/llm/client.js"
@@ -99,6 +107,14 @@
       "types": "./dist/llm/providers/base.d.ts",
       "import": "./dist/llm/providers/base.js"
     },
+    "./llm/response-cache": {
+      "types": "./dist/llm/response-cache.d.ts",
+      "import": "./dist/llm/response-cache.js"
+    },
+    "./llm/semantic-cache": {
+      "types": "./dist/llm/semantic-cache.d.ts",
+      "import": "./dist/llm/semantic-cache.js"
+    },
     "./tools/admin": {
       "types": "./dist/tools/admin/index.d.ts",
       "import": "./dist/tools/admin/index.js"
@@ -110,6 +126,10 @@
     "./ingestion": {
       "types": "./dist/ingestion/index.d.ts",
       "import": "./dist/ingestion/index.js"
+    },
+    "./orchestration/runtime": {
+      "types": "./dist/orchestration/runtime.d.ts",
+      "import": "./dist/orchestration/runtime.js"
     },
     "./orchestration/streaming-runtime": {
       "types": "./dist/orchestration/streaming-runtime.d.ts",


### PR DESCRIPTION
## Summary

- Adds 5 missing `@revealui/ai` subpath exports (`./llm/cache-utils`, `./llm/response-cache`, `./llm/semantic-cache`, `./orchestration/runtime`, `./skills/registry`). Source files exist, dist files exist — they just were not in the exports map.
- Fixes `docs/ai/PROMPT_CACHING.md:157` sample: `loadSkill` is not exported anywhere in `@revealui/ai`; the example even calls `skillRegistry.loadSkill(...)` on an undeclared variable. Replaced the dead import with the real `globalSkillRegistry` singleton.
- `@revealui/ai` minor bump (0.x rules: internal breaking/meaningful-change bumps minor).

## Drift impact

- Total docs-import-drift findings: 211 → 206 (−5)
- `docs/ai/PROMPT_CACHING.md`: 10 → 0
- `docs/ai/RESPONSE_CACHING.md`: 2 → 0
- `docs/ai/SEMANTIC_CACHING.md`: 2 → 0

## Test plan

- [x] Pre-push gate passes (lint, typecheck, tests, build — phase 1 on feature branch)
- [x] `scripts/validate/docs-import-drift.ts` confirms AI caching docs report zero findings
- [x] Changeset present at `.changeset/ai-llm-orchestration-subpaths.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)