### PR TITLE
feat(api): seat-count guard for accountMemberships inserts (partial #397 / CR8-P2-03)

### DIFF
--- a/.changeset/api-seat-count-guard.md
+++ b/.changeset/api-seat-count-guard.md
@@ -1,0 +1,21 @@
+---
+'api': patch
+---
+
+Add application-level seat-count guard for `accountMemberships` inserts (partial closure of #397 / CR8-P2-03).
+
+The `maxUsers` cap per hosted tier (pro=25, max=100, enterprise=unlimited) was defined but never enforced on `accountMemberships` inserts. A Pro team could silently add 200 active members with no rejection. Issue #397 calls for both application-level pre-insert check and DB-level defense-in-depth.
+
+This PR ships the application-level half:
+
+- **`apps/api/src/lib/seat-count-guard.ts`** — exports `SeatLimitReachedError` (with structured `{ code: 'seat_limit_reached', accountId, current, max }` fields for 402 responses) and `assertSeatAvailable(db, accountId, maxUsers)`. Returns early when `maxUsers` is null/undefined (enterprise); throws the structured error when the active-member count meets or exceeds the cap.
+- **8 unit tests** covering all three branches (unlimited no-op, under-cap resolve, at-or-over-cap throw) + structured-error-field assertions + edge cases (empty count result, maxUsers=0 literal cap).
+
+Not in this PR (deferred follow-ups so the shipped piece is reviewable in isolation):
+
+- **Integration at call sites.** Currently the only `accountMemberships` insert is the bootstrap owner-insert in `webhooks.ts:376` (always count=0, always passes trivially — not a meaningful demonstration). The guard will be wired by whichever PR adds the team-invite flow.
+- **DB-level trigger defense-in-depth.** Needs a drizzle-kit-generated migration per the 2026-04-19 journal discipline (see CR9 / migration-discipline docs). Separate PR.
+- **`apps/api/src/lib/tier-limits.ts` extraction.** Planned move of `getHostedLimitsForTier` out of `webhooks.ts` into a shared module; the guard takes `maxUsers` as a parameter so the extraction isn't a blocker. Deferred to reduce contention with in-flight edits on `webhooks.ts`.
+- **Admin UI seat counter + invite-flow preview.** Product-surface work for the admin app, separate from the API enforcement.
+
+The guard is exported and ready to wire; no behavior change until a caller invokes it.

--- a/apps/api/src/lib/__tests__/seat-count-guard.test.ts
+++ b/apps/api/src/lib/__tests__/seat-count-guard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for seat-count-guard.ts (#397 / CR8-P2-03).
+ *
+ * Covers the three behavioral branches of assertSeatAvailable:
+ *   1. Unlimited (maxUsers == null) — no DB read, resolves.
+ *   2. Under cap — resolves.
+ *   3. At or over cap — throws SeatLimitReachedError with structured fields.
+ *
+ * Concurrency (two-request race) is not covered here — that's the DB-trigger
+ * follow-up that lands in a separate PR.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { assertSeatAvailable, SeatLimitReachedError } from '../seat-count-guard.js';
+
+// Minimal Drizzle-shaped mock: select().from().where() returning the result.
+function makeDbMock(currentCount: number | null) {
+  const where = vi.fn().mockResolvedValue(currentCount === null ? [] : [{ count: currentCount }]);
+  const from = vi.fn().mockReturnValue({ where });
+  const select = vi.fn().mockReturnValue({ from });
+  return { select, from, where };
+}
+
+describe('assertSeatAvailable', () => {
+  it('no-ops when maxUsers is null (enterprise / unlimited)', async () => {
+    const mock = makeDbMock(999);
+    await expect(assertSeatAvailable(mock, 'acct-x', null)).resolves.toBeUndefined();
+    expect(mock.select).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when maxUsers is undefined (enterprise / unlimited)', async () => {
+    const mock = makeDbMock(999);
+    await expect(assertSeatAvailable(mock, 'acct-x', undefined)).resolves.toBeUndefined();
+    expect(mock.select).not.toHaveBeenCalled();
+  });
+
+  it('resolves when current count is under the cap', async () => {
+    const mock = makeDbMock(10);
+    await expect(assertSeatAvailable(mock, 'acct-pro', 25)).resolves.toBeUndefined();
+    expect(mock.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves when table returns no rows (empty account)', async () => {
+    const mock = makeDbMock(null);
+    await expect(assertSeatAvailable(mock, 'acct-new', 25)).resolves.toBeUndefined();
+  });
+
+  it('throws SeatLimitReachedError when current count equals cap', async () => {
+    const mock = makeDbMock(25);
+    await expect(assertSeatAvailable(mock, 'acct-pro-full', 25)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+
+  it('throws SeatLimitReachedError when current count exceeds cap', async () => {
+    const mock = makeDbMock(30);
+    await expect(assertSeatAvailable(mock, 'acct-overshoot', 25)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+
+  it('the thrown error carries structured fields for API 402 rendering', async () => {
+    const mock = makeDbMock(25);
+    try {
+      await assertSeatAvailable(mock, 'acct-pro-full', 25);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SeatLimitReachedError);
+      const typed = err as SeatLimitReachedError;
+      expect(typed.code).toBe('seat_limit_reached');
+      expect(typed.accountId).toBe('acct-pro-full');
+      expect(typed.current).toBe(25);
+      expect(typed.max).toBe(25);
+      expect(typed.message).toContain('25/25');
+      expect(typed.message).toContain('acct-pro-full');
+    }
+  });
+
+  it('maxUsers=0 is treated as a literal cap', async () => {
+    const mock = makeDbMock(0);
+    await expect(assertSeatAvailable(mock, 'acct-deactivated', 0)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+});

--- a/apps/api/src/lib/seat-count-guard.ts
+++ b/apps/api/src/lib/seat-count-guard.ts
@@ -1,0 +1,97 @@
+/**
+ * Seat count guard — per-account membership cap enforcement.
+ *
+ * Issue #397 (CR8-P2-03): `accountMemberships` inserts had no cap check.
+ * A Pro-tier team (maxUsers=25) could silently add 200 members.
+ *
+ * This module provides an application-level guard that callers MUST invoke
+ * before inserting a new active membership. A database trigger is tracked
+ * separately as defense-in-depth (to catch direct-SQL paths) and will land
+ * via a drizzle-kit-generated migration — see `MASTER_PLAN §CR-8 CR8-P2-03`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { getHostedLimitsForTier } from './tier-limits.js';
+ * import { assertSeatAvailable } from './seat-count-guard.js';
+ *
+ * const limits = getHostedLimitsForTier(tier);
+ * await assertSeatAvailable(tx, accountId, limits.maxUsers);
+ * await tx.insert(accountMemberships).values({ ... });
+ * ```
+ *
+ * The guard throws `SeatLimitReachedError` (not a generic Error) so API
+ * handlers can catch it and return a structured 402 `seat_limit_reached`
+ * response instead of a 500.
+ */
+
+import { accountMemberships } from '@revealui/db/schema';
+import { and, count, eq } from 'drizzle-orm';
+
+export interface SeatLimitReachedDetails {
+  accountId: string;
+  current: number;
+  max: number;
+}
+
+/**
+ * Thrown when an `accountMemberships` insert would exceed the account's
+ * tier-based maxUsers cap. Carries structured fields so API routes can
+ * render a 402 with an actionable upgrade link.
+ */
+export class SeatLimitReachedError extends Error {
+  readonly code = 'seat_limit_reached' as const;
+  readonly accountId: string;
+  readonly current: number;
+  readonly max: number;
+
+  constructor(details: SeatLimitReachedDetails) {
+    super(
+      `Seat limit reached for account ${details.accountId} (${details.current}/${details.max}). Upgrade the tier to add more members.`,
+    );
+    this.name = 'SeatLimitReachedError';
+    this.accountId = details.accountId;
+    this.current = details.current;
+    this.max = details.max;
+  }
+}
+
+/**
+ * Asserts that adding one more active membership to `accountId` would not
+ * exceed the cap. Caller resolves `maxUsers` from the tier — unlimited
+ * tiers (enterprise) pass `undefined` or `null` to skip the check.
+ *
+ * **Behavior:**
+ * - `maxUsers` is `undefined` / `null` → no-op (enterprise / unlimited)
+ * - current active count `< maxUsers` → resolves
+ * - current active count `>= maxUsers` → throws `SeatLimitReachedError`
+ *
+ * **Concurrency note:** this is a read-then-decide check. Two concurrent
+ * inserts can both read `count < max` and both proceed, overshooting the
+ * cap by one. That's acceptable at the application level — the DB-trigger
+ * follow-up (CR8-P2-03 defense-in-depth) closes the last-writer race.
+ */
+export async function assertSeatAvailable(
+  db: unknown,
+  accountId: string,
+  maxUsers: number | null | undefined,
+): Promise<void> {
+  if (maxUsers == null) return; // enterprise / unlimited sentinel
+
+  // `db` is typed `unknown` to accept Drizzle's HTTP client + tx callback
+  // shapes without importing either directly (keeps this module testable
+  // without a real DB). Cast at the query boundary.
+  // biome-ignore lint/suspicious/noExplicitAny: narrow Drizzle client types differ between HTTP client and tx callback
+  const result = await (db as any)
+    .select({ count: count() })
+    .from(accountMemberships)
+    .where(
+      and(eq(accountMemberships.accountId, accountId), eq(accountMemberships.status, 'active')),
+    );
+
+  const current = Number(result[0]?.count ?? 0);
+
+  if (current >= maxUsers) {
+    throw new SeatLimitReachedError({ accountId, current, max: maxUsers });
+  }
+}

--- a/packages/db/docs/migrations-discipline.md
+++ b/packages/db/docs/migrations-discipline.md
@@ -38,6 +38,61 @@ Migrations `0003_shared_facts.sql`, `0004_yjs_document_patches.sql`, and `0005_s
 
 Fix: journal entries were retrofitted manually. This document exists to prevent the next occurrence.
 
+### Incident: 2026-04-19 (follow-on)
+
+The retroactive journal entries from the 2026-04-18 incident triggered two more failures the next time `drizzle-kit migrate` ran against production:
+
+1. **Non-idempotent ADD CONSTRAINT in `0005_shared_memory_scope.sql`.** Production already had `agent_memories_scope_check` (applied out-of-band before the journal was retrofitted). `ALTER TABLE ... ADD CONSTRAINT` has no `IF NOT EXISTS` form, so the re-apply attempt threw `duplicate_object`, the migrator's transaction rolled back, and `drizzle-kit` exited 1 — message eaten by its TTY spinner.
+2. **Out-of-order `when` on `0006_must_rotate_password`.** Journal `when=1776579007043` was earlier than `0005.when=1776912000000`. The drizzle-orm migrator (`pg-core/dialect.js`) only applies entries where `when > last_applied_row.created_at`, so even after fixing #1, **0006 would have been silently skipped on every future deploy**.
+
+Fixes (this PR):
+- `0005` `ADD CONSTRAINT` wrapped in `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;`.
+- `0006.when` corrected to `1776912000001` (strictly greater than `0005.when`).
+- `__drizzle_migrations` rows backfilled on prod via `pnpm --filter @revealui/db db:backfill-migrations -- --tags=...` (see "Recovering from out-of-band SQL" below).
+
+### Idempotency Rules for Hand-Written SQL
+
+Whenever a migration touches an object that *might* already exist in the target environment (anything outside a fresh schema), the DDL must be idempotent:
+
+| DDL | Idempotent form |
+|---|---|
+| `CREATE TABLE` | `CREATE TABLE IF NOT EXISTS` |
+| `ALTER TABLE ... ADD COLUMN` | `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` |
+| `CREATE INDEX` | `CREATE INDEX IF NOT EXISTS` |
+| `CREATE TRIGGER` | `CREATE OR REPLACE TRIGGER` (PG14+) |
+| `CREATE FUNCTION` | `CREATE OR REPLACE FUNCTION` |
+| `ALTER TABLE ... ADD CONSTRAINT` | `DO $$ BEGIN ALTER TABLE ... ADD CONSTRAINT ...; EXCEPTION WHEN duplicate_object THEN NULL; END $$;` |
+| `DROP TABLE / INDEX / CONSTRAINT` | `... IF EXISTS` |
+
+Prod state can drift from journal state for many reasons (manual psql, prior tooling, partial rollback). Idempotent DDL converges; non-idempotent DDL leaves prod stuck.
+
+### Recovering from Out-of-Band SQL
+
+When SQL has been applied to prod outside the migrator (manual psql, prior tooling), the schema is correct but `drizzle.__drizzle_migrations` is missing rows. The migrator will then re-apply the SQL and either succeed (if idempotent) or fail (if not).
+
+Recovery procedure:
+
+```bash
+cd ~/suite/revealui
+
+# 1. Pull the production POSTGRES_URL
+vercel env pull .vercel/.env.production.local --environment=production
+set -a; . .vercel/.env.production.local; set +a
+
+# 2. Confirm what's actually in prod's tracking table (read-only)
+psql "$POSTGRES_URL" -c \
+  "SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id"
+
+# 3. Backfill the missing rows (explicit tag list — never implicit)
+pnpm --filter @revealui/db db:backfill-migrations -- \
+  --tags=0003_shared_facts,0004_yjs_document_patches,0005_shared_memory_scope
+
+# 4. Re-run drizzle-kit migrate to apply anything new
+pnpm --filter @revealui/db db:migrate
+```
+
+The script is idempotent — re-running after rows exist is a no-op. It only inserts rows whose `created_at` is not already present in the table.
+
 ### Exception: Migrations Drizzle Can't Express
 
 Rarely, you need SQL that `drizzle-kit generate` can't produce (complex data backfills, custom triggers, partial indexes with expressions). In that case:

--- a/packages/db/migrations/0005_shared_memory_scope.sql
+++ b/packages/db/migrations/0005_shared_memory_scope.sql
@@ -6,8 +6,12 @@ ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "session_scope" text;
 ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "source_facts" jsonb DEFAULT '[]'::jsonb;
 ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "reconciled_at" timestamp with time zone;
 
-ALTER TABLE "agent_memories" ADD CONSTRAINT "agent_memories_scope_check"
-  CHECK (scope IN ('private', 'shared', 'reconciled'));
+DO $$ BEGIN
+  ALTER TABLE "agent_memories" ADD CONSTRAINT "agent_memories_scope_check"
+    CHECK (scope IN ('private', 'shared', 'reconciled'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE INDEX IF NOT EXISTS "agent_memories_scope_idx" ON "agent_memories" ("scope");
 CREATE INDEX IF NOT EXISTS "agent_memories_session_scope_idx" ON "agent_memories" ("session_scope");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -47,7 +47,7 @@
     {
       "idx": 6,
       "version": "7",
-      "when": 1776579007043,
+      "when": 1776912000001,
       "tag": "0006_must_rotate_password",
       "breakpoints": true
     }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -255,6 +255,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
+    "db:backfill-migrations": "tsx src/scripts/backfill-migrations.ts",
     "db:cleanup": "tsx src/scripts/cleanup-expired.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/packages/db/src/scripts/backfill-migrations.ts
+++ b/packages/db/src/scripts/backfill-migrations.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env tsx
+
+/**
+ * Backfill missing rows in drizzle.__drizzle_migrations.
+ *
+ * Used when SQL was applied out-of-band (manual psql, prior tooling) and the
+ * migration journal entries were added retroactively, leaving drizzle-kit's
+ * tracking table out of sync with reality. Without backfill, drizzle-kit's
+ * migrator either re-applies non-idempotent statements (transaction rolls
+ * back) or silently skips later migrations whose `when` is earlier than the
+ * last applied row's `created_at`.
+ *
+ * Reference incident: 2026-04-18 (orphaned 0003/0004/0005); see
+ * packages/db/docs/migrations-discipline.md.
+ *
+ * Usage:
+ *   POSTGRES_URL=... tsx src/scripts/backfill-migrations.ts \
+ *     --tags=0003_shared_facts,0004_yjs_document_patches,0005_shared_memory_scope
+ *
+ * Tags are matched against meta/_journal.json. Each tag's row is inserted
+ * iff a row with matching `created_at` (= journal `when`) does not already
+ * exist. Re-running is a safe no-op once rows are in place.
+ */
+
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(here, '../../migrations');
+const JOURNAL_PATH = join(MIGRATIONS_DIR, 'meta/_journal.json');
+
+function parseTags(): string[] {
+  const arg = process.argv.find((a) => a.startsWith('--tags='));
+  if (!arg) {
+    console.error('error: --tags=<tag1,tag2,...> is required (no implicit backfill)');
+    process.exit(2);
+  }
+  return arg
+    .slice('--tags='.length)
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function loadJournal(): Journal {
+  return JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8'));
+}
+
+function hashSql(tag: string): string {
+  const sql = readFileSync(join(MIGRATIONS_DIR, `${tag}.sql`), 'utf-8');
+  return crypto.createHash('sha256').update(sql).digest('hex');
+}
+
+async function main(): Promise<void> {
+  const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    console.error('error: POSTGRES_URL or DATABASE_URL must be set');
+    process.exit(2);
+  }
+
+  const tags = parseTags();
+  const journal = loadJournal();
+  const byTag = new Map(journal.entries.map((e) => [e.tag, e]));
+
+  for (const tag of tags) {
+    if (!byTag.has(tag)) {
+      console.error(`error: tag "${tag}" not found in meta/_journal.json`);
+      process.exit(2);
+    }
+  }
+
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+
+  try {
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash text NOT NULL,
+        created_at bigint
+      )`,
+    );
+
+    const existing = await client.query<{ created_at: string }>(
+      'SELECT created_at FROM drizzle.__drizzle_migrations',
+    );
+    const presentWhens = new Set(existing.rows.map((r) => Number(r.created_at)));
+
+    let inserted = 0;
+    let skipped = 0;
+
+    for (const tag of tags) {
+      const entry = byTag.get(tag)!;
+      if (presentWhens.has(entry.when)) {
+        console.log(`skip ${tag} (already present at created_at=${entry.when})`);
+        skipped += 1;
+        continue;
+      }
+      const hash = hashSql(tag);
+      await client.query(
+        'INSERT INTO drizzle.__drizzle_migrations ("hash", "created_at") VALUES ($1, $2)',
+        [hash, entry.when],
+      );
+      console.log(`backfilled ${tag} (created_at=${entry.when}, hash=${hash.slice(0, 16)}...)`);
+      inserted += 1;
+    }
+
+    console.log(`\ndone: ${inserted} inserted, ${skipped} skipped`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.stack : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Dual-scope notice (cross-session contamination)

This PR contains **two independent commits** that landed on this branch due to concurrent Claude Code sessions sharing the working tree. Both are ready to ship; flagged here so the audit trail is honest and reviewers know to look at both.

| Commit | Scope | Origin |
|---|---|---|
| `c96213f29` | seat-count guard (described below) | This PR's intended work |
| `c149f1978` | migration journal repair + backfill script + idempotency fix on 0005 + corrected 0006 `when` | Originally PR1 of the 3-PR migration-recovery plan; landed on this branch when the parallel session checked out `fix/seat-count-enforcement` mid-commit |

The migration commit is the urgent fix for the 2026-04-19 deploy failure ([Apply Migrations job](https://github.com/RevealUIStudio/revealui/actions/runs/24641688427/job/72046709549)). Backfill rows have already been inserted into prod's `drizzle.__drizzle_migrations` (3 rows, idempotent re-run verified), so on next deploy the migrator will apply 0006 cleanly. PR2 (validator extensions + deploy-workflow observability) and PR3 (drizzle-kit generate parity enforcement) follow as separate PRs against `test`.

---

Partial closure of [#397](https://github.com/RevealUIStudio/revealui/issues/397) — ships the application-level enforcement. DB-level defense-in-depth + admin UI surfacing tracked for follow-up PRs.

## Summary

Adds a reusable seat-count guard that callers invoke before `accountMemberships` inserts:

```ts
import { getHostedLimitsForTier } from './tier-limits.js';  // existing inline in webhooks.ts; extraction deferred
import { assertSeatAvailable } from './seat-count-guard.js';

const limits = getHostedLimitsForTier(tier);
await assertSeatAvailable(tx, accountId, limits.maxUsers);
await tx.insert(accountMemberships).values({ ... });
```

Throws `SeatLimitReachedError` (not generic `Error`) with structured `{ code: 'seat_limit_reached', accountId, current, max }` fields so API routes can render 402 responses with actionable upgrade links.

## Ground-truth state before this PR

- `maxUsers` per tier IS defined (`webhooks.ts:310-318`: free=3, pro=25, max=100, enterprise=unlimited).
- Downgrade-capping exists (`apps/api/src/lib/downgrade-cap.ts`) — fires when a tier drops and current members exceed the new cap.
- **Add-a-member path has no guard at all.** The only current `accountMemberships` insert is the bootstrap owner-insert in `webhooks.ts:376` (always count=0, passes trivially).
- No team-invite flow exists yet that would add teammates beyond the owner — so #397 is prophylactic for when that flow lands.

## What ships

- **`apps/api/src/lib/seat-count-guard.ts`** — `SeatLimitReachedError` + `assertSeatAvailable(db, accountId, maxUsers)`. Returns early when `maxUsers` is null/undefined (enterprise bypass). Throws structured error when `count >= max`. Uses `accountMemberships.status = 'active'` as the membership filter (matches existing downgrade-capping logic).
- **`apps/api/src/lib/__tests__/seat-count-guard.test.ts`** — 8 unit tests. All branches covered: unlimited no-op (null), unlimited no-op (undefined), under cap, empty-account edge case, at-cap throws, overshoot throws, structured-error-fields assertion, `maxUsers=0` literal cap.
- **Changeset** — api patch.

## What deliberately doesn't ship (tracked for follow-ups)

| Item | Why deferred |
|---|---|
| Integration into bootstrap owner-insert (`webhooks.ts:376`) | Always passes (count=0). Synthetic demonstration, not meaningful. Integration will happen in the team-invite PR when that path lands. |
| `getHostedLimitsForTier` extraction from `webhooks.ts` into shared `tier-limits.ts` | Guard takes `maxUsers` as a parameter so extraction isn't a blocker. Attempting it in this PR hit cross-session working-tree contention. Will land as its own small refactor PR. |
| DB-level trigger defense-in-depth | Needs a drizzle-kit-generated migration following the journal discipline ([#401](https://github.com/RevealUIStudio/revealui/issues/401)). Separate PR. |
| Admin UI seat counter ("15/25 seats used") | Admin app surface. Separate PR. |
| Team-invite flow cap preview before invitee accepts | Admin app surface. Separate PR. |

## Concurrency note

This is a read-then-decide check. Two concurrent membership inserts can both read `count < max` and both proceed, overshooting the cap by 1. Acceptable at the application level — the DB-trigger follow-up closes the last-writer race. Called out in the module docstring.

## Test plan

- [x] `pnpm --filter api test --run seat-count` — 8/8 pass
- [x] `pnpm --filter api typecheck` — clean
- [ ] CI runs green (automatic)

## Cross-session notes

Same branch-switch pattern as [#427](https://github.com/RevealUIStudio/revealui/pull/427) and [#428](https://github.com/RevealUIStudio/revealui/pull/428) — my commit landed on `feat/shared-memory-read-routes` (Terminal CC's active branch), then cherry-picked onto the intended branch. Working tree mutation by a parallel session also led me to drop `tier-limits.ts` from this PR when it was deleted between create and commit. Shipped scope is stable against that environment; deferred items are what needed a coherent working tree to complete.

## Related

- MASTER_PLAN §CR-8 Phase 2 item CR8-P2-03 (partial, application layer)
- Existing pattern reference: `apps/api/src/lib/downgrade-cap.ts` uses the same `accountMemberships.status = 'active'` filter
