### PR TITLE
docs(mcp): correct MCP server count drift to ground-truth 13

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@ Centralized MCP server infrastructure, configuration, and documentation for Reve
 
 This package contains everything MCP-related:
 
-- **10 MCP Servers** - Code validator, Vercel, Stripe, Neon, Supabase, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Stripe
+- **13 MCP Servers** — Code Validator, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, Vultr Test, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
 - **Configuration Templates** - For Claude Code / Claude Desktop
 - **Utilities** - Config management, database adapters
 - **Documentation** - Complete guides and per-server docs
@@ -55,14 +55,9 @@ tsx packages/mcp/src/servers/code-validator.ts
 ```
 packages/mcp/
 ├── src/
-│   ├── servers/          # 7 MCP server implementations
+│   ├── servers/          # MCP server implementations (run `ls packages/mcp/src/servers/` for the current list)
 │   │   ├── code-validator.ts   ← AI code standards enforcer
-│   │   ├── vercel.ts
-│   │   ├── stripe.ts
-│   │   ├── neon.ts
-│   │   ├── supabase.ts
-│   │   ├── playwright.ts
-│   │   └── next-devtools.ts
+│   │   └── …                   ← Neon, Next.js DevTools, Playwright, RevealUI-*, Stripe, Supabase, Vercel, Vultr Test
 │   ├── config/           # Configuration utilities
 │   │   ├── index.ts
 │   │   ├── config.json

--- a/packages/mcp/docs/README.md
+++ b/packages/mcp/docs/README.md
@@ -21,15 +21,21 @@ Complete guide for setting up and using Model Context Protocol (MCP) servers in 
 
 ## Overview
 
-RevealUI includes 7 MCP servers for enhanced AI capabilities:
+RevealUI includes 13 MCP servers for enhanced AI capabilities (ground-truth count enforced by `pnpm validate:claims`):
 
-- **Code Validator MCP** - Static analysis and code quality checks
-- **Vercel MCP** - Deploy and manage Vercel projects
-- **Stripe MCP** - Payment processing and billing operations
-- **NeonDB MCP** - Database operations and SQL queries
-- **Supabase MCP** - Supabase project management and CRUD operations
-- **Playwright MCP** - Browser automation and web scraping
-- **Next.js DevTools MCP** - Next.js 16+ runtime diagnostics and automation
+- **Code Validator MCP** — Static analysis and code quality checks
+- **Neon MCP** — NeonDB database operations and SQL queries
+- **Next.js DevTools MCP** — Next.js 16+ runtime diagnostics and automation
+- **Playwright MCP** — Browser automation and web scraping
+- **RevealUI Content MCP** — Content collection CRUD through RevealUI's own API
+- **RevealUI Email MCP** — Transactional email send + template management
+- **RevealUI Memory MCP** — Agent memory store reads/writes
+- **RevealUI Stripe MCP** — RevealUI-specific Stripe ops (billing portal, webhooks, tier enforcement)
+- **Stripe MCP** — Generic Stripe payment / subscription / invoice ops
+- **Supabase MCP** — Supabase project management + CRUD operations
+- **Vercel MCP** — Vercel deploy, env var, log inspection
+- **Vultr Test MCP** — Vultr GPU inference test harness
+- **Email Provider** — shared helper surface for other email-capable servers
 
 All servers are **free** and run locally as npm packages.
 


### PR DESCRIPTION
## Summary

Fix the sharpest instance of the MCP-server count drift called out in CR9-P1-06: the `@revealui/mcp` package's two own READMEs were advertising **10** and **7** servers when the ground truth is **13** (enforced by `pnpm validate:claims`).

## The drift

Ran `pnpm validate:claims` — actual metrics from `scripts/validate/claim-drift.ts`:

```
Packages:      25
Apps:          5
Workspaces:    30 (25 + 5)
Test files:    887
UI components: 57
MCP servers:   13
```

Meanwhile the mcp package was saying:

| Location | Claim |
|---|---|
| [`packages/mcp/README.md:14`](packages/mcp/README.md#L14) | `10 MCP Servers` (+ listed 10 by name) |
| [`packages/mcp/README.md:58`](packages/mcp/README.md#L58) | `7 MCP server implementations` (ASCII tree) |
| [`packages/mcp/docs/README.md:24`](packages/mcp/docs/README.md#L24) | `7 MCP servers` (+ listed 7) |

Root `README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/PRO.md:101`, and all blog drafts already say 13. The mcp package's own docs were the outlier.

## Changes (2 files)

### `packages/mcp/README.md`
- Bullet at line 14 rewritten to name all 13 servers (Code Validator, Neon, Next.js DevTools, Playwright, RevealUI Content/Email/Memory/Stripe, Stripe, Supabase, Vercel, Vultr Test, Email Provider helper) plus a pointer to `pnpm validate:claims` as the enforced source of truth.
- ASCII tree at line 58: replaced the "7 implementations" literal enumeration (which was stale — missed six servers added later) with a pointer to `ls packages/mcp/src/servers/` for the current list, keeping `code-validator.ts` as the illustrative example so the diagram still conveys the folder layout.

### `packages/mcp/docs/README.md`
- 7-server bullet list at line 24 replaced with the full 13, each with a one-line description. Kept the closing `All servers are **free** and run locally as npm packages.` line.

## Out of scope

CR9-P1-06 also flagged table-count drift (82 vs 81) and package-count drift. This PR intentionally scopes to MCP-server count only because:

- The mcp package's own READMEs were the clearest and most contradictory cases (10 vs 7 vs 13 within the same package).
- Tables drift (82 vs 81) touches ~16 surfaces and wants schema-file counting before picking a number — separate pass.
- Marketing page (`apps/marketing/src/app/marketplace/page.tsx`) says 13 in its heading but its `mcpServers` array has 11 entries *and* includes an "Auth" entry that is not an actual server — that's a content issue, not just a count issue, and deserves its own PR.
- Wiring `packages/mcp/README.md` and `packages/mcp/docs/README.md` into the `claim-drift.ts` validator's scanned-files set is the proper long-term fix — separate follow-up (tracked in MASTER_PLAN update).

## Verification

- `git diff --cached --stat`: 2 files, 18 insertions, 17 deletions
- `secrets:scan` clean
- No code path touched; docs-only
- `pnpm validate:claims` still passes (these files weren't in its scanned set — which is exactly why the drift persisted)

## Related

- MASTER_PLAN §CR-9 CR9-P1-06
- `AGENTS.md:32` already references `pnpm validate:claims` as the enforced ground truth for this count; these READMEs now match that reference
