### PR TITLE
fix(core,db): expose cache/query-cache + db/pool subpaths

### DIFF
--- a/.changeset/core-cache-query-cache-db-pool.md
+++ b/.changeset/core-cache-query-cache-db-pool.md
@@ -1,0 +1,13 @@
+---
+'@revealui/core': minor
+'@revealui/db': minor
+---
+
+Expose two previously internal-but-documented modules as public subpath imports:
+
+- `@revealui/core/cache/query-cache` — `cacheQuery`, `cacheList`, `cacheItem`, `invalidateCache`, `invalidateCachePattern`, `invalidateResource`, `cacheSWR`
+- `@revealui/db/pool` — `getPool`, `pool`, `checkDatabaseHealth`, `getPoolStats`, `startPoolMonitoring`, `warmupPool`
+
+Both modules have existed in source with full unit test coverage (`packages/core/src/cache/query-cache.ts`, `packages/db/src/pool.ts`) but were not listed in `package.json#exports`, so `docs/DATABASE.md` examples like `import { monitorQuery } from '@revealui/core/monitoring/query-monitor'` and `import { getPoolStats } from '@revealui/db/pool'` would fail at the module resolver. No code changes — purely exports-map additions.
+
+`@revealui/core/monitoring/query-monitor` is exposed separately in the companion PR that adds `api/*` subpaths.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -293,6 +293,10 @@
       "types": "./dist/caching/index.d.ts",
       "import": "./dist/caching/index.js"
     },
+    "./cache/query-cache": {
+      "types": "./dist/cache/query-cache.d.ts",
+      "import": "./dist/cache/query-cache.js"
+    },
     "./optimization/code-splitting": {
       "types": "./dist/optimization/code-splitting.d.ts",
       "import": "./dist/optimization/code-splitting.js"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -201,6 +201,10 @@
     "./saga": {
       "types": "./dist/saga/index.d.ts",
       "import": "./dist/saga/index.js"
+    },
+    "./pool": {
+      "types": "./dist/pool.d.ts",
+      "import": "./dist/pool.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

Adds two missing subpath exports for modules that already exist in source with full test coverage:

- `@revealui/core/cache/query-cache` — query caching helpers (`cacheQuery`, `cacheList`, `cacheItem`, `invalidateCache`, `invalidateCachePattern`, `invalidateResource`, `cacheSWR`)
- `@revealui/db/pool` — pool diagnostics (`getPoolStats`, `checkDatabaseHealth`, `warmupPool`, `startPoolMonitoring`, `getPool`, `pool`)

Both packages bump minor (0.x pre-1.0 rules). No code changes — purely exports-map additions.

## Drift impact

- `docs/DATABASE.md`: 16 → 5 (−11)
- The remaining 5 are `monitoring/query-monitor` imports handled by companion PR #351

## Merge order note

#351 adds `@revealui/core/monitoring/query-monitor` separately. Both PRs edit `packages/core/package.json` exports map but in non-overlapping locations (this one adds `./cache/query-cache` next to `./caching`; #351 adds `./monitoring/query-monitor` next to `./monitoring/process-registry`). Merging in either order should clean apply; otherwise a trivial rebase resolves it.

## Test plan

- [x] Pre-push gate passes (lint, typecheck, tests, build)
- [x] `scripts/validate/docs-import-drift.ts` confirms 11 DATABASE.md findings cleared
- [x] Changesets present for both `@revealui/core` and `@revealui/db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)