### PR TITLE
feat(api,db): durable agent-dispatch via queue — phase C (CR8-P2-01)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,11 @@ import { sql } from 'drizzle-orm';
 import { bodyLimit } from 'hono/body-limit';
 import { createMiddleware } from 'hono/factory';
 import { logger as honoLogger } from 'hono/logger';
+// Side-effect import: registers durable-queue handlers at module top
+// level so both the producer (POST /api/agent-tasks) and the worker
+// (POST /api/jobs/run) invocations see the same registry. See
+// CR8-P2-01 phase C.
+import { assertDispatchFlagConfigured } from './jobs/register-handlers.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { PostgresAuditStorage } from './lib/postgres-audit-storage.js';
 import { auditMiddleware } from './middleware/audit.js';
@@ -150,6 +155,11 @@ process.once('SIGINT', () => gracefulShutdown('SIGINT'));
 
 // Validate Forge config at startup  -  exits if FORGE_* env vars are inconsistent
 validateForgeConfig();
+
+// Validate durable-dispatch flag config (CR8-P2-01 phase C) — if the
+// flag is on, the wake secret must be set, or every dispatch silently
+// falls back to the daily cron cadence.
+assertDispatchFlagConfigured();
 
 /**
  * Parse and validate CORS origins from environment variable.

--- a/apps/api/src/jobs/agent-dispatch.ts
+++ b/apps/api/src/jobs/agent-dispatch.ts
@@ -1,0 +1,206 @@
+/**
+ * Durable agent-dispatch handler (CR8-P2-01 phase C).
+ *
+ * Registered at boot under `agent.dispatch` via register-handlers.ts.
+ * Invoked by the queue worker when a ticket's POST handler enqueues a
+ * dispatch job (see apps/api/src/routes/agent-tasks.ts).
+ *
+ * Durability guarantees provided by the combination of:
+ *   1. The queue's visibility timeout + retry-with-backoff (phase A).
+ *   2. The cron safety-net that reclaims stalled claims (phase B).
+ *   3. `idempotentWrite` memoization of the LLM dispatch result so a
+ *      crash-and-resume returns the cached output rather than
+ *      re-calling the LLM (this file).
+ *   4. Deterministic comment ids from `TicketAgentDispatcher(dispatchId)`
+ *      (revealui#477) so tool-call side-effects re-issued during
+ *      resume collide on the DB PK constraint instead of producing
+ *      duplicate rows.
+ *
+ * The handler is self-contained — it reads the ticket, builds a fresh
+ * dispatcher per invocation, and cleans up after itself. No state
+ * leaks across jobs.
+ */
+
+import { isFeatureEnabled } from '@revealui/core/features';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db/client';
+import * as ticketQueries from '@revealui/db/queries/tickets';
+import { idempotentWrite } from '@revealui/db/saga';
+import type { Job } from '@revealui/db/schema';
+import { agentMemories } from '@revealui/db/schema/agents';
+import { safeVectorInsert } from '@revealui/db/validation/cross-db';
+import { buildDispatcher } from '../lib/agent-dispatcher.js';
+
+const LLM_MEMOIZE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface AgentDispatchPayload extends Record<string, unknown> {
+  ticketId: string;
+  /** Caller's tenant id at enqueue time. Worker carries it through. */
+  tenantId?: string;
+  /** Caller's user id at enqueue time. For audit logging / future RBAC. */
+  userId: string;
+  /**
+   * Correlation id from the originating POST request. All logs from the
+   * handler carry this so POST / worker / status-poll share a trace.
+   */
+  requestId?: string;
+}
+
+export interface AgentDispatchOutput extends Record<string, unknown> {
+  success: boolean;
+  /** Final text output produced by the agent, or null on blocked/failed. */
+  output: string | null;
+  /** Final ticket status written by the handler. */
+  status: 'done' | 'blocked';
+  /** Metadata passed through from the LLM provider. */
+  executionTime?: number;
+  tokensUsed?: number;
+  /**
+   * True when the LLM call was skipped on this attempt because the
+   * memoized result from a prior attempt was still fresh. Useful for
+   * crash-resume observability.
+   */
+  replayedFromCache?: boolean;
+}
+
+export async function agentDispatchHandler(
+  data: AgentDispatchPayload,
+  job: Job,
+): Promise<AgentDispatchOutput> {
+  const db = getClient();
+  const log = (event: string, extra?: Record<string, unknown>): void => {
+    logger.info(`[agent.dispatch] ${event}`, {
+      jobId: job.id,
+      ticketId: data.ticketId,
+      requestId: data.requestId,
+      ...extra,
+    });
+  };
+
+  // License re-check. The POST handler already gated on requireAIAccess;
+  // this catches the edge case where the license lapsed between enqueue
+  // and claim. Pre-existing gap: isFeatureEnabled reads the singleton
+  // license state (not per-tenant), so the tenant-scoped variant
+  // depends on a future fix. Naming it here so when that lands the
+  // worker gets stricter enforcement automatically.
+  if (!isFeatureEnabled('ai')) {
+    throw new Error('AI feature unavailable at dispatch time (license lapsed or revoked)');
+  }
+
+  const ticket = await ticketQueries.getTicketById(db, data.ticketId);
+  if (!ticket) {
+    throw new Error(`Ticket not found: ${data.ticketId}`);
+  }
+
+  const dispatcher = await buildDispatcher(db, data.tenantId);
+  if (!dispatcher) {
+    throw new Error(
+      "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+    );
+  }
+
+  log('claimed', { retryCount: job.retryCount });
+
+  // Transition to in_progress if the caller hasn't already. Idempotent:
+  // re-running on the same ticket is a no-op.
+  if (ticket.status !== 'in_progress') {
+    await ticketQueries.updateTicket(db, ticket.id, { status: 'in_progress' });
+  }
+
+  // Memoize the LLM dispatch keyed on the job id. First attempt runs the
+  // LLM, caches the result, and proceeds. Crash-resume sees the cached
+  // row and returns it directly — no second LLM call, no second bill.
+  const { result: memoized, alreadyProcessed } = await idempotentWrite<AgentDispatchOutput>(
+    db,
+    `agent.dispatch.llm:${job.id}`,
+    'agent-dispatch-llm',
+    async () => {
+      log('llm.start');
+      const raw = await dispatcher.dispatch(
+        {
+          id: ticket.id,
+          title: ticket.title,
+          description: ticket.description,
+          type: ticket.type,
+          priority: ticket.priority,
+        },
+        { dispatchId: job.id },
+      );
+      log('llm.done', {
+        success: raw.success,
+        executionTime: raw.metadata?.executionTime,
+        tokensUsed: raw.metadata?.tokensUsed,
+      });
+      return {
+        success: raw.success,
+        output: raw.output ?? null,
+        status: (raw.success ? 'done' : 'blocked') as 'done' | 'blocked',
+        executionTime: raw.metadata?.executionTime,
+        tokensUsed: raw.metadata?.tokensUsed,
+      };
+    },
+    { ttlMs: LLM_MEMOIZE_TTL_MS, cacheResult: true },
+  );
+
+  if (!memoized) {
+    // Defensive: idempotentWrite should return the fresh result on a new
+    // execution or the cached one on replay. Hitting this branch means
+    // the operation ran but returned nothing — treat as a handler bug.
+    throw new Error('agent.dispatch: idempotentWrite returned no result');
+  }
+
+  if (alreadyProcessed) {
+    log('replayed-from-cache');
+  }
+
+  // Write the final ticket status. Idempotent: updating to the same status
+  // is a no-op. Skip if the memoized output already matches the current
+  // status (avoids a no-op write on the happy path).
+  const freshTicket = await ticketQueries.getTicketById(db, ticket.id);
+  if (freshTicket && freshTicket.status !== memoized.status) {
+    await ticketQueries.updateTicket(db, ticket.id, { status: memoized.status });
+  }
+
+  // Persist to agent_memories (best-effort, same as the legacy sync path).
+  // Side-effect duplication on crash-resume is prevented by the memoization
+  // above — this block only runs once per dispatch (the first time that
+  // dispatcher.dispatch() actually executes), because subsequent replays
+  // hit the `alreadyProcessed` branch and skip writes.
+  if (!alreadyProcessed && memoized.output) {
+    try {
+      const memoryValues = {
+        id: crypto.randomUUID(),
+        siteId: 'system',
+        content: memoized.output,
+        type: 'decision',
+        source: {
+          type: 'agent',
+          id: `ticket-agent-${ticket.id}`,
+          confidence: memoized.success ? 1 : 0.5,
+        },
+        agentId: `ticket-agent-${ticket.id}`,
+        metadata: {
+          ticketId: ticket.id,
+          jobId: job.id,
+          success: memoized.success,
+          executionTime: memoized.executionTime,
+          tokensUsed: memoized.tokensUsed,
+        },
+      };
+      await safeVectorInsert<void>(
+        db,
+        async () => {
+          await db.insert(agentMemories).values(memoryValues);
+        },
+        { siteId: memoryValues.siteId },
+      );
+    } catch {
+      // Best-effort — memory persistence failure does not fail the job.
+    }
+  }
+
+  return {
+    ...memoized,
+    replayedFromCache: alreadyProcessed,
+  };
+}

--- a/apps/api/src/jobs/register-handlers.test.ts
+++ b/apps/api/src/jobs/register-handlers.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertDispatchFlagConfigured } from './register-handlers.js';
+
+describe('assertDispatchFlagConfigured', () => {
+  const originalFlag = process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED;
+  const originalSecret = process.env.REVEALUI_JOBS_WAKE_SECRET;
+
+  beforeEach(() => {
+    delete process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED;
+    delete process.env.REVEALUI_JOBS_WAKE_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalFlag !== undefined) {
+      process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED = originalFlag;
+    } else {
+      delete process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED;
+    }
+    if (originalSecret !== undefined) {
+      process.env.REVEALUI_JOBS_WAKE_SECRET = originalSecret;
+    } else {
+      delete process.env.REVEALUI_JOBS_WAKE_SECRET;
+    }
+  });
+
+  it('is a no-op when the flag is unset', () => {
+    expect(() => assertDispatchFlagConfigured()).not.toThrow();
+  });
+
+  it('is a no-op when the flag is explicitly off', () => {
+    process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED = 'false';
+    expect(() => assertDispatchFlagConfigured()).not.toThrow();
+  });
+
+  it('throws when flag=true but wake secret is unset', () => {
+    process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED = 'true';
+    expect(() => assertDispatchFlagConfigured()).toThrow(
+      /REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true requires REVEALUI_JOBS_WAKE_SECRET/,
+    );
+  });
+
+  it('passes when flag=true and wake secret is set', () => {
+    process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED = 'true';
+    process.env.REVEALUI_JOBS_WAKE_SECRET = 'shh';
+    expect(() => assertDispatchFlagConfigured()).not.toThrow();
+  });
+
+  it('treats truthy non-"true" values as off (strict equality with "true")', () => {
+    process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED = '1';
+    expect(() => assertDispatchFlagConfigured()).not.toThrow();
+  });
+});

--- a/apps/api/src/jobs/register-handlers.ts
+++ b/apps/api/src/jobs/register-handlers.ts
@@ -1,0 +1,52 @@
+/**
+ * Durable-queue handler registration (CR8-P2-01 phase C).
+ *
+ * Imported for side-effect at module top-level in apps/api/src/index.ts
+ * so every Vercel invocation — including the worker route at
+ * /api/jobs/run — has the handlers registered before any job is
+ * claimed.
+ *
+ * Why top-level: Vercel cold-start re-imports the entry module and its
+ * top-level statements re-run. Registering inside a route handler
+ * would miss the worker invocation that claims the job (it doesn't
+ * go through the producer's route).
+ */
+
+import { registerHandler } from '@revealui/db/jobs';
+import { type AgentDispatchPayload, agentDispatchHandler } from './agent-dispatch.js';
+
+// Register idempotently: double-import (test harness + prod boot) is a
+// no-op because registerHandler throws on duplicates. The try/catch
+// downgrades that to a warning — two modules both importing this file
+// shouldn't crash the app.
+try {
+  registerHandler<AgentDispatchPayload, Awaited<ReturnType<typeof agentDispatchHandler>>>(
+    'agent.dispatch',
+    agentDispatchHandler,
+  );
+} catch (err) {
+  // Already registered (re-import in hot-reload or test). Ignore.
+  if (!(err instanceof Error && err.message.includes('already registered'))) {
+    throw err;
+  }
+}
+
+/**
+ * Boot-time assertion: when the queue-based dispatch flag is on, the
+ * wake secret MUST be configured. Without the wake secret, the
+ * producer's fan-out call to /api/jobs/run fires no-op and the job
+ * waits for the cron safety-net — which runs daily. End result: every
+ * dispatch appears to hang for up to 24 hours. Fail fast instead.
+ */
+export function assertDispatchFlagConfigured(): void {
+  const flagOn = process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED === 'true';
+  if (!flagOn) return;
+  const secret = process.env.REVEALUI_JOBS_WAKE_SECRET;
+  if (!secret) {
+    throw new Error(
+      'REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true requires REVEALUI_JOBS_WAKE_SECRET to be set. ' +
+        'Without the wake secret, enqueued dispatches wait for the daily cron tick instead of ' +
+        'running immediately. Set both or unset the flag.',
+    );
+  }
+}

--- a/apps/api/src/lib/agent-dispatcher.ts
+++ b/apps/api/src/lib/agent-dispatcher.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared construction of the Pro-package TicketAgentDispatcher.
+ *
+ * Used by both the synchronous POST handler in routes/agent-tasks.ts
+ * (legacy flag-off path) and the durable queue handler in
+ * jobs/agent-dispatch.ts (flag-on path). Extracted here so both
+ * surfaces see the same dispatcher shape, same license gate, and
+ * same DB-backed ticket mutation client.
+ *
+ * Returns null when the AI feature is not installed or not configured
+ * — callers must treat that as a license / configuration failure.
+ */
+
+import type { Database } from '@revealui/db/client';
+import * as commentQueries from '@revealui/db/queries/ticket-comments';
+import * as ticketQueries from '@revealui/db/queries/tickets';
+
+export interface DispatcherResult {
+  success: boolean;
+  output?: string;
+  metadata?: { executionTime?: number; tokensUsed?: number };
+}
+
+export interface DispatcherTicket {
+  id: string;
+  title: string;
+  description: unknown;
+  type?: string;
+  priority?: string;
+}
+
+export interface Dispatcher {
+  dispatch(ticket: DispatcherTicket, options?: { dispatchId?: string }): Promise<DispatcherResult>;
+}
+
+export async function buildDispatcher(
+  db: Database,
+  _tenantId: string | undefined,
+): Promise<Dispatcher | null> {
+  const aiMod = await import('@revealui/ai').catch(() => null);
+  if (!aiMod) return null;
+
+  let llmClient: unknown;
+  try {
+    llmClient = aiMod.createLLMClientFromEnv();
+  } catch {
+    return null;
+  }
+
+  // TicketMutationClient backed by real DB queries. Honors the optional
+  // `id` field on createComment so deterministic ids from the Pro
+  // package (revealui#477) flow through and a crash-resume's second
+  // attempt at the same comment collides on the PK constraint rather
+  // than producing a duplicate row.
+  const ticketClient = {
+    async updateTicket(
+      id: string,
+      data: { status?: string; columnId?: string; metadata?: Record<string, unknown> },
+    ) {
+      return ticketQueries.updateTicket(db, id, data);
+    },
+    async createComment(id: string, body: Record<string, unknown>, options?: { id?: string }) {
+      return commentQueries.createComment(db, {
+        id: options?.id ?? crypto.randomUUID(),
+        ticketId: id,
+        body,
+      });
+    },
+  };
+
+  const adminBaseUrl = process.env.ADMIN_URL ?? process.env.NEXT_PUBLIC_ADMIN_URL;
+  const apiClient = buildCMSClient(adminBaseUrl);
+
+  // Type assertions: TicketAgentDispatcher comes from the Pro package via
+  // dynamic import; the runtime shape matches Dispatcher.
+  type DispatcherConfig = ConstructorParameters<typeof aiMod.TicketAgentDispatcher>[0];
+  return new aiMod.TicketAgentDispatcher({
+    llmClient: llmClient as DispatcherConfig['llmClient'],
+    apiClient,
+    ticketClient,
+  }) as unknown as Dispatcher;
+}
+
+/**
+ * AdminAPIClient over HTTP. Routes through the admin REST API if
+ * ADMIN_URL / NEXT_PUBLIC_ADMIN_URL is configured; otherwise returns
+ * a stub that throws, so misconfiguration surfaces on first tool use
+ * rather than silently returning empty data.
+ */
+function buildCMSClient(baseUrl: string | undefined) {
+  if (!baseUrl) {
+    const stub = async () => {
+      throw new Error(
+        'ADMIN_URL not configured. Set ADMIN_URL to connect the agent to the admin app.',
+      );
+    };
+    return {
+      find: stub,
+      findById: stub,
+      create: stub,
+      update: stub,
+      delete: stub,
+      findGlobal: stub,
+      updateGlobal: stub,
+    };
+  }
+
+  const headers = () => ({
+    'Content-Type': 'application/json',
+    ...(process.env.CMS_API_KEY ? { Authorization: `Bearer ${process.env.CMS_API_KEY}` } : {}),
+  });
+
+  return {
+    async find(options: {
+      collection: string;
+      page?: number;
+      limit?: number;
+      where?: Record<string, unknown>;
+      sort?: string;
+    }) {
+      const params = new URLSearchParams();
+      if (options.page) params.set('page', String(options.page));
+      if (options.limit) params.set('limit', String(options.limit));
+      if (options.sort) params.set('sort', options.sort);
+      const res = await fetch(`${baseUrl}/api/${options.collection}?${params}`, {
+        headers: headers(),
+      });
+      if (!res.ok) throw new Error(`Admin find failed: ${res.statusText}`);
+      const body: unknown = await res.json();
+      const data =
+        body !== null && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+      return {
+        docs: Array.isArray(data.docs) ? (data.docs as unknown[]) : undefined,
+        totalDocs: typeof data.totalDocs === 'number' ? data.totalDocs : undefined,
+        page: typeof data.page === 'number' ? data.page : undefined,
+        totalPages: typeof data.totalPages === 'number' ? data.totalPages : undefined,
+      };
+    },
+
+    async findById(collection: string, id: string) {
+      const res = await fetch(`${baseUrl}/api/${collection}/${id}`, { headers: headers() });
+      if (!res.ok) throw new Error(`Admin findById failed: ${res.statusText}`);
+      return res.json();
+    },
+
+    async create(options: { collection: string; data: Record<string, unknown> }) {
+      const res = await fetch(`${baseUrl}/api/${options.collection}`, {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify(options.data),
+      });
+      if (!res.ok) throw new Error(`Admin create failed: ${res.statusText}`);
+      return res.json();
+    },
+
+    async update(options: { collection: string; id: string; data: Record<string, unknown> }) {
+      const res = await fetch(`${baseUrl}/api/${options.collection}/${options.id}`, {
+        method: 'PATCH',
+        headers: headers(),
+        body: JSON.stringify(options.data),
+      });
+      if (!res.ok) throw new Error(`Admin update failed: ${res.statusText}`);
+      return res.json();
+    },
+
+    async delete(options: { collection: string; id: string }) {
+      const res = await fetch(`${baseUrl}/api/${options.collection}/${options.id}`, {
+        method: 'DELETE',
+        headers: headers(),
+      });
+      if (!res.ok) throw new Error(`Admin delete failed: ${res.statusText}`);
+    },
+
+    async findGlobal(options: { slug: string; depth?: number }) {
+      const params = options.depth !== undefined ? `?depth=${options.depth}` : '';
+      const res = await fetch(`${baseUrl}/api/globals/${options.slug}${params}`, {
+        headers: headers(),
+      });
+      if (!res.ok) throw new Error(`Admin findGlobal failed: ${res.statusText}`);
+      return res.json();
+    },
+
+    async updateGlobal(options: { slug: string; data: Record<string, unknown> }) {
+      const res = await fetch(`${baseUrl}/api/globals/${options.slug}`, {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify(options.data),
+      });
+      if (!res.ok) throw new Error(`Admin updateGlobal failed: ${res.statusText}`);
+      return res.json();
+    },
+  };
+}

--- a/apps/api/src/routes/agent-tasks.ts
+++ b/apps/api/src/routes/agent-tasks.ts
@@ -10,21 +10,40 @@
  * POST /api/agent-tasks/:ticketId/dispatch
  *   Dispatches an agent for an existing ticket. Use this when a ticket
  *   was created manually and you want to hand it to the agent system.
+ *
+ * GET /api/agent-tasks/:ticketId/status (CR8-P2-01 phase C)
+ *   Returns the canonical dispatch status for a ticket — usable by any
+ *   caller (admin UI, external agent, RevDev) to poll after receiving a
+ *   202 from the POST endpoints.
+ *
+ * Durable dispatch (CR8-P2-01 phase C):
+ *   When REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true, POST handlers enqueue
+ *   an `agent.dispatch` job and poll for up to 22 s. Completion within
+ *   the window returns 200 with the dispatch result (same shape as the
+ *   legacy sync path). Timeout returns 202 with a jobId and statusUrl
+ *   the caller can poll. Crashes mid-dispatch are reclaimed by the cron
+ *   safety-net (phase B); the LLM call is memoized so a resume doesn't
+ *   double-bill (phase C handler). When the flag is off, the route
+ *   behaves exactly as it did pre-phase-C.
  */
 
 import type { DatabaseClient } from '@revealui/db/client';
+import { enqueue, getJobById } from '@revealui/db/jobs';
 import * as boardQueries from '@revealui/db/queries/boards';
-import * as commentQueries from '@revealui/db/queries/ticket-comments';
 import * as ticketQueries from '@revealui/db/queries/tickets';
+import type { Job } from '@revealui/db/schema';
 import { agentMemories } from '@revealui/db/schema/agents';
 import { safeVectorInsert } from '@revealui/db/validation/cross-db';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import type { AgentDispatchOutput, AgentDispatchPayload } from '../jobs/agent-dispatch.js';
+import { buildDispatcher, type Dispatcher } from '../lib/agent-dispatcher.js';
 
 type Variables = {
   db: DatabaseClient;
   tenant?: { id: string };
   user?: { id: string; role: string };
+  requestId?: string;
 };
 
 const AGENT_TASK_ROLES = new Set(['admin', 'owner', 'editor', 'agent']);
@@ -40,9 +59,32 @@ function requireAgentTaskRole(c: { get: (key: string) => unknown }): { id: strin
   return user;
 }
 
+function isDurableDispatchEnabled(): boolean {
+  return process.env.REVEALUI_JOBS_AGENT_DISPATCH_ENABLED === 'true';
+}
+
 const app = new OpenAPIHono<{ Variables: Variables }>();
 
 const ErrorSchema = z.object({ success: z.literal(false), error: z.string() });
+
+const DispatchSuccessShape = {
+  success: z.literal(true),
+  ticketId: z.string(),
+  agentOutput: z.string().nullable(),
+  status: z.string(),
+  /** Present when the dispatch ran through the durable queue. */
+  jobId: z.string().optional(),
+};
+
+const DispatchPendingShape = {
+  success: z.literal(true),
+  ticketId: z.string(),
+  ticketNumber: z.number().optional(),
+  jobId: z.string(),
+  statusUrl: z.string(),
+  /** Human-readable hint for UIs while polling. */
+  message: z.string(),
+};
 
 // =============================================================================
 // POST /api/agent-tasks  -  natural language → ticket → agent → outcome
@@ -55,7 +97,7 @@ app.openapi(
     tags: ['agent-tasks'],
     summary: 'Submit a natural language task for an agent to execute',
     description:
-      'Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result.',
+      'Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. When durable dispatch is enabled and the agent takes longer than ~22 s, returns 202 with a jobId the caller can poll at /status.',
     request: {
       body: {
         content: {
@@ -76,15 +118,17 @@ app.openapi(
         content: {
           'application/json': {
             schema: z.object({
-              success: z.literal(true),
-              ticketId: z.string(),
+              ...DispatchSuccessShape,
               ticketNumber: z.number(),
-              agentOutput: z.string().nullable(),
-              status: z.string(),
             }),
           },
         },
-        description: 'Agent task completed',
+        description: 'Agent task completed within the sync/poll window',
+      },
+      202: {
+        content: { 'application/json': { schema: z.object(DispatchPendingShape) } },
+        description:
+          'Dispatch enqueued but still running at the poll-window timeout. Caller polls the statusUrl.',
       },
       400: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Bad request' },
       403: {
@@ -94,12 +138,11 @@ app.openapi(
     },
   }),
   async (c) => {
-    requireAgentTaskRole(c);
+    const user = requireAgentTaskRole(c);
     const db = c.get('db');
     const tenant = c.get('tenant');
     const { instruction, boardId, priority } = c.req.valid('json');
 
-    // Verify board exists and caller is in the same tenant
     const board = await boardQueries.getBoardById(db, boardId);
     if (!board) {
       return c.json({ success: false as const, error: `Board "${boardId}" not found` }, 400);
@@ -108,7 +151,6 @@ app.openapi(
       return c.json({ success: false as const, error: `Board "${boardId}" not found` }, 400);
     }
 
-    // Create the ticket  -  the agent's work item
     const ticket = await ticketQueries.createTicket(db, {
       id: crypto.randomUUID(),
       boardId,
@@ -122,10 +164,41 @@ app.openapi(
       return c.json({ success: false as const, error: 'Failed to create ticket' }, 400);
     }
 
-    // Build the dispatcher with DB-backed ticket mutation client
+    // --- Durable dispatch path (flag on) ---
+    if (isDurableDispatchEnabled()) {
+      const outcome = await runDurableDispatch(db, ticket, user, tenant, c.get('requestId'));
+      if (outcome.kind === 'complete') {
+        return c.json(
+          {
+            success: true as const,
+            ticketId: ticket.id,
+            ticketNumber: ticket.ticketNumber,
+            agentOutput: outcome.agentOutput,
+            status: outcome.status,
+            jobId: outcome.jobId,
+          },
+          200,
+        );
+      }
+      if (outcome.kind === 'failed') {
+        return c.json({ success: false as const, error: outcome.error }, 403);
+      }
+      return c.json(
+        {
+          success: true as const,
+          ticketId: ticket.id,
+          ticketNumber: ticket.ticketNumber,
+          jobId: outcome.jobId,
+          statusUrl: outcome.statusUrl,
+          message: 'Dispatch is running; poll statusUrl for completion.',
+        },
+        202,
+      );
+    }
+
+    // --- Legacy sync path (flag off) ---
     const dispatcher = await buildDispatcher(db, tenant?.id);
     if (!dispatcher) {
-      // AI not configured  -  return the ticket but note it was not dispatched
       await ticketQueries.updateTicket(db, ticket.id, { status: 'open' });
       return c.json(
         {
@@ -137,16 +210,12 @@ app.openapi(
       );
     }
 
-    // Dispatch agent with timeout, persist outcome to memory
     const dispatchResult = await dispatchWithTimeout(db, dispatcher, ticket);
     if (!dispatchResult.success) {
       return c.json({ success: false as const, error: dispatchResult.error }, 403);
     }
     const { result } = dispatchResult;
-
-    // Re-fetch final ticket state
     const finalTicket = await ticketQueries.getTicketById(db, ticket.id);
-
     return c.json(
       {
         success: true as const,
@@ -177,17 +246,12 @@ app.openapi(
     },
     responses: {
       200: {
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              ticketId: z.string(),
-              agentOutput: z.string().nullable(),
-              status: z.string(),
-            }),
-          },
-        },
-        description: 'Agent dispatch completed',
+        content: { 'application/json': { schema: z.object(DispatchSuccessShape) } },
+        description: 'Agent dispatch completed within the sync/poll window',
+      },
+      202: {
+        content: { 'application/json': { schema: z.object(DispatchPendingShape) } },
+        description: 'Dispatch enqueued but still running at the poll-window timeout',
       },
       404: {
         content: { 'application/json': { schema: ErrorSchema } },
@@ -196,6 +260,125 @@ app.openapi(
       403: {
         content: { 'application/json': { schema: ErrorSchema } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+    },
+  }),
+  async (c) => {
+    const user = requireAgentTaskRole(c);
+    const db = c.get('db');
+    const tenant = c.get('tenant');
+    const { ticketId } = c.req.valid('param');
+
+    const ticket = await ticketQueries.getTicketById(db, ticketId);
+    if (!ticket) {
+      return c.json({ success: false as const, error: 'Ticket not found' }, 404);
+    }
+    const board = await boardQueries.getBoardById(db, ticket.boardId);
+    if (tenant && board?.tenantId && board.tenantId !== tenant.id) {
+      return c.json({ success: false as const, error: 'Ticket not found' }, 404);
+    }
+
+    // --- Durable dispatch path ---
+    if (isDurableDispatchEnabled()) {
+      await ticketQueries.updateTicket(db, ticketId, { status: 'in_progress' });
+      const outcome = await runDurableDispatch(db, ticket, user, tenant, c.get('requestId'));
+      if (outcome.kind === 'complete') {
+        return c.json(
+          {
+            success: true as const,
+            ticketId,
+            agentOutput: outcome.agentOutput,
+            status: outcome.status,
+            jobId: outcome.jobId,
+          },
+          200,
+        );
+      }
+      if (outcome.kind === 'failed') {
+        return c.json({ success: false as const, error: outcome.error }, 403);
+      }
+      return c.json(
+        {
+          success: true as const,
+          ticketId,
+          jobId: outcome.jobId,
+          statusUrl: outcome.statusUrl,
+          message: 'Dispatch is running; poll statusUrl for completion.',
+        },
+        202,
+      );
+    }
+
+    // --- Legacy sync path ---
+    const dispatcher = await buildDispatcher(db, tenant?.id);
+    if (!dispatcher) {
+      return c.json(
+        {
+          success: false as const,
+          error:
+            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+        },
+        403,
+      );
+    }
+
+    await ticketQueries.updateTicket(db, ticketId, { status: 'in_progress' });
+
+    const dispatchResult = await dispatchWithTimeout(db, dispatcher, ticket);
+    if (!dispatchResult.success) {
+      return c.json({ success: false as const, error: dispatchResult.error }, 403);
+    }
+    const { result } = dispatchResult;
+    const finalTicket = await ticketQueries.getTicketById(db, ticketId);
+
+    return c.json(
+      {
+        success: true as const,
+        ticketId,
+        agentOutput: result.output ?? null,
+        status: finalTicket?.status ?? (result.success ? 'done' : 'blocked'),
+      },
+      200,
+    );
+  },
+);
+
+// =============================================================================
+// GET /api/agent-tasks/:ticketId/status  -  canonical dispatch status
+// =============================================================================
+
+const StatusShape = z.object({
+  success: z.literal(true),
+  ticketId: z.string(),
+  jobId: z.string().nullable(),
+  status: z.enum(['idle', 'pending', 'running', 'completed', 'failed']),
+  output: z.string().nullable(),
+  error: z.string().nullable(),
+  attemptsMade: z.number().nullable(),
+  nextAttemptAt: z.string().nullable(),
+});
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{ticketId}/status',
+    tags: ['agent-tasks'],
+    summary: 'Fetch the canonical dispatch status for a ticket',
+    description:
+      'Returns the current state of the most recent dispatch job for a ticket. `status = idle` means no job was ever queued (legacy sync dispatch or ticket never dispatched). Safe to poll; returns 200 even when nothing is in flight.',
+    request: {
+      params: z.object({
+        ticketId: z.string().openapi({ param: { name: 'ticketId', in: 'path' } }),
+      }),
+    },
+    responses: {
+      200: {
+        content: { 'application/json': { schema: StatusShape } },
+        description: 'Dispatch status',
+      },
+      404: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Ticket not found',
       },
     },
   }),
@@ -214,62 +397,179 @@ app.openapi(
       return c.json({ success: false as const, error: 'Ticket not found' }, 404);
     }
 
-    const dispatcher = await buildDispatcher(db, tenant?.id);
-    if (!dispatcher) {
+    const job = await getJobById(jobIdForTicket(ticketId));
+    if (!job) {
       return c.json(
         {
-          success: false as const,
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+          success: true as const,
+          ticketId,
+          jobId: null,
+          status: 'idle' as const,
+          output: null,
+          error: null,
+          attemptsMade: null,
+          nextAttemptAt: null,
         },
-        403,
+        200,
       );
     }
 
-    // Mark in_progress before dispatch
-    await ticketQueries.updateTicket(db, ticketId, { status: 'in_progress' });
-
-    // Dispatch agent with timeout, persist outcome to memory
-    const dispatchResult = await dispatchWithTimeout(db, dispatcher, ticket);
-    if (!dispatchResult.success) {
-      return c.json({ success: false as const, error: dispatchResult.error }, 403);
-    }
-    const { result } = dispatchResult;
-
-    const finalTicket = await ticketQueries.getTicketById(db, ticketId);
-
-    return c.json(
-      {
-        success: true as const,
-        ticketId,
-        agentOutput: result.output ?? null,
-        status: finalTicket?.status ?? (result.success ? 'done' : 'blocked'),
-      },
-      200,
-    );
+    return c.json(serializeStatus(ticketId, job), 200);
   },
 );
 
 // =============================================================================
-// Helpers
+// Durable dispatch helper (CR8-P2-01 phase C)
+// =============================================================================
+
+/** Poll window before falling back to 202. Leaves ~8 s of Vercel's 30 s budget
+ *  for ticket create + response serialization + network. */
+const POLL_WINDOW_MS = 22_000;
+/** Capped exponential backoff for the poll loop. */
+const POLL_INITIAL_MS = 200;
+const POLL_MAX_MS = 2_000;
+
+type DispatchOutcome =
+  | {
+      kind: 'complete';
+      jobId: string;
+      agentOutput: string | null;
+      status: string;
+    }
+  | {
+      kind: 'failed';
+      error: string;
+    }
+  | {
+      kind: 'pending';
+      jobId: string;
+      statusUrl: string;
+    };
+
+async function runDurableDispatch(
+  db: DatabaseClient,
+  ticket: { id: string },
+  user: { id: string },
+  tenant: { id: string } | undefined,
+  requestId: string | undefined,
+): Promise<DispatchOutcome> {
+  const jobId = jobIdForTicket(ticket.id);
+
+  await enqueue<AgentDispatchPayload>(
+    'agent.dispatch',
+    {
+      ticketId: ticket.id,
+      tenantId: tenant?.id,
+      userId: user.id,
+      requestId,
+    },
+    { idempotencyKey: jobId, retryLimit: 3 },
+  );
+
+  const deadline = Date.now() + POLL_WINDOW_MS;
+  let backoff = POLL_INITIAL_MS;
+  while (Date.now() < deadline) {
+    await sleep(Math.min(backoff, deadline - Date.now()));
+    backoff = Math.min(backoff * 2, POLL_MAX_MS);
+
+    const job = await getJobById(jobId);
+    if (!job) continue;
+
+    if (job.state === 'completed') {
+      const output = (job.output ?? {}) as Partial<AgentDispatchOutput>;
+      const finalTicket = await ticketQueries.getTicketById(db, ticket.id);
+      return {
+        kind: 'complete',
+        jobId,
+        agentOutput: output.output ?? null,
+        status: finalTicket?.status ?? output.status ?? 'done',
+      };
+    }
+
+    if (job.state === 'failed') {
+      return {
+        kind: 'failed',
+        error: job.lastError ?? 'Agent dispatch failed',
+      };
+    }
+    // else state === 'created' or 'active' — keep polling
+  }
+
+  return {
+    kind: 'pending',
+    jobId,
+    statusUrl: `/api/agent-tasks/${ticket.id}/status`,
+  };
+}
+
+/**
+ * One job per ticket: the job id is derived from the ticket id so
+ * repeated POSTs for the same ticket dedupe at `enqueue()` via the
+ * ON CONFLICT DO NOTHING branch. Re-dispatching a completed ticket
+ * returns the cached result; force-re-dispatch is a future tracker.
+ */
+function jobIdForTicket(ticketId: string): string {
+  return `agent.dispatch:${ticketId}`;
+}
+
+function serializeStatus(
+  ticketId: string,
+  job: Job,
+): {
+  success: true;
+  ticketId: string;
+  jobId: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  output: string | null;
+  error: string | null;
+  attemptsMade: number;
+  nextAttemptAt: string | null;
+} {
+  const outputValue = job.output as Partial<AgentDispatchOutput> | null;
+  const status: 'pending' | 'running' | 'completed' | 'failed' =
+    job.state === 'completed'
+      ? 'completed'
+      : job.state === 'failed'
+        ? 'failed'
+        : job.state === 'active'
+          ? 'running'
+          : 'pending';
+  const nextAttemptAt =
+    status === 'pending' && job.startAfter && job.startAfter > new Date()
+      ? job.startAfter.toISOString()
+      : null;
+  return {
+    success: true,
+    ticketId,
+    jobId: job.id,
+    status,
+    output: outputValue?.output ?? null,
+    error: job.lastError ?? null,
+    attemptsMade: job.retryCount,
+    nextAttemptAt,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+// =============================================================================
+// Legacy sync dispatch helper (flag-off path)
 // =============================================================================
 
 /** Agent dispatch timeout  -  configurable via AGENT_TIMEOUT_MS env var */
 const AGENT_TIMEOUT_MS = Number(process.env.AGENT_TIMEOUT_MS) || 120_000;
 
 /**
- * Dispatch an agent for a ticket with a timeout guard, then persist the
- * outcome to agent_memories. Shared by both POST handlers.
+ * Legacy in-request dispatch with in-process timeout + best-effort memory
+ * write. Preserved so the flag-off path behaves exactly as it did pre-
+ * phase-C. When the flag flips default-on and the deletion PR lands,
+ * this helper and dispatchWithTimeout go away.
  */
 async function dispatchWithTimeout(
   db: DatabaseClient,
-  dispatcher: {
-    dispatch: (ticket: Record<string, unknown>) => Promise<{
-      success: boolean;
-      output?: string;
-      metadata?: { executionTime?: number; tokensUsed?: number };
-    }>;
-  },
+  dispatcher: Dispatcher,
   ticket: { id: string; title: string; description: unknown; type: string; priority: string },
 ): Promise<
   | {
@@ -290,7 +590,7 @@ async function dispatchWithTimeout(
     );
   });
 
-  let result: Awaited<ReturnType<typeof dispatcher.dispatch>>;
+  let result: Awaited<ReturnType<Dispatcher['dispatch']>>;
   try {
     result = await Promise.race([
       dispatcher
@@ -321,7 +621,6 @@ async function dispatchWithTimeout(
     await ticketQueries.updateTicket(db, ticket.id, { status: 'blocked' });
   }
 
-  // Persist agent outcome to agent_memories (best-effort)
   if (result.output) {
     try {
       const memoryValues = {
@@ -346,180 +645,11 @@ async function dispatchWithTimeout(
         siteId: memoryValues.siteId,
       });
     } catch {
-      // Memory persistence is best-effort  -  don't fail the request
+      // Memory persistence is best-effort
     }
   }
 
   return { success: true, result };
-}
-
-/**
- * Build a TicketAgentDispatcher backed by the real DB client.
- * Returns null if no LLM provider is configured or @revealui/ai is not installed.
- */
-async function buildDispatcher(
-  db: DatabaseClient,
-  _tenantId: string | undefined,
-): Promise<{
-  dispatch: (ticket: Record<string, unknown>) => Promise<{
-    success: boolean;
-    output?: string;
-    metadata?: { executionTime?: number; tokensUsed?: number };
-  }>;
-} | null> {
-  const aiMod = await import('@revealui/ai').catch(() => null);
-  if (!aiMod) return null;
-
-  let llmClient: unknown;
-  try {
-    llmClient = aiMod.createLLMClientFromEnv();
-  } catch {
-    return null;
-  }
-
-  // TicketMutationClient backed by real DB queries
-  const ticketClient = {
-    async updateTicket(
-      id: string,
-      data: { status?: string; columnId?: string; metadata?: Record<string, unknown> },
-    ) {
-      return ticketQueries.updateTicket(db, id, data);
-    },
-    async createComment(id: string, body: Record<string, unknown>, options?: { id?: string }) {
-      // When the caller (createTicketTools) passes a deterministic id, use
-      // it so a crash-and-resume of the same dispatch produces the same
-      // row and the PK constraint dedupes naturally. Otherwise fall back
-      // to a random UUID for backward compatibility.
-      return commentQueries.createComment(db, {
-        id: options?.id ?? crypto.randomUUID(),
-        ticketId: id,
-        body,
-      });
-    },
-  };
-
-  // AdminAPIClient  -  routes through the admin REST API if configured, otherwise no-ops
-  const adminBaseUrl = process.env.ADMIN_URL ?? process.env.NEXT_PUBLIC_ADMIN_URL;
-  const apiClient = buildCMSClient(adminBaseUrl);
-
-  // Type assertions needed: TicketAgentDispatcher comes from Pro package with its own
-  // type resolution path. llmClient is unknown from dynamic import; the dispatcher's
-  // dispatch() accepts TicketInput (narrower than Record<string, unknown>).
-  type DispatcherConfig = ConstructorParameters<typeof aiMod.TicketAgentDispatcher>[0];
-  return new aiMod.TicketAgentDispatcher({
-    llmClient: llmClient as DispatcherConfig['llmClient'],
-    apiClient,
-    ticketClient,
-  }) as unknown as NonNullable<Awaited<ReturnType<typeof buildDispatcher>>>;
-}
-
-/**
- * Build a AdminAPIClient that calls the admin REST API.
- * If no admin URL is available, returns a stub that reports the misconfiguration.
- */
-function buildCMSClient(baseUrl: string | undefined) {
-  if (!baseUrl) {
-    const stub = async () => {
-      throw new Error(
-        'ADMIN_URL not configured. Set ADMIN_URL to connect the agent to the admin app.',
-      );
-    };
-    return {
-      find: stub,
-      findById: stub,
-      create: stub,
-      update: stub,
-      delete: stub,
-      findGlobal: stub,
-      updateGlobal: stub,
-    };
-  }
-
-  const headers = () => ({
-    'Content-Type': 'application/json',
-    ...(process.env.CMS_API_KEY ? { Authorization: `Bearer ${process.env.CMS_API_KEY}` } : {}),
-  });
-
-  return {
-    async find(options: {
-      collection: string;
-      page?: number;
-      limit?: number;
-      where?: Record<string, unknown>;
-      sort?: string;
-    }) {
-      const params = new URLSearchParams();
-      if (options.page) params.set('page', String(options.page));
-      if (options.limit) params.set('limit', String(options.limit));
-      if (options.sort) params.set('sort', options.sort);
-      const res = await fetch(`${baseUrl}/api/${options.collection}?${params}`, {
-        headers: headers(),
-      });
-      if (!res.ok) throw new Error(`Admin find failed: ${res.statusText}`);
-      const body: unknown = await res.json();
-      const data =
-        body !== null && typeof body === 'object' ? (body as Record<string, unknown>) : {};
-      return {
-        docs: Array.isArray(data.docs) ? (data.docs as unknown[]) : undefined,
-        totalDocs: typeof data.totalDocs === 'number' ? data.totalDocs : undefined,
-        page: typeof data.page === 'number' ? data.page : undefined,
-        totalPages: typeof data.totalPages === 'number' ? data.totalPages : undefined,
-      };
-    },
-
-    async findById(collection: string, id: string) {
-      const res = await fetch(`${baseUrl}/api/${collection}/${id}`, { headers: headers() });
-      if (!res.ok) throw new Error(`Admin findById failed: ${res.statusText}`);
-      return res.json();
-    },
-
-    async create(options: { collection: string; data: Record<string, unknown> }) {
-      const res = await fetch(`${baseUrl}/api/${options.collection}`, {
-        method: 'POST',
-        headers: headers(),
-        body: JSON.stringify(options.data),
-      });
-      if (!res.ok) throw new Error(`Admin create failed: ${res.statusText}`);
-      return res.json();
-    },
-
-    async update(options: { collection: string; id: string; data: Record<string, unknown> }) {
-      const res = await fetch(`${baseUrl}/api/${options.collection}/${options.id}`, {
-        method: 'PATCH',
-        headers: headers(),
-        body: JSON.stringify(options.data),
-      });
-      if (!res.ok) throw new Error(`Admin update failed: ${res.statusText}`);
-      return res.json();
-    },
-
-    async delete(options: { collection: string; id: string }) {
-      const res = await fetch(`${baseUrl}/api/${options.collection}/${options.id}`, {
-        method: 'DELETE',
-        headers: headers(),
-      });
-      if (!res.ok) throw new Error(`Admin delete failed: ${res.statusText}`);
-    },
-
-    async findGlobal(options: { slug: string; depth?: number }) {
-      const params = options.depth !== undefined ? `?depth=${options.depth}` : '';
-      const res = await fetch(`${baseUrl}/api/globals/${options.slug}${params}`, {
-        headers: headers(),
-      });
-      if (!res.ok) throw new Error(`Admin findGlobal failed: ${res.statusText}`);
-      return res.json();
-    },
-
-    async updateGlobal(options: { slug: string; data: Record<string, unknown> }) {
-      const res = await fetch(`${baseUrl}/api/globals/${options.slug}`, {
-        method: 'POST',
-        headers: headers(),
-        body: JSON.stringify(options.data),
-      });
-      if (!res.ok) throw new Error(`Admin updateGlobal failed: ${res.statusText}`);
-      return res.json();
-    },
-  };
 }
 
 export default app;

--- a/docs/runbook-agent-dispatch-flag.md
+++ b/docs/runbook-agent-dispatch-flag.md
@@ -1,0 +1,98 @@
+# Runbook — `REVEALUI_JOBS_AGENT_DISPATCH_ENABLED` flag
+
+## What the flag does
+
+When `REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true`, the
+`POST /api/agent-tasks` and `POST /api/agent-tasks/:ticketId/dispatch`
+endpoints route through the durable work queue
+(CR8-P2-01 phase C):
+
+1. The route enqueues an `agent.dispatch` job and polls the job row
+   for up to 22 seconds.
+2. If the dispatch completes within the poll window, the route
+   returns **200** with the same response shape as the legacy sync
+   path (callers see no behavior change).
+3. If the poll window elapses, the route returns **202** with
+   `jobId` and `statusUrl` so the caller can poll
+   `GET /api/agent-tasks/:ticketId/status`.
+
+When the flag is **unset** or **`false`**, both endpoints behave
+exactly as they did before phase C: synchronous dispatch with an
+in-process `setTimeout` budget. A pod crash mid-dispatch silently
+loses the work — that's the durability gap phase C exists to close.
+
+## Flipping the flag on
+
+### Prerequisites
+
+- `REVEALUI_JOBS_WAKE_SECRET` is set (≥ 32 random bytes).  
+  Without it, the producer's wake fan-out is a no-op and every
+  dispatch waits up to 24 h for the cron safety-net. **The API
+  refuses to start with the flag on and the wake secret unset** —
+  fail fast at boot via `assertDispatchFlagConfigured()`.
+- `REVEALUI_INTERNAL_BASE_URL` is set when the API and worker
+  invocations resolve each other via something other than
+  `http://localhost:3004`. In Vercel prod, point this at the API's
+  public URL.
+- The `agent.dispatch` handler is registered at boot (handled
+  automatically by the side-effect import in
+  `apps/api/src/index.ts`).
+
+### Procedure
+
+1. **Confirm both env vars are set in the target environment**
+   (Vercel preview / prod). Pull from revvault:
+   `revvault get revealui/prod/jobs/wake-secret`.
+2. Set `REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true` in the
+   environment's variable pane.
+3. Redeploy. The boot assertion runs on the first request after
+   deploy; if either variable is missing the function will throw
+   loudly in the logs.
+4. Smoke test: `curl -X POST /api/agent-tasks/<known-ticket>/dispatch`
+   and confirm the response is **200** within ~22 s for a small
+   prompt, or **202** with a `statusUrl` for a long one.
+5. Monitor `[agent.dispatch]` log lines:
+   - `claimed` — worker picked up the job
+   - `llm.start` / `llm.done` — dispatcher ran (with timing)
+   - `replayed-from-cache` — crash-resume hit the memoized result
+   - `[jobs.run] handler failed` — handler threw; check
+     `lastError` in `jobs` table
+
+## Flipping the flag off (rollback)
+
+Set `REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=false` (or unset it)
+and redeploy. The route immediately reverts to the legacy sync
+path. **In-flight queued jobs continue to drain** — the worker
+keeps pulling them, completing them, and writing results to the
+ticket. New dispatches use the sync path until the flag flips
+back on.
+
+There is no destructive cleanup required. Rollback is safe at
+any point.
+
+## Per-tenant rollout (future)
+
+Phase C ships the global env flag only. A future enhancement can
+gate per-tenant via `account_entitlements.limits.durableDispatch`.
+The handler already accepts a `tenantId` in its payload, so the
+plumbing is in place — only a check inside `isDurableDispatchEnabled()`
+needs to consult the entitlement row.
+
+## Failure modes and recovery
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| API refuses to start, log mentions `REVEALUI_JOBS_WAKE_SECRET` | Flag on, secret missing | Set the secret OR flip flag off |
+| Dispatch returns 202 but `/status` stays `pending` for hours | Wake secret mismatch (worker rejecting wakes); cron safety-net is the floor | Verify both `REVEALUI_JOBS_WAKE_SECRET` values match. If still stuck, check the worker route logs at `/api/jobs/run` for 401s. |
+| `/status` returns `failed` with `lastError: "stalled: claim expired before completion"` | Worker crashed mid-dispatch; cron safety-net reclaimed | Job retries automatically with backoff. Check the next attempt's logs. |
+| `/status` returns `failed` with `lastError: "AI feature unavailable at dispatch time"` | License revoked between enqueue and claim | Restore the license; manually re-enqueue. |
+| Duplicate comments on a ticket | Crash mid-dispatch BEFORE the LLM idempotency key was written | Pre-existing limitation: the LLM call boundary is the memoization point; tool calls inside the agent loop use deterministic ids ([revealui#477](https://github.com/RevealUIStudio/revealui/pull/477)) but a crash mid-loop and a successful retry can still produce a small number of extra rows. File a follow-up tracker if frequency exceeds noise. |
+
+## Related infrastructure
+
+- Phase A — queue primitive: `packages/db/src/jobs/`,
+  `apps/api/src/routes/jobs/run.ts`
+- Phase B — cron safety-net: `apps/api/src/routes/cron/jobs-safety-net.ts`
+- Design doc: `~/suite/.jv/docs/CR8-P2-01-native-queue-design.md`
+- Flag-removal follow-up: filed at PR-merge time, scheduled
+  ≥ 2 weeks of clean prod operation before removal.

--- a/packages/db/src/jobs/claim.ts
+++ b/packages/db/src/jobs/claim.ts
@@ -307,6 +307,17 @@ export async function markUnhandled(
 // =============================================================================
 
 /**
+ * Fetch a single job row by id. Returns null when the id doesn't exist.
+ * Used by the hybrid POST path (CR8-P2-01 phase C) for poll-to-complete
+ * and by the canonical status endpoint.
+ */
+export async function getJobById(jobId: string, opts: DbOverride = {}): Promise<Job | null> {
+  const db = opts.db ?? getClient();
+  const rows = await db.select().from(jobs).where(eq(jobs.id, jobId)).limit(1);
+  return rows[0] ?? null;
+}
+
+/**
  * Count jobs eligible right now (state='created', start_after <= now()).
  * Used by the cron safety-net (phase B) to decide whether to fire a wake.
  */

--- a/packages/db/src/jobs/index.ts
+++ b/packages/db/src/jobs/index.ts
@@ -23,6 +23,7 @@ export {
   DEFAULT_VISIBILITY_TIMEOUT_MS,
   DeadlineExceededError,
   deadlineSignal,
+  getJobById,
   markCompleted,
   markFailedOrRetry,
   markUnhandled,

--- a/packages/db/src/saga/__tests__/idempotent-operation.test.ts
+++ b/packages/db/src/saga/__tests__/idempotent-operation.test.ts
@@ -81,6 +81,39 @@ describe('idempotentWrite', () => {
     expect(operation).not.toHaveBeenCalled();
   });
 
+  it('returns the cached result on replay when cacheResult was set originally', async () => {
+    // Replay: existing row has a stored result jsonb (because original
+    // call passed cacheResult: true and the operation returned an
+    // object). New behavior: idempotentWrite surfaces that cached value
+    // in `result` instead of leaving it undefined.
+    const selectChain = createSelectChain([
+      {
+        key: 'agent.dispatch.llm:job-42',
+        expiresAt: new Date(Date.now() + 60_000),
+        result: { success: true, output: 'memoized response', tokensUsed: 1234 },
+      },
+    ]);
+    db.select.mockReturnValue(selectChain);
+
+    const operation = vi.fn().mockResolvedValue({ should: 'never run' });
+
+    const result = await idempotentWrite(
+      db as never,
+      'agent.dispatch.llm:job-42',
+      'agent-dispatch-llm',
+      operation,
+      { cacheResult: true },
+    );
+
+    expect(result.alreadyProcessed).toBe(true);
+    expect(result.result).toEqual({
+      success: true,
+      output: 'memoized response',
+      tokensUsed: 1234,
+    });
+    expect(operation).not.toHaveBeenCalled();
+  });
+
   it('executes operation when key exists but is expired', async () => {
     // Return an existing key with past expiry
     const selectChain = createSelectChain([

--- a/packages/db/src/saga/idempotent-operation.ts
+++ b/packages/db/src/saga/idempotent-operation.ts
@@ -31,7 +31,14 @@ import { idempotencyKeys } from '../schema/idempotency.js';
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface IdempotentWriteResult<T> {
-  /** The operation's return value (undefined if already processed) */
+  /**
+   * The operation's return value. Populated in two cases:
+   *   1. Fresh execution: the function ran and returned this value.
+   *   2. Replay after a prior run that stored `cacheResult: true`: this
+   *      is the memoized value from the original run.
+   * Undefined only when the key already exists but no result was cached
+   * (e.g. operations that don't opt into `cacheResult`).
+   */
   result?: T;
   /** True if the operation was skipped because the key already existed */
   alreadyProcessed: boolean;
@@ -68,7 +75,11 @@ export async function idempotentWrite<T>(
 
   // Step 1: Check if already processed
   const existing = await db
-    .select({ key: idempotencyKeys.key, expiresAt: idempotencyKeys.expiresAt })
+    .select({
+      key: idempotencyKeys.key,
+      expiresAt: idempotencyKeys.expiresAt,
+      result: idempotencyKeys.result,
+    })
     .from(idempotencyKeys)
     .where(eq(idempotencyKeys.key, key))
     .limit(1);
@@ -77,7 +88,13 @@ export async function idempotentWrite<T>(
   if (row) {
     // Check if expired
     if (!row.expiresAt || row.expiresAt >= new Date()) {
-      return { alreadyProcessed: true };
+      // Replay — surface the cached result when the original write opted
+      // in via `cacheResult: true`. Callers that didn't opt in get
+      // `alreadyProcessed: true` and `result: undefined` as before.
+      return {
+        alreadyProcessed: true,
+        result: (row.result ?? undefined) as T | undefined,
+      };
     }
     // Expired  -  clean up and proceed
     await db.delete(idempotencyKeys).where(eq(idempotencyKeys.key, key));

--- a/packages/test/src/integration/database/agent-dispatch-resume.integration.test.ts
+++ b/packages/test/src/integration/database/agent-dispatch-resume.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration test for agent-dispatch crash-resume durability
+ * (CR8-P2-01 phase C).
+ *
+ * Proves the load-bearing contract from the design doc: if a worker
+ * crashes after the LLM call has succeeded, the queue retry
+ * re-invokes `idempotentWrite` with the same key, which returns the
+ * memoized result instead of re-running the LLM. The customer is
+ * billed for one LLM call across the whole crash-resume cycle.
+ *
+ * The handler in apps/api/src/jobs/agent-dispatch.ts is glue around
+ * `idempotentWrite` (the load-bearing primitive), so this test
+ * exercises that primitive directly against PGlite. Testing the
+ * handler end-to-end would require pulling apps/api into the test
+ * package's import graph, which the existing integration suite avoids.
+ */
+
+import { idempotentWrite } from '@revealui/db/saga';
+import { idempotencyKeys } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
+
+interface FakeLLMResult {
+  success: boolean;
+  output: string;
+  tokensUsed: number;
+}
+
+describe('agent-dispatch crash-resume (CR8-P2-01 phase C)', () => {
+  let testDb: TestDb;
+
+  beforeAll(async () => {
+    testDb = await createTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await testDb.close();
+  });
+
+  beforeEach(async () => {
+    await testDb.pglite.exec('DELETE FROM idempotency_keys');
+  });
+
+  it('runs the LLM exactly once across a crash-and-resume cycle', async () => {
+    const dispatcher = vi.fn().mockResolvedValue({
+      success: true,
+      output: 'agent finished the task',
+      tokensUsed: 4321,
+    } satisfies FakeLLMResult);
+
+    const jobId = 'job-resume-1';
+    const key = `agent.dispatch.llm:${jobId}`;
+
+    // --- First attempt: dispatcher runs, result memoized.
+    const first = await idempotentWrite<FakeLLMResult>(
+      testDb.drizzle as never,
+      key,
+      'agent-dispatch-llm',
+      async () => dispatcher(),
+      { cacheResult: true },
+    );
+    expect(first.alreadyProcessed).toBe(false);
+    expect(first.result).toEqual({
+      success: true,
+      output: 'agent finished the task',
+      tokensUsed: 4321,
+    });
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+
+    // --- Simulated crash: the worker crashes here, the cron safety-net
+    //     reclaims the job, the worker is invoked again with the same
+    //     job id. The handler calls idempotentWrite with the same key.
+
+    const second = await idempotentWrite<FakeLLMResult>(
+      testDb.drizzle as never,
+      key,
+      'agent-dispatch-llm',
+      async () => dispatcher(),
+      { cacheResult: true },
+    );
+
+    // --- The dispatcher MUST NOT have been called a second time. The
+    //     memoized result is returned directly.
+    expect(second.alreadyProcessed).toBe(true);
+    expect(second.result).toEqual({
+      success: true,
+      output: 'agent finished the task',
+      tokensUsed: 4321,
+    });
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT memoize when the operation throws (no key written)', async () => {
+    const dispatcher = vi.fn().mockRejectedValue(new Error('LLM provider down'));
+    const jobId = 'job-failed-1';
+    const key = `agent.dispatch.llm:${jobId}`;
+
+    await expect(
+      idempotentWrite<FakeLLMResult>(
+        testDb.drizzle as never,
+        key,
+        'agent-dispatch-llm',
+        async () => dispatcher(),
+        { cacheResult: true },
+      ),
+    ).rejects.toThrow('LLM provider down');
+
+    // Key should not exist — next attempt re-runs the dispatcher.
+    const rows = await testDb.drizzle
+      .select()
+      .from(idempotencyKeys)
+      .where(eq(idempotencyKeys.key, key));
+    expect(rows).toHaveLength(0);
+
+    // Retry: dispatcher runs again, this time succeeds, key is written.
+    dispatcher.mockResolvedValueOnce({
+      success: true,
+      output: 'recovered',
+      tokensUsed: 100,
+    });
+    const second = await idempotentWrite<FakeLLMResult>(
+      testDb.drizzle as never,
+      key,
+      'agent-dispatch-llm',
+      async () => dispatcher(),
+      { cacheResult: true },
+    );
+    expect(second.alreadyProcessed).toBe(false);
+    expect(second.result?.output).toBe('recovered');
+    expect(dispatcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('three concurrent attempts produce one LLM call (race safety)', async () => {
+    // Simulates: worker A claims, fan-out wake also fires, worker B
+    // races to handle. Both call idempotentWrite simultaneously. Only
+    // one should win the LLM call; the other should see the cached
+    // result.
+    let activeCalls = 0;
+    let maxActive = 0;
+    const dispatcher = vi.fn().mockImplementation(async () => {
+      activeCalls += 1;
+      maxActive = Math.max(maxActive, activeCalls);
+      // Simulate LLM latency.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      activeCalls -= 1;
+      return { success: true, output: 'done', tokensUsed: 7 };
+    });
+
+    const jobId = 'job-race-1';
+    const key = `agent.dispatch.llm:${jobId}`;
+
+    const results = await Promise.all([
+      idempotentWrite<FakeLLMResult>(
+        testDb.drizzle as never,
+        key,
+        'agent-dispatch-llm',
+        async () => dispatcher(),
+        { cacheResult: true },
+      ),
+      idempotentWrite<FakeLLMResult>(
+        testDb.drizzle as never,
+        key,
+        'agent-dispatch-llm',
+        async () => dispatcher(),
+        { cacheResult: true },
+      ),
+      idempotentWrite<FakeLLMResult>(
+        testDb.drizzle as never,
+        key,
+        'agent-dispatch-llm',
+        async () => dispatcher(),
+        { cacheResult: true },
+      ),
+    ]);
+
+    // Note: idempotentWrite uses ON CONFLICT DO NOTHING for the insert
+    // and pre-checks for an existing key. Without DB-level locking,
+    // concurrent first-attempts can race past the SELECT and each call
+    // the operation. This test documents that limitation: the
+    // dispatcher MAY be called more than once under concurrent racing,
+    // but never more than `numAttempts` times. After at least one
+    // attempt completes and writes the key, subsequent attempts dedupe
+    // via the cached result.
+    expect(dispatcher.mock.calls.length).toBeLessThanOrEqual(3);
+    expect(dispatcher.mock.calls.length).toBeGreaterThan(0);
+    // All callers receive equivalent successful results (either the
+    // fresh one or a memoized replay of one of the attempts).
+    for (const r of results) {
+      expect(r.result?.success).toBe(true);
+      expect(r.result?.output).toBe('done');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase C of CR8-P2-01 — migrates the agent-tasks dispatch path off in-process `setTimeout` onto the durable work queue. **Closes [revealui#470](https://github.com/RevealUIStudio/revealui/issues/470)**.

Builds on phase A ([#471](https://github.com/RevealUIStudio/revealui/pull/471)), phase B ([#478](https://github.com/RevealUIStudio/revealui/pull/478)), and the deterministic-comment-ids prerequisite ([#477](https://github.com/RevealUIStudio/revealui/pull/477)).

Behavior is gated behind `REVEALUI_JOBS_AGENT_DISPATCH_ENABLED=true` (default off). When the flag is unset, both endpoints behave exactly as they did pre-phase-C — zero behavior change. When the flag is on, the route enqueues the dispatch and polls for up to 22 s; completion within the window returns 200 with the same response shape (callers see no change for the happy path); only genuinely long dispatches return 202 with a jobId + statusUrl.

## The durability story (load-bearing)

When the flag is on, a worker crash mid-dispatch is now recoverable instead of losing paid work:

1. Phase A's visibility timeout + retry-with-backoff catches the stalled claim.
2. Phase B's cron safety-net reclaims it after the visibility window.
3. The phase C handler wraps `dispatcher.dispatch()` in `idempotentWrite` keyed on the job id with `cacheResult: true`. The retry returns the **memoized LLM result** instead of re-calling the LLM — no second bill.
4. #477's deterministic comment ids ensure that any tool-call side-effects re-issued during the narrow pre-memoize crash window collide on the DB PK constraint instead of producing duplicate rows.

## Changes

**`apps/api`:**
- [`jobs/agent-dispatch.ts`](revealui/apps/api/src/jobs/agent-dispatch.ts) — handler. License re-check, ticket load, dispatcher build, `idempotentWrite`-wrapped LLM call, ticket status write, agent_memories persistence.
- [`jobs/register-handlers.ts`](revealui/apps/api/src/jobs/register-handlers.ts) — boot-time registration via top-level side-effect import in `apps/api/src/index.ts`. Includes `assertDispatchFlagConfigured()` that **hard-fails startup if the flag is on but `REVEALUI_JOBS_WAKE_SECRET` is unset** (otherwise every dispatch silently waits 24 h for the cron tick — see runbook).
- [`lib/agent-dispatcher.ts`](revealui/apps/api/src/lib/agent-dispatcher.ts) — extracted `buildDispatcher` + `buildCMSClient` so the route and the handler share the same Pro-package wiring.
- [`routes/agent-tasks.ts`](revealui/apps/api/src/routes/agent-tasks.ts) — flag-gated branch in both POST handlers. Hybrid 22 s poll + 202 fallback. **New `GET /:ticketId/status` endpoint** with canonical response shape (`status` enum: `idle / pending / running / completed / failed`). OpenAPI schemas updated to include the 202 branch.

**`packages/db`:**
- [`saga/idempotent-operation.ts`](revealui/packages/db/src/saga/idempotent-operation.ts) — `idempotentWrite` now returns the cached result on replay when `cacheResult` was set originally. Was returning `undefined`; the cached row was written but never read back. Required for the phase C handler to actually skip the LLM call on resume rather than just skipping the operation.
- [`jobs/claim.ts`](revealui/packages/db/src/jobs/claim.ts) — `getJobById` helper added for the POST poll loop and the status endpoint.

**`docs`:**
- [`runbook-agent-dispatch-flag.md`](revealui/docs/runbook-agent-dispatch-flag.md) — operator runbook covering prerequisites, flip procedure, rollback, per-tenant rollout future path, and a failure-mode → recovery table.

## Test plan

- [x] `pnpm --filter @revealui/db test src/jobs src/saga` — **49 tests pass** (including 1 new for `idempotentWrite` cache-replay)
- [x] `pnpm --filter api test src/jobs` — **5 new `assertDispatchFlagConfigured` unit tests pass**
- [x] `pnpm --filter api test src/routes/__tests__/agent-tasks` — **all 26 existing tests still pass**
- [x] `pnpm --filter @revealui/test test:integration src/integration/database/jobs src/integration/database/agent-dispatch` — **13 integration tests pass** (6 phase A queue + 4 phase B safety-net + 3 new phase C crash-resume)
- [x] `pnpm --filter @revealui/db typecheck` + `pnpm --filter api typecheck` clean
- [x] `pnpm lint` clean
- [ ] CI on push: validate green
- [ ] Smoke on `test` deploy after merge: `POST /api/agent-tasks/<known-ticket>/dispatch` with flag off returns 200 in legacy shape; flip flag on (in test env), confirm 200 within ~22 s for short prompts and 202 with `statusUrl` for long ones.

**Local gate flake to call out:** `pnpm gate` failed locally with a 30 s `beforeAll` timeout in 5 unrelated `@revealui/ai` test files (PGlite spin-up under heavy turbo concurrency on UNC-mounted WSL). The same files pass cleanly when run in isolation. None of them touch code I changed (only `ticket-tools.ts` was changed in `@revealui/ai`, and that file's tests pass). Phases A, B, and #477 hit the same flake locally and went green in CI's native Linux runners — expecting the same here.

## Operator action required

These need values set in revvault + Vercel env BEFORE flipping the flag:

- **`REVEALUI_JOBS_AGENT_DISPATCH_ENABLED`** — default off; flip to `true` only after the next two are set.
- **`REVEALUI_JOBS_WAKE_SECRET`** — already documented in #471. Required when flag is on. Boot will fail fast if missing.
- **`REVEALUI_INTERNAL_BASE_URL`** — already documented in #471. Required if API and worker invocations resolve each other via something other than `http://localhost:3004`.

The runbook walks through the flip procedure step-by-step.

## Forward-thinking deferrals (called out for future)

- **Per-tenant rollout** — phase C ships the global env flag only. The handler already accepts `tenantId` in its payload, so a future enhancement gating on `account_entitlements.limits.durableDispatch` is a small follow-up.
- **`tokensUsed` metering** — preserved through to `jobs.output` so CR8-P0-02 (meter-billing gate) has a stable data source when it ships. No additional wiring in this PR.
- **Comment-id idempotency limitation** — a crash mid-agent-loop BEFORE the LLM idempotency key is written can still produce a small number of duplicate rows on retry. Documented in the runbook's failure-modes table; file a follow-up if frequency exceeds noise.

## Flag-removal follow-up

Will be filed at PR-merge time, scheduled for **2026-05-19** (≥ 2 weeks of clean prod operation post-flip). Removal PR deletes the `setTimeout` legacy path, the flag check, and the runbook.

## Design doc

internal docs §11 (agent-tasks migration) + §13 (failure modes).
