### PR TITLE
docs(cr9): replace drifting test-count claims with grep-reproducible language

### DIFF
--- a/apps/admin/src/seed.ts
+++ b/apps/admin/src/seed.ts
@@ -210,7 +210,7 @@ const sampleContent = {
       title: 'LAUNCH',
       name: 'RevealUI is Open Source',
       description:
-        'The core runtime is MIT-licensed and available on npm. 21 packages, 20,000+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
+        'The core runtime is MIT-licensed and available on npm. Built with TypeScript strict mode, extensive test coverage, and zero avoidable type errors. Run npx create-revealui to start building.',
       alt: 'RevealUI open source launch',
     },
     {

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -237,7 +237,7 @@ I want to be honest about where RevealUI is and isn't the right choice.
 
 **It's opinionated.** That's the **Justifiable** principle  -  every choice has a reason you can explain in one sentence. React 19, Next.js 16, Hono, Drizzle ORM, NeonDB, Tailwind v4. If you need Vue or Svelte on the frontend, RevealUI isn't for you today. The API layer (Hono) is framework-agnostic and serves standard REST, so you could consume it from any frontend  -  but the admin dashboard and admin are React. The point isn't that these are the *right* choices for every team  -  it's that they're a coherent set of choices that work well together. If you're not sure what to pick, this is a slam dunk starting point. When your needs outgrow a specific tool, swap it  -  the **Orthogonal** architecture means nothing is welded shut.
 
-**It's early.** This is a v0 launch. The core is stable (5,500+ tests, full TypeScript strict mode, comprehensive security hardening), but the ecosystem is young. There's no plugin marketplace yet. The template library is small. The community is just getting started.
+**It's early.** This is a v0 launch. The core is stable (extensive test coverage, full TypeScript strict mode, comprehensive security hardening — run `pnpm test` for the current count), but the ecosystem is young. There's no plugin marketplace yet. The template library is small. The community is just getting started.
 
 **It's a solo project.** I'm one developer at RevealUI Studio. The upside is that decisions are fast and the vision is coherent. The downside is that there's one person triaging issues and reviewing PRs. I'm building in public precisely because I need the community to grow with the project.
 

--- a/scripts/setup/seed.ts
+++ b/scripts/setup/seed.ts
@@ -203,7 +203,7 @@ const sampleContent = {
       title: 'LAUNCH',
       name: 'RevealUI is Open Source',
       description:
-        'The core runtime is MIT-licensed and available on npm. 25 packages, 20,000+ tests, zero avoidable type errors. Run npx create-revealui to start building.',
+        'The core runtime is MIT-licensed and available on npm. Built with TypeScript strict mode, extensive test coverage, and zero avoidable type errors. Run npx create-revealui to start building.',
       alt: 'RevealUI open source launch',
     },
     {


### PR DESCRIPTION
## Summary

Three public-facing surfaces cited three different specific test counts, all drifting against each other and against the actual test suite size:

| Surface | Claim |
|---|---|
| [`docs/blog/01-why-we-built-revealui.md:240`](docs/blog/01-why-we-built-revealui.md#L240) | **5,500+ tests** |
| [`scripts/setup/seed.ts:206`](scripts/setup/seed.ts#L206) | **25 packages, 20,000+ tests** |
| [`apps/admin/src/seed.ts:213`](apps/admin/src/seed.ts#L213) | **21 packages, 20,000+ tests** |

`CLAUDE.md` already softened its own claim to "Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)" per the precedent set in the 2026-04-18 audit pass. This PR applies the same pattern to the remaining three surfaces.

## Changes

### `docs/blog/01-why-we-built-revealui.md` (line 240)

```diff
-**It's early.** This is a v0 launch. The core is stable (5,500+ tests, full TypeScript strict mode, comprehensive security hardening), but the ecosystem is young.
+**It's early.** This is a v0 launch. The core is stable (extensive test coverage, full TypeScript strict mode, comprehensive security hardening — run `pnpm test` for the current count), but the ecosystem is young.
```

The "core is stable" framing and the companion claims (TypeScript strict mode, security hardening) stay. Only the drifting number is replaced with soft language + a reproducible pointer.

### `scripts/setup/seed.ts` + `apps/admin/src/seed.ts` (LAUNCH event seed content)

Both seed files contain the same LAUNCH event with slightly different package counts (25 vs 21). Both get the same replacement:

```diff
-The core runtime is MIT-licensed and available on npm. 25 packages, 20,000+ tests, zero avoidable type errors. Run npx create-revealui to start building.
+The core runtime is MIT-licensed and available on npm. Built with TypeScript strict mode, extensive test coverage, and zero avoidable type errors. Run npx create-revealui to start building.
```

The three-claim rhythm of the sentence is preserved — TypeScript strict mode, extensive tests, zero avoidable type errors. The specific (and drifting) numbers are removed. A side-effect: the 21-vs-25 package-count drift between the two seed files collapses, which is a small relief for CR9-P1-06.

## Deliberately left in place

- `docs/system-tune/CRASH-POSTMORTEMS.md:12` — *"862 test files"* is a specific factual incident report from a vitest OOM crash, not a general marketing claim.
- `docs/security/CHANGE_MANAGEMENT_POLICY.md:68` and `docs/security/SECURITY_TRAINING.md:124` — *"58 tests"* for RBAC enforcement is scoped to a specific testable surface (`packages/core/src/auth/access.ts`) and serves as audit evidence for role isolation.
- `docs/DOCUMENTATION_ASSESSMENT.md` — per-package test counts (*"196 tests"* for harnesses, *"354 tests"* for services) inside an internal audit document whose purpose is to log those measurements.

## Verification

- `git diff --cached --stat`: 3 files, 3 insertions, 3 deletions
- `secrets:scan` clean
- Biome format + code-standards check: ✅ passed
- No behavior change

## Related

- MASTER_PLAN §CR-9 CR9-P1-01
- Follows the pattern established in `revealui/CLAUDE.md` (soft language + grep-reproducible pointer)
