### PR TITLE
feat: shared memory read routes + RPC list methods

### DIFF
--- a/.changeset/api-invoice-payment-action-required.md
+++ b/.changeset/api-invoice-payment-action-required.md
@@ -1,0 +1,18 @@
+---
+'api': patch
+'@revealui/contracts': patch
+---
+
+Add `invoice.payment_action_required` handling for 3DS / SCA authentication flows.
+
+When a customer's bank returns an authentication challenge (3D Secure / Strong Customer Authentication), Stripe sends `invoice.payment_action_required` separately from a payment failure. The customer has **not** failed — they just need to complete authentication on the hosted invoice URL. Prior to this change, the event was acked but skipped, so customers in SCA flows received no notification and could drift toward an actual `invoice.payment_failed` when Stripe's retry schedule eventually gave up.
+
+Adds:
+
+- `invoice.payment_action_required` to the canonical `RELEVANT_STRIPE_WEBHOOK_EVENTS` in `@revealui/contracts` (count 12 → 13). `seed-stripe.ts` will register the event on the next run.
+- `sendPaymentActionRequiredEmail()` in `apps/api/src/lib/webhook-emails.ts` — notifies the customer, explains their access is not interrupted, directs them to the billing portal to complete authentication.
+- Handler branch in `webhooks.ts` that logs the event, resolves tier + email, sends the notification email, and audit-logs `payment.action_required` at info severity. **Does not modify entitlement state** — a customer in an SCA flow has not failed and should not be downgraded.
+
+Does **not** change the existing `invoice.payment_failed` handler (which already implements grace-period logic per the prior attempt-count-based suspension flow).
+
+Closes the `invoice.payment_action_required` gap from the CR-8 billing audit; issue #393 receives a status comment with the reality-vs-issue-body delta (most of #393's acceptance criteria are already handled by the existing `invoice.payment_failed` branch; remaining items — 7-day-vs-period-end grace duration, reminder-email cadence, nightly downgrade cron — are product-behavior decisions, not bug fixes).

--- a/.changeset/api-seat-count-guard.md
+++ b/.changeset/api-seat-count-guard.md
@@ -1,0 +1,21 @@
+---
+'api': patch
+---
+
+Add application-level seat-count guard for `accountMemberships` inserts (partial closure of #397 / CR8-P2-03).
+
+The `maxUsers` cap per hosted tier (pro=25, max=100, enterprise=unlimited) was defined but never enforced on `accountMemberships` inserts. A Pro team could silently add 200 active members with no rejection. Issue #397 calls for both application-level pre-insert check and DB-level defense-in-depth.
+
+This PR ships the application-level half:
+
+- **`apps/api/src/lib/seat-count-guard.ts`** — exports `SeatLimitReachedError` (with structured `{ code: 'seat_limit_reached', accountId, current, max }` fields for 402 responses) and `assertSeatAvailable(db, accountId, maxUsers)`. Returns early when `maxUsers` is null/undefined (enterprise); throws the structured error when the active-member count meets or exceeds the cap.
+- **8 unit tests** covering all three branches (unlimited no-op, under-cap resolve, at-or-over-cap throw) + structured-error-field assertions + edge cases (empty count result, maxUsers=0 literal cap).
+
+Not in this PR (deferred follow-ups so the shipped piece is reviewable in isolation):
+
+- **Integration at call sites.** Currently the only `accountMemberships` insert is the bootstrap owner-insert in `webhooks.ts:376` (always count=0, always passes trivially — not a meaningful demonstration). The guard will be wired by whichever PR adds the team-invite flow.
+- **DB-level trigger defense-in-depth.** Needs a drizzle-kit-generated migration per the 2026-04-19 journal discipline (see CR9 / migration-discipline docs). Separate PR.
+- **`apps/api/src/lib/tier-limits.ts` extraction.** Planned move of `getHostedLimitsForTier` out of `webhooks.ts` into a shared module; the guard takes `maxUsers` as a parameter so the extraction isn't a blocker. Deferred to reduce contention with in-flight edits on `webhooks.ts`.
+- **Admin UI seat counter + invite-flow preview.** Product-surface work for the admin app, separate from the API enforcement.
+
+The guard is exported and ready to wire; no behavior change until a caller invokes it.

--- a/apps/admin/src/app/api/sync/shared-facts/route.ts
+++ b/apps/admin/src/app/api/sync/shared-facts/route.ts
@@ -12,6 +12,7 @@ import { getSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { sharedFacts } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
+import { and, desc, eq, isNull } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
@@ -27,6 +28,46 @@ export const runtime = 'nodejs';
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const VALID_FACT_TYPES = new Set(['discovery', 'bug', 'decision', 'warning', 'question', 'answer']);
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+    const sessionId = request.nextUrl.searchParams.get('session_id');
+    if (!(sessionId && SESSION_ID_RE.test(sessionId))) {
+      return createValidationErrorResponse(
+        'session_id query param is required',
+        'session_id',
+        sessionId,
+      );
+    }
+    const activeOnly = request.nextUrl.searchParams.get('active') !== 'false';
+    const limit = Math.min(
+      Number.parseInt(request.nextUrl.searchParams.get('limit') ?? '100', 10),
+      500,
+    );
+    const db = getClient();
+    const conditions = [eq(sharedFacts.sessionId, sessionId)];
+    if (activeOnly) conditions.push(isNull(sharedFacts.supersededBy));
+    const rows = await db
+      .select()
+      .from(sharedFacts)
+      .where(and(...conditions))
+      .orderBy(desc(sharedFacts.createdAt))
+      .limit(limit);
+    return NextResponse.json(rows);
+  } catch (error) {
+    logger.error('Error listing shared facts', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-facts',
+      operation: 'list_shared_facts',
+    });
+  }
+}
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const aiGate = checkAIFeatureGate();

--- a/apps/admin/src/app/api/sync/shared-memories/route.ts
+++ b/apps/admin/src/app/api/sync/shared-memories/route.ts
@@ -12,6 +12,7 @@ import { getSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { agentMemories, eq, sites } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
+import { and, desc, or } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
@@ -26,6 +27,48 @@ export const runtime = 'nodejs';
 
 const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+    const sessionScope = request.nextUrl.searchParams.get('session_scope');
+    if (!(sessionScope && SESSION_SCOPE_RE.test(sessionScope))) {
+      return createValidationErrorResponse(
+        'session_scope query param is required',
+        'session_scope',
+        sessionScope,
+      );
+    }
+    const limit = Math.min(
+      Number.parseInt(request.nextUrl.searchParams.get('limit') ?? '100', 10),
+      500,
+    );
+    const db = getClient();
+    const rows = await db
+      .select()
+      .from(agentMemories)
+      .where(
+        and(
+          eq(agentMemories.sessionScope, sessionScope),
+          or(eq(agentMemories.scope, 'shared'), eq(agentMemories.scope, 'reconciled')),
+        ),
+      )
+      .orderBy(desc(agentMemories.createdAt))
+      .limit(limit);
+    return NextResponse.json(rows);
+  } catch (error) {
+    logger.error('Error listing shared memories', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-memories',
+      operation: 'list_shared_memories',
+    });
+  }
+}
 const VALID_MEMORY_TYPES = new Set([
   'fact',
   'preference',

--- a/apps/api/src/lib/__tests__/seat-count-guard.test.ts
+++ b/apps/api/src/lib/__tests__/seat-count-guard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for seat-count-guard.ts (#397 / CR8-P2-03).
+ *
+ * Covers the three behavioral branches of assertSeatAvailable:
+ *   1. Unlimited (maxUsers == null) — no DB read, resolves.
+ *   2. Under cap — resolves.
+ *   3. At or over cap — throws SeatLimitReachedError with structured fields.
+ *
+ * Concurrency (two-request race) is not covered here — that's the DB-trigger
+ * follow-up that lands in a separate PR.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { assertSeatAvailable, SeatLimitReachedError } from '../seat-count-guard.js';
+
+// Minimal Drizzle-shaped mock: select().from().where() returning the result.
+function makeDbMock(currentCount: number | null) {
+  const where = vi.fn().mockResolvedValue(currentCount === null ? [] : [{ count: currentCount }]);
+  const from = vi.fn().mockReturnValue({ where });
+  const select = vi.fn().mockReturnValue({ from });
+  return { select, from, where };
+}
+
+describe('assertSeatAvailable', () => {
+  it('no-ops when maxUsers is null (enterprise / unlimited)', async () => {
+    const mock = makeDbMock(999);
+    await expect(assertSeatAvailable(mock, 'acct-x', null)).resolves.toBeUndefined();
+    expect(mock.select).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when maxUsers is undefined (enterprise / unlimited)', async () => {
+    const mock = makeDbMock(999);
+    await expect(assertSeatAvailable(mock, 'acct-x', undefined)).resolves.toBeUndefined();
+    expect(mock.select).not.toHaveBeenCalled();
+  });
+
+  it('resolves when current count is under the cap', async () => {
+    const mock = makeDbMock(10);
+    await expect(assertSeatAvailable(mock, 'acct-pro', 25)).resolves.toBeUndefined();
+    expect(mock.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves when table returns no rows (empty account)', async () => {
+    const mock = makeDbMock(null);
+    await expect(assertSeatAvailable(mock, 'acct-new', 25)).resolves.toBeUndefined();
+  });
+
+  it('throws SeatLimitReachedError when current count equals cap', async () => {
+    const mock = makeDbMock(25);
+    await expect(assertSeatAvailable(mock, 'acct-pro-full', 25)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+
+  it('throws SeatLimitReachedError when current count exceeds cap', async () => {
+    const mock = makeDbMock(30);
+    await expect(assertSeatAvailable(mock, 'acct-overshoot', 25)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+
+  it('the thrown error carries structured fields for API 402 rendering', async () => {
+    const mock = makeDbMock(25);
+    try {
+      await assertSeatAvailable(mock, 'acct-pro-full', 25);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SeatLimitReachedError);
+      const typed = err as SeatLimitReachedError;
+      expect(typed.code).toBe('seat_limit_reached');
+      expect(typed.accountId).toBe('acct-pro-full');
+      expect(typed.current).toBe(25);
+      expect(typed.max).toBe(25);
+      expect(typed.message).toContain('25/25');
+      expect(typed.message).toContain('acct-pro-full');
+    }
+  });
+
+  it('maxUsers=0 is treated as a literal cap', async () => {
+    const mock = makeDbMock(0);
+    await expect(assertSeatAvailable(mock, 'acct-deactivated', 0)).rejects.toThrow(
+      SeatLimitReachedError,
+    );
+  });
+});

--- a/apps/api/src/lib/seat-count-guard.ts
+++ b/apps/api/src/lib/seat-count-guard.ts
@@ -1,0 +1,97 @@
+/**
+ * Seat count guard — per-account membership cap enforcement.
+ *
+ * Issue #397 (CR8-P2-03): `accountMemberships` inserts had no cap check.
+ * A Pro-tier team (maxUsers=25) could silently add 200 members.
+ *
+ * This module provides an application-level guard that callers MUST invoke
+ * before inserting a new active membership. A database trigger is tracked
+ * separately as defense-in-depth (to catch direct-SQL paths) and will land
+ * via a drizzle-kit-generated migration — see `MASTER_PLAN §CR-8 CR8-P2-03`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { getHostedLimitsForTier } from './tier-limits.js';
+ * import { assertSeatAvailable } from './seat-count-guard.js';
+ *
+ * const limits = getHostedLimitsForTier(tier);
+ * await assertSeatAvailable(tx, accountId, limits.maxUsers);
+ * await tx.insert(accountMemberships).values({ ... });
+ * ```
+ *
+ * The guard throws `SeatLimitReachedError` (not a generic Error) so API
+ * handlers can catch it and return a structured 402 `seat_limit_reached`
+ * response instead of a 500.
+ */
+
+import { accountMemberships } from '@revealui/db/schema';
+import { and, count, eq } from 'drizzle-orm';
+
+export interface SeatLimitReachedDetails {
+  accountId: string;
+  current: number;
+  max: number;
+}
+
+/**
+ * Thrown when an `accountMemberships` insert would exceed the account's
+ * tier-based maxUsers cap. Carries structured fields so API routes can
+ * render a 402 with an actionable upgrade link.
+ */
+export class SeatLimitReachedError extends Error {
+  readonly code = 'seat_limit_reached' as const;
+  readonly accountId: string;
+  readonly current: number;
+  readonly max: number;
+
+  constructor(details: SeatLimitReachedDetails) {
+    super(
+      `Seat limit reached for account ${details.accountId} (${details.current}/${details.max}). Upgrade the tier to add more members.`,
+    );
+    this.name = 'SeatLimitReachedError';
+    this.accountId = details.accountId;
+    this.current = details.current;
+    this.max = details.max;
+  }
+}
+
+/**
+ * Asserts that adding one more active membership to `accountId` would not
+ * exceed the cap. Caller resolves `maxUsers` from the tier — unlimited
+ * tiers (enterprise) pass `undefined` or `null` to skip the check.
+ *
+ * **Behavior:**
+ * - `maxUsers` is `undefined` / `null` → no-op (enterprise / unlimited)
+ * - current active count `< maxUsers` → resolves
+ * - current active count `>= maxUsers` → throws `SeatLimitReachedError`
+ *
+ * **Concurrency note:** this is a read-then-decide check. Two concurrent
+ * inserts can both read `count < max` and both proceed, overshooting the
+ * cap by one. That's acceptable at the application level — the DB-trigger
+ * follow-up (CR8-P2-03 defense-in-depth) closes the last-writer race.
+ */
+export async function assertSeatAvailable(
+  db: unknown,
+  accountId: string,
+  maxUsers: number | null | undefined,
+): Promise<void> {
+  if (maxUsers == null) return; // enterprise / unlimited sentinel
+
+  // `db` is typed `unknown` to accept Drizzle's HTTP client + tx callback
+  // shapes without importing either directly (keeps this module testable
+  // without a real DB). Cast at the query boundary.
+  // biome-ignore lint/suspicious/noExplicitAny: narrow Drizzle client types differ between HTTP client and tx callback
+  const result = await (db as any)
+    .select({ count: count() })
+    .from(accountMemberships)
+    .where(
+      and(eq(accountMemberships.accountId, accountId), eq(accountMemberships.status, 'active')),
+    );
+
+  const current = Number(result[0]?.count ?? 0);
+
+  if (current >= maxUsers) {
+    throw new SeatLimitReachedError({ accountId, current, max: maxUsers });
+  }
+}

--- a/apps/api/src/lib/webhook-emails.ts
+++ b/apps/api/src/lib/webhook-emails.ts
@@ -121,6 +121,24 @@ ${supportFooter('If you have questions, reply to this email or contact')}`,
   });
 }
 
+export async function sendPaymentActionRequiredEmail(to: string, tier = 'pro'): Promise<void> {
+  const portal = billingUrl();
+  const label = tierLabel(tier);
+  await sendEmail({
+    to,
+    subject: `Action required: authenticate your RevealUI payment`,
+    html: emailShell(
+      'Authentication Required',
+      `<h1 style="color: #2563eb;">Authentication Required</h1>
+<p>Your RevealUI ${escapeHtml(label)} subscription renewal requires additional authentication from your bank (3D Secure / Strong Customer Authentication).</p>
+<p>Your access is <strong>not interrupted</strong> — but to avoid a payment failure on the next retry, please complete authentication on your billing portal:</p>
+${ctaButton(portal, 'Complete Authentication')}
+${supportFooter('If you have questions, contact')}`,
+    ),
+    text: `Your RevealUI ${label} renewal requires 3D Secure authentication from your bank. Your access is not interrupted. Complete authentication at ${portal} to avoid a payment failure.`,
+  });
+}
+
 export async function sendPaymentFailedEmail(to: string, tier = 'pro'): Promise<void> {
   const portal = billingUrl();
   const label = tierLabel(tier);

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -38,6 +38,7 @@ import {
   sendDisputeReceivedEmail,
   sendGracePeriodStartedEmail,
   sendLicenseActivatedEmail,
+  sendPaymentActionRequiredEmail,
   sendPaymentFailedEmail,
   sendPaymentReceiptEmail,
   sendPaymentRecoveredEmail,
@@ -2385,6 +2386,61 @@ app.openapi(stripeWebhookRoute, async (c) => {
             });
           });
         }
+        break;
+      }
+
+      case 'invoice.payment_action_required': {
+        // Customer's bank returned a 3D Secure / SCA authentication challenge.
+        // The payment has NOT failed yet — they need to complete authentication
+        // on the hosted invoice URL. Access is not interrupted; we notify
+        // the customer so they can complete auth before Stripe retries.
+        //
+        // Distinct from `invoice.payment_failed`:
+        //   - action_required: customer CAN recover by authenticating
+        //   - payment_failed: a hard failure (declined, insufficient funds, etc.)
+        //     after which Stripe's retry schedule kicks in.
+        //
+        // We do NOT modify entitlement state here — that would prematurely
+        // downgrade someone who is simply in an SCA flow.
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId = resolveCustomerId(invoice.customer);
+        if (!customerId) break;
+
+        logger.info('Invoice payment requires authentication (3DS/SCA)', {
+          customerId,
+          invoiceId: invoice.id,
+          hostedInvoiceUrl: invoice.hosted_invoice_url,
+        });
+
+        // Resolve tier for email personalization.
+        let actionRequiredTier = 'pro';
+        const [actionTierRow] = await db
+          .select({ tier: licenses.tier })
+          .from(licenses)
+          .where(and(eq(licenses.customerId, customerId), isNull(licenses.deletedAt)))
+          .orderBy(desc(licenses.updatedAt))
+          .limit(1);
+        if (actionTierRow?.tier) {
+          actionRequiredTier = actionTierRow.tier;
+        }
+
+        const actionRequiredEmail =
+          invoice.customer_email ?? (await findUserEmailByCustomerId(db, customerId));
+        if (actionRequiredEmail) {
+          sendPaymentActionRequiredEmail(actionRequiredEmail, actionRequiredTier).catch(
+            (err: unknown) => {
+              logger.error('Failed to send payment-action-required email', undefined, {
+                detail: err instanceof Error ? err.message : 'unknown',
+              });
+            },
+          );
+        }
+
+        auditLicenseEvent(db, 'payment.action_required', 'info', {
+          customerId,
+          invoiceId: invoice.id,
+          hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+        });
         break;
       }
 

--- a/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
+++ b/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
@@ -36,6 +36,7 @@ describe('stripe-webhook-events', () => {
     // Invoice + payment intent (payment flow)
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_succeeded');
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_failed');
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('invoice.payment_action_required');
     expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toContain('payment_intent.payment_failed');
 
     // Dispute + refund (reversals)

--- a/packages/contracts/src/stripe-webhook-events.ts
+++ b/packages/contracts/src/stripe-webhook-events.ts
@@ -44,6 +44,7 @@ export const RELEVANT_STRIPE_WEBHOOK_EVENTS = [
   'customer.subscription.updated',
 
   // Invoice / payment lifecycle
+  'invoice.payment_action_required',
   'invoice.payment_failed',
   'invoice.payment_succeeded',
   'payment_intent.payment_failed',
@@ -65,4 +66,4 @@ export type RelevantStripeWebhookEvent = (typeof RELEVANT_STRIPE_WEBHOOK_EVENTS)
  * Expected event count — acts as a coarse drift detector for reviewers.
  * If you're adjusting the array above, update this too.
  */
-export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 12;
+export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 13;

--- a/packages/harnesses/src/server/rpc-server.ts
+++ b/packages/harnesses/src/server/rpc-server.ts
@@ -804,6 +804,18 @@ export class RpcServer {
         return { jsonrpc: '2.0', id, result: fact };
       }
 
+      case 'shared.facts.list': {
+        if (!this.sharedMemory) return this.noService(id, 'sharedMemory');
+        const sessionId = p.sessionId as string | undefined;
+        if (!sessionId) return this.missingParam(id, 'sessionId');
+        const facts = await this.sharedMemory.listFacts({
+          sessionId,
+          activeOnly: p.activeOnly as boolean | undefined,
+          limit: p.limit as number | undefined,
+        });
+        return { jsonrpc: '2.0', id, result: facts };
+      }
+
       case 'shared.memory.store': {
         if (!this.sharedMemory) return this.noService(id, 'sharedMemory');
         const agentId = p.agentId as string | undefined;
@@ -825,6 +837,17 @@ export class RpcServer {
           sourceFacts: p.sourceFacts as string[] | undefined,
         });
         return { jsonrpc: '2.0', id, result: memory };
+      }
+
+      case 'shared.memory.list': {
+        if (!this.sharedMemory) return this.noService(id, 'sharedMemory');
+        const sessionScope = p.sessionScope as string | undefined;
+        if (!sessionScope) return this.missingParam(id, 'sessionScope');
+        const memories = await this.sharedMemory.listMemories({
+          sessionScope,
+          limit: p.limit as number | undefined,
+        });
+        return { jsonrpc: '2.0', id, result: memories };
       }
 
       case 'shared.scratchpad.patch': {

--- a/packages/harnesses/src/server/shared-memory-client.ts
+++ b/packages/harnesses/src/server/shared-memory-client.ts
@@ -68,6 +68,21 @@ export class SharedMemoryClient {
     this.cookie = `revealui-session=${config.sessionCookie}`;
   }
 
+  private async get<T>(path: string, params: Record<string, string>): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`);
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+    const res = await fetch(url, {
+      headers: { Cookie: this.cookie },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`${res.status} ${res.statusText}: ${text}`);
+    }
+    return (await res.json()) as T;
+  }
+
   private async post<T>(path: string, body: unknown): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const res = await fetch(url, {
@@ -146,6 +161,25 @@ export class SharedMemoryClient {
       path: params.path,
       content: params.content,
     });
+  }
+
+  /** List shared facts for a coordination session. */
+  async listFacts(params: {
+    sessionId: string;
+    activeOnly?: boolean;
+    limit?: number;
+  }): Promise<SharedFact[]> {
+    const query: Record<string, string> = { session_id: params.sessionId };
+    if (params.activeOnly === false) query.active = 'false';
+    if (params.limit) query.limit = String(params.limit);
+    return this.get('/api/sync/shared-facts', query);
+  }
+
+  /** List shared memories for a coordination session scope. */
+  async listMemories(params: { sessionScope: string; limit?: number }): Promise<SharedMemory[]> {
+    const query: Record<string, string> = { session_scope: params.sessionScope };
+    if (params.limit) query.limit = String(params.limit);
+    return this.get('/api/sync/shared-memories', query);
   }
 
   /** Trigger reconciliation for a coordination session. */


### PR DESCRIPTION
## Summary

Completes the shared memory RPC surface by adding read operations to complement the write methods from #426.

**API routes (admin app):**
- `GET /api/sync/shared-facts?session_id=...` — list facts for a coordination session, with optional `active=false` to include superseded facts and `limit` param (default 100, max 500)
- `GET /api/sync/shared-memories?session_scope=...` — list shared + reconciled memories by session scope

**RPC methods (daemon):**
- `shared.facts.list` — queries facts via the admin API
- `shared.memory.list` — queries shared memories via the admin API

**SharedMemoryClient:**
- New `get()` private helper for authenticated GET requests
- `listFacts()` and `listMemories()` methods

## Test plan

- [x] `pnpm --filter @revealui/harnesses typecheck` passes
- [x] Pre-push gate passes
- [ ] CI checks on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)