### PR TITLE
feat(db): seat-limit trigger on account_memberships (CR8-P2-03 defense)

### DIFF
--- a/packages/db/migrations/0007_account_membership_seat_limit.sql
+++ b/packages/db/migrations/0007_account_membership_seat_limit.sql
@@ -1,0 +1,60 @@
+-- Custom migration: DB-level enforcement of per-account seat limits
+-- (CR8-P2-03 defense-in-depth).
+--
+-- App-level guard at apps/api/src/lib/seat-count-guard.ts enforces the same
+-- rule before inserts in normal application paths. This trigger is the
+-- backstop for direct-SQL paths (admin scripts, manual fixes, future code
+-- that forgets to call the guard). Rule source of truth is
+-- account_entitlements.limits->>'maxUsers'; NULL means unlimited
+-- (enterprise / Forge) and the trigger is a no-op.
+--
+-- All statements idempotent (CREATE OR REPLACE, DROP ... IF EXISTS, create-
+-- before-drop-before-create for triggers).
+
+CREATE OR REPLACE FUNCTION enforce_account_membership_seat_limit()
+RETURNS trigger AS $$
+DECLARE
+  v_max_users integer;
+  v_current_count integer;
+BEGIN
+  -- Only active memberships count toward the cap. Invited / revoked rows are
+  -- allowed without bound.
+  IF NEW.status IS DISTINCT FROM 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Read the tier-derived limit from the entitlements row. Absent row OR
+  -- absent maxUsers key = unlimited (enterprise / Forge default).
+  SELECT (limits->>'maxUsers')::integer
+  INTO v_max_users
+  FROM account_entitlements
+  WHERE account_id = NEW.account_id;
+
+  IF v_max_users IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Count current active memberships. For UPDATE transitioning status to
+  -- 'active', exclude the row being updated so a self-update doesn't
+  -- double-count.
+  SELECT COUNT(*)
+  INTO v_current_count
+  FROM account_memberships
+  WHERE account_id = NEW.account_id
+    AND status = 'active'
+    AND (TG_OP = 'INSERT' OR id <> NEW.id);
+
+  IF v_current_count >= v_max_users THEN
+    RAISE EXCEPTION 'seat_limit_reached: account % has % active members (max: %)',
+      NEW.account_id, v_current_count, v_max_users
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS account_memberships_seat_limit_check ON "account_memberships";
+CREATE TRIGGER account_memberships_seat_limit_check
+  BEFORE INSERT OR UPDATE OF status ON "account_memberships"
+  FOR EACH ROW EXECUTE FUNCTION enforce_account_membership_seat_limit();

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -26,6 +26,12 @@
       "rationale": "Hand-written ALTER TABLE on agent_memories adding scope/session_scope/source_facts/reconciled_at + scope CHECK constraint (CRDT layer 3). Should have been produced by drizzle-kit generate; pre-existing debt from the 2026-04-18 incident. ADD CONSTRAINT now wrapped in DO $$ idempotency block as of #434.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as 0003."
+    },
+    {
+      "tag": "0007_account_membership_seat_limit",
+      "rationale": "PG PL/pgSQL trigger (enforce_account_membership_seat_limit) plus BEFORE INSERT / UPDATE OF status trigger on account_memberships — DB-level backstop for the app-level guard at apps/api/src/lib/seat-count-guard.ts. CR8-P2-03 defense-in-depth. Not expressible in Drizzle's schema DSL (no schema changes; trigger + function only).",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Snapshot would be a copy of 0006's snapshot (this migration adds no Drizzle-modeled columns/tables), but is omitted to avoid confusion, matching the 0002_triggers_search_vectors precedent."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776912000001,
       "tag": "0006_must_rotate_password",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776912000002,
+      "tag": "0007_account_membership_seat_limit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/test/src/integration/database/seat-limit-trigger.integration.test.ts
+++ b/packages/test/src/integration/database/seat-limit-trigger.integration.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration tests for the account_memberships seat-limit trigger
+ * (CR8-P2-03 defense-in-depth).
+ *
+ * Migration: packages/db/migrations/0007_account_membership_seat_limit.sql
+ * App-level guard: apps/api/src/lib/seat-count-guard.ts (unit-tested separately).
+ *
+ * This file exercises the DB-level enforcement — the trigger fires on direct
+ * SQL inserts that bypass the app guard, which is the whole point of
+ * defense-in-depth. Covers:
+ *   1. Enforcement when an entitlement limit exists
+ *   2. No-op when entitlement row is absent (unlimited / enterprise)
+ *   3. No-op when limits.maxUsers is absent (enterprise shape)
+ *   4. Only active memberships count (invited / revoked don't consume seats)
+ *   5. UPDATE OF status to 'active' also triggers the check
+ *   6. PostgreSQL error code is check_violation so callers can classify
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
+
+describe('account_memberships seat-limit trigger (CR8-P2-03)', () => {
+  let db: TestDb;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    // Clean between tests. Order matters: memberships before entitlements
+    // before accounts; users after memberships (FK cascade paths).
+    await db.pglite.exec('DELETE FROM account_memberships');
+    await db.pglite.exec('DELETE FROM account_entitlements');
+    await db.pglite.exec('DELETE FROM accounts');
+    await db.pglite.exec('DELETE FROM users');
+  });
+
+  async function createAccount(id: string) {
+    await db.pglite.exec(
+      `INSERT INTO accounts (id, name, slug) VALUES ('${id}', '${id}', '${id}')`,
+    );
+  }
+
+  async function createEntitlement(
+    accountId: string,
+    tier: string,
+    limits: { maxUsers?: number } | null,
+  ) {
+    const limitsJson = limits === null ? '{}' : JSON.stringify(limits);
+    await db.pglite.query(
+      `INSERT INTO account_entitlements (account_id, plan_id, tier, limits)
+       VALUES ($1, $2, $3, $4::jsonb)`,
+      [accountId, `${tier}-plan`, tier, limitsJson],
+    );
+  }
+
+  async function createUser(id: string) {
+    await db.pglite.query(
+      `INSERT INTO users (id, email, password, name)
+       VALUES ($1, $2, 'x', $3)`,
+      [id, `${id}@test.com`, id],
+    );
+  }
+
+  async function createMembership(
+    id: string,
+    accountId: string,
+    userId: string,
+    status: 'active' | 'invited' | 'revoked' = 'active',
+  ) {
+    await db.pglite.query(
+      `INSERT INTO account_memberships (id, account_id, user_id, status)
+       VALUES ($1, $2, $3, $4)`,
+      [id, accountId, userId, status],
+    );
+  }
+
+  it('allows inserts when under the cap', async () => {
+    await createAccount('acct-pro');
+    await createEntitlement('acct-pro', 'pro', { maxUsers: 3 });
+    for (let i = 0; i < 3; i++) {
+      await createUser(`u-${i}`);
+    }
+    await createMembership('m-1', 'acct-pro', 'u-0');
+    await createMembership('m-2', 'acct-pro', 'u-1');
+    await createMembership('m-3', 'acct-pro', 'u-2');
+
+    const result = await db.pglite.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM account_memberships WHERE account_id = 'acct-pro'`,
+    );
+    expect(result.rows[0]?.count).toBe('3');
+  });
+
+  it('blocks direct INSERT that would exceed the cap', async () => {
+    await createAccount('acct-pro-full');
+    await createEntitlement('acct-pro-full', 'pro', { maxUsers: 2 });
+    for (let i = 0; i < 3; i++) {
+      await createUser(`v-${i}`);
+    }
+    await createMembership('mm-1', 'acct-pro-full', 'v-0');
+    await createMembership('mm-2', 'acct-pro-full', 'v-1');
+
+    // Third insert should fail with check_violation via trigger RAISE EXCEPTION.
+    await expect(createMembership('mm-3', 'acct-pro-full', 'v-2')).rejects.toThrow(
+      /seat_limit_reached/,
+    );
+
+    // Confirm only two rows persisted.
+    const result = await db.pglite.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM account_memberships WHERE account_id = 'acct-pro-full'`,
+    );
+    expect(result.rows[0]?.count).toBe('2');
+  });
+
+  it('no-ops when entitlement row is missing (unlimited default)', async () => {
+    await createAccount('acct-no-ent');
+    // No entitlement row inserted at all.
+    for (let i = 0; i < 5; i++) {
+      await createUser(`w-${i}`);
+    }
+    for (let i = 0; i < 5; i++) {
+      await createMembership(`nm-${i}`, 'acct-no-ent', `w-${i}`);
+    }
+    const result = await db.pglite.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM account_memberships WHERE account_id = 'acct-no-ent'`,
+    );
+    expect(result.rows[0]?.count).toBe('5');
+  });
+
+  it('no-ops when limits.maxUsers is absent (enterprise shape)', async () => {
+    await createAccount('acct-enterprise');
+    await createEntitlement('acct-enterprise', 'enterprise', {});
+    for (let i = 0; i < 10; i++) {
+      await createUser(`x-${i}`);
+    }
+    for (let i = 0; i < 10; i++) {
+      await createMembership(`em-${i}`, 'acct-enterprise', `x-${i}`);
+    }
+    const result = await db.pglite.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM account_memberships WHERE account_id = 'acct-enterprise'`,
+    );
+    expect(result.rows[0]?.count).toBe('10');
+  });
+
+  it('only active memberships count toward the cap', async () => {
+    await createAccount('acct-mixed');
+    await createEntitlement('acct-mixed', 'pro', { maxUsers: 2 });
+    for (let i = 0; i < 5; i++) {
+      await createUser(`y-${i}`);
+    }
+    // Two active + two invited + one revoked.
+    await createMembership('am-1', 'acct-mixed', 'y-0', 'active');
+    await createMembership('am-2', 'acct-mixed', 'y-1', 'active');
+    await createMembership('am-3', 'acct-mixed', 'y-2', 'invited');
+    await createMembership('am-4', 'acct-mixed', 'y-3', 'invited');
+    await createMembership('am-5', 'acct-mixed', 'y-4', 'revoked');
+
+    // Adding another active should fail.
+    await createUser('y-5');
+    await expect(createMembership('am-6', 'acct-mixed', 'y-5', 'active')).rejects.toThrow(
+      /seat_limit_reached/,
+    );
+
+    // But another invited is fine.
+    await createUser('y-6');
+    await createMembership('am-7', 'acct-mixed', 'y-6', 'invited');
+  });
+
+  it('UPDATE of status to active triggers the check', async () => {
+    await createAccount('acct-promote');
+    await createEntitlement('acct-promote', 'pro', { maxUsers: 2 });
+    for (let i = 0; i < 3; i++) {
+      await createUser(`z-${i}`);
+    }
+    // Two active + one invited (promotable).
+    await createMembership('pm-1', 'acct-promote', 'z-0', 'active');
+    await createMembership('pm-2', 'acct-promote', 'z-1', 'active');
+    await createMembership('pm-3', 'acct-promote', 'z-2', 'invited');
+
+    // Promoting the invited row would bring active count from 2 → 3 (> 2).
+    await expect(
+      db.pglite.query(`UPDATE account_memberships SET status = 'active' WHERE id = 'pm-3'`),
+    ).rejects.toThrow(/seat_limit_reached/);
+  });
+
+  it('uses check_violation error code so callers can classify', async () => {
+    await createAccount('acct-err');
+    await createEntitlement('acct-err', 'pro', { maxUsers: 1 });
+    await createUser('err-0');
+    await createUser('err-1');
+    await createMembership('err-m-1', 'acct-err', 'err-0');
+
+    try {
+      await createMembership('err-m-2', 'acct-err', 'err-1');
+      expect.fail('should have thrown');
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      expect(code).toBe('23514'); // PostgreSQL check_violation
+    }
+  });
+});


### PR DESCRIPTION
## Closes

Closes the agent-side of CR8-P2-03 per MASTER_PLAN §CR-8 (2026-04-19 re-audit). App-level guard at `apps/api/src/lib/seat-count-guard.ts` was already in place; this PR adds the DB-level backstop the re-audit flagged as missing.

## Summary

Migration `0007_account_membership_seat_limit.sql` adds a PL/pgSQL trigger on `account_memberships` that enforces per-account seat limits at the database layer — catching direct-SQL paths (admin scripts, manual fixes, future code that forgets to call the guard).

**Cap source:** `account_entitlements.limits->>'maxUsers'` per account. Absent entitlement row OR absent `maxUsers` key = unlimited (enterprise / Forge default — trigger no-ops).

**Fires on:** `BEFORE INSERT` and `BEFORE UPDATE OF status` on `account_memberships`. Only 'active' rows count toward the cap; invited / revoked don't consume seats. On UPDATE, the current row is excluded from the count so self-updates don't double-count.

**Error shape:** `RAISE EXCEPTION 'seat_limit_reached: account X has N active members (max: M)' USING ERRCODE = 'check_violation'` — PostgreSQL error code `23514` so callers can classify and return a structured 402 `seat_limit_reached` response, matching the app-level guard's `SeatLimitReachedError.code`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI/CD or tooling

## Migration discipline

Registered in `packages/db/migrations/meta/_custom.json` as a hand-written migration (not drizzle-kit-generated) with rationale matching the `0002_triggers_search_vectors` precedent — triggers + functions aren't expressible in Drizzle's schema DSL, and this migration adds no new Drizzle-modeled columns/tables.

Journal entry added at `idx: 7`. Idempotent via `CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER`.

## Tests

New integration test at `packages/test/src/integration/database/seat-limit-trigger.integration.test.ts` — 7 cases, all passing:

1. under-cap inserts allowed
2. over-cap `INSERT` rejected with `seat_limit_reached`
3. missing entitlement row → unlimited (no-op)
4. empty limits JSON → unlimited (no-op)
5. invited / revoked rows don't count toward the cap
6. `UPDATE` of status to 'active' triggers the check (not just inserts)
7. error code is PostgreSQL `23514` (check_violation) so callers can classify

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

App-level guard (`seat-count-guard.ts`) is unchanged — it gives better error messages on the happy path and saves a DB round-trip. The trigger is the defense-in-depth backstop.

## Verification

- `pnpm gate:quick` — all 13 checks pass locally.
- `pnpm exec vitest run --config vitest.integration.config.ts src/integration/database/seat-limit-trigger.integration.test.ts` — 7/7 green.
- Migration-journal validator passes (`_custom.json` entry present).
- Pre-push gate green (`pnpm gate` wrap, full tier).

## Checklist

- [x] `pnpm gate:quick` passes (lint + typecheck)
- [x] Tests added and passing
- [x] No `any` types or `console.*` in production code
- [x] Any future-tense claims cite a tracker per `CONTRIBUTING.md#future-tense-claims`
