### PR TITLE
docs(db): migration-journal discipline + CI validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",
-    "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts"
+    "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
+    "validate:migrations": "tsx scripts/validate/migration-journal.ts"
   },
   "type": "module"
 }

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -138,6 +138,7 @@ await db.insert(users).values({
 
 ## Related Documentation
 
+- [Migration Discipline](./docs/migrations-discipline.md) - How migrations work and rules to prevent silent failures
 - [Database Guide](../../docs/DATABASE.md) - Complete database setup and configuration
 - [Database Management](../../docs/DATABASE_MANAGEMENT.md) - Operations and maintenance
 - [Drizzle ORM Docs](https://orm.drizzle.team/) - Official Drizzle documentation

--- a/packages/db/docs/migrations-discipline.md
+++ b/packages/db/docs/migrations-discipline.md
@@ -1,0 +1,71 @@
+# Migration Discipline
+
+How database migrations work in this monorepo, and the rules that prevent silent failures.
+
+## Canonical Flow
+
+All migrations follow this sequence:
+
+```bash
+# 1. Edit the Drizzle schema
+#    packages/db/src/schema/*.ts
+
+# 2. Generate the migration (creates BOTH the .sql AND the journal entry)
+cd ~/suite/revealui && pnpm --filter @revealui/db db:generate
+
+# 3. Review the generated files
+#    packages/db/migrations/NNNN_<name>.sql   — the DDL
+#    packages/db/migrations/meta/_journal.json — updated entry list
+#    packages/db/migrations/meta/NNNN_snapshot.json — schema snapshot
+
+# 4. Apply locally
+cd ~/suite/revealui && pnpm db:migrate
+
+# 5. Commit all generated files together
+git add packages/db/migrations/
+git commit -m "feat(db): add <description>"
+```
+
+`drizzle-kit generate` always emits the SQL file, the journal entry, and the snapshot as an atomic set. Never create one without the others.
+
+## Hand-Written SQL Is Forbidden
+
+Do not create `.sql` files manually in `packages/db/migrations/`. The migration runner (`drizzle-kit migrate`) reconciles SQL files against `meta/_journal.json`. An SQL file without a matching journal entry causes a **silent exit code 1** — no error message, no named file, no diagnostic output.
+
+### Incident: 2026-04-18
+
+Migrations `0003_shared_facts.sql`, `0004_yjs_document_patches.sql`, and `0005_shared_memory_scope.sql` were hand-written and committed without journal entries. `pnpm db:migrate` silently failed in CI. Debugging took a significant chunk of session time before the mismatch was located by comparing `ls migrations/*.sql | wc -l` against `_journal.json` entry count.
+
+Fix: journal entries were retrofitted manually. This document exists to prevent the next occurrence.
+
+### Exception: Migrations Drizzle Can't Express
+
+Rarely, you need SQL that `drizzle-kit generate` can't produce (complex data backfills, custom triggers, partial indexes with expressions). In that case:
+
+1. Write the `.sql` file
+2. **Manually add the journal entry** to `meta/_journal.json` with the correct `idx`, `tag`, and `when` timestamp
+3. **Create the snapshot JSON** — copy the previous snapshot as `meta/NNNN_snapshot.json` and update it to reflect the new schema state
+4. Commit all three files together
+5. **Flag the PR for extra review** — hand-written migrations are a red flag
+
+## Diagnostic: Silent Exit 1
+
+If `pnpm db:migrate` exits 1 with no useful output:
+
+```bash
+# Count SQL files
+ls packages/db/migrations/*.sql | wc -l
+
+# Count journal entries
+cat packages/db/migrations/meta/_journal.json | python3 -c \
+  "import json,sys; j=json.load(sys.stdin); print(len(j['entries']))"
+
+# Mismatch = the bug. Find the orphan:
+diff <(ls packages/db/migrations/*.sql | xargs -I{} basename {} .sql | sort) \
+     <(cat packages/db/migrations/meta/_journal.json | python3 -c \
+       "import json,sys; [print(e['tag']) for e in json.load(sys.stdin)['entries']]" | sort)
+```
+
+## CI Validation
+
+The `migration-journal` validator in `scripts/validate/migration-journal.ts` runs during the CI gate quality phase. It compares SQL file count against journal entry count and fails hard on mismatch, naming the orphaned files explicitly.

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -289,6 +289,11 @@ async function gate(): Promise<void> {
         args: ['validate:gitignore'],
       },
       {
+        name: 'Migration journal',
+        command: 'pnpm',
+        args: ['validate:migrations'],
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],

--- a/scripts/validate/migration-journal.ts
+++ b/scripts/validate/migration-journal.ts
@@ -1,0 +1,87 @@
+/**
+ * Migration Journal Validator
+ *
+ * Ensures every .sql file in packages/db/migrations/ has a corresponding
+ * entry in meta/_journal.json. Prevents the silent exit-1 failure mode
+ * where drizzle-kit sees orphaned SQL files and fails without diagnostics.
+ *
+ * Incident reference: 2026-04-18 (orphaned 0003/0004/0005 migrations).
+ * See packages/db/docs/migrations-discipline.md for full context.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+const MIGRATIONS_DIR = join(import.meta.dirname ?? '.', '../../packages/db/migrations');
+const JOURNAL_PATH = join(MIGRATIONS_DIR, 'meta/_journal.json');
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+function validate(): void {
+  // Collect SQL file tags (filenames without .sql extension)
+  const sqlFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .map((f) => basename(f, '.sql'))
+    .sort();
+
+  // Parse journal
+  const journalRaw = readFileSync(JOURNAL_PATH, 'utf-8');
+  const journal: Journal = JSON.parse(journalRaw);
+  const journalTags = new Set(journal.entries.map((e) => e.tag));
+
+  // Find orphaned SQL files (no journal entry)
+  const orphaned = sqlFiles.filter((tag) => !journalTags.has(tag));
+
+  // Find ghost journal entries (no SQL file)
+  const sqlTagSet = new Set(sqlFiles);
+  const ghosts = journal.entries.filter((e) => !sqlTagSet.has(e.tag)).map((e) => e.tag);
+
+  let failed = false;
+
+  if (orphaned.length > 0) {
+    console.error(
+      `\n  migration-journal: ${orphaned.length} orphaned SQL file(s) without journal entry:`,
+    );
+    for (const tag of orphaned) {
+      console.error(`    - ${tag}.sql`);
+    }
+    console.error(
+      '  Fix: either run `pnpm --filter @revealui/db db:generate` or manually add journal entries.',
+    );
+    console.error('  See: packages/db/docs/migrations-discipline.md\n');
+    failed = true;
+  }
+
+  if (ghosts.length > 0) {
+    console.error(
+      `\n  migration-journal: ${ghosts.length} journal entry/entries without SQL file:`,
+    );
+    for (const tag of ghosts) {
+      console.error(`    - ${tag}`);
+    }
+    console.error('  Fix: the SQL file was deleted but the journal entry remains.\n');
+    failed = true;
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  console.log(
+    `  migration-journal: ${sqlFiles.length} SQL files, ${journalTags.size} journal entries — OK`,
+  );
+}
+
+validate();

--- a/scripts/validate/migration-journal.ts
+++ b/scripts/validate/migration-journal.ts
@@ -10,7 +10,7 @@
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { basename, join } from 'node:path';
 
 const MIGRATIONS_DIR = join(import.meta.dirname ?? '.', '../../packages/db/migrations');
 const JOURNAL_PATH = join(MIGRATIONS_DIR, 'meta/_journal.json');


### PR DESCRIPTION
Closes #401

## Summary
- Add `packages/db/docs/migrations-discipline.md` documenting the canonical migration flow, the 2026-04-18 orphan-SQL incident, and diagnostic steps for silent drizzle-kit failures
- Add `scripts/validate/migration-journal.ts` CI validator that compares SQL file count against `_journal.json` entry count — hard-fails on mismatch with named files
- Wire validator into `pnpm gate` Phase 1 quality checks as `Migration journal`
- Add `pnpm validate:migrations` script entry
- Link doc from `packages/db/README.md`

## Test plan
- [x] `pnpm validate:migrations` passes (6 SQL files, 6 journal entries)
- [x] `pnpm gate --phase=1 --changed` passes with new validator included
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)