### PR TITLE
feat(mcp)!: delete raw-SQL CRDT_TABLE_SQL bootstrap (Phase 3b.1)

### DIFF
--- a/.changeset/mcp-3b-1-delete-raw-sql-bootstrap.md
+++ b/.changeset/mcp-3b-1-delete-raw-sql-bootstrap.md
@@ -1,0 +1,16 @@
+---
+'@revealui/mcp': minor
+---
+
+Delete the raw-SQL `CRDT_TABLE_SQL` bootstrap from `connectPglite()` and `connectPostgres()`.
+
+These factories previously executed a `CREATE TABLE IF NOT EXISTS crdt_operations (...)` statement at connect time with a document-oriented shape (`document_id`, `vector_clock`, `applied_at`) that conflicted silently with the operation-log shape (`crdt_id`, `crdt_type`, `timestamp`) that `@revealui/db` migrates into the same-named table. No MCP server invokes the factories today, but the collision was a real latent failure mode for any external caller.
+
+**Breaking behavior:** after upgrade, `connectPglite()` / `connectPostgres()` / `createMcpDbClient()` no longer bootstrap any tables. Callers must apply drizzle-kit migrations (or the PGlite equivalent) before issuing queries. There are no known external consumers.
+
+**Removed type re-exports:** `CrdtOperationsInsert` and `CrdtOperationsRow` are no longer re-exported from `@revealui/mcp` or `@revealui/mcp/db`. They were Drizzle-`crdt_operations`-shaped typings that did not match the document-oriented SQL the adapter actually ran — keeping them around was a type-checker lie. Import the canonical types from `@revealui/contracts` directly if still needed.
+
+See `.jv/docs/mcp-crdt-reconciliation-design.md` for the full Phase 3b design. Two follow-up PRs land the replacement:
+
+- **3b.2** — add `mcp_document_operations` as a Drizzle-tracked schema + migration.
+- **3b.3** — rewire MCP's integration test to the new table and re-export typed helpers.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -73,8 +73,6 @@ packages/mcp/
 │   ├── SETUP.md          # Setup instructions
 │   └── servers/          # Per-server documentation
 │       └── code-validator.md
-├── migrations/           # Performance indexes for core tables (pending port to drizzle-kit)
-│   └── 005_performance_indexes.sql
 └── package.json
 ```
 

--- a/packages/mcp/__tests__/crdt.integration.test.ts
+++ b/packages/mcp/__tests__/crdt.integration.test.ts
@@ -1,156 +1,16 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import adapters, { connectPglite, type McpDbClient } from '../src/adapters/db.js';
+import { describe, expect, it } from 'vitest';
+import adapters from '../src/adapters/db.js';
 
-describe('CRDT integration (smoke)', () => {
-  it('adapter functions exist', () => {
+describe('MCP DB adapter (smoke)', () => {
+  it('adapter factory functions are exported', () => {
     expect(typeof adapters.connectPglite).toBe('function');
     expect(typeof adapters.connectPostgres).toBe('function');
     expect(typeof adapters.createMcpDbClient).toBe('function');
   });
 });
 
-// Skip integration tests in unit test mode
-// Integration tests need TEST_DATABASE_URL explicitly set or PGlite in test environment
-// Don't run by default as PGlite initialization can be slow
-const testDatabaseUrl = process.env.TEST_DATABASE_URL;
-const isTestMode = process.env.NODE_ENV === 'test';
-
-describe.skipIf(!testDatabaseUrl || isTestMode)('CRDT integration with PGlite', () => {
-  let client: McpDbClient;
-
-  beforeAll(async () => {
-    // Use in-memory PGlite for testing
-    client = await connectPglite({ dataDir: ':memory:' });
-  });
-
-  afterAll(async () => {
-    if (client) {
-      await client.close();
-    }
-  });
-
-  it('should create crdt_operations table', async () => {
-    // Verify table exists by querying it
-    const result = await client.query(
-      `SELECT column_name FROM information_schema.columns WHERE table_name = 'crdt_operations'`,
-    );
-
-    const columns = result.rows.map((r) => r.column_name);
-    expect(columns).toContain('id');
-    expect(columns).toContain('document_id');
-    expect(columns).toContain('operation_type');
-    expect(columns).toContain('payload');
-    expect(columns).toContain('vector_clock');
-    expect(columns).toContain('node_id');
-  });
-
-  it('should insert and query CRDT operations', async () => {
-    const opId = `op-${Date.now()}`;
-    const docId = 'doc-test-1';
-    const nodeId = 'node-a';
-
-    // Insert a CRDT operation
-    await client.query(
-      `INSERT INTO crdt_operations (id, document_id, operation_type, payload, vector_clock, node_id)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [
-        opId,
-        docId,
-        'insert',
-        JSON.stringify({ field: 'title', value: 'Test' }),
-        JSON.stringify({ [nodeId]: 1 }),
-        nodeId,
-      ],
-    );
-
-    // Query it back
-    const result = await client.query(`SELECT * FROM crdt_operations WHERE id = $1`, [opId]);
-
-    expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]?.document_id).toBe(docId);
-    expect(result.rows[0]?.operation_type).toBe('insert');
-    expect(result.rows[0]?.node_id).toBe(nodeId);
-  });
-
-  it('should support concurrent operations from multiple nodes', async () => {
-    const docId = `doc-concurrent-${Date.now()}`;
-    const nodeA = 'node-a';
-    const nodeB = 'node-b';
-
-    // Simulate concurrent writes from two nodes
-    await Promise.all([
-      client.query(
-        `INSERT INTO crdt_operations (id, document_id, operation_type, payload, vector_clock, node_id)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-        [
-          `op-a-${Date.now()}`,
-          docId,
-          'update',
-          JSON.stringify({ field: 'content', value: 'From A' }),
-          JSON.stringify({ [nodeA]: 1 }),
-          nodeA,
-        ],
-      ),
-      client.query(
-        `INSERT INTO crdt_operations (id, document_id, operation_type, payload, vector_clock, node_id)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-        [
-          `op-b-${Date.now()}`,
-          docId,
-          'update',
-          JSON.stringify({ field: 'content', value: 'From B' }),
-          JSON.stringify({ [nodeB]: 1 }),
-          nodeB,
-        ],
-      ),
-    ]);
-
-    // Query all operations for this document
-    const result = await client.query(
-      `SELECT * FROM crdt_operations WHERE document_id = $1 ORDER BY created_at`,
-      [docId],
-    );
-
-    // Both operations should be preserved (CRDT property)
-    expect(result.rows).toHaveLength(2);
-
-    const nodes = result.rows.map((r) => r.node_id);
-    expect(nodes).toContain(nodeA);
-    expect(nodes).toContain(nodeB);
-  });
-
-  it('should handle vector clock ordering', async () => {
-    const docId = `doc-clock-${Date.now()}`;
-    const nodeId = 'node-clock';
-
-    // Insert operations with incrementing vector clock
-    for (let i = 1; i <= 3; i++) {
-      await client.query(
-        `INSERT INTO crdt_operations (id, document_id, operation_type, payload, vector_clock, node_id)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-        [
-          `op-${docId}-${i}`,
-          docId,
-          'update',
-          JSON.stringify({ field: 'counter', value: i }),
-          JSON.stringify({ [nodeId]: i }),
-          nodeId,
-        ],
-      );
-    }
-
-    const result = await client.query(
-      `SELECT * FROM crdt_operations WHERE document_id = $1 ORDER BY created_at`,
-      [docId],
-    );
-
-    expect(result.rows).toHaveLength(3);
-
-    // Verify vector clocks are preserved and can be used for ordering
-    const clocks = result.rows.map((r) => {
-      const vc = r.vector_clock as Record<string, number>;
-      return vc[nodeId];
-    });
-    expect(clocks).toEqual([1, 2, 3]);
-  });
-});
+// Deeper CRDT integration coverage (insert/query/vector-clock) is restored in
+// PR-3b.3 against `mcp_document_operations`, a Drizzle-tracked table. The
+// previous skip-by-default block here exercised a runtime-bootstrapped
+// `crdt_operations` schema removed in PR-3b.1 to close the latent divergence
+// with @revealui/ai's canonical `crdt_operations`.

--- a/packages/mcp/src/adapters/db.ts
+++ b/packages/mcp/src/adapters/db.ts
@@ -1,16 +1,17 @@
 /**
  * DB adapter for MCP.
- * - `connectPglite()` initializes ElectricSQL/pglite client with CRDT metadata.
- * - `connectPostgres()` creates a standard Postgres client with Electric metadata.
- * - `createMcpDbClient()` factory that selects adapter based on config.
+ * - `connectPglite()` returns a PGlite-backed client.
+ * - `connectPostgres()` returns a `pg.Pool`-backed client.
+ * - `createMcpDbClient()` selects adapter based on `persistenceDriver` config.
  *
- * Uses @revealui/contracts as the single source of truth for CRDT operation types.
+ * Schema is the caller's responsibility — these factories do NOT bootstrap any
+ * tables. Apply drizzle-kit migrations (`pnpm --filter @revealui/db db:migrate`
+ * or the PGlite equivalent) before issuing queries.
  */
 
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import getMcpConfig from '@revealui/config/mcp';
-import type { CrdtOperationsInsert, CrdtOperationsRow } from '@revealui/contracts';
 import { getSSLConfig } from '@revealui/core/database/ssl-config';
 
 export interface QueryResult<T = Record<string, unknown>> {
@@ -23,9 +24,6 @@ export type McpDbClient = {
   close: () => Promise<void>;
 };
 
-/** Re-export contracts CRDT types for consumers */
-export type { CrdtOperationsInsert, CrdtOperationsRow };
-
 // Type for PGlite instance (minimal interface to avoid import issues)
 interface PGliteInstance {
   waitReady: Promise<void>;
@@ -36,23 +34,6 @@ interface PGliteInstance {
   exec(query: string): Promise<unknown>;
   close(): Promise<void>;
 }
-
-// CRDT operations table schema for conflict-free replication
-const CRDT_TABLE_SQL = `
-  CREATE TABLE IF NOT EXISTS crdt_operations (
-    id TEXT PRIMARY KEY,
-    document_id TEXT NOT NULL,
-    operation_type TEXT NOT NULL,
-    payload JSONB NOT NULL,
-    vector_clock JSONB NOT NULL,
-    node_id TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    applied_at TIMESTAMPTZ
-  );
-  CREATE INDEX IF NOT EXISTS idx_crdt_ops_document ON crdt_operations(document_id);
-  CREATE INDEX IF NOT EXISTS idx_crdt_ops_node ON crdt_operations(node_id);
-  CREATE INDEX IF NOT EXISTS idx_crdt_ops_created ON crdt_operations(created_at DESC);
-`;
 
 /**
  * Connect to PGlite (embedded PostgreSQL) for local development/testing.
@@ -88,9 +69,6 @@ export async function connectPglite(options?: { dataDir?: string }): Promise<Mcp
     }
     throw error;
   }
-
-  // Create CRDT operations table
-  await db.exec(CRDT_TABLE_SQL);
 
   return {
     async query<T = Record<string, unknown>>(
@@ -141,9 +119,6 @@ export async function connectPostgres(): Promise<McpDbClient> {
   } finally {
     client.release();
   }
-
-  // Create CRDT operations table
-  await pool.query(CRDT_TABLE_SQL);
 
   return {
     async query<T = Record<string, unknown>>(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -39,8 +39,6 @@ export async function checkMcpLicense(): Promise<boolean> {
 
 // Database adapter
 export {
-  type CrdtOperationsInsert,
-  type CrdtOperationsRow,
   connectPglite,
   connectPostgres,
   createMcpDbClient,


### PR DESCRIPTION
## Summary

Phase 3b.1 of the raw-SQL migration arc. Deletes the `CRDT_TABLE_SQL` raw-SQL bootstrap that `@revealui/mcp` executed at connect time via `connectPglite()` / `connectPostgres()`.

### The latent divergence

The bootstrap defined a document-oriented schema (`document_id`, `vector_clock`, `applied_at`) under the name `crdt_operations` — which collides with the operation-log shape (`crdt_id`, `crdt_type`, `timestamp`) that `@revealui/db` migrates into the same-named table. No MCP server invokes the factories today, but the collision is a real latent failure mode for any external caller of MCP's public API:

- `CREATE TABLE IF NOT EXISTS` is a no-op against the Drizzle-created table.
- Subsequent `INSERT` / `SELECT` referencing `document_id` / `vector_clock` / `applied_at` hit columns that don't exist.

See internal docs (private-repo link) for the full Phase 3b design. This PR is the first of three:

- **3b.1 (this PR)** — delete the raw-SQL bootstrap + stale type re-exports
- **3b.2** — add `mcp_document_operations` as a Drizzle-tracked schema + migration
- **3b.3** — rewire the integration test + re-export typed helpers

## Changes

### Behavior

- `connectPglite()`, `connectPostgres()`, `createMcpDbClient()` no longer bootstrap any tables. Callers must apply drizzle-kit migrations (or the PGlite equivalent) before issuing queries. **Breaking** → minor bump on `@revealui/mcp` (`0.2.0` → `0.3.0`).

### Removed re-exports

- `CrdtOperationsInsert` and `CrdtOperationsRow` are no longer re-exported from `@revealui/mcp` or `@revealui/mcp/db`. They were Drizzle-`crdt_operations`-shaped typings attached to a document-oriented SQL runtime — a type-checker lie. Canonical types live in `@revealui/contracts`.

### Test

- `packages/mcp/__tests__/crdt.integration.test.ts` trimmed to a factory-exists smoke block. The skip-by-default deep-insert/vector-clock coverage will be restored against the new `mcp_document_operations` table in PR-3b.3.

### Docs

- `packages/mcp/README.md` — drop stale `migrations/` directory entry (deleted in Phase 4a, [#464](https://github.com/RevealUIStudio/revealui/pull/464)).
- `packages/mcp/src/adapters/db.ts` module JSDoc — rewritten to reflect the "schema is caller's responsibility" posture.

## Context

Part of the raw-SQL migration arc (`raw-sql-migration-plan.md`). Correction to `HANDOFF-2026-04-21-raw-sql-migration-complete.md`: that handoff claimed `CRDT_TABLE_SQL` had been deleted in Phase 3a ([#473](https://github.com/RevealUIStudio/revealui/pull/473)) — it had not; only the migration *files* were deleted. Handoff is updated alongside this PR in the private repo.

## Test plan

- [x] `pnpm --filter @revealui/mcp typecheck` → clean
- [x] `pnpm --filter @revealui/mcp test` → 117 passed
- [x] `pnpm gate:quick` → PASS (14/14)
- [x] `git grep CrdtOperationsInsert CrdtOperationsRow` — no consumer imports from `@revealui/mcp`
- [ ] All 10 required checks green on `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
