### PR TITLE
docs(sanitization): fix table count + clarify Snaps status (CR-9 Phase 1 partial)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ revealui/
 │   ├── config/         # Type-safe env config (Zod)
 │   ├── contracts/      # Zod schemas + TypeScript types
 │   ├── core/           # Runtime engine, REST API, plugins
-│   ├── db/             # Drizzle ORM schema (81 tables, dual-DB)
+│   ├── db/             # Drizzle ORM schema (82 tables, dual-DB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
 │   ├── presentation/   # 57 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -907,12 +907,12 @@ RevealUI AI runs exclusively on open source models. No proprietary cloud APIs, n
 
 ## Supported Inference Paths
 
-| Path | Runtime | Notes |
-|------|---------|-------|
-| **Ubuntu Inference Snaps** | Canonical snap runtime | Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano |
-| **Ollama** | Local GGUF models | Any open source GGUF model. Default: `gemma4:e2b` |
-| **HuggingFace** | HuggingFace Inference API | Open models hosted on HuggingFace infrastructure |
-| **Vultr** | Vultr GPU Cloud | Open models on Vultr serverless inference |
+| Path | Runtime | Status | Notes |
+|------|---------|--------|-------|
+| **Ollama** | Local GGUF models | Supported | Any open source GGUF model. Default: `gemma4:e2b` |
+| **HuggingFace** | HuggingFace Inference API | Supported | Open models hosted on HuggingFace infrastructure |
+| **Vultr** | Vultr GPU Cloud | Supported | Open models on Vultr serverless inference |
+| **Ubuntu Inference Snaps** | Canonical snap runtime | Planned — CLI install available; Studio UI integration in development | Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano. Install via `sudo snap install <model>`; full Studio lifecycle management coming in a later phase. Set `INFERENCE_SNAPS_BASE_URL` env var to wire an existing snap service to the LLM client. |
 
 ## Server-side usage
 


### PR DESCRIPTION
## Summary

Partial execution of the §CR-9 docs alignment plan (see internal MASTER_PLAN — internal docs §CR-9 Phase 1`). Fixes two concrete drift items the 2026-04-18 docs audit surfaced. Other §CR-9 items tracked for follow-up PRs.

## What changed

### `CONTRIBUTING.md`

- Drizzle table count corrected from `81 tables` → `82 tables` in the package map tree. Was the lone remaining 81-vs-82 dissonance after everywhere else had converged on 82. Consistent with `README.md`, `CLAUDE.md`, and `MASTER_PLAN.md` now.

### `docs/PRO.md`

- **Ubuntu Inference Snaps** row in the Supported Inference Paths table now carries an explicit `Status: Planned — CLI install available; Studio UI integration in development` column, separated from the three Supported paths (Ollama, HuggingFace, Vultr).
- Rationale: Leg 4 of the four-legged-stool (per the internal honest-status docs) is stubbed in `apps/studio/src/invoke.ts` — CLI install works today, but the Studio UI lifecycle management that the prior phrasing implied isn't shipped. This table row was the single most likely place for a customer to form a wrong expectation. Now reads as honest roadmap.
- `INFERENCE_SNAPS_BASE_URL` env-var configuration (documented elsewhere in the same file) still works against an externally-provisioned snap service — this change is about the Studio integration specifically, not the LLM client wiring.

## Scope notes

- **`AGENTS.md` intentionally not edited here.** The audit flagged an out-of-date MCP server list in `AGENTS.md`, but the file is gitignored (per `.gitignore`), so drift in it doesn't reach external readers. If it becomes tracked in a future change, sanitize at that point.
- Other §CR-9 items (blog-post usage-billing framing, `coming soon` markers without ETAs, `production-ready` qualifiers, session-summary Layer framing) remain queued for separate small PRs — keeping PRs tight so claim-drift regressions are traceable.

## Verification

- `pnpm validate:claims` — 53/53 claims match, 0 mismatches (claim-drift is the hard-fail Quality step wired in [#418](https://github.com/RevealUIStudio/revealui/pull/418)).
- `pnpm gate:quick` — Phase 1 passes, including claim-drift + Biome + structure + boundary.

## Test plan

- [x] `pnpm validate:claims` exits 0
- [x] `pnpm gate:quick` passes
- [ ] CI runs green (automatic)
- [ ] Merge does not re-introduce 81-vs-82 drift (claim-drift enforces)
