### PR TITLE
fix(security): audit phase 1 — pre-perpetual-license hardening

### DIFF
--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -485,8 +485,8 @@ describe('GET /api/auth/callback/[provider]', () => {
     expect(sessionCookie).toContain('HttpOnly');
     expect(sessionCookie).toContain('Path=/');
     expect(sessionCookie?.toLowerCase()).toContain('samesite=lax');
-    // 7 days = 604800 seconds
-    expect(sessionCookie).toContain('Max-Age=604800');
+    // 1 day = 86400 seconds (matches DB session expiry)
+    expect(sessionCookie).toContain('Max-Age=86400');
   });
 
   it('should delete oauth_state cookie on success', async () => {

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -151,7 +151,7 @@ export async function GET(
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+      maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain:
         process.env.NODE_ENV === 'production'
           ? (() => {

--- a/apps/admin/src/app/api/auth/mfa/backup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/backup/route.ts
@@ -110,7 +110,7 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+      maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain:
         process.env.NODE_ENV === 'production'
           ? (() => {

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -106,7 +106,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+      maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain:
         process.env.NODE_ENV === 'production'
           ? (() => {

--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -128,7 +128,7 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+      maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain:
         process.env.NODE_ENV === 'production'
           ? (() => {

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -226,7 +226,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',
         path: '/',
-        maxAge: 60 * 60 * 24 * 7, // 7 days
+        maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
         domain:
           process.env.NODE_ENV === 'production'
             ? (() => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,6 +53,7 @@ import {
   checkLicenseStatus,
   checkSupportExpiry,
   requireAIAccess,
+  requireDomain,
   requireFeature,
 } from './middleware/license.js';
 import { rateLimitMiddleware, tieredRateLimitMiddleware } from './middleware/rate-limit.js';
@@ -614,6 +615,11 @@ const licenseStatusCheck = checkLicenseStatus(async (customerId) => {
 });
 app.use('/api/*', licenseStatusCheck);
 app.use('/api/v1/*', licenseStatusCheck);
+
+// Domain restriction enforcement  -  validates the request origin against the license's
+// allowed domains. Skips validation when no domain restrictions exist (most licenses).
+app.use('/api/*', requireDomain());
+app.use('/api/v1/*', requireDomain());
 
 // Perpetual license support expiry enforcement  -  downgrades premium features to free
 // when the annual support contract has expired. Basic admin access remains perpetual.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "next": ">=16.2.3",
       "react": ">=19.2.4",
       "react-dom": ">=19.2.4",
-      "basic-ftp": ">=5.2.2",
+      "basic-ftp": ">=5.3.0",
       "underscore": ">=1.13.8",
       "express-rate-limit": ">=8.2.2",
       "srvx": ">=0.11.13",

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -15,6 +15,10 @@ import { z } from 'zod';
 import { decryptLicenseKey } from './license-encryption.js';
 import { logger } from './utils/logger.js';
 
+/** JWT issuer and audience for license tokens — prevents cross-environment replay */
+const LICENSE_ISSUER = process.env.REVEALUI_LICENSE_ISSUER ?? 'https://revealui.com';
+const LICENSE_AUDIENCE = process.env.REVEALUI_LICENSE_AUDIENCE ?? 'revealui-license';
+
 /** Available license tiers */
 export type LicenseTier = 'free' | 'pro' | 'max' | 'enterprise';
 
@@ -214,8 +218,10 @@ export async function validateLicenseKey(
     // Accept tokens expired within the subscription grace window so the
     // payload is available for grace-period calculations in isLicensed().
     const { payload } = await jwtVerify(licenseKey, key, {
-      algorithms: ['RS256', 'ES256'],
+      algorithms: ['RS256'],
       clockTolerance: graceConfig.subscriptionDays * 86_400,
+      issuer: LICENSE_ISSUER,
+      audience: LICENSE_AUDIENCE,
     });
 
     const result = licensePayloadSchema.safeParse(payload);
@@ -489,7 +495,11 @@ export async function generateLicenseKey(
   if (kid) {
     header.kid = kid;
   }
-  const builder = new SignJWT({ ...payload }).setProtectedHeader(header).setIssuedAt();
+  const builder = new SignJWT({ ...payload })
+    .setProtectedHeader(header)
+    .setIssuedAt()
+    .setIssuer(LICENSE_ISSUER)
+    .setAudience(LICENSE_AUDIENCE);
   if (expiresInSeconds !== null) {
     builder.setExpirationTime(`${expiresInSeconds}s`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ overrides:
   next: '>=16.2.3'
   react: '>=19.2.4'
   react-dom: '>=19.2.4'
-  basic-ftp: '>=5.2.2'
+  basic-ftp: '>=5.3.0'
   underscore: '>=1.13.8'
   express-rate-limit: '>=8.2.2'
   srvx: '>=0.11.13'
@@ -5383,8 +5383,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.2:
-    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   bcryptjs@3.0.3:
@@ -13102,7 +13102,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   bcryptjs@3.0.3: {}
 
@@ -13985,7 +13985,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Five security fixes from the codebase audit, all required before first perpetual license sale:

- Remove ES256 from allowed JWT algorithms (only RS256 issued)
- Add iss/aud claims to license JWTs (prevents cross-environment replay)
- Mount requireDomain() globally (domain-restricted licenses now enforced)
- Fix basic-ftp override to >=5.3.0 (DoS CVE)
- Align session cookie maxAge with DB session expiry (7d -> 1d)

## Test plan

- [x] 2,596 core tests pass (including all license tests with iss/aud)
- [x] Typecheck clean: core, API, admin
- [x] Pre-push gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)