### PR TITLE
docs(cr9): qualify Stripe Billing Meters framing in 02-five-primitives blog draft

### DIFF
--- a/docs/blog-drafts/02-five-primitives.md
+++ b/docs/blog-drafts/02-five-primitives.md
@@ -249,7 +249,7 @@ This is used as middleware in the API. AI routes check `requireFeature('ai')`. M
 RevealUI supports three billing models simultaneously:
 
 1. **Subscriptions** -- Monthly recurring charges via Stripe. Standard for SaaS.
-2. **Agent credits** -- Usage-based metering for AI tasks. Pro tier gets 10,000 tasks/month, Max gets 50,000, Forge is unlimited. Overage is reported to Stripe Billing Meters.
+2. **Agent credits** -- Task quotas enforced per tier. Pro gets 10,000 tasks/month, Max gets 50,000, Forge is unlimited. Overage is tracked in the `agent_task_usage` table today; Stripe Billing Meters emission for cross-cycle overage invoicing is on the roadmap.
 3. **Perpetual licenses** -- One-time purchase, own forever, with an optional annual support renewal. The license JWT has no expiration, and the system tracks `supportExpiresAt` separately from the license validity.
 
 ### License verification API
@@ -465,11 +465,11 @@ AI is not free. RevealUI tracks task usage per billing cycle:
 | Max | 50,000 tasks |
 | Forge      | Unlimited |
 
-Overage beyond the quota is tracked in the `agent_task_usage` table and reported to Stripe Billing Meters at the end of each cycle via a cron job. This enables usage-based pricing without blocking execution in real-time.
+Overage beyond the quota is tracked in the `agent_task_usage` table. Stripe Billing Meters emission — the end-of-cycle cron that would post accrued overage to `stripe.billing.meterEvents.create` — is on the roadmap, not shipped. Once that lands, the quota-track-and-bill loop closes without blocking execution in real-time. Until then, usage accrues in the DB without cross-cycle invoicing.
 
 ### How Intelligence connects to everything else
 
-AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered as a Product (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
+AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered as a Product (task quotas per tier). Overage-billing emission through Payments (Stripe Billing Meters) is on the roadmap; usage is already tracked in `agent_task_usage` today. The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
 
 ---
 


### PR DESCRIPTION
## Summary

Qualify three passages in `docs/blog-drafts/02-five-primitives.md` that framed Stripe Billing Meters overage-billing as if the full quota-track-and-bill loop was already shipping. Reality: task-quota enforcement and `agent_task_usage` DB tracking are live; the end-of-cycle cron that emits meter events (`stripe.billing.meterEvents.create`) is still a TODO in `apps/api/src/routes/billing.ts:1849-1850`.

## Background

`CR8-P0-02` (the "Track B meter-billing honesty gate") was closed on 2026-04-18 via revealui#398 — that PR stripped the aspirational meter-billing copy from the marketing surfaces that CR8 targeted. The five-primitives blog draft was **not** in that sweep because it lives under `docs/blog-drafts/` (drafted, not yet published). `CR9-P1-02` catches it in the pre-publication doc-audit pass.

## Changes (one file, three passages)

### Line 252 — "Three pricing tracks" bullet

```diff
-2. **Agent credits** -- Usage-based metering for AI tasks. Pro tier gets 10,000 tasks/month, Max gets 50,000, Forge is unlimited. Overage is reported to Stripe Billing Meters.
+2. **Agent credits** -- Task quotas enforced per tier. Pro gets 10,000 tasks/month, Max gets 50,000, Forge is unlimited. Overage is tracked in the `agent_task_usage` table today; Stripe Billing Meters emission for cross-cycle overage invoicing is on the roadmap.
```

Kept the quota numbers (10k/50k/unlimited) since those are actually enforced by `apps/api/src/middleware/task-quota.ts`.

### Line 468 — "How Intelligence connects to everything else" quota overage

```diff
-Overage beyond the quota is tracked in the `agent_task_usage` table and reported to Stripe Billing Meters at the end of each cycle via a cron job. This enables usage-based pricing without blocking execution in real-time.
+Overage beyond the quota is tracked in the `agent_task_usage` table. Stripe Billing Meters emission — the end-of-cycle cron that would post accrued overage to `stripe.billing.meterEvents.create` — is on the roadmap, not shipped. Once that lands, the quota-track-and-bill loop closes without blocking execution in real-time. Until then, usage accrues in the DB without cross-cycle invoicing.
```

### Line 472 — "How Intelligence connects to everything else" wrap-up

```diff
-AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered as a Product (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
+AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered as a Product (task quotas per tier). Overage-billing emission through Payments (Stripe Billing Meters) is on the roadmap; usage is already tracked in `agent_task_usage` today. The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
```

## Verification

- `git diff --cached --stat`: 1 file, 3 insertions, 3 deletions
- `secrets:scan` clean
- No code touched — pure draft editing; no tests, build, or CI impact

## Related

- MASTER_PLAN §CR-9 CR9-P1-02
- Complements revealui#398 (closed CR8-P0-02 for marketing surfaces); this covers the blog-drafts corner that wasn't in that PR's scope
