### PR TITLE
chore(changeset): version bumps for audit session

### DIFF
--- a/.changeset/db-supabase-url-required.md
+++ b/.changeset/db-supabase-url-required.md
@@ -1,0 +1,5 @@
+---
+"@revealui/db": minor
+---
+
+**BREAKING (pre-1.0):** `SUPABASE_DATABASE_URL` is now required for vector queries — no longer falls back silently to `DATABASE_URL`. Prevents vector data routing to the wrong database in misconfigured deployments. Restore pool cleanup handler for graceful shutdown (SIGTERM/SIGINT/beforeExit). Add HNSW index for `rag_chunks.embedding` in Supabase vector setup SQL.

--- a/.changeset/license-grace-periods.md
+++ b/.changeset/license-grace-periods.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": minor
+---
+
+Add tiered license fail-mode with grace periods. New `getLicenseStatus()` returns `LicenseCheckResult` with mode (active/grace/read-only/expired/invalid/missing), grace remaining, and read-only flag. Configurable grace windows: 3-day subscription, 30-day perpetual, 7-day infra-unreachable. Add iss/aud claims to license JWTs for cross-environment replay prevention. Remove ES256 from allowed JWT algorithms (only RS256 is issued).

--- a/.changeset/services-pricing-calcom.md
+++ b/.changeset/services-pricing-calcom.md
@@ -1,0 +1,5 @@
+---
+"@revealui/contracts": patch
+---
+
+Add prices to service offerings (Architecture Review $3,500, Launch Package $7,500, Migration Assist $300/hr, Consulting Hour $300/hr). CTAs now link to Cal.com booking instead of mailto. Update service offering order: launch package before migration assist.

--- a/.changeset/signup-default-closed.md
+++ b/.changeset/signup-default-closed.md
@@ -1,0 +1,5 @@
+---
+"@revealui/auth": minor
+---
+
+**BREAKING (pre-1.0):** Signup now defaults to closed. New deployments must set `REVEALUI_SIGNUP_OPEN=true` or `REVEALUI_SIGNUP_WHITELIST` to allow registration. Prevents accidental open registration on new deployments.

--- a/.changeset/stripe-consolidation.md
+++ b/.changeset/stripe-consolidation.md
@@ -1,0 +1,5 @@
+---
+"@revealui/services": minor
+---
+
+Add `invoices.list`, `invoices.retrieve`, and `refunds.create` to `protectedStripe` — all routed through the DB-backed circuit breaker with retry logic. Enables billing routes to use a single shared Stripe client instead of maintaining a separate in-memory circuit breaker.


### PR DESCRIPTION
## Summary

Changesets for all packages modified during the commercial readiness audit:

- `@revealui/core` minor → 0.6.0 (license grace periods, getLicenseStatus, iss/aud)
- `@revealui/auth` minor → 0.4.0 (signup defaults to closed)
- `@revealui/db` minor → 0.4.0 (SUPABASE_DATABASE_URL required, pool cleanup, HNSW)
- `@revealui/services` minor → 0.4.0 (invoices + refunds on protectedStripe)
- `@revealui/contracts` patch → 1.3.8 (services pricing + Cal.com CTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)