### PR TITLE
refactor(contracts): single-source Stripe webhook events (part of #406)

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -9,6 +9,7 @@
  * duplicate processing across Vercel multi-region deployments.
  */
 
+import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '@revealui/contracts';
 import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import { generateLicenseKey, type LicenseTier, resetLicenseState } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
@@ -630,20 +631,10 @@ async function findHostedStatusByCustomerId(
 
 // ─── Webhook Endpoint ────────────────────────────────────────────────────────
 
-const relevantEvents = new Set([
-  'checkout.session.completed',
-  'customer.subscription.created',
-  'customer.subscription.updated',
-  'customer.subscription.deleted',
-  'customer.deleted',
-  'invoice.payment_failed',
-  'invoice.payment_succeeded',
-  'payment_intent.payment_failed',
-  'customer.subscription.trial_will_end',
-  'charge.dispute.closed',
-  'charge.dispute.created',
-  'charge.refunded',
-]);
+// Canonical list lives in `@revealui/contracts` so seed-stripe.ts and this
+// handler cannot drift. To add/remove events, edit the source there.
+// Tracked by CR-8 audit finding revealui#406.
+const relevantEvents = new Set<string>(RELEVANT_STRIPE_WEBHOOK_EVENTS);
 
 const stripeWebhookRoute = createRoute({
   method: 'post',

--- a/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
+++ b/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT,
+  RELEVANT_STRIPE_WEBHOOK_EVENTS,
+  type RelevantStripeWebhookEvent,
+} from '../stripe-webhook-events.js';
+
+describe('stripe-webhook-events', () => {
+  it('exposes exactly RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT events', () => {
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toHaveLength(RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT);
+  });
+
+  it('has no duplicates', () => {
+    const set = new Set(RELEVANT_STRIPE_WEBHOOK_EVENTS);
+    expect(set.size).toBe(RELEVANT_STRIPE_WEBHOOK_EVENTS.length);
+  });
+
+  it('every event name follows Stripe event-name dot-notation', () => {
+    for (const event of RELEVANT_STRIPE_WEBHOOK_EVENTS) {
+      // e.g. "customer.subscription.created" — at least one dot, lowercase
+      expect(event).toMatch(/^[a-z][a-z_]*(\.[a-z_]+)+$/);
+    }
+  });
+
+  it('covers the four required event categories', () => {
+    // Checkout completion
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('checkout.session.completed');
+
+    // Customer + subscription lifecycle
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('customer.deleted');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('customer.subscription.created');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('customer.subscription.updated');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('customer.subscription.deleted');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('customer.subscription.trial_will_end');
+
+    // Invoice + payment intent (payment flow)
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_succeeded');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_failed');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('payment_intent.payment_failed');
+
+    // Dispute + refund (reversals)
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('charge.dispute.created');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('charge.dispute.closed');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('charge.refunded');
+  });
+
+  it('RelevantStripeWebhookEvent type accepts canonical events (compile-time check)', () => {
+    // This test doesn't run assertions at runtime; it fails at typecheck
+    // if the type narrows incorrectly. The `as` casts here exercise the
+    // union constraint on the expected narrowest values.
+    const checkout: RelevantStripeWebhookEvent = 'checkout.session.completed';
+    const refunded: RelevantStripeWebhookEvent = 'charge.refunded';
+    expect(checkout).toBe('checkout.session.completed');
+    expect(refunded).toBe('charge.refunded');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -526,6 +526,16 @@ export {
 } from './pricing.js';
 
 // =============================================================================
+// Stripe Webhook Events (canonical list — single source of truth)
+// =============================================================================
+
+export {
+  RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT,
+  RELEVANT_STRIPE_WEBHOOK_EVENTS,
+  type RelevantStripeWebhookEvent,
+} from './stripe-webhook-events.js';
+
+// =============================================================================
 // RevealCoin (RVUI)
 // =============================================================================
 

--- a/packages/contracts/src/stripe-webhook-events.ts
+++ b/packages/contracts/src/stripe-webhook-events.ts
@@ -1,0 +1,68 @@
+/**
+ * Canonical list of Stripe webhook events the RevealUI platform handles.
+ *
+ * This list is the single source of truth for BOTH sides of the webhook
+ * contract:
+ *   1. `apps/api/src/routes/webhooks.ts` — handler's `relevantEvents` Set,
+ *      which determines which events the handler processes (anything not
+ *      listed is acked but skipped).
+ *   2. `scripts/setup/seed-stripe.ts` — the webhook endpoint provisioning
+ *      script, which configures Stripe's dashboard to send these events.
+ *
+ * If these two sides drift, the handler either (a) receives events it
+ * doesn't handle (wasted webhook deliveries + alert noise) or (b) fails to
+ * receive events it needs (silent billing gaps — e.g. missed dispute or
+ * refund notifications). Both have real operational cost.
+ *
+ * **To add a new event:**
+ *   1. Add the event name to this array (keep alphabetical within groups
+ *      for diff-friendliness).
+ *   2. Implement the handler branch in `apps/api/src/routes/webhooks.ts`.
+ *   3. Re-run `pnpm stripe:seed` against the live Stripe account to
+ *      register the new event on the existing webhook endpoint.
+ *
+ * **To remove an event:**
+ *   1. Remove the handler branch.
+ *   2. Remove from this array.
+ *   3. Re-run `pnpm stripe:seed` (the seed script should detect removed
+ *      events and unsubscribe them — tracked separately; as of 2026-04-19
+ *      the script does not prune removed events).
+ *
+ * Tracked by: MASTER_PLAN §CR-8 audit finding revealui#406 (2026-04-18).
+ */
+export const RELEVANT_STRIPE_WEBHOOK_EVENTS = [
+  // Checkout completion
+  'checkout.session.completed',
+
+  // Customer lifecycle
+  'customer.deleted',
+
+  // Subscription lifecycle
+  'customer.subscription.created',
+  'customer.subscription.deleted',
+  'customer.subscription.trial_will_end',
+  'customer.subscription.updated',
+
+  // Invoice / payment lifecycle
+  'invoice.payment_failed',
+  'invoice.payment_succeeded',
+  'payment_intent.payment_failed',
+
+  // Dispute + refund (customer-initiated reversals)
+  'charge.dispute.closed',
+  'charge.dispute.created',
+  'charge.refunded',
+] as const;
+
+/**
+ * Type-safe union of the canonical webhook events.
+ * Narrower than Stripe's global `Event.Type` — only the events RevealUI
+ * actually handles.
+ */
+export type RelevantStripeWebhookEvent = (typeof RELEVANT_STRIPE_WEBHOOK_EVENTS)[number];
+
+/**
+ * Expected event count — acts as a coarse drift detector for reviewers.
+ * If you're adjusting the array above, update this too.
+ */
+export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 12;

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -26,6 +26,9 @@ import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { config } from 'dotenv';
 import type Stripe from 'stripe';
+// Relative TS import resolves via tsx at script runtime; avoids adding
+// @revealui/contracts as a root-level dep. Script only; not bundled.
+import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '../../packages/contracts/src/stripe-webhook-events.js';
 
 // Load env from root .env
 config({ path: resolve(import.meta.dirname, '../../.env') });
@@ -315,21 +318,15 @@ const CATALOG: ProductDefinition[] = [
   },
 ];
 
-// Canonical webhook events  -  must mirror `relevantEvents` in apps/api/src/routes/webhooks.ts
-const WEBHOOK_EVENTS: Stripe.WebhookEndpointCreateParams.EnabledEvent[] = [
-  'checkout.session.completed',
-  'customer.subscription.created',
-  'customer.subscription.updated',
-  'customer.subscription.deleted',
-  'customer.deleted',
-  'invoice.payment_failed',
-  'invoice.payment_succeeded',
-  'payment_intent.payment_failed',
-  'customer.subscription.trial_will_end',
-  'charge.dispute.closed',
-  'charge.dispute.created',
-  'charge.refunded',
-];
+// Canonical webhook events now sourced from `@revealui/contracts` so this
+// script and `apps/api/src/routes/webhooks.ts` cannot drift.
+// `satisfies` preserves type-checking: if any event name in the shared
+// constant is NOT a valid Stripe EnabledEvent (e.g. stripe SDK types
+// change), TypeScript errors here rather than silently accepting it.
+// Tracked by CR-8 audit finding revealui#406.
+const WEBHOOK_EVENTS = [
+  ...RELEVANT_STRIPE_WEBHOOK_EVENTS,
+] satisfies Stripe.WebhookEndpointCreateParams.EnabledEvent[];
 
 // Env vars to track: public-facing price IDs + server-side aliases
 const PRICE_ENV_KEYS: Record<string, string> = {


### PR DESCRIPTION
## Summary

Extract the canonical 12 Stripe webhook events into a shared `@revealui/contracts` constant so the handler (`apps/api/src/routes/webhooks.ts`) and the provisioning script (`scripts/setup/seed-stripe.ts`) cannot drift. Closes drift-risk portion of #406.

## Context

The 2026-04-18 Stripe-account audit (§CR-8 audit finding) surfaced that dev and test webhook endpoints subscribe to only 6 of 12 canonical events. Root cause: two copies of the event list — one in the handler, one in the seed script — with nothing structural enforcing they stay in sync. The seed script even carried a comment acknowledging the drift risk:

```ts
// Canonical webhook events  -  must mirror `relevantEvents` in apps/api/src/routes/webhooks.ts
```

This PR replaces that comment with a structural guarantee.

## What changes

- **New file `packages/contracts/src/stripe-webhook-events.ts`** — exports `RELEVANT_STRIPE_WEBHOOK_EVENTS` (the canonical 12-event list, `as const` for literal-type preservation), `RelevantStripeWebhookEvent` type, and `RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT` for coarse drift detection.

- **`apps/api/src/routes/webhooks.ts`** — imports `RELEVANT_STRIPE_WEBHOOK_EVENTS` from `@revealui/contracts` and constructs `relevantEvents = new Set(...)` from it. Local 12-element array deleted.

- **`scripts/setup/seed-stripe.ts`** — imports the same constant via relative TS path (`../../packages/contracts/src/stripe-webhook-events.js`, resolved by tsx at runtime). Uses `satisfies Stripe.WebhookEndpointCreateParams.EnabledEvent[]` rather than `as` to preserve type-checking — if any of our event names ceases to be a valid Stripe `EnabledEvent` (e.g. stripe SDK type change), TypeScript errors here at build time.

- **New test `packages/contracts/src/__tests__/stripe-webhook-events.test.ts`** — asserts: count matches, no duplicates, every event name follows Stripe's dot-notation shape, all four required categories (checkout / lifecycle / invoice / reversal) are covered, type-level compile check.

## What this does NOT address (from issue #406)

- Dev and test webhook endpoints in the Stripe dashboard still subscribe to only 6 of 12 events — that's a dashboard operation, not a code change. Follow-up action on the owner side, or a seed-script enhancement to update existing endpoints (out of scope for this PR).
- `seed-stripe.ts` idempotency bug (duplicate products) — tracked separately in #404.

This PR closes the drift-prevention part of the issue; the remaining items stay open until those are landed.

## Test plan

- [ ] CI: `packages/contracts/src/__tests__/stripe-webhook-events.test.ts` passes
- [ ] CI: type-check succeeds across webhooks.ts and seed-stripe.ts (confirms the `satisfies` cast holds against current `stripe` SDK types)
- [ ] Manual spot-check: `grep -rn "charge.dispute.created\|charge.refunded" apps/api/src/routes/webhooks.ts scripts/setup/seed-stripe.ts` shows no more literal event-string arrays
- [ ] Regression: re-add a fake event to the constant, verify seed-stripe.ts `satisfies` cast fails with a helpful error

Related: MASTER_PLAN §CR-8 audit finding, [revealui#406](https://github.com/RevealUIStudio/revealui/issues/406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
