### PR TITLE
fix(billing): handle invoice.payment_action_required for 3DS/SCA flows

### DIFF
--- a/.changeset/api-invoice-payment-action-required.md
+++ b/.changeset/api-invoice-payment-action-required.md
@@ -1,0 +1,18 @@
+---
+'api': patch
+'@revealui/contracts': patch
+---
+
+Add `invoice.payment_action_required` handling for 3DS / SCA authentication flows.
+
+When a customer's bank returns an authentication challenge (3D Secure / Strong Customer Authentication), Stripe sends `invoice.payment_action_required` separately from a payment failure. The customer has **not** failed — they just need to complete authentication on the hosted invoice URL. Prior to this change, the event was acked but skipped, so customers in SCA flows received no notification and could drift toward an actual `invoice.payment_failed` when Stripe's retry schedule eventually gave up.
+
+Adds:
+
+- `invoice.payment_action_required` to the canonical `RELEVANT_STRIPE_WEBHOOK_EVENTS` in `@revealui/contracts` (count 12 → 13). `seed-stripe.ts` will register the event on the next run.
+- `sendPaymentActionRequiredEmail()` in `apps/api/src/lib/webhook-emails.ts` — notifies the customer, explains their access is not interrupted, directs them to the billing portal to complete authentication.
+- Handler branch in `webhooks.ts` that logs the event, resolves tier + email, sends the notification email, and audit-logs `payment.action_required` at info severity. **Does not modify entitlement state** — a customer in an SCA flow has not failed and should not be downgraded.
+
+Does **not** change the existing `invoice.payment_failed` handler (which already implements grace-period logic per the prior attempt-count-based suspension flow).
+
+Closes the `invoice.payment_action_required` gap from the CR-8 billing audit; issue #393 receives a status comment with the reality-vs-issue-body delta (most of #393's acceptance criteria are already handled by the existing `invoice.payment_failed` branch; remaining items — 7-day-vs-period-end grace duration, reminder-email cadence, nightly downgrade cron — are product-behavior decisions, not bug fixes).

--- a/apps/api/src/lib/webhook-emails.ts
+++ b/apps/api/src/lib/webhook-emails.ts
@@ -121,6 +121,24 @@ ${supportFooter('If you have questions, reply to this email or contact')}`,
   });
 }
 
+export async function sendPaymentActionRequiredEmail(to: string, tier = 'pro'): Promise<void> {
+  const portal = billingUrl();
+  const label = tierLabel(tier);
+  await sendEmail({
+    to,
+    subject: `Action required: authenticate your RevealUI payment`,
+    html: emailShell(
+      'Authentication Required',
+      `<h1 style="color: #2563eb;">Authentication Required</h1>
+<p>Your RevealUI ${escapeHtml(label)} subscription renewal requires additional authentication from your bank (3D Secure / Strong Customer Authentication).</p>
+<p>Your access is <strong>not interrupted</strong> — but to avoid a payment failure on the next retry, please complete authentication on your billing portal:</p>
+${ctaButton(portal, 'Complete Authentication')}
+${supportFooter('If you have questions, contact')}`,
+    ),
+    text: `Your RevealUI ${label} renewal requires 3D Secure authentication from your bank. Your access is not interrupted. Complete authentication at ${portal} to avoid a payment failure.`,
+  });
+}
+
 export async function sendPaymentFailedEmail(to: string, tier = 'pro'): Promise<void> {
   const portal = billingUrl();
   const label = tierLabel(tier);

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -38,6 +38,7 @@ import {
   sendDisputeReceivedEmail,
   sendGracePeriodStartedEmail,
   sendLicenseActivatedEmail,
+  sendPaymentActionRequiredEmail,
   sendPaymentFailedEmail,
   sendPaymentReceiptEmail,
   sendPaymentRecoveredEmail,
@@ -2385,6 +2386,61 @@ app.openapi(stripeWebhookRoute, async (c) => {
             });
           });
         }
+        break;
+      }
+
+      case 'invoice.payment_action_required': {
+        // Customer's bank returned a 3D Secure / SCA authentication challenge.
+        // The payment has NOT failed yet — they need to complete authentication
+        // on the hosted invoice URL. Access is not interrupted; we notify
+        // the customer so they can complete auth before Stripe retries.
+        //
+        // Distinct from `invoice.payment_failed`:
+        //   - action_required: customer CAN recover by authenticating
+        //   - payment_failed: a hard failure (declined, insufficient funds, etc.)
+        //     after which Stripe's retry schedule kicks in.
+        //
+        // We do NOT modify entitlement state here — that would prematurely
+        // downgrade someone who is simply in an SCA flow.
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId = resolveCustomerId(invoice.customer);
+        if (!customerId) break;
+
+        logger.info('Invoice payment requires authentication (3DS/SCA)', {
+          customerId,
+          invoiceId: invoice.id,
+          hostedInvoiceUrl: invoice.hosted_invoice_url,
+        });
+
+        // Resolve tier for email personalization.
+        let actionRequiredTier = 'pro';
+        const [actionTierRow] = await db
+          .select({ tier: licenses.tier })
+          .from(licenses)
+          .where(and(eq(licenses.customerId, customerId), isNull(licenses.deletedAt)))
+          .orderBy(desc(licenses.updatedAt))
+          .limit(1);
+        if (actionTierRow?.tier) {
+          actionRequiredTier = actionTierRow.tier;
+        }
+
+        const actionRequiredEmail =
+          invoice.customer_email ?? (await findUserEmailByCustomerId(db, customerId));
+        if (actionRequiredEmail) {
+          sendPaymentActionRequiredEmail(actionRequiredEmail, actionRequiredTier).catch(
+            (err: unknown) => {
+              logger.error('Failed to send payment-action-required email', undefined, {
+                detail: err instanceof Error ? err.message : 'unknown',
+              });
+            },
+          );
+        }
+
+        auditLicenseEvent(db, 'payment.action_required', 'info', {
+          customerId,
+          invoiceId: invoice.id,
+          hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+        });
         break;
       }
 

--- a/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
+++ b/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
@@ -36,6 +36,7 @@ describe('stripe-webhook-events', () => {
     // Invoice + payment intent (payment flow)
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_succeeded');
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_failed');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_action_required');
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('payment_intent.payment_failed');
 
     // Dispute + refund (reversals)

--- a/packages/contracts/src/stripe-webhook-events.ts
+++ b/packages/contracts/src/stripe-webhook-events.ts
@@ -44,6 +44,7 @@ export const RELEVANT_STRIPE_WEBHOOK_EVENTS = [
   'customer.subscription.updated',
 
   // Invoice / payment lifecycle
+  'invoice.payment_action_required',
   'invoice.payment_failed',
   'invoice.payment_succeeded',
   'payment_intent.payment_failed',
@@ -65,4 +66,4 @@ export type RelevantStripeWebhookEvent = (typeof RELEVANT_STRIPE_WEBHOOK_EVENTS)
  * Expected event count — acts as a coarse drift detector for reviewers.
  * If you're adjusting the array above, update this too.
  */
-export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 12;
+export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 13;


### PR DESCRIPTION
Partial closure of [#393](https://github.com/RevealUIStudio/revealui/issues/393) — the one genuine code gap in the issue. See the status comment on #393 for why the other acceptance criteria are not addressed here.

## Summary

Adds `invoice.payment_action_required` webhook handling for 3D Secure / Strong Customer Authentication flows.

## The gap

When a customer's bank returns an SCA / 3DS authentication challenge during subscription renewal, Stripe sends `invoice.payment_action_required`. The payment has **not failed** — the customer just needs to complete authentication at the hosted invoice URL.

Prior to this change, that event wasn't in `RELEVANT_STRIPE_WEBHOOK_EVENTS`, so it was acked by the outer dispatcher and silently skipped. The customer received no notification and could drift toward an actual `invoice.payment_failed` when Stripe's retry schedule eventually gave up.

## What ships

- **`packages/contracts`**: `invoice.payment_action_required` added to `RELEVANT_STRIPE_WEBHOOK_EVENTS` (canonical count 12 → 13). `seed-stripe.ts` registers it on the next run.
- **`apps/api/src/lib/webhook-emails.ts`**: `sendPaymentActionRequiredEmail()` — notifies the customer, explains access is not interrupted, links to the billing portal for auth completion.
- **`apps/api/src/routes/webhooks.ts`**: new handler branch. Logs at `info`, resolves tier + email, sends email (async), audit-logs `payment.action_required` at `info` severity. **Does not modify entitlement state** — an SCA-challenged customer has not failed.
- **Test**: canonical-list test updated for the new count; 758/758 contracts tests pass.

## What deliberately doesn't ship

Three items from #393's acceptance criteria are product-behavior decisions, not bug fixes. The `invoice.payment_failed` handler ALREADY implements grace-period logic (sets `graceUntil = invoice.period_end`, transitions `past_due` → `expired` based on `attempt_count`, suspends licenses after N failures). Making the following changes would be behavior shifts requiring product review:

- **Grace duration: 7 days vs period_end.** Current uses `invoice.period_end`; issue asks for fixed 7 days. Trade-off: period_end is customer-friendly (keeps access through the billing period they already paid for); fixed 7 days is more conservative. Not a bug — deferred to product decision.
- **Reminder email cadence (day 0, day 3, day 6).** Not implemented — would need scheduler + distinct templates. Separate PR.
- **Nightly downgrade cron.** Not implemented — suspension already fires at webhook-receive time via `attempt_count >= threshold`, which reaches the desired end-state. A cron would be belt-and-suspenders. Separate PR if wanted.

## Test plan

- [x] `pnpm --filter @revealui/contracts test` — 758/758 pass (incl. stripe-webhook-events check for count 13)
- [x] `pnpm --filter api typecheck` — clean
- [ ] CI runs green (automatic)

## Note on the commit

Same cross-session branch-switch pattern as [#427](https://github.com/RevealUIStudio/revealui/pull/427) — my initial commit landed on `feat/shared-memory-read-routes` (Terminal CC's active branch). Cherry-picked onto the intended `fix/invoice-payment-failed-grace`, stashed unrelated harnesses WIP to unblock the checkout. If the commit appears in a later Terminal CC PR, one of the two should get dropped via rebase.

## Related

- MASTER_PLAN §CR-8 Phase 1 item CR8-P1-03 (partial)
- Cross-references CR-8 audit finding [revealui#406](https://github.com/RevealUIStudio/revealui/issues/406) (webhook endpoints missing events)
