### PR TITLE
docs(validate): reclassify raw-SQL allowlist per 2026-04-21 recon (Phase 6)

### DIFF
--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -29,8 +29,8 @@
     {
       "path": "scripts/seed-admin.mjs",
       "rules": ["direct-import"],
-      "reason": "Admin-user seed script. .mjs standalone runner that predates @revealui/db. Works outside the pnpm workspace context. Could be migrated to TS + @revealui/db but low ROI.",
-      "migrationPhase": 6
+      "reason": "Admin-user seed script. Queries Neon Auth's own schema (`neon_auth.\"user\"`), not the app's public.users table — that's a third-party schema provided by Neon Auth which Drizzle correctly does not track. Routing this through @revealui/db would require adding neon_auth tables to the schema, which would be misleading (they are not owned by this project). Permanent.",
+      "migrationPhase": null
     },
     {
       "path": "apps/admin/src/app/api/auth/passkey/register-verify/route.ts",
@@ -53,26 +53,26 @@
     {
       "path": "apps/api/src/index.ts",
       "rules": ["execute-sql-literal"],
-      "reason": "db.execute(sql`SELECT 1`) liveness probe. Trivially migratable to db.select().from(someTable).limit(1) but a SELECT 1 is clearer intent for a liveness check.",
-      "migrationPhase": 6
+      "reason": "db.execute(sql`SELECT 1`) database liveness probe inside createDatabaseAlert. SELECT 1 is the canonical idiomatic liveness check — it asks 'is the DB reachable and responding?' without coupling the probe to any specific application table (which would change the probe's semantic to 'is this particular table reachable?'). Permanent idiomatic raw SQL.",
+      "migrationPhase": null
     },
     {
       "path": "apps/api/src/routes/health.ts",
       "rules": ["execute-sql-literal"],
-      "reason": "db.execute(sql`SELECT 1`) liveness probe (route variant). Same rationale as apps/api/src/index.ts.",
-      "migrationPhase": 6
+      "reason": "db.execute(sql`SELECT 1`) database liveness probe inside createDatabaseHealthCheck. Same idiomatic-SELECT-1 rationale as apps/api/src/index.ts. Permanent.",
+      "migrationPhase": null
     },
     {
       "path": "packages/ai/src/memory/utils/sql-helpers.ts",
       "rules": ["execute-sql-literal"],
-      "reason": "4 plain parameterized SELECTs with manual snake_case → camelCase transformation. Trivially migratable to typed Drizzle query builder.",
+      "reason": "4 parameterized SELECTs on node_id_mappings, agent_contexts, and users with manual snake_case → camelCase transformation. The production code is migratable to Drizzle core query builder (db.select().from().where().limit()) — verified via a 2026-04-21 port that built cleanly — BUT breaks ~18 tests across 4 files (node-id-service.test.ts, edge-cases.test.ts, performance.test.ts, agent-context-manager.test.ts) which mock db.execute rather than db.select chains. Durable migration requires replacing the mock-based tests with PGlite-backed integration tests (or rewriting all ~20 mock sites to stub the full query-builder chain). Blocked on that test-infrastructure migration.",
       "migrationPhase": 6
     },
     {
       "path": "scripts/dev-tools/verify-test-setup.ts",
       "rules": ["execute-sql-literal"],
-      "reason": "Dev-tool diagnostic that verifies test-harness DB state with multiple SELECTs. Runs outside production; migration to query builder is low-value (schema introspection queries).",
-      "migrationPhase": 6
+      "reason": "Dev-tool that verifies test-harness DB state. Of its 7 raw-SQL calls, 3 are `SELECT 1` / `SELECT vector(...)` connectivity probes (same idiomatic-liveness rationale as apps/api/src/routes/health.ts) and 4 are information_schema / pg_indexes introspection queries that cannot go through Drizzle's query builder (Drizzle queries defined tables, not Postgres metadata). Permanent.",
+      "migrationPhase": null
     },
     {
       "path": "packages/db/src/supabase/setup-vector-extension.sql",


### PR DESCRIPTION
## Summary

Phase 6 of the raw-SQL migration plan — but not the "cosmetic cleanup" originally planned. Reclassify the allowlist to honestly reflect what's permanent idiomatic raw-SQL vs what's genuinely migratable. **No code or behavior changes in this PR** — only allowlist metadata (reasons + `migrationPhase` fields). Stacked on [#468 (Phase 4b.4)](https://github.com/RevealUIStudio/revealui/pull/468).

## Why the reframe

Phase 6 was originally labeled "cosmetic cleanup" — health-check simplification, sql-helpers query-builder port, billing advisory-lock wrap, etc. The 2026-04-21 recon revealed that **4 of the 5 entries tagged `migrationPhase: 6` are actually permanent idiomatic raw-SQL, not cosmetic-cleanup candidates**, and the 5th is blocked on a test-infrastructure migration that is beyond cosmetic scope.

## Reclassified to `migrationPhase: null` (permanent)

| File | Why permanent |
|---|---|
| `scripts/seed-admin.mjs` | Queries `neon_auth."user"` — **Neon Auth's own schema, not our `public.users`**. Drizzle correctly does not track third-party platform schemas. Routing through `@revealui/db` would misleadingly add non-app tables. |
| `apps/api/src/index.ts` | `db.execute(sql\`SELECT 1\`)` inside `createDatabaseAlert`. SELECT 1 is the canonical liveness probe — asks "is the DB reachable?" without coupling the probe to any specific application table. |
| `apps/api/src/routes/health.ts` | Same SELECT 1 pattern inside `createDatabaseHealthCheck`. |
| `scripts/dev-tools/verify-test-setup.ts` | 7 raw-SQL calls: 3 are SELECT 1 / SELECT vector(...) liveness probes (idiomatic), **4 are `information_schema` / `pg_indexes` introspection that cannot go through Drizzle's query builder at all** (Drizzle operates on defined tables, not Postgres metadata). |

## Clarified `migrationPhase: 6` (genuinely migratable, but blocked)

**`packages/ai/src/memory/utils/sql-helpers.ts`** is the only real cosmetic-cleanup candidate. The production-code port to Drizzle's core query builder was attempted during this investigation and **builds cleanly** — `db.select().from(nodeIdMappings).where(eq(nodeIdMappings.id, hash)).limit(1)` works on the same `Database` client that's already calling `.update()` and `.insert()` against the same tables.

But it breaks **~18 tests across 4 files** (`node-id-service.test.ts`, `edge-cases.test.ts`, `performance.test.ts`, `agent-context-manager.test.ts`) which mock `db.execute` rather than `db.select` chains. Durable migration requires either:

1. Replacing the mock-based tests with PGlite-backed integration tests (the existing `@revealui/test` harness supports this pattern for other tables)
2. Rewriting ~20 mock sites to stub the full `.select().from().where().limit()` chain

Either approach is meaningful infrastructure work, not a cosmetic cleanup. The allowlist reason now documents this as the prerequisite.

## Allowlist state after this PR

13 entries, unchanged count — accuracy improved, not size:

- **`null` (permanent escape hatches):** 10 entries
  - pg type imports in `@revealui/scripts` (2)
  - Standalone CLIs and seed scripts (3)
  - pg system functions: `pg_advisory_xact_lock`, `pg_current_xact_id` (3)
  - SELECT 1 liveness probes (2)
  - information_schema / pg_indexes introspection (in verify-test-setup.ts)
- **`6` (genuinely migratable, blocked):** 1 entry
  - `sql-helpers.ts`, pending PGlite-based integration-test migration
- **`7` (drizzle-consolidation-spec territory):** 2 entries
  - Supabase-side bootstrap, `universal-postgres.ts`

## Test plan

- [x] Validator still passes (allowlist is syntactically valid)
- [x] `pnpm gate:quick` → PASS (all 14 checks green)
- [x] No code or behavior changes — only JSON metadata
- [ ] CI stays green on this branch

## What's next

With Phase 6 reclassified, the durable work remaining on the plan:

- **Phase 6.1 (optional, blocked)**: sql-helpers.ts port, after PGlite integration-test migration.
- **Phase 7 (major arc)**: `universal-postgres.ts` consolidation per [`drizzle-consolidation-spec.md`](../internal docs); Supabase-side drizzle-kit pipeline evaluation.
- **Phase 4c (separate arc)**: evidence-based posts/users/sessions performance indexes, driven by current query traces — not a port of any historical wishlist.
- **Phase 3b (deferred)**: `crdt_operations` schema reconciliation when MCP moves toward production.
