### PR TITLE
feat(ai,api): deterministic comment ids in TicketAgentDispatcher

### DIFF
--- a/apps/api/src/routes/agent-tasks.ts
+++ b/apps/api/src/routes/agent-tasks.ts
@@ -385,9 +385,13 @@ async function buildDispatcher(
     ) {
       return ticketQueries.updateTicket(db, id, data);
     },
-    async createComment(id: string, body: Record<string, unknown>) {
+    async createComment(id: string, body: Record<string, unknown>, options?: { id?: string }) {
+      // When the caller (createTicketTools) passes a deterministic id, use
+      // it so a crash-and-resume of the same dispatch produces the same
+      // row and the PK constraint dedupes naturally. Otherwise fall back
+      // to a random UUID for backward compatibility.
       return commentQueries.createComment(db, {
-        id: crypto.randomUUID(),
+        id: options?.id ?? crypto.randomUUID(),
         ticketId: id,
         body,
       });

--- a/packages/ai/src/orchestration/ticket-agent.ts
+++ b/packages/ai/src/orchestration/ticket-agent.ts
@@ -150,14 +150,23 @@ export class TicketAgentDispatcher {
    * - Have access to all admin tools (create/update/delete content, globals, media, users)
    * - Have access to ticket mutation tools (update status, add comment)
    * - Run the agentic loop until done or max iterations
+   *
+   * When `options.dispatchId` is provided, id-generating tool calls
+   * (currently `add_ticket_comment`) derive their ids deterministically
+   * from (dispatchId, call-ordinal). This makes the dispatch retry-safe:
+   * a crash-and-resume re-issues tool calls in the same order and
+   * produces the same ids, so the persistence layer's PK constraint
+   * dedupes naturally. Pair with the durable work queue's jobId.
    */
-  async dispatch(ticket: TicketInput): Promise<AgentResult> {
+  async dispatch(ticket: TicketInput, options: { dispatchId?: string } = {}): Promise<AgentResult> {
     const { apiClient, ticketClient, collections, globals, memory: sharedMemory, db } = this.config;
 
     // Build tool set: admin tools + ticket mutation tools + web scraper + optional summarizer
     const cmsConfig: AdminToolsConfig = { apiClient, collections, globals };
     const cmsTools = createAdminTools(cmsConfig);
-    const ticketTools = createTicketTools(ticket.id, ticketClient);
+    const ticketTools = createTicketTools(ticket.id, ticketClient, {
+      dispatchId: options.dispatchId,
+    });
     const extraTools = db
       ? [webScraperTool, createDocumentSummarizerTool(db, this.config.llmClient)]
       : [webScraperTool];

--- a/packages/ai/src/tools/ticket-tools.test.ts
+++ b/packages/ai/src/tools/ticket-tools.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTicketTools, deriveCommentId, type TicketMutationClient } from './ticket-tools.js';
+
+function makeClient(): TicketMutationClient & {
+  createComment: ReturnType<typeof vi.fn>;
+  updateTicket: ReturnType<typeof vi.fn>;
+} {
+  return {
+    createComment: vi.fn().mockImplementation(async (ticketId, _body, options) => ({
+      id: options?.id ?? 'random-id-from-client',
+      ticketId,
+    })),
+    updateTicket: vi.fn().mockResolvedValue({ id: 'tkt', status: 'done' }),
+  };
+}
+
+describe('deriveCommentId', () => {
+  it('produces a stable id for the same inputs', () => {
+    expect(deriveCommentId('dispatch-1', 0)).toBe(deriveCommentId('dispatch-1', 0));
+  });
+
+  it('differs across ordinals within the same dispatch', () => {
+    expect(deriveCommentId('dispatch-1', 0)).not.toBe(deriveCommentId('dispatch-1', 1));
+  });
+
+  it('differs across dispatches', () => {
+    expect(deriveCommentId('dispatch-1', 0)).not.toBe(deriveCommentId('dispatch-2', 0));
+  });
+
+  it('starts with the cmt_ prefix and is 36 chars total', () => {
+    const id = deriveCommentId('dispatch-x', 5);
+    expect(id).toMatch(/^cmt_[0-9a-f]{32}$/);
+    expect(id).toHaveLength(36);
+  });
+});
+
+describe('createTicketTools — add_ticket_comment', () => {
+  it('passes no options to createComment when dispatchId is absent', async () => {
+    const client = makeClient();
+    const [, addComment] = createTicketTools('tkt-1', client);
+    expect(addComment).toBeDefined();
+    await addComment?.execute({ text: 'hello' });
+
+    expect(client.createComment).toHaveBeenCalledTimes(1);
+    const [ticketId, body, opts] = client.createComment.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      unknown,
+    ];
+    expect(ticketId).toBe('tkt-1');
+    expect(body).toMatchObject({ type: 'doc' });
+    expect(opts).toBeUndefined();
+  });
+
+  it('passes a deterministic id when dispatchId is present', async () => {
+    const client = makeClient();
+    const [, addComment] = createTicketTools('tkt-1', client, { dispatchId: 'job-42' });
+    await addComment?.execute({ text: 'first' });
+
+    const [, , opts] = client.createComment.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      { id: string } | undefined,
+    ];
+    expect(opts?.id).toBe(deriveCommentId('job-42', 0));
+  });
+
+  it('increments the call ordinal across multiple invocations in a single dispatch', async () => {
+    const client = makeClient();
+    const [, addComment] = createTicketTools('tkt-1', client, { dispatchId: 'job-42' });
+    await addComment?.execute({ text: 'first' });
+    await addComment?.execute({ text: 'second' });
+    await addComment?.execute({ text: 'third' });
+
+    const ids = client.createComment.mock.calls.map(
+      (call) => (call[2] as { id?: string } | undefined)?.id,
+    );
+    expect(ids).toEqual([
+      deriveCommentId('job-42', 0),
+      deriveCommentId('job-42', 1),
+      deriveCommentId('job-42', 2),
+    ]);
+  });
+
+  it('resets ordinal in a fresh createTicketTools call (crash-resume behavior)', async () => {
+    // Simulates: first dispatch crashes after one comment. Second
+    // dispatch (resume) calls createTicketTools again with the same
+    // dispatchId. Each fresh invocation starts at ordinal 0, so the
+    // first comment of the resume has the same id as the first comment
+    // of the original run — DB PK constraint will dedupe.
+    const client1 = makeClient();
+    const [, addComment1] = createTicketTools('tkt-1', client1, { dispatchId: 'job-42' });
+    await addComment1?.execute({ text: 'first attempt' });
+    const firstRunId = (client1.createComment.mock.calls[0]?.[2] as { id: string } | undefined)?.id;
+
+    const client2 = makeClient();
+    const [, addComment2] = createTicketTools('tkt-1', client2, { dispatchId: 'job-42' });
+    await addComment2?.execute({ text: 'second attempt' });
+    const secondRunId = (client2.createComment.mock.calls[0]?.[2] as { id: string } | undefined)
+      ?.id;
+
+    expect(firstRunId).toBe(secondRunId);
+    expect(firstRunId).toBe(deriveCommentId('job-42', 0));
+  });
+
+  it('surfaces a failure when createComment returns null', async () => {
+    const client = makeClient();
+    client.createComment.mockResolvedValueOnce(null);
+    const [, addComment] = createTicketTools('tkt-1', client, { dispatchId: 'job-42' });
+    const result = await addComment?.execute({ text: 'whatever' });
+    expect(result).toEqual({ success: false, error: 'Failed to create comment' });
+  });
+});

--- a/packages/ai/src/tools/ticket-tools.ts
+++ b/packages/ai/src/tools/ticket-tools.ts
@@ -7,8 +7,17 @@
  *
  * These are injected by createTicketTools() and are always paired with
  * admin tools so agents can act on content AND report back through the ticket.
+ *
+ * Retry-safe ids (CR8-P2-01 phase C prerequisite): when a `dispatchId`
+ * is provided, comment ids are derived deterministically from
+ * (dispatchId, call-ordinal). A crash-and-resume of the same dispatch
+ * re-issues tool calls in the same order and generates the same ids,
+ * letting the persistence layer's primary-key constraint dedupe
+ * naturally. When `dispatchId` is omitted, ids remain random (the
+ * caller's `TicketMutationClient` picks its own id).
  */
 
+import { createHash } from 'node:crypto';
 import { z } from 'zod/v4';
 import type { Tool, ToolResult } from './base.js';
 
@@ -26,13 +35,55 @@ export interface TicketMutationClient {
     },
   ): Promise<{ id: string; status: string } | null>;
 
+  /**
+   * Create a comment on a ticket. When `options.id` is provided the
+   * implementation MUST use that id (enables deterministic replay under
+   * retry); when omitted the implementation picks its own id (typically
+   * a random UUID for backward compatibility).
+   */
   createComment(
     ticketId: string,
     body: Record<string, unknown>,
+    options?: { id?: string },
   ): Promise<{ id: string; ticketId: string } | null | undefined>;
 }
 
-export function createTicketTools(ticketId: string, client: TicketMutationClient): Tool[] {
+export interface CreateTicketToolsOptions {
+  /**
+   * When set, tool calls that write rows (e.g. add_ticket_comment) use
+   * this as the seed for deterministic id derivation. Pair with the
+   * durable work queue's jobId so crash-resume produces the same ids
+   * and the DB's PK constraint dedupes duplicate attempts.
+   *
+   * When omitted, ids remain random (existing behavior).
+   */
+  dispatchId?: string;
+}
+
+/**
+ * Derive a deterministic, URL-safe comment id from (dispatchId,
+ * callOrdinal). Exported so the handler side can assert that the same
+ * inputs produce the same id (e.g. during crash-sim tests).
+ */
+export function deriveCommentId(dispatchId: string, callOrdinal: number): string {
+  const hash = createHash('sha256').update(`${dispatchId}:comment:${callOrdinal}`).digest('hex');
+  // 32 hex chars (~128 bits) is plenty for a PK and keeps the column
+  // narrower than a full hex digest.
+  return `cmt_${hash.slice(0, 32)}`;
+}
+
+export function createTicketTools(
+  ticketId: string,
+  client: TicketMutationClient,
+  options: CreateTicketToolsOptions = {},
+): Tool[] {
+  // Per-instance call counter. Because createTicketTools() is invoked
+  // fresh inside each dispatcher.dispatch() call, the ordinal is
+  // stable across the agentic loop of a single dispatch but reset for
+  // the next dispatch — which is exactly what retry-safe id derivation
+  // needs.
+  let commentOrdinal = 0;
+
   const updateStatusTool: Tool = {
     name: 'update_ticket_status',
     description:
@@ -72,12 +123,21 @@ export function createTicketTools(ticketId: string, client: TicketMutationClient
     }),
     async execute(params): Promise<ToolResult> {
       const { text } = params as { text: string };
+      const ordinal = commentOrdinal++;
+      const derivedId = options.dispatchId
+        ? deriveCommentId(options.dispatchId, ordinal)
+        : undefined;
+
       try {
         const body = {
           type: 'doc',
           content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
         };
-        const comment = await client.createComment(ticketId, body);
+        const comment = await client.createComment(
+          ticketId,
+          body,
+          derivedId ? { id: derivedId } : undefined,
+        );
         if (!comment) {
           return { success: false, error: 'Failed to create comment' };
         }


### PR DESCRIPTION
## Summary

Prerequisite for [CR8-P2-01 phase C](https://github.com/RevealUIStudio/revealui/issues/470). Makes the ticket agent dispatch **retry-safe at the tool-call boundary** so a crash-and-resume of the same dispatch produces the same comment ids — letting the DB's PK constraint dedupe naturally rather than producing duplicate comment rows.

Standalone change; phase C uses it but this PR is useful on its own (any caller that wraps `TicketAgentDispatcher.dispatch()` in a retry mechanism — saga, worker queue, manual retry — benefits). Base = `test`; merge independently of #471 / #474.

## Scope

- **`packages/ai/src/tools/ticket-tools.ts`**:
  - `TicketMutationClient.createComment` gains an optional `options?: { id?: string }` parameter. When provided, the implementation **MUST** honor the id (interface contract documented inline).
  - `createTicketTools` gains `options: { dispatchId?: string }`. When `dispatchId` is set, `add_ticket_comment` derives its id deterministically via `deriveCommentId(dispatchId, ordinal)` and passes it through the new client option.
  - `deriveCommentId(dispatchId, ordinal)` exported so handler-side crash-sim tests can assert the same input produces the same id. Format: `cmt_<32 hex chars>` (~128 bits).
- **`packages/ai/src/orchestration/ticket-agent.ts`**:
  - `TicketAgentDispatcher.dispatch(ticket, options?)` gains an optional second arg `{ dispatchId? }` threaded through to `createTicketTools`. Default behavior (no `dispatchId`) is unchanged.
- **`apps/api/src/routes/agent-tasks.ts`**:
  - The inline `ticketClient.createComment` honors `options.id` when provided, falls back to `crypto.randomUUID()` when absent. Backward-compatible for every current caller.

## Why "at the tool-call boundary" matters

Phase C wraps the whole `dispatcher.dispatch()` call in `idempotentWrite` (keyed on jobId), which memoizes the aggregate result. If the worker crashes **between** the LLM call and the `idempotentWrite` commit, the re-run starts from scratch and re-invokes all tool calls — today that means duplicate comment rows. With this PR, the re-run issues the same tool calls in the same order, generates the same ids, and hits the PK constraint → no duplicates.

Outer idempotency + inner deterministic ids = two independent safety nets.

## Test plan

- [x] `pnpm --filter @revealui/ai test src/tools/ticket-tools` — **9 new tests pass** (stable id, differs across ordinals/dispatches, ordinal resets per dispatch, client-call shape with and without dispatchId, null-return error path)
- [x] `pnpm --filter @revealui/ai typecheck` + `pnpm --filter api typecheck` clean
- [x] `pnpm gate` full pass (481 s)
- [ ] CI on push: validate green

## Not in scope

- The queue-side integration that actually calls `dispatch(ticket, { dispatchId: jobId })` — that's phase C.
- Broader tool-call idempotency (other tools that create rows) — the only id-generating tool today is `add_ticket_comment`; other tools either UPDATE existing rows (naturally idempotent) or hit external APIs with their own dedup. File a follow-up if this changes.

## Forward compatibility

`TicketMutationClient.createComment`'s new third arg is optional and documented as "implementation MUST honor when provided". Any future client (e.g. external integration via SDK, test harness) can safely omit it and get today's behavior.
