### PR TITLE
feat(mcp): add McpClient with resources + prompts (Stage 0 PR-0.1)

### DIFF
--- a/.changeset/mcp-0-1-client-resources-prompts.md
+++ b/.changeset/mcp-0-1-client-resources-prompts.md
@@ -1,0 +1,27 @@
+---
+'@revealui/mcp': minor
+---
+
+Add `McpClient` — a typed wrapper around `@modelcontextprotocol/sdk`'s `Client` class, scoped to the resources + prompts protocol surface (Stage 0 PR-0.1 of the MCP v1 plan).
+
+The existing hypervisor speaks its own custom JSON-RPC 2.0 and only calls `tools/list` / `tools/call` / `ping`. That serves the 13 first-party servers well but leaves resources, prompts, sampling, elicitation, roots, logging, progress, cancellation, completions, and notifications entirely unavailable to RevealUI callers. `McpClient` is a parallel surface for non-tool primitives; later stages migrate the hypervisor to route through it.
+
+**Ships in this release:**
+
+- `McpClient` class with `connect()` / `close()` (idempotent), `getServerCapabilities()`, `ping()`.
+- Resources: `listResources()`, `readResource(uri)`, `subscribeResource(uri, handler)` → returns unsubscribe function; automatic protocol-level subscribe/unsubscribe based on subscriber count per URI.
+- Prompts: `listPrompts()`, `getPrompt(name, args?)`.
+- List-changed subscriptions: `onResourcesListChanged(handler)`, `onPromptsListChanged(handler)`, `onToolsListChanged(handler)` — each returns an unregister function.
+- Transport discriminated union: `{ kind: 'stdio', command, args?, env?, cwd? }` or `{ kind: 'custom', transport }` (the second form accepts any SDK `Transport`, used today for tests via `InMemoryTransport`). Stage 1 will extend this with `{ kind: 'streamable-http' }`.
+- Typed errors: `McpCapabilityError` (thrown by any method whose server-side capability wasn't advertised) and `McpNotConnectedError` (method called before `connect()`).
+
+**Testing:** the SDK's `InMemoryTransport.createLinkedPair()` is used for a real wire-protocol round-trip in tests — no subprocess spawning, no stdio flakiness. Integration test covers 19 cases including connect idempotency, resource read, per-URI subscription fan-out with multiple subscribers, unsubscribe after close, prompt argument passthrough, list-changed fan-out, and capability-error enforcement against minimal servers.
+
+**Not yet:**
+
+- Sampling, elicitation, roots, completions, logging, progress, cancellation, notifications — PR-0.2 / PR-0.3.
+- Streamable HTTP transport — Stage 1.
+- OAuth 2.1 — Stage 2.
+- Admin UI surface — Stage 3.
+
+See `.jv/docs/mcp-productionization-scope.md` for the full v1 plan.

--- a/packages/mcp/__tests__/client.integration.test.ts
+++ b/packages/mcp/__tests__/client.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * McpClient integration tests (Stage 0, PR-0.1).
+ *
+ * Exercises the client against a real MCP Server using InMemoryTransport —
+ * every request/response traverses the full SDK stack (validation, schemas,
+ * notification routing) without subprocess overhead. No flaky piping, no
+ * spawn timeouts, just wire-protocol coverage.
+ */
+
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpCapabilityError, McpClient, McpNotConnectedError } from '../src/client.js';
+import {
+  createResourcesPromptsFixture,
+  type FixtureServer,
+} from './fixtures/resources-prompts-server.js';
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+async function connectedFixture(): Promise<{ fixture: FixtureServer; client: McpClient }> {
+  const fixture = createResourcesPromptsFixture();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await fixture.server.connect(serverTransport);
+
+  const client = new McpClient({
+    clientInfo: { name: 'mcp-client-integration-test', version: '0.0.1' },
+    transport: { kind: 'custom', transport: clientTransport },
+  });
+  await client.connect();
+
+  return { fixture, client };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe('McpClient lifecycle', () => {
+  let client: McpClient | undefined;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = undefined;
+    }
+  });
+
+  it('negotiates capabilities on connect', async () => {
+    const harness = await connectedFixture();
+    client = harness.client;
+
+    const caps = client.getServerCapabilities();
+    expect(caps).toBeDefined();
+    expect(caps?.resources).toMatchObject({ subscribe: true, listChanged: true });
+    expect(caps?.prompts).toMatchObject({ listChanged: true });
+  });
+
+  it('connect() is idempotent', async () => {
+    const harness = await connectedFixture();
+    client = harness.client;
+
+    // Second connect is a no-op; it must not re-initialize or throw.
+    await client.connect();
+    expect(client.getServerCapabilities()).toBeDefined();
+  });
+
+  it('close() is idempotent', async () => {
+    const harness = await connectedFixture();
+    client = harness.client;
+    await client.close();
+    await client.close(); // second close does not throw
+    client = undefined;
+  });
+
+  it('methods before connect throw McpNotConnectedError', async () => {
+    const unconnected = new McpClient({
+      clientInfo: { name: 't', version: '0' },
+      transport: { kind: 'custom', transport: InMemoryTransport.createLinkedPair()[0] },
+    });
+
+    await expect(unconnected.listResources()).rejects.toBeInstanceOf(McpNotConnectedError);
+    await expect(unconnected.listPrompts()).rejects.toBeInstanceOf(McpNotConnectedError);
+    await expect(unconnected.readResource('mem://doc/alpha')).rejects.toBeInstanceOf(
+      McpNotConnectedError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+
+describe('McpClient resources', () => {
+  let client: McpClient;
+  let fixture: FixtureServer;
+
+  beforeEach(async () => {
+    const harness = await connectedFixture();
+    client = harness.client;
+    fixture = harness.fixture;
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it('lists the fixture resources', async () => {
+    const resources = await client.listResources();
+    expect(resources).toHaveLength(2);
+    expect(resources.map((r) => r.uri).sort()).toEqual(['mem://doc/alpha', 'mem://doc/beta']);
+  });
+
+  it('reads a known resource', async () => {
+    const contents = await client.readResource('mem://doc/alpha');
+    expect(contents).toHaveLength(1);
+    expect(contents[0]?.uri).toBe('mem://doc/alpha');
+    expect(contents[0]?.mimeType).toBe('text/plain');
+    expect(contents[0]?.text).toBe('Contents of alpha');
+  });
+
+  it('rejects an unknown resource URI', async () => {
+    await expect(client.readResource('mem://doc/does-not-exist')).rejects.toThrow();
+  });
+
+  it('subscribes and fans updates out to handlers', async () => {
+    const handler = vi.fn();
+    const unsubscribe = await client.subscribeResource('mem://doc/alpha', handler);
+
+    await fixture.triggerResourceUpdate('mem://doc/alpha');
+    // Yield a tick so the notification makes it through InMemoryTransport.
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ uri: 'mem://doc/alpha' });
+
+    await unsubscribe();
+
+    await fixture.triggerResourceUpdate('mem://doc/alpha');
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1); // no new calls after unsubscribe
+  });
+
+  it('fans to multiple subscribers on the same URI', async () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = await client.subscribeResource('mem://doc/beta', a);
+    const unsubB = await client.subscribeResource('mem://doc/beta', b);
+
+    await fixture.triggerResourceUpdate('mem://doc/beta');
+    await Promise.resolve();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+
+    await unsubA();
+
+    await fixture.triggerResourceUpdate('mem://doc/beta');
+    await Promise.resolve();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
+
+    await unsubB();
+  });
+
+  it('fires resources/list_changed to registered handlers', async () => {
+    // The SDK re-fetches the resource list before invoking onChanged, so we
+    // have a full client→server→client round-trip between the notification
+    // and the handler firing. Poll with vi.waitFor instead of awaiting a
+    // single microtask tick.
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    const unregH1 = client.onResourcesListChanged(h1);
+    client.onResourcesListChanged(h2);
+
+    await fixture.triggerResourcesListChanged();
+
+    await vi.waitFor(() => {
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(1);
+    });
+
+    unregH1();
+    await fixture.triggerResourcesListChanged();
+
+    await vi.waitFor(() => {
+      expect(h2).toHaveBeenCalledTimes(2);
+    });
+    expect(h1).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe after close does not throw', async () => {
+    const handler = vi.fn();
+    const unsubscribe = await client.subscribeResource('mem://doc/alpha', handler);
+    await client.close();
+
+    // After close the resource map is cleared; unsubscribe must tolerate it.
+    await expect(unsubscribe()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+describe('McpClient prompts', () => {
+  let client: McpClient;
+  let fixture: FixtureServer;
+
+  beforeEach(async () => {
+    const harness = await connectedFixture();
+    client = harness.client;
+    fixture = harness.fixture;
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it('lists the fixture prompts', async () => {
+    const prompts = await client.listPrompts();
+    expect(prompts).toHaveLength(2);
+    expect(prompts.map((p) => p.name).sort()).toEqual(['greet', 'summarize']);
+  });
+
+  it('gets a prompt with arguments', async () => {
+    const result = await client.getPrompt('greet', { who: 'Joshua' });
+    expect(result.description).toBe('Generate a greeting');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe('user');
+    const content = result.messages[0]?.content;
+    expect(content && content.type).toBe('text');
+    if (content && content.type === 'text') {
+      expect(content.text).toBe('Greet Joshua.');
+    }
+  });
+
+  it('gets a prompt without arguments', async () => {
+    const result = await client.getPrompt('greet');
+    expect(result.messages).toHaveLength(1);
+    const content = result.messages[0]?.content;
+    if (content && content.type === 'text') {
+      expect(content.text).toBe('Greet world.');
+    }
+  });
+
+  it('rejects an unknown prompt name', async () => {
+    await expect(client.getPrompt('nonexistent')).rejects.toThrow();
+  });
+
+  it('fires prompts/list_changed to registered handlers', async () => {
+    const handler = vi.fn();
+    const unregister = client.onPromptsListChanged(handler);
+
+    await fixture.triggerPromptsListChanged();
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    unregister();
+    await fixture.triggerPromptsListChanged();
+    // Give the SDK time to run its re-fetch; confirm our unregistered handler
+    // stays at 1 call.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability enforcement
+// ---------------------------------------------------------------------------
+
+describe('McpClient capability enforcement', () => {
+  async function connectWithCapabilities(
+    capabilities: ConstructorParameters<typeof Server>[1]['capabilities'],
+  ): Promise<McpClient> {
+    const server = new Server({ name: 'empty-caps-fixture', version: '0.0.1' }, { capabilities });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new McpClient({
+      clientInfo: { name: 'cap-test', version: '0.0.1' },
+      transport: { kind: 'custom', transport: clientTransport },
+    });
+    await client.connect();
+    return client;
+  }
+
+  it('throws McpCapabilityError when server does not advertise resources', async () => {
+    const client = await connectWithCapabilities({ prompts: {} });
+    try {
+      const err = await client.listResources().catch((e) => e);
+      expect(err).toBeInstanceOf(McpCapabilityError);
+      expect((err as McpCapabilityError).capability).toBe('resources');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('throws McpCapabilityError when server does not advertise prompts', async () => {
+    const client = await connectWithCapabilities({ resources: {} });
+    try {
+      const err = await client.listPrompts().catch((e) => e);
+      expect(err).toBeInstanceOf(McpCapabilityError);
+      expect((err as McpCapabilityError).capability).toBe('prompts');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('throws McpCapabilityError when server advertises resources but not subscribe', async () => {
+    const client = await connectWithCapabilities({
+      resources: {} /* no subscribe:true */,
+    });
+    try {
+      const err = await client.subscribeResource('mem://x', () => {}).catch((e) => e);
+      expect(err).toBeInstanceOf(McpCapabilityError);
+      expect((err as McpCapabilityError).capability).toBe('resources.subscribe');
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/mcp/__tests__/fixtures/resources-prompts-server.ts
+++ b/packages/mcp/__tests__/fixtures/resources-prompts-server.ts
@@ -1,0 +1,150 @@
+/**
+ * Test fixture: an in-process MCP server exposing resources + prompts.
+ *
+ * Consumed only by McpClient tests. Intentionally minimal — just enough shape
+ * to exercise every code path in the client's resources + prompts surface
+ * (including subscribe / unsubscribe, list-changed notifications, resource
+ * updates, and prompt argument passthrough).
+ *
+ * Usage:
+ *   const fixture = createResourcesPromptsFixture();
+ *   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+ *   await fixture.server.connect(serverTransport);
+ *   // ... point McpClient at clientTransport via { kind: 'custom', transport: clientTransport }
+ *
+ * The returned handle exposes helpers to trigger server-initiated notifications
+ * (resource updates, list-changed) so tests can assert client-side fan-out.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+const RESOURCES = [
+  { uri: 'mem://doc/alpha', name: 'Alpha', description: 'Alpha doc', mimeType: 'text/plain' },
+  { uri: 'mem://doc/beta', name: 'Beta', description: 'Beta doc', mimeType: 'text/plain' },
+] as const;
+
+const RESOURCE_CONTENTS: Record<string, string> = {
+  'mem://doc/alpha': 'Contents of alpha',
+  'mem://doc/beta': 'Contents of beta',
+};
+
+const PROMPTS = [
+  {
+    name: 'greet',
+    description: 'Generate a greeting',
+    arguments: [{ name: 'who', description: 'Who to greet', required: true }],
+  },
+  {
+    name: 'summarize',
+    description: 'Summarize a passage',
+    arguments: [{ name: 'text', description: 'Text to summarize', required: true }],
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export type FixtureServer = {
+  server: Server;
+  /** Emit `notifications/resources/updated` for a URI. */
+  triggerResourceUpdate(uri: string): Promise<void>;
+  /** Emit `notifications/resources/list_changed`. */
+  triggerResourcesListChanged(): Promise<void>;
+  /** Emit `notifications/prompts/list_changed`. */
+  triggerPromptsListChanged(): Promise<void>;
+};
+
+export function createResourcesPromptsFixture(): FixtureServer {
+  const server = new Server(
+    { name: 'revealui-mcp-test-fixture', version: '0.0.1' },
+    {
+      capabilities: {
+        resources: { subscribe: true, listChanged: true },
+        prompts: { listChanged: true },
+      },
+    },
+  );
+
+  // -----------------------------------------------------------------
+  // Resource handlers
+  // -----------------------------------------------------------------
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: RESOURCES.map((r) => ({ ...r })),
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const text = RESOURCE_CONTENTS[uri];
+    if (text === undefined) {
+      throw new Error(`Resource not found: ${uri}`);
+    }
+    return { contents: [{ uri, mimeType: 'text/plain', text }] };
+  });
+
+  // Subscribe / unsubscribe are acknowledged but track nothing — tests trigger
+  // updates explicitly via `triggerResourceUpdate()`.
+  server.setRequestHandler(SubscribeRequestSchema, async () => ({}));
+  server.setRequestHandler(UnsubscribeRequestSchema, async () => ({}));
+
+  // -----------------------------------------------------------------
+  // Prompt handlers
+  // -----------------------------------------------------------------
+
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: PROMPTS.map((p) => ({
+      ...p,
+      arguments: p.arguments.map((a) => ({ ...a })),
+    })),
+  }));
+
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    const name = request.params.name;
+    const args = request.params.arguments ?? {};
+
+    if (name === 'greet') {
+      const who = args.who ?? 'world';
+      return {
+        description: 'Generate a greeting',
+        messages: [{ role: 'user', content: { type: 'text', text: `Greet ${who}.` } }],
+      };
+    }
+    if (name === 'summarize') {
+      const text = args.text ?? '';
+      return {
+        description: 'Summarize a passage',
+        messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }],
+      };
+    }
+    throw new Error(`Prompt not found: ${name}`);
+  });
+
+  return {
+    server,
+    async triggerResourceUpdate(uri: string) {
+      await server.notification({
+        method: 'notifications/resources/updated',
+        params: { uri },
+      });
+    },
+    async triggerResourcesListChanged() {
+      await server.notification({ method: 'notifications/resources/list_changed' });
+    },
+    async triggerPromptsListChanged() {
+      await server.notification({ method: 'notifications/prompts/list_changed' });
+    },
+  };
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,343 @@
+/**
+ * MCP Client wrapper for `@revealui/mcp`.
+ *
+ * Phase: Stage 0 of the MCP v1 plan (see `.jv/docs/mcp-productionization-scope.md`).
+ *
+ * Wraps `@modelcontextprotocol/sdk`'s `Client` with a RevealUI-shaped surface:
+ * transport selection, capability enforcement (method throws a typed error if
+ * the server doesn't advertise the feature), and per-URI resource
+ * subscription fan-out with automatic protocol-level subscribe/unsubscribe.
+ *
+ * PR-0.1 (this PR) ships the resources + prompts surface. Subsequent Stage 0
+ * PRs layer on sampling, elicitation, roots, completions, logging, progress,
+ * cancellation, and generic notification handling using the same `McpClient`
+ * instance.
+ *
+ * The hypervisor (`./hypervisor.ts`) continues to speak its custom JSON-RPC
+ * for tool calls. Stage 1 migrates the hypervisor to route through this
+ * client so transport abstraction (Streamable HTTP) lands cleanly.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  type Prompt,
+  type PromptMessage,
+  type Resource,
+  type ResourceContents,
+  ResourceUpdatedNotificationSchema,
+  type ServerCapabilities,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ---------------------------------------------------------------------------
+// Transport options
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn a local subprocess and talk MCP over its stdio.
+ * Matches `StdioClientTransport` from the SDK; we surface the fields we use.
+ */
+export type StdioTransportOptions = {
+  kind: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+};
+
+/**
+ * Inject a pre-built SDK `Transport`. Intended for tests (`InMemoryTransport`)
+ * and for experimental transports not yet first-classed in this discriminator.
+ * Stage 1 adds `{ kind: 'streamable-http'; ... }`.
+ */
+export type CustomTransportOptions = {
+  kind: 'custom';
+  transport: Transport;
+};
+
+export type TransportOptions = StdioTransportOptions | CustomTransportOptions;
+
+// ---------------------------------------------------------------------------
+// Client options
+// ---------------------------------------------------------------------------
+
+export type McpClientOptions = {
+  /** Advertised to the server during `initialize`. Required by spec. */
+  clientInfo: { name: string; version: string };
+  /** Where and how to reach the server. */
+  transport: TransportOptions;
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a caller invokes a method that requires a server-side capability
+ * the server did NOT advertise during initialize. Signals a misconfiguration
+ * or a version mismatch — not a transient failure; do not retry.
+ */
+export class McpCapabilityError extends Error {
+  public readonly capability: string;
+  constructor(capability: string) {
+    super(`MCP server does not advertise the '${capability}' capability`);
+    this.name = 'McpCapabilityError';
+    this.capability = capability;
+  }
+}
+
+/**
+ * Thrown when a method is called before `connect()` has resolved.
+ */
+export class McpNotConnectedError extends Error {
+  constructor(method: string) {
+    super(`McpClient.${method}() called before connect()`);
+    this.name = 'McpNotConnectedError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public types re-exported for convenience
+// ---------------------------------------------------------------------------
+
+export type { Prompt, PromptMessage, Resource, ResourceContents, ServerCapabilities };
+
+/** Parameters delivered to a `subscribeResource` handler. */
+export type ResourceUpdatedParams = { uri: string };
+
+/** Return shape of `getPrompt` — the spec's `GetPromptResult`, narrowed. */
+export type GetPromptResult = {
+  description?: string;
+  messages: PromptMessage[];
+};
+
+// ---------------------------------------------------------------------------
+// McpClient
+// ---------------------------------------------------------------------------
+
+type ListChangedChannel = 'resources' | 'prompts' | 'tools';
+
+export class McpClient {
+  private readonly sdk: Client;
+  private readonly options: McpClientOptions;
+  private connected = false;
+  private readonly resourceSubscribers = new Map<
+    string,
+    Set<(params: ResourceUpdatedParams) => void>
+  >();
+  private readonly listChangedHandlers: Record<ListChangedChannel, Set<() => void>> = {
+    resources: new Set(),
+    prompts: new Set(),
+    tools: new Set(),
+  };
+
+  constructor(options: McpClientOptions) {
+    this.options = options;
+    this.sdk = new Client(options.clientInfo, {
+      capabilities: {},
+      listChanged: {
+        resources: { onChanged: () => this.fireListChanged('resources') },
+        prompts: { onChanged: () => this.fireListChanged('prompts') },
+        tools: { onChanged: () => this.fireListChanged('tools') },
+      },
+    });
+
+    // Fan notifications/resources/updated out to per-URI subscribers. The SDK
+    // calls this handler for every update; we dispatch to interested parties.
+    this.sdk.setNotificationHandler(ResourceUpdatedNotificationSchema, (notification) => {
+      const uri = notification.params.uri;
+      const subscribers = this.resourceSubscribers.get(uri);
+      if (!subscribers) return;
+      for (const handler of subscribers) {
+        try {
+          handler({ uri });
+        } catch {
+          // Swallow per-subscriber errors; one bad handler must not disrupt
+          // the others, and the SDK doesn't care either way.
+        }
+      }
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Connect the underlying transport and run MCP `initialize`. Idempotent:
+   * calling twice is a no-op on the second call.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    const transport = this.createTransport();
+    await this.sdk.connect(transport);
+    this.connected = true;
+  }
+
+  /**
+   * Close the underlying transport and invalidate the client. Idempotent.
+   */
+  async close(): Promise<void> {
+    if (!this.connected) return;
+    await this.sdk.close();
+    this.connected = false;
+    this.resourceSubscribers.clear();
+  }
+
+  /** Server capabilities returned by `initialize`. Undefined before connect. */
+  getServerCapabilities(): ServerCapabilities | undefined {
+    return this.sdk.getServerCapabilities();
+  }
+
+  // -------------------------------------------------------------------------
+  // Resources
+  // -------------------------------------------------------------------------
+
+  async listResources(): Promise<Resource[]> {
+    this.assertConnected('listResources');
+    this.requireCapability('resources');
+    const result = await this.sdk.listResources();
+    return result.resources;
+  }
+
+  async readResource(uri: string): Promise<ResourceContents[]> {
+    this.assertConnected('readResource');
+    this.requireCapability('resources');
+    const result = await this.sdk.readResource({ uri });
+    return result.contents;
+  }
+
+  /**
+   * Subscribe to updates for a single resource URI. The returned function
+   * removes this subscription (and unsubscribes on the wire once no
+   * subscribers remain for the URI).
+   *
+   * Requires the server to advertise `resources.subscribe`; throws
+   * `McpCapabilityError` otherwise.
+   */
+  async subscribeResource(
+    uri: string,
+    handler: (params: ResourceUpdatedParams) => void,
+  ): Promise<() => Promise<void>> {
+    this.assertConnected('subscribeResource');
+    const caps = this.getServerCapabilities();
+    if (!caps?.resources) throw new McpCapabilityError('resources');
+    if (!caps.resources.subscribe) throw new McpCapabilityError('resources.subscribe');
+
+    let subscribers = this.resourceSubscribers.get(uri);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.resourceSubscribers.set(uri, subscribers);
+      await this.sdk.subscribeResource({ uri });
+    }
+    subscribers.add(handler);
+
+    let disposed = false;
+    return async () => {
+      if (disposed) return;
+      disposed = true;
+      const current = this.resourceSubscribers.get(uri);
+      if (!current) return;
+      current.delete(handler);
+      if (current.size === 0) {
+        this.resourceSubscribers.delete(uri);
+        if (this.connected) {
+          await this.sdk.unsubscribeResource({ uri });
+        }
+      }
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompts
+  // -------------------------------------------------------------------------
+
+  async listPrompts(): Promise<Prompt[]> {
+    this.assertConnected('listPrompts');
+    this.requireCapability('prompts');
+    const result = await this.sdk.listPrompts();
+    return result.prompts;
+  }
+
+  async getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult> {
+    this.assertConnected('getPrompt');
+    this.requireCapability('prompts');
+    const params = args === undefined ? { name } : { name, arguments: args };
+    const result = await this.sdk.getPrompt(params);
+    return {
+      description: result.description,
+      messages: result.messages,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // List-changed subscriptions
+  // -------------------------------------------------------------------------
+
+  onResourcesListChanged(handler: () => void): () => void {
+    return this.addListChanged('resources', handler);
+  }
+
+  onPromptsListChanged(handler: () => void): () => void {
+    return this.addListChanged('prompts', handler);
+  }
+
+  onToolsListChanged(handler: () => void): () => void {
+    return this.addListChanged('tools', handler);
+  }
+
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+
+  async ping(): Promise<void> {
+    this.assertConnected('ping');
+    await this.sdk.ping();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private createTransport(): Transport {
+    const t = this.options.transport;
+    switch (t.kind) {
+      case 'stdio':
+        return new StdioClientTransport({
+          command: t.command,
+          args: t.args,
+          env: t.env,
+          cwd: t.cwd,
+        });
+      case 'custom':
+        return t.transport;
+    }
+  }
+
+  private assertConnected(method: string): void {
+    if (!this.connected) throw new McpNotConnectedError(method);
+  }
+
+  private requireCapability(capability: 'resources' | 'prompts' | 'tools' | 'logging'): void {
+    const caps = this.getServerCapabilities();
+    if (!caps?.[capability]) throw new McpCapabilityError(capability);
+  }
+
+  private addListChanged(channel: ListChangedChannel, handler: () => void): () => void {
+    this.listChangedHandlers[channel].add(handler);
+    return () => {
+      this.listChangedHandlers[channel].delete(handler);
+    };
+  }
+
+  private fireListChanged(channel: ListChangedChannel): void {
+    for (const handler of this.listChangedHandlers[channel]) {
+      try {
+        handler();
+      } catch {
+        // Swallow per-subscriber errors.
+      }
+    }
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -54,6 +54,23 @@ export {
   McpAuthClaimsSchema,
   validateMcpClaims,
 } from './auth.js';
+// MCP protocol client (Stage 0 — PR-0.1 ships resources + prompts)
+export {
+  type CustomTransportOptions,
+  type GetPromptResult,
+  McpCapabilityError,
+  McpClient,
+  type McpClientOptions,
+  McpNotConnectedError,
+  type Prompt,
+  type PromptMessage,
+  type Resource,
+  type ResourceContents,
+  type ResourceUpdatedParams,
+  type ServerCapabilities,
+  type StdioTransportOptions,
+  type TransportOptions,
+} from './client.js';
 // Configuration
 export {
   getMcpConfig,


### PR DESCRIPTION
## Summary

Stage 0 PR-0.1 of the MCP v1 plan. Introduces `McpClient` in `packages/mcp/src/client.ts` — a typed wrapper around `@modelcontextprotocol/sdk`'s `Client` class, scoped to the resources + prompts protocol primitives. First concrete step toward treating MCP as a first-class platform primitive in RevealUI instead of a narrow tool-call RPC.

## Why

The existing hypervisor (`packages/mcp/src/hypervisor.ts`) speaks its own custom JSON-RPC 2.0 and only calls `tools/list` / `tools/call` / `ping`. That serves the 13 first-party tool adapters, but the entire non-tool MCP surface (resources, prompts, sampling, elicitation, roots, logging, progress, cancellation, completions, notifications) has no client-side support in RevealUI today.

`McpClient` is a parallel surface for those primitives. Stage 1 (Streamable HTTP transport) migrates the hypervisor to route through this same client so transport abstraction lands cleanly. See the full v1 plan in internal docs (private repo).

## Ships in this PR

**New `McpClient` class** (`packages/mcp/src/client.ts`, exported from `@revealui/mcp`):

- `connect()` / `close()` — both idempotent. `getServerCapabilities()`. `ping()`.
- **Resources:** `listResources()`, `readResource(uri)`, `subscribeResource(uri, handler)` → returns unsubscribe function. Per-URI subscriber fan-out with automatic protocol-level `resources/subscribe` + `resources/unsubscribe` based on subscriber count.
- **Prompts:** `listPrompts()`, `getPrompt(name, args?)`.
- **List-changed:** `onResourcesListChanged`, `onPromptsListChanged`, `onToolsListChanged` — each returns an unregister function. Plumbed through the SDK's `listChanged` option (which auto-refetches and delivers the new list to our callback).
- **Transport discriminated union:** `{ kind: 'stdio', command, args?, env?, cwd? }` or `{ kind: 'custom', transport }` (the custom variant accepts any SDK `Transport`, used today for tests via `InMemoryTransport`). Stage 1 extends with `{ kind: 'streamable-http' }`.
- **Typed errors:** `McpCapabilityError` (thrown when the caller invokes a method whose server capability wasn't advertised) and `McpNotConnectedError` (method called before `connect()`).

**Test fixture** (`packages/mcp/__tests__/fixtures/resources-prompts-server.ts`): an in-process SDK `Server` exposing 2 resources + 2 prompts, plus helpers to trigger `resources/updated`, `resources/list_changed`, `prompts/list_changed` notifications. Reusable for PR-0.2 / PR-0.3 by layering additive handlers.

## Testing

19 integration cases against a real MCP `Server` via `InMemoryTransport.createLinkedPair()` — full SDK stack (validation, schemas, notification routing) without subprocess spawning:

- **Lifecycle:** capability negotiation, `connect()` idempotency, `close()` idempotency, `McpNotConnectedError` for pre-connect calls
- **Resources:** list, read known URI, read unknown URI (rejects), subscribe + receive update, unsubscribe stops updates, multi-subscriber fan-out on same URI, list-changed fan-out, unsubscribe after close
- **Prompts:** list, get with args, get without args (defaults), get unknown (rejects), list-changed fan-out
- **Capability enforcement:** listResources / listPrompts / subscribeResource all throw `McpCapabilityError` against minimal servers lacking the respective capability

## Not in this PR

Stage 0 follow-ups:

- **PR-0.2** — sampling, elicitation, roots, completions handlers
- **PR-0.3** — logging, progress, cancellation, generic notification pattern

Future stages: Streamable HTTP transport (Stage 1), OAuth 2.1 (Stage 2), admin UI surface (Stage 3), content pipeline resources (Stage 4), agent runtime consumption (Stage 5), observability aggregation (Stage 6).

## Test plan

- [x] `pnpm --filter @revealui/mcp typecheck` → clean
- [x] `pnpm --filter @revealui/mcp test` → 136 passed, 5 skipped (pre-existing `mcp_document_operations` integration gate)
- [x] `pnpm gate:quick` → PASS (14/14)
- [ ] All 10 required checks green on `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
