### PR TITLE
fix(billing): complete Stripe portal feature set + drift detection (#408)

### DIFF
--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -663,13 +663,9 @@ async function setupBillingPortal(
     log.warn(
       `Default billing portal config (${currentDefault.id}) was NOT created by this script.`,
     );
-    log.warn(
-      `  Its features may differ from the canonical set below. Review in Stripe dashboard:`,
-    );
+    log.warn(`  Its features may differ from the canonical set below. Review in Stripe dashboard:`);
     log.warn(`    https://dashboard.stripe.com/settings/billing/portal`);
-    log.warn(
-      `  Recommendation: archive it and select the seed-managed config as default.`,
-    );
+    log.warn(`  Recommendation: archive it and select the seed-managed config as default.`);
   }
 
   // Canonical feature set  -  all five portal capabilities enabled.

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -655,10 +655,37 @@ async function setupBillingPortal(
   log.info('Setting up billing portal configuration...');
 
   const existing = await stripe.billingPortal.configurations.list({ limit: 100 });
-  const match = existing.data.find((c) => c.metadata?.revealui_portal === 'true');
+  const seedCreated = existing.data.find((c) => c.metadata?.revealui_portal === 'true');
+  const currentDefault = existing.data.find((c) => c.is_default === true);
 
-  // Build the features config with all products for plan switching
+  // Drift detection: warn if the current default is NOT the seed-managed one.
+  // This was the CR-8 audit finding  -  a non-seed-managed config was default
+  // in test mode, missing subscription_update (customers couldn't self-serve
+  // plan switches). Warn loudly so the operator archives/reassigns in dashboard.
+  if (currentDefault && currentDefault.metadata?.revealui_portal !== 'true') {
+    log.warn(
+      `Default billing portal config (${currentDefault.id}) was NOT created by this script.`,
+    );
+    log.warn(
+      `  Its features may differ from the canonical set below. Review in Stripe dashboard:`,
+    );
+    log.warn(`    https://dashboard.stripe.com/settings/billing/portal`);
+    log.warn(
+      `  Recommendation: archive it and select the seed-managed config as default.`,
+    );
+  }
+
+  // Canonical feature set  -  all five portal capabilities enabled.
+  // The pre-CR-8 default had subscription_update disabled, blocking customer
+  // self-serve plan switches. Customers should be able to fully manage their
+  // account from the portal without contacting support.
   const portalFeatures: Stripe.BillingPortal.ConfigurationCreateParams.Features = {
+    customer_update: {
+      enabled: true,
+      // `email` intentionally omitted — RevealUI uses email as auth identity,
+      // and portal-editing it would drift from the auth session.
+      allowed_updates: ['address', 'name', 'phone', 'shipping', 'tax_id'],
+    },
     subscription_cancel: { enabled: true, mode: 'at_period_end' },
     subscription_update: {
       enabled: true,
@@ -673,14 +700,20 @@ async function setupBillingPortal(
     payment_method_update: { enabled: true },
   };
 
-  if (match) {
+  if (seedCreated) {
     if (dryRun) {
-      log.info(`Would update billing portal config: ${match.id}`);
+      log.info(`Would update billing portal config: ${seedCreated.id}`);
     } else {
-      await stripe.billingPortal.configurations.update(match.id, {
+      await stripe.billingPortal.configurations.update(seedCreated.id, {
         features: portalFeatures,
       });
-      log.success(`Updated billing portal config: ${match.id}`);
+      log.success(`Updated billing portal config: ${seedCreated.id}`);
+    }
+    if (seedCreated.is_default === false) {
+      log.warn(
+        `Seed-managed config ${seedCreated.id} is NOT the account default. Select it in Stripe dashboard:`,
+      );
+      log.warn(`    https://dashboard.stripe.com/settings/billing/portal`);
     }
     return;
   }
@@ -691,6 +724,9 @@ async function setupBillingPortal(
       `  Products for plan switching: ${subscriptionProducts
         .map((product) => product.productId)
         .join(', ')}`,
+    );
+    log.info(
+      `  Features enabled: customer_update, subscription_cancel, subscription_update, invoice_history, payment_method_update`,
     );
     return;
   }
@@ -704,8 +740,11 @@ async function setupBillingPortal(
   });
 
   log.success(`Created billing portal config: ${portalConfig.id}`);
+  log.warn(`ACTION REQUIRED: select this config as the default customer portal.`);
+  log.warn(`  Stripe API does not expose default-config selection — dashboard-only:`);
+  log.warn(`    https://dashboard.stripe.com/settings/billing/portal`);
   log.warn(
-    'Review the Stripe dashboard if you need this configuration selected as the default customer portal.',
+    `  Then archive any other portal configurations that are not the seed-managed one (metadata.revealui_portal='true').`,
   );
 }
 

--- a/scripts/validate/catalog-changeset.ts
+++ b/scripts/validate/catalog-changeset.ts
@@ -16,7 +16,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = join(import.meta.dirname, '..', '..');


### PR DESCRIPTION
## Summary

Fix the seed script's billing-portal configuration so (a) customers can self-serve plan switches, (b) all five portal features are enabled, and (c) operators are warned loudly if a non-seed config is the active default.

## Background — CR-8 audit finding

The 2026-04-18 Stripe-account audit found two billing portal configurations in test mode, with the **wrong one marked default**:

| Config | is_default | customer_update | subscription_update |
|--------|-----------|------------------|----------------------|
| `bpc_1T5vsZ…` | ✅ **true** | ✅ | ❌ |
| `bpc_1TATVR…` (seed-managed) | false | ❌ | ✅ |

Effect: customers hitting the portal today can't self-serve plan switches — they have to email support to upgrade. Worst UX possible at the exact moment they're trying to give you more money.

## What this PR changes

**`scripts/setup/seed-stripe.ts` `setupBillingPortal()`:**

1. **Adds `customer_update` to the canonical feature set** (previously missing from seed output) — enables customers to edit name, address, phone, shipping, tax ID. `email` is intentionally omitted since it's also our auth-identity field and portal-editing would drift from the session.

2. **Drift detection**: lists existing portal configs, identifies the one marked `is_default: true`, and logs a loud warning if that config was NOT created by the seed (i.e. doesn't have `metadata.revealui_portal === 'true'`). Warning includes the exact dashboard URL for operator remediation.

3. **Post-create guidance**: when the seed script creates its config, explicitly tells the operator that Stripe's API does not expose default-config selection (verified — no `is_default` param on Create/Update endpoints), so the operator must set the default manually via `https://dashboard.stripe.com/settings/billing/portal`.

4. **Post-update detection**: if the seed-managed config exists but is NOT currently the account default, the updated run warns on every invocation with the same dashboard URL — nagging until the operator does the one-time dashboard step.

## What this does NOT fix

- The operator still has to manually select the seed-managed config as default (+ archive the old default) in the Stripe dashboard. Stripe's API does not support programmatic default-config selection. The script now tells them to do it, with URL.
- Existing test-mode dashboard cleanup (archive the wrong-default config, `bpc_1T5vsZ…`) is an owner action, not code.

## Test plan

- [ ] CI typecheck passes (confirms the new `customer_update.allowed_updates` values are valid `CustomerUpdatePortalFeature`-allowed fields in stripe v22 types)
- [ ] Manual: run `pnpm stripe:seed --dry-run` and verify the log output mentions "Features enabled: customer_update, …" in create mode
- [ ] Manual: delete the `revealui_portal` metadata from the existing seed-managed config in test Stripe, re-run seed → confirm it creates a new config + nags about default-selection
- [ ] After live-mode setup: run seed, confirm the new config has all 5 features, select it as default in dashboard, archive pre-existing configs

Tracked by: MASTER_PLAN §CR-8 audit finding, [revealui#408](https://github.com/RevealUIStudio/revealui/issues/408).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
