### PR TITLE
docs: normalize test counts to reproducible language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Boundary validation (hard fail)
         run: pnpm validate:boundary
 
+      - name: Claim drift validation (hard fail)
+        run: pnpm validate:claims
+
   # ---------------------------------------------------------------------------
   # Phase 2: Typecheck (all branches)
   # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,11 @@ Schemas are in `packages/db/src/schema/`. Use Drizzle ORM for queries. Dual-data
 
 ## CI Gate Architecture
 The `pnpm gate` script runs 3 phases:
-1. **Quality** (parallel): Biome lint (hard fail), audits (warn), structure (warn), security (warn)
+1. **Quality** (parallel): Biome lint (hard fail), audits (warn), structure (warn), security (warn), boundary validation (hard fail), claim-drift validation (hard fail)
 2. **Type checking** (serial): `pnpm -r typecheck` across all workspaces
 3. **Test + Build** (parallel): Vitest (hard fail), turbo build (hard fail)
 
-Biome, typecheck, tests, and build all block pushes. Audits and structure checks are warn-only.
+Biome, boundary, claim-drift, typecheck, tests, and build all block pushes. Audits and structure checks are warn-only.
 
 ## Security
 - CSP, CORS, HSTS headers in `@revealui/security` (re-exported via `packages/core/src/security/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Schemas are in `packages/db/src/schema/`. Use Drizzle ORM for queries. Dual-data
 
 ## Build & Security Status
 - 30 workspaces build and typecheck clean
-- 12,185+ tests across 1,660 test files
+- Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
 - 36 pnpm overrides enforce minimum safe versions for transitive deps
 - React 19.2.4 (CVE-2025-55182 React2Shell patched)
 - 0 GitHub CodeQL alerts, 0 Dependabot alerts (as of 2026-04-12)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You have:
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
 - **57 UI components:** built with Tailwind CSS v4, zero external UI dependencies
-- **12 MCP servers:** agents discover and use your business data through the same API humans use
+- **13 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
 No assembly required. Define your data once. Humans manage it through the dashboard, agents operate on it through MCP. Same permissions, same audit trail.
@@ -49,7 +49,7 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 | **Content**      | Collections, rich text (Lexical), media, draft/live, REST API    | Collections auto-exposed as MCP tools. No integration step.  |
 | **Products**     | Product catalog, pricing tiers, usage tracking                   | Feature gates control which agent capabilities unlock.       |
 | **Payments**     | Stripe checkout, subscriptions, webhooks, billing portal         | x402 micropayments via RevealCoin. Agents transact natively. |
-| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 12 MCP servers.                   |
+| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 13 MCP servers.                   |
 
 ## The JOSHUA Stack
 

--- a/apps/marketing/src/app/marketplace/page.tsx
+++ b/apps/marketing/src/app/marketplace/page.tsx
@@ -201,7 +201,7 @@ export default function MarketplacePage() {
               Production Ready
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              12 MCP Servers
+              13 MCP Servers
             </h2>
             <p className="mt-4 text-lg text-gray-600">
               Production MCP servers included with RevealUI. Each server is rate-limited, audited,

--- a/apps/marketing/src/components/ValueProposition.tsx
+++ b/apps/marketing/src/components/ValueProposition.tsx
@@ -21,7 +21,7 @@ export function ValueProposition() {
     {
       title: 'AI + Agents, Done',
       description:
-        '12 MCP servers, agent coordination, and open-model inference, built into the foundation, not bolted on. Agents discover tools, remember context, and transact autonomously. No proprietary API keys required.',
+        '13 MCP servers, agent coordination, and open-model inference, built into the foundation, not bolted on. Agents discover tools, remember context, and transact autonomously. No proprietary API keys required.',
       icon: 'M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09zM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456z',
       accent: 'bg-violet-600',
       href: 'https://docs.revealui.com/docs/AI',

--- a/apps/marketing/src/components/__tests__/ValueProposition.test.tsx
+++ b/apps/marketing/src/components/__tests__/ValueProposition.test.tsx
@@ -41,7 +41,7 @@ describe('ValueProposition', () => {
     const html = JSON.stringify(result);
     expect(html).toContain('Session auth, Stripe subscriptions, and webhooks');
     expect(html).toContain('Define collections in TypeScript');
-    expect(html).toContain('12 MCP servers, agent coordination');
+    expect(html).toContain('13 MCP servers, agent coordination');
   });
 
   it('contains links to documentation', () => {

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -53,7 +53,7 @@ Comprehensive guide to AI agent capabilities, configurations, and workflows in t
 
 - **Framework**: RevealUI  -  Full-stack React 19 + Next.js 16 Admin Framework
 - **Package Count**: 25 packages (23 OSS + 2 Pro)
-- **Test Status**: 1,300+ test files, all packages build and typecheck ✅
+- **Test Status**: extensive test suite, all packages build and typecheck ✅
 - **Build Status**: All 30 workspaces build successfully ✅
 
 ### Commercial Direction

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -539,7 +539,7 @@ The agent has access to extensive automation scripts in `/scripts`:
 
 ### Configured MCP Servers
 
-The agent has access to **12 MCP servers** configured specifically for RevealUI:
+The agent has access to **13 MCP servers** configured specifically for RevealUI:
 
 1. **Code Validator MCP** (`mcp-code-validator`)
    - Static analysis and code quality checks

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -15,7 +15,7 @@ Brutally honest audit of what RevealUI documentation claims versus what the code
 
 ## Executive Summary
 
-RevealUI's core framework is **real and production-grade**  -  auth, billing, runtime engine, 57 UI components, 81-table database, 20,000+ tests. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
+RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 57 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
 
 ---
 
@@ -54,7 +54,7 @@ RevealUI's core framework is **real and production-grade**  -  auth, billing, ru
 | Stripe checkout/subscriptions/webhooks | 1,100-line webhook handler, 12 event types |
 | Drizzle ORM dual-DB (NeonDB + Supabase) | Schema + queries + boundary enforcement |
 | Biome 2 linting | Pre-commit hooks, CI hard-fail |
-| 20,000+ tests | Vitest + Playwright, passing in CI |
+| Extensive test suite | Vitest + Playwright, passing in CI |
 | MCP servers | 11 server files in packages/mcp/src/servers/ |
 | Content layer | 29 canonical definitions, byte-identical generation |
 
@@ -192,7 +192,7 @@ _Updated: 2026-03-28 | Commit: e1858051_
 | Pro tier purchasable | ✅ MET | Stripe flow verified (test mode) |
 | All 5 apps deployed | ✅ MET | revealui.com, admin, api, docs all return 200 |
 | CI gate passes | ✅ MET | `pnpm gate:quick` PASS |
-| 20,000+ tests | ✅ MET | 20,000+ tests across 1,300+ test files |
+| Extensive test suite | ✅ MET | Unit + integration + E2E across the monorepo |
 | Zero avoidable `any` types | ✅ MET | `pnpm audit:any` = 0 avoidable |
 | Zero production console stmts | ✅ MET | `pnpm audit:console` = 0 |
 | Security audit complete | ✅ MET | Session 133 (2026-03-28) |

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -133,7 +133,7 @@ Note: `npx create-revealui` scaffolds a working basic-blog from npm templates  -
 | Package | Docs claim | Actual state | Completeness |
 |---------|-----------|--------------|-------------|
 | `@revealui/ai` | AI agents, memory, LLM orchestration | 40+ files, 18 import subpaths, real agents | ~80% |
-| `@revealui/mcp` | 12 MCP servers | **12 server files** (plus adapters/utils) | ~90% |
+| `@revealui/mcp` | 13 MCP servers | **13 server files** (plus adapters/utils) | ~90% |
 | `@revealui/harnesses` | AI coordination, workboard | 196 tests, JSON-RPC 2.0, content layer | ~95% |
 | `@revealui/editors` | Editor config sync | 20+ files, 6 test files | ~70% |
 | `@revealui/services` | Stripe + Supabase integrations | 354 tests passing | ~85% |

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -20,7 +20,7 @@ All gates must pass on the `main` branch before deploy.
 - [ ] `pnpm gate` passes all three phases (quality, typecheck, test + build) **(blocking)**
 - [ ] `pnpm lint` reports zero errors (Biome 2) **(blocking)**
 - [ ] `pnpm typecheck:all` clean across all 30 workspaces **(blocking)**
-- [ ] `pnpm test` passes 20,000+ tests across 1,704 test files **(blocking)**
+- [ ] `pnpm test` passes the full test suite **(blocking)**
 - [ ] `pnpm build` succeeds for all apps and packages **(blocking)**
 - [ ] `pnpm validate:structure` confirms workspace structure integrity **(blocking)**
 - [ ] `pnpm audit:any` reports zero avoidable `any` types **(advisory)**

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -22,7 +22,7 @@
 - **History:** 2,410+ commits (Dec 30, 2025 – Apr 2026), solo developer
 - **Apps:** 5 (api, admin, docs, marketing, revealcoin)
 - **Packages:** 25 packages + 5 apps = 30 workspaces
-- **Tests:** 1,706 test files, 20,000+ tests passing, all workspaces build and typecheck
+- **Tests:** extensive test suite across unit, integration, and E2E layers; all workspaces build and typecheck (run `pnpm test` for current count)
 - **Database:** 81 tables (Drizzle ORM, dual NeonDB + Supabase), 61 CHECK constraints enforced (migration 0001 applied 2026-04-15)
 - **UI Components:** 57 native components (Tailwind v4, zero external UI deps)
 - **CI:** GitHub Actions (ci.yml with E2E smoke, release.yml, release-pro.yml, security.yml, system-tune-snapshot.yml), 3-phase CI gate + E2E + CodeQL + Gitleaks

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -98,7 +98,7 @@ The MIT-licensed components (RevVault CLI, RevKit agent coordination) are free f
 
 ## MCP Setup
 
-RevealUI includes 12 MCP servers for enhanced AI capabilities:
+RevealUI includes 13 MCP servers for enhanced AI capabilities:
 
 - **Code Validator MCP** - Static analysis and code quality checks
 - **Vercel MCP** - Deploy and manage Vercel projects

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ Honest labels for every product in the RevealUI ecosystem. Updated 2026-04-10.
 
 | Product | Maturity | Notes |
 |---------|----------|-------|
-| **RevealUI** (monorepo) | Beta | Deployed, 20,000+ tests, 25 npm packages. No paying users yet. |
+| **RevealUI** (monorepo) | Beta | Deployed, 25 npm packages, extensive test suite. No paying users yet. |
 | **Forge** (self-hosted) | Beta | Docker stack complete, license enforcement built. No external customers. |
 | **RevVault** (secrets) | Beta | Rust CLI + desktop app, age-encrypted vault. Not published to crates.io. |
 | **Studio** (desktop) | Alpha | Tauri 2 + React 19, agent coordination UI. No published binaries. |

--- a/docs/SCRIPT_MANAGEMENT.md
+++ b/docs/SCRIPT_MANAGEMENT.md
@@ -1,6 +1,6 @@
 # Script Management System
 
-Complete guide to the RevealUI Script Management Enhancement System - an enterprise-grade infrastructure for managing 222+ TypeScript scripts with complete visibility, type safety, verification, and rollback capabilities.
+Complete guide to the RevealUI Script Management Enhancement System - infrastructure for managing 222+ TypeScript scripts with visibility, type safety, verification, and rollback capabilities.
 
 ## Table of Contents
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,7 +11,7 @@ Reference guide to testing in the RevealUI monorepo.
 
 ## Overview
 
-RevealUI has **~20,000 test cases across 1,300+ test files**.
+RevealUI has an extensive test suite across unit, integration, and end-to-end layers. For a fresh count, run `pnpm test` or `find . -name "*.test.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" | wc -l`.
 
 ### Testing Stack
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -40,8 +40,8 @@ seen real production traffic.
 working config, database setup, and development server.
 
 ### CI and code quality
-3-phase CI gate (lint, typecheck, test, build). 26,000+ test cases across 1,451 test
-files. CodeQL and Gitleaks in CI. Biome for linting and formatting (no ESLint/Prettier).
+3-phase CI gate (lint, typecheck, test, build) with an extensive test suite across
+unit, integration, and E2E layers. CodeQL and Gitleaks in CI. Biome for linting and formatting (no ESLint/Prettier).
 Pre-push gate on protected branches.
 
 ---
@@ -124,8 +124,8 @@ Honest list of things that are not done, not deployed, or not verified.
 | UI components | 65 | Yes |
 | Database tables | 81 | Yes |
 | Database CHECK constraints | 61 | Yes |
-| Test cases | 26,000+ | Yes |
-| Test files | 1,451 | Yes |
+| Test cases | run `pnpm test` for current count | Reproducible |
+| Test files | run `find . -name "*.test.ts*" -not -path "*/node_modules/*"` | Reproducible |
 | API route files | 120+ | Yes |
 | CodeQL alerts | 0 | Yes (as of 2026-04-12) |
 | Dependabot alerts | 0 | Yes (as of 2026-04-12) |
@@ -143,7 +143,7 @@ git clone https://github.com/RevealUIStudio/revealui
 cd revealui
 pnpm install
 pnpm gate        # Run the full CI gate locally
-pnpm test        # Run all 26,000+ tests
+pnpm test        # Run the full test suite
 pnpm typecheck:all  # Typecheck all 31 workspaces
 ```
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -17,7 +17,7 @@ and a REST API. 287 source files in the core package. This is the heart of Revea
 and the most mature part of the codebase.
 
 ### UI component library
-65 native React components built on Tailwind CSS v4. No external UI dependencies
+57 native React components built on Tailwind CSS v4. No external UI dependencies
 (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA.
 Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
@@ -144,7 +144,7 @@ cd revealui
 pnpm install
 pnpm gate        # Run the full CI gate locally
 pnpm test        # Run the full test suite
-pnpm typecheck:all  # Typecheck all 31 workspaces
+pnpm typecheck:all  # Typecheck all 30 workspaces
 ```
 
 If something on this page doesn't match what you see in the code, file an issue.

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -73,7 +73,7 @@ RevealUI launched with:
 - **25 npm packages** published to the public registry
 - **81 database tables** via Drizzle ORM (NeonDB + Supabase)
 - **57 UI components** with zero external dependencies
-- **12 MCP servers** for AI tool access (all MIT)
+- **13 MCP servers** for AI tool access (all MIT)
 - **Extensive test coverage** across unit, integration, and E2E layers
 - **4 GitHub template repos** for different starting points
 

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -74,7 +74,7 @@ RevealUI launched with:
 - **81 database tables** via Drizzle ORM (NeonDB + Supabase)
 - **57 UI components** with zero external dependencies
 - **12 MCP servers** for AI tool access (all MIT)
-- **20,000+ tests** across all packages
+- **Extensive test coverage** across unit, integration, and E2E layers
 - **4 GitHub template repos** for different starting points
 
 You can start right now:

--- a/docs/blog-drafts/04-agent-first-future.md
+++ b/docs/blog-drafts/04-agent-first-future.md
@@ -108,7 +108,7 @@ Four protocols converge to create the agent-first web. Each solves a different p
 | Protocol | Created by | Governed by | Purpose | RevealUI implementation |
 |---|---|---|---|---|
 | **A2A** (Agent-to-Agent) | Google | Linux Foundation (Agentic AI Foundation) | Agents discover and delegate work to other agents | Full A2A 1.0: Agent Cards, JSON-RPC task lifecycle (`tasks/send`, `tasks/get`, `tasks/cancel`), SSE streaming |
-| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 12 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Stripe, Vultr Test, Email Provider |
+| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 13 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Vultr Test, Email Provider |
 | **x402** (HTTP 402 Payment Required) | Coinbase | Open standard | Internet-native micropayments for machine-to-machine commerce | Per-call USDC payments on Base, Coinbase facilitator verification, marketplace payment proxy |
 | **OpenAPI** | OpenAPI Initiative | Linux Foundation | Machine-readable API descriptions | Auto-generated from Hono route definitions with Zod schemas |
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -227,7 +227,7 @@ Some numbers on what's actually shipped:
 - **25 packages** across the monorepo (5 apps, 23 OSS packages, and 2 Pro packages)
 - **81 database tables** via Drizzle ORM
 - **57 UI components** in the presentation layer (zero external UI dependencies  -  just Tailwind v4, clsx, and CVA)
-- **20,000+ tests** across all packages
+- **Extensive test coverage** across unit, integration, and E2E layers
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -108,7 +108,7 @@ Four protocols converge to create the agent-first web. Each solves a different p
 | Protocol | Created by | Governed by | Purpose | RevealUI implementation |
 |---|---|---|---|---|
 | **A2A** (Agent-to-Agent) | Google | Linux Foundation (Agentic AI Foundation) | Agents discover and delegate work to other agents | Full A2A 1.0: Agent Cards, JSON-RPC task lifecycle (`tasks/send`, `tasks/get`, `tasks/cancel`), SSE streaming |
-| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 12 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Stripe, Vultr Test, Email Provider |
+| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 13 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Vultr Test, Email Provider |
 | **x402** (HTTP 402 Payment Required) | Coinbase | Open standard | Internet-native micropayments for machine-to-machine commerce | Per-call USDC payments on Base, Coinbase facilitator verification, marketplace payment proxy |
 | **OpenAPI** | OpenAPI Initiative | Linux Foundation | Machine-readable API descriptions | Auto-generated from Hono route definitions with Zod schemas |
 

--- a/docs/security/CHANGE_MANAGEMENT_POLICY.md
+++ b/docs/security/CHANGE_MANAGEMENT_POLICY.md
@@ -111,7 +111,7 @@ The CI gate (`pnpm gate`) enforces quality standards automatically:
 
 | Check | Type | Failure Mode |
 |-------|------|-------------|
-| Vitest | 20,000+ tests across 1,704 test files | Hard fail (blocks merge) |
+| Vitest | Full test suite across the monorepo | Hard fail (blocks merge) |
 | Turborepo build | Full build across all workspaces | Hard fail (blocks merge) |
 
 ### Pre-Push Gate

--- a/docs/security/INCIDENT_RESPONSE.md
+++ b/docs/security/INCIDENT_RESPONSE.md
@@ -74,7 +74,7 @@ As the team grows, an on-call rotation will be established. Currently, the found
 ### Phase 3: Remediation
 
 1. **Develop the fix** on a private branch (for P0/P1) or a standard feature branch (P2/P3).
-2. **Run the full CI gate**: `pnpm gate` (lint, typecheck, 20,000+ tests, build).
+2. **Run the full CI gate**: `pnpm gate` (lint, typecheck, full test suite, build).
 3. **Deploy via the standard pipeline**: feature branch, PR to `test`, verify on staging, PR to `main`, production deploy.
 4. **For P0**: Skip the `test` branch soak. Merge directly to `main` after CI passes.
 

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -128,7 +128,7 @@ All changes pass through the CI gate before reaching `test` or `main`:
 
 1. **Quality** (parallel): Biome lint (hard fail), security audits (warn), structure checks (warn)
 2. **Type checking** (serial): TypeScript strict mode across all 30 workspaces
-3. **Test + Build** (parallel): 20,000+ Vitest tests, Turborepo build verification
+3. **Test + Build** (parallel): Vitest (full suite, hard fail), Turborepo build verification
 
 ### Branch Pipeline
 

--- a/docs/security/SECURITY_TRAINING.md
+++ b/docs/security/SECURITY_TRAINING.md
@@ -171,7 +171,7 @@ Reviewer: [Name] on [Date]
 | Module | Status | Assessment Result | Date |
 |--------|--------|-------------------|------|
 | 1. Security Foundations | Complete | Policy authored, RevVault implemented | 2026-04-12 |
-| 2. Secure Development | Complete | All OWASP controls implemented and tested (20,000+ tests) | 2026-04-12 |
+| 2. Secure Development | Complete | All OWASP controls implemented; verified by the full Vitest + Playwright suite in CI | 2026-04-12 |
 | 3. CI/CD & Infrastructure | Complete | CI gate designed and operational, deployments automated | 2026-04-12 |
 | 4. Data Protection | Complete | GDPR framework implemented, encryption standards in production | 2026-04-12 |
 | 5. Incident Response | Complete | Incident response plan authored, 6 runbooks documented | 2026-04-12 |


### PR DESCRIPTION
## Summary

- Replace hand-typed, drift-prone test-file and test-case counts across 15 docs with `pnpm test` / grep-reproducible pointers and neutral phrasing ("extensive test suite")
- Drop unsubstantiated "production-grade" / "enterprise-grade" qualifiers in two docs where the claim was not directly supported
- Scope: public CLAUDE.md, public MASTER_PLAN, ROADMAP, LAUNCH-CHECKLIST, TESTING, WHAT_WORKS_TODAY, AUTOMATION, DOCUMENTATION_ASSESSMENT, SCRIPT_MANAGEMENT, two blog posts, and four security policy docs (INFORMATION_SECURITY_POLICY, INCIDENT_RESPONSE, SECURITY_TRAINING, CHANGE_MANAGEMENT_POLICY)

## Why

Docs carried three conflicting test-case counts (12,185 / 20,000+ / 26,000+) and five conflicting test-file counts (1,300 / 1,451 / 1,660 / 1,704 / 1,706). Ground truth at commit time:

- Test files: ~886 (`.test.ts` / `.test.tsx` / `.spec.ts` / `.e2e.ts`, excluding `node_modules` / `dist` / `.next` / `coverage`)
- `it()` / `test()` invocations: ~19,700 via grep

File counts were inflated ~2x; case counts were approximately accurate. Reproducible language (`pnpm test`, `find ... | wc -l`) is durable across drift where specific numbers rot silently.

## Test plan

- [ ] CI green on `chore/normalize-doc-test-counts`
- [ ] Spot-check three rendered docs on GitHub (TESTING.md, WHAT_WORKS_TODAY.md, CHANGE_MANAGEMENT_POLICY.md) — no markdown breakage from the edits
- [ ] Grep the tree once more post-merge for stray `\d{1,3}(,\d{3})+\+? tests?` patterns — none should remain outside allowlisted contexts

## Follow-up (separate commit, same PR)

A tiny lint script + CI wiring that fails if new hand-typed test counts land in any `docs/**/*.md`. Willpower is the wrong control for this class of drift; grep is the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)