### PR TITLE
docs(cr9): drop unsupported "Production-ready" qualifiers from status blocks

### DIFF
--- a/.revealui/skills/revealui-architecture-guide/SKILL.md
+++ b/.revealui/skills/revealui-architecture-guide/SKILL.md
@@ -58,13 +58,13 @@ RevealUI/
 - Drizzle ORM schemas
 - PostgreSQL/PGlite adapters
 - Migration management
-- **Status**: Production ready
+- **Status**: Stable
 
 **@revealui/auth** - Authentication & Authorization
 - JWT management
 - Role-based access control (RBAC)
 - Session handling
-- **Status**: Production ready
+- **Status**: Stable
 
 ### Feature Packages
 
@@ -79,7 +79,7 @@ RevealUI/
 - Input sanitization
 - CSRF protection
 - Rate limiting
-- **Status**: Production ready
+- **Status**: Stable
 
 ### Infrastructure Packages
 
@@ -87,7 +87,7 @@ RevealUI/
 - Environment variable management
 - Type-safe config with Zod validation
 - Multi-environment support
-- **Status**: Production ready
+- **Status**: Stable
 
 **@revealui/contracts** - Type contracts
 - Shared TypeScript interfaces

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -504,6 +504,5 @@ LLM_ENABLE_SEMANTIC_CACHE=true
 
 ---
 
-**Implementation**: Production-ready
 **Status**: Fully tested
 **Inference paths**: All (Ubuntu Inference Snaps, Ollama)

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -9,8 +9,6 @@ audience: developer
 
 **Last Updated:** 2026-03-05
 **Package:** `@revealui/auth`
-**Status:** Production-ready
-**Production Readiness:** 8.5/10 🟢
 
 ---
 

--- a/docs/ai/RESPONSE_CACHING.md
+++ b/docs/ai/RESPONSE_CACHING.md
@@ -481,7 +481,6 @@ Response caching provides:
 
 ---
 
-**Implementation**: Production-ready
 **Status**: ✅ Fully tested
 **Provider**: All providers
 **Deployment**: Set `LLM_ENABLE_RESPONSE_CACHE=true`

--- a/docs/ai/SEMANTIC_CACHING.md
+++ b/docs/ai/SEMANTIC_CACHING.md
@@ -519,7 +519,6 @@ Semantic caching provides:
 
 ---
 
-**Implementation**: Production-ready
 **Status**: ✅ Fully tested
 **Provider**: All providers (requires pgvector)
 **Deployment**: Set `LLM_ENABLE_SEMANTIC_CACHE=true`


### PR DESCRIPTION
## Summary

Drop five instances of **"Production-ready"** / **"Production Readiness"** from doc status blocks where the claim was unsupported or redundant with the document body. Per the Honest Audit Playbook: replace with defensible specifics, or drop.

## Files touched (5, docs-only)

### `docs/AUTH.md`
Drop two header lines:

```diff
-**Status:** Production-ready
-**Production Readiness:** 8.5/10 🟢
```

The `8.5/10` score had no provenance — no rubric, no audit link, no test basis. The `Production-ready` label was redundant with the document body which describes session + OAuth + rate limiting coverage in detail. Kept `Last Updated` and `Package` fields.

### `docs/AI.md`
Drop `**Implementation**: Production-ready` from the footer status block. Kept `**Status**: Fully tested` — that one is a verifiable claim against the existing test suite, which the `Implementation: Production-ready` line did not add to.

### `docs/ai/SEMANTIC_CACHING.md`
Same pattern — drop `**Implementation**: Production-ready`, keep `**Status**: ✅ Fully tested`.

### `docs/ai/RESPONSE_CACHING.md`
Same pattern — drop `**Implementation**: Production-ready`, keep `**Status**: ✅ Fully tested`.

### `.revealui/skills/revealui-architecture-guide/SKILL.md`
Replace four instances of `- **Status**: Production ready` (on `@revealui/db`, `@revealui/auth`, `@revealui/security`, `@revealui/config`) with `- **Status**: Stable`. Yields a consistent status taxonomy across the file alongside the existing `Stable` / `Active development` / `Critical path, stable` vocabulary already used for other packages.

## Why

The CR9-P1-03 audit item identifies unsupported qualifiers as a drift vector: `Production-ready` is a claim the reader evaluates against their own bar, not a verifiable statement. The dropped lines either duplicated claims the document body already made stronger (AUTH.md), or stood alone as marketing copy with nothing behind them (`Implementation: Production-ready` in the AI cache docs, `Production Readiness: 8.5/10` in AUTH.md).

Each file's body already describes *what works* in specific terms. The headers now get out of the way of that evidence rather than layering a self-graded summary on top.

## Out of scope for this PR

- `docs/PRO.md:1324` and `packages/contracts/src/pricing.ts:307` — both describe service-offering deliverables (`"Production-ready deployment within 5 business days"` etc.) rather than code-state claims. Those are editorial decisions about marketing copy, separate from docs-audit discipline. Left for an owner pass.
- `apps/marketing/src/app/marketplace/page.tsx:201` — `Production Ready` UI label in the marketplace page. Marketing-copy decision, same category as above.
- `scripts/setup/seed.ts:168` — appears in admin seed content (user-visible). Marketing-copy decision.
- `packages/core/src/client/richtext/index.ts:50` — `// Main editor component - production ready` inline comment. Code-comment cleanup, different change class.
- `docs/CORE_STABILITY.md:34` — `"Stable — Production-ready"` is the *name* of a classification tier in that file's stability framework; changing it has ripple effects on every package currently mapped to that tier. Separate pass.
- `docs/CI_CD_GUIDE.md:1754` — describes Chainguard hardened images; third-party vendor claim, not ours.
- `packages/services/src/supabase/config.toml:117` — generic `"Use a production-ready SMTP server"` advice comment; third-party SMTP recommendation, not a self-claim.
- `scripts/validate/verify-claims.ts` — the claim-drift validator itself contains the pattern in its rule definitions by design.

## Verification

- `git diff --cached --stat`: 5 files, 4 insertions, 9 deletions
- `secrets:scan` clean
- No code path touched — no tests affected
- Pre-push gate passed (not triggered since docs-only, but lint-staged reported "no matching tasks")

## Related

- MASTER_PLAN §CR-9 CR9-P1-03
- Follow-on (separate PRs): marketing UI label, seed content, richtext code comment
