### PR TITLE
feat(sync): multi-agent shared memory — 3-layer architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ apps/docs/dist/docs/
 # ElectricSQL generated files
 .electric/
 
+# Supabase CLI local state (project link, temp files)
+supabase/.temp/
+
 # Editor configs (tracked externally: github.com/RevealUIStudio/editor-configs)
 .zed
 .zedignore

--- a/apps/admin/src/app/api/shapes/shared-facts/route.ts
+++ b/apps/admin/src/app/api/shapes/shared-facts/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared Facts Shape Proxy Route
+ *
+ * GET /api/shapes/shared-facts?session_id=<session_id>
+ *
+ * Authenticated proxy for ElectricSQL shared_facts shape.
+ * Scoped by coordination session ID so only agents in the same
+ * session receive each other's discoveries.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const sessionId = new URL(request.url).searchParams.get('session_id');
+    if (!sessionId || sessionId.trim().length === 0) {
+      return createValidationErrorResponse(
+        'session_id query parameter is required',
+        'session_id',
+        sessionId,
+        { example: '/api/shapes/shared-facts?session_id=coord-abc123' },
+      );
+    }
+
+    if (!SESSION_ID_RE.test(sessionId)) {
+      return createValidationErrorResponse(
+        'session_id must contain only alphanumeric characters, hyphens, and underscores',
+        'session_id',
+        sessionId,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'shared_facts');
+    originUrl.searchParams.set('where', `session_id = '${sessionId}'`);
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying shared facts shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/shared-facts',
+      operation: 'shared_facts_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/shared-memories/route.ts
+++ b/apps/admin/src/app/api/shapes/shared-memories/route.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared Memories Shape Proxy Route
+ *
+ * GET /api/shapes/shared-memories?session_scope=<session_scope>
+ *
+ * Authenticated proxy for ElectricSQL agent_memories shape,
+ * filtered to shared and reconciled memories within a coordination session.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const sessionScope = new URL(request.url).searchParams.get('session_scope');
+    if (!sessionScope || sessionScope.trim().length === 0) {
+      return createValidationErrorResponse(
+        'session_scope query parameter is required',
+        'session_scope',
+        sessionScope,
+        { example: '/api/shapes/shared-memories?session_scope=coord-abc123' },
+      );
+    }
+
+    if (!SESSION_SCOPE_RE.test(sessionScope)) {
+      return createValidationErrorResponse(
+        'session_scope must contain only alphanumeric characters, hyphens, and underscores',
+        'session_scope',
+        sessionScope,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'agent_memories');
+    originUrl.searchParams.set(
+      'where',
+      `session_scope = '${sessionScope}' AND (scope = 'shared' OR scope = 'reconciled')`,
+    );
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying shared memories shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/shared-memories',
+      operation: 'shared_memories_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Yjs Document Patches Shape Proxy Route
+ *
+ * GET /api/shapes/yjs-document-patches?document_id=<document_id>
+ *
+ * Authenticated proxy for ElectricSQL yjs_document_patches shape.
+ * Scoped by document ID so subscribers see patches for their scratchpad.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const DOCUMENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const documentId = new URL(request.url).searchParams.get('document_id');
+    if (!documentId || documentId.trim().length === 0) {
+      return createValidationErrorResponse(
+        'document_id query parameter is required',
+        'document_id',
+        documentId,
+        { example: '/api/shapes/yjs-document-patches?document_id=scratchpad-abc123' },
+      );
+    }
+
+    if (!DOCUMENT_ID_RE.test(documentId)) {
+      return createValidationErrorResponse(
+        'document_id must contain only alphanumeric characters, hyphens, and underscores',
+        'document_id',
+        documentId,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'yjs_document_patches');
+    originUrl.searchParams.set('where', `document_id = '${documentId}'`);
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying yjs document patches shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/yjs-document-patches',
+      operation: 'yjs_document_patches_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/reconcile/route.ts
+++ b/apps/admin/src/app/api/sync/reconcile/route.ts
@@ -1,0 +1,171 @@
+/**
+ * Reconciliation Trigger Route
+ *
+ * POST /api/sync/reconcile - Trigger LLM reconciliation for a coordination session
+ *
+ * Reads unreconciled shared facts, calls the reconciliation service,
+ * creates canonical memories, and marks source facts as superseded.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { agentMemories, sharedFacts } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { and, eq, isNull } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+interface ReconciliationResult {
+  canonicalFacts: Array<{
+    content: string;
+    type: string;
+    sourceFactIds: string[];
+    confidence: number;
+  }>;
+  contradictions: Array<{
+    factIds: string[];
+    resolution: string;
+  }>;
+  duplicates: string[][];
+}
+
+/**
+ * Simple reconciliation logic. In production this calls the LLM reconciliation
+ * service from @revealui/ai. For now, deduplicates by content similarity and
+ * groups facts by type.
+ */
+function reconcileFacts(
+  facts: Array<{ id: string; content: string; factType: string; confidence: number }>,
+): ReconciliationResult {
+  const seen = new Map<string, string[]>();
+  const canonicalFacts: ReconciliationResult['canonicalFacts'] = [];
+  const duplicates: string[][] = [];
+
+  // Group by normalized content for dedup
+  for (const fact of facts) {
+    const normalized = fact.content.toLowerCase().trim();
+    const existing = seen.get(normalized);
+    if (existing) {
+      existing.push(fact.id);
+    } else {
+      seen.set(normalized, [fact.id]);
+    }
+  }
+
+  for (const [, ids] of seen) {
+    if (ids.length > 1) {
+      duplicates.push(ids);
+    }
+    // Take the first fact as canonical
+    const sourceFact = facts.find((f) => f.id === ids[0]);
+    if (sourceFact) {
+      canonicalFacts.push({
+        content: sourceFact.content,
+        type: sourceFact.factType === 'bug' ? 'warning' : 'fact',
+        sourceFactIds: ids,
+        confidence: sourceFact.confidence,
+      });
+    }
+  }
+
+  return { canonicalFacts, contradictions: [], duplicates };
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      session_id?: string;
+      site_id?: string;
+    };
+
+    if (!(body.session_id && SESSION_ID_RE.test(body.session_id))) {
+      return createValidationErrorResponse(
+        'session_id is required and must be alphanumeric with hyphens/underscores',
+        'session_id',
+        body.session_id,
+      );
+    }
+
+    if (!body.site_id || body.site_id.trim().length === 0) {
+      return createValidationErrorResponse('site_id is required', 'site_id', body.site_id);
+    }
+
+    const db = getClient();
+
+    // Get unreconciled facts (not yet superseded)
+    const unreconciledFacts = await db
+      .select()
+      .from(sharedFacts)
+      .where(and(eq(sharedFacts.sessionId, body.session_id), isNull(sharedFacts.supersededBy)));
+
+    if (unreconciledFacts.length === 0) {
+      return NextResponse.json({
+        reconciled: 0,
+        message: 'No unreconciled facts found',
+      });
+    }
+
+    // Run reconciliation
+    const result = reconcileFacts(unreconciledFacts);
+    const now = new Date();
+    const createdMemories: unknown[] = [];
+
+    // Create reconciled memories
+    for (const canonical of result.canonicalFacts) {
+      const id = crypto.randomUUID();
+      const [memory] = await db
+        .insert(agentMemories)
+        .values({
+          id,
+          content: canonical.content,
+          type: canonical.type,
+          source: { reconciliation: true, sessionId: body.session_id },
+          siteId: body.site_id,
+          scope: 'reconciled',
+          sessionScope: body.session_id,
+          sourceFacts: canonical.sourceFactIds,
+          reconciledAt: now,
+        })
+        .returning();
+      createdMemories.push(memory);
+
+      // Mark source facts as superseded
+      for (const factId of canonical.sourceFactIds) {
+        await db.update(sharedFacts).set({ supersededBy: id }).where(eq(sharedFacts.id, factId));
+      }
+    }
+
+    return NextResponse.json({
+      reconciled: result.canonicalFacts.length,
+      duplicatesFound: result.duplicates.length,
+      contradictions: result.contradictions.length,
+      memories: createdMemories,
+    });
+  } catch (error) {
+    logger.error('Error running reconciliation', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/reconcile',
+      operation: 'reconcile_shared_facts',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/shared-facts/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/shared-facts/[id]/route.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared Facts Sync Mutation Route (by ID)
+ *
+ * PATCH /api/sync/shared-facts/:id - Update a shared fact
+ * DELETE /api/sync/shared-facts/:id - Delete a shared fact
+ *
+ * Authenticated. ID must be a valid UUID.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { sharedFacts } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { eq } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!UUID_RE.test(id)) {
+      return createValidationErrorResponse('id must be a valid UUID', 'id', id);
+    }
+
+    const body = (await request.json()) as {
+      confidence?: number;
+      tags?: string[];
+      superseded_by?: string;
+    };
+
+    const updates: Record<string, unknown> = {};
+    if (body.confidence !== undefined) {
+      if (body.confidence < 0 || body.confidence > 1) {
+        return createValidationErrorResponse(
+          'confidence must be between 0 and 1',
+          'confidence',
+          body.confidence,
+        );
+      }
+      updates.confidence = body.confidence;
+    }
+    if (body.tags !== undefined) updates.tags = body.tags;
+    if (body.superseded_by !== undefined) {
+      if (body.superseded_by !== null && !UUID_RE.test(body.superseded_by)) {
+        return createValidationErrorResponse(
+          'superseded_by must be a valid UUID or null',
+          'superseded_by',
+          body.superseded_by,
+        );
+      }
+      updates.supersededBy = body.superseded_by;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return createValidationErrorResponse('No fields to update', 'body', body);
+    }
+
+    const db = getClient();
+    const [updated] = await db
+      .update(sharedFacts)
+      .set(updates)
+      .where(eq(sharedFacts.id, id))
+      .returning();
+
+    if (!updated) {
+      return createApplicationErrorResponse('Shared fact not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error('Error updating shared fact', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-facts/[id]',
+      operation: 'update_shared_fact',
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!UUID_RE.test(id)) {
+      return createValidationErrorResponse('id must be a valid UUID', 'id', id);
+    }
+
+    const db = getClient();
+    const [deleted] = await db.delete(sharedFacts).where(eq(sharedFacts.id, id)).returning();
+
+    if (!deleted) {
+      return createApplicationErrorResponse('Shared fact not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('Error deleting shared fact', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-facts/[id]',
+      operation: 'delete_shared_fact',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/shared-facts/route.ts
+++ b/apps/admin/src/app/api/sync/shared-facts/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared Facts Sync Mutation Route
+ *
+ * POST /api/sync/shared-facts - Publish a new shared fact
+ *
+ * Authenticated. Facts are scoped by coordination session_id.
+ * ElectricSQL picks up the database change and pushes it to all shape subscribers.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { sharedFacts } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const VALID_FACT_TYPES = new Set(['discovery', 'bug', 'decision', 'warning', 'question', 'answer']);
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      session_id?: string;
+      agent_id?: string;
+      content?: string;
+      fact_type?: string;
+      confidence?: number;
+      tags?: string[];
+      source_ref?: Record<string, unknown>;
+    };
+
+    if (!(body.session_id && SESSION_ID_RE.test(body.session_id))) {
+      return createValidationErrorResponse(
+        'session_id is required and must be alphanumeric with hyphens/underscores',
+        'session_id',
+        body.session_id,
+      );
+    }
+
+    if (!(body.agent_id && AGENT_ID_RE.test(body.agent_id))) {
+      return createValidationErrorResponse(
+        'agent_id is required and must be alphanumeric with hyphens/underscores',
+        'agent_id',
+        body.agent_id,
+      );
+    }
+
+    if (!body.content || body.content.trim().length === 0) {
+      return createValidationErrorResponse('content is required', 'content', body.content);
+    }
+
+    if (!(body.fact_type && VALID_FACT_TYPES.has(body.fact_type))) {
+      return createValidationErrorResponse(
+        `fact_type must be one of: ${[...VALID_FACT_TYPES].join(', ')}`,
+        'fact_type',
+        body.fact_type,
+      );
+    }
+
+    if (body.confidence !== undefined && (body.confidence < 0 || body.confidence > 1)) {
+      return createValidationErrorResponse(
+        'confidence must be between 0 and 1',
+        'confidence',
+        body.confidence,
+      );
+    }
+
+    const db = getClient();
+    const id = crypto.randomUUID();
+
+    const [created] = await db
+      .insert(sharedFacts)
+      .values({
+        id,
+        sessionId: body.session_id,
+        agentId: body.agent_id,
+        content: body.content,
+        factType: body.fact_type,
+        confidence: body.confidence ?? 1.0,
+        tags: body.tags ?? [],
+        sourceRef: body.source_ref,
+      })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating shared fact', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-facts',
+      operation: 'create_shared_fact',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/shared-memories/route.ts
+++ b/apps/admin/src/app/api/sync/shared-memories/route.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared Memories Sync Mutation Route
+ *
+ * POST /api/sync/shared-memories - Create a shared memory
+ *
+ * Authenticated. Creates an agent_memories row with scope='shared'
+ * and the given session_scope. Electric fans out to all subscribers.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { agentMemories, eq, sites } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
+const VALID_MEMORY_TYPES = new Set([
+  'fact',
+  'preference',
+  'decision',
+  'feedback',
+  'example',
+  'correction',
+  'skill',
+  'warning',
+]);
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      agent_id?: string;
+      site_id?: string;
+      session_scope?: string;
+      content?: string;
+      type?: string;
+      source?: Record<string, unknown>;
+      metadata?: Record<string, unknown>;
+      source_facts?: string[];
+    };
+
+    if (!(body.session_scope && SESSION_SCOPE_RE.test(body.session_scope))) {
+      return createValidationErrorResponse(
+        'session_scope is required and must be alphanumeric with hyphens/underscores',
+        'session_scope',
+        body.session_scope,
+      );
+    }
+
+    if (!(body.agent_id && AGENT_ID_RE.test(body.agent_id))) {
+      return createValidationErrorResponse(
+        'agent_id is required and must be alphanumeric with hyphens/underscores',
+        'agent_id',
+        body.agent_id,
+      );
+    }
+
+    if (!body.content || body.content.trim().length === 0) {
+      return createValidationErrorResponse('content is required', 'content', body.content);
+    }
+
+    if (!(body.type && VALID_MEMORY_TYPES.has(body.type))) {
+      return createValidationErrorResponse(
+        `type must be one of: ${[...VALID_MEMORY_TYPES].join(', ')}`,
+        'type',
+        body.type,
+      );
+    }
+
+    if (!body.source || typeof body.source !== 'object') {
+      return createValidationErrorResponse(
+        'source is required and must be an object',
+        'source',
+        body.source,
+      );
+    }
+
+    if (!body.site_id || body.site_id.trim().length === 0) {
+      return createValidationErrorResponse('site_id is required', 'site_id', body.site_id);
+    }
+
+    const db = getClient();
+
+    // Validate site ownership for non-admins
+    if (session.user.role !== 'admin') {
+      const [site] = await db
+        .select({ ownerId: sites.ownerId })
+        .from(sites)
+        .where(eq(sites.id, body.site_id))
+        .limit(1);
+      if (!site || site.ownerId !== session.user.id) {
+        return createApplicationErrorResponse(
+          'Access denied: you do not own this site',
+          'FORBIDDEN',
+          403,
+        );
+      }
+    }
+
+    const id = crypto.randomUUID();
+
+    const [created] = await db
+      .insert(agentMemories)
+      .values({
+        id,
+        agentId: body.agent_id,
+        siteId: body.site_id,
+        content: body.content,
+        type: body.type,
+        source: body.source,
+        metadata: body.metadata ?? {},
+        scope: 'shared',
+        sessionScope: body.session_scope,
+        sourceFacts: body.source_facts ?? [],
+      })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating shared memory', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-memories',
+      operation: 'create_shared_memory',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
@@ -11,7 +11,7 @@
 import { getSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { yjsDocumentPatches, yjsDocuments } from '@revealui/db/schema';
-import { applyPatches } from '@revealui/sync/collab';
+import { applyPatches } from '@revealui/sync/collab/server';
 import { logger } from '@revealui/utils/logger';
 import { eq } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';

--- a/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
@@ -1,0 +1,153 @@
+/**
+ * Yjs Document Patches Sync Mutation Route
+ *
+ * POST /api/sync/yjs-document-patches - Submit a structured patch
+ *
+ * Authenticated. Inserts the patch and applies it to the Yjs document
+ * state inline. Electric picks up both the patch row and the updated
+ * yjs_documents state.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { yjsDocumentPatches, yjsDocuments } from '@revealui/db/schema';
+import { applyPatches } from '@revealui/sync/collab';
+import { logger } from '@revealui/utils/logger';
+import { eq } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const DOCUMENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const VALID_PATCH_TYPES = new Set(['append_section', 'append_item', 'replace_section', 'set_key']);
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      document_id?: string;
+      agent_id?: string;
+      patch_type?: string;
+      path?: string;
+      content?: string;
+    };
+
+    if (!(body.document_id && DOCUMENT_ID_RE.test(body.document_id))) {
+      return createValidationErrorResponse(
+        'document_id is required and must be alphanumeric with hyphens/underscores',
+        'document_id',
+        body.document_id,
+      );
+    }
+
+    if (!(body.agent_id && AGENT_ID_RE.test(body.agent_id))) {
+      return createValidationErrorResponse(
+        'agent_id is required and must be alphanumeric with hyphens/underscores',
+        'agent_id',
+        body.agent_id,
+      );
+    }
+
+    if (!(body.patch_type && VALID_PATCH_TYPES.has(body.patch_type))) {
+      return createValidationErrorResponse(
+        `patch_type must be one of: ${[...VALID_PATCH_TYPES].join(', ')}`,
+        'patch_type',
+        body.patch_type,
+      );
+    }
+
+    if (!body.path || body.path.trim().length === 0) {
+      return createValidationErrorResponse('path is required', 'path', body.path);
+    }
+
+    if (!body.content || body.content.trim().length === 0) {
+      return createValidationErrorResponse('content is required', 'content', body.content);
+    }
+
+    const db = getClient();
+
+    // Insert the patch record
+    const [patch] = await db
+      .insert(yjsDocumentPatches)
+      .values({
+        documentId: body.document_id,
+        agentId: body.agent_id,
+        patchType: body.patch_type,
+        path: body.path,
+        content: body.content,
+      })
+      .returning();
+
+    if (!patch) {
+      return createApplicationErrorResponse('Failed to insert patch', 'INTERNAL_ERROR', 500);
+    }
+
+    // Load existing document state
+    const [existing] = await db
+      .select()
+      .from(yjsDocuments)
+      .where(eq(yjsDocuments.id, body.document_id))
+      .limit(1);
+
+    // Apply patch via the sync package's patch applier
+    const existingState = existing?.state ? new Uint8Array(existing.state) : null;
+    const result = applyPatches(existingState, [
+      {
+        patchType: body.patch_type as
+          | 'set_key'
+          | 'append_section'
+          | 'append_item'
+          | 'replace_section',
+        path: body.path,
+        content: body.content,
+      },
+    ]);
+
+    // Save updated state
+    const state = Buffer.from(result.state);
+    const stateVector = Buffer.from(result.stateVector);
+
+    if (existing) {
+      await db
+        .update(yjsDocuments)
+        .set({ state, stateVector, updatedAt: new Date() })
+        .where(eq(yjsDocuments.id, body.document_id));
+    } else {
+      await db.insert(yjsDocuments).values({
+        id: body.document_id,
+        state,
+        stateVector,
+      });
+    }
+
+    // Mark patch as applied
+    await db
+      .update(yjsDocumentPatches)
+      .set({ applied: true })
+      .where(eq(yjsDocumentPatches.id, patch.id));
+
+    return NextResponse.json({ ...patch, applied: true }, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating yjs document patch', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/yjs-document-patches',
+      operation: 'create_yjs_document_patch',
+    });
+  }
+}

--- a/docs/AUDIT_STATUS.md
+++ b/docs/AUDIT_STATUS.md
@@ -1,0 +1,35 @@
+# Security Audit Status
+
+**Last updated:** 2026-04-18
+**Session:** Commercial readiness marathon (continuation)
+
+## Closed
+
+| ID | Finding | Fix | PR |
+|----|---------|-----|----|
+| P2-1 | Trusted-proxy: X-Forwarded-For spoofable | `getClientIp()` with rightmost-untrusted strategy | #371 |
+| P2-2 | SSRF: MCP adapter fetches to private IPs | `assertPublicUrl()` with DNS + private IP blocking | #371 |
+| P2-3 | Manual SQL outside Drizzle | Migration 0002 + deleted 5 redundant files | #371 |
+| P3-1 | Cross-DB FK: VectorMemoryService.update() | `assertCrossDbRefs` on siteId changes | #371 |
+| P3-2 | Transaction guards: direct db.transaction() | Replaced with `withTransaction()` in 3 API routes | #371 |
+| P3-3 | Audit-log writable via UPDATE/DELETE | Trigger deployed to production NeonDB (verified) | #371 |
+| P3-4 | OTP attempt increment | Already atomic with Neon HTTP fallback | N/A |
+| P3-5 | No backup verification | `verify-backup.ts` + GitHub Actions daily cron | #371 |
+| WH-1 | Silent payment drop on cleanup failure | `unreconciled_webhooks` table + 200-on-failure | #372 |
+| WH-4 | Wrong tier in payment receipt | Scoped license query to `invoice.subscription` | #372 |
+| DOCS | Inflated numbers in README/MASTER_PLAN | Replaced with grep-reproducible counts | #372 |
+
+## Open
+
+| ID | Finding | Severity | Blocker? | Notes |
+|----|---------|----------|----------|-------|
+| WH-2 | License key non-idempotent across saga retries | High | No | Needs saga step refactor; checkpoint is NOT transactional with step effects, so idempotency guard on `(customerId, subscriptionId)` is also needed |
+| WH-3 | Concurrent event race on syncHostedSubscriptionState | Medium | No | Add event timestamp guard to UPDATE WHERE clause; failure mode is temporary stale status, not data loss |
+| CRON | Reconciliation cron for unreconciled_webhooks | Medium | No | Table exists, consumer pending; without cron, rows land but nobody is alerted |
+
+## Verification Checks (2026-04-18)
+
+- **Revealcoin keys:** Private key files on disk, never committed to git, gitignored, 0600 permissions. No rotation needed.
+- **Config secret literal:** Comment/example only (line 87), not runtime code.
+- **RevDev socket:** No chmod 0600 in Rust source. Socket not running. Low priority.
+- **Dependabot PRs:** Zero open.

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -41,7 +41,7 @@
 | Stripe integration | Built | Medium  -  DB-backed circuit breaker (circuit_breaker_state table) |
 | Lexical rich text | Built | Medium  -  recently integrated |
 | REST API (Hono) | Built | Medium  -  routes exist, no production traffic |
-| ElectricSQL sync | **Verified** | **High  -  proxy + auth + shapes working in production (Railway → NeonDB)** |
+| ElectricSQL sync | **Verified** | **High  -  proxy + auth + shapes working in production (Railway → NeonDB, Supabase CLI linked, Vercel env wired)** |
 
 ### What Doesn't Exist
 

--- a/packages/ai/src/memory/services/index.ts
+++ b/packages/ai/src/memory/services/index.ts
@@ -6,3 +6,14 @@
 
 export type { EntityType } from './node-id-service.js';
 export { NodeIdService } from './node-id-service.js';
+export type {
+  Contradiction,
+  ReconciledMemory,
+  ReconciliationResult,
+  SharedFactInput,
+} from './reconciliation-service.js';
+export {
+  buildReconciliationPrompt,
+  parseReconciliationResponse,
+  reconcileHeuristic,
+} from './reconciliation-service.js';

--- a/packages/ai/src/memory/services/reconciliation-service.ts
+++ b/packages/ai/src/memory/services/reconciliation-service.ts
@@ -1,0 +1,180 @@
+/**
+ * Reconciliation Service - LLM-powered fact resolution for multi-agent memory.
+ *
+ * Reads shared facts from a coordination session, groups related facts,
+ * calls an LLM to determine canonical truths, resolve contradictions,
+ * and deduplicate. Produces reconciled memories for Layer 3.
+ *
+ * Layer 3 of the multi-agent shared memory architecture.
+ */
+
+export interface SharedFactInput {
+  id: string;
+  agentId: string;
+  content: string;
+  factType: string;
+  confidence: number;
+  tags: string[];
+  sourceRef?: Record<string, unknown> | null;
+}
+
+export interface ReconciledMemory {
+  content: string;
+  type: string;
+  sourceFactIds: string[];
+  confidence: number;
+}
+
+export interface Contradiction {
+  factIds: string[];
+  description: string;
+  resolution: string;
+}
+
+export interface ReconciliationResult {
+  canonicalFacts: ReconciledMemory[];
+  contradictions: Contradiction[];
+  duplicates: string[][];
+  summary: string;
+}
+
+/**
+ * Build the reconciliation prompt for an LLM.
+ * The prompt asks the model to analyze facts from multiple agents and
+ * produce a structured reconciliation result.
+ */
+export function buildReconciliationPrompt(
+  facts: SharedFactInput[],
+  scratchpadContent?: Record<string, unknown>,
+): string {
+  const factList = facts
+    .map(
+      (f, i) =>
+        `${i + 1}. [${f.factType}] (agent: ${f.agentId}, confidence: ${f.confidence}) ${f.content}` +
+        (f.tags.length > 0 ? ` [tags: ${f.tags.join(', ')}]` : ''),
+    )
+    .join('\n');
+
+  const scratchpadSection = scratchpadContent
+    ? `\n\nShared scratchpad content:\n${JSON.stringify(scratchpadContent, null, 2)}`
+    : '';
+
+  return `You are reconciling discoveries from multiple AI agents working on the same task.
+
+Facts discovered by agents:
+${factList}
+${scratchpadSection}
+
+Analyze these facts and produce a JSON response with:
+1. "canonicalFacts": Array of canonical truths. For each:
+   - "content": The canonical fact statement
+   - "type": One of: fact, preference, decision, warning, skill
+   - "sourceFactIds": Array of source fact indices (1-based) that support this
+   - "confidence": 0-1 confidence score
+2. "contradictions": Array of contradictions found. For each:
+   - "factIndices": The conflicting fact indices
+   - "description": What contradicts
+   - "resolution": How to resolve (which is correct and why)
+3. "duplicates": Array of arrays of fact indices that say the same thing
+4. "summary": One-sentence summary of the reconciliation
+
+Rules:
+- Merge duplicate facts into one canonical fact
+- When facts contradict, determine which is correct based on confidence and specificity
+- Preserve the most specific and actionable version of each fact
+- Do not invent facts not supported by the inputs
+
+Respond with ONLY valid JSON, no markdown fencing.`;
+}
+
+/**
+ * Parse the LLM response into a structured reconciliation result.
+ * Maps 1-based fact indices back to actual fact IDs.
+ */
+export function parseReconciliationResponse(
+  response: string,
+  facts: SharedFactInput[],
+): ReconciliationResult {
+  const parsed = JSON.parse(response) as {
+    canonicalFacts?: Array<{
+      content: string;
+      type: string;
+      sourceFactIds?: number[];
+      confidence?: number;
+    }>;
+    contradictions?: Array<{
+      factIndices?: number[];
+      description?: string;
+      resolution?: string;
+    }>;
+    duplicates?: number[][];
+    summary?: string;
+  };
+
+  const mapIndices = (indices: number[]): string[] =>
+    indices
+      .filter((i) => i >= 1 && i <= facts.length)
+      .map((i) => facts[i - 1]?.id)
+      .filter((id): id is string => id !== undefined);
+
+  return {
+    canonicalFacts: (parsed.canonicalFacts ?? []).map((cf) => ({
+      content: cf.content,
+      type: cf.type,
+      sourceFactIds: mapIndices(cf.sourceFactIds ?? []),
+      confidence: cf.confidence ?? 1.0,
+    })),
+    contradictions: (parsed.contradictions ?? []).map((c) => ({
+      factIds: mapIndices(c.factIndices ?? []),
+      description: c.description ?? '',
+      resolution: c.resolution ?? '',
+    })),
+    duplicates: (parsed.duplicates ?? []).map((group) => mapIndices(group)),
+    summary: parsed.summary ?? 'Reconciliation complete.',
+  };
+}
+
+/**
+ * Simple heuristic reconciliation (no LLM required).
+ * Deduplicates by normalized content and groups by type.
+ * Use this as a fallback when no LLM provider is configured.
+ */
+export function reconcileHeuristic(facts: SharedFactInput[]): ReconciliationResult {
+  const seen = new Map<string, string[]>();
+  const canonicalFacts: ReconciledMemory[] = [];
+  const duplicates: string[][] = [];
+
+  for (const fact of facts) {
+    const normalized = fact.content.toLowerCase().trim();
+    const existing = seen.get(normalized);
+    if (existing) {
+      existing.push(fact.id);
+    } else {
+      seen.set(normalized, [fact.id]);
+    }
+  }
+
+  for (const [, ids] of seen) {
+    if (ids.length > 1) {
+      duplicates.push(ids);
+    }
+    const sourceFact = facts.find((f) => f.id === ids[0]);
+    if (sourceFact) {
+      const memoryType =
+        sourceFact.factType === 'bug' || sourceFact.factType === 'warning' ? 'warning' : 'fact';
+      canonicalFacts.push({
+        content: sourceFact.content,
+        type: memoryType,
+        sourceFactIds: ids,
+        confidence: sourceFact.confidence,
+      });
+    }
+  }
+
+  return {
+    canonicalFacts,
+    contradictions: [],
+    duplicates,
+    summary: `Reconciled ${facts.length} facts into ${canonicalFacts.length} canonical facts (${duplicates.length} duplicates).`,
+  };
+}

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -1705,6 +1705,32 @@ export const SessionsInsertContract = createContract({
 })
 
 // =============================================================================
+// SharedFacts Contracts
+// =============================================================================
+
+/**
+ * Contract for sharedFacts row (Select)
+ * Database table: shared_facts
+ */
+export const SharedFactsRowContract = createContract({
+  name: 'SharedFactsRow',
+  version: '1',
+  description: 'Database row contract for shared_facts table',
+  schema: Schemas.SharedFactsSelectSchema,
+})
+
+/**
+ * Contract for sharedFacts insert
+ * Database table: shared_facts
+ */
+export const SharedFactsInsertContract = createContract({
+  name: 'SharedFactsInsert',
+  version: '1',
+  description: 'Database insert contract for shared_facts table',
+  schema: Schemas.SharedFactsInsertSchema,
+})
+
+// =============================================================================
 // SiteCollaborators Contracts
 // =============================================================================
 
@@ -2118,6 +2144,32 @@ export const WaitlistInsertContract = createContract({
   version: '1',
   description: 'Database insert contract for waitlist table',
   schema: Schemas.WaitlistInsertSchema,
+})
+
+// =============================================================================
+// YjsDocumentPatches Contracts
+// =============================================================================
+
+/**
+ * Contract for yjsDocumentPatches row (Select)
+ * Database table: yjs_document_patches
+ */
+export const YjsDocumentPatchesRowContract = createContract({
+  name: 'YjsDocumentPatchesRow',
+  version: '1',
+  description: 'Database row contract for yjs_document_patches table',
+  schema: Schemas.YjsDocumentPatchesSelectSchema,
+})
+
+/**
+ * Contract for yjsDocumentPatches insert
+ * Database table: yjs_document_patches
+ */
+export const YjsDocumentPatchesInsertContract = createContract({
+  name: 'YjsDocumentPatchesInsert',
+  version: '1',
+  description: 'Database insert contract for yjs_document_patches table',
+  schema: Schemas.YjsDocumentPatchesInsertSchema,
 })
 
 // =============================================================================

--- a/packages/contracts/src/generated/zod-schemas.ts
+++ b/packages/contracts/src/generated/zod-schemas.ts
@@ -1704,6 +1704,32 @@ export type SessionsRow = z.infer<typeof SessionsSelectSchema>
 export type SessionsInsert = z.infer<typeof SessionsInsertSchema>
 
 // =============================================================================
+// SharedFacts Schemas
+// =============================================================================
+
+/**
+ * Zod schema for selecting sharedFacts rows from database
+ * Generated from Drizzle table definition: tables.sharedFacts
+ */
+export const SharedFactsSelectSchema = createSelectSchema(tables.sharedFacts)
+
+/**
+ * Zod schema for inserting sharedFacts rows to database
+ * Generated from Drizzle table definition: tables.sharedFacts
+ */
+export const SharedFactsInsertSchema = createInsertSchema(tables.sharedFacts)
+
+/**
+ * TypeScript type for sharedFacts row (Select)
+ */
+export type SharedFactsRow = z.infer<typeof SharedFactsSelectSchema>
+
+/**
+ * TypeScript type for sharedFacts insert
+ */
+export type SharedFactsInsert = z.infer<typeof SharedFactsInsertSchema>
+
+// =============================================================================
 // SiteCollaborators Schemas
 // =============================================================================
 
@@ -2118,6 +2144,32 @@ export type WaitlistRow = z.infer<typeof WaitlistSelectSchema>
  * TypeScript type for waitlist insert
  */
 export type WaitlistInsert = z.infer<typeof WaitlistInsertSchema>
+
+// =============================================================================
+// YjsDocumentPatches Schemas
+// =============================================================================
+
+/**
+ * Zod schema for selecting yjsDocumentPatches rows from database
+ * Generated from Drizzle table definition: tables.yjsDocumentPatches
+ */
+export const YjsDocumentPatchesSelectSchema = createSelectSchema(tables.yjsDocumentPatches)
+
+/**
+ * Zod schema for inserting yjsDocumentPatches rows to database
+ * Generated from Drizzle table definition: tables.yjsDocumentPatches
+ */
+export const YjsDocumentPatchesInsertSchema = createInsertSchema(tables.yjsDocumentPatches)
+
+/**
+ * TypeScript type for yjsDocumentPatches row (Select)
+ */
+export type YjsDocumentPatchesRow = z.infer<typeof YjsDocumentPatchesSelectSchema>
+
+/**
+ * TypeScript type for yjsDocumentPatches insert
+ */
+export type YjsDocumentPatchesInsert = z.infer<typeof YjsDocumentPatchesInsertSchema>
 
 // =============================================================================
 // YjsDocuments Schemas

--- a/packages/db/migrations/0003_shared_facts.sql
+++ b/packages/db/migrations/0003_shared_facts.sql
@@ -1,0 +1,21 @@
+-- Layer 1: Shared Facts - Append-only agent discovery log
+-- Multi-agent coordination via ElectricSQL shape subscriptions
+
+CREATE TABLE IF NOT EXISTS "shared_facts" (
+  "id" text PRIMARY KEY NOT NULL,
+  "session_id" text NOT NULL,
+  "agent_id" text NOT NULL,
+  "content" text NOT NULL,
+  "fact_type" text NOT NULL,
+  "confidence" real NOT NULL DEFAULT 1.0,
+  "tags" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "source_ref" jsonb,
+  "superseded_by" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "shared_facts_fact_type_check" CHECK (fact_type IN ('discovery', 'bug', 'decision', 'warning', 'question', 'answer'))
+);
+
+CREATE INDEX IF NOT EXISTS "shared_facts_session_id_idx" ON "shared_facts" ("session_id");
+CREATE INDEX IF NOT EXISTS "shared_facts_agent_id_idx" ON "shared_facts" ("agent_id");
+CREATE INDEX IF NOT EXISTS "shared_facts_fact_type_idx" ON "shared_facts" ("fact_type");
+CREATE INDEX IF NOT EXISTS "shared_facts_created_at_idx" ON "shared_facts" ("created_at");

--- a/packages/db/migrations/0004_yjs_document_patches.sql
+++ b/packages/db/migrations/0004_yjs_document_patches.sql
@@ -1,0 +1,17 @@
+-- Layer 2: Yjs Document Patches - Structured CLI agent scratchpad edits
+-- Patches are applied server-side to Yjs document state
+
+CREATE TABLE IF NOT EXISTS "yjs_document_patches" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "document_id" text NOT NULL REFERENCES "yjs_documents"("id") ON DELETE CASCADE,
+  "agent_id" text NOT NULL,
+  "patch_type" text NOT NULL,
+  "path" text NOT NULL,
+  "content" text NOT NULL,
+  "applied" boolean NOT NULL DEFAULT false,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "yjs_document_patches_type_check" CHECK (patch_type IN ('append_section', 'append_item', 'replace_section', 'set_key'))
+);
+
+CREATE INDEX IF NOT EXISTS "yjs_document_patches_doc_applied_idx" ON "yjs_document_patches" ("document_id", "applied");
+CREATE INDEX IF NOT EXISTS "yjs_document_patches_created_at_idx" ON "yjs_document_patches" ("created_at");

--- a/packages/db/migrations/0005_shared_memory_scope.sql
+++ b/packages/db/migrations/0005_shared_memory_scope.sql
@@ -1,0 +1,13 @@
+-- Layer 3: Shared Memory Scope - Extend agent_memories for multi-agent sharing
+-- Adds scope (private/shared/reconciled), session binding, and reconciliation tracking
+
+ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "scope" text NOT NULL DEFAULT 'private';
+ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "session_scope" text;
+ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "source_facts" jsonb DEFAULT '[]'::jsonb;
+ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "reconciled_at" timestamp with time zone;
+
+ALTER TABLE "agent_memories" ADD CONSTRAINT "agent_memories_scope_check"
+  CHECK (scope IN ('private', 'shared', 'reconciled'));
+
+CREATE INDEX IF NOT EXISTS "agent_memories_scope_idx" ON "agent_memories" ("scope");
+CREATE INDEX IF NOT EXISTS "agent_memories_session_scope_idx" ON "agent_memories" ("session_scope");

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -133,6 +133,12 @@ export const agentMemories = pgTable(
       .references(() => sites.id, { onDelete: 'cascade' }),
     agentId: text('agent_id'),
 
+    // Multi-agent sharing scope (Layer 3)
+    scope: text('scope').default('private').notNull(),
+    sessionScope: text('session_scope'),
+    sourceFacts: jsonb('source_facts').$type<string[]>().default([]),
+    reconciledAt: timestamp('reconciled_at', { withTimezone: true }),
+
     // Timestamps
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }),
@@ -143,10 +149,13 @@ export const agentMemories = pgTable(
     index('agent_memories_verified_idx').on(table.verified),
     index('agent_memories_expires_at_idx').on(table.expiresAt),
     index('agent_memories_type_idx').on(table.type),
+    index('agent_memories_scope_idx').on(table.scope),
+    index('agent_memories_session_scope_idx').on(table.sessionScope),
     check(
       'agent_memories_type_check',
       sql`type IN ('fact', 'preference', 'decision', 'feedback', 'example', 'correction', 'skill', 'warning')`,
     ),
+    check('agent_memories_scope_check', sql`scope IN ('private', 'shared', 'reconciled')`),
   ],
 );
 

--- a/packages/db/src/schema/rest.ts
+++ b/packages/db/src/schema/rest.ts
@@ -66,6 +66,7 @@ export * from './products.js';
 export * from './rate-limits.js';
 export * from './revealcoin.js';
 export * from './revmarket.js';
+export * from './shared-facts.js';
 export * from './sites.js';
 export * from './tenants.js';
 export * from './tickets.js';
@@ -73,6 +74,7 @@ export * from './users.js';
 export * from './waitlist.js';
 export * from './webhook-events.js';
 export * from './webhook-reconciliation.js';
+export * from './yjs-document-patches.js';
 export * from './yjs-documents.js';
 
 // Note: Relations are defined in index.ts to avoid circular dependencies

--- a/packages/db/src/schema/shared-facts.ts
+++ b/packages/db/src/schema/shared-facts.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared Facts table - Append-only agent discovery log for multi-agent coordination.
+ *
+ * When agent A discovers "file X has bug Y," all concurrent agents see it
+ * in real-time via ElectricSQL shape subscriptions. Facts are scoped to a
+ * coordination session so only agents working on the same task share context.
+ *
+ * Layer 1 of the multi-agent shared memory architecture.
+ */
+
+import { sql } from 'drizzle-orm';
+import { check, index, jsonb, pgTable, real, text, timestamp } from 'drizzle-orm/pg-core';
+
+// =============================================================================
+// Shared Facts Table
+// =============================================================================
+
+export const sharedFacts = pgTable(
+  'shared_facts',
+  {
+    id: text('id').primaryKey(),
+
+    // Coordination session scope - all agents in the same session see these facts
+    sessionId: text('session_id').notNull(),
+
+    // Agent that discovered this fact
+    agentId: text('agent_id').notNull(),
+
+    // The fact itself
+    content: text('content').notNull(),
+
+    // Classification
+    factType: text('fact_type').notNull(),
+
+    // How certain the agent is (0-1)
+    confidence: real('confidence').default(1.0).notNull(),
+
+    // Free-form tags for filtering and grouping
+    tags: jsonb('tags').$type<string[]>().default([]).notNull(),
+
+    // Source reference (file path, line number, tool that produced it)
+    sourceRef: jsonb('source_ref').$type<Record<string, unknown>>(),
+
+    // Layer 3: reconciliation marks superseded facts
+    supersededBy: text('superseded_by'),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('shared_facts_session_id_idx').on(table.sessionId),
+    index('shared_facts_agent_id_idx').on(table.agentId),
+    index('shared_facts_fact_type_idx').on(table.factType),
+    index('shared_facts_created_at_idx').on(table.createdAt),
+    check(
+      'shared_facts_fact_type_check',
+      sql`fact_type IN ('discovery', 'bug', 'decision', 'warning', 'question', 'answer')`,
+    ),
+  ],
+);
+
+// =============================================================================
+// Type exports
+// =============================================================================
+
+export type SharedFact = typeof sharedFacts.$inferSelect;
+export type NewSharedFact = typeof sharedFacts.$inferInsert;

--- a/packages/db/src/schema/yjs-document-patches.ts
+++ b/packages/db/src/schema/yjs-document-patches.ts
@@ -1,0 +1,62 @@
+/**
+ * Yjs Document Patches table - Structured patches for CLI agent scratchpad edits.
+ *
+ * CLI agents cannot run WebSocket Yjs connections. Instead they submit structured
+ * patches (append section, add item, replace section, set key) which are applied
+ * server-side to the Yjs document state. Electric fans out the updated state to
+ * all browser subscribers.
+ *
+ * Layer 2 of the multi-agent shared memory architecture.
+ */
+
+import { sql } from 'drizzle-orm';
+import { boolean, check, index, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { yjsDocuments } from './yjs-documents.js';
+
+// =============================================================================
+// Yjs Document Patches Table
+// =============================================================================
+
+export const yjsDocumentPatches = pgTable(
+  'yjs_document_patches',
+  {
+    id: serial('id').primaryKey(),
+
+    // Which document this patch applies to
+    documentId: text('document_id')
+      .notNull()
+      .references(() => yjsDocuments.id, { onDelete: 'cascade' }),
+
+    // Agent that submitted this patch
+    agentId: text('agent_id').notNull(),
+
+    // Type of structured edit
+    patchType: text('patch_type').notNull(),
+
+    // Target path in the document (e.g. "findings" or "plan.phase1")
+    path: text('path').notNull(),
+
+    // Content to insert/replace
+    content: text('content').notNull(),
+
+    // Whether this patch has been applied to the Yjs document state
+    applied: boolean('applied').default(false).notNull(),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('yjs_document_patches_doc_applied_idx').on(table.documentId, table.applied),
+    index('yjs_document_patches_created_at_idx').on(table.createdAt),
+    check(
+      'yjs_document_patches_type_check',
+      sql`patch_type IN ('append_section', 'append_item', 'replace_section', 'set_key')`,
+    ),
+  ],
+);
+
+// =============================================================================
+// Type exports
+// =============================================================================
+
+export type YjsDocumentPatch = typeof yjsDocumentPatches.$inferSelect;
+export type NewYjsDocumentPatch = typeof yjsDocumentPatches.$inferInsert;

--- a/packages/db/src/types/database.ts
+++ b/packages/db/src/types/database.ts
@@ -74,6 +74,7 @@ import type {
   revealcoinPayments,
   revealcoinPriceSnapshots,
   sessions,
+  sharedFacts,
   siteCollaborators,
   sites,
   syncMetadata,
@@ -90,6 +91,7 @@ import type {
   userDevices,
   users,
   waitlist,
+  yjsDocumentPatches,
   yjsDocuments,
 } from '../schema/index.js'
 
@@ -422,6 +424,11 @@ export type SessionsRow = typeof sessions.$inferSelect
 export type SessionsInsert = typeof sessions.$inferInsert
 export type SessionsUpdate = Partial<SessionsInsert>
 
+// Shared Facts
+export type SharedFactsRow = typeof sharedFacts.$inferSelect
+export type SharedFactsInsert = typeof sharedFacts.$inferInsert
+export type SharedFactsUpdate = Partial<SharedFactsInsert>
+
 // Site Collaborators
 export type SiteCollaboratorsRow = typeof siteCollaborators.$inferSelect
 export type SiteCollaboratorsInsert = typeof siteCollaborators.$inferInsert
@@ -501,6 +508,11 @@ export type UsersUpdate = Partial<UsersInsert>
 export type WaitlistRow = typeof waitlist.$inferSelect
 export type WaitlistInsert = typeof waitlist.$inferInsert
 export type WaitlistUpdate = Partial<WaitlistInsert>
+
+// Yjs Document Patches
+export type YjsDocumentPatchesRow = typeof yjsDocumentPatches.$inferSelect
+export type YjsDocumentPatchesInsert = typeof yjsDocumentPatches.$inferInsert
+export type YjsDocumentPatchesUpdate = Partial<YjsDocumentPatchesInsert>
 
 // Yjs Documents
 export type YjsDocumentsRow = typeof yjsDocuments.$inferSelect
@@ -596,6 +608,7 @@ export type DatabaseRelationships = {
   revealcoinPayments: Relationship[]
   revealcoinPriceSnapshots: Relationship[]
   sessions: Relationship[]
+  sharedFacts: Relationship[]
   siteCollaborators: Relationship[]
   sites: Relationship[]
   syncMetadata: Relationship[]
@@ -612,6 +625,7 @@ export type DatabaseRelationships = {
   userDevices: Relationship[]
   users: Relationship[]
   waitlist: Relationship[]
+  yjsDocumentPatches: Relationship[]
   yjsDocuments: Relationship[]
 }
 
@@ -873,6 +887,9 @@ export const sessionsRelationships = [
   { foreignKeyName: 'sessions_user_id_users_id_fk', columns: ['user_id'], isOneToOne: true, referencedRelation: 'users', referencedColumns: ['id'] },
 ] as const satisfies readonly Relationship[]
 
+// SharedFacts relationships
+export const sharedFactsRelationships: readonly Relationship[] = []
+
 // SiteCollaborators relationships
 export const siteCollaboratorsRelationships = [
   { foreignKeyName: 'site_collaborators_site_id_sites_id_fk', columns: ['site_id'], isOneToOne: true, referencedRelation: 'sites', referencedColumns: ['id'] },
@@ -947,6 +964,9 @@ export const usersRelationships: readonly Relationship[] = []
 
 // Waitlist relationships
 export const waitlistRelationships: readonly Relationship[] = []
+
+// YjsDocumentPatches relationships
+export const yjsDocumentPatchesRelationships: readonly Relationship[] = []
 
 // YjsDocuments relationships
 export const yjsDocumentsRelationships: readonly Relationship[] = []
@@ -1378,6 +1398,12 @@ export type Database = {
         Update: SessionsUpdate
         Relationships: typeof sessionsRelationships
       }
+      shared_facts: {
+        Row: SharedFactsRow
+        Insert: SharedFactsInsert
+        Update: SharedFactsUpdate
+        Relationships: typeof sharedFactsRelationships
+      }
       site_collaborators: {
         Row: SiteCollaboratorsRow
         Insert: SiteCollaboratorsInsert
@@ -1473,6 +1499,12 @@ export type Database = {
         Insert: WaitlistInsert
         Update: WaitlistUpdate
         Relationships: typeof waitlistRelationships
+      }
+      yjs_document_patches: {
+        Row: YjsDocumentPatchesRow
+        Insert: YjsDocumentPatchesInsert
+        Update: YjsDocumentPatchesUpdate
+        Relationships: typeof yjsDocumentPatchesRelationships
       }
       yjs_documents: {
         Row: YjsDocumentsRow

--- a/packages/sync/src/collab/index.ts
+++ b/packages/sync/src/collab/index.ts
@@ -1,4 +1,6 @@
 export { MESSAGE_AWARENESS, MESSAGE_SYNC } from './protocol-constants.js';
+export type { ApplyResult, PatchType, ScratchpadPatch } from './scratchpad-patch-applier.js';
+export { applyPatch, applyPatches, readScratchpad } from './scratchpad-patch-applier.js';
 export type { CollabDocumentState } from './use-collab-document.js';
 export { useCollabDocument } from './use-collab-document.js';
 export type {

--- a/packages/sync/src/collab/scratchpad-patch-applier.ts
+++ b/packages/sync/src/collab/scratchpad-patch-applier.ts
@@ -1,0 +1,118 @@
+/**
+ * Scratchpad Patch Applier - Server-side Yjs structured patch application.
+ *
+ * CLI agents submit structured patches instead of real-time Yjs updates.
+ * This module applies those patches to a Yjs document and returns the
+ * updated state for persistence.
+ *
+ * Patch types:
+ * - set_key: Set a root-level key to a string value
+ * - append_section: Append text to a Y.Text section (create if missing)
+ * - append_item: Push an item to a Y.Array section (create if missing)
+ * - replace_section: Replace a section entirely with new Y.Text content
+ */
+
+import * as Y from 'yjs';
+
+export type PatchType = 'set_key' | 'append_section' | 'append_item' | 'replace_section';
+
+export interface ScratchpadPatch {
+  patchType: PatchType;
+  path: string;
+  content: string;
+}
+
+export interface ApplyResult {
+  state: Uint8Array;
+  stateVector: Uint8Array;
+}
+
+/**
+ * Apply a single structured patch to a Yjs document.
+ * The document uses a Y.Map('root') as the top-level container.
+ */
+export function applyPatch(doc: Y.Doc, patch: ScratchpadPatch): void {
+  const root = doc.getMap('root');
+
+  switch (patch.patchType) {
+    case 'set_key': {
+      root.set(patch.path, patch.content);
+      break;
+    }
+    case 'append_section': {
+      let section = root.get(patch.path);
+      if (!(section instanceof Y.Text)) {
+        section = new Y.Text();
+        root.set(patch.path, section);
+      }
+      (section as Y.Text).insert((section as Y.Text).length, patch.content);
+      break;
+    }
+    case 'append_item': {
+      let arr = root.get(patch.path);
+      if (!(arr instanceof Y.Array)) {
+        arr = new Y.Array();
+        root.set(patch.path, arr);
+      }
+      (arr as Y.Array<string>).push([patch.content]);
+      break;
+    }
+    case 'replace_section': {
+      const text = new Y.Text();
+      text.insert(0, patch.content);
+      root.set(patch.path, text);
+      break;
+    }
+  }
+}
+
+/**
+ * Apply one or more patches to an existing Yjs document state.
+ * Returns the updated encoded state and state vector.
+ */
+export function applyPatches(
+  existingState: Uint8Array | null,
+  patches: ScratchpadPatch[],
+): ApplyResult {
+  const doc = new Y.Doc();
+
+  if (existingState) {
+    Y.applyUpdate(doc, existingState);
+  }
+
+  for (const patch of patches) {
+    applyPatch(doc, patch);
+  }
+
+  const result: ApplyResult = {
+    state: Y.encodeStateAsUpdate(doc),
+    stateVector: Y.encodeStateVector(doc),
+  };
+
+  doc.destroy();
+  return result;
+}
+
+/**
+ * Read the current content of a Yjs scratchpad as a plain object.
+ * Converts Y.Text to strings and Y.Array to string arrays.
+ */
+export function readScratchpad(state: Uint8Array): Record<string, unknown> {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, state);
+  const root = doc.getMap('root');
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of root.entries()) {
+    if (value instanceof Y.Text) {
+      result[key] = value.toString();
+    } else if (value instanceof Y.Array) {
+      result[key] = value.toArray();
+    } else {
+      result[key] = value;
+    }
+  }
+
+  doc.destroy();
+  return result;
+}

--- a/packages/sync/src/collab/server-index.ts
+++ b/packages/sync/src/collab/server-index.ts
@@ -3,3 +3,5 @@ export { AgentCollabClient } from './agent-client.js';
 export type { CreateAgentClientOptions } from './agent-client-factory.js';
 export { createAgentClient, createAndConnectAgentClient } from './agent-client-factory.js';
 export { MESSAGE_AWARENESS, MESSAGE_SYNC } from './protocol-constants.js';
+export type { ApplyResult, PatchType, ScratchpadPatch } from './scratchpad-patch-applier.js';
+export { applyPatch, applyPatches, readScratchpad } from './scratchpad-patch-applier.js';

--- a/packages/sync/src/hooks/useSharedFacts.ts
+++ b/packages/sync/src/hooks/useSharedFacts.ts
@@ -1,0 +1,89 @@
+'use client';
+
+import { useShape } from '@electric-sql/react';
+import { fetchWithTimeout } from '../fetch-with-timeout.js';
+import type { MutationResult } from '../mutations.js';
+import { useSyncMutations } from '../mutations.js';
+import { useElectricConfig } from '../provider/index.js';
+import { toRecords } from '../shape-utils.js';
+
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+export interface SharedFactRecord {
+  id: string;
+  session_id: string;
+  agent_id: string;
+  content: string;
+  fact_type: string;
+  confidence: number;
+  tags: string[];
+  source_ref: Record<string, unknown> | null;
+  superseded_by: string | null;
+  created_at: string;
+}
+
+export interface CreateSharedFactInput {
+  session_id: string;
+  agent_id: string;
+  content: string;
+  fact_type: string;
+  confidence?: number;
+  tags?: string[];
+  source_ref?: Record<string, unknown>;
+}
+
+export interface UpdateSharedFactInput {
+  confidence?: number;
+  tags?: string[];
+  superseded_by?: string | null;
+}
+
+export interface UseSharedFactsResult {
+  facts: SharedFactRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  publish: (data: CreateSharedFactInput) => Promise<MutationResult<SharedFactRecord>>;
+  update: (id: string, data: UpdateSharedFactInput) => Promise<MutationResult<SharedFactRecord>>;
+  remove: (id: string) => Promise<MutationResult<void>>;
+}
+
+export function useSharedFacts(sessionId: string): UseSharedFactsResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const isValid = sessionId.length > 0 && SESSION_ID_RE.test(sessionId);
+
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/shared-facts`,
+    params: { session_id: isValid ? sessionId : '00000000-0000-0000-0000-000000000000' },
+    fetchClient: fetchWithTimeout,
+  });
+
+  const {
+    create: publish,
+    update,
+    remove,
+  } = useSyncMutations<CreateSharedFactInput, UpdateSharedFactInput, SharedFactRecord>(
+    'shared-facts',
+  );
+
+  if (!isValid) {
+    return {
+      facts: [],
+      isLoading: false,
+      error: new Error(
+        'Invalid sessionId: must be non-empty alphanumeric, hyphens, underscores only',
+      ),
+      publish,
+      update,
+      remove,
+    };
+  }
+
+  return {
+    facts: toRecords<SharedFactRecord>(data),
+    isLoading,
+    error: error || null,
+    publish,
+    update,
+    remove,
+  };
+}

--- a/packages/sync/src/hooks/useSharedMemories.ts
+++ b/packages/sync/src/hooks/useSharedMemories.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { useShape } from '@electric-sql/react';
+import { useCallback } from 'react';
+import { fetchWithTimeout } from '../fetch-with-timeout.js';
+import type { MutationResult } from '../mutations.js';
+import { useSyncMutations } from '../mutations.js';
+import { useElectricConfig } from '../provider/index.js';
+import { toRecords } from '../shape-utils.js';
+
+const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
+
+export interface SharedMemoryRecord {
+  id: string;
+  content: string;
+  type: string;
+  agent_id: string | null;
+  scope: string;
+  session_scope: string | null;
+  source_facts: string[];
+  reconciled_at: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface CreateSharedMemoryInput {
+  agent_id: string;
+  site_id: string;
+  session_scope: string;
+  content: string;
+  type: string;
+  source: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  source_facts?: string[];
+}
+
+export interface UpdateSharedMemoryInput {
+  content?: string;
+  type?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UseSharedMemoriesResult {
+  memories: SharedMemoryRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  share: (data: CreateSharedMemoryInput) => Promise<MutationResult<SharedMemoryRecord>>;
+  update: (
+    id: string,
+    data: UpdateSharedMemoryInput,
+  ) => Promise<MutationResult<SharedMemoryRecord>>;
+  remove: (id: string) => Promise<MutationResult<void>>;
+  triggerReconciliation: (sessionId: string, siteId: string) => Promise<MutationResult<unknown>>;
+}
+
+export function useSharedMemories(sessionScope: string): UseSharedMemoriesResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const isValid = sessionScope.length > 0 && SESSION_SCOPE_RE.test(sessionScope);
+
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/shared-memories`,
+    params: {
+      session_scope: isValid ? sessionScope : '00000000-0000-0000-0000-000000000000',
+    },
+    fetchClient: fetchWithTimeout,
+  });
+
+  const {
+    create: share,
+    update,
+    remove,
+  } = useSyncMutations<CreateSharedMemoryInput, UpdateSharedMemoryInput, SharedMemoryRecord>(
+    'shared-memories',
+  );
+
+  const triggerReconciliation = useCallback(
+    async (sessionId: string, siteId: string): Promise<MutationResult<unknown>> => {
+      const response = await fetch(`${proxyBaseUrl}/api/sync/reconcile`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: sessionId, site_id: siteId }),
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        return {
+          success: false,
+          error: errorData?.error ?? `Reconciliation failed with status ${response.status}`,
+        };
+      }
+
+      const result = await response.json();
+      return { success: true, data: result };
+    },
+    [proxyBaseUrl],
+  );
+
+  if (!isValid) {
+    return {
+      memories: [],
+      isLoading: false,
+      error: new Error(
+        'Invalid sessionScope: must be non-empty alphanumeric, hyphens, underscores only',
+      ),
+      share,
+      update,
+      remove,
+      triggerReconciliation,
+    };
+  }
+
+  return {
+    memories: toRecords<SharedMemoryRecord>(data),
+    isLoading,
+    error: error || null,
+    share,
+    update,
+    remove,
+    triggerReconciliation,
+  };
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -53,6 +53,20 @@ export type {
 } from './hooks/useConversations.js';
 export { useConversations } from './hooks/useConversations.js';
 export type {
+  CreateSharedFactInput,
+  SharedFactRecord,
+  UpdateSharedFactInput,
+  UseSharedFactsResult,
+} from './hooks/useSharedFacts.js';
+export { useSharedFacts } from './hooks/useSharedFacts.js';
+export type {
+  CreateSharedMemoryInput,
+  SharedMemoryRecord,
+  UpdateSharedMemoryInput,
+  UseSharedMemoriesResult,
+} from './hooks/useSharedMemories.js';
+export { useSharedMemories } from './hooks/useSharedMemories.js';
+export type {
   CoordinationSessionRecord,
   CreateCoordinationSessionInput,
   UpdateCoordinationSessionInput,

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -53,20 +53,6 @@ export type {
 } from './hooks/useConversations.js';
 export { useConversations } from './hooks/useConversations.js';
 export type {
-  CreateSharedFactInput,
-  SharedFactRecord,
-  UpdateSharedFactInput,
-  UseSharedFactsResult,
-} from './hooks/useSharedFacts.js';
-export { useSharedFacts } from './hooks/useSharedFacts.js';
-export type {
-  CreateSharedMemoryInput,
-  SharedMemoryRecord,
-  UpdateSharedMemoryInput,
-  UseSharedMemoriesResult,
-} from './hooks/useSharedMemories.js';
-export { useSharedMemories } from './hooks/useSharedMemories.js';
-export type {
   CoordinationSessionRecord,
   CreateCoordinationSessionInput,
   UpdateCoordinationSessionInput,
@@ -85,5 +71,19 @@ export type { OnlineStatusResult } from './hooks/useOnlineStatus.js';
 export { useOnlineStatus } from './hooks/useOnlineStatus.js';
 export type { InvalidationAction } from './hooks/useShapeCacheInvalidation.js';
 export { useShapeCacheInvalidation } from './hooks/useShapeCacheInvalidation.js';
+export type {
+  CreateSharedFactInput,
+  SharedFactRecord,
+  UpdateSharedFactInput,
+  UseSharedFactsResult,
+} from './hooks/useSharedFacts.js';
+export { useSharedFacts } from './hooks/useSharedFacts.js';
+export type {
+  CreateSharedMemoryInput,
+  SharedMemoryRecord,
+  UpdateSharedMemoryInput,
+  UseSharedMemoriesResult,
+} from './hooks/useSharedMemories.js';
+export { useSharedMemories } from './hooks/useSharedMemories.js';
 export type { MutationResult } from './mutations.js';
 export { ElectricProvider, useElectricConfig } from './provider/index.js';


### PR DESCRIPTION
## Summary

- **Layer 1 — Shared Fact Log:** append-only `shared_facts` table synced via ElectricSQL. Agents publish discoveries (bugs, decisions, warnings) scoped by coordination session. Shape proxy, POST/PATCH/DELETE mutation routes, `useSharedFacts` hook.
- **Layer 2 — Yjs CRDT Scratchpad:** `yjs_document_patches` table for structured CLI agent edits (append_section, append_item, replace_section, set_key). Patches applied server-side to Yjs document state via `scratchpad-patch-applier.ts`. Browser agents use existing WebSocket collab; both converge on `yjs_documents`.
- **Layer 3 — Shared Memory + Reconciliation:** extended `agent_memories` with `scope` (private/shared/reconciled), `session_scope`, `source_facts`, `reconciled_at`. Heuristic + LLM-ready reconciliation service. `/api/sync/reconcile` endpoint deduplicates facts, marks superseded, creates canonical memories. `useSharedMemories` hook with `triggerReconciliation`.

3 migrations (0003–0005), 8 new API routes, 3 new hooks, reconciliation service, scratchpad patch applier. All typecheck clean across db, sync, ai, and admin.

## Test plan

- [ ] Run `pnpm typecheck:all` — all packages pass
- [ ] Run `pnpm test --filter @revealui/sync --filter @revealui/db` — unit tests
- [ ] Verify migrations apply cleanly: `pnpm db:migrate`
- [ ] Verify Electric health: `curl https://electric-production-99bd.up.railway.app/v1/health`
- [ ] Test shape proxy returns 401 without auth, 200 with auth
- [ ] Test POST `/api/sync/shared-facts` creates row, Electric fans out
- [ ] Test POST `/api/sync/reconcile` deduplicates and creates reconciled memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)