### PR TITLE
feat(billing): Stripe price parity check in billing-readiness cron (CR8-P2-04)

### DIFF
--- a/apps/api/src/lib/tier-pricing.ts
+++ b/apps/api/src/lib/tier-pricing.ts
@@ -1,0 +1,34 @@
+/**
+ * Hosted-tier MRR fallback pricing — display-only fallback used when the
+ * `billing_catalog` DB row has no Stripe price ID set for a tier.
+ *
+ * Stripe Dashboard is the source of truth for what customers actually pay.
+ * `billing_catalog.stripePriceId` is the DB cache of that truth. This
+ * constant is the last-resort display fallback for the admin MRR metrics
+ * route — used only when both of the above are unavailable or null.
+ *
+ * Formerly named `CANONICAL_TIER_PRICES` in `apps/api/src/routes/billing.ts`
+ * — the rename (CR8-P2-04) fixes a misleading label: this is not canonical;
+ * Stripe is. The `billing-readiness` cron (`./cron/billing-readiness.ts`)
+ * asserts drift by fetching each Stripe price on the `STRIPE_*_PRICE_ID` env
+ * var and comparing `price.unit_amount` to the cents values derived here.
+ */
+
+export type SubscriptionTierId = 'pro' | 'max' | 'enterprise';
+
+/**
+ * MRR fallback monthly price per tier, in USD (whole dollars).
+ * Consumed by the admin MRR metrics route when `billing_catalog.stripePriceId`
+ * is null for a tier. Must stay in sync with Stripe Dashboard; drift is
+ * surfaced as a hard-fail by the `billing-readiness` cron.
+ */
+export const MRR_TIER_PRICE_FALLBACK_USD: Record<SubscriptionTierId, number> = {
+  pro: 49,
+  max: 149,
+  enterprise: 299,
+};
+
+/** Same values in cents — convenience for Stripe comparisons. */
+export const MRR_TIER_PRICE_FALLBACK_CENTS: Record<SubscriptionTierId, number> = Object.fromEntries(
+  Object.entries(MRR_TIER_PRICE_FALLBACK_USD).map(([tier, usd]) => [tier, usd * 100]),
+) as Record<SubscriptionTierId, number>;

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -25,6 +25,7 @@ import { protectedStripe } from '@revealui/services';
 import { and, count, countDistinct, desc, eq, gt, gte, isNull, lt, lte, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import Stripe from 'stripe';
+import { MRR_TIER_PRICE_FALLBACK_CENTS } from '../lib/tier-pricing.js';
 import {
   sendDowngradeConfirmationEmail,
   sendUpgradeConfirmationEmail,
@@ -37,17 +38,6 @@ const TRIAL_PERIOD_DAYS = Number.parseInt(process.env.REVEALUI_TRIAL_DAYS ?? '7'
 /** How far ahead to look for expiring support contracts (overridable via env, default 30 days) */
 const SUPPORT_RENEWAL_WINDOW_MS =
   Number.parseInt(process.env.REVEALUI_SUPPORT_RENEWAL_DAYS ?? '30', 10) * 24 * 60 * 60 * 1000;
-
-/**
- * Canonical monthly tier prices in USD (whole dollars).
- * Single source of truth  -  used for RVUI payment recording and MRR fallbacks.
- * Must match the marketing site and Stripe product catalog.
- */
-const CANONICAL_TIER_PRICES: Record<string, number> = {
-  pro: 49,
-  max: 149,
-  enterprise: 299,
-};
 
 /**
  * Computes a Stripe meter event timestamp for the last second of a billing cycle.
@@ -2177,10 +2167,12 @@ app.openapi(rvuiPaymentRoute, async (c) => {
 
 // ─── Admin Revenue Metrics ────────────────────────────────────────────────────
 
-/** Fallback monthly prices (cents) for MRR estimation when catalog has no Stripe price */
-const FALLBACK_TIER_PRICE_CENTS: Record<string, number> = Object.fromEntries(
-  Object.entries(CANONICAL_TIER_PRICES).map(([tier, usd]) => [tier, usd * 100]),
-);
+/**
+ * Fallback monthly prices (cents) for MRR estimation when catalog has no
+ * Stripe price. Imported from `../lib/tier-pricing.ts` so the cron-level
+ * parity check and this route share the same source of truth.
+ */
+const FALLBACK_TIER_PRICE_CENTS = MRR_TIER_PRICE_FALLBACK_CENTS;
 
 const MetricsTierBreakdownSchema = z.object({
   pro: z.number().openapi({ description: 'Active pro subscriptions' }),

--- a/apps/api/src/routes/cron/billing-readiness.test.ts
+++ b/apps/api/src/routes/cron/billing-readiness.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the billing-readiness cron's Stripe price parity check
+ * (CR8-P2-04). Exercises the new section 4 added in this PR.
+ *
+ * The cron response only surfaces FAILED checks in `body.failures`, so the
+ * tests assert:
+ *   - parity pass → no `stripe:price:*` entries in `failures`
+ *   - parity fail → `stripe:price:<tier>` in `failures` with the detail
+ *
+ * Covers:
+ *   1. Parity pass — Stripe unit_amount matches MRR fallback
+ *   2. Parity fail — Stripe unit_amount differs (hard-fail check)
+ *   3. Null unit_amount — Stripe returned a free-form / tiered price
+ *   4. Stripe lookup error — prices.retrieve throws (deleted / network)
+ *   5. Missing env var — tier is skipped (earlier check already flags)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MRR_TIER_PRICE_FALLBACK_CENTS } from '../../lib/tier-pricing.js';
+
+// --- Module mocks ---
+
+const mockRetrieve = vi.fn();
+
+vi.mock('stripe', () => ({
+  default: class MockStripe {
+    prices = { retrieve: mockRetrieve };
+  },
+}));
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: vi.fn(() => mockDb),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  billingCatalog: { planId: 'plan_id', stripePriceId: 'stripe_price_id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (a: unknown, b: unknown) => [a, b],
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../../lib/email.js', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Billing catalog mock — return rows for every EXPECTED_PLAN_IDS entry so
+// section 3 passes cleanly and isn't the source of failures in these tests.
+const mockDb = {
+  select: vi.fn(() => mockDb),
+  from: vi.fn(() =>
+    Promise.resolve([
+      { planId: 'subscription:pro', stripePriceId: 'price_pro' },
+      { planId: 'subscription:max', stripePriceId: 'price_max' },
+      { planId: 'subscription:enterprise', stripePriceId: 'price_enterprise' },
+      { planId: 'perpetual:pro', stripePriceId: 'price_perp_pro' },
+      { planId: 'perpetual:max', stripePriceId: 'price_perp_max' },
+      { planId: 'perpetual:enterprise', stripePriceId: 'price_perp_enterprise' },
+      { planId: 'credits:starter', stripePriceId: 'price_credits_starter' },
+      { planId: 'credits:standard', stripePriceId: 'price_credits_standard' },
+      { planId: 'credits:scale', stripePriceId: 'price_credits_scale' },
+    ]),
+  ),
+};
+
+// --- Setup ---
+
+const CRON_SECRET = 'test-cron-secret-long-enough-32chars!';
+
+interface CronBody {
+  status: 'ok' | 'failed';
+  checkCount: number;
+  failureCount: number;
+  failures: Array<{ check: string; detail: string }>;
+  warningCount: number;
+  warnings: Array<{ check: string; detail: string }>;
+  checkedAt: string;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockDb.select.mockReturnValue(mockDb);
+
+  process.env.REVEALUI_CRON_SECRET = CRON_SECRET;
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_mock';
+  process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'mock_priv_key';
+  process.env.STRIPE_PRO_PRICE_ID = 'price_pro';
+  process.env.STRIPE_MAX_PRICE_ID = 'price_max';
+  process.env.STRIPE_ENTERPRISE_PRICE_ID = 'price_enterprise';
+
+  // Default: every price matches the fallback (parity pass)
+  mockRetrieve.mockImplementation((id: string) => {
+    const tierMap: Record<string, keyof typeof MRR_TIER_PRICE_FALLBACK_CENTS> = {
+      price_pro: 'pro',
+      price_max: 'max',
+      price_enterprise: 'enterprise',
+    };
+    const tier = tierMap[id];
+    if (!tier) throw new Error(`no mock for ${id}`);
+    return Promise.resolve({ id, unit_amount: MRR_TIER_PRICE_FALLBACK_CENTS[tier] });
+  });
+});
+
+// Dynamic import to respect the env/module mocks above.
+async function callCron(): Promise<{ status: number; body: CronBody }> {
+  const { default: app } = await import('./billing-readiness.js');
+  const res = await app.request('/billing-readiness', {
+    method: 'POST',
+    headers: { 'X-Cron-Secret': CRON_SECRET },
+  });
+  return { status: res.status, body: (await res.json()) as CronBody };
+}
+
+// --- Tests ---
+
+describe('billing-readiness cron — Stripe price parity (CR8-P2-04)', () => {
+  it('parity pass: no stripe:price:* entries in failures', async () => {
+    const { body } = await callCron();
+    const priceFailures = body.failures.filter((f) => f.check.startsWith('stripe:price:'));
+    expect(priceFailures).toHaveLength(0);
+  });
+
+  it('parity fail: pro unit_amount drifts → stripe:price:pro in failures', async () => {
+    mockRetrieve.mockImplementation((id: string) => {
+      if (id === 'price_pro') return Promise.resolve({ id, unit_amount: 5900 }); // drift from 4900
+      const tierMap: Record<string, keyof typeof MRR_TIER_PRICE_FALLBACK_CENTS> = {
+        price_max: 'max',
+        price_enterprise: 'enterprise',
+      };
+      const tier = tierMap[id];
+      return Promise.resolve({ id, unit_amount: MRR_TIER_PRICE_FALLBACK_CENTS[tier!] });
+    });
+
+    const { body } = await callCron();
+    const pro = body.failures.find((f) => f.check === 'stripe:price:pro');
+    expect(pro).toBeDefined();
+    expect(pro?.detail).toContain('5900');
+    expect(pro?.detail).toContain('4900');
+  });
+
+  it('null unit_amount → check fails with tiered-price message', async () => {
+    mockRetrieve.mockImplementation((id: string) => {
+      if (id === 'price_pro') return Promise.resolve({ id, unit_amount: null });
+      const tierMap: Record<string, keyof typeof MRR_TIER_PRICE_FALLBACK_CENTS> = {
+        price_max: 'max',
+        price_enterprise: 'enterprise',
+      };
+      const tier = tierMap[id];
+      return Promise.resolve({ id, unit_amount: MRR_TIER_PRICE_FALLBACK_CENTS[tier!] });
+    });
+
+    const { body } = await callCron();
+    const pro = body.failures.find((f) => f.check === 'stripe:price:pro');
+    expect(pro).toBeDefined();
+    expect(pro?.detail).toMatch(/no unit_amount|tiered|free-form/);
+  });
+
+  it('Stripe lookup error → check fails with lookup-failed detail', async () => {
+    mockRetrieve.mockImplementation((id: string) => {
+      if (id === 'price_max') return Promise.reject(new Error('resource_missing'));
+      const tierMap: Record<string, keyof typeof MRR_TIER_PRICE_FALLBACK_CENTS> = {
+        price_pro: 'pro',
+        price_enterprise: 'enterprise',
+      };
+      const tier = tierMap[id];
+      return Promise.resolve({ id, unit_amount: MRR_TIER_PRICE_FALLBACK_CENTS[tier!] });
+    });
+
+    const { body } = await callCron();
+    const max = body.failures.find((f) => f.check === 'stripe:price:max');
+    expect(max).toBeDefined();
+    expect(max?.detail).toContain('lookup failed');
+    expect(max?.detail).toContain('resource_missing');
+  });
+
+  it('missing env var → parity check skipped; env-var failure still surfaced', async () => {
+    delete process.env.STRIPE_ENTERPRISE_PRICE_ID;
+
+    const { body } = await callCron();
+    // No stripe:price:enterprise parity entry because we skip when env-var missing.
+    const enterpriseParity = body.failures.find((f) => f.check === 'stripe:price:enterprise');
+    expect(enterpriseParity).toBeUndefined();
+    // But the missing env var IS flagged by section 1.
+    const envCheck = body.failures.find((f) => f.check === 'env:STRIPE_ENTERPRISE_PRICE_ID');
+    expect(envCheck).toBeDefined();
+    expect(envCheck?.detail).toBe('MISSING');
+  });
+});

--- a/apps/api/src/routes/cron/billing-readiness.ts
+++ b/apps/api/src/routes/cron/billing-readiness.ts
@@ -18,8 +18,29 @@ import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
 import { Hono } from 'hono';
+import Stripe from 'stripe';
+import { MRR_TIER_PRICE_FALLBACK_CENTS, type SubscriptionTierId } from '../../lib/tier-pricing.js';
 
 const app = new Hono();
+
+let cachedStripe: Stripe | undefined;
+function getStripeClient(): Stripe {
+  if (cachedStripe) return cachedStripe;
+  const key = process.env.STRIPE_SECRET_KEY?.trim();
+  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
+  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
+  return cachedStripe;
+}
+
+/** Subscription tiers whose Stripe prices must match the MRR fallback. */
+const SUBSCRIPTION_TIERS: Array<{
+  tier: SubscriptionTierId;
+  priceEnvVar: 'STRIPE_PRO_PRICE_ID' | 'STRIPE_MAX_PRICE_ID' | 'STRIPE_ENTERPRISE_PRICE_ID';
+}> = [
+  { tier: 'pro', priceEnvVar: 'STRIPE_PRO_PRICE_ID' },
+  { tier: 'max', priceEnvVar: 'STRIPE_MAX_PRICE_ID' },
+  { tier: 'enterprise', priceEnvVar: 'STRIPE_ENTERPRISE_PRICE_ID' },
+];
 
 const ALERT_EMAIL = process.env.REVEALUI_ALERT_EMAIL ?? 'founder@revealui.com';
 
@@ -123,7 +144,49 @@ app.post('/billing-readiness', async (c) => {
     });
   }
 
-  // 4. Check email provider configuration (warning only  -  billing works without
+  // 4. Check Stripe price parity against MRR fallback (CR8-P2-04)
+  //
+  //    For each subscription tier, fetch the Stripe price on the configured
+  //    env var and compare `price.unit_amount` to the MRR fallback cents.
+  //    Drift means the admin dashboard will misreport MRR for one full day
+  //    until the next cron run, and — more importantly — that the published
+  //    marketing price has diverged from what Stripe will charge.
+  //
+  //    We skip tiers whose env var is missing (earlier check already flags
+  //    that) to avoid double-alerting. Stripe errors (network, permission,
+  //    deleted price) surface as check failures so they page someone.
+  for (const { tier, priceEnvVar } of SUBSCRIPTION_TIERS) {
+    const priceId = process.env[priceEnvVar]?.trim();
+    if (!priceId) continue; // env-var absence already flagged by section 1
+    try {
+      const stripe = getStripeClient();
+      const price = await stripe.prices.retrieve(priceId);
+      const expected = MRR_TIER_PRICE_FALLBACK_CENTS[tier];
+      if (price.unit_amount === null) {
+        results.push({
+          check: `stripe:price:${tier}`,
+          ok: false,
+          detail: `${priceId} has no unit_amount (free-form or tiered price?)`,
+        });
+      } else if (price.unit_amount !== expected) {
+        results.push({
+          check: `stripe:price:${tier}`,
+          ok: false,
+          detail: `Stripe price ${price.unit_amount} cents != fallback ${expected} cents (${priceId})`,
+        });
+      } else {
+        results.push({ check: `stripe:price:${tier}`, ok: true, detail: `${expected} cents` });
+      }
+    } catch (err) {
+      results.push({
+        check: `stripe:price:${tier}`,
+        ok: false,
+        detail: `lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  // 5. Check email provider configuration (warning only  -  billing works without
   //    email, but transactional emails will silently fail)
   const hasGmail =
     Boolean(process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL) && Boolean(process.env.GOOGLE_PRIVATE_KEY);


### PR DESCRIPTION
## Closes

Closes CR8-P2-04 per MASTER_PLAN §CR-8 2026-04-19 re-audit. Path-to-A+ advances (Phase 2 now 3/4 closed after this).

## Summary

Surfaces drift between the hardcoded admin-MRR-fallback prices, `billing_catalog.stripePriceId`, and Stripe Dashboard as a cron-level hard-fail. Three changes:

**1. Extract `MRR_TIER_PRICE_FALLBACK_USD` to `apps/api/src/lib/tier-pricing.ts`**

The former `CANONICAL_TIER_PRICES` at `billing.ts:46-50` was misleadingly named — Stripe is canonical, `billing_catalog` is the DB cache, this is a last-resort display fallback. Rename fixes the lie; extraction matches the `tier-limits.ts` pattern established by [#433](https://github.com/RevealUIStudio/revealui/pull/433) so the cron can consume it without pulling all of `billing.ts`.

**2. Extend `billing-readiness` cron (new section 4)**

Per subscription tier (pro/max/enterprise), fetch the Stripe price on the `STRIPE_*_PRICE_ID` env var and compare `price.unit_amount` to `MRR_TIER_PRICE_FALLBACK_CENTS`. Hard-fail on:
- drift (unit_amount doesn't match fallback)
- null unit_amount (free-form or tiered price)
- lookup error (deleted price, network, permission)

Tiers missing their env var are skipped (section 1 already flags those so we don't double-alert).

**3. Test coverage**

`apps/api/src/routes/cron/billing-readiness.test.ts` — 5 new cases. Existing 66 `billing.ts` + `billing-metrics.ts` tests unaffected.

## Type of Change

- [x] Bug fix (drift-prevention wiring)
- [x] Refactor (extraction + rename)
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD or tooling

## Design decisions (owner-confirmed in session)

1. **Where does the check run?** Cron only, not startup. Blast radius is 24h-of-wrong-MRR-display; refund-scale recovery if drift slipped. Startup-level would block deploys on Stripe hiccups.
2. **Mismatch behavior?** Hard-fail at the check level (`check.ok=false` → alert email to `REVEALUI_ALERT_EMAIL`). Matches existing env-var and DB-row treatment. Can downgrade to tier-specific (hard-fail on amount, soft-log on price_id rotation) later if routine Stripe price rotations cause noise.
3. **Does the fallback stay?** Kept but renamed — defensible last-resort for when `billing_catalog` AND Stripe are both unavailable (narrow case but real). Removing entirely would empty the admin MRR dashboard on those outages.

## Verification

- `pnpm gate:quick` — 13/13 checks pass.
- `pnpm exec vitest run src/routes/cron/billing-readiness.test.ts` — 5/5 green.
- `pnpm exec vitest run src/routes/__tests__/billing.test.ts src/routes/__tests__/billing-metrics.test.ts` — 66/66 green (no regression from the extraction).
- Pre-push gate green.

## Checklist

- [x] `pnpm gate:quick` passes (lint + typecheck)
- [x] Tests added and passing
- [x] No `any` types or `console.*` in production code
- [x] Any future-tense claims cite a tracker per `CONTRIBUTING.md#future-tense-claims`
