### PR TITLE
fix(db,config,cli,docs): expose documented APIs + correct REFERENCE.md schema paths

### DIFF
--- a/.changeset/reference-docs-db-config-cli-exports.md
+++ b/.changeset/reference-docs-db-config-cli-exports.md
@@ -1,0 +1,25 @@
+---
+'@revealui/db': minor
+'@revealui/config': minor
+'@revealui/cli': minor
+---
+
+Expose previously-documented APIs that weren't actually on the public surface:
+
+**`@revealui/db` — 8 new schema subpath exports** (source + dist existed; only the exports map was missing):
+- `./schema/password-reset-tokens`
+- `./schema/admin` (`posts`, `media`, `globalHeader`, `globalFooter`, `globalSettings`)
+- `./schema/licenses`
+- `./schema/api-keys` (`userApiKeys`, `tenantProviderConfigs`)
+- `./schema/audit-log`
+- `./schema/app-logs`
+- `./schema/error-events`
+
+**`@revealui/config` — 4 re-exports from the package root:**
+- `validateAndThrow` — already in `./validator.js`, now on the root barrel
+- `getDatabaseConfig` / `getRevealConfig` / `getStripeConfig` — from `./modules/{database,reveal,stripe}.js`
+
+**`@revealui/cli` — programmatic project creation:**
+- `createProject` and `CreateProjectConfig` are now exported from the package root for use in tests and custom tooling (documented in `docs/REFERENCE.md`).
+
+No behavior changes — purely surface-area additions. Drops docs-import-drift findings in REFERENCE.md by 19 (21 → 2; the remaining 2 are `@revealui/core/api/rate-limit` which the companion PR handles).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -74,7 +74,7 @@ Next.js configuration wrapper. Merges RevealUI's webpack/Turbopack aliases, envi
 
 ```ts
 // next.config.ts
-import { withRevealUI } from "@revealui/core";
+import { withRevealUI } from "@revealui/core/nextjs/withRevealUI";
 
 export default withRevealUI(
   {
@@ -471,7 +471,7 @@ Requires a valid session (`req.user` must be present).
 Returns `true` if the user has the `'admin'` role.
 
 ```ts
-import { isAdmin } from '@revealui/core'
+import { isAdmin } from '@revealui/core/auth'
 
 access: { delete: isAdmin }
 ```
@@ -485,7 +485,7 @@ Returns `true` if the user has the `'super-admin'` role.
 Factory: returns an access function that requires a specific role.
 
 ```ts
-import { hasRole } from "@revealui/core";
+import { hasRole } from "@revealui/core/auth";
 
 access: {
   update: hasRole("editor");
@@ -497,7 +497,7 @@ access: {
 Factory: returns an access function that passes if the user has **any** of the given roles.
 
 ```ts
-import { hasAnyRole } from "@revealui/core";
+import { hasAnyRole } from "@revealui/core/auth";
 
 access: {
   create: hasAnyRole(["editor", "admin"]);
@@ -1540,11 +1540,8 @@ All tables are defined with Drizzle ORM and exported from subpath modules.
 ### Users & Auth
 
 ```ts
-import {
-  users,
-  sessions,
-  passwordResetTokens,
-} from "@revealui/db/schema/users";
+import { users, sessions } from "@revealui/db/schema/users";
+import { passwordResetTokens } from "@revealui/db/schema/password-reset-tokens";
 ```
 
 | Table                 | Key columns                                                         |
@@ -1585,7 +1582,9 @@ import {
 ### Audit & Monitoring
 
 ```ts
-import { auditLog, appLogs, errorEvents } from "@revealui/db/schema/rest";
+import { auditLog } from "@revealui/db/schema/audit-log";
+import { appLogs } from "@revealui/db/schema/app-logs";
+import { errorEvents } from "@revealui/db/schema/error-events";
 ```
 
 ---
@@ -2117,7 +2116,6 @@ import {
   Tabs,
   TabList,
   Tab,
-  TabPanels,
   TabPanel,
 } from "@revealui/presentation";
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,6 +46,9 @@ const CLI_VERSION: string = (cliRequire('../package.json') as { version: string 
 
 const logger = createLogger({ prefix: 'CLI' });
 
+// Re-export the programmatic project-creation API (documented in docs/REFERENCE.md).
+export { createProject, type CreateProjectConfig } from './commands/create.js';
+
 export interface CliOptions {
   template?: string;
   skipGit?: boolean;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,7 +47,7 @@ const CLI_VERSION: string = (cliRequire('../package.json') as { version: string 
 const logger = createLogger({ prefix: 'CLI' });
 
 // Re-export the programmatic project-creation API (documented in docs/REFERENCE.md).
-export { createProject, type CreateProjectConfig } from './commands/create.js';
+export { type CreateProjectConfig, createProject } from './commands/create.js';
 
 export interface CliOptions {
   template?: string;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -329,4 +329,9 @@ export type {
   SupabaseConfig,
 };
 // Export validation functions
-export { formatValidationErrors, validateEnvVars };
+export { formatValidationErrors, validateAndThrow, validateEnvVars };
+
+// Export module-level config getters (documented in docs/REFERENCE.md as standalone helpers)
+export { getDatabaseConfig } from './modules/database.js';
+export { getRevealConfig } from './modules/reveal.js';
+export { getStripeConfig } from './modules/stripe.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -307,6 +307,10 @@ export default configProxy;
 export type { Environment } from './loader.js';
 // Export loader utilities (for advanced usage)
 export { detectEnvironment, loadEnvironment } from './loader.js';
+// Export module-level config getters (documented in docs/REFERENCE.md as standalone helpers)
+export { getDatabaseConfig } from './modules/database.js';
+export { getRevealConfig } from './modules/reveal.js';
+export { getStripeConfig } from './modules/stripe.js';
 // Export shared RevealUI configuration functions
 export {
   getSharedCMSConfig,
@@ -330,8 +334,3 @@ export type {
 };
 // Export validation functions
 export { formatValidationErrors, validateAndThrow, validateEnvVars };
-
-// Export module-level config getters (documented in docs/REFERENCE.md as standalone helpers)
-export { getDatabaseConfig } from './modules/database.js';
-export { getRevealConfig } from './modules/reveal.js';
-export { getStripeConfig } from './modules/stripe.js';

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -86,6 +86,34 @@
       "types": "./dist/schema/users.d.ts",
       "import": "./dist/schema/users.js"
     },
+    "./schema/password-reset-tokens": {
+      "types": "./dist/schema/password-reset-tokens.d.ts",
+      "import": "./dist/schema/password-reset-tokens.js"
+    },
+    "./schema/admin": {
+      "types": "./dist/schema/admin.d.ts",
+      "import": "./dist/schema/admin.js"
+    },
+    "./schema/licenses": {
+      "types": "./dist/schema/licenses.d.ts",
+      "import": "./dist/schema/licenses.js"
+    },
+    "./schema/api-keys": {
+      "types": "./dist/schema/api-keys.d.ts",
+      "import": "./dist/schema/api-keys.js"
+    },
+    "./schema/audit-log": {
+      "types": "./dist/schema/audit-log.d.ts",
+      "import": "./dist/schema/audit-log.js"
+    },
+    "./schema/app-logs": {
+      "types": "./dist/schema/app-logs.d.ts",
+      "import": "./dist/schema/app-logs.js"
+    },
+    "./schema/error-events": {
+      "types": "./dist/schema/error-events.d.ts",
+      "import": "./dist/schema/error-events.js"
+    },
     "./schema/code-provenance": {
       "types": "./dist/schema/code-provenance.d.ts",
       "import": "./dist/schema/code-provenance.js"


### PR DESCRIPTION
## Summary

Drops `docs/REFERENCE.md` drift-detector findings from **21 → 2** (the remaining 2 are `@revealui/core/api/rate-limit` which the companion core-api/* subpaths PR handles).

Three independent gaps, one PR because all three are small and only touch `docs/REFERENCE.md` + `packages/{db,config,cli}`:

### \`@revealui/db\` — 8 new schema subpath exports
Source and dist already existed; only the \`exports\` map was missing these entries:
- \`./schema/password-reset-tokens\`
- \`./schema/admin\` (\`posts\`, \`media\`, \`globalHeader\`, \`globalFooter\`, \`globalSettings\`)
- \`./schema/licenses\`
- \`./schema/api-keys\` (\`userApiKeys\`, \`tenantProviderConfigs\`)
- \`./schema/audit-log\`
- \`./schema/app-logs\`
- \`./schema/error-events\`

### \`@revealui/config\` — 4 root re-exports
- \`validateAndThrow\` — already in \`./validator.js\`, now on the root barrel
- \`getDatabaseConfig\` / \`getRevealConfig\` / \`getStripeConfig\` — from \`./modules/{database,reveal,stripe}.js\`

### \`@revealui/cli\` — programmatic \`createProject\`
- \`createProject\` and \`CreateProjectConfig\` re-exported from package root (documented in \`docs/REFERENCE.md\` for use in tests + custom tooling).

### \`docs/REFERENCE.md\` — corrected import paths where docs referenced real code at wrong subpaths
- \`withRevealUI\` → \`@revealui/core/nextjs/withRevealUI\`
- \`isAdmin\` / \`hasRole\` / \`hasAnyRole\` → \`@revealui/core/auth\`
- Split combined user-table imports into the real subpaths (\`./schema/users\` + \`./schema/password-reset-tokens\`)
- Fixed audit-log / app-logs / error-events to reference each schema at its own subpath
- Removed phantom \`TabPanels\` (plural) from \`@revealui/presentation\` sample (real export is singular \`TabPanel\`)

No behavior changes — purely surface-area + doc accuracy.

## Test plan

- [x] \`pnpm gate:quick\` / pre-push gate passes (biome, audits, security, secrets, policy, coverage)
- [x] docs-import-drift validator confirms REFERENCE.md drops from 21 → 2
- [x] Rebuilt \`@revealui/config\` + \`@revealui/cli\` before re-running validator so \`.d.ts\` reflects new surface
- [x] Changeset: \`@revealui/db\`, \`@revealui/config\`, \`@revealui/cli\` minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)