### PR TITLE
docs(cr9): add CONTRIBUTING convention for future-tense claims

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,30 @@ docs: update QUICK_START guide
 - Update relevant guides in `/docs`
 - Include code examples for new features
 
+#### Future-tense claims
+
+Every future-tense claim in docs — "coming soon", "(planned)", "will ship", "roadmap", "TBD" — **must cite a GitHub issue or milestone** so a reader can track the actual delivery state. The rule applies to prose, table cells, tier descriptions, blog drafts, feature comparisons, and README status lines alike.
+
+Acceptable forms:
+
+```markdown
+- **Multi-tenant SSO** (planned — [#123](https://github.com/RevealUIStudio/revealui/issues/123))
+- **Forge self-hosted artifact** (roadmap — tracked in [milestone: Forge v1](https://github.com/RevealUIStudio/revealui/milestones))
+- Studio binary release (CI in progress — see `studio-release.yml`)
+```
+
+Not acceptable:
+
+```markdown
+- **Multi-tenant SSO** (coming soon)          ← no issue link, no date
+- Forge self-hosted artifact (planned)         ← no tracking reference
+- Studio binary release (TBD)                  ← same
+```
+
+Why: every unlinked "coming soon" either ages into a broken promise or becomes load-bearing for a reader making a purchase / adoption decision. The pattern already hit us once — see MASTER_PLAN §CR-8 and §CR-9 for the audit that surfaced it. If the feature is real, it has a tracked issue; if it doesn't, it shouldn't be surfaced as "coming soon" in the first place.
+
+File a GitHub issue before writing the claim. Link it in the prose. If the feature is abandoned later, close the issue and remove the claim in the same PR.
+
 ### Script Standards
 
 When creating or modifying packages:

--- a/apps/marketing/src/app/marketplace/page.tsx
+++ b/apps/marketing/src/app/marketplace/page.tsx
@@ -87,9 +87,22 @@ const mcpServers: McpServer[] = [
     status: 'live',
   },
   {
-    name: 'Auth',
-    description: 'Manage users, sessions, roles, and permissions programmatically.',
-    category: 'Security',
+    name: 'RevealUI Memory',
+    description:
+      'Read and write the agent memory store (episodic, semantic, and procedural layers).',
+    category: 'Content',
+    status: 'live',
+  },
+  {
+    name: 'Vultr Test',
+    description: 'Vultr GPU inference test harness for validating open-model endpoints.',
+    category: 'AI',
+    status: 'live',
+  },
+  {
+    name: 'Email Provider',
+    description: 'Shared helper surface powering the other email-capable MCP servers.',
+    category: 'Communication',
     status: 'live',
   },
 ];
@@ -102,7 +115,7 @@ const categoryColors: Record<string, string> = {
   Development: 'bg-indigo-100 text-indigo-700',
   Content: 'bg-pink-100 text-pink-700',
   Communication: 'bg-orange-100 text-orange-700',
-  Security: 'bg-red-100 text-red-700',
+  AI: 'bg-violet-100 text-violet-700',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Primary deliverable for **CR9-P1-05**: add a `CONTRIBUTING.md` convention requiring every future-tense claim in docs (`coming soon`, `(planned)`, `will ship`, `roadmap`, `TBD`) to cite a GitHub issue or milestone so the delivery state is always trackable.

## Why

Unlinked aspirational markers are the cleanest path to one of two bad outcomes:

1. **Docs age into broken promises** — "coming soon" written 18 months ago still sits in a README nobody revisited.
2. **A reader treats them as load-bearing** for a purchase / adoption decision with no way to check when (or whether) the feature actually ships.

The project already hit this pattern — see the MASTER_PLAN §CR-8 (Track B meter-billing marketing copy had to be stripped) and §CR-9 (the whole audit track exists because unlinked claims drifted against reality). A repeat is mechanically preventable: require a tracked issue before the claim is written.

## Changes (1 file)

Added a `#### Future-tense claims` subsection under the existing `### Documentation` section in `CONTRIBUTING.md`. The new section gives:

- **Acceptable forms** — three worked examples:
  - `**Multi-tenant SSO** (planned — [#123](...))`
  - `**Forge self-hosted artifact** (roadmap — tracked in [milestone: Forge v1](...))`
  - `Studio binary release (CI in progress — see `studio-release.yml`)`
- **Not acceptable** — same kinds of claims *without* links, for side-by-side visual contrast.
- **Why it matters** — one paragraph naming the failure mode and pointing at the CR-8 / CR-9 precedent.
- **Workflow** — file the issue before writing the claim; if the feature is abandoned, close the issue and remove the claim in the same PR.

## What this PR does NOT do

- Does not re-audit the ~27 existing doc surfaces that already contain unlinked markers. Those are tracked as **CR9-P1-05 follow-up** — each surface gets its own cheap-to-review PR.
- Does not wire the convention into claim-drift validator or the PR template. That's **CR9-P2-02** enforcement work, separate track.

## Verification

- `git diff --cached --stat`: 1 file, 24 insertions, 0 deletions.
- `secrets:scan` clean.
- No code touched — pure documentation.

## Related

- MASTER_PLAN §CR-9 CR9-P1-05 (primary deliverable)
- CR9-P2-02 (enforcement follow-up, separate PR)
- §CR-8 CR8-P0-02 (the meter-billing marketing-copy strip — the pattern this convention is designed to prevent)
