### PR TITLE
chore(gate): wire pnpm validate:claims as hard-fail in Phase 1

### DIFF
--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -289,6 +289,11 @@ async function gate(): Promise<void> {
         args: ['validate:gitignore'],
       },
       {
+        name: 'Claim drift (hard fail)',
+        command: 'pnpm',
+        args: ['validate:claims'],
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],


### PR DESCRIPTION
## Summary

Wires `pnpm validate:claims` into the local `pnpm gate` Phase 1 array as a hard-fail check.

## The mismatch this closes

Before this PR:

- **CLAUDE.md** (repo-level agent context) declares: *"1. Quality (parallel): Biome lint (hard fail), audits (warn), structure (warn), security (warn), boundary validation (hard fail), **claim-drift validation (hard fail)**"*
- **`.github/workflows/ci.yml:76-77`** runs `pnpm validate:claims` as a dedicated CI step
- **`scripts/gates/ci-gate.ts` Phase 1 array** — silently missing this check

So `pnpm gate` on a developer's machine (and in the pre-push hook) passed while GitHub CI ran the same check independently. A local/CI mismatch where doc-reality drift could slip past pre-push only to fail in remote CI.

This PR adds the check to the local array so both gates are symmetric.

## What changed

One entry inserted into the Phase 1 checks list in `scripts/gates/ci-gate.ts`:

```ts
{
  name: 'Claim drift (hard fail)',
  command: 'pnpm',
  args: ['validate:claims'],
},
```

Placed next to the other `validate:*` hard-fail steps (structure, boundary, version policy, Pro license). No other changes.

## Verification

Ran `pnpm gate:quick` locally on `test` tip + this change:

```
✓ Claim drift (hard fail)     4.5s
...
Result: PASS
```

53/53 claims match codebase metrics per `claim-drift.ts` at time of commit (packages: 25, apps: 5, workspaces: 30, test files: 885, UI components: 57, MCP servers: 13). Safe to wire as hard-fail — baseline is clean.

## Context

Closes the final step of the Honest Audit Playbook for the 2026-04-18 docs alignment audit, tracked internally as MASTER_PLAN §CR-9 CR9-P2-01. Per the playbook precedent (the 2026-04-18 test-suite audit that wired this validator): this enforcement is what stops the drift from recurring. Without it, the same inflation accumulates again over the months after every audit.

## Breaking changes

None. The check already existed — this PR only causes it to run in one additional context (local gate) where the script was already present as a pnpm command (`package.json:196`).

Impact on existing workflows:

- Pre-push hook (`pnpm gate` on `test` / `main`): adds ~4.5s and one additional fail condition for doc-reality drift
- `pnpm gate:quick` (Phase 1 only, feature branches): same
- GitHub Actions `ci.yml`: unchanged — already runs this check independently
- Local `pnpm validate:claims`: unchanged — still invocable directly

## Test plan

- [x] `pnpm gate:quick` passes with the new check
- [x] Check appears in the Phase 1 CI Gate Summary output
- [x] `pnpm validate:claims` exits 0 at time of commit (all 53 claims match)
- [ ] PR CI runs green (automatic)
