### PR TITLE
fix(core): cap LICENSE_CACHE_TTL_MS at 15 minutes (CR8-P1-05)

### DIFF
--- a/packages/core/src/__tests__/license.test.ts
+++ b/packages/core/src/__tests__/license.test.ts
@@ -678,7 +678,9 @@ describe('parseLicenseCacheTtlEnv', () => {
   });
 
   it('accepts values up to the exact cap', () => {
-    expect(parseLicenseCacheTtlEnv(String(MAX_LICENSE_CACHE_TTL_MS))).toBe(MAX_LICENSE_CACHE_TTL_MS);
+    expect(parseLicenseCacheTtlEnv(String(MAX_LICENSE_CACHE_TTL_MS))).toBe(
+      MAX_LICENSE_CACHE_TTL_MS,
+    );
   });
 
   it('clamps values above cap and emits a console warning', () => {

--- a/packages/core/src/__tests__/license.test.ts
+++ b/packages/core/src/__tests__/license.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { decodeProtectedHeader } from 'jose';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   computeKeyId,
   configureGracePeriods,
@@ -20,6 +20,8 @@ import {
   initializeLicense,
   isLicensed,
   type LicenseTier,
+  MAX_LICENSE_CACHE_TTL_MS,
+  parseLicenseCacheTtlEnv,
   resetLicenseState,
   validateLicenseKey,
 } from '../license.js';
@@ -640,5 +642,60 @@ describe('getLicenseStatus', () => {
     const status = getLicenseStatus('enterprise');
     expect(status.mode).toBe('active');
     expect(status.allowed).toBe(false);
+  });
+});
+
+// =============================================================================
+// parseLicenseCacheTtlEnv  -  LICENSE_CACHE_TTL_MS env parsing + cap (CR8-P1-05)
+// =============================================================================
+
+describe('parseLicenseCacheTtlEnv', () => {
+  const DEFAULT_TTL_MS = 15_000;
+
+  it('returns default when env is undefined', () => {
+    expect(parseLicenseCacheTtlEnv(undefined)).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns default when env is empty string', () => {
+    expect(parseLicenseCacheTtlEnv('')).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns default when env is non-numeric', () => {
+    expect(parseLicenseCacheTtlEnv('abc')).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns default when env is zero', () => {
+    expect(parseLicenseCacheTtlEnv('0')).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns default when env is negative', () => {
+    expect(parseLicenseCacheTtlEnv('-1')).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns parsed value when within cap', () => {
+    expect(parseLicenseCacheTtlEnv('30000')).toBe(30_000);
+    expect(parseLicenseCacheTtlEnv('60000')).toBe(60_000);
+  });
+
+  it('accepts values up to the exact cap', () => {
+    expect(parseLicenseCacheTtlEnv(String(MAX_LICENSE_CACHE_TTL_MS))).toBe(MAX_LICENSE_CACHE_TTL_MS);
+  });
+
+  it('clamps values above cap and emits a console warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+      expect(parseLicenseCacheTtlEnv(String(sevenDaysMs))).toBe(MAX_LICENSE_CACHE_TTL_MS);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('exceeds');
+      expect(warnSpy.mock.calls[0][0]).toContain('cap');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('cap is 15 minutes (900_000 ms)', () => {
+    expect(MAX_LICENSE_CACHE_TTL_MS).toBe(15 * 60 * 1000);
+    expect(MAX_LICENSE_CACHE_TTL_MS).toBe(900_000);
   });
 });

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -126,15 +126,42 @@ export interface LicenseCacheConfig {
 
 const DEFAULT_TTL_MS = 15_000; // 15 seconds  -  revoked licenses lose access quickly
 
+/**
+ * Hard cap on cache TTL. Any env override exceeding this is clamped + warned.
+ * Revoked licenses must not stay cached longer than this, regardless of
+ * operator misconfiguration. 15 minutes balances revocation responsiveness
+ * against DB load for high-traffic deployments.
+ *
+ * Tracked by MASTER_PLAN §CR-8 CR8-P1-05.
+ */
+export const MAX_LICENSE_CACHE_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Parse and validate the `LICENSE_CACHE_TTL_MS` env value.
+ *
+ * Rules:
+ * - Unset / non-numeric / non-positive → `DEFAULT_TTL_MS` (15s)
+ * - Above `MAX_LICENSE_CACHE_TTL_MS` → clamped to cap, warning emitted
+ * - Otherwise → parsed value
+ *
+ * Exported for unit testing. Production code uses the module-load-time
+ * evaluation in `DEFAULT_CACHE_CONFIG` below.
+ */
+export function parseLicenseCacheTtlEnv(envValue: string | undefined): number {
+  if (!envValue) return DEFAULT_TTL_MS;
+  const parsed = Number.parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TTL_MS;
+  if (parsed > MAX_LICENSE_CACHE_TTL_MS) {
+    console.warn(
+      `LICENSE_CACHE_TTL_MS=${parsed} exceeds the ${MAX_LICENSE_CACHE_TTL_MS}ms (15-minute) cap; using ${MAX_LICENSE_CACHE_TTL_MS}. Longer TTLs extend the window where revoked licenses retain access and are not permitted.`,
+    );
+    return MAX_LICENSE_CACHE_TTL_MS;
+  }
+  return parsed;
+}
+
 const DEFAULT_CACHE_CONFIG: LicenseCacheConfig = {
-  ttlMs: (() => {
-    const envTtl = process.env.LICENSE_CACHE_TTL_MS;
-    if (envTtl) {
-      const parsed = Number.parseInt(envTtl, 10);
-      if (Number.isFinite(parsed) && parsed > 0) return parsed;
-    }
-    return DEFAULT_TTL_MS;
-  })(),
+  ttlMs: parseLicenseCacheTtlEnv(process.env.LICENSE_CACHE_TTL_MS),
 };
 
 let cacheConfig: LicenseCacheConfig = { ...DEFAULT_CACHE_CONFIG };

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -152,7 +152,7 @@ export function parseLicenseCacheTtlEnv(envValue: string | undefined): number {
   const parsed = Number.parseInt(envValue, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TTL_MS;
   if (parsed > MAX_LICENSE_CACHE_TTL_MS) {
-    console.warn(
+    logger.warn(
       `LICENSE_CACHE_TTL_MS=${parsed} exceeds the ${MAX_LICENSE_CACHE_TTL_MS}ms (15-minute) cap; using ${MAX_LICENSE_CACHE_TTL_MS}. Longer TTLs extend the window where revoked licenses retain access and are not permitted.`,
     );
     return MAX_LICENSE_CACHE_TTL_MS;

--- a/scripts/validate/catalog-changeset.ts
+++ b/scripts/validate/catalog-changeset.ts
@@ -16,7 +16,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..', '..');


### PR DESCRIPTION
## Summary

Cap `LICENSE_CACHE_TTL_MS` at 15 minutes to prevent a misconfigured env variable from leaving revoked licenses cached for days.

## Context

The 2026-04-18 4-agent charge-readiness audit (§CR-8) flagged the current `LICENSE_CACHE_TTL_MS` parse path as unbounded — any positive integer was accepted, so setting `LICENSE_CACHE_TTL_MS=604800000` (7 days) would cache a revoked license for a week. That's outside any reasonable operational window and undermines the revocation guarantee `checkLicenseStatus()` is supposed to provide.

Fix: hard cap at 15 minutes (`MAX_LICENSE_CACHE_TTL_MS = 900_000`). Env values above the cap are clamped with a one-time `console.warn`. Values at or below cap pass through unchanged. Unset / invalid / zero / negative still fall back to the 15-second default.

## Changes

- `packages/core/src/license.ts`
  - New exported constant `MAX_LICENSE_CACHE_TTL_MS` (15 minutes in ms)
  - New exported pure function `parseLicenseCacheTtlEnv(envValue)` with cap + warning emission
  - `DEFAULT_CACHE_CONFIG.ttlMs` now uses the extracted function

- `packages/core/src/__tests__/license.test.ts`
  - 9 new test cases in a dedicated `describe('parseLicenseCacheTtlEnv')` block
  - Covers: unset, empty string, non-numeric, zero, negative, within-cap, at-cap exact, above-cap clamped + warning emitted, cap value correctness

## Notes

- The programmatic `configureLicenseCache({ ttlMs })` path is **intentionally not capped** — tests use short TTLs (< default) to test revocation, and deliberate operator overrides via code are permitted. Only the env-var path is capped, since that's where misconfiguration was the risk.
- No migration needed. Existing deployments using default (unset) or sub-cap values see zero behavior change. Any deployment currently setting `LICENSE_CACHE_TTL_MS > 900_000` will log a warning on boot and get a 15-min effective TTL.

## Test plan

- [ ] CI green (license.test.ts passes all 9 new cases + existing 600-line suite)
- [ ] Verify locally: `pnpm --filter @revealui/core test -- license.test`
- [ ] Deploy-time: inspect logs for any `LICENSE_CACHE_TTL_MS=... exceeds the ... cap` warnings after rollout — if seen, follow up with affected operator to lower their env var

Tracked by MASTER_PLAN §CR-8 CR8-P1-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
