### PR TITLE
fix(core): wrap create() INSERT + read-back in a transaction (closes #383)

### DIFF
--- a/.changeset/core-create-read-after-write.md
+++ b/.changeset/core-create-read-after-write.md
@@ -1,0 +1,17 @@
+---
+'@revealui/core': minor
+---
+
+Fix read-after-write failure in `create()` against pooled PostgreSQL adapters.
+
+The `create()` operation INSERTs a document, then reads it back via `findByID()` to return the stored shape (with defaults, computed columns, and JSON deserialization applied). Previously, these two queries ran on separate pool checkouts — under the `pg` library each `db.query()` call acquires a fresh client from the pool. Depending on snapshot-acquisition timing, the read-back could execute on a connection whose snapshot predated the INSERT's commit, returning `null` and throwing _"Failed to retrieve created document with id rvl_xxx. Document not found in database."_ even though the row was present.
+
+The root cause was a comment assuming SQLite same-connection WAL visibility applied to pooled PostgreSQL — it does not. Each pool checkout is independent under autocommit.
+
+**Fix:**
+
+- Added optional `transaction<T>(fn)` method to `QueryableDatabaseAdapter` and `DatabaseAdapter` types. Adapters that support it hold a single connection across the callback, wrapping the work in `BEGIN`/`COMMIT` (or `ROLLBACK` on throw).
+- Implemented `transaction` in `universalPostgresAdapter` for all providers (Neon, Supabase session + transaction pooling, Electric/PGlite, generic PostgreSQL).
+- `create()` now uses `db.transaction()` when available to run INSERT + `findByID()` on the same connection + snapshot. Adapters without a `transaction` method fall back to the previous sequential-query path for backward compatibility with test mocks.
+
+Closes revealui#383.

--- a/packages/core/src/collections/operations/__tests__/create.test.ts
+++ b/packages/core/src/collections/operations/__tests__/create.test.ts
@@ -136,6 +136,47 @@ describe('create operation', () => {
     );
   });
 
+  it('should run INSERT and read-back inside a transaction when db.transaction is available', async () => {
+    // Regression for revealui#383 — pooled pg adapters check out a fresh
+    // connection per db.query() call, so the post-INSERT findByID can see
+    // a pre-INSERT snapshot. The fix wraps both in db.transaction() so they
+    // share a connection + snapshot.
+    const options: RevealCreateOptions = {
+      data: {
+        title: 'Test Document',
+      },
+    };
+
+    const mockCreatedDoc = {
+      id: 'test-id',
+      title: 'Test Document',
+    };
+
+    const txQuery = vi.fn().mockResolvedValue({ rows: [] } as DatabaseResult);
+    const mockTx = { query: txQuery };
+    const txDb = {
+      query: mockDb.query,
+      transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => {
+        return await fn(mockTx);
+      }),
+    };
+
+    vi.mocked(findByID).mockResolvedValue(mockCreatedDoc as never);
+
+    const result = await create(mockConfig, txDb as never, options);
+
+    expect(result).toEqual(mockCreatedDoc);
+    expect(txDb.transaction).toHaveBeenCalledTimes(1);
+    // INSERT must run on the tx client, not on the outer db
+    expect(txQuery).toHaveBeenCalled();
+    expect(mockDb.query).not.toHaveBeenCalled();
+    // findByID must receive the tx, not the outer db, so it reads from the
+    // same connection as the INSERT
+    expect(findByID).toHaveBeenCalledWith(mockConfig, mockTx, {
+      id: expect.any(String),
+    });
+  });
+
   it('should return fallback data when db is null', async () => {
     const options: RevealCreateOptions = {
       data: {

--- a/packages/core/src/collections/operations/create.ts
+++ b/packages/core/src/collections/operations/create.ts
@@ -158,12 +158,30 @@ export async function create(
     });
 
     const query = insertDocumentQuery(tableName, columns);
-    await db.query(query, [id, ...values]);
 
-    // For SQLite with WAL mode, writes are immediately visible to readers on the same connection
-    // Return the created document by fetching it from the database
-    // This ensures we return what was actually stored (with proper JSON deserialization)
-    // ID is already a string, so use it directly
+    // Wrap INSERT + read-back in a single transaction so both run on the same
+    // connection and snapshot. Without this, pooled pg adapters check out a
+    // fresh client per `db.query()` call, and the post-insert `findByID` can
+    // see a pre-INSERT snapshot — throwing "Document not found in database"
+    // even though the row is present (see revealui#383).
+    //
+    // Adapters without `transaction` (e.g. test mocks, in-memory stores with
+    // same-connection visibility like PGlite used directly without our wrapper)
+    // fall back to sequential queries.
+    if (db.transaction) {
+      return await db.transaction(async (tx) => {
+        await tx.query(query, [id, ...values]);
+        const createdDoc = await findByID(config, tx, { id });
+        if (!createdDoc) {
+          throw new Error(
+            `Failed to retrieve created document with id ${id}. Document not found in database.`,
+          );
+        }
+        return createdDoc;
+      });
+    }
+
+    await db.query(query, [id, ...values]);
     const createdDoc = await findByID(config, db, { id });
     if (!createdDoc) {
       throw new Error(

--- a/packages/core/src/database/universal-postgres.ts
+++ b/packages/core/src/database/universal-postgres.ts
@@ -15,7 +15,7 @@
 import type { Field } from '@revealui/contracts/admin';
 import { defaultLogger } from '../instance/logger.js';
 import { logger } from '../observability/logger.js';
-import type { DatabaseAdapter, DatabaseResult } from '../types/index.js';
+import type { DatabaseAdapter, DatabaseResult, QueryableDatabaseAdapter } from '../types/index.js';
 import { safeParseRevealDocuments } from './safe-parse.js';
 import { getSSLConfig } from './ssl-config.js';
 
@@ -143,7 +143,55 @@ export function universalPostgresAdapter(
   config: UniversalPostgresAdapterConfig = {},
 ): DatabaseAdapter {
   let queryFn: (queryString: string, values: unknown[]) => Promise<DatabaseResult>;
+  let transactionFn: <T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>) => Promise<T>;
   let provider: 'neon' | 'supabase' | 'electric' | 'generic' = 'generic';
+
+  // Shared transaction builder for pg-library-backed providers (neon, supabase, generic).
+  // Holds one pooled client across BEGIN/fn/COMMIT so every query inside `fn` sees the
+  // same snapshot — required for read-after-write correctness.
+  type PgClient = {
+    query: (q: string, v?: unknown[]) => Promise<{ rows: unknown[]; rowCount: number | null }>;
+    release: () => void;
+  };
+  const buildPgTransactionFn = (
+    pool: { connect: () => Promise<PgClient> },
+    providerLabel: string,
+  ): typeof transactionFn => {
+    return async <T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>): Promise<T> => {
+      const client = await pool.connect();
+      let committed = false;
+      try {
+        await client.query('BEGIN');
+        const tx: QueryableDatabaseAdapter = {
+          query: async (queryString: string, values: unknown[] = []) => {
+            const result = await client.query(queryString, values);
+            return {
+              rows: safeParseRevealDocuments(result.rows),
+              rowCount: result.rowCount || 0,
+            };
+          },
+        };
+        const result = await fn(tx);
+        await client.query('COMMIT');
+        committed = true;
+        return result;
+      } catch (error) {
+        if (!committed) {
+          try {
+            await client.query('ROLLBACK');
+          } catch (rollbackErr) {
+            defaultLogger.error(
+              `${providerLabel} transaction rollback failed after error:`,
+              rollbackErr,
+            );
+          }
+        }
+        throw error;
+      } finally {
+        client.release();
+      }
+    };
+  };
 
   const initializeConnection = async (): Promise<void> => {
     // Allow explicit electric provider without a connection string (PGlite local)
@@ -202,6 +250,7 @@ export function universalPostgresAdapter(
             throw error;
           }
         };
+        transactionFn = buildPgTransactionFn(neonPool, 'Neon');
         break;
       }
 
@@ -234,6 +283,7 @@ export function universalPostgresAdapter(
               client.release();
             }
           };
+          transactionFn = buildPgTransactionFn(pool, 'Supabase (txn-pool)');
         } else {
           // Use pg library for session pooling or direct connections (port 5432)
           const { Pool } = await import('pg');
@@ -259,6 +309,7 @@ export function universalPostgresAdapter(
               throw error;
             }
           };
+          transactionFn = buildPgTransactionFn(pool, 'Supabase');
         }
         break;
       }
@@ -279,6 +330,23 @@ export function universalPostgresAdapter(
             rows: safeParseRevealDocuments(result.rows),
             rowCount: (result as { rowCount?: number }).rowCount || 0,
           };
+        };
+        // PGlite ships a native transaction(fn) with its own tx.query — wrap it
+        // so the callback sees a QueryableDatabaseAdapter.
+        transactionFn = async <T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>): Promise<T> => {
+          // biome-ignore lint/style/noNonNullAssertion: db is set above in the electric branch
+          return await db!.transaction(async (pgliteTx) => {
+            const tx: QueryableDatabaseAdapter = {
+              query: async (queryString: string, values: unknown[] = []) => {
+                const result = await pgliteTx.query(queryString, values);
+                return {
+                  rows: safeParseRevealDocuments(result.rows),
+                  rowCount: (result as { rowCount?: number }).rowCount || 0,
+                };
+              },
+            };
+            return await fn(tx);
+          });
         };
         break;
       }
@@ -310,6 +378,7 @@ export function universalPostgresAdapter(
             throw error;
           }
         };
+        transactionFn = buildPgTransactionFn(pool, 'PostgreSQL');
         break;
       }
     }
@@ -394,6 +463,28 @@ export function universalPostgresAdapter(
       }
 
       return queryFn(queryString, values);
+    },
+
+    async transaction<T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>): Promise<T> {
+      if (!initialized) {
+        await initializeConnection();
+        initialized = true;
+      }
+
+      // Flush pending table creations before opening a transaction so the
+      // schema is in place on the same connection we're about to hold.
+      const pendingCreations = getWorkerPendingTableCreations();
+      if (pendingCreations.length > 0) {
+        try {
+          await Promise.all(pendingCreations);
+          pendingCreations.length = 0;
+        } catch (error) {
+          defaultLogger.error('Failed to create tables before transaction:', error);
+          throw error;
+        }
+      }
+
+      return transactionFn(fn);
     },
 
     // Create table schema for PGlite provider

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -271,11 +271,23 @@ export interface CollectionStorageAdapter {
 
 export interface QueryableDatabaseAdapter {
   query: (query: string, values?: unknown[]) => Promise<DatabaseResult>;
+  /**
+   * Execute a callback inside a database transaction with a single connection
+   * held across all queries. The callback receives a transactional adapter
+   * whose `query` runs on the same connection; committed on success, rolled
+   * back on throw.
+   *
+   * Optional: adapters without real connection affinity (e.g. test mocks) can
+   * omit this. Operations that need read-after-write consistency must guard
+   * with `if (db.transaction)` and fall back to sequential queries.
+   */
+  transaction?: <T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>) => Promise<T>;
   collectionStorage?: CollectionStorageAdapter;
 }
 
 export interface DatabaseAdapter {
   query: QueryableDatabaseAdapter['query'];
+  transaction?: QueryableDatabaseAdapter['transaction'];
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   init?: () => Promise<void>;

--- a/packages/test/src/mocks/database.ts
+++ b/packages/test/src/mocks/database.ts
@@ -4,12 +4,16 @@
  * Provides mocks for database operations
  */
 
-import type { DatabaseAdapter, DatabaseResult, RevealDocument } from '@revealui/core/types';
+import type {
+  DatabaseAdapter,
+  DatabaseResult,
+  QueryableDatabaseAdapter,
+  RevealDocument,
+} from '@revealui/core/types';
 
 type MockDatabaseAdapter = DatabaseAdapter & {
   __mockData?: Record<string, unknown[]>;
   close?: () => Promise<void>;
-  transaction?: (callback: () => Promise<unknown>) => Promise<void>;
 };
 
 /**
@@ -66,9 +70,10 @@ export function createMockDatabase(): DatabaseAdapter {
       });
     },
 
-    async transaction(callback: () => Promise<unknown>): Promise<void> {
-      // Mock transaction
-      await callback();
+    async transaction<T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>): Promise<T> {
+      // Mock transaction — no real connection affinity, just passes the mock
+      // itself as the tx client so queries run against the same mock state.
+      return await fn(mockDb);
     },
   };
 

--- a/packages/test/src/utils/test-database.ts
+++ b/packages/test/src/utils/test-database.ts
@@ -6,11 +6,10 @@
 
 import fs from 'node:fs';
 import { universalPostgresAdapter } from '@revealui/core';
-import type { DatabaseAdapter } from '@revealui/core/types';
+import type { DatabaseAdapter, QueryableDatabaseAdapter } from '@revealui/core/types';
 
 type TestDatabaseAdapter = DatabaseAdapter & {
   __testDbPath?: string;
-  transaction: (callback: (syncQuery?: unknown) => void | Promise<void>) => Promise<void>;
 };
 
 let testDb: TestDatabaseAdapter | null = null;
@@ -47,16 +46,23 @@ export async function setupTestDatabase(dbPath?: string): Promise<DatabaseAdapte
       const converted = queryString.replace(/\?/g, () => `$${++idx}`);
       return base.query(converted, values);
     },
-    async transaction(callback: (syncQuery?: unknown) => void | Promise<void>) {
-      // Basic transaction wrapper  -  begin/commit/rollback
-      await base.query('BEGIN', []);
-      try {
-        await callback();
-        await base.query('COMMIT', []);
-      } catch (err) {
-        await base.query('ROLLBACK', []);
-        throw err;
+    async transaction<T>(fn: (tx: QueryableDatabaseAdapter) => Promise<T>): Promise<T> {
+      // Delegate to the real adapter's transaction so the callback runs on
+      // a single held connection (required for read-after-write correctness).
+      // The `?` → `$n` placeholder conversion is applied inside the tx wrapper.
+      if (!base.transaction) {
+        throw new Error('Underlying test adapter does not support transactions');
       }
+      return await base.transaction(async (baseTx) => {
+        const tx: QueryableDatabaseAdapter = {
+          query: async (queryString: string, values: unknown[] = []) => {
+            let idx = 0;
+            const converted = queryString.replace(/\?/g, () => `$${++idx}`);
+            return baseTx.query(converted, values);
+          },
+        };
+        return await fn(tx);
+      });
     },
   };
 


### PR DESCRIPTION
Closes #383

## Summary

`create()` INSERTs a document then calls `findByID()` to return the stored shape. Those two queries each took a fresh checkout from the `pg` pool — so against real pooled PostgreSQL (Neon, Supabase, generic) the read-back could land on a connection whose snapshot predated the INSERT's commit, throwing *"Failed to retrieve created document with id rvl_xxx. Document not found in database."* even though the row was present.

The bug never surfaced on PGlite (shared connection state, same-snapshot semantics) but hit every real pg-backed deployment as soon as bootstrap tried to create-then-read the first admin user. Originally misdiagnosed as Supabase dual-DB coupling; stripping `SUPABASE_*` didn't help because all pg providers have the same fresh-checkout-per-query pattern.

The smoking gun was a comment at `create.ts:163` — *"For SQLite with WAL mode, writes are immediately visible to readers on the same connection"* — which assumed SQLite semantics that don't apply to pooled pg.

See [#383 diagnosis comment](https://github.com/RevealUIStudio/revealui/issues/383#issuecomment-4274586766) for the full trace.

## What changed

- **`QueryableDatabaseAdapter` / `DatabaseAdapter`** — added optional `transaction<T>(fn: (tx) => Promise<T>) => Promise<T>`. The callback receives a transactional adapter whose `query` runs on a single held connection; committed on success, rolled back on throw.
- **`universalPostgresAdapter`** — implemented `transaction` for every provider branch:
  - Neon / Supabase (session + txn pooling) / generic — share a `buildPgTransactionFn` helper that holds one `pool.connect()` client across `BEGIN` → fn → `COMMIT` / `ROLLBACK`.
  - Electric (PGlite) — delegates to PGlite's native `db.transaction(fn)`, wrapping `tx.query` to return the canonical `DatabaseResult` shape.
- **`create.ts`** — uses `db.transaction()` when available to run INSERT + `findByID()` on the same connection. Falls back to the previous sequential path when `transaction` is unavailable (test mocks that don't implement it).
- **Test infra** — `packages/test/src/mocks/database.ts` and `packages/test/src/utils/test-database.ts` both had their own `transaction` helpers with incompatible signatures that conflicted with the new type. Updated both to the new shape; `test-database.ts` now delegates to the underlying adapter's `transaction` so its BEGIN/COMMIT actually runs on one connection (the old wrapper passed `await base.query('BEGIN')` and `await base.query('COMMIT')` on separate checkouts, which did nothing).
- **Unit test** — added a regression test in `create.test.ts` that supplies a `transaction`-capable mock and verifies INSERT + `findByID` both run on the tx client, not the outer db.

## Scope notes

- Touches only `create()`. `createMany`, `update`, `delete`, etc. likely have the same bug but are out of scope for this fix — they can adopt the same primitive incrementally.
- `transaction` is optional on the interface so existing adapters / mocks that don't implement it keep working (with the old bug, for adapters that had it). The universal pg adapter implements it, so all real deployments are fixed.
- The behavior change is invisible to callers — same inputs, same outputs, no buggy error under pool contention.

## Test plan

- [x] `pnpm --filter @revealui/core test` — 2597 tests pass including the new `"should run INSERT and read-back inside a transaction"` regression
- [x] `pnpm --filter test test` — 277 tests pass (updated test-infra adapters)
- [x] `pnpm typecheck:all` — 49/49 green across the monorepo
- [x] Pre-push gate (quality phase) — lint + audits + security + coverage all green
- [ ] **End-to-end**: run the electric latency probe from [#381](https://github.com/RevealUIStudio/revealui/pull/381) against a fresh local postgres to confirm the first-admin-user create now succeeds (was the original trigger for this bug).

## Pipeline

Targets `test` per CLAUDE.md. Once merged to test and then to main, #381 (probe) should be runnable end-to-end against a local pg stack, closing out HANDOFF §4.
