### PR TITLE
feat(scripts): add electric latency probe scaffold

### DIFF
--- a/scripts/electric-latency-probe/README.md
+++ b/scripts/electric-latency-probe/README.md
@@ -1,0 +1,160 @@
+# Electric Latency Probe
+
+Measures end-to-end propagation latency through the local admin app:
+write → DB → Electric → shape stream → subscriber callback.
+
+Produces a small notes file with a median + p95 number you can quote
+in a meeting, with a header that identifies which backend was measured.
+
+## Why local, not prod
+
+- Allevia's Forge deployment is local-box, not cloud. The honest
+  number is the local number; the cloud path adds Vercel→Railway
+  and Railway→Supabase hops that Allevia won't experience.
+- Avoids writing 50 POSTs into a prod shape other subscribers read.
+- Secrets posture: the script pulls from revvault rather than
+  env-vars you have to paste anywhere.
+
+## One-time setup (~10 min)
+
+### 1. Store the config values in revvault
+
+Revvault is the single source of truth for all secrets. See
+`~/.claude/rules/secrets.md` for the hard rule.
+
+```bash
+# Electric service URL — LOCAL running Electric (see step 2). Do NOT use prod.
+echo "http://localhost:5133" | revvault set revealui/dev/electric/service-url
+
+# Electric shared secret if your local Electric is configured with one
+# (ELECTRIC_SECRET env var on the Electric process). Skip this set if
+# running Electric with ELECTRIC_INSECURE=true for local dev.
+echo "<secret>" | revvault set revealui/dev/electric/secret
+
+# A valid signed-in session cookie for the local admin app.
+# Get this by signing into http://localhost:4000/admin in a browser,
+# opening devtools → Application → Cookies → copy the value of
+# `revealui-session`.
+echo "<cookie_value>" | revvault set revealui/dev/admin-session-cookie
+
+# The admin app base URL (usually localhost:4000 in dev)
+echo "http://localhost:4000" | revvault set revealui/dev/admin-base-url
+```
+
+### 2. Bring up the probe stack (postgres + electric)
+
+Isolated compose in this directory. Uses ports 5434 (postgres) and 5133
+(electric) — doesn't collide with any other compose.
+
+```bash
+cd /home/joshua-v-dev/suite/revealui
+docker compose -f scripts/electric-latency-probe/docker-compose.yml up -d
+docker compose -f scripts/electric-latency-probe/docker-compose.yml ps
+# Both services should report "healthy" within ~30s.
+```
+
+### 3. Apply the schema to the probe postgres
+
+Drizzle migrations create the tables the probe writes to (`shared_facts`,
+etc.). Run once after bringing up the stack:
+
+```bash
+cd /home/joshua-v-dev/suite/revealui
+DATABASE_URL='postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable' \
+  pnpm --filter @revealui/db db:migrate
+```
+
+### 4. Point admin at the probe DB for this session
+
+The admin app's `.env.local` usually points at cloud. For the probe run,
+swap `DATABASE_URL` to the probe DB. Back up first so the swap is reversible:
+
+```bash
+cd /home/joshua-v-dev/suite/revealui/apps/admin
+cp .env.local .env.local.backup
+
+# Replace the DATABASE_URL line:
+sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable|' .env.local
+
+# Add the probe Electric URL (or edit if present):
+grep -q '^ELECTRIC_SERVICE_URL=' .env.local \
+  && sed -i 's|^ELECTRIC_SERVICE_URL=.*|ELECTRIC_SERVICE_URL=http://localhost:5133|' .env.local \
+  || echo 'ELECTRIC_SERVICE_URL=http://localhost:5133' >> .env.local
+```
+
+Restore after the probe run: `cp .env.local.backup .env.local && rm .env.local.backup`.
+
+### 5. Start admin, sign in, store session cookie
+
+```bash
+cd /home/joshua-v-dev/suite/revealui
+pnpm dev:admin
+# admin now serving on http://localhost:4000
+```
+
+In a browser:
+
+1. Open `http://localhost:4000/admin`
+2. Create an account (fresh probe DB has no users)
+3. Devtools → Application → Cookies → `localhost:4000` → copy the value
+   of `revealui-session`
+4. Store it in revvault:
+
+```bash
+echo '<cookie_value>' | revvault set revealui/dev/admin-session-cookie
+```
+
+### 6. Run the probe
+
+```bash
+cd /home/joshua-v-dev/suite/revealui
+pnpm exec tsx scripts/electric-latency-probe/probe.ts
+
+# Output file:
+#   scripts/electric-latency-probe/latency-notes-<timestamp>.md
+```
+
+### 7. Teardown
+
+```bash
+# Restore admin env
+cd /home/joshua-v-dev/suite/revealui/apps/admin
+cp .env.local.backup .env.local && rm .env.local.backup
+
+# Bring down the probe stack (-v removes the postgres volume → fresh DB next time)
+cd /home/joshua-v-dev/suite/revealui
+docker compose -f scripts/electric-latency-probe/docker-compose.yml down -v
+```
+
+## Known gotchas — verify before first run
+
+- [ ] **AI feature gate.** The shared-facts mutation route may run through
+      `checkAIFeatureGate`. If it rejects without a license key, the first
+      write fails with 403 and the probe exits before warmup completes.
+      Resolve by issuing a dev license or bypassing the gate for
+      localhost in dev mode.
+- [ ] **session_id uniqueness.** Probe uses a UUID prefixed `probe-`,
+      visible in the notes file header. Low clash risk; flagged for
+      traceability only.
+
+## What it measures (two timings per write)
+
+- **mutation_accepted_to_subscriber_ms** — wall-clock from
+  `POST /api/sync/shared-facts` returning 201 (server has committed
+  the row) to the subscriber's callback firing with the new row.
+  **This is the number you quote in the room.**
+- **commit_confirmed_to_subscriber_ms** — wall-clock from the `fetch`
+  call starting to the subscriber's callback firing. Includes the
+  mutation route's own latency (auth, validation, DB insert, network).
+  **Diagnostic only.** Use to decompose if the room number regresses.
+
+Output has both, labeled unambiguously.
+
+## What it does NOT measure
+
+- Concurrent load. All writes are serial. Don't quote the measured
+  number as an upper bound on propagation under concurrent writes —
+  the real number at 50 concurrent agents is unknown and not addressed
+  by this script. If someone asks, say exactly that.
+- The Vercel → Railway → Supabase cloud path. Prod would have that
+  plus CDN caching behavior we don't simulate here.

--- a/scripts/electric-latency-probe/README.md
+++ b/scripts/electric-latency-probe/README.md
@@ -26,20 +26,16 @@ Revvault is the single source of truth for all secrets. See
 # Electric service URL — LOCAL running Electric (see step 2). Do NOT use prod.
 echo "http://localhost:5133" | revvault set revealui/dev/electric/service-url
 
-# Electric shared secret if your local Electric is configured with one
-# (ELECTRIC_SECRET env var on the Electric process). Skip this set if
-# running Electric with ELECTRIC_INSECURE=true for local dev.
-echo "<secret>" | revvault set revealui/dev/electric/secret
-
-# A valid signed-in session cookie for the local admin app.
-# Get this by signing into http://localhost:4000/admin in a browser,
-# opening devtools → Application → Cookies → copy the value of
-# `revealui-session`.
-echo "<cookie_value>" | revvault set revealui/dev/admin-session-cookie
-
-# The admin app base URL (usually localhost:4000 in dev)
+# The admin app base URL (usually localhost:4000 in dev).
 echo "http://localhost:4000" | revvault set revealui/dev/admin-base-url
+
+# Session cookie — deferred to step 5 (requires signed-in browser session).
 ```
+
+(Electric's shared secret, if any, is handled server-side by the admin
+proxy — the probe doesn't need its own copy in revvault.)
+
+All command blocks below assume your shell is at the repo root.
 
 ### 2. Bring up the probe stack (postgres + electric)
 
@@ -47,7 +43,6 @@ Isolated compose in this directory. Uses ports 5434 (postgres) and 5133
 (electric) — doesn't collide with any other compose.
 
 ```bash
-cd /home/joshua-v-dev/suite/revealui
 docker compose -f scripts/electric-latency-probe/docker-compose.yml up -d
 docker compose -f scripts/electric-latency-probe/docker-compose.yml ps
 # Both services should report "healthy" within ~30s.
@@ -59,7 +54,6 @@ Drizzle migrations create the tables the probe writes to (`shared_facts`,
 etc.). Run once after bringing up the stack:
 
 ```bash
-cd /home/joshua-v-dev/suite/revealui
 DATABASE_URL='postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable' \
   pnpm --filter @revealui/db db:migrate
 ```
@@ -70,24 +64,24 @@ The admin app's `.env.local` usually points at cloud. For the probe run,
 swap `DATABASE_URL` to the probe DB. Back up first so the swap is reversible:
 
 ```bash
-cd /home/joshua-v-dev/suite/revealui/apps/admin
-cp .env.local .env.local.backup
+cp apps/admin/.env.local apps/admin/.env.local.backup
 
 # Replace the DATABASE_URL line:
-sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable|' .env.local
+sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable|' \
+  apps/admin/.env.local
 
 # Add the probe Electric URL (or edit if present):
-grep -q '^ELECTRIC_SERVICE_URL=' .env.local \
-  && sed -i 's|^ELECTRIC_SERVICE_URL=.*|ELECTRIC_SERVICE_URL=http://localhost:5133|' .env.local \
-  || echo 'ELECTRIC_SERVICE_URL=http://localhost:5133' >> .env.local
+grep -q '^ELECTRIC_SERVICE_URL=' apps/admin/.env.local \
+  && sed -i 's|^ELECTRIC_SERVICE_URL=.*|ELECTRIC_SERVICE_URL=http://localhost:5133|' apps/admin/.env.local \
+  || echo 'ELECTRIC_SERVICE_URL=http://localhost:5133' >> apps/admin/.env.local
 ```
 
-Restore after the probe run: `cp .env.local.backup .env.local && rm .env.local.backup`.
+Restore after the probe run:
+`cp apps/admin/.env.local.backup apps/admin/.env.local && rm apps/admin/.env.local.backup`.
 
 ### 5. Start admin, sign in, store session cookie
 
 ```bash
-cd /home/joshua-v-dev/suite/revealui
 pnpm dev:admin
 # admin now serving on http://localhost:4000
 ```
@@ -107,7 +101,6 @@ echo '<cookie_value>' | revvault set revealui/dev/admin-session-cookie
 ### 6. Run the probe
 
 ```bash
-cd /home/joshua-v-dev/suite/revealui
 pnpm exec tsx scripts/electric-latency-probe/probe.ts
 
 # Output file:
@@ -118,11 +111,9 @@ pnpm exec tsx scripts/electric-latency-probe/probe.ts
 
 ```bash
 # Restore admin env
-cd /home/joshua-v-dev/suite/revealui/apps/admin
-cp .env.local.backup .env.local && rm .env.local.backup
+cp apps/admin/.env.local.backup apps/admin/.env.local && rm apps/admin/.env.local.backup
 
 # Bring down the probe stack (-v removes the postgres volume → fresh DB next time)
-cd /home/joshua-v-dev/suite/revealui
 docker compose -f scripts/electric-latency-probe/docker-compose.yml down -v
 ```
 

--- a/scripts/electric-latency-probe/docker-compose.yml
+++ b/scripts/electric-latency-probe/docker-compose.yml
@@ -1,0 +1,76 @@
+#
+# Electric Latency Probe — isolated local stack
+#
+# Brings up a postgres + electric pair on non-default ports so it doesn't
+# collide with packages/mcp/docker-compose.yml (5432) or any other running
+# compose. Admin runs locally (pnpm dev:admin) against these services.
+#
+# Bring up:
+#   docker compose -f scripts/electric-latency-probe/docker-compose.yml up -d
+#
+# Tear down (removes volume — fresh DB next time):
+#   docker compose -f scripts/electric-latency-probe/docker-compose.yml down -v
+#
+# Ports:
+#   postgres: 5434  (avoids 5432 used by other composes)
+#   electric: 5133
+#
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: revealui-probe-postgres
+    # Logical replication is required by Electric. This is durable config,
+    # not a runtime flag — it survives restarts.
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_wal_senders=10
+      - -c
+      - max_replication_slots=10
+    environment:
+      POSTGRES_USER: revealui
+      POSTGRES_PASSWORD: revealui
+      POSTGRES_DB: revealui_probe
+    ports:
+      - '5434:5432'
+    volumes:
+      - probe-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U revealui -d revealui_probe']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    labels:
+      - 'com.revealui.service=probe-postgres'
+      - 'com.revealui.environment=probe'
+
+  electric:
+    image: electricsql/electric:latest
+    container_name: revealui-probe-electric
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      # Electric connects to postgres via the service name on the compose network.
+      DATABASE_URL: postgres://revealui:revealui@postgres:5432/revealui_probe?sslmode=disable
+      # ELECTRIC_INSECURE=true disables the shared-secret check for local dev.
+      # Probe's revealui/dev/electric/secret should be unset when running this way.
+      ELECTRIC_INSECURE: 'true'
+      ELECTRIC_HTTP_PORT: '3000'
+    ports:
+      - '5133:3000'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/v1/health']
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    labels:
+      - 'com.revealui.service=probe-electric'
+      - 'com.revealui.environment=probe'
+
+volumes:
+  probe-pgdata:
+    name: revealui-probe-pgdata

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -56,11 +56,9 @@ See scripts/electric-latency-probe/README.md for the full path list.
 const ADMIN_BASE_URL = revvault('revealui/dev/admin-base-url');
 const ELECTRIC_SERVICE_URL = revvault('revealui/dev/electric/service-url');
 const SESSION_COOKIE = revvault('revealui/dev/admin-session-cookie');
-// Electric secret is optional — only set if local Electric is configured with one
-const ELECTRIC_SECRET = revvault('revealui/dev/electric/secret', { optional: true });
+// Electric's shared secret (if any) is handled server-side by the admin proxy;
+// the probe never calls Electric directly, so it doesn't need the secret here.
 
-// TODO: confirm the cookie name before running. Inspect devtools →
-// Application → Cookies on the admin origin after signing in.
 const SESSION_COOKIE_NAME = 'revealui-session';
 
 // ---------------------------------------------------------------------------
@@ -368,7 +366,6 @@ async function main(): Promise<void> {
   // ----- Format report -----
   samples.sort((a, b) => a.sampleIndex - b.sampleIndex);
   const measured = samples.filter((s) => !s.isWarmup);
-  const warmup = samples.filter((s) => s.isWarmup);
   const roomQuoteValues = measured.map((s) => s.mutationAcceptedToSubscriberMs);
   const diagnosticValues = measured.map((s) => s.commitConfirmedToSubscriberMs);
 

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -1,0 +1,436 @@
+/**
+ * Electric Latency Probe — Local End-to-End Measurement
+ *
+ * Scaffold per web Claude's spec. Measures propagation latency through
+ * your LOCAL admin app:
+ *     write → POST /api/sync/shared-facts → DB
+ *          → Electric shape stream → subscriber callback
+ *
+ * See README.md in this directory for setup + TODO list.
+ *
+ * Run:
+ *     pnpm exec tsx scripts/electric-latency-probe/probe.ts
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Config — revvault is the single source of truth. No env fallback.
+// See ~/.claude/rules/secrets.md for the hard rule.
+// ---------------------------------------------------------------------------
+
+const REVVAULT_BIN =
+  process.env.REVVAULT ?? '/home/joshua-v-dev/suite/revvault/target/release/revvault';
+
+interface SecretOptions {
+  optional?: boolean;
+}
+
+function revvault(path: string): string;
+function revvault(path: string, options: { optional: true }): string | null;
+function revvault(path: string, options: SecretOptions = {}): string | null {
+  const result = spawnSync(REVVAULT_BIN, ['get', '--full', path], { encoding: 'utf8' });
+  if (result.status === 0) {
+    const value = result.stdout.trimEnd();
+    if (value.length > 0) return value;
+  }
+
+  if (options.optional) return null;
+
+  console.error(`
+FAIL: revvault path not found or empty.
+  path:   '${path}'
+  binary: ${REVVAULT_BIN}
+
+Set it:
+  echo "<value>" | revvault set ${path}
+
+See scripts/electric-latency-probe/README.md for the full path list.
+`);
+  process.exit(1);
+}
+
+const ADMIN_BASE_URL = revvault('revealui/dev/admin-base-url');
+const ELECTRIC_SERVICE_URL = revvault('revealui/dev/electric/service-url');
+const SESSION_COOKIE = revvault('revealui/dev/admin-session-cookie');
+// Electric secret is optional — only set if local Electric is configured with one
+const ELECTRIC_SECRET = revvault('revealui/dev/electric/secret', { optional: true });
+
+// TODO: confirm the cookie name before running. Inspect devtools →
+// Application → Cookies on the admin origin after signing in.
+const SESSION_COOKIE_NAME = 'revealui-session';
+
+// ---------------------------------------------------------------------------
+// Probe parameters
+// ---------------------------------------------------------------------------
+
+const TOTAL_SAMPLES = 50;
+const WARMUP_SAMPLES = 5;
+const PROBE_SESSION_ID = `probe-${crypto.randomUUID()}`;
+const PROBE_AGENT_ID = 'latency-probe';
+// Must match one of the VALID_FACT_TYPES in the mutation route:
+//   discovery | bug | decision | warning | question | answer
+const FACT_TYPE = 'discovery';
+const SLEEP_BETWEEN_SAMPLES_MS = 250;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const NOTES_PATH = join(
+  __dirname,
+  `latency-notes-${new Date().toISOString().replace(/[:.]/g, '-')}.md`,
+);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Sample {
+  sampleIndex: number;
+  isWarmup: boolean;
+  factId: string;
+  mutationStartMs: number;
+  mutation201Ms: number;
+  subscriberFiredMs: number;
+  /** Write initiated → subscriber fires (diagnostic). */
+  commitConfirmedToSubscriberMs: number;
+  /** Mutation 201 → subscriber fires (room-quotable). */
+  mutationAcceptedToSubscriberMs: number;
+}
+
+interface HealthInfo {
+  electricReachable: boolean;
+  electricResponse: string;
+  adminReachable: boolean;
+  adminResponse: string;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shape stream subscription (long-poll against the admin proxy)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribes to the shared-facts shape for PROBE_SESSION_ID via the
+ * admin proxy (http://admin/api/shapes/shared-facts?session_id=...).
+ *
+ * Fires `onRow` with the current wall-clock and the fact_id whenever a
+ * new row arrives. Returns an abort handle.
+ */
+function subscribeToShape(onRow: (factId: string, ts: number) => void): () => void {
+  const controller = new AbortController();
+  let offset = '-1';
+  let shapeHandle: string | undefined;
+  let cancelled = false;
+  const seenIds = new Set<string>();
+
+  (async () => {
+    while (!cancelled) {
+      const url = new URL(`${ADMIN_BASE_URL}/api/shapes/shared-facts`);
+      url.searchParams.set('session_id', PROBE_SESSION_ID);
+      url.searchParams.set('offset', offset);
+      if (shapeHandle) url.searchParams.set('handle', shapeHandle);
+      url.searchParams.set('live', 'true');
+
+      try {
+        const res = await fetch(url.toString(), {
+          signal: controller.signal,
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}` },
+        });
+        if (!res.ok) {
+          if (res.status === 401) {
+            console.error('Shape subscribe unauthorized — session cookie invalid or expired.');
+            process.exit(2);
+          }
+          if (res.status === 409) {
+            // Handle shift — Electric says our handle/offset is stale.
+            shapeHandle = undefined;
+            offset = '-1';
+            continue;
+          }
+          console.error(`Shape subscribe HTTP ${res.status} — retrying.`);
+          await sleep(500);
+          continue;
+        }
+
+        const newHandle = res.headers.get('electric-handle');
+        const newOffset = res.headers.get('electric-offset');
+        if (newHandle) shapeHandle = newHandle;
+        if (newOffset) offset = newOffset;
+
+        const ts = performance.now();
+        const messages = (await res.json()) as Array<{
+          headers?: { operation?: string };
+          value?: { id?: string };
+        }>;
+
+        for (const msg of messages) {
+          if (msg.headers?.operation === 'insert' && msg.value?.id) {
+            const factId = msg.value.id;
+            if (!seenIds.has(factId)) {
+              seenIds.add(factId);
+              onRow(factId, ts);
+            }
+          }
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const name = (err as Error).name;
+        if (name === 'AbortError') return;
+        console.error('Shape subscribe error:', (err as Error).message, '— retrying.');
+        await sleep(500);
+      }
+    }
+  })();
+
+  return () => {
+    cancelled = true;
+    controller.abort();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Write a single fact, measure propagation
+// ---------------------------------------------------------------------------
+
+async function postOneFact(): Promise<{ factId: string; startMs: number; acceptedMs: number }> {
+  const content = `probe-${crypto.randomUUID().slice(0, 8)}`;
+  const startMs = performance.now();
+
+  const res = await fetch(`${ADMIN_BASE_URL}/api/sync/shared-facts`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}`,
+    },
+    body: JSON.stringify({
+      session_id: PROBE_SESSION_ID,
+      agent_id: PROBE_AGENT_ID,
+      content,
+      fact_type: FACT_TYPE,
+      confidence: 1.0,
+    }),
+  });
+
+  const acceptedMs = performance.now();
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`POST shared-facts HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const created = (await res.json()) as { id: string };
+  return { factId: created.id, startMs, acceptedMs };
+}
+
+// ---------------------------------------------------------------------------
+// Liveness check
+// ---------------------------------------------------------------------------
+
+async function checkHealth(): Promise<HealthInfo> {
+  const info: HealthInfo = {
+    electricReachable: false,
+    electricResponse: '',
+    adminReachable: false,
+    adminResponse: '',
+    timestamp: new Date().toISOString(),
+  };
+
+  // Electric direct
+  try {
+    const res = await fetch(`${ELECTRIC_SERVICE_URL}/v1/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    info.electricReachable = res.ok;
+    info.electricResponse = `HTTP ${res.status} ${res.statusText}`;
+  } catch (err) {
+    info.electricResponse = `unreachable: ${(err as Error).message}`;
+  }
+
+  // Admin proxy (via a shape request with auth — lighter-weight than signing in)
+  try {
+    const url = new URL(`${ADMIN_BASE_URL}/api/shapes/shared-facts`);
+    url.searchParams.set('session_id', 'liveness-check');
+    url.searchParams.set('offset', '-1');
+    const res = await fetch(url.toString(), {
+      signal: AbortSignal.timeout(3000),
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}` },
+    });
+    info.adminReachable = res.ok || res.status === 404; // 404 means route works but no shape yet
+    info.adminResponse = `HTTP ${res.status} ${res.statusText}`;
+  } catch (err) {
+    info.adminResponse = `unreachable: ${(err as Error).message}`;
+  }
+
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2
+    : (sorted[mid] ?? 0);
+}
+
+function p95(values: number[]): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.floor(sorted.length * 0.95);
+  return sorted[Math.min(idx, sorted.length - 1)] ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log(`
+================================================================
+  Electric Latency Probe
+================================================================
+  session_id:  ${PROBE_SESSION_ID}
+  admin:       ${ADMIN_BASE_URL}
+  electric:    ${ELECTRIC_SERVICE_URL}
+  samples:     ${TOTAL_SAMPLES} (${WARMUP_SAMPLES} warmup, ${TOTAL_SAMPLES - WARMUP_SAMPLES} measured)
+  notes file:  ${NOTES_PATH}
+`);
+
+  console.log('Liveness check...');
+  const health = await checkHealth();
+  console.log(`  electric: ${health.electricResponse}`);
+  console.log(`  admin:    ${health.adminResponse}`);
+  if (!health.adminReachable) {
+    console.error('\nAdmin app not reachable. Is `pnpm dev:admin` running on the URL in revvault?');
+    process.exit(3);
+  }
+
+  console.log('\nOpening shape subscription...');
+  const samples: Sample[] = [];
+  const pending = new Map<string, { sampleIndex: number; startMs: number; acceptedMs: number }>();
+
+  const stopSubscribe = subscribeToShape((factId, subscriberFiredMs) => {
+    const entry = pending.get(factId);
+    if (!entry) return; // not from this probe run
+    pending.delete(factId);
+
+    samples.push({
+      sampleIndex: entry.sampleIndex,
+      isWarmup: entry.sampleIndex < WARMUP_SAMPLES,
+      factId,
+      mutationStartMs: entry.startMs,
+      mutation201Ms: entry.acceptedMs,
+      subscriberFiredMs,
+      commitConfirmedToSubscriberMs: subscriberFiredMs - entry.startMs,
+      mutationAcceptedToSubscriberMs: subscriberFiredMs - entry.acceptedMs,
+    });
+  });
+
+  // Give the subscription a moment to establish before the first write.
+  await sleep(1000);
+
+  console.log(`\nRunning ${TOTAL_SAMPLES} samples (first ${WARMUP_SAMPLES} are warmup)...\n`);
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    try {
+      const { factId, startMs, acceptedMs } = await postOneFact();
+      pending.set(factId, { sampleIndex: i, startMs, acceptedMs });
+    } catch (err) {
+      console.error(`  sample ${i}: write failed — ${(err as Error).message}`);
+      if (i === 0) {
+        console.error('\nFirst sample failed. Stopping — check the AI feature gate + auth.');
+        stopSubscribe();
+        process.exit(4);
+      }
+    }
+    if (i < TOTAL_SAMPLES - 1) await sleep(SLEEP_BETWEEN_SAMPLES_MS);
+  }
+
+  // Give the tail writes time to propagate
+  console.log('\nWaiting 5s for any in-flight propagation...');
+  await sleep(5000);
+  stopSubscribe();
+
+  if (pending.size > 0) {
+    console.warn(`\nWARN: ${pending.size} writes did not receive a subscriber callback.`);
+  }
+
+  // ----- Format report -----
+  samples.sort((a, b) => a.sampleIndex - b.sampleIndex);
+  const measured = samples.filter((s) => !s.isWarmup);
+  const warmup = samples.filter((s) => s.isWarmup);
+  const roomQuoteValues = measured.map((s) => s.mutationAcceptedToSubscriberMs);
+  const diagnosticValues = measured.map((s) => s.commitConfirmedToSubscriberMs);
+
+  const report = `# Electric Latency Probe — ${new Date().toISOString()}
+
+**Measured against:** local admin (\`${ADMIN_BASE_URL}\`) → local Electric (\`${ELECTRIC_SERVICE_URL}\`)
+**Backend identification:**
+- Electric: ${health.electricResponse}
+- Admin:    ${health.adminResponse}
+
+**Measured in dev mode; prod middleware posture may differ.**
+
+---
+
+## Summary (room-quotable number)
+
+**mutation_accepted_to_subscriber_ms** — wall-clock from the server
+committing the write (HTTP 201 returned) to the Electric shape subscriber
+receiving the row.
+
+- **median: ${median(roomQuoteValues).toFixed(0)} ms**
+- p95:    ${p95(roomQuoteValues).toFixed(0)} ms
+- samples: ${measured.length} of ${TOTAL_SAMPLES} (first ${WARMUP_SAMPLES} excluded as warmup)
+
+## Diagnostic (decomposition only)
+
+**commit_confirmed_to_subscriber_ms** — includes the mutation route's
+own latency (auth, validation, DB insert, network back to client).
+
+- median: ${median(diagnosticValues).toFixed(0)} ms
+- p95:    ${p95(diagnosticValues).toFixed(0)} ms
+
+## Raw samples (warmup excluded from summary)
+
+| # | warmup | mut 201→sub (ms) | commit start→sub (ms) | fact_id |
+|---|--------|-----------------:|---------------------:|---------|
+${samples
+  .map(
+    (s) =>
+      `| ${s.sampleIndex} | ${s.isWarmup ? '[warmup, excluded]' : ''} | ${s.mutationAcceptedToSubscriberMs.toFixed(0)} | ${s.commitConfirmedToSubscriberMs.toFixed(0)} | ${s.factId.slice(0, 8)}… |`,
+  )
+  .join('\n')}
+
+## Not measured
+
+- Concurrent-write load. This is an unloaded serial measurement.
+  Propagation under 50 concurrent agents is unknown.
+- The Vercel→Railway→Supabase cloud path. Allevia's Forge deployment
+  is local-box; cloud measurement would add hops that won't exist on
+  the customer's box.
+`;
+
+  mkdirSync(dirname(NOTES_PATH), { recursive: true });
+  writeFileSync(NOTES_PATH, report);
+  console.log(`\n================================================================`);
+  console.log(`Written to: ${NOTES_PATH}`);
+  console.log(`\nmedian (room-quotable): ${median(roomQuoteValues).toFixed(0)} ms`);
+  console.log(`p95:                     ${p95(roomQuoteValues).toFixed(0)} ms`);
+  console.log(`samples:                 ${measured.length}/${TOTAL_SAMPLES}`);
+}
+
+main().catch((err) => {
+  console.error('Probe failed:', err);
+  process.exit(1);
+});

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 // ---------------------------------------------------------------------------
 
 const REVVAULT_BIN =
-  process.env.REVVAULT ?? '/home/joshua-v-dev/suite/revvault/target/release/revvault';
+  process.env.REVVAULT ?? `${process.env.HOME}/suite/revvault/target/release/revvault`;
 
 interface SecretOptions {
   optional?: boolean;


### PR DESCRIPTION
See commits for details. Adds isolated docker-compose + probe.ts + README. Gate passes. Never run end-to-end — see HANDOFF-2026-04-18-v2.md §4 for the remaining core read-after-write blocker.