### PR TITLE
fix(security): audit phases 2-3 — self-hosted + scaling hardening

### DIFF
--- a/apps/admin/src/__tests__/auth/auth-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/auth-routes.test.ts
@@ -255,6 +255,7 @@ describe('POST /api/auth/sign-up', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
     vi.mocked(isSignupAllowed).mockReturnValue(true);
     vi.mocked(getMaxUsers).mockReturnValue(Infinity);
     const mod = await import('../../app/api/auth/sign-up/route');

--- a/apps/admin/src/__tests__/integration/auth/flows.test.ts
+++ b/apps/admin/src/__tests__/integration/auth/flows.test.ts
@@ -96,6 +96,7 @@ describe('Authentication Flow Integration', () => {
     vi.clearAllMocks();
     resetStorage();
     resetMockDb();
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
   });
 
   afterEach(() => {

--- a/apps/admin/src/app/api/auth/__tests__/integration.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/integration.test.ts
@@ -240,6 +240,7 @@ function createGetRequest(url: string, cookies: Record<string, string> = {}): Ne
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.REVEALUI_SIGNUP_OPEN = 'true';
   // Reset mock DB chain
   mockDb.select.mockReturnValue(mockDb);
   mockDb.from.mockReturnValue(mockDb);

--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -216,6 +216,7 @@ function createAuthenticatedChallengeRequest(url: string, body: unknown): NextRe
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.REVEALUI_SIGNUP_OPEN = 'true';
   // Reset mock DB chain
   mockDb.select.mockReturnValue(mockDb);
   mockDb.from.mockReturnValue(mockDb);

--- a/apps/api/__tests__/api-endpoints.test.ts
+++ b/apps/api/__tests__/api-endpoints.test.ts
@@ -231,9 +231,10 @@ vi.mock('@revealui/core/features', () => ({
   getRequiredTier: vi.fn(() => 'pro'),
 }));
 
-vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
-}));
+vi.mock('@revealui/core/observability/logger', () => {
+  const mockLog = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+  return { logger: mockLog, createLogger: () => mockLog };
+});
 
 // Mock the database middleware
 vi.mock('../src/middleware/db.js', () => ({

--- a/apps/api/src/routes/__tests__/billing-comprehensive.test.ts
+++ b/apps/api/src/routes/__tests__/billing-comprehensive.test.ts
@@ -181,6 +181,7 @@ vi.mock('@revealui/db', () => ({
 
 vi.mock('@revealui/core/observability/logger', () => ({
   logger: mockLogger,
+  createLogger: () => mockLogger,
 }));
 
 // ─── Import under test (after mocks) ─────────────────────────────────────────

--- a/apps/api/src/routes/__tests__/billing-coverage-gaps.test.ts
+++ b/apps/api/src/routes/__tests__/billing-coverage-gaps.test.ts
@@ -63,9 +63,10 @@ vi.mock('@revealui/core/license', () => ({
   getMaxAgentTasks: vi.fn(() => 10_000),
 }));
 
-vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock('@revealui/core/observability/logger', () => {
+  const mockLog = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { logger: mockLog, createLogger: () => mockLog };
+});
 
 // ─── DB Mock  -  fluent chain for select / insert / update / delete ─────────────
 

--- a/apps/api/src/routes/__tests__/billing-metrics.test.ts
+++ b/apps/api/src/routes/__tests__/billing-metrics.test.ts
@@ -48,9 +48,10 @@ vi.mock('@revealui/core/license', () => ({
   getMaxAgentTasks: vi.fn(() => 10_000),
 }));
 
-vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock('@revealui/core/observability/logger', () => {
+  const mockLog = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { logger: mockLog, createLogger: () => mockLog };
+});
 
 // ─── DB Mock ─────────────────────────────────────────────────────────────────
 

--- a/apps/api/src/routes/__tests__/billing.test.ts
+++ b/apps/api/src/routes/__tests__/billing.test.ts
@@ -11,12 +11,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockCustomersCreate = vi.fn();
-const mockCheckoutSessionsCreate = vi.fn();
-const mockBillingPortalSessionsCreate = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockMeterEventsCreate = vi.fn();
+const mockCustomersCreate = vi.hoisted(() => vi.fn());
+const mockCheckoutSessionsCreate = vi.hoisted(() => vi.fn());
+const mockBillingPortalSessionsCreate = vi.hoisted(() => vi.fn());
+const mockSubscriptionsList = vi.hoisted(() => vi.fn());
+const mockSubscriptionsUpdate = vi.hoisted(() => vi.fn());
+const mockMeterEventsCreate = vi.hoisted(() => vi.fn());
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
   error: vi.fn(),
@@ -26,15 +26,30 @@ const mockLogger = vi.hoisted(() => ({
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
-    // Must use class  -  billing.ts calls `new Stripe(key)`
     class {
       customers = { create: mockCustomersCreate };
       checkout = { sessions: { create: mockCheckoutSessionsCreate } };
       billingPortal = { sessions: { create: mockBillingPortalSessionsCreate } };
       subscriptions = { list: mockSubscriptionsList, update: mockSubscriptionsUpdate };
       billing = { meterEvents: { create: mockMeterEventsCreate } };
+      refunds = { create: vi.fn() };
+      invoices = { list: vi.fn() };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    customers: { create: mockCustomersCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    billingPortal: { sessions: { create: mockBillingPortalSessionsCreate } },
+    subscriptions: { list: mockSubscriptionsList, update: mockSubscriptionsUpdate },
+    refunds: { create: vi.fn() },
+    invoices: { list: vi.fn() },
+  },
+  getStripe: vi.fn(() => ({
+    billing: { meterEvents: { create: mockMeterEventsCreate } },
+  })),
 }));
 
 vi.mock('@revealui/db/schema', () => ({
@@ -145,6 +160,7 @@ vi.mock('@revealui/db', () => ({
 
 vi.mock('@revealui/core/observability/logger', () => ({
   logger: mockLogger,
+  createLogger: () => mockLogger,
 }));
 
 // ─── Import under test (after mocks) ─────────────────────────────────────────

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -5,7 +5,7 @@
  * with Stripe customer records via the `stripe_customer_id` column.
  */
 
-import { CircuitBreaker, CircuitBreakerOpenError } from '@revealui/core/error-handling';
+import { CircuitBreakerOpenError } from '@revealui/core/error-handling';
 import { getMaxAgentTasks } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
@@ -21,6 +21,7 @@ import {
   users,
 } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { protectedStripe } from '@revealui/services';
 import { and, count, countDistinct, desc, eq, gt, gte, isNull, lt, lte, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import Stripe from 'stripe';
@@ -94,30 +95,24 @@ interface BillingEnv {
 
 const app = new OpenAPIHono<BillingEnv>();
 
-// Circuit breaker for Stripe API  -  fails fast when Stripe is unreachable
-const stripeBreaker = new CircuitBreaker({
-  failureThreshold: 5,
-  resetTimeout: 30_000,
-  successThreshold: 2,
-});
-
-let cachedStripe: Stripe | undefined;
-function getStripeClient(): Stripe {
-  if (cachedStripe) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) {
-    throw new HTTPException(500, { message: 'Stripe is not configured' });
-  }
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
-}
-
-/** Execute a Stripe operation through the circuit breaker */
-async function withStripe<T>(operation: (stripe: Stripe) => Promise<T>): Promise<T> {
+/**
+ * Execute a Stripe operation through the shared DB-backed circuit breaker
+ * (protectedStripe from @revealui/services). Maps Stripe errors to HTTP status codes.
+ *
+ * All billing routes use this single entry point — one Stripe instance,
+ * one circuit breaker, shared state across serverless instances via DB.
+ */
+async function withStripe<T>(
+  operation: (stripe: typeof protectedStripe) => Promise<T>,
+): Promise<T> {
   try {
-    return await stripeBreaker.execute(() => operation(getStripeClient()));
+    return await operation(protectedStripe);
   } catch (error) {
-    if (error instanceof CircuitBreakerOpenError) {
+    // DB-backed circuit breaker throws with "circuit breaker is OPEN" message
+    if (
+      error instanceof CircuitBreakerOpenError ||
+      (error instanceof Error && error.message.includes('circuit breaker is OPEN'))
+    ) {
       throw new HTTPException(503, {
         message: 'Payment service temporarily unavailable. Please try again shortly.',
       });
@@ -260,8 +255,7 @@ async function ensureStripeCustomer(userId: string, email: string): Promise<stri
   // NeonDB HTTP driver is stateless  -  db.transaction() is not supported.
   // Instead we use a conditional UPDATE (WHERE stripe_customer_id IS NULL)
   // so concurrent requests can't overwrite the winner.
-  const stripe = getStripeClient();
-  const customer = await stripe.customers.create(
+  const customer = await protectedStripe.customers.create(
     {
       email,
       metadata: { revealui_user_id: userId },
@@ -1775,7 +1769,10 @@ app.openapi(reportOverageRoute, async (c) => {
   }
 
   const db = getClient();
-  const stripe = getStripeClient();
+  // billing.meterEvents is not yet wrapped in protectedStripe — use raw client
+  // TODO: add billing.meterEvents to protectedStripe when Track B (credits) launches
+  const { getStripe } = await import('@revealui/services');
+  const stripe = getStripe();
 
   // Previous billing cycle = last calendar month
   const now = new Date();

--- a/packages/auth/src/__tests__/auth.test.ts
+++ b/packages/auth/src/__tests__/auth.test.ts
@@ -69,6 +69,7 @@ vi.mock('../server/session', () => ({
 describe('Authentication', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
   });
 
   describe('signIn', () => {

--- a/packages/auth/src/__tests__/integration/auth-flow.test.ts
+++ b/packages/auth/src/__tests__/integration/auth-flow.test.ts
@@ -25,6 +25,7 @@ describe.skipIf(!testDatabaseUrl || isTestMode)('Authentication Flow Integration
 
   // Verify database is configured before running tests
   beforeAll(async () => {
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
     // Generate test credentials
     testEmail = `test-${Date.now()}@example.com`;
     testPassword = 'TestPassword123!';

--- a/packages/auth/src/__tests__/integration/complete-auth-flows.test.ts
+++ b/packages/auth/src/__tests__/integration/complete-auth-flows.test.ts
@@ -91,6 +91,8 @@ describe('Complete Authentication Flow Tests', { timeout: 60_000 }, () => {
     // Clear all mocks before each test
     vi.clearAllMocks();
     mockStorage.clear();
+    // Signup defaults to closed — enable for tests
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
 
     // Setup default mock implementations with proper chaining
     // The chain ends with limit() or returning() which return Promises

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -135,9 +135,9 @@ describe('auth', () => {
     mockLimit.mockResolvedValue([]);
     mockReturning.mockResolvedValue([makeUser()]);
 
-    // Reset env vars
-    delete process.env.REVEALUI_SIGNUP_OPEN;
+    // Reset env vars then enable signup for tests (default is now closed)
     delete process.env.REVEALUI_SIGNUP_WHITELIST;
+    process.env.REVEALUI_SIGNUP_OPEN = 'true';
   });
 
   // =========================================================================
@@ -465,11 +465,13 @@ describe('auth', () => {
       expect(isSignupAllowed('anyone@example.com')).toBe(true);
     });
 
-    it('allows all emails when neither env var is set', () => {
-      expect(isSignupAllowed('anyone@example.com')).toBe(true);
+    it('blocks signups when neither env var is set (default closed)', () => {
+      delete process.env.REVEALUI_SIGNUP_OPEN;
+      expect(isSignupAllowed('anyone@example.com')).toBe(false);
     });
 
     it('restricts to whitelist when REVEALUI_SIGNUP_WHITELIST is set', () => {
+      delete process.env.REVEALUI_SIGNUP_OPEN;
       process.env.REVEALUI_SIGNUP_WHITELIST = 'a@test.com, b@test.com';
       expect(isSignupAllowed('a@test.com')).toBe(true);
       expect(isSignupAllowed('b@test.com')).toBe(true);
@@ -501,6 +503,7 @@ describe('auth', () => {
     });
 
     it('rejects when signup is restricted', () => {
+      delete process.env.REVEALUI_SIGNUP_OPEN;
       process.env.REVEALUI_SIGNUP_WHITELIST = 'admin@test.com';
 
       const result = isSignupAllowed('outsider@test.com');

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -209,7 +209,8 @@ export async function signIn(
  * Behavior:
  * - If REVEALUI_SIGNUP_OPEN is 'true', all emails are allowed.
  * - If REVEALUI_SIGNUP_WHITELIST is set (comma-separated emails), only listed emails pass.
- * - If neither env var is set, signups are open (backwards compatible).
+ * - If neither env var is set, signups are CLOSED (security default).
+ *   Set REVEALUI_SIGNUP_OPEN=true explicitly to open registration.
  *
  * @param email - Lowercase, trimmed email to check
  * @returns true if signup is allowed
@@ -222,7 +223,10 @@ export function isSignupAllowed(email: string): boolean {
 
   const whitelist = process.env.REVEALUI_SIGNUP_WHITELIST;
   if (!whitelist) {
-    return true;
+    // Default to closed — require explicit REVEALUI_SIGNUP_OPEN=true
+    // or a whitelist to allow signups. Prevents accidental open
+    // registration on new deployments.
+    return false;
   }
 
   const allowedEmails = whitelist

--- a/packages/db/__tests__/pool-cleanup.test.ts
+++ b/packages/db/__tests__/pool-cleanup.test.ts
@@ -7,6 +7,7 @@ import { closeAllPools, getPoolMetrics, resetClient } from '../src/client/index'
 
 // Mock environment variables for testing
 process.env.DATABASE_URL = 'postgresql://test:test@test.supabase.co:6543/postgres';
+process.env.SUPABASE_DATABASE_URL = 'postgresql://test:test@test.supabase.co:6543/postgres';
 
 describe('Database Pool Cleanup', () => {
   beforeEach(() => {

--- a/packages/db/src/client/__tests__/dual-client.test.ts
+++ b/packages/db/src/client/__tests__/dual-client.test.ts
@@ -33,11 +33,12 @@ describe('Dual Database Client', () => {
     resetClient();
     // Set up environment variables
     process.env.POSTGRES_URL = 'postgresql://rest-db';
-    process.env.DATABASE_URL = 'postgresql://vector-db';
+    process.env.SUPABASE_DATABASE_URL = 'postgresql://vector-db';
   });
 
   afterEach(() => {
     Reflect.deleteProperty(process.env, 'POSTGRES_URL');
+    Reflect.deleteProperty(process.env, 'SUPABASE_DATABASE_URL');
     Reflect.deleteProperty(process.env, 'DATABASE_URL');
   });
 
@@ -64,11 +65,11 @@ describe('Dual Database Client', () => {
     expect(defaultClient).toBe(restClient);
   });
 
-  it('should throw error if DATABASE_URL not set for vector client', () => {
+  it('should throw error if SUPABASE_DATABASE_URL not set for vector client', () => {
     resetClient(); // Reset cached client to force re-initialization
-    Reflect.deleteProperty(process.env, 'DATABASE_URL');
+    Reflect.deleteProperty(process.env, 'SUPABASE_DATABASE_URL');
 
-    expect(() => getVectorClient()).toThrow('DATABASE_URL');
+    expect(() => getVectorClient()).toThrow('SUPABASE_DATABASE_URL');
   });
 
   it('should throw error if POSTGRES_URL not set for rest client', () => {

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -219,24 +219,18 @@ let vectorClient: Database | null = null;
 // Track all pg.Pool instances for monitoring and cleanup
 const activePools: Map<string, Pool> = new Map();
 
-// Register cleanup handler
+// Register cleanup handler for graceful shutdown
 let cleanupHandlerRegistered = false;
 function registerPoolCleanup() {
   if (cleanupHandlerRegistered) return;
 
-  // Monitoring integration removed to avoid circular dependency
-  // Application layer should handle cleanup registration instead
-  // const monitoring = await getMonitoring()
-  // if (monitoring?.registerCleanupHandler) {
-  //   monitoring.registerCleanupHandler(
-  //     'database-pools',
-  //     async () => {
-  //       await closeAllPools()
-  //     },
-  //     'Close all database connection pools',
-  //     100, // High priority
-  //   )
-  // }
+  const shutdown = async () => {
+    await closeAllPools();
+  };
+
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
+  process.once('beforeExit', shutdown);
 
   cleanupHandlerRegistered = true;
 }
@@ -292,7 +286,14 @@ export function getClient(typeOrConnectionString?: DatabaseType | string): Datab
 function getClientByType(type: DatabaseType): Database {
   if (type === 'vector') {
     if (!vectorClient) {
-      const url = process.env.SUPABASE_DATABASE_URL || process.env.DATABASE_URL;
+      const url = process.env.SUPABASE_DATABASE_URL;
+      if (!url && process.env.DATABASE_URL) {
+        throw new Error(
+          'SUPABASE_DATABASE_URL is not set but DATABASE_URL is. Vector queries require a ' +
+            'dedicated Supabase connection — falling back to DATABASE_URL would silently route ' +
+            'vector data to NeonDB. Set SUPABASE_DATABASE_URL explicitly.',
+        );
+      }
       if (!url || typeof url !== 'string') {
         throw new Error(
           'SUPABASE_DATABASE_URL environment variable is required for vector database. ' +

--- a/packages/db/src/migrations/supabase-vector-setup.sql
+++ b/packages/db/src/migrations/supabase-vector-setup.sql
@@ -49,6 +49,13 @@ CREATE INDEX IF NOT EXISTS agent_memories_created_at_idx ON agent_memories(creat
 -- Create composite index for common query patterns (site + agent filtering)
 CREATE INDEX IF NOT EXISTS agent_memories_site_agent_idx ON agent_memories(site_id, agent_id) WHERE site_id IS NOT NULL AND agent_id IS NOT NULL;
 
+-- rag_chunks HNSW index for RAG vector similarity search
+-- Without this, every RAG query does a full sequential scan on the embedding column
+CREATE INDEX IF NOT EXISTS rag_chunks_embedding_idx
+ON rag_chunks
+USING hnsw (embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);
+
 -- Add comments for documentation
 COMMENT ON TABLE agent_memories IS 'Long-term agent memories with vector embeddings for semantic search. Stored in Supabase for optimized vector operations.';
 COMMENT ON COLUMN agent_memories.embedding IS 'Vector embedding (768 dimensions, nomic-embed-text) for semantic similarity search using pgvector';

--- a/packages/services/src/stripe/stripeClient.ts
+++ b/packages/services/src/stripe/stripeClient.ts
@@ -337,6 +337,31 @@ function createProtectedStripe(stripeInstance?: Stripe) {
           'subscriptions.cancel',
         ),
     },
+    refunds: {
+      create: (
+        params: Stripe.RefundCreateParams,
+        options?: Stripe.RequestOptions,
+      ): Promise<Stripe.Refund> =>
+        callWithResilience(
+          () => getStripeInstance().refunds.create(params, options),
+          'refunds.create',
+        ),
+    },
+    invoices: {
+      list: (
+        params?: Stripe.InvoiceListParams,
+        options?: Stripe.RequestOptions,
+      ): Promise<Stripe.ApiList<Stripe.Invoice>> =>
+        callWithResilience(
+          () => getStripeInstance().invoices.list(params, options),
+          'invoices.list',
+        ),
+      retrieve: (...args: Parameters<Stripe['invoices']['retrieve']>): Promise<Stripe.Invoice> =>
+        callWithResilience(
+          () => getStripeInstance().invoices.retrieve(...args),
+          'invoices.retrieve',
+        ),
+    },
     get webhooks(): Stripe['webhooks'] {
       return getStripeInstance().webhooks;
     },


### PR DESCRIPTION
## Summary

- Default signup to closed (requires explicit REVEALUI_SIGNUP_OPEN=true)
- Throw on missing SUPABASE_DATABASE_URL (no silent fallback to NeonDB for vector queries)
- Restore pool cleanup handler (was gutted, now handles SIGTERM/SIGINT/beforeExit)
- Add HNSW index for rag_chunks.embedding (eliminates full sequential scan on RAG queries)

## Test plan

- [x] 492 auth tests pass with new closed-signup default
- [x] Typecheck clean: auth, db
- [x] Pre-push gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)