### PR TITLE
feat(validate): raw-SQL linter — block non-Drizzle DB access (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Migration journal validation (hard fail)
         run: pnpm validate:migrations
 
+      - name: Raw-SQL validation (hard fail)
+        run: pnpm validate:raw-sql
+
   # ---------------------------------------------------------------------------
   # Phase 1.5: Drizzle migration apply (all branches)
   #

--- a/package.json
+++ b/package.json
@@ -197,7 +197,8 @@
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
-    "validate:migrations": "tsx scripts/validate/migration-journal.ts"
+    "validate:migrations": "tsx scripts/validate/migration-journal.ts",
+    "validate:raw-sql": "tsx scripts/validate/raw-sql.ts"
   },
   "type": "module"
 }

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -299,6 +299,11 @@ async function gate(): Promise<void> {
         args: ['validate:migrations'],
       },
       {
+        name: 'Raw-SQL (hard fail)',
+        command: 'pnpm',
+        args: ['validate:raw-sql'],
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -1,0 +1,120 @@
+{
+  "$comment": "Phase 2 raw-SQL linter allowlist. See .jv/docs/raw-sql-migration-plan.md. File-scoped exemptions for pre-existing raw-SQL sites. New raw SQL must either (a) be added here with a reason and migrationPhase, or (b) carry an inline `// drizzle-raw: <reason>` comment on the same line.",
+  "version": 1,
+  "entries": [
+    {
+      "path": "packages/mcp/migrations/backfill_crdt_meta.js",
+      "rules": ["direct-import"],
+      "reason": "MCP parallel migration runner. Uses pg.Pool directly to backfill CRDT metadata columns. Slated for consolidation into the main drizzle-kit pipeline.",
+      "migrationPhase": 3
+    },
+    {
+      "path": "packages/scripts/database/connection.ts",
+      "rules": ["direct-import"],
+      "reason": "Type-only import of Pool/PoolClient from pg for the @revealui/scripts DB-connection factory. Scripts package is tooling and needs pg's type shape; routing through @revealui/db would invert the dependency.",
+      "migrationPhase": null
+    },
+    {
+      "path": "packages/scripts/database/transaction-manager.ts",
+      "rules": ["direct-import"],
+      "reason": "Type-only import of pg Client/Pool for the @revealui/scripts transaction helper. Same rationale as connection.ts — scripts package owns its own DB helpers.",
+      "migrationPhase": null
+    },
+    {
+      "path": "scripts/commands/database/check-unreconciled.ts",
+      "rules": ["direct-import"],
+      "reason": "Standalone diagnostic CLI for payment-reconciliation monitoring. Runs in GitHub Actions, uses pg Client directly against DATABASE_URL to keep the script dependency-minimal.",
+      "migrationPhase": null
+    },
+    {
+      "path": "scripts/db/precheck-migration-0001.ts",
+      "rules": ["direct-import"],
+      "reason": "Pre-migration check script — intentionally uses pg directly to verify constraints before drizzle-kit applies migration 0001. Cannot depend on @revealui/db being in a valid state.",
+      "migrationPhase": null
+    },
+    {
+      "path": "scripts/seed-admin.mjs",
+      "rules": ["direct-import"],
+      "reason": "Admin-user seed script. .mjs standalone runner that predates @revealui/db. Works outside the pnpm workspace context. Could be migrated to TS + @revealui/db but low ROI.",
+      "migrationPhase": 6
+    },
+    {
+      "path": "apps/admin/src/app/api/auth/passkey/register-verify/route.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "pg_advisory_xact_lock for user-limit race-free check inside db.transaction. Postgres system function; no Drizzle query-builder helper exists. Permanent escape hatch.",
+      "migrationPhase": null
+    },
+    {
+      "path": "apps/admin/src/app/api/auth/sign-up/route.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "pg_advisory_xact_lock for user-limit race-free check inside db.transaction. Same pattern as passkey/register-verify. Postgres system function, permanent escape hatch.",
+      "migrationPhase": null
+    },
+    {
+      "path": "apps/admin/src/lib/api/txid.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "SELECT pg_current_xact_id()::xid::text — Postgres transaction-ID helper used to match logical-replication streams against ElectricSQL client updates. Postgres system function, no Drizzle helper.",
+      "migrationPhase": null
+    },
+    {
+      "path": "apps/api/src/index.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "db.execute(sql`SELECT 1`) liveness probe. Trivially migratable to db.select().from(someTable).limit(1) but a SELECT 1 is clearer intent for a liveness check.",
+      "migrationPhase": 6
+    },
+    {
+      "path": "apps/api/src/routes/health.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "db.execute(sql`SELECT 1`) liveness probe (route variant). Same rationale as apps/api/src/index.ts.",
+      "migrationPhase": 6
+    },
+    {
+      "path": "packages/ai/src/memory/utils/sql-helpers.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "4 plain parameterized SELECTs with manual snake_case → camelCase transformation. Trivially migratable to typed Drizzle query builder.",
+      "migrationPhase": 6
+    },
+    {
+      "path": "scripts/dev-tools/verify-test-setup.ts",
+      "rules": ["execute-sql-literal"],
+      "reason": "Dev-tool diagnostic that verifies test-harness DB state with multiple SELECTs. Runs outside production; migration to query builder is low-value (schema introspection queries).",
+      "migrationPhase": 6
+    },
+    {
+      "path": "packages/db/src/migrations/audit-log-revoke.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "Hand-applied DDL patch for audit-log access control. Will be imported into drizzle-kit migrations or documented as explicit pre-drizzle bootstrap.",
+      "migrationPhase": 4
+    },
+    {
+      "path": "packages/db/src/migrations/supabase-vector-setup.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "Supabase-specific vector extension setup (applied once to the Supabase-side DB). Will be imported into drizzle-kit migrations or documented as explicit pre-drizzle bootstrap for the dual-DB architecture.",
+      "migrationPhase": 4
+    },
+    {
+      "path": "packages/db/src/orm/drizzle/0000_grey_malcolm_colcord.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "Orphan from previous drizzle-kit tooling layout. Candidate for deletion or archival in Phase 4.",
+      "migrationPhase": 4
+    },
+    {
+      "path": "packages/sync/setup-sync-schema.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "ElectricSQL sync-schema definition consumed by Electric tooling, not drizzle-kit. Standalone by design — Electric owns this schema lifecycle.",
+      "migrationPhase": null
+    },
+    {
+      "path": "scripts/db/fix-audit-log-severity.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "Ad-hoc data-correction script for audit-log severity backfill. Candidate for either deletion (if already applied) or promotion to drizzle-kit migration in Phase 4.",
+      "migrationPhase": 4
+    },
+    {
+      "path": "scripts/setup-sync-schema.sql",
+      "rules": ["sql-file-outside-migrations"],
+      "reason": "Duplicate of packages/sync/setup-sync-schema.sql at the scripts/ level. Likely orphaned — target for deletion in Phase 4.",
+      "migrationPhase": 4
+    }
+  ]
+}

--- a/scripts/validate/raw-sql.ts
+++ b/scripts/validate/raw-sql.ts
@@ -1,0 +1,494 @@
+#!/usr/bin/env tsx
+
+/**
+ * Raw-SQL Validator — Phase 2 of the raw-SQL migration plan.
+ *
+ * Blocks new raw-SQL usage across the codebase. Every pre-existing
+ * violation is enumerated in raw-sql-allowlist.json with a reason and
+ * (optionally) a migrationPhase tag pointing to the future phase that
+ * will remove the exemption.
+ *
+ * See .jv/docs/raw-sql-migration-plan.md for the full plan.
+ *
+ * Rules (HARD BLOCK unless allowlisted or suppressed):
+ *
+ *   direct-import
+ *     Import of pg / postgres / @neondatabase/serverless from
+ *     anywhere outside packages/db/src/client/. All DB connections
+ *     must route through the canonical Drizzle client.
+ *
+ *   rpc-call
+ *     Any .rpc( call. Recon 2026-04-20 found zero runtime consumers.
+ *     Production vector search uses Drizzle query builder with
+ *     sql`` fragments for the pgvector <-> operator, not .rpc().
+ *     Excluded dirs: packages/harnesses (string-content definitions),
+ *     __tests__.
+ *
+ *   execute-sql-literal
+ *     db.execute(sql`...`) where the template is a full
+ *     SELECT/UPDATE/DELETE/INSERT/CREATE/DROP/ALTER/TRUNCATE
+ *     statement. Excluded paths: tests, migration runners, setup
+ *     scripts. Bare `sql`` fragments inside query-builder calls
+ *     (.select, .where, .orderBy, etc.) are the idiomatic way to
+ *     use pgvector operators and are never flagged — this rule
+ *     only fires on .execute() with a literal DDL/DML payload.
+ *
+ *   sql-file-outside-migrations
+ *     Any .sql file not under packages/db/migrations/. Catches
+ *     hand-applied migrations that bypass drizzle-kit.
+ *
+ * Suppression: add `// drizzle-raw: <reason>` on the same line OR
+ * the line immediately preceding the banned pattern. Reason is
+ * required — empty reasons do not suppress.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+
+const ALLOWLIST_PATH = join(REPO_ROOT, 'scripts/validate/raw-sql-allowlist.json');
+
+// Directories scanned for source-code violations
+const SCAN_ROOTS = ['apps', 'packages', 'scripts'];
+
+// Source file extensions considered source code
+const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+
+// Directories skipped entirely during scan
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  'opensrc',
+]);
+
+// Rule: direct-import. The @revealui/db package is the canonical Drizzle
+// client provider; imports within it are legitimate. Outside code must
+// route through @revealui/db rather than pulling pg directly.
+const DIRECT_IMPORT_ALLOWED_PREFIXES = ['packages/db/src/'];
+const DIRECT_IMPORT_EXCLUDED_PATH_SEGMENTS = [
+  '__tests__/',
+  '__mocks__/',
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.integration.test.ts',
+  '.integration.test.tsx',
+  '.e2e.ts',
+  '.e2e.tsx',
+  // Validators describe the banned patterns and must not self-flag.
+  'scripts/validate/',
+];
+
+const DIRECT_IMPORT_MODULES = ['pg', 'postgres', '@neondatabase/serverless'];
+
+// Rule: rpc-call. Paths here have been verified (2026-04-20) to contain
+// only string-embedded examples or test connectivity probes — never
+// runtime .rpc() usage.
+const RPC_EXCLUDED_PATH_SEGMENTS = [
+  'packages/harnesses/',
+  '__tests__/',
+  '__mocks__/',
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.integration.test.ts',
+  '.integration.test.tsx',
+  '.e2e.ts',
+  '.e2e.tsx',
+  // Validators describe the banned patterns and must not self-flag.
+  'scripts/validate/',
+];
+
+// Rule: execute-sql-literal. Legitimate hosts of .execute(sql`...`):
+//   - test harnesses (teardown, schema bootstrapping)
+//   - migration / setup scripts (DDL that drizzle-kit doesn't cover)
+const EXECUTE_SQL_LITERAL_EXCLUDED_PATH_SEGMENTS = [
+  '__tests__/',
+  '__mocks__/',
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.integration.test.ts',
+  '.integration.test.tsx',
+  '.e2e.ts',
+  '.e2e.tsx',
+  'scripts/setup/',
+  'scripts/db/',
+  'packages/db/src/scripts/',
+  'packages/test/src/',
+  'packages/db/__tests__/',
+  // Drizzle migration runner (official drizzle-orm pattern)
+  'packages/db/src/migrate',
+  // Validators describe the banned patterns and must not self-flag.
+  'scripts/validate/',
+];
+
+// Rule: sql-file-outside-migrations. drizzle-kit writes SQL under this dir.
+const SQL_MIGRATIONS_DIR = 'packages/db/migrations';
+
+// Paths where bare .sql files are explicitly allowed (e.g., test fixtures,
+// ElectricSQL sync schema applied outside drizzle-kit by design).
+const SQL_FILE_ALLOWED_PATH_SEGMENTS = [
+  '__tests__/',
+  'node_modules/',
+  'dist/',
+  '.turbo/',
+  'coverage/',
+  // MCP parallel migration runner — exempt until Phase 3 consolidates
+  // it into the main drizzle-kit pipeline. Tracked in raw-sql-migration-plan.md.
+  'packages/mcp/migrations/',
+];
+
+// Suppression comment — must carry a non-empty reason after the colon.
+const SUPPRESSION_PATTERN = /\/\/\s*drizzle-raw\s*:\s*\S/;
+
+// =============================================================================
+// Allowlist loading
+// =============================================================================
+
+type RuleId = 'direct-import' | 'rpc-call' | 'execute-sql-literal' | 'sql-file-outside-migrations';
+
+interface AllowlistEntry {
+  path: string;
+  rules: RuleId[];
+  reason: string;
+  migrationPhase?: number;
+}
+
+interface AllowlistFile {
+  version: number;
+  entries?: AllowlistEntry[];
+  [key: string]: unknown;
+}
+
+function loadAllowlist(): Map<string, Set<RuleId>> {
+  if (!existsSync(ALLOWLIST_PATH)) {
+    return new Map();
+  }
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as AllowlistFile;
+  const map = new Map<string, Set<RuleId>>();
+  for (const entry of raw.entries ?? []) {
+    if (!entry.reason?.trim()) {
+      throw new Error(
+        `raw-sql-allowlist.json: entry "${entry.path}" is missing a non-empty reason.`,
+      );
+    }
+    map.set(entry.path, new Set(entry.rules));
+  }
+  return map;
+}
+
+function isAllowlisted(
+  allowlist: Map<string, Set<RuleId>>,
+  relPath: string,
+  rule: RuleId,
+): boolean {
+  const normalized = relPath.split('\\').join('/');
+  return allowlist.get(normalized)?.has(rule) ?? false;
+}
+
+// =============================================================================
+// Suppression detection
+// =============================================================================
+
+/**
+ * Returns true if the given line (or the line immediately preceding it)
+ * carries a `// drizzle-raw: <reason>` comment with a non-empty reason.
+ */
+function isLineSuppressed(lines: string[], lineIdx: number): boolean {
+  const current = lines[lineIdx] ?? '';
+  if (SUPPRESSION_PATTERN.test(current)) return true;
+  const prev = lineIdx > 0 ? (lines[lineIdx - 1] ?? '') : '';
+  if (SUPPRESSION_PATTERN.test(prev)) return true;
+  return false;
+}
+
+// =============================================================================
+// File collection
+// =============================================================================
+
+interface FoundFile {
+  abs: string;
+  rel: string;
+  ext: string;
+}
+
+function collectFiles(dir: string, out: FoundFile[] = []): FoundFile[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectFiles(abs, out);
+      continue;
+    }
+    const ext = extname(entry.name);
+    out.push({ abs, rel: relative(REPO_ROOT, abs).split('\\').join('/'), ext });
+  }
+  return out;
+}
+
+function includesAnyPathSegment(path: string, segments: readonly string[]): boolean {
+  return segments.some((seg) => path.includes(seg));
+}
+
+// =============================================================================
+// Rule: direct-import
+// =============================================================================
+
+function checkDirectImport(
+  file: FoundFile,
+  content: string,
+  allowlist: Map<string, Set<RuleId>>,
+): string[] {
+  if (!SOURCE_EXTS.has(file.ext)) return [];
+  if (DIRECT_IMPORT_ALLOWED_PREFIXES.some((p) => file.rel.startsWith(p))) return [];
+  if (includesAnyPathSegment(file.rel, DIRECT_IMPORT_EXCLUDED_PATH_SEGMENTS)) return [];
+
+  const violations: string[] = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const trimmed = line.trimStart();
+    // Fast path — skip anything not starting with import/export/require/from
+    if (
+      !trimmed.startsWith('import') &&
+      !trimmed.startsWith('export') &&
+      !trimmed.includes('require(')
+    ) {
+      continue;
+    }
+    for (const mod of DIRECT_IMPORT_MODULES) {
+      // Only flag module specifiers in an import/require context — avoid
+      // false positives on string literals like `'postgres' | 'positional'`.
+      const specifiers = [
+        `from '${mod}'`,
+        `from "${mod}"`,
+        `from \`${mod}\``,
+        `from '${mod}/`,
+        `from "${mod}/`,
+        `require('${mod}')`,
+        `require("${mod}")`,
+        `require('${mod}/`,
+        `require("${mod}/`,
+      ];
+      if (specifiers.some((s) => line.includes(s))) {
+        if (isAllowlisted(allowlist, file.rel, 'direct-import')) return violations;
+        if (isLineSuppressed(lines, i)) continue;
+        violations.push(
+          `  ${file.rel}:${i + 1}  imports ${mod} outside @revealui/db (route via packages/db/src/)`,
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+// =============================================================================
+// Rule: rpc-call
+// =============================================================================
+
+const RPC_CALL_REGEX = /\.rpc\s*\(/;
+
+function checkRpcCall(
+  file: FoundFile,
+  content: string,
+  allowlist: Map<string, Set<RuleId>>,
+): string[] {
+  if (!SOURCE_EXTS.has(file.ext)) return [];
+  if (includesAnyPathSegment(file.rel, RPC_EXCLUDED_PATH_SEGMENTS)) return [];
+
+  const violations: string[] = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (!RPC_CALL_REGEX.test(line)) continue;
+    if (isAllowlisted(allowlist, file.rel, 'rpc-call')) return violations;
+    if (isLineSuppressed(lines, i)) continue;
+    violations.push(
+      `  ${file.rel}:${i + 1}  .rpc() call (use Drizzle query builder; see rag-vector-service.ts for pgvector pattern)`,
+    );
+  }
+
+  return violations;
+}
+
+// =============================================================================
+// Rule: execute-sql-literal
+// =============================================================================
+
+// Matches .execute(sql`<whitespace or newline>KEYWORD...` where KEYWORD is a
+// DDL/DML verb. Multiline-aware via `[\s\S]`. The specific keywords guard
+// against flagging short-form calls like .execute(sql`${fragment}`) that are
+// interpolation-only (those are typically query-builder composition, not
+// full statements).
+const EXECUTE_SQL_LITERAL_REGEX =
+  /\.execute\s*\(\s*sql\s*`\s*(?:--[^\n]*\n\s*)*(?:SELECT|UPDATE|DELETE|INSERT|CREATE|DROP|ALTER|TRUNCATE|GRANT|REVOKE|WITH|DO)\b/i;
+
+function checkExecuteSqlLiteral(
+  file: FoundFile,
+  content: string,
+  allowlist: Map<string, Set<RuleId>>,
+): string[] {
+  if (!SOURCE_EXTS.has(file.ext)) return [];
+  if (includesAnyPathSegment(file.rel, EXECUTE_SQL_LITERAL_EXCLUDED_PATH_SEGMENTS)) return [];
+
+  const violations: string[] = [];
+  const lines = content.split('\n');
+
+  // Multiline match at file scope — gives us the offset of each hit.
+  // Then we translate offset to line and check suppression there.
+  const globalPattern = new RegExp(EXECUTE_SQL_LITERAL_REGEX.source, 'gi');
+  for (;;) {
+    const match = globalPattern.exec(content);
+    if (match === null) break;
+    const offset = match.index;
+    const lineIdx = content.slice(0, offset).split('\n').length - 1;
+    if (isAllowlisted(allowlist, file.rel, 'execute-sql-literal')) return violations;
+    if (isLineSuppressed(lines, lineIdx)) continue;
+    violations.push(
+      `  ${file.rel}:${lineIdx + 1}  db.execute(sql\`<literal DDL/DML>\`) — migrate to Drizzle query builder`,
+    );
+  }
+
+  return violations;
+}
+
+// =============================================================================
+// Rule: sql-file-outside-migrations
+// =============================================================================
+
+function checkSqlFileOutsideMigrations(
+  file: FoundFile,
+  allowlist: Map<string, Set<RuleId>>,
+): string[] {
+  if (file.ext !== '.sql') return [];
+  if (file.rel.startsWith(`${SQL_MIGRATIONS_DIR}/`)) return [];
+  if (includesAnyPathSegment(file.rel, SQL_FILE_ALLOWED_PATH_SEGMENTS)) return [];
+  if (isAllowlisted(allowlist, file.rel, 'sql-file-outside-migrations')) return [];
+
+  return [
+    `  ${file.rel}  .sql file outside ${SQL_MIGRATIONS_DIR}/ (apply via drizzle-kit or allowlist with reason)`,
+  ];
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+function collectAllFiles(): FoundFile[] {
+  const all: FoundFile[] = [];
+  for (const root of SCAN_ROOTS) {
+    const abs = join(REPO_ROOT, root);
+    if (existsSync(abs) && statSync(abs).isDirectory()) {
+      collectFiles(abs, all);
+    }
+  }
+  return all;
+}
+
+function main(): void {
+  const Sep = '='.repeat(64);
+  console.log(`\n${Sep}`);
+  console.log('Raw-SQL Validator');
+  console.log(Sep);
+
+  const allowlist = loadAllowlist();
+  const files = collectAllFiles();
+  console.log(`\n  Scanning ${files.length} files across ${SCAN_ROOTS.join(', ')}`);
+  console.log(`  Allowlist entries: ${allowlist.size}`);
+
+  const sourceFiles = files.filter((f) => SOURCE_EXTS.has(f.ext));
+  const sqlFiles = files.filter((f) => f.ext === '.sql');
+
+  const allViolations: string[] = [];
+
+  console.log('\n→ direct-import  (pg / postgres / @neondatabase/serverless)');
+  let ruleViolations: string[] = [];
+  for (const file of sourceFiles) {
+    const content = readFileSync(file.abs, 'utf8');
+    ruleViolations.push(...checkDirectImport(file, content, allowlist));
+  }
+  if (ruleViolations.length === 0) {
+    console.log('  ✓ clean');
+  } else {
+    for (const v of ruleViolations) console.log(v);
+    allViolations.push(...ruleViolations);
+  }
+
+  console.log('\n→ rpc-call');
+  ruleViolations = [];
+  for (const file of sourceFiles) {
+    const content = readFileSync(file.abs, 'utf8');
+    ruleViolations.push(...checkRpcCall(file, content, allowlist));
+  }
+  if (ruleViolations.length === 0) {
+    console.log('  ✓ clean');
+  } else {
+    for (const v of ruleViolations) console.log(v);
+    allViolations.push(...ruleViolations);
+  }
+
+  console.log('\n→ execute-sql-literal');
+  ruleViolations = [];
+  for (const file of sourceFiles) {
+    const content = readFileSync(file.abs, 'utf8');
+    ruleViolations.push(...checkExecuteSqlLiteral(file, content, allowlist));
+  }
+  if (ruleViolations.length === 0) {
+    console.log('  ✓ clean');
+  } else {
+    for (const v of ruleViolations) console.log(v);
+    allViolations.push(...ruleViolations);
+  }
+
+  console.log('\n→ sql-file-outside-migrations');
+  ruleViolations = [];
+  for (const file of sqlFiles) {
+    ruleViolations.push(...checkSqlFileOutsideMigrations(file, allowlist));
+  }
+  if (ruleViolations.length === 0) {
+    console.log('  ✓ clean');
+  } else {
+    for (const v of ruleViolations) console.log(v);
+    allViolations.push(...ruleViolations);
+  }
+
+  console.log(`\n${Sep}`);
+  if (allViolations.length === 0) {
+    console.log('Result: PASS (0 violations)');
+    console.log(Sep);
+    process.exit(0);
+  }
+  console.log(
+    `Result: FAIL (${allViolations.length} violation${allViolations.length === 1 ? '' : 's'})`,
+  );
+  console.log('');
+  console.log('  Fix options:');
+  console.log('    1. Migrate to Drizzle query builder (preferred).');
+  console.log('    2. Add an entry to scripts/validate/raw-sql-allowlist.json');
+  console.log('       with a non-empty reason and (ideally) a migrationPhase.');
+  console.log('    3. Add `// drizzle-raw: <reason>` on the offending line.');
+  console.log(Sep);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Phase 2 of the raw-SQL migration plan. Introduces a blocking validator (`pnpm validate:raw-sql`) that enforces Drizzle as the sole runtime DB access path and drizzle-kit as the sole schema-migration path.

**Blocks from day one** — no warn-only posture. Per durable-only directive 2026-04-20, every pre-existing violation is enumerated in `scripts/validate/raw-sql-allowlist.json` with a reason and (where applicable) a `migrationPhase` tag pointing to the future phase that will remove the exemption.

## Rules (HARD BLOCK)

| Rule | What it catches |
|---|---|
| `direct-import` | `import … from 'pg'` / `'postgres'` / `'@neondatabase/serverless'` outside `packages/db/src/` |
| `rpc-call` | Any `.rpc(…)` call (zero runtime consumers as of 2026-04-20 recon — Drizzle query builder with `sql\`\`` fragments is the idiomatic escape hatch for pgvector operators) |
| `execute-sql-literal` | `db.execute(sql\`<SELECT/UPDATE/DELETE/INSERT/CREATE/DROP/ALTER/TRUNCATE/GRANT/REVOKE/WITH/DO>…\`)` outside tests, setup scripts, and migration runners |
| `sql-file-outside-migrations` | `.sql` files outside `packages/db/migrations/` (catches hand-applied DDL that bypasses drizzle-kit) |

## Allowlist

- 19 entries covering 29 pre-existing violations in the current tree.
- Each entry has a `reason` (required, non-empty) and optional `migrationPhase`:
  - **Phase 3** (MCP consolidation): MCP parallel migration runner
  - **Phase 4** (loose-SQL cleanup): 5 of 6 `.sql` files outside drizzle-kit
  - **Phase 6** (cosmetic cleanup): health checks, `sql-helpers.ts` SELECTs, dev-tools verify script, seed-admin
  - **null** (permanent): `pg_advisory_xact_lock`, `pg_current_xact_id`, type-only scripts imports, ElectricSQL sync schema

## Explicitly allowed (no allowlist/suppression required)

`sql\`\`` fragments inside Drizzle query-builder methods (`.where`, `.select`, `.orderBy`, `.having`, `.groupBy`, `.innerJoin`) are never flagged — they're the idiomatic way to use pgvector operators (`<->`, `<=>`) and Postgres system functions. Canonical example: [`rag-vector-service.ts:70-99`](packages/ai/src/ingestion/rag-vector-service.ts).

## Suppression

For one-off cases: inline `// drizzle-raw: <reason>` on the same line or the line immediately preceding the banned pattern. Empty reasons do not suppress.

## Test plan

- [x] Enumerate all current violations (29 found; validator output matched the 2026-04-20 audit)
- [x] Populate allowlist; re-run validator → PASS
- [x] Negative test: remove one allowlist entry → validator correctly fails with that exact violation; restore → PASS
- [x] `pnpm gate:quick` locally → PASS (raw-SQL check runs in 5.4s)
- [ ] CI `quality` job includes `pnpm validate:raw-sql` as a hard-fail step

## What this closes

- The largest structural gap from the 2026-04-20 raw-SQL audit: new violations can no longer land silently.
- Makes the subsequent phases (MCP consolidation, loose-SQL cleanup, cosmetic cleanup) well-defined — each is "remove N allowlist entries."

## What this does not close

- Existing violations stay in the codebase until their migrationPhase ships. They're allowlisted, not fixed.
- `universal-postgres.ts` (the architectural raw-SQL site) is covered by `drizzle-consolidation-spec.md`, not this PR.

See internal docs for full context.
