### PR TITLE
docs(component-catalog): import Text/Heading from @revealui/presentation

### DIFF
--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -121,7 +121,7 @@ extends React.HTMLAttributes<HTMLElement>
 
 **Usage:**
 ```tsx
-import { Text } from '@revealui/presentation/primitives'
+import { Text } from '@revealui/presentation'
 
 <Text className="text-muted-foreground">
   Description text
@@ -143,7 +143,7 @@ interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
 
 **Usage:**
 ```tsx
-import { Heading } from '@revealui/presentation/primitives'
+import { Heading } from '@revealui/presentation'
 
 <Heading level={2}>Section Title</Heading>
 ```


### PR DESCRIPTION
## Summary
- Replaces 2 stale `@revealui/presentation/primitives` imports for `Text` and `Heading` with the canonical barrel import
- The primitives subpath only exports `TextPrimitive` / `HeadingPrimitive` aliases; canonical `Text` and `Heading` live in `./components`
- Clears the last 2 docs-import-drift findings on `test` (216 → 0 after the §4.19 Phase C cascade)

## Test plan
- [x] `npx tsx scripts/validate/docs-import-drift.ts` — clean (96 files scanned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)