### PR TITLE
refactor(api): extract getHostedLimitsForTier into lib/tier-limits.ts

### DIFF
--- a/.changeset/api-extract-tier-limits.md
+++ b/.changeset/api-extract-tier-limits.md
@@ -1,0 +1,13 @@
+---
+'api': patch
+---
+
+Extract `getHostedLimitsForTier` into `apps/api/src/lib/tier-limits.ts`.
+
+Pure refactor — no behavior change. The function (and its `HostedTierLimits` shape + `HostedTierId` union) moves out of `apps/api/src/routes/webhooks.ts` into a dedicated module so `seat-count-guard.ts` and future limit-driven paths can import the same canonical values without re-declaring the per-tier limits.
+
+Completes the deferred follow-up called out in the seat-count-guard changeset (2026-04-19): the guard already takes `maxUsers` as a parameter so this extraction isn't a blocker for the guard, but having one source of truth for the four hosted tiers is a prerequisite for any future path that needs both the limit and the guard on the same `accountMemberships` insert.
+
+Tests that oracle against the limits (`pricing-accuracy.test.ts`, `billing-feature-matrix.test.ts`, `checkout-to-feature-e2e.test.ts`) retain their independent expected-values — they're drift-catchers, not consumers — with their "must match" comments updated to point at the new path.
+
+All 2274 api tests pass.

--- a/apps/api/src/lib/tier-limits.ts
+++ b/apps/api/src/lib/tier-limits.ts
@@ -1,0 +1,27 @@
+/**
+ * Hosted-tier resource limits — single source of truth for the four hosted tiers.
+ *
+ * Originally inlined in `apps/api/src/routes/webhooks.ts` where it was applied
+ * to `accountEntitlements` on subscription events. Extracted so the seat-count
+ * guard in `./seat-count-guard.ts` and any future limit-driven paths can share
+ * the same values without re-declaring them.
+ *
+ * Enterprise is tier-coded for Forge self-hosted deployments; it gets an
+ * effectively-unlimited agent-task budget and intentionally omits site/user
+ * caps (Forge operators set their own).
+ */
+
+export type HostedTierId = 'free' | 'pro' | 'max' | 'enterprise';
+
+export interface HostedTierLimits {
+  maxSites?: number;
+  maxUsers?: number;
+  maxAgentTasks?: number;
+}
+
+export function getHostedLimitsForTier(tier: HostedTierId): HostedTierLimits {
+  if (tier === 'enterprise') return { maxAgentTasks: Number.MAX_SAFE_INTEGER };
+  if (tier === 'max') return { maxSites: 15, maxUsers: 100, maxAgentTasks: 50_000 };
+  if (tier === 'pro') return { maxSites: 5, maxUsers: 25, maxAgentTasks: 10_000 };
+  return { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 };
+}

--- a/apps/api/src/routes/__tests__/billing-feature-matrix.test.ts
+++ b/apps/api/src/routes/__tests__/billing-feature-matrix.test.ts
@@ -379,7 +379,7 @@ describe('Resource Limits Match Tier Definitions', () => {
   });
 
   it('documented resource limits match hosted tier definitions', () => {
-    // These must match the hosted limits in webhooks.ts getHostedLimitsForTier()
+    // These must match the hosted limits in apps/api/src/lib/tier-limits.ts getHostedLimitsForTier()
     // and the license module getMaxSites/getMaxUsers/getMaxAgentTasks defaults
     expect(TIER_LIMITS.free).toEqual({ maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 });
     expect(TIER_LIMITS.pro).toEqual({ maxSites: 5, maxUsers: 25, maxAgentTasks: 10_000 });

--- a/apps/api/src/routes/__tests__/checkout-to-feature-e2e.test.ts
+++ b/apps/api/src/routes/__tests__/checkout-to-feature-e2e.test.ts
@@ -104,7 +104,7 @@ const PRO_FEATURES = [
 const MAX_FEATURES = ['aiMemory', 'aiInference', 'auditLog'] as const;
 const ENTERPRISE_FEATURES = ['multiTenant', 'whiteLabel', 'sso'] as const;
 
-/** Hosted tier limits (must match getHostedLimitsForTier in webhooks.ts) */
+/** Hosted tier limits (must match getHostedLimitsForTier in apps/api/src/lib/tier-limits.ts) */
 const HOSTED_LIMITS: Record<Tier, { maxSites: number; maxUsers: number; maxAgentTasks: number }> = {
   free: { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 },
   pro: { maxSites: 5, maxUsers: 25, maxAgentTasks: 10_000 },

--- a/apps/api/src/routes/__tests__/pricing-accuracy.test.ts
+++ b/apps/api/src/routes/__tests__/pricing-accuracy.test.ts
@@ -46,7 +46,7 @@ const EXPECTED_FEATURE_TIER_MAP: Record<FeatureFlagKey, LicenseTierId> = {
   sso: 'enterprise',
 };
 
-/** Must match getHostedLimitsForTier in webhooks.ts */
+/** Must match getHostedLimitsForTier in apps/api/src/lib/tier-limits.ts */
 const EXPECTED_HOSTED_LIMITS: Record<
   LicenseTierId,
   { maxSites: number; maxUsers: number; maxAgentTasks: number }

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -31,6 +31,7 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, desc, eq, isNull, lt, sql } from 'drizzle-orm';
 import Stripe from 'stripe';
 import { capResourcesOnDowngrade, isDowngrade } from '../lib/downgrade-cap.js';
+import { getHostedLimitsForTier } from '../lib/tier-limits.js';
 import {
   provisionGitHubAccess,
   sendCancellationConfirmationEmail,
@@ -306,17 +307,6 @@ function resolveSubscriptionId(subscription: string | Stripe.Subscription | null
   if (!subscription) return null;
   if (typeof subscription === 'string') return subscription;
   return subscription.id;
-}
-
-function getHostedLimitsForTier(tier: 'free' | 'pro' | 'max' | 'enterprise'): {
-  maxSites?: number;
-  maxUsers?: number;
-  maxAgentTasks?: number;
-} {
-  if (tier === 'enterprise') return { maxAgentTasks: Number.MAX_SAFE_INTEGER };
-  if (tier === 'max') return { maxSites: 15, maxUsers: 100, maxAgentTasks: 50_000 };
-  if (tier === 'pro') return { maxSites: 5, maxUsers: 25, maxAgentTasks: 10_000 };
-  return { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 };
 }
 
 function buildAccountSlug(userId: string): string {


### PR DESCRIPTION
## Summary

- Extract `getHostedLimitsForTier` from `apps/api/src/routes/webhooks.ts` into a dedicated module at `apps/api/src/lib/tier-limits.ts`
- Export `HostedTierId` and `HostedTierLimits` alongside the function so callers get the types without re-declaring them
- Update `webhooks.ts` to import from the new module; no behavior change
- Update "must match" oracle-comments in three test files to point at the new path (`pricing-accuracy.test.ts`, `billing-feature-matrix.test.ts`, `checkout-to-feature-e2e.test.ts`) — those tests keep their own independent expected-values so they still catch drift

## Why

Completes the deferred follow-up called out explicitly in the [seat-count-guard changeset](https://github.com/RevealUIStudio/revealui/blob/test/.changeset/api-seat-count-guard.md) (2026-04-19):

> `apps/api/src/lib/tier-limits.ts` extraction. Planned move of `getHostedLimitsForTier` out of `webhooks.ts` into a shared module; the guard takes `maxUsers` as a parameter so the extraction isn't a blocker. Deferred to reduce contention with in-flight edits on `webhooks.ts`.

The guard (`apps/api/src/lib/seat-count-guard.ts:15`) already documents the target import path in its JSDoc usage block, assuming the extraction. This PR makes that assumption true.

Single source of truth for the four hosted tiers means:
- Future code paths that need both the limit value and the seat-count guard on the same `accountMemberships` insert can import both from `apps/api/src/lib/*`
- Subscription webhooks, admin UI, OpenAPI schema generators, and any future tier-aware path all pull from the same constants
- Drift becomes a one-file correction instead of a find-and-replace across oracles

## Scope discipline

This is a pure extraction — **no behavior change**, no API-shape change, no test logic change. Only moves:
- Function body: `webhooks.ts:311-320` → `tier-limits.ts:22-27`
- Added: explicit `HostedTierId` + `HostedTierLimits` exports (previously inlined as a literal union + object-type annotation)

## Verification

- `pnpm --filter api typecheck` → clean
- `pnpm --filter api test --run` → 100 test files, **2274 tests passing**
- Pre-push gate: claim-drift, migration-journal, security-audit, coverage — all passed

## Related

- Depends on [#430](https://github.com/RevealUIStudio/revealui/pull/430) (already merged to `test`) for the seat-count-guard landing
- Unblocks any future PR that wires `assertSeatAvailable(tx, accountId, getHostedLimitsForTier(tier).maxUsers)` on team-invite flows
- Follow-up: DB-trigger defense-in-depth migration for seat count (tracked separately under CR-8 CR8-P2-03)
