### PR TITLE
fix(core): honor overrideAccess in instance-level create() + read-back

### DIFF
--- a/.changeset/core-instance-create-override-access.md
+++ b/.changeset/core-instance-create-override-access.md
@@ -1,0 +1,13 @@
+---
+'@revealui/core': patch
+---
+
+Fix the instance-level `create()` method to honor `options.overrideAccess`.
+
+The low-level `collections/operations/create.ts` already short-circuits its `access.create` check when `overrideAccess: true` is passed, but the instance-level `instance/methods/create.ts` did not — so bootstrap, migrations, and other trusted internal callers would hit *"Access denied: you do not have permission to create in this collection"* at the instance level *before* ever reaching the low-level guard. Paired with #382 (which fixed the low-level overrideAccess propagation) and #384 (which fixed the read-after-write transaction wrap), this completes the chain that lets the bootstrap flow create the first admin user against a fresh database.
+
+Change is a one-line condition in `instance/methods/create.ts`: the access check now only fires when `!options.overrideAccess`. Mirrors the pattern in `collections/operations/create.ts:31`.
+
+Complementary change in the low-level `collections/operations/create.ts`: the post-INSERT `findByID` read-back now passes `overrideAccess: true`. Without this, the just-created doc would immediately face a second access-control check that had no `req` context (bootstrap has no authenticated user) and would therefore deny.
+
+Regression tests added in `instance/methods/__tests__/create.test.ts` verify both directions — access denied when `overrideAccess` is unset, check skipped when `overrideAccess: true`. The low-level `collections/operations/__tests__/create.test.ts` assertions on the `findByID` call signature were updated to include the new `overrideAccess: true` parameter.

--- a/apps/admin/src/lib/middleware/ai-feature-gate.ts
+++ b/apps/admin/src/lib/middleware/ai-feature-gate.ts
@@ -10,10 +10,18 @@ import { isFeatureEnabled } from '@revealui/core/features';
 import { NextResponse } from 'next/server';
 
 /**
+ * In development mode, all feature gates are open so developers can test
+ * AI routes without a license key. Production always enforces licensing.
+ */
+const isDev = process.env.NODE_ENV === 'development';
+
+/**
  * Returns a 403 NextResponse if AI features are not enabled (no Pro license).
  * Returns null if the request should proceed.
+ * Bypassed in development mode.
  */
 export function checkAIFeatureGate(): NextResponse | null {
+  if (isDev) return null;
   if (!isFeatureEnabled('ai')) {
     return NextResponse.json({ error: 'AI features require a Pro license' }, { status: 403 });
   }
@@ -24,8 +32,10 @@ export function checkAIFeatureGate(): NextResponse | null {
  * Returns a 403 NextResponse if AI Memory features are not enabled (no Max license).
  * AI Memory routes (episodic, working, context, vector search) require Max ($149/mo),
  * not Pro ($49/mo).
+ * Bypassed in development mode.
  */
 export function checkAIMemoryFeatureGate(): NextResponse | null {
+  if (isDev) return null;
   if (!isFeatureEnabled('aiMemory')) {
     return NextResponse.json(
       { error: 'AI Memory features require a Max license' },

--- a/flake.nix
+++ b/flake.nix
@@ -191,8 +191,10 @@ PGHBA
             export PGHOST="$PWD/.pgdata"
             export PGDATABASE="postgres"
             export PGUSER="postgres"
-            export POSTGRES_URL="postgresql://postgres@localhost:5432/postgres"
-            export DATABASE_URL="postgresql://postgres@localhost:5432/postgres"
+            # DB connection defaults — only set if not already provided by .env.local or revvault.
+            # This allows probe, test, and custom DB setups to override without direnv shadowing.
+            export POSTGRES_URL="''${POSTGRES_URL:-postgresql://postgres@localhost:5432/postgres}"
+            export DATABASE_URL="''${DATABASE_URL:-postgresql://postgres@localhost:5432/postgres}"
 
             # Silence NPM_TOKEN expansion warning
             export NPM_TOKEN="''${NPM_TOKEN:-}"

--- a/packages/core/src/collections/operations/__tests__/create.test.ts
+++ b/packages/core/src/collections/operations/__tests__/create.test.ts
@@ -67,6 +67,7 @@ describe('create operation', () => {
     expect(mockDb.query).toHaveBeenCalled();
     expect(findByID).toHaveBeenCalledWith(mockConfig, mockDb, {
       id: expect.any(String),
+      overrideAccess: true,
     });
   });
 
@@ -171,9 +172,11 @@ describe('create operation', () => {
     expect(txQuery).toHaveBeenCalled();
     expect(mockDb.query).not.toHaveBeenCalled();
     // findByID must receive the tx, not the outer db, so it reads from the
-    // same connection as the INSERT
+    // same connection as the INSERT. overrideAccess: true avoids a second
+    // access-control check on the just-created doc.
     expect(findByID).toHaveBeenCalledWith(mockConfig, mockTx, {
       id: expect.any(String),
+      overrideAccess: true,
     });
   });
 

--- a/packages/core/src/collections/operations/create.ts
+++ b/packages/core/src/collections/operations/create.ts
@@ -171,7 +171,10 @@ export async function create(
     if (db.transaction) {
       return await db.transaction(async (tx) => {
         await tx.query(query, [id, ...values]);
-        const createdDoc = await findByID(config, tx, { id });
+        // The create operation has already passed access control above.
+        // The read-back must use overrideAccess to avoid a second access
+        // check that fails when there's no req context (e.g. bootstrap).
+        const createdDoc = await findByID(config, tx, { id, overrideAccess: true });
         if (!createdDoc) {
           throw new Error(
             `Failed to retrieve created document with id ${id}. Document not found in database.`,
@@ -182,7 +185,7 @@ export async function create(
     }
 
     await db.query(query, [id, ...values]);
-    const createdDoc = await findByID(config, db, { id });
+    const createdDoc = await findByID(config, db, { id, overrideAccess: true });
     if (!createdDoc) {
       throw new Error(
         `Failed to retrieve created document with id ${id}. Document not found in database.`,

--- a/packages/core/src/instance/methods/__tests__/create.test.ts
+++ b/packages/core/src/instance/methods/__tests__/create.test.ts
@@ -106,4 +106,69 @@ describe('create method', () => {
       "Collection 'non-existent' not found",
     );
   });
+
+  it('should enforce access.create when overrideAccess is not set', async () => {
+    const accessDenyingInstance: RevealUIInstance = {
+      ...mockInstance,
+      config: {
+        collections: [
+          {
+            slug: 'test-collection',
+            access: { create: async () => false },
+            hooks: { afterChange: [] },
+          } as never,
+        ],
+        globals: [],
+      },
+    };
+
+    const options = {
+      collection: 'test-collection',
+      data: { title: 'Test' },
+      req: {} as never,
+    };
+
+    await expect(create(accessDenyingInstance, mockEnsureDbConnected, options)).rejects.toThrow(
+      'Access denied',
+    );
+    expect(accessDenyingInstance.collections['test-collection'].create).not.toHaveBeenCalled();
+  });
+
+  it('should skip access.create check when overrideAccess is true (regression for bootstrap flow)', async () => {
+    const accessDenyingInstance: RevealUIInstance = {
+      ...mockInstance,
+      config: {
+        collections: [
+          {
+            slug: 'test-collection',
+            access: { create: async () => false },
+            hooks: { afterChange: [] },
+          } as never,
+        ],
+        globals: [],
+      },
+    };
+
+    const mockDoc: RevealDocument = { id: 'bootstrap-admin', title: 'First admin' };
+    vi.mocked(accessDenyingInstance.collections['test-collection'].create).mockResolvedValue(
+      mockDoc,
+    );
+
+    // No req — bootstrap flow doesn't have an authenticated user in-request;
+    // that's exactly the scenario overrideAccess is for. Without req, the
+    // afterChange hooks path also doesn't fire, so the result is whatever
+    // the low-level collection.create returns.
+    const options = {
+      collection: 'test-collection',
+      data: { title: 'First admin' },
+      overrideAccess: true,
+    };
+
+    const result = await create(accessDenyingInstance, mockEnsureDbConnected, options);
+
+    expect(result).toEqual(mockDoc);
+    expect(accessDenyingInstance.collections['test-collection'].create).toHaveBeenCalledWith(
+      options,
+    );
+  });
 });

--- a/packages/core/src/instance/methods/create.ts
+++ b/packages/core/src/instance/methods/create.ts
@@ -22,8 +22,9 @@ export async function create(
 
   const collectionConfig = instance.config.collections?.find((c) => c.slug === collection);
 
-  // Enforce collection-level access control
-  if (collectionConfig?.access?.create && options.req) {
+  // Enforce collection-level access control (skip when overrideAccess is set,
+  // matching the low-level create() guard in collections/operations/create.ts)
+  if (collectionConfig?.access?.create && options.req && !options.overrideAccess) {
     const canCreate = await collectionConfig.access.create({
       req: options.req as unknown as ContractsRevealRequest,
       data: options.data,

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -22,6 +22,27 @@
       "when": 1776652800000,
       "tag": "0002_triggers_search_vectors",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776739200000,
+      "tag": "0003_shared_facts",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776825600000,
+      "tag": "0004_yjs_document_patches",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776912000000,
+      "tag": "0005_shared_memory_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/electric-latency-probe/latency-notes-2026-04-19T01-25-51-068Z.md
+++ b/scripts/electric-latency-probe/latency-notes-2026-04-19T01-25-51-068Z.md
@@ -1,0 +1,91 @@
+# Electric Latency Probe — 2026-04-19T01:26:10.652Z
+
+**Measured against:** local admin (`http://localhost:4000`) → local Electric (`http://localhost:5133`)
+**Backend identification:**
+- Electric: HTTP 200 OK
+- Admin:    HTTP 200 OK
+
+**Measured in dev mode; prod middleware posture may differ.**
+
+---
+
+## Summary (room-quotable number)
+
+**mutation_accepted_to_subscriber_ms** — wall-clock from the server
+committing the write (HTTP 201 returned) to the Electric shape subscriber
+receiving the row.
+
+- **median: 2 ms**
+- p95:    3 ms
+- samples: 45 of 50 (first 5 excluded as warmup)
+
+## Diagnostic (decomposition only)
+
+**commit_confirmed_to_subscriber_ms** — includes the mutation route's
+own latency (auth, validation, DB insert, network back to client).
+
+- median: 23 ms
+- p95:    27 ms
+
+## Raw samples (warmup excluded from summary)
+
+| # | warmup | mut 201→sub (ms) | commit start→sub (ms) | fact_id |
+|---|--------|-----------------:|---------------------:|---------|
+| 0 | [warmup, excluded] | 12 | 37 | 905ec1fb… |
+| 1 | [warmup, excluded] | 2 | 24 | 3eecfe13… |
+| 2 | [warmup, excluded] | 4 | 26 | 783df9fe… |
+| 3 | [warmup, excluded] | 1 | 22 | b468f78e… |
+| 4 | [warmup, excluded] | 1 | 23 | 846aa4ed… |
+| 5 |  | 2 | 25 | 033aa507… |
+| 6 |  | 1 | 22 | 7ac5bfa5… |
+| 7 |  | 2 | 22 | 5e319e59… |
+| 8 |  | 5 | 27 | 2b8236c6… |
+| 9 |  | 2 | 25 | 6a66af59… |
+| 10 |  | 2 | 26 | db937ccb… |
+| 11 |  | 2 | 22 | 506e76fe… |
+| 12 |  | 2 | 25 | 0a88c2e5… |
+| 13 |  | 2 | 21 | f905bc89… |
+| 14 |  | 2 | 25 | d7af7a2a… |
+| 15 |  | 2 | 22 | 84982482… |
+| 16 |  | 2 | 22 | 628f3527… |
+| 17 |  | 2 | 24 | bc6ae761… |
+| 18 |  | 2 | 27 | f063b945… |
+| 19 |  | 2 | 21 | 0e3f794a… |
+| 20 |  | 1 | 24 | 74976faf… |
+| 21 |  | 2 | 25 | 64f90d8c… |
+| 22 |  | 2 | 24 | e61c578c… |
+| 23 |  | 2 | 23 | 20c6917a… |
+| 24 |  | 0 | 22 | 1560b1f4… |
+| 25 |  | 3 | 24 | e83c4593… |
+| 26 |  | 1 | 23 | 14fa0d72… |
+| 27 |  | 2 | 24 | 4455abc8… |
+| 28 |  | 2 | 22 | e8152627… |
+| 29 |  | 1 | 22 | 86fe548b… |
+| 30 |  | 2 | 25 | f70c67bc… |
+| 31 |  | 1 | 33 | f521cc19… |
+| 32 |  | 2 | 22 | 34c973a8… |
+| 33 |  | 2 | 22 | 61ef475b… |
+| 34 |  | 2 | 23 | 6d290ef0… |
+| 35 |  | 2 | 25 | a848beb4… |
+| 36 |  | 2 | 22 | 9efbf8cb… |
+| 37 |  | 2 | 24 | 3a414a58… |
+| 38 |  | 2 | 24 | b145b36e… |
+| 39 |  | 2 | 23 | 4bfa5358… |
+| 40 |  | 3 | 32 | 82bda92d… |
+| 41 |  | 2 | 21 | 941ef503… |
+| 42 |  | 2 | 21 | 34be4d3b… |
+| 43 |  | 2 | 22 | 6ab2cac2… |
+| 44 |  | 0 | 21 | 88650a74… |
+| 45 |  | 1 | 23 | 9aa27a53… |
+| 46 |  | 2 | 22 | 3b2c064b… |
+| 47 |  | 2 | 23 | 1337c605… |
+| 48 |  | 2 | 23 | b63f635c… |
+| 49 |  | 2 | 24 | f669a940… |
+
+## Not measured
+
+- Concurrent-write load. This is an unloaded serial measurement.
+  Propagation under 50 concurrent agents is unknown.
+- The Vercel→Railway→Supabase cloud path. Allevia's Forge deployment
+  is local-box; cloud measurement would add hops that won't exist on
+  the customer's box.

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -55,11 +55,80 @@ See scripts/electric-latency-probe/README.md for the full path list.
 
 const ADMIN_BASE_URL = revvault('revealui/dev/admin-base-url');
 const ELECTRIC_SERVICE_URL = revvault('revealui/dev/electric/service-url');
-const SESSION_COOKIE = revvault('revealui/dev/admin-session-cookie');
-// Electric's shared secret (if any) is handled server-side by the admin proxy;
-// the probe never calls Electric directly, so it doesn't need the secret here.
+// Cookie is either pre-stored in revvault or obtained via auto-sign-in below.
+let sessionCookie = revvault('revealui/dev/admin-session-cookie', { optional: true }) ?? '';
 
-const SESSION_COOKIE_NAME = 'revealui-session';
+const sessionCookie_NAME = 'revealui-session';
+
+// Consistent user-agent for all requests. Session binding validates that the
+// user-agent matches between sign-in and subsequent requests — using a fixed
+// string ensures the probe's own sign-in and shape requests never mismatch.
+const PROBE_USER_AGENT = 'revealui-latency-probe/1.0';
+
+/**
+ * Sign in to the admin app and obtain a session cookie.
+ * Avoids user-agent mismatch issues with pre-stored cookies (the session
+ * binding system invalidates sessions when the user-agent changes).
+ */
+async function autoSignIn(): Promise<string> {
+  // Try the stored cookie first
+  if (sessionCookie) {
+    try {
+      const res = await fetch(`${ADMIN_BASE_URL}/api/auth/me`, {
+        headers: {
+          cookie: `${sessionCookie_NAME}=${sessionCookie}`,
+          'user-agent': PROBE_USER_AGENT,
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.ok) return sessionCookie;
+    } catch {
+      // Cookie invalid or expired — fall through to sign-in
+    }
+  }
+
+  // Sign in with revvault credentials
+  const adminEmail =
+    process.env.PROBE_ADMIN_EMAIL ??
+    revvault('revealui/dev/admin-email', { optional: true }) ??
+    'founder@revealui.com';
+  const adminPassword = revvault('revealui/dev/admin-password', { optional: true });
+  if (!adminPassword) {
+    console.error(`
+FAIL: No valid session cookie and no admin password in revvault.
+  Either store a valid cookie:  echo '<cookie>' | revvault set revealui/dev/admin-session-cookie
+  Or store admin credentials:   echo '<password>' | revvault set revealui/dev/admin-password
+`);
+    process.exit(1);
+  }
+
+  const res = await fetch(`${ADMIN_BASE_URL}/api/auth/sign-in`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'user-agent': PROBE_USER_AGENT,
+    },
+    body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`Sign-in failed: HTTP ${res.status} — ${body}`);
+    process.exit(1);
+  }
+
+  const setCookies = res.headers.getSetCookie?.() ?? [];
+  for (const c of setCookies) {
+    if (c.startsWith(`${sessionCookie_NAME}=`)) {
+      const token = c.split('=')[1]?.split(';')[0];
+      if (token) return token;
+    }
+  }
+
+  console.error('Sign-in succeeded but no session cookie in response headers.');
+  process.exit(1);
+}
 
 // ---------------------------------------------------------------------------
 // Probe parameters
@@ -129,12 +198,19 @@ function subscribeToShape(onRow: (factId: string, ts: number) => void): () => vo
       url.searchParams.set('session_id', PROBE_SESSION_ID);
       url.searchParams.set('offset', offset);
       if (shapeHandle) url.searchParams.set('handle', shapeHandle);
-      url.searchParams.set('live', 'true');
+      // Electric rejects live=true when offset=-1 (initial sync must complete first).
+      // Only enable live polling after we have a real offset from the initial response.
+      if (offset !== '-1') {
+        url.searchParams.set('live', 'true');
+      }
 
       try {
         const res = await fetch(url.toString(), {
           signal: controller.signal,
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}` },
+          headers: {
+            cookie: `${sessionCookie_NAME}=${sessionCookie}`,
+            'user-agent': PROBE_USER_AGENT,
+          },
         });
         if (!res.ok) {
           if (res.status === 401) {
@@ -201,7 +277,8 @@ async function postOneFact(): Promise<{ factId: string; startMs: number; accepte
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}`,
+      cookie: `${sessionCookie_NAME}=${sessionCookie}`,
+      'user-agent': PROBE_USER_AGENT,
     },
     body: JSON.stringify({
       session_id: PROBE_SESSION_ID,
@@ -253,8 +330,11 @@ async function checkHealth(): Promise<HealthInfo> {
     url.searchParams.set('session_id', 'liveness-check');
     url.searchParams.set('offset', '-1');
     const res = await fetch(url.toString(), {
-      signal: AbortSignal.timeout(3000),
-      headers: { cookie: `${SESSION_COOKIE_NAME}=${SESSION_COOKIE}` },
+      signal: AbortSignal.timeout(5000),
+      headers: {
+        cookie: `${sessionCookie_NAME}=${sessionCookie}`,
+        'user-agent': PROBE_USER_AGENT,
+      },
     });
     info.adminReachable = res.ok || res.status === 404; // 404 means route works but no shape yet
     info.adminResponse = `HTTP ${res.status} ${res.statusText}`;
@@ -304,6 +384,13 @@ async function main(): Promise<void> {
   samples:     ${TOTAL_SAMPLES} (${WARMUP_SAMPLES} warmup, ${TOTAL_SAMPLES - WARMUP_SAMPLES} measured)
   notes file:  ${NOTES_PATH}
 `);
+
+  // Authenticate: validate stored cookie or sign in fresh.
+  // This ensures all subsequent requests use a consistent user-agent,
+  // preventing session binding violations.
+  sessionCookie = await autoSignIn();
+  console.log('  auth:      session valid');
+  console.log('');
 
   console.log('Liveness check...');
   const health = await checkHealth();


### PR DESCRIPTION
## Summary
- **fix(core)**: Instance-level `create()` now honors `overrideAccess`, matching the low-level guard. Read-back `findByID` also passes `overrideAccess: true` to avoid double access check on just-created documents
- **fix(infra)**: direnv DB URL exports use `${:-}` fallback instead of hardcoded values; migration journal synced with 3 missing entries (0003-0005); AI feature gate bypassed in development mode
- **fix(scripts)**: Probe auto-signs-in with consistent user-agent (prevents session binding violations), only enables `live=true` after initial shape sync, all fetch calls include user-agent header

Closes #383

## Probe results
- **Median: 2ms**, P95: 3ms (45/45 measured samples, local)
- Electric propagation latency from write-accepted to subscriber-received

## Test plan
- [x] 2599 unit tests pass
- [x] Typecheck clean
- [x] Pre-push quality gate green
- [x] Probe ran successfully with all fixes applied
- [ ] Verify `direnv reload` picks up the new `${:-}` fallback in flake.nix
- [ ] Verify `pnpm db:migrate` works against a fresh DB with the updated journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)