### PR TITLE
refactor(ai,test): port sql-helpers.ts to Drizzle query builder (Phase 6.1)

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,6 +31,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.4",
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.3",
     "@revealui/dev": "workspace:*",

--- a/packages/ai/src/__tests__/agent-context-manager.test.ts
+++ b/packages/ai/src/__tests__/agent-context-manager.test.ts
@@ -1,29 +1,28 @@
+/**
+ * AgentContextManager tests
+ *
+ * These tests exercise the CRDT merge semantics layered over a MockPersistence
+ * (in-memory Map) for speed and determinism. The Database argument is now a
+ * real PGlite client (with the pgvector extension enabled) rather than an
+ * ad-hoc MockDatabase — `AgentContextManager.sync()` calls
+ * `findAgentContextById`, which in Phase 6.1 became a Drizzle
+ * `db.select().from(agentContexts)` query. An empty `agent_contexts` table
+ * satisfies that call (returns undefined) without changing any assertion.
+ */
+
 import type { Database } from '@revealui/db/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../../test/src/utils/drizzle-test-db.js';
 import { AgentContextManager } from '../memory/agent/context-manager.js';
 import { ValidationError } from '../memory/errors/index.js';
 import type { CRDTPersistence } from '../memory/persistence/crdt-persistence.js';
 import { WorkingMemory } from '../memory/stores/working-memory.js';
 
-// Mock database and persistence with actual state storage
+// In-memory state store that simulates the persistence layer for WorkingMemory.
+// This lets us test CRDT merge semantics without round-tripping through the DB.
 const mockStorage = new Map<string, Map<string, unknown>>();
 
-class MockDatabase {
-  query = {
-    agentContexts: {
-      findFirst: async () => null,
-    },
-  };
-  insert = () => ({ values: async () => undefined });
-  update = () => ({ set: () => ({ where: async () => undefined }) });
-  delete = () => ({ where: async () => undefined });
-  execute = async () => []; // Add execute method for raw SQL queries
-}
-
-// Mock persistence that actually stores state for WorkingMemory
-// Note: UserPreferencesManager no longer uses persistence, it uses direct DB access
 class MockPersistence {
-  // For WorkingMemory (composite state)
   loadCompositeState = async (crdtId: string) => {
     return mockStorage.get(crdtId) || new Map();
   };
@@ -36,15 +35,25 @@ class MockPersistence {
 type CircularContext = { a: number; self?: CircularContext };
 
 describe('AgentContextManager', () => {
+  let testDb: TestDb;
   let db: Database;
   let persistence: CRDTPersistence;
   let manager: AgentContextManager;
 
+  beforeAll(async () => {
+    // enableVector: true so agent_contexts (which has a vector(768) embedding)
+    // is created in PGlite. The table stays empty for these tests; sync() only
+    // probes for an existing row and correctly returns undefined.
+    testDb = await createTestDb({ enableVector: true });
+    db = testDb.drizzle as unknown as Database;
+  }, 30_000);
+
+  afterAll(async () => {
+    await testDb?.close();
+  });
+
   beforeEach(() => {
-    // Clear mock storage before each test
     mockStorage.clear();
-    db = new MockDatabase() as unknown as Database;
-    // Use a persistence that actually stores state for merge tests
     persistence = new MockPersistence() as unknown as CRDTPersistence;
     manager = new AgentContextManager('session-123', 'agent-456', 'node-abc', db, persistence);
   });
@@ -78,10 +87,7 @@ describe('AgentContextManager', () => {
       manager.setContext('language', 'en');
 
       const context = manager.getAllContext();
-      expect(context).toEqual({
-        theme: 'dark',
-        language: 'en',
-      });
+      expect(context).toEqual({ theme: 'dark', language: 'en' });
     });
   });
 
@@ -91,10 +97,7 @@ describe('AgentContextManager', () => {
       manager.setAllContext({ language: 'fr', timezone: 'UTC' });
 
       const context = manager.getAllContext();
-      expect(context).toEqual({
-        language: 'fr',
-        timezone: 'UTC',
-      });
+      expect(context).toEqual({ language: 'fr', timezone: 'UTC' });
       expect(context.theme).toBeUndefined();
     });
   });
@@ -105,10 +108,7 @@ describe('AgentContextManager', () => {
       manager.updateContext({ language: 'en' });
 
       const context = manager.getAllContext();
-      expect(context).toEqual({
-        theme: 'dark',
-        language: 'en',
-      });
+      expect(context).toEqual({ theme: 'dark', language: 'en' });
     });
 
     it('should overwrite existing keys', () => {
@@ -140,41 +140,28 @@ describe('AgentContextManager', () => {
 
   describe('mergeContext', () => {
     it('should preserve non-conflicting keys from both contexts', async () => {
-      // Set initial context with some keys and save
       manager.setContext('theme', 'dark');
       manager.setContext('language', 'en');
       await manager.save();
 
-      // Merge with remote context that has different keys
-      // Note: mergeContext loads state, merges, and saves
       await manager.mergeContext({ timezone: 'UTC', currency: 'USD' });
-
-      // Reload to get the merged state
       await manager.sync();
 
       const context = manager.getAllContext();
-      // Remote keys should definitely be present after merge
       expect(context.timezone).toBe('UTC');
       expect(context.currency).toBe('USD');
-      // Local keys should also be present after merge
       expect(context.theme).toBe('dark');
       expect(context.language).toBe('en');
     });
 
     it('should apply last-writer-wins for conflicting keys', async () => {
-      // Set initial context and save it
       manager.setContext('theme', 'dark');
       await manager.save();
 
-      // Wait a bit to ensure timestamp difference
       await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Merge with remote context that has same key but different value
-      // The remote context will have a later timestamp, so it should win
       await manager.mergeContext({ theme: 'light' });
 
       const context = manager.getAllContext();
-      // Remote value should win due to later timestamp (LWW semantics)
       expect(context.theme).toBe('light');
     });
 
@@ -183,16 +170,12 @@ describe('AgentContextManager', () => {
       manager.setContext('language', 'en');
       await manager.save();
 
-      // Merge with empty context - this creates a new LWWRegister with {}
-      // Due to LWW semantics, if the empty object has a later timestamp, it will win
-      // This is correct CRDT behavior, but we verify the method doesn't throw
       await manager.mergeContext({});
 
       const context = manager.getAllContext();
-      // Note: Due to LWW semantics, empty merge might overwrite if it has later timestamp
-      // This is correct CRDT behavior - we just verify the operation completes
+      // LWW semantics: empty merge may or may not overwrite depending on timestamp.
+      // This test only asserts the operation completes without throwing.
       expect(context).toBeDefined();
-      // The actual values depend on timestamp comparison, which is correct
     });
 
     it('should merge complex nested objects correctly', async () => {
@@ -202,7 +185,6 @@ describe('AgentContextManager', () => {
       await manager.mergeContext({ user: { name: 'Bob', city: 'NYC' } });
 
       const context = manager.getAllContext();
-      // LWW applies to entire object, so remote should replace local
       expect(context.user).toEqual({ name: 'Bob', city: 'NYC' });
     });
 
@@ -217,7 +199,6 @@ describe('AgentContextManager', () => {
       await manager.mergeContext({ counter: 3 });
 
       const context = manager.getAllContext();
-      // Last merge should win
       expect(context.counter).toBe(3);
     });
 
@@ -226,12 +207,9 @@ describe('AgentContextManager', () => {
       await manager.save();
 
       await manager.mergeContext({ value: 'merged' });
-
-      // Make local change after merge
       manager.setContext('value', 'local');
 
       const context = manager.getAllContext();
-      // Local change should win (most recent write)
       expect(context.value).toBe('local');
     });
   });
@@ -259,7 +237,6 @@ describe('AgentContextManager', () => {
     });
 
     it('should reject dangerous keys in updateContext', () => {
-      // __proto__ in object literals is not enumerable, so use constructor instead
       expect(() => manager.updateContext({ constructor: { polluted: true } })).toThrow(
         ValidationError,
       );
@@ -272,12 +249,10 @@ describe('AgentContextManager', () => {
     });
 
     it('should reject dangerous keys in mergeContext', async () => {
-      // Test with constructor (enumerable dangerous key)
       await expect(manager.mergeContext({ constructor: { polluted: true } })).rejects.toThrow(
         ValidationError,
       );
 
-      // Test with __proto__ set via Object.defineProperty (non-enumerable but should be caught)
       const protoContext: Record<string, unknown> = { normal: 'value' };
       Object.defineProperty(protoContext, '__proto__', {
         value: { polluted: true },
@@ -295,7 +270,6 @@ describe('AgentContextManager', () => {
 
     it('should provide detailed error messages', async () => {
       try {
-        // Use 'constructor' as __proto__ in object literals is not enumerable
         await manager.mergeContext({ constructor: { polluted: true } });
         expect.fail('Should have thrown');
       } catch (error) {

--- a/packages/ai/src/__tests__/edge-cases.test.ts
+++ b/packages/ai/src/__tests__/edge-cases.test.ts
@@ -1,17 +1,29 @@
 /**
  * Edge Case Tests
  *
- * Verifies that all edge cases are handled correctly.
+ * Covers NodeIdService input validation, DB-error handling (connection
+ * failure + transient retry), collision resolution, and concurrent requests,
+ * plus EpisodicMemory embedding / DB-error edge paths.
+ *
+ * History: previously mock-based (`db.execute` stubs). Now runs against a
+ * real in-memory Postgres via PGlite for NodeIdService tests, with
+ * `vi.spyOn` on the Drizzle client used to simulate transient failures
+ * where the real DB is always up. EpisodicMemory tests still rely on
+ * VectorMemoryService mocks (that layer is intentionally mockable) —
+ * unchanged from before.
  */
 
+import { createHash } from 'node:crypto';
 import type { AgentMemory } from '@revealui/contracts/agents';
 import type { Database } from '@revealui/db/client';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nodeIdMappings } from '@revealui/db/schema';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestDb } from '../../../test/src/utils/drizzle-test-db.js';
 import { NodeIdService } from '../memory/services/node-id-service.js';
 import { EpisodicMemory } from '../memory/stores/episodic-memory.js';
 import type { VectorMemoryService } from '../memory/vector/vector-memory-service.js';
 
-// Mock VectorMemoryService - all variables must be inside the factory to avoid hoisting issues
+// Mock VectorMemoryService — all variables must be inside the factory to avoid hoisting issues
 vi.mock('../memory/vector/vector-memory-service', () => {
   const mockMemory: AgentMemory = {
     id: 'mem-1',
@@ -34,15 +46,12 @@ vi.mock('../memory/vector/vector-memory-service', () => {
     searchSimilar = vi.fn().mockResolvedValue([]);
   }
 
-  return {
-    VectorMemoryService: MockVectorMemoryService,
-  };
+  return { VectorMemoryService: MockVectorMemoryService };
 });
 
 const getVectorService = (memory: EpisodicMemory): VectorMemoryService =>
   (memory as EpisodicMemory & { vectorService: VectorMemoryService }).vectorService;
 
-type InsertResult = ReturnType<Database['insert']>;
 type NodeIdEntityType = Parameters<NodeIdService['getNodeId']>[0];
 type NodeIdEntityId = Parameters<NodeIdService['getNodeId']>[1];
 type MemorySetStub = {
@@ -50,44 +59,31 @@ type MemorySetStub = {
   entries?: () => Array<[string, string]>;
 };
 
-const createInsertResult = (): InsertResult =>
-  ({ values: vi.fn().mockResolvedValue(undefined) }) as unknown as InsertResult;
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
 
-// Mock database
-const createMockDb = (): Database => {
-  return {
-    query: {
-      nodeIdMappings: {
-        findFirst: vi.fn(),
-      },
-      agentMemories: {
-        findFirst: vi.fn(),
-      },
-    },
-    insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined),
-    }),
-    update: vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
-    }),
-    delete: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined),
-    }),
-    execute: vi.fn().mockResolvedValue([]), // Add execute method for raw SQL queries
-  } as unknown as Database;
-};
+// =============================================================================
+// NodeIdService Edge Cases (PGlite-backed)
+// =============================================================================
 
 describe('Edge Cases', () => {
   describe('NodeIdService Edge Cases', () => {
-    let service: NodeIdService;
+    let testDb: TestDb;
     let db: Database;
+    let service: NodeIdService;
 
-    beforeEach(() => {
-      db = createMockDb();
+    beforeAll(async () => {
+      testDb = await createTestDb();
+      db = testDb.drizzle as unknown as Database;
+    }, 30_000);
+
+    afterAll(async () => {
+      await testDb?.close();
+    });
+
+    beforeEach(async () => {
+      await testDb.drizzle.delete(nodeIdMappings);
       service = new NodeIdService(db);
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
 
     describe('Input Validation', () => {
@@ -128,7 +124,7 @@ describe('Edge Cases', () => {
       });
 
       it('should reject very long entityId', async () => {
-        const longId = 'a'.repeat(1001); // Exceeds MAX_ENTITY_ID_LENGTH (1000)
+        const longId = 'a'.repeat(1001); // Exceeds MaxEntityIdLength (1000)
         await expect(service.getNodeId('session', longId)).rejects.toThrow(
           'Invalid entityId: length 1001 exceeds maximum of 1000 characters',
         );
@@ -136,183 +132,140 @@ describe('Edge Cases', () => {
     });
 
     describe('Database Error Handling', () => {
-      it('should handle database connection failure', async () => {
-        vi.mocked(db.execute).mockRejectedValue(new Error('Database connection failed'));
+      it('should wrap repeated DB failures in a retry-exhausted error', async () => {
+        // Force every `.select()` invocation to throw. The service retries
+        // up to 3 times (with backoff), then wraps the final error.
+        vi.spyOn(db, 'select').mockImplementation(() => {
+          throw new Error('Database connection failed');
+        });
 
         await expect(service.getNodeId('session', 'session-123')).rejects.toThrow(
-          'Database operation failed',
+          /Database operation failed/,
         );
       });
 
       it('should retry on transient database errors', async () => {
-        let callCount = 0;
-        vi.mocked(db.execute).mockImplementation(() => {
-          callCount++;
-          if (callCount < 3) {
-            return Promise.reject(new Error('Transient error'));
+        // First two select() calls throw, third succeeds (delegates to real DB).
+        const real = db.select.bind(db);
+        let attempts = 0;
+        vi.spyOn(db, 'select').mockImplementation(((...args: unknown[]) => {
+          attempts++;
+          if (attempts < 3) {
+            throw new Error('Transient error');
           }
-          return Promise.resolve([]); // No existing mapping
-        });
-        vi.mocked(db.insert).mockReturnValue(createInsertResult());
+          return (real as unknown as (...a: unknown[]) => unknown)(...args);
+        }) as unknown as typeof db.select);
 
         const nodeId = await service.getNodeId('session', 'session-123');
 
         expect(nodeId).toBeDefined();
-        expect(db.execute).toHaveBeenCalledTimes(3);
+        expect(attempts).toBeGreaterThanOrEqual(3);
       });
 
       it('should not retry on validation errors', async () => {
+        const selectSpy = vi.spyOn(db, 'select');
+
         await expect(service.getNodeId('session', '')).rejects.toThrow('Invalid entityId');
 
-        // Should not retry validation errors
-        expect(db.execute).not.toHaveBeenCalled();
+        // Validation short-circuits before any DB call.
+        expect(selectSpy).not.toHaveBeenCalled();
       });
     });
 
     describe('Collision Handling', () => {
       it('should handle hash collision (same hash, different entityId)', async () => {
-        // First call: existing mapping with different entityId (collision)
-        // Note: db.execute() returns snake_case data
-        vi.mocked(db.execute)
-          .mockResolvedValueOnce([
-            {
-              id: 'hash-123',
-              entity_type: 'session',
-              entity_id: 'different-session-id', // Different entityId = collision
-              node_id: 'existing-node-id',
-              created_at: new Date(),
-              updated_at: new Date(),
-            },
-          ])
-          // Second call: check collision hash
-          .mockResolvedValueOnce([]);
+        // Seed a row at the primary hash but with a different entityId.
+        // Service should detect the collision and create a new row at the
+        // collision-resistant hash derived from entityType:entityId:1.
+        const entityId = 'session-123';
+        const primaryHash = sha256(entityId);
 
-        vi.mocked(db.insert).mockReturnValue(createInsertResult());
+        await testDb.drizzle.insert(nodeIdMappings).values({
+          id: primaryHash,
+          entityType: 'session',
+          entityId: 'different-session-id',
+          nodeId: 'existing-node-id',
+        });
 
-        const nodeId = await service.getNodeId('session', 'session-123');
+        const nodeId = await service.getNodeId('session', entityId);
 
-        expect(nodeId).toBeDefined();
-        // Should create new mapping with collision hash
-        expect(db.insert).toHaveBeenCalled();
+        // Service should have created a new row at sha256(`session:${entityId}:1`).
+        const collisionHash = sha256(`session:${entityId}:1`);
+        const allRows = await testDb.drizzle.select().from(nodeIdMappings);
+        const created = allRows.find((r) => r.id === collisionHash);
+
+        expect(created).toBeDefined();
+        expect(created?.nodeId).toBe(nodeId);
+        expect(created?.entityId).toBe(entityId);
       });
 
       it('should handle multiple collision attempts', async () => {
-        // Simulate multiple collisions
-        // Note: db.execute() returns snake_case data
-        vi.mocked(db.execute)
-          .mockResolvedValueOnce([
-            {
-              id: 'hash-123',
-              entity_type: 'session',
-              entity_id: 'different-1',
-              node_id: 'node-1',
-              created_at: new Date(),
-              updated_at: new Date(),
-            },
-          ])
-          .mockResolvedValueOnce([
-            {
-              id: 'collision-hash-1',
-              entity_type: 'session',
-              entity_id: 'different-2',
-              node_id: 'node-2',
-              created_at: new Date(),
-              updated_at: new Date(),
-            },
-          ])
-          .mockResolvedValueOnce([]); // Finally, no collision
+        // Seed collisions at both the primary hash AND the first collision hash,
+        // each with a different entityId. The service should walk through two
+        // collision attempts and land at the second collision-resistant hash.
+        const entityId = 'session-123';
+        const primaryHash = sha256(entityId);
+        const firstCollisionHash = sha256(`session:${entityId}:1`);
+        const secondCollisionHash = sha256(`session:${entityId}:2`);
 
-        vi.mocked(db.insert).mockReturnValue(createInsertResult());
-
-        const nodeId = await service.getNodeId('session', 'session-123');
-
-        expect(nodeId).toBeDefined();
-        expect(db.execute).toHaveBeenCalledTimes(3);
-      });
-
-      it('should throw error after max collision attempts', async () => {
-        // Simulate max collisions exceeded
-        vi.mocked(db.query.nodeIdMappings.findFirst).mockResolvedValue({
-          id: 'hash-123',
-          entityType: 'session',
-          entityId: 'different',
-          nodeId: 'node-id',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        });
-
-        // Mock collision resolution to always find existing mapping
-        let attempt = 0;
-        vi.mocked(db.query.nodeIdMappings.findFirst).mockImplementation(() => {
-          attempt++;
-          if (attempt > 10) {
-            // After 10 attempts, return null to allow insert
-            return Promise.resolve(null);
-          }
-          return Promise.resolve({
-            id: `collision-${attempt}`,
+        await testDb.drizzle.insert(nodeIdMappings).values([
+          {
+            id: primaryHash,
             entityType: 'session',
-            entityId: 'different',
-            nodeId: 'node-id',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          });
-        });
+            entityId: 'different-1',
+            nodeId: 'node-1',
+          },
+          {
+            id: firstCollisionHash,
+            entityType: 'session',
+            entityId: 'different-2',
+            nodeId: 'node-2',
+          },
+        ]);
 
-        // This should eventually succeed (after 10+ attempts)
-        // But we can't easily test the failure case without mocking more deeply
-        // The actual implementation has MAX_COLLISION_ATTEMPTS = 10
+        const nodeId = await service.getNodeId('session', entityId);
+
+        const rows = await testDb.drizzle.select().from(nodeIdMappings);
+        const created = rows.find((r) => r.id === secondCollisionHash);
+
+        expect(created).toBeDefined();
+        expect(created?.nodeId).toBe(nodeId);
+        expect(created?.entityId).toBe(entityId);
       });
     });
 
     describe('Concurrent Operations', () => {
       it('should handle concurrent requests for same entity', async () => {
-        let callCount = 0;
-        vi.mocked(db.query.nodeIdMappings.findFirst).mockImplementation(() => {
-          callCount++;
-          if (callCount === 1) {
-            // First request: no mapping exists
-            return Promise.resolve(null);
-          } else {
-            // Subsequent requests: mapping now exists
-            return Promise.resolve({
-              id: 'hash-123',
-              entityType: 'session',
-              entityId: 'session-123',
-              nodeId: 'node-id-123',
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            });
-          }
-        });
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () => service.getNodeId('session', 'session-123')),
+        );
 
-        vi.mocked(db.insert).mockReturnValue(createInsertResult());
-
-        // Simulate 5 concurrent requests
-        const results = await Promise.all([
-          service.getNodeId('session', 'session-123'),
-          service.getNodeId('session', 'session-123'),
-          service.getNodeId('session', 'session-123'),
-          service.getNodeId('session', 'session-123'),
-          service.getNodeId('session', 'session-123'),
-        ]);
-
-        // All should get valid node IDs
         expect(results).toHaveLength(5);
         expect(results.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
+
+        // Deterministic hash → exactly one row regardless of race outcome;
+        // all callers must resolve to the winning node_id.
+        const rows = await testDb.drizzle.select().from(nodeIdMappings);
+        expect(rows).toHaveLength(1);
+        expect(results.every((id) => id === rows[0]?.nodeId)).toBe(true);
       });
     });
   });
 
+  // ===========================================================================
+  // EpisodicMemory Edge Cases (VectorMemoryService mocked — DB unused)
+  // ===========================================================================
+
   describe('EpisodicMemory Edge Cases', () => {
     let memory: EpisodicMemory;
-    let db: Database;
     const userId = 'user-123';
     const nodeId = 'node-abc';
 
     beforeEach(() => {
-      db = createMockDb();
-      memory = new EpisodicMemory(userId, nodeId, db);
+      // EpisodicMemory goes through the mocked VectorMemoryService; the Database
+      // argument is never touched in these tests. Pass a minimal sentinel.
+      const unusedDb = {} as Database;
+      memory = new EpisodicMemory(userId, nodeId, unusedDb);
       vi.clearAllMocks();
     });
 
@@ -323,24 +276,16 @@ describe('Edge Cases', () => {
           version: 1,
           content: 'Memory without embedding',
           type: 'fact',
-          source: {
-            type: 'user',
-            id: userId,
-            confidence: 1,
-          },
+          source: { type: 'user', id: userId, confidence: 1 },
           metadata: {},
           createdAt: new Date().toISOString(),
         };
 
         await memory.add(testMemory);
 
-        // Verify VectorMemoryService.create() was called
         const vectorService = getVectorService(memory);
         expect(vectorService.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: 'mem-1',
-            content: 'Memory without embedding',
-          }),
+          expect.objectContaining({ id: 'mem-1', content: 'Memory without embedding' }),
         );
       });
 
@@ -350,24 +295,16 @@ describe('Edge Cases', () => {
           version: 1,
           content: 'Memory with undefined embedding',
           type: 'fact',
-          source: {
-            type: 'user',
-            id: userId,
-            confidence: 1,
-          },
+          source: { type: 'user', id: userId, confidence: 1 },
           metadata: {},
           createdAt: new Date().toISOString(),
         };
 
         await memory.add(testMemory);
 
-        // Verify VectorMemoryService.create() was called
         const vectorService = getVectorService(memory);
         expect(vectorService.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: 'mem-2',
-            content: 'Memory with undefined embedding',
-          }),
+          expect.objectContaining({ id: 'mem-2', content: 'Memory with undefined embedding' }),
         );
       });
 
@@ -377,16 +314,11 @@ describe('Edge Cases', () => {
           version: 1,
           content: 'Memory with invalid embedding',
           type: 'fact',
-          source: {
-            type: 'user',
-            id: userId,
-            confidence: 1,
-          },
+          source: { type: 'user', id: userId, confidence: 1 },
           embedding: {
             model: 'invalid-model',
             vector: [1, 2, 3],
-            dimension: 1536, // Mismatch
-            generatedAt: new Date().toISOString(),
+            dimension: 1536,
           } as unknown as AgentMemory['embedding'],
           metadata: {},
           createdAt: new Date().toISOString(),
@@ -401,14 +333,10 @@ describe('Edge Cases', () => {
           version: 1,
           content: 'Memory with dimension mismatch',
           type: 'fact',
-          source: {
-            type: 'user',
-            id: userId,
-            confidence: 1,
-          },
+          source: { type: 'user', id: userId, confidence: 1 },
           embedding: {
             model: 'openai-text-embedding-3-small',
-            vector: Array(768).fill(0.1), // Wrong dimension
+            vector: Array(768).fill(0.1),
             dimension: 1536,
             generatedAt: new Date().toISOString(),
           },
@@ -422,7 +350,6 @@ describe('Edge Cases', () => {
 
     describe('Database Edge Cases', () => {
       it('should handle database error when loading memory', async () => {
-        // Mock VectorMemoryService.getById() to throw an error
         const vectorService = getVectorService(memory);
         vi.spyOn(vectorService, 'getById').mockRejectedValue(new Error('Database error'));
 
@@ -434,7 +361,6 @@ describe('Edge Cases', () => {
       });
 
       it('should handle memory not found in database', async () => {
-        // Mock VectorMemoryService.getById() to return null (no memory found)
         const vectorService = getVectorService(memory);
         vi.spyOn(vectorService, 'getById').mockResolvedValue(null);
 
@@ -443,20 +369,21 @@ describe('Edge Cases', () => {
         } as unknown as MemorySetStub;
 
         const result = await memory.get('mem-1');
-
         expect(result).toBeNull();
       });
 
-      it('should handle memory not in ORSet', async () => {
+      it('should handle memory not in ORSet (skip DB lookup entirely)', async () => {
+        const vectorService = getVectorService(memory);
+        const getByIdSpy = vi.spyOn(vectorService, 'getById');
+
         memory.memories = {
-          values: () => [], // Empty set
+          values: () => [],
         } as unknown as MemorySetStub;
 
         const result = await memory.get('mem-1');
 
         expect(result).toBeNull();
-        // Should not query database if not in ORSet
-        expect(db.execute).not.toHaveBeenCalled();
+        expect(getByIdSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -467,7 +394,6 @@ describe('Edge Cases', () => {
         } as unknown as MemorySetStub;
 
         const all = await memory.getAll();
-
         expect(all).toEqual([]);
       });
 
@@ -478,7 +404,6 @@ describe('Edge Cases', () => {
         } as unknown as MemorySetStub;
 
         const count = await memory.removeById('non-existent');
-
         expect(count).toBe(0);
       });
     });

--- a/packages/ai/src/__tests__/node-id-service.test.ts
+++ b/packages/ai/src/__tests__/node-id-service.test.ts
@@ -1,125 +1,141 @@
+import { createHash } from 'node:crypto';
 import type { Database } from '@revealui/db/client';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nodeIdMappings } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../../test/src/utils/drizzle-test-db.js';
 import { NodeIdService } from '../memory/services/node-id-service.js';
 
-type InsertResult = ReturnType<Database['insert']>;
-type NodeIdEntityType = Parameters<NodeIdService['getNodeId']>[0];
-type NodeIdEntityId = Parameters<NodeIdService['getNodeId']>[1];
+/**
+ * NodeIdService tests — PGlite-backed integration tests.
+ *
+ * These used to mock `db.execute` against hand-crafted rows. After the
+ * sql-helpers.ts port to Drizzle's core query builder (Phase 6.1), the
+ * tests run against a real in-memory Postgres via @revealui/test's
+ * PGlite harness. Each test gets a fresh `node_id_mappings` table via
+ * truncation in beforeEach.
+ */
 
-const createInsertResult = (): InsertResult =>
-  ({ values: vi.fn().mockResolvedValue(undefined) }) as unknown as InsertResult;
+const entityId = 'session-123';
+const entityType = 'session' as const;
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
 
-// Mock database
-const mockDb = {
-  query: {
-    nodeIdMappings: {
-      findFirst: vi.fn(),
-    },
-  },
-  insert: vi.fn().mockReturnValue({
-    values: vi.fn(),
-  }),
-  execute: vi.fn(), // Add execute method for raw SQL queries
-} as unknown as Database;
+let testDb: TestDb;
+let db: Database;
+
+beforeAll(async () => {
+  testDb = await createTestDb();
+  // PGlite's Drizzle client is structurally compatible with the Database
+  // union type for the surface NodeIdService uses (select/insert/update).
+  db = testDb.drizzle as unknown as Database;
+}, 30_000);
+
+afterAll(async () => {
+  await testDb?.close();
+});
+
+beforeEach(async () => {
+  // Clean slate per test
+  await testDb.drizzle.delete(nodeIdMappings);
+});
 
 describe('NodeIdService', () => {
   let service: NodeIdService;
-  const entityId = 'session-123';
-  const entityType = 'session' as const;
 
   beforeEach(() => {
-    service = new NodeIdService(mockDb);
-    vi.clearAllMocks();
+    service = new NodeIdService(db);
   });
 
   describe('Hash Generation', () => {
     it('should generate deterministic SHA-256 hash', async () => {
-      // Test that service generates same hash for same input
-      vi.mocked(mockDb.execute).mockResolvedValue([]); // No existing mapping
-      vi.mocked(mockDb.insert).mockReturnValue(createInsertResult());
-
+      // First call: no existing mapping, service creates one.
       const nodeId1 = await service.getNodeId(entityType, entityId);
-      vi.clearAllMocks();
 
-      vi.mocked(mockDb.execute).mockResolvedValue([]); // No existing mapping
-      vi.mocked(mockDb.insert).mockReturnValue(createInsertResult());
+      // Look up the created row — its id is the SHA-256 hash of entityId.
+      const expectedHash = sha256(entityId);
+      const [stored] = await testDb.drizzle
+        .select()
+        .from(nodeIdMappings)
+        .where(eq(nodeIdMappings.id, expectedHash))
+        .limit(1);
 
+      expect(stored?.nodeId).toBe(nodeId1);
+
+      // Second call: should return the SAME node ID (read path, not create).
       const nodeId2 = await service.getNodeId(entityType, entityId);
-
-      // Note: Since we're creating new UUIDs each time, they'll be different
-      // But the hash lookup should be the same
-      expect(nodeId1).toBeDefined();
-      expect(nodeId2).toBeDefined();
+      expect(nodeId2).toBe(nodeId1);
     });
   });
 
   describe('getNodeId', () => {
     it('should return existing node ID from database', async () => {
       const existingNodeId = 'existing-node-id-123';
+      const hash = sha256(entityId);
 
-      // Return data only on first call, empty on subsequent calls (for collision checks)
-      vi.mocked(mockDb.execute)
-        .mockResolvedValueOnce([
-          {
-            id: 'hash-123',
-            entity_type: 'session',
-            entity_id: entityId,
-            node_id: existingNodeId,
-            created_at: new Date(),
-            updated_at: new Date(),
-          },
-        ])
-        .mockResolvedValue([]); // Subsequent calls return empty
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: hash,
+        entityType,
+        entityId,
+        nodeId: existingNodeId,
+      });
 
       const nodeId = await service.getNodeId(entityType, entityId);
-
       expect(nodeId).toBe(existingNodeId);
-      expect(mockDb.execute).toHaveBeenCalled();
     });
 
     it('should create new node ID if not exists', async () => {
-      vi.mocked(mockDb.execute).mockResolvedValue([]); // No existing mapping
-      vi.mocked(mockDb.insert).mockReturnValue(createInsertResult());
+      const hash = sha256(entityId);
 
       const nodeId = await service.getNodeId(entityType, entityId);
 
       expect(nodeId).toBeDefined();
       expect(typeof nodeId).toBe('string');
-      expect(mockDb.insert).toHaveBeenCalled();
+
+      // Verify row was created at the expected primary-key hash.
+      const [stored] = await testDb.drizzle
+        .select()
+        .from(nodeIdMappings)
+        .where(eq(nodeIdMappings.id, hash))
+        .limit(1);
+
+      expect(stored).toBeDefined();
+      expect(stored?.nodeId).toBe(nodeId);
+      expect(stored?.entityType).toBe(entityType);
+      expect(stored?.entityId).toBe(entityId);
     });
 
     it('should detect and resolve collisions', async () => {
+      // Seed a row at the primary hash but with a DIFFERENT entityId.
+      // getNodeId for our entityId should then fall through to a collision-
+      // resistant hash (entityType:entityId:1) and create a fresh mapping.
       const differentEntityId = 'session-456';
+      const primaryHash = sha256(entityId);
 
-      // First call: existing mapping with different entityId (collision)
-      vi.mocked(mockDb.execute)
-        .mockResolvedValueOnce([
-          {
-            id: 'hash-123',
-            entity_type: 'session',
-            entity_id: differentEntityId, // Different entityId = collision
-            node_id: 'existing-node-id',
-            created_at: new Date(),
-            updated_at: new Date(),
-          },
-        ])
-        // Second call: check collision hash - no existing mapping
-        .mockResolvedValueOnce([]);
-
-      vi.mocked(mockDb.insert).mockReturnValue({
-        values: vi.fn().mockResolvedValue(undefined),
-      } as unknown as InsertResult);
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: primaryHash,
+        entityType,
+        entityId: differentEntityId,
+        nodeId: 'node-for-other-entity',
+      });
 
       const nodeId = await service.getNodeId(entityType, entityId);
 
-      expect(nodeId).toBeDefined();
-      // Should create new mapping with collision hash
-      expect(mockDb.insert).toHaveBeenCalled();
+      // Resolver derives the collision hash as sha256(`${type}:${id}:1`).
+      const collisionHash = sha256(`${entityType}:${entityId}:1`);
+      const [stored] = await testDb.drizzle
+        .select()
+        .from(nodeIdMappings)
+        .where(eq(nodeIdMappings.id, collisionHash))
+        .limit(1);
+
+      expect(stored).toBeDefined();
+      expect(stored?.nodeId).toBe(nodeId);
+      expect(stored?.entityId).toBe(entityId);
     });
 
     it('should throw error for invalid entityType', async () => {
       await expect(
-        service.getNodeId('invalid' as unknown as NodeIdEntityType, entityId),
+        service.getNodeId('invalid' as unknown as typeof entityType, entityId),
       ).rejects.toThrow("Invalid entityType: invalid. Must be 'session' or 'user'");
     });
 
@@ -130,42 +146,30 @@ describe('NodeIdService', () => {
     });
 
     it('should throw error for non-string entityId', async () => {
-      await expect(
-        service.getNodeId(entityType, null as unknown as NodeIdEntityId),
-      ).rejects.toThrow('Invalid entityId: must be a non-empty string');
+      await expect(service.getNodeId(entityType, null as unknown as string)).rejects.toThrow(
+        'Invalid entityId: must be a non-empty string',
+      );
     });
   });
 
   describe('Concurrent Requests', () => {
     it('should handle concurrent requests for same entity', async () => {
-      // First request: no existing mapping
-      vi.mocked(mockDb.execute)
-        .mockResolvedValueOnce([]) // No existing mapping
-        // Second request: mapping now exists (created by first request)
-        .mockResolvedValueOnce([
-          {
-            id: 'hash-123',
-            entity_type: 'session',
-            entity_id: entityId,
-            node_id: 'node-id-123',
-            created_at: new Date(),
-            updated_at: new Date(),
-          },
-        ]);
-
-      vi.mocked(mockDb.insert).mockReturnValue({
-        values: vi.fn().mockResolvedValue(undefined),
-      } as unknown as InsertResult);
-
-      // Simulate concurrent requests
       const [nodeId1, nodeId2] = await Promise.all([
         service.getNodeId(entityType, entityId),
         service.getNodeId(entityType, entityId),
       ]);
 
-      // Both should get valid node IDs
       expect(nodeId1).toBeDefined();
       expect(nodeId2).toBeDefined();
+
+      // Both must resolve to the same node_id (the hash is deterministic, so
+      // whichever insert lost the race should read the winning row).
+      expect(nodeId1).toBe(nodeId2);
+
+      // Exactly one row should exist.
+      const rows = await testDb.drizzle.select().from(nodeIdMappings);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.nodeId).toBe(nodeId1);
     });
   });
 });

--- a/packages/ai/src/__tests__/performance.test.ts
+++ b/packages/ai/src/__tests__/performance.test.ts
@@ -1,266 +1,209 @@
 /**
- * Performance Tests
+ * Performance Tests — NodeIdService
  *
- * Verifies that node ID lookup meets performance requirements (< 10ms).
+ * Verifies that node-ID lookup + create flows stay within reasonable bounds
+ * end-to-end against a real in-memory Postgres (PGlite) via the shared
+ * @revealui/test harness.
+ *
+ * History: this file used to assert very tight timing bounds against a
+ * fake `db.execute` mock that simulated 1-2ms delays via setTimeout. That
+ * told us nothing about real DB-client behavior. The ported version runs
+ * the real sql-helpers / Drizzle queries against PGlite, which is a much
+ * more honest signal — but PGlite has a fixed per-query overhead that
+ * varies with host load, so thresholds are widened accordingly. The goal
+ * is to catch *regressions* (e.g. accidental N+1s, missing indexes), not
+ * to measure absolute speed.
  */
 
+import { createHash } from 'node:crypto';
 import type { Database } from '@revealui/db/client';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nodeIdMappings } from '@revealui/db/schema';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../../test/src/utils/drizzle-test-db.js';
 import { NodeIdService } from '../memory/services/node-id-service.js';
 
-type InsertResult = ReturnType<Database['insert']>;
-type MappingRow = Record<string, unknown>;
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
 
-const createInsertResult = (): InsertResult =>
-  ({ values: vi.fn().mockResolvedValue(undefined) }) as unknown as InsertResult;
+let testDb: TestDb;
+let db: Database;
 
-// Mock database with timing
-const createMockDb = (): Database => {
-  const mappings: Record<string, MappingRow> = {};
-  return {
-    query: {
-      nodeIdMappings: {
-        findFirst: vi.fn(() => {
-          // Simulate database query delay (1-2ms typical)
-          return new Promise((resolve) => {
-            setTimeout(() => {
-              const id = 'hash-123'; // Simplified for testing
-              resolve(mappings[id] || null);
-            }, 1);
-          });
-        }),
-      },
-    },
-    insert: vi.fn(() => ({
-      values: vi.fn((data: { id: string } & MappingRow) => {
-        // Simulate database insert delay (2-3ms typical)
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            mappings[data.id] = {
-              ...data,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            };
-            resolve(undefined);
-          }, 2);
-        });
-      }),
-    })),
-    execute: vi.fn((sql) => {
-      // Simulate database execute delay (1-2ms typical)
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          // Extract hash from SQL query (simplified for testing)
-          const hashMatch = sql.queryChunks?.find((chunk: string) => chunk.includes('hash-'));
-          const id = hashMatch || 'hash-123';
-          const mapping = mappings[id];
-          resolve(mapping ? [mapping] : []);
-        }, 1);
-      });
-    }),
-  } as unknown as Database;
-};
+beforeAll(async () => {
+  testDb = await createTestDb();
+  db = testDb.drizzle as unknown as Database;
+}, 30_000);
+
+afterAll(async () => {
+  await testDb?.close();
+});
+
+beforeEach(async () => {
+  await testDb.drizzle.delete(nodeIdMappings);
+});
 
 describe('Node ID Service Performance', () => {
   let service: NodeIdService;
-  let db: Database;
   const entityId = 'session-123';
   const entityType = 'session' as const;
 
   beforeEach(() => {
-    db = createMockDb();
     service = new NodeIdService(db);
-    vi.clearAllMocks();
   });
 
   describe('Node ID Lookup Performance', () => {
-    it('should complete node ID lookup in < 10ms for existing mapping', async () => {
-      // Pre-populate mapping
-      vi.mocked(db.execute).mockResolvedValue([
-        {
-          id: 'hash-123',
-          entity_type: 'session',
-          entity_id: entityId,
-          node_id: 'existing-node-id',
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ]);
+    it('should complete node ID lookup for existing mapping quickly', async () => {
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: sha256(entityId),
+        entityType,
+        entityId,
+        nodeId: 'existing-node-id',
+      });
 
       const start = performance.now();
       const nodeId = await service.getNodeId(entityType, entityId);
       const duration = performance.now() - start;
 
-      expect(nodeId).toBeDefined();
-      expect(duration).toBeLessThan(50); // Should be < 50ms (relaxed for CI parallel load)
+      expect(nodeId).toBe('existing-node-id');
+      // PGlite in-memory + current host: lookups typically <20ms, allow 100ms slack for CI noise.
+      expect(duration).toBeLessThan(100);
     });
 
-    it('should complete node ID creation in < 50ms for new mapping', async () => {
-      // No existing mapping
-      vi.mocked(db.execute).mockResolvedValue([]);
-      vi.mocked(db.insert).mockReturnValue(createInsertResult());
-
+    it('should complete node ID creation for new mapping quickly', async () => {
       const start = performance.now();
       const nodeId = await service.getNodeId(entityType, entityId);
       const duration = performance.now() - start;
 
       expect(nodeId).toBeDefined();
-      expect(duration).toBeLessThan(50); // Should be < 50ms (accounts for test environment overhead)
+      // Create path = lookup + insert, usually <30ms on PGlite; 150ms is generous.
+      expect(duration).toBeLessThan(150);
     });
 
-    it('should handle concurrent lookups efficiently', async () => {
-      // Pre-populate mapping
-      vi.mocked(db.execute).mockResolvedValue([
-        {
-          id: 'hash-123',
-          entity_type: 'session',
-          entity_id: entityId,
-          node_id: 'existing-node-id',
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ]);
+    it('should handle 5 concurrent lookups of the same entity', async () => {
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: sha256(entityId),
+        entityType,
+        entityId,
+        nodeId: 'existing-node-id',
+      });
 
       const start = performance.now();
-      const results = await Promise.all([
-        service.getNodeId(entityType, entityId),
-        service.getNodeId(entityType, entityId),
-        service.getNodeId(entityType, entityId),
-        service.getNodeId(entityType, entityId),
-        service.getNodeId(entityType, entityId),
-      ]);
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => service.getNodeId(entityType, entityId)),
+      );
       const duration = performance.now() - start;
 
       expect(results).toHaveLength(5);
       expect(results.every((id) => id === 'existing-node-id')).toBe(true);
-      // Concurrent lookups should still be fast
-      expect(duration).toBeLessThan(50); // 5 lookups * 10ms = 50ms max
+      expect(duration).toBeLessThan(200);
     });
 
-    it('should handle hash generation efficiently', async () => {
-      // Test that SHA-256 hash generation is fast
-      // Note: This includes database operations, so it's slower than pure hash generation
-      vi.mocked(db.execute).mockResolvedValue([]);
-      vi.mocked(db.insert).mockReturnValue(createInsertResult());
-
+    it('should handle 10 create operations at reasonable average latency', async () => {
       const start = performance.now();
-
-      // Generate 10 node IDs (each includes hash + DB operation)
       for (let i = 0; i < 10; i++) {
         await service.getNodeId(entityType, `entity-${i}`);
       }
-
       const duration = performance.now() - start;
-      const avgDuration = duration / 10;
+      const avg = duration / 10;
 
-      // Each operation (hash + DB) should average < 10ms
-      expect(avgDuration).toBeLessThan(10);
+      // Each op = SELECT (miss) + INSERT; typically <20ms avg on PGlite. Allow 30ms.
+      expect(avg).toBeLessThan(30);
     });
   });
 
-  describe('Database Query Optimization', () => {
-    it('should use primary key lookup (fast)', async () => {
-      // Pre-populate mapping
-      vi.mocked(db.execute).mockResolvedValue([
-        {
-          id: 'hash-123',
-          entity_type: 'session',
-          entity_id: entityId,
-          node_id: 'existing-node-id',
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ]);
+  describe('Database Query Shape', () => {
+    it('should use primary-key lookup (single SELECT on existing mapping)', async () => {
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: sha256(entityId),
+        entityType,
+        entityId,
+        nodeId: 'existing-node-id',
+      });
 
-      const start = performance.now();
-      await service.getNodeId(entityType, entityId);
-      const duration = performance.now() - start;
+      // Snapshot row count before; service should not add rows on a hit.
+      const before = await testDb.drizzle.select().from(nodeIdMappings);
 
-      // Primary key lookup should be very fast (mocked DB, generous threshold for CI/WSL)
-      expect(duration).toBeLessThan(50);
-      expect(db.execute).toHaveBeenCalledTimes(1);
+      const nodeId = await service.getNodeId(entityType, entityId);
+
+      const after = await testDb.drizzle.select().from(nodeIdMappings);
+
+      expect(nodeId).toBe('existing-node-id');
+      expect(after.length).toBe(before.length); // no extra INSERT on hit
     });
 
-    it('should cache results for same entity (no repeated DB calls)', async () => {
-      // Pre-populate mapping
-      vi.mocked(db.execute).mockResolvedValue([
-        {
-          id: 'hash-123',
-          entity_type: 'session',
-          entity_id: entityId,
-          node_id: 'existing-node-id',
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ]);
+    it('should not cache results in-memory (repeated lookups each hit the DB)', async () => {
+      // The service has no in-memory cache by design. After we seed one row
+      // and call getNodeId thrice, the row count stays at 1 and each call
+      // returns the same node_id — confirming the service reads fresh each
+      // time rather than caching a stale value.
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: sha256(entityId),
+        entityType,
+        entityId,
+        nodeId: 'existing-node-id',
+      });
 
-      // Call multiple times
-      await service.getNodeId(entityType, entityId);
-      await service.getNodeId(entityType, entityId);
-      await service.getNodeId(entityType, entityId);
+      const id1 = await service.getNodeId(entityType, entityId);
+      const id2 = await service.getNodeId(entityType, entityId);
+      const id3 = await service.getNodeId(entityType, entityId);
 
-      // Each call should query the database (no in-memory cache in service)
-      // But database should have query cache
-      expect(db.execute).toHaveBeenCalledTimes(3);
+      expect([id1, id2, id3]).toEqual(['existing-node-id', 'existing-node-id', 'existing-node-id']);
+
+      const rows = await testDb.drizzle.select().from(nodeIdMappings);
+      expect(rows).toHaveLength(1);
     });
   });
 
   describe('Performance Under Load', () => {
-    it('should handle 100 sequential lookups efficiently', async () => {
-      // Pre-populate mapping
-      vi.mocked(db.execute).mockResolvedValue([
-        {
-          id: 'hash-123',
-          entity_type: 'session',
-          entity_id: entityId,
-          node_id: 'existing-node-id',
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ]);
+    it('should handle 50 sequential lookups of an existing mapping in bounded time', async () => {
+      await testDb.drizzle.insert(nodeIdMappings).values({
+        id: sha256(entityId),
+        entityType,
+        entityId,
+        nodeId: 'existing-node-id',
+      });
 
       const start = performance.now();
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 50; i++) {
         await service.getNodeId(entityType, entityId);
       }
       const duration = performance.now() - start;
 
-      // 100 lookups should complete in reasonable time
-      // With 1ms per lookup, should be ~100ms, but allow some overhead
-      expect(duration).toBeLessThan(200);
+      // 50 lookups = 50 SELECT ... LIMIT 1 on a 1-row table. Typically <500ms;
+      // 2s is generous for CI under load.
+      expect(duration).toBeLessThan(2000);
     });
 
-    it('should handle mixed operations (lookup + create) efficiently', async () => {
-      let callCount = 0;
-      vi.mocked(db.execute).mockImplementation(() => {
-        callCount++;
-        if (callCount <= 50) {
-          // First 50: existing mappings
-          return Promise.resolve({
-            id: 'hash-123',
-            entityType: 'session',
-            entityId: 'session-123',
-            nodeId: 'existing-node-id',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          });
-        } else {
-          // Next 50: new mappings
-          return Promise.resolve(null);
-        }
+    it('should handle mixed lookup + create across 100 entities', async () => {
+      // Seed mappings for the first 50 entity IDs; the remaining 50 are new.
+      const seeded = Array.from({ length: 50 }, (_, i) => {
+        const id = `entity-${i}`;
+        return {
+          id: sha256(id),
+          entityType,
+          entityId: id,
+          nodeId: `seeded-${i}`,
+        };
       });
-      vi.mocked(db.insert).mockReturnValue(createInsertResult());
+      await testDb.drizzle.insert(nodeIdMappings).values(seeded);
 
       const start = performance.now();
-      const promises = [];
-      for (let i = 0; i < 100; i++) {
-        promises.push(service.getNodeId('session', `session-${i}`));
-      }
-      await Promise.all(promises);
+      const results = await Promise.all(
+        Array.from({ length: 100 }, (_, i) => service.getNodeId(entityType, `entity-${i}`)),
+      );
       const duration = performance.now() - start;
 
-      // Mixed operations should still be efficient
-      expect(duration).toBeLessThan(500); // Allow more time for inserts
+      // First 50 should return seeded IDs; last 50 should be fresh UUIDs.
+      for (let i = 0; i < 50; i++) {
+        expect(results[i]).toBe(`seeded-${i}`);
+      }
+      for (let i = 50; i < 100; i++) {
+        expect(typeof results[i]).toBe('string');
+        expect(results[i]).not.toBe(`seeded-${i}`);
+      }
+
+      const finalRows = await testDb.drizzle.select().from(nodeIdMappings);
+      expect(finalRows).toHaveLength(100);
+
+      expect(duration).toBeLessThan(3000);
     });
   });
 });

--- a/packages/ai/src/memory/utils/sql-helpers.ts
+++ b/packages/ai/src/memory/utils/sql-helpers.ts
@@ -1,39 +1,24 @@
 /**
- * SQL Helper Utilities
+ * Memory-layer query helpers
  *
- * Provides type-safe raw SQL query helpers to work around Neon HTTP driver
- * compatibility issues with Drizzle's relational query builder.
+ * Small, typed helpers for lookups performed by the agent-memory persistence
+ * layer. Every helper returns a Drizzle-inferred row shape — no manual
+ * snake_case → camelCase transformation needed.
  *
- * These helpers use Drizzle's sql tagged template for type safety and
- * SQL injection prevention.
+ * History: originally written with `db.execute(sql`…`)` + hand-rolled result
+ * unwrapping as a defensive posture against an early Neon HTTP driver
+ * incompatibility with Drizzle's relational query builder (`db.query.*`).
+ * Ported to the core query builder (`db.select().from(…).where(…).limit(1)`)
+ * in Phase 6.1 — the same callers already use `.update()` and `.insert()`
+ * against the same tables on the same Database client without issue, and the
+ * core builder is a different code path from the relational one.
  */
 
 import type { NodeIdMappingsRow } from '@revealui/contracts/generated';
 import type { Database } from '@revealui/db/client';
-import { sql } from 'drizzle-orm';
-
-type QueryResult = unknown[] | { rows?: unknown[] };
-type AgentContextRow = {
-  id: string;
-  version: number | null;
-  session_id: string;
-  agent_id: string;
-  context: unknown;
-  priority: number | null;
-  embedding: number[] | null;
-  created_at: Date;
-  updated_at: Date;
-};
-
-const getRows = (result: QueryResult): unknown[] => {
-  if (Array.isArray(result)) {
-    return result;
-  }
-  if (result && typeof result === 'object' && Array.isArray(result.rows)) {
-    return result.rows;
-  }
-  return [];
-};
+import type { AgentContext, User } from '@revealui/db/schema';
+import { agentContexts, nodeIdMappings, users } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
 
 // =============================================================================
 // Node ID Mappings Queries
@@ -50,39 +35,12 @@ export async function findNodeIdMappingByHash(
   db: Database,
   hash: string,
 ): Promise<NodeIdMappingsRow | undefined> {
-  const result = await db.execute(
-    sql`SELECT id, entity_type, entity_id, node_id, created_at, updated_at
-        FROM node_id_mappings
-        WHERE id = ${hash}
-        LIMIT 1`,
-  );
-
-  // Handle different result formats (Neon HTTP vs direct Postgres)
-  const rows = getRows(result as QueryResult);
-  if (!rows[0]) return undefined;
-
-  // Transform snake_case to camelCase to match NodeIdMappingsRow type
-  const row = rows[0] as {
-    id: string;
-    entity_type: string;
-    entity_id: string;
-    node_id: string;
-    created_at: Date;
-    updated_at: Date;
-  };
-
-  return {
-    id: row.id,
-    entityType: row.entity_type,
-    entityId: row.entity_id,
-    nodeId: row.node_id,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  } as NodeIdMappingsRow;
+  const [row] = await db.select().from(nodeIdMappings).where(eq(nodeIdMappings.id, hash)).limit(1);
+  return row as NodeIdMappingsRow | undefined;
 }
 
 /**
- * Finds a node ID mapping by entity ID and type.
+ * Finds a node ID mapping by entity type + entity ID.
  *
  * @param db - Database client
  * @param entityType - Type of entity ('session' or 'user')
@@ -94,34 +52,12 @@ export async function findNodeIdMappingByEntity(
   entityType: 'session' | 'user',
   entityId: string,
 ): Promise<NodeIdMappingsRow | undefined> {
-  const result = await db.execute(
-    sql`SELECT id, entity_type, entity_id, node_id, created_at, updated_at
-        FROM node_id_mappings
-        WHERE entity_type = ${entityType} AND entity_id = ${entityId}
-        LIMIT 1`,
-  );
-
-  const rows = getRows(result as QueryResult);
-  if (!rows[0]) return undefined;
-
-  // Transform snake_case to camelCase to match NodeIdMappingsRow type
-  const row = rows[0] as {
-    id: string;
-    entity_type: string;
-    entity_id: string;
-    node_id: string;
-    created_at: Date;
-    updated_at: Date;
-  };
-
-  return {
-    id: row.id,
-    entityType: row.entity_type,
-    entityId: row.entity_id,
-    nodeId: row.node_id,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  } as NodeIdMappingsRow;
+  const [row] = await db
+    .select()
+    .from(nodeIdMappings)
+    .where(and(eq(nodeIdMappings.entityType, entityType), eq(nodeIdMappings.entityId, entityId)))
+    .limit(1);
+  return row as NodeIdMappingsRow | undefined;
 }
 
 // =============================================================================
@@ -129,52 +65,18 @@ export async function findNodeIdMappingByEntity(
 // =============================================================================
 
 /**
- * Finds an agent context by CRDT ID (returns raw database record format).
+ * Finds an agent context by CRDT ID.
  *
  * @param db - Database client
  * @param crdtId - CRDT identifier (format: sessionId:agentId)
- * @returns Raw database context record or undefined if not found
+ * @returns Agent context row or undefined if not found
  */
 export async function findAgentContextById(
   db: Database,
   crdtId: string,
-): Promise<
-  | {
-      id: string;
-      version: number;
-      sessionId: string;
-      agentId: string;
-      context: unknown;
-      priority: number | null;
-      embedding: number[] | null;
-      createdAt: Date;
-      updatedAt: Date;
-    }
-  | undefined
-> {
-  const result = await db.execute(
-    sql`SELECT id, version, session_id, agent_id, context, priority, 
-               embedding, created_at, updated_at
-        FROM agent_contexts 
-        WHERE id = ${crdtId} 
-        LIMIT 1`,
-  );
-
-  const rows = getRows(result as QueryResult);
-  if (!rows[0]) return undefined;
-
-  const row = rows[0] as AgentContextRow;
-  return {
-    id: row.id,
-    version: row.version || 1,
-    sessionId: row.session_id,
-    agentId: row.agent_id,
-    context: row.context || {},
-    priority: row.priority || 0.5,
-    embedding: row.embedding,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
+): Promise<AgentContext | undefined> {
+  const [row] = await db.select().from(agentContexts).where(eq(agentContexts.id, crdtId)).limit(1);
+  return row;
 }
 
 // =============================================================================
@@ -182,23 +84,20 @@ export async function findAgentContextById(
 // =============================================================================
 
 /**
- * Finds a user by ID.
+ * Finds a user by ID, returning only the columns the memory layer needs.
  *
  * @param db - Database client
  * @param userId - User identifier
- * @returns User record or undefined if not found
+ * @returns User record (id + preferences) or undefined if not found
  */
 export async function findUserById(
   db: Database,
   userId: string,
-): Promise<{ id: string; preferences: unknown } | undefined> {
-  const result = await db.execute(
-    sql`SELECT id, preferences 
-        FROM users 
-        WHERE id = ${userId} 
-        LIMIT 1`,
-  );
-
-  const rows = getRows(result as QueryResult);
-  return rows[0] as { id: string; preferences: unknown } | undefined;
+): Promise<Pick<User, 'id' | 'preferences'> | undefined> {
+  const [row] = await db
+    .select({ id: users.id, preferences: users.preferences })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return row;
 }

--- a/packages/test/src/utils/drizzle-test-db.ts
+++ b/packages/test/src/utils/drizzle-test-db.ts
@@ -42,6 +42,15 @@ export interface CreateTestDbOptions {
   migrationsDir?: string;
   /** Enable query logging (default: false) */
   logger?: boolean;
+  /**
+   * Enable the PGlite pgvector extension. When true, the harness loads
+   * `@electric-sql/pglite/vector`, enables the `vector` type, and keeps
+   * (rather than skips) tables + statements that reference vector columns.
+   * Required for tests that query tables like `agent_contexts`, `agent_memories`,
+   * or `rag_chunks` which have pgvector-typed embedding columns.
+   * Default: false.
+   */
+  enableVector?: boolean;
 }
 
 // =============================================================================
@@ -96,32 +105,51 @@ export async function createTestDb(options?: CreateTestDbOptions): Promise<TestD
   const { drizzle } = await import('drizzle-orm/pglite');
   const dbSchema = await import('@revealui/db/schema');
 
-  // Create in-memory PGlite instance
-  const pglite = new PGlite();
+  // Optionally load the pgvector extension. When `enableVector` is true, we
+  // register the extension up front so `CREATE EXTENSION vector` + `vector(N)`
+  // columns succeed natively and vector-typed tables can be created.
+  const enableVector = options?.enableVector === true;
+  let pglite: PGlite;
+  if (enableVector) {
+    const { vector } = await import('@electric-sql/pglite/vector');
+    pglite = new PGlite({ extensions: { vector } });
+  } else {
+    pglite = new PGlite();
+  }
 
   // Apply all migrations
   const migrationsDir = options?.migrationsDir ?? findMigrationsDir();
   const statements = await loadMigrations(migrationsDir);
 
-  // Tables that use vector columns  -  PGlite doesn't support pgvector
+  // Tables that use vector columns — PGlite skips these unless the vector
+  // extension was loaded via `enableVector: true`.
   const vectorTables = new Set<string>();
 
   for (const stmt of statements) {
     const lower = stmt.toLowerCase();
 
-    // Skip CREATE EXTENSION for vector
-    if (lower.includes('create extension') && lower.includes('vector')) continue;
+    // CREATE EXTENSION vector: skip unless vector is enabled (so the
+    // extension statement becomes a no-op to keep migrations ordering clean).
+    if (lower.includes('create extension') && lower.includes('vector')) {
+      if (enableVector) {
+        try {
+          await pglite.exec(stmt);
+        } catch {
+          // already loaded via options — ignore
+        }
+      }
+      continue;
+    }
 
-    // Detect and skip tables that use vector columns
-    if (lower.includes('vector(') && lower.includes('create table')) {
-      // Extract table name: CREATE TABLE "table_name" (
+    // Detect and skip tables that use vector columns — ONLY when vector is disabled.
+    if (!enableVector && lower.includes('vector(') && lower.includes('create table')) {
       const tableMatch = stmt.match(/create\s+table\s+"([^"]+)"/i);
       if (tableMatch) vectorTables.add(tableMatch[1]);
       continue;
     }
 
-    // Skip statements referencing vector tables
-    if (vectorTables.size > 0) {
+    // Skip statements referencing vector tables (only applies when vector is disabled).
+    if (!enableVector && vectorTables.size > 0) {
       const refsVectorTable = [...vectorTables].some(
         (t) => lower.includes(`"${t}"`) || lower.includes(`"${t}".`),
       );
@@ -134,7 +162,7 @@ export async function createTestDb(options?: CreateTestDbOptions): Promise<TestD
       const msg = err instanceof Error ? err.message : String(err);
       // Skip errors from unsupported extensions or vector types
       if (msg.includes('extension') || msg.includes('EXTENSION')) continue;
-      if (msg.includes('"vector"') || msg.includes('type "vector"')) continue;
+      if (!enableVector && (msg.includes('"vector"') || msg.includes('type "vector"'))) continue;
       if (msg.includes('does not exist')) continue;
       if (msg.includes('already exists')) continue;
       // CONCURRENTLY  -  retry without it

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -63,12 +63,6 @@
       "migrationPhase": null
     },
     {
-      "path": "packages/ai/src/memory/utils/sql-helpers.ts",
-      "rules": ["execute-sql-literal"],
-      "reason": "4 parameterized SELECTs on node_id_mappings, agent_contexts, and users with manual snake_case → camelCase transformation. The production code is migratable to Drizzle core query builder (db.select().from().where().limit()) — verified via a 2026-04-21 port that built cleanly — BUT breaks ~18 tests across 4 files (node-id-service.test.ts, edge-cases.test.ts, performance.test.ts, agent-context-manager.test.ts) which mock db.execute rather than db.select chains. Durable migration requires replacing the mock-based tests with PGlite-backed integration tests (or rewriting all ~20 mock sites to stub the full query-builder chain). Blocked on that test-infrastructure migration.",
-      "migrationPhase": 6
-    },
-    {
       "path": "scripts/dev-tools/verify-test-setup.ts",
       "rules": ["execute-sql-literal"],
       "reason": "Dev-tool that verifies test-harness DB state. Of its 7 raw-SQL calls, 3 are `SELECT 1` / `SELECT vector(...)` connectivity probes (same idiomatic-liveness rationale as apps/api/src/routes/health.ts) and 4 are information_schema / pg_indexes introspection queries that cannot go through Drizzle's query builder (Drizzle queries defined tables, not Postgres metadata). Permanent.",


### PR DESCRIPTION
## Summary

Phase 6.1 of the raw-SQL migration plan — **the only genuine migratable item in Phase 6** (the other 4 Phase-6 candidates were reclassified as permanent in [#472](https://github.com/RevealUIStudio/revealui/pull/472)). Ports `packages/ai/src/memory/utils/sql-helpers.ts` from `db.execute(sql\`…\`)` to Drizzle's core query builder and migrates the 4 test files that were blocking the port onto a PGlite-backed integration-test pattern.

**Net: +491 / −720 LOC** across 9 files (tests smaller and more honest; harness slightly enhanced).

## Production port

`packages/ai/src/memory/utils/sql-helpers.ts` — 4 parameterized SELECTs that used hand-rolled `db.execute(sql\`…\`)` + snake_case→camelCase transformation now use `db.select().from(table).where(eq(…)).limit(1)`. Drizzle infers row shape from the schema, so the manual column remap drops out entirely.

Same `Database` client; the core query builder is a different code path from the relational builder that prompted the original raw-SQL defensive posture.

## Test-infrastructure migration

All four AI-package test files previously mocked `db.execute` directly, incompatible with `.select()` chains. Now run against real PGlite via the shared `@revealui/test` harness:

| File | Tests | Approach |
|---|---|---|
| `node-id-service.test.ts` | 8 | PGlite, clean slate per test (`beforeEach` truncates) |
| `performance.test.ts` | 8 | PGlite; thresholds widened to match real-query semantics (not fake setTimeout mocks) |
| `edge-cases.test.ts` | 22 | PGlite + `vi.spyOn(db, 'select')` for retry/transient-failure simulation |
| `agent-context-manager.test.ts` | 25 | PGlite with `enableVector: true` (agent_contexts has `vector(768)`); `MockPersistence` retained since those tests exercise CRDT merge logic, not DB persistence |

## Harness enhancement

`packages/test/src/utils/drizzle-test-db.ts` gains an **`enableVector: true`** option that loads `@electric-sql/pglite/vector` as an extension. When enabled, vector-typed tables (`agent_contexts`, `agent_memories`, `rag_chunks`) are created normally instead of being skipped. Default stays `false` so tests that don't need vectors don't pay for the extension.

This is a durable harness improvement — any future test against a vector-backed table opts in with one flag instead of needing custom schema workarounds.

## Allowlist

`sql-helpers.ts` entry removed. **13 → 12 entries.** The only remaining `migrationPhase`-tagged entry is the Phase 7 Supabase-side bootstrap, which belongs to a separate architectural arc (`drizzle-consolidation-spec.md`).

## Test verification

- `pnpm --filter @revealui/ai test` → **843 passed** (58 files) — no regressions
- `pnpm --filter @revealui/test test` → **277 passed** — harness enhancement verified
- `pnpm gate:quick` → all 14 checks green

## State of the raw-SQL migration plan after this PR

| Phase | State |
|---|---|
| 1 — CI drift detection | ✅ merged |
| 2 — Raw-SQL linter (blocking) | ✅ merged |
| 3a — MCP parallel-runner delete | ✅ merged |
| 4a — stale SQL tree delete | ✅ merged |
| 4b.1–4b.4 — loose-SQL cleanup | ✅ merged |
| 6 — allowlist reclassification | ✅ merged |
| **6.1 — sql-helpers.ts port** | **this PR** |
| 3b — `crdt_operations` schema reconciliation | deferred (unblocks when MCP productionizes) |
| 4c — evidence-based indexes | separate arc (needs query traces) |
| 7 — `universal-postgres.ts` + Supabase pipeline | covered by `drizzle-consolidation-spec.md` |

## Test plan

- [x] Production port builds cleanly (`pnpm --filter @revealui/ai... build`)
- [x] All 4 migrated test files pass (63 tests total)
- [x] No regressions in the full AI test suite (843 pass)
- [x] No regressions in the test package (277 pass)
- [x] Raw-SQL validator passes (12 allowlist entries)
- [x] `pnpm gate:quick` → PASS
- [ ] CI stays green on this branch
