### PR TITLE
chore(cr9): drop "Production-ready" qualifiers from three non-docs sites

### DIFF
--- a/apps/marketing/src/app/marketplace/page.tsx
+++ b/apps/marketing/src/app/marketplace/page.tsx
@@ -211,14 +211,14 @@ export default function MarketplacePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-12">
             <span className="text-sm font-semibold tracking-wide text-violet-600 uppercase">
-              Production Ready
+              Open Source
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
               13 MCP Servers
             </h2>
             <p className="mt-4 text-lg text-gray-600">
-              Production MCP servers included with RevealUI. Each server is rate-limited, audited,
-              and governed by RBAC.
+              MCP servers included with RevealUI. Each server is rate-limited, audited, and governed
+              by RBAC.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/packages/core/src/client/richtext/index.ts
+++ b/packages/core/src/client/richtext/index.ts
@@ -47,7 +47,6 @@ export type { ToolbarPluginProps } from './plugins/ToolbarPlugin.js';
 // Toolbar plugins
 export { ToolbarPlugin } from './plugins/ToolbarPlugin.js';
 export type { RichTextEditorProps } from './RichTextEditor.js';
-// Main editor component - production ready
 export { RichTextEditor, richTextEditorStyles } from './RichTextEditor.js';
 
 // Feature client components (implementations coming in Phase 2)

--- a/scripts/setup/seed.ts
+++ b/scripts/setup/seed.ts
@@ -165,7 +165,7 @@ const sampleContent = {
     {
       name: 'Five Primitives, One Stack',
       description:
-        'Users. Content. Products. Payments. Intelligence. Every business application needs these five primitives. RevealUI pre-wires them into a single deployable stack  -  authenticated, tested, and production-ready from day one.',
+        'Users. Content. Products. Payments. Intelligence. Every business application needs these five primitives. RevealUI pre-wires them into a single deployable stack  -  authenticated, tested, and wired together from day one.',
     },
   ],
   cards: [


### PR DESCRIPTION
## Summary

Follow-on to [#436](https://github.com/RevealUIStudio/revealui/pull/436) which covered the docs-side sweep for unsupported "Production-ready" qualifiers. That PR explicitly deferred three non-docs sites as follow-ups — this PR lands them.

Each is a different change class (marketing UI label, admin seed content, internal code comment), bundled here because the fix pattern is uniform and the whole change is ~3 lines of real delta.

## Files touched (3)

### `apps/marketing/src/app/marketplace/page.tsx` — section label

The eyebrow `Production Ready` over the *13 MCP Servers* heading read as a blanket readiness claim spanning all 13 servers. Per `docs/PRO.md` the individual server statuses are mixed — some `✅ Working`, others `⚠️ Requires API key setup` or `Requires credentials setup`.

```diff
-              Production Ready
+              Open Source
```

Also dropped the word *Production* from the paragraph opening ("Production MCP servers included with RevealUI" → "MCP servers included with RevealUI"). The rest of the paragraph ("rate-limited, audited, and governed by RBAC") describes what is actually implemented and stays untouched.

### `scripts/setup/seed.ts` — admin seed content

Seed data that populates example posts in a freshly seeded RevealUI install. The "Five Primitives, One Stack" example description claimed `"authenticated, tested, and production-ready from day one"`.

```diff
-RevealUI pre-wires them into a single deployable stack  -  authenticated, tested, and production-ready from day one.
+RevealUI pre-wires them into a single deployable stack  -  authenticated, tested, and wired together from day one.
```

Preserves the pre-integrated-stack framing (which is the product's actual positioning) and drops the readiness claim. `authenticated` and `tested` are both defensible.

### `packages/core/src/client/richtext/index.ts` — code comment

Internal code comment `// Main editor component - production ready` was a bare assertion with no supporting context in the file. Added no information the symbol name `RichTextEditor` did not already communicate.

```diff
-// Main editor component - production ready
 export { RichTextEditor, richTextEditorStyles } from './RichTextEditor.js';
```

Dropped entirely rather than qualified — nothing in the comment was worth preserving.

## Verification

- `git diff --cached --stat`: 3 files, 4 insertions, 5 deletions
- `secrets:scan` clean
- Biome format + code-standards check: ✅ passed (3 staged `.ts`/`.tsx` files processed)
- No logic touched — pure text edits

## Closes

With this PR merged, every `Production-ready` / `Production Ready` self-claim surfaced by the CR9-P1-03 audit grep is either shipped honestly (via [#436](https://github.com/RevealUIStudio/revealui/pull/436) + this PR) or deliberately left in place with an explicit reason — service-offering prose in `docs/PRO.md` + `packages/contracts/src/pricing.ts` (editorial decision on marketing copy, separate track), `docs/CORE_STABILITY.md` (classification-tier name that ripples across every tier assignment, separate pass), and third-party references (`docs/CI_CD_GUIDE.md` Chainguard blurb, `packages/services/src/supabase/config.toml` generic SMTP advice, `scripts/validate/verify-claims.ts` which detects the pattern by design).

Closes the agent side of **CR9-P1-03** in MASTER_PLAN.
