### PR TITLE
docs(pro): split Inference Paths into Shipped vs Planned (roadmap)

### DIFF
--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -48,7 +48,7 @@ This guide covers the full Pro surface area, not just MCP setup:
 
 - account-level commercial packaging
 - MCP servers and developer tooling
-- Open-model inference (Ubuntu snaps, Ollama)
+- Open-model inference (Ollama shipped; Ubuntu Inference Snaps on roadmap)
 - editor and harness workflows
 - Stripe, Supabase, and x402 payment features
 - marketplace monetization
@@ -905,21 +905,31 @@ All MCP servers are **completely free**:
 
 RevealUI AI runs exclusively on open source models. No proprietary cloud APIs, no vendor lock-in, no API bills.
 
-## Supported Inference Paths
+## Inference Paths
 
-| Path | Runtime | Status | Notes |
-|------|---------|--------|-------|
-| **Ollama** | Local GGUF models | Supported | Any open source GGUF model. Default: `gemma4:e2b` |
-| **HuggingFace** | HuggingFace Inference API | Supported | Open models hosted on HuggingFace infrastructure |
-| **Vultr** | Vultr GPU Cloud | Supported | Open models on Vultr serverless inference |
-| **Ubuntu Inference Snaps** | Canonical snap runtime | Planned — CLI install available; Studio UI integration in development | Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano. Install via `sudo snap install <model>`; full Studio lifecycle management coming in a later phase. Set `INFERENCE_SNAPS_BASE_URL` env var to wire an existing snap service to the LLM client. |
+### Shipped
+
+| Path | Runtime | Notes |
+|------|---------|-------|
+| **Ollama** | Local GGUF models | Any open source GGUF model. Default: `gemma4:e2b` |
+| **HuggingFace** | HuggingFace Inference API | Open models hosted on HuggingFace infrastructure |
+| **Vultr** | Vultr GPU Cloud | Open models on Vultr serverless inference |
+
+### Planned (roadmap)
+
+| Path | Runtime | Current state | Tracking |
+|------|---------|---------------|----------|
+| **Ubuntu Inference Snaps** | Canonical snap runtime | CLI install works today for Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano (`sudo snap install <model>`). Setting `INFERENCE_SNAPS_BASE_URL` wires an already-running snap service to the LLM client. Studio lifecycle management (start / stop / health / model discovery) is **not shipped**. | Integration issue to be filed; see MASTER_PLAN §CR-9 P1-04 |
 
 ## Server-side usage
 
 ```typescript
 import { createLLMClientFromEnv } from "@revealui/ai/llm/client";
 
-// Auto-detects from environment (snaps > Ollama)
+// Auto-detects from environment in precedence order:
+//   INFERENCE_SNAPS_BASE_URL (if set — planned path, manual wiring)
+//   OLLAMA_BASE_URL (default local runtime)
+//   HUGGINGFACE_API_KEY / VULTR_API_KEY (hosted fallbacks)
 const llm = createLLMClientFromEnv();
 
 const response = await llm.chat([{ role: "user", content: "Hello!" }]);
@@ -928,7 +938,8 @@ const response = await llm.chat([{ role: "user", content: "Hello!" }]);
 ## Environment configuration
 
 ```bash
-# Ubuntu inference snap
+# Ubuntu inference snap — planned path; requires manual snap install + service
+# (see Planned roadmap table above). Studio UI lifecycle not shipped.
 INFERENCE_SNAPS_BASE_URL=http://localhost:8080/v1
 
 # Ollama (any open source model)
@@ -942,7 +953,7 @@ VULTR_API_KEY=VXUUC6WSXXXXXXXXXXXXXXXXXXXXXXXXXX
 VULTR_BASE_URL=https://api.vultrinference.com/v1
 
 # Force specific inference path (overrides auto-detection)
-# Valid values: ollama, huggingface, vultr, inference-snaps
+# Valid values: ollama, huggingface, vultr, inference-snaps (planned)
 LLM_PROVIDER=ollama
 ```
 


### PR DESCRIPTION
## Summary

Split the **Inference Paths** section in `docs/PRO.md` into two explicit tables — **Shipped** (Ollama, HuggingFace, Vultr) and **Planned (roadmap)** (Ubuntu Inference Snaps) — so a reader evaluating an inference path can tell which ones are fully wired and which require manual setup plus a missing Studio UI.

## Why

The previous layout combined all four paths in one "Supported Inference Paths" table with a mixed `Status` column (three "Supported", one "Planned — ..."). The top-level Overview bullet at line 51 read *"Open-model inference (Ubuntu snaps, Ollama)"* as if the two were parallel shipped options. Ground truth:

- **Ollama / HuggingFace / Vultr** — fully wired through `@revealui/ai/llm/client`, auto-detected from env.
- **Ubuntu Inference Snaps** — CLI install works (`sudo snap install gemma3` etc.), and `INFERENCE_SNAPS_BASE_URL` wires an already-running snap service to the LLM client. But Studio UI lifecycle management (start / stop / health / model discovery) is **not shipped**. The previous mixed-table framing buried this in a row-level cell where a reader skimming the section could miss it.

## Changes (single file)

`docs/PRO.md`:

1. Rename section heading from **Supported Inference Paths** → **Inference Paths**.
2. Split into `### Shipped` table (Ollama, HuggingFace, Vultr — drop the `Status` column since everything in this table is shipped by definition) and `### Planned (roadmap)` table (Ubuntu Inference Snaps with explicit *Current state* + *Tracking* columns).
3. Rewrite the Snaps row to name what works today (CLI install for Gemma3 / DeepSeek-R1 / Qwen-VL / Nemotron-Nano; `INFERENCE_SNAPS_BASE_URL` hook) and what does not (Studio lifecycle), so the gap is visible at the table level, not buried in prose.
4. Update the `createLLMClientFromEnv()` example comment: replace terse `"Auto-detects from environment (snaps > Ollama)"` with the full precedence order plus a `"planned path, manual wiring"` qualifier on the snaps env var.
5. Mark `inference-snaps (planned)` in the `LLM_PROVIDER` valid-values comment.
6. Update the Overview bullet at line 51 from `"Open-model inference (Ubuntu snaps, Ollama)"` to `"Open-model inference (Ollama shipped; Ubuntu Inference Snaps on roadmap)"`.

## What is NOT in this PR

- No code changes. `@revealui/ai/llm/client` already handles `INFERENCE_SNAPS_BASE_URL` correctly; that env-var path works today (what is missing is the Studio UI over it, which is a separate track).
- No new GitHub issue filed for the Studio-lifecycle integration — the Planned row cites the doc-audit tracking reference. A code-level issue for the Studio wiring is a separate follow-up (not scope here).
- No changes to other docs that mention Snaps in passing — this PR targets the single source of truth in `docs/PRO.md`.

## Verification

- Visual read of the rendered PRO.md Inference Paths section (local preview) — Shipped / Planned split renders cleanly; no broken markdown.
- `secrets:scan` clean, pre-push gate all green (claim-drift, migration-journal, security-audit, coverage — 8.1s total).
