### PR TITLE
fix(db): make 0005 ADD CONSTRAINT idempotent + correct 0006 when (unblocks deploy)

### DIFF
--- a/packages/db/migrations/0005_shared_memory_scope.sql
+++ b/packages/db/migrations/0005_shared_memory_scope.sql
@@ -6,8 +6,12 @@ ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "session_scope" text;
 ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "source_facts" jsonb DEFAULT '[]'::jsonb;
 ALTER TABLE "agent_memories" ADD COLUMN IF NOT EXISTS "reconciled_at" timestamp with time zone;
 
-ALTER TABLE "agent_memories" ADD CONSTRAINT "agent_memories_scope_check"
-  CHECK (scope IN ('private', 'shared', 'reconciled'));
+DO $$ BEGIN
+  ALTER TABLE "agent_memories" ADD CONSTRAINT "agent_memories_scope_check"
+    CHECK (scope IN ('private', 'shared', 'reconciled'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE INDEX IF NOT EXISTS "agent_memories_scope_idx" ON "agent_memories" ("scope");
 CREATE INDEX IF NOT EXISTS "agent_memories_session_scope_idx" ON "agent_memories" ("session_scope");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -47,7 +47,7 @@
     {
       "idx": 6,
       "version": "7",
-      "when": 1776579007043,
+      "when": 1776912000001,
       "tag": "0006_must_rotate_password",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

Two surgical fixes to unblock the next production deploy after the [2026-04-19 Apply Migrations failure](https://github.com/RevealUIStudio/revealui/actions/runs/24641688427/job/72046709549). Minimal scope; broader migration discipline tooling follows in PR2 / PR3.

| Change | File | Why |
|---|---|---|
| Wrap `ALTER TABLE ... ADD CONSTRAINT` in `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$` | `packages/db/migrations/0005_shared_memory_scope.sql` | Prod already had `agent_memories_scope_check` (applied out-of-band pre-2026-04-18). Unguarded re-apply threw `duplicate_object`, the migrator's transaction rolled back, drizzle-kit exited 1, error eaten by the TTY spinner. |
| Fix `0006.when` from `1776579007043` to `1776912000001` | `packages/db/migrations/meta/_journal.json` | drizzle-orm's `pg-core/dialect.js` migrator only applies entries where `when > last_applied_row.created_at`. Original out-of-order `when` (Mar 18, *earlier* than `0005.when=1776912000000` from Mar 22) would have caused **0006 to be silently skipped on every future deploy** — `must_rotate_password` column never reaches prod, breaking auth for users with the flag set. |

## Already done (not in this PR)

- **Backfill of prod's `drizzle.__drizzle_migrations`** — 3 rows inserted for 0003/0004/0005 (which had been applied OOB but never tracked). Idempotent re-run verified clean (0 inserted, 3 skipped). Last `created_at` now matches `0005.when`, so the new `0006.when=1776912000001` will be picked up on the next deploy.

## What lands in PR2 (separate PR, not blocking deploy)

- Checked-in `packages/db/src/scripts/backfill-migrations.ts` + `db:backfill-migrations` npm script (so future drift recovery is one command, not a manual psql session).
- `scripts/validate/migration-journal.ts` extensions: monotonic-`when` check, snapshot-presence check, raw-`ADD CONSTRAINT`/`DROP CONSTRAINT` idempotency lint.
- `.github/workflows/deploy.yml` Run-migrations step hardening: `NO_COLOR=1` + non-TTY redirect (no more spinner-eats-stderr), post-migrate count assertion (`COUNT(*) FROM __drizzle_migrations == journal.entries.length`), automatic backfill step ahead of `drizzle-kit migrate`.
- `packages/db/docs/migrations-discipline.md` — 2026-04-19 incident postmortem + idempotency rules table + recovery procedure.

## What lands in PR3 (separate PR)

- `packages/db/migrations/meta/_custom.json` — explicit allowlist for hand-written migrations (only `0002_triggers_search_vectors` qualifies today: triggers + HNSW indexes that drizzle's DSL can't express).
- `scripts/validate/drizzle-generate-parity.ts` — runs `drizzle-kit generate` into a tempdir and asserts SQL/snapshot byte-for-byte equality against committed migrations, except those in `_custom.json` (which must contain idempotency markers and a snapshot-chain link).
- Wired to `deploy.yml` as a CI gate before `Apply Migrations`.

## Test plan

- [x] `pnpm validate:migrations` — passes (7 SQL files / 7 journal entries OK)
- [x] `pnpm --filter @revealui/db typecheck` — clean
- [x] Backfill applied to prod + read-back verified (last `created_at = 1776912000000`)
- [ ] CI green on this PR
- [ ] Next deploy applies 0006 successfully (verifiable via `SELECT count(*) FROM drizzle.__drizzle_migrations` returning 7 rows + `must_rotate_password` column existing on `users`)
