### PR TITLE
fix(setup): record tosAcceptedAt + tosVersion in admin bootstrap

### DIFF
--- a/packages/setup/src/__tests__/bootstrap.test.ts
+++ b/packages/setup/src/__tests__/bootstrap.test.ts
@@ -142,6 +142,46 @@ describe('bootstrap', () => {
     );
   });
 
+  it('records tosAcceptedAt and tosVersion on the bootstrap admin', async () => {
+    // Regression guard for revealui#431 — web signup records TOS acceptance;
+    // bootstrap must match so the first admin has the same legal record.
+    const before = new Date();
+    await bootstrap({
+      revealui: mockRevealUI,
+      admin: VALID_ADMIN,
+    });
+    const after = new Date();
+
+    const createCall = (mockRevealUI.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const data = createCall?.data as Record<string, unknown>;
+
+    expect(data.tosAcceptedAt).toBeInstanceOf(Date);
+    const acceptedAt = data.tosAcceptedAt as Date;
+    expect(acceptedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(acceptedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+
+    expect(typeof data.tosVersion).toBe('string');
+    expect((data.tosVersion as string).length).toBeGreaterThan(0);
+  });
+
+  it('honors TOS_VERSION env override when present', async () => {
+    const prev = process.env.TOS_VERSION;
+    process.env.TOS_VERSION = '2099-01-01';
+    try {
+      await bootstrap({
+        revealui: mockRevealUI,
+        admin: VALID_ADMIN,
+      });
+
+      const createCall = (mockRevealUI.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const data = createCall?.data as Record<string, unknown>;
+      expect(data.tosVersion).toBe('2099-01-01');
+    } finally {
+      if (prev === undefined) delete process.env.TOS_VERSION;
+      else process.env.TOS_VERSION = prev;
+    }
+  });
+
   it('continues even if seed fails (non-fatal)', async () => {
     const seedFails: RevealUILike = {
       find: vi

--- a/packages/setup/src/bootstrap/index.ts
+++ b/packages/setup/src/bootstrap/index.ts
@@ -186,6 +186,12 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
   // while the Payload `roles` array uses the application taxonomy
   // (super-admin/admin). Both layers consume different fields;
   // first user is 'owner' at the DB layer and 'super-admin' at the app layer.
+  //
+  // TOS capture: record acceptance at bootstrap time so the bootstrap admin has
+  // the same legal-defensibility record as web-signup users. Web signup sets
+  // these fields in apps/admin/src/app/api/auth/sign-up/route.ts:61-62;
+  // matching the pattern (including the same env-var default) keeps the two
+  // code paths in sync.
   try {
     await revealui.create({
       collection: 'users',
@@ -195,6 +201,8 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
         password: admin.password,
         role: 'owner',
         roles: ['super-admin'],
+        tosAcceptedAt: new Date(),
+        tosVersion: process.env.TOS_VERSION ?? '2026-03-01',
       },
       overrideAccess: true,
     });


### PR DESCRIPTION
## Closes

Closes [#431](https://github.com/RevealUIStudio/revealui/issues/431). Unblocks CR-8 path-to-A per [MASTER_PLAN §CR-8 re-audit 2026-04-19](../blob/main/docs/MASTER_PLAN.md).

## Summary

Bootstrap admin user creation now records `tosAcceptedAt` + `tosVersion`, matching the web signup path. Both fields were always in the `users` schema; the `bootstrap()` helper's insert payload simply didn't set them.

```diff
  await revealui.create({
    collection: 'users',
    data: {
      name: admin.name ?? 'Admin',
      email: admin.email,
      password: admin.password,
      role: 'owner',
      roles: ['super-admin'],
+     tosAcceptedAt: new Date(),
+     tosVersion: process.env.TOS_VERSION ?? '2026-03-01',
    },
    overrideAccess: true,
  });
```

Exact pattern from [`apps/admin/src/app/api/auth/sign-up/route.ts:61-62`](https://github.com/RevealUIStudio/revealui/blob/test/apps/admin/src/app/api/auth/sign-up/route.ts#L61-L62) — same env-var default, same `new Date()` semantics.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI/CD or tooling

## Tests

Two new cases in [`packages/setup/src/__tests__/bootstrap.test.ts`](../blob/test/packages/setup/src/__tests__/bootstrap.test.ts):

1. **`records tosAcceptedAt and tosVersion on the bootstrap admin`** — asserts the Date is within the bootstrap time window and the version string is non-empty.
2. **`honors TOS_VERSION env override when present`** — asserts `process.env.TOS_VERSION = '2099-01-01'` flows through correctly; cleans up on teardown.

```
 Test Files  5 passed (5)
      Tests  80 passed (80)    ← was 78
```

## Scope notes

The [#431 issue](https://github.com/RevealUIStudio/revealui/issues/431) lists four acceptance criteria. Items 1 + 3 are in this PR. Items 2 + 4 are deliberately **deferred to follow-up issues** and will be filed alongside this PR:

| AC | Scope | Status |
|---|---|---|
| **1. Record TOS fields in bootstrap** | This PR | ✅ |
| **2. Audit-log entry `admin.bootstrap_created`** | Follow-up | Deferred — requires `AuditSystem` wiring which is better done at the caller layer (CLI + setup route) than inside the dep-light `bootstrap()` helper. Threading IP + bootstrap-source through an optional callback preserves the dep-light contract. |
| **3. Test coverage** | This PR | ✅ |
| **4. Backfill migration for existing bootstrap admins** | Follow-up | Deferred — only needed if a prod/staging deployment already has a bootstrap admin pre-fix. Issue notes "low immediate risk (single admin today)". Owner confirms whether a backfill is warranted. |

## Verification

- `pnpm --filter @revealui/setup test --run` — 80 passed (5 files).
- `pnpm gate:quick` — all 13 checks pass locally.
- Pre-push gate green on branch.

## Checklist

- [x] `pnpm gate:quick` passes (lint + typecheck)
- [x] Tests added and passing
- [x] No `any` types or `console.*` in production code
- [x] Any future-tense claims cite a tracker per `CONTRIBUTING.md#future-tense-claims`
