### PR TITLE
docs(db): remove stale references to deleted orm/drizzle/ tree

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -918,15 +918,10 @@ NODE_ENV="production"  # Enables secure cookies
 1. **Run database migrations:**
 
 ```bash
-# Apply migration to add password_hash field and indexes
-psql $DATABASE_URL -f packages/db/src/orm/drizzle/0001_add_password_hash.sql
-```
-
-Or use the migration script:
-
-```bash
 pnpm db:migrate
 ```
+
+Migrations live in `packages/db/migrations/` and are applied by drizzle-kit; the `users.password` column (bcrypt hash) is created by the initial migration (`0000_init.sql`).
 
 2. **Verify tables exist:**
 
@@ -960,14 +955,7 @@ RevealUI supports migrating from JWT-based authentication to database-backed ses
 
 #### 1. Database Migration
 
-Run the migration to add `password_hash` field and indexes:
-
-```bash
-# Apply migration
-psql $DATABASE_URL -f packages/db/src/orm/drizzle/0001_add_password_hash.sql
-```
-
-Or use the migration script:
+Run migrations to ensure the schema (including `users.password` and session/reset-token indexes) is up to date:
 
 ```bash
 pnpm db:migrate

--- a/scripts/dev-tools/README.md
+++ b/scripts/dev-tools/README.md
@@ -110,7 +110,7 @@ pnpm db:setup-test
 - Review Docker Compose logs
 
 **Migrations fail**
-- Verify migration files exist in `packages/db/src/orm/drizzle/`
+- Verify migration files exist in `packages/db/migrations/`
 - Check database permissions
 - Ensure pgvector extension is available
 

--- a/scripts/dev-tools/test-database.ts
+++ b/scripts/dev-tools/test-database.ts
@@ -7,9 +7,7 @@
  *
  * @dependencies
  * - scripts/lib/errors.ts - ErrorCode enum for exit codes
- * - scripts/lib/index.ts - Shared utilities (commandExists, createLogger, execCommand, fileExists, getProjectRoot, waitFor)
- * - node:path - Path manipulation utilities (join)
- * - node:fs/promises - File system operations (readFile, dynamic import)
+ * - scripts/lib/index.ts - Shared utilities (commandExists, createLogger, execCommand, getProjectRoot, waitFor)
  *
  * @requires
  * - External: docker - Container runtime
@@ -17,13 +15,11 @@
  * - External: psql - PostgreSQL client (in test container)
  */
 
-import { join } from 'node:path';
 import { ErrorCode } from '@revealui/scripts/errors.js';
 import {
   commandExists,
   createLogger,
   execCommand,
-  fileExists,
   getProjectRoot,
   waitFor,
 } from '@revealui/scripts/index.js';
@@ -89,60 +85,20 @@ async function waitForDatabase(composeCmd: string, projectRoot: string) {
   logger.success('Database is ready!');
 }
 
-async function applyMigrations(composeCmd: string, projectRoot: string) {
-  logger.info('Running migrations...');
+async function applyMigrations(_composeCmd: string, projectRoot: string) {
+  logger.info('Applying schema via drizzle-kit push...');
 
-  const migrationFile = join(
-    projectRoot,
-    'packages/db/src/orm/drizzle/0000_misty_pepper_potts.sql',
-  );
+  const result = await execCommand('pnpm', ['--filter', '@revealui/db', 'db:push'], {
+    cwd: projectRoot,
+    env: {
+      POSTGRES_URL: 'postgresql://test:test@localhost:5433/test_revealui',
+    },
+  });
 
-  if (await fileExists(migrationFile)) {
-    logger.info('Applying migration SQL directly...');
-    const { readFile } = await import('node:fs/promises');
-    const sql = await readFile(migrationFile, 'utf-8');
-
-    const [cmd, ...args] = composeCmd.split(' ');
-    const result = await execCommand(
-      cmd,
-      [
-        ...args,
-        '-f',
-        'infrastructure/docker-compose/services/test.yml',
-        'exec',
-        '-T',
-        'postgres-test',
-        'psql',
-        '-U',
-        'test',
-        '-d',
-        'test_revealui',
-      ],
-      {
-        cwd: projectRoot,
-        stdin: sql,
-        silent: true,
-      },
-    );
-
-    if (result.success) {
-      logger.success('Migration applied');
-    } else {
-      logger.warning(`Migration had issues: ${result.message}`);
-      // Continue anyway - might be non-critical errors
-    }
+  if (result.success) {
+    logger.success('Schema applied');
   } else {
-    logger.warning('Migration SQL file not found, attempting drizzle-kit push...');
-    const result = await execCommand('pnpm', ['--filter', '@revealui/db', 'db:push'], {
-      cwd: projectRoot,
-      env: {
-        POSTGRES_URL: 'postgresql://test:test@localhost:5433/test_revealui',
-      },
-    });
-
-    if (!result.success) {
-      logger.warning('Migration failed, but continuing...');
-    }
+    logger.warning('Schema push failed, but continuing...');
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 4a ([#464](https://github.com/RevealUIStudio/revealui/pull/464)) deleted `packages/db/src/orm/drizzle/`, but three places still pointed at non-existent files in that tree. This PR removes the stale pointers — pure cleanup, no behavior change.

- `docs/AUTH.md` (2x): dropped misleading `psql -f packages/db/src/orm/drizzle/0001_add_password_hash.sql` instructions. The `users.password` column (bcrypt hash) is created by `packages/db/migrations/0000_init.sql`; no separate add-password-hash migration exists. Replaced with the canonical `pnpm db:migrate` flow plus a pointer to the current migrations directory.
- `scripts/dev-tools/README.md`: updated generic directory pointer to `packages/db/migrations/`.
- `scripts/dev-tools/test-database.ts`: `applyMigrations` had a dead branch keyed on `0000_misty_pepper_potts.sql` (never existed in this tree) with a graceful fallback to `pnpm --filter @revealui/db db:push` that always fired. Collapsed the function to just call `db:push`; dropped now-unused `join` / `fileExists` / `readFile` imports.

Closes the reachable-work scope of the raw-SQL migration arc per `HANDOFF-2026-04-21-raw-sql-migration-complete.md` §3.

## Test plan

- [x] `pnpm gate:quick` → PASS locally
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — no new errors under `scripts/` (pre-existing errors in apps/admin and scripts/__tests__ are unrelated)
- [x] Grep for `packages/db/src/orm/drizzle`, `0000_misty_pepper_potts`, `0001_add_password_hash` across the tree → 0 matches after cleanup
- [ ] All 10 required checks green on `test` (Drizzle Migrations, CodeQL, Dependency Review, Submodule Audit, Quality, Typecheck, Unit Tests, Build, Security Gate, Secret Scanning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
