### PR TITLE
feat(mcp): logging, progress, cancellation, generic notifications (Stage 0 PR-0.3)

### DIFF
--- a/.changeset/mcp-0-3-logging-progress-cancellation-notifications.md
+++ b/.changeset/mcp-0-3-logging-progress-cancellation-notifications.md
@@ -1,0 +1,31 @@
+---
+'@revealui/mcp': minor
+---
+
+Close Stage 0 of the MCP v1 plan. Extends `McpClient` with the transport-level protocol primitives: logging, progress, cancellation, and generic notification routing. With this PR merged, `@revealui/mcp` speaks the full MCP client surface defined by the current spec.
+
+**New on McpClient:**
+
+- **`setLoggingLevel(level, options?)`** — set the server's minimum log level. Requires `logging` capability.
+- **`onLog(handler)`** — subscribe to server-emitted `notifications/message` log events. Returns unregister. Multiple subscribers fan out.
+- **`on(schema, handler)`** — generic notification subscription. First call per schema installs a single SDK handler; later calls join the fan-out. Returns unregister. Used internally by `onLog` and by the constructor's resource-updated wiring, so external `on(ResourceUpdatedNotificationSchema, …)` calls coexist with `subscribeResource` without overwriting each other.
+
+**New per-request options** (threaded through `listResources`, `readResource`, `listPrompts`, `getPrompt`, `complete`, `ping`, `subscribeResource`, `setLoggingLevel`):
+
+- `signal` — `AbortSignal` for cancellation. Aborting sends `notifications/cancelled` and rejects the pending promise.
+- `onProgress` — subscribe to per-request progress notifications. SDK auto-correlates by the generated progress token.
+- `timeout` — request-level timeout in ms.
+- `resetTimeoutOnProgress` — if true, incoming progress resets the timeout clock.
+
+No explicit `cancelRequest()` method — `AbortSignal` is the web-idiomatic cancellation primitive and the SDK handles it natively.
+
+**Testing:** 8 new integration cases in `packages/mcp/__tests__/client.transport-primitives.test.ts` via `InMemoryTransport`:
+
+- **Logging** — setLoggingLevel round-trip, onLog fan-out with multiple subscribers + unregister, `McpCapabilityError` without logging capability
+- **Progress** — server emits `notifications/progress` with the request's progress token; client's `onProgress` callback receives all events in order
+- **Cancellation** — mid-flight abort rejects the promise; pre-aborted signal rejects immediately
+- **Generic `on()`** — fan-out to multiple handlers, unregister, coexistence with `subscribeResource`'s resource-updated path
+
+MCP total: **155 passing / 5 skipped** (was 147 after PR-0.2).
+
+Stage 0 is now closed. Stage 1 (Streamable HTTP transport + dual-mode first-party servers) is the next unit of work. See `.jv/docs/mcp-productionization-scope.md`.

--- a/packages/mcp/__tests__/client.transport-primitives.test.ts
+++ b/packages/mcp/__tests__/client.transport-primitives.test.ts
@@ -1,0 +1,282 @@
+/**
+ * McpClient integration tests — transport-level primitives.
+ *
+ * PR-0.3 of Stage 0. Covers logging, progress, cancellation, and generic
+ * notification routing. Every case uses `InMemoryTransport.createLinkedPair()`
+ * for a real wire round-trip.
+ */
+
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListResourcesRequestSchema,
+  ResourceListChangedNotificationSchema,
+  SetLevelRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { McpClient, type McpClientOptions, type Progress } from '../src/client.js';
+
+// ---------------------------------------------------------------------------
+// Shared harness
+// ---------------------------------------------------------------------------
+
+const closers: Array<() => Promise<void>> = [];
+
+async function link(
+  server: Server,
+  options?: Omit<McpClientOptions, 'transport' | 'clientInfo'>,
+): Promise<{ server: Server; client: McpClient }> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new McpClient({
+    clientInfo: { name: 'transport-primitives-test', version: '0.0.1' },
+    transport: { kind: 'custom', transport: clientTransport },
+    ...options,
+  });
+  await client.connect();
+  closers.push(async () => {
+    await client.close().catch(() => undefined);
+    await server.close().catch(() => undefined);
+  });
+  return { server, client };
+}
+
+afterEach(async () => {
+  while (closers.length > 0) {
+    const close = closers.pop();
+    if (close) await close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+describe('McpClient logging', () => {
+  it('setLoggingLevel sends the level to the server', async () => {
+    const levelSeen = vi.fn();
+    const server = new Server(
+      { name: 'logging-server', version: '0.0.1' },
+      { capabilities: { logging: {} } },
+    );
+    server.setRequestHandler(SetLevelRequestSchema, async (request) => {
+      levelSeen(request.params.level);
+      return {};
+    });
+
+    const { client } = await link(server);
+    await client.setLoggingLevel('warning');
+
+    expect(levelSeen).toHaveBeenCalledWith('warning');
+  });
+
+  it('onLog fans server-emitted log notifications out to all subscribers', async () => {
+    const server = new Server(
+      { name: 'logging-emitter', version: '0.0.1' },
+      { capabilities: { logging: {} } },
+    );
+    const { client } = await link(server);
+
+    const a = vi.fn();
+    const b = vi.fn();
+    const unregA = client.onLog(a);
+    client.onLog(b);
+
+    await server.notification({
+      method: 'notifications/message',
+      params: { level: 'info', data: 'hello world' },
+    });
+
+    await vi.waitFor(() => {
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+    expect(a.mock.calls[0]?.[0]).toMatchObject({ level: 'info', data: 'hello world' });
+
+    unregA();
+    await server.notification({
+      method: 'notifications/message',
+      params: { level: 'error', data: 'only b now' },
+    });
+
+    await vi.waitFor(() => {
+      expect(b).toHaveBeenCalledTimes(2);
+    });
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+
+  it('setLoggingLevel throws McpCapabilityError without logging capability', async () => {
+    const server = new Server({ name: 'no-logging', version: '0.0.1' }, { capabilities: {} });
+    const { client } = await link(server);
+
+    await expect(client.setLoggingLevel('info')).rejects.toMatchObject({
+      name: 'McpCapabilityError',
+      capability: 'logging',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+describe('McpClient progress', () => {
+  it('delivers progress notifications to the onProgress callback', async () => {
+    const server = new Server(
+      { name: 'progress-server', version: '0.0.1' },
+      { capabilities: { resources: {} } },
+    );
+    server.setRequestHandler(ListResourcesRequestSchema, async (_request, extra) => {
+      const token = extra._meta?.progressToken;
+      if (token !== undefined) {
+        await extra.sendNotification({
+          method: 'notifications/progress',
+          params: { progressToken: token, progress: 50, total: 100 },
+        });
+        await extra.sendNotification({
+          method: 'notifications/progress',
+          params: { progressToken: token, progress: 100, total: 100 },
+        });
+      }
+      return { resources: [] };
+    });
+
+    const { client } = await link(server);
+    const progressEvents: Progress[] = [];
+
+    await client.listResources({
+      onProgress: (progress) => progressEvents.push(progress),
+    });
+
+    await vi.waitFor(() => {
+      expect(progressEvents).toHaveLength(2);
+    });
+    expect(progressEvents[0]).toMatchObject({ progress: 50, total: 100 });
+    expect(progressEvents[1]).toMatchObject({ progress: 100, total: 100 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation (AbortSignal)
+// ---------------------------------------------------------------------------
+
+describe('McpClient cancellation', () => {
+  it('aborts an in-flight request when the AbortSignal fires', async () => {
+    const server = new Server(
+      { name: 'slow-server', version: '0.0.1' },
+      { capabilities: { resources: {} } },
+    );
+
+    server.setRequestHandler(ListResourcesRequestSchema, async (_request, extra) => {
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          extra.signal.removeEventListener('abort', onAbort);
+          reject(new Error('server saw abort'));
+        };
+        if (extra.signal.aborted) {
+          onAbort();
+          return;
+        }
+        extra.signal.addEventListener('abort', onAbort);
+      });
+      return { resources: [] };
+    });
+
+    const { client } = await link(server);
+
+    const controller = new AbortController();
+    const inflight = client.listResources({ signal: controller.signal });
+
+    setTimeout(() => controller.abort('user cancel'), 10);
+
+    await expect(inflight).rejects.toThrow();
+  });
+
+  it('rejects immediately with a pre-aborted signal', async () => {
+    const server = new Server(
+      { name: 'would-work', version: '0.0.1' },
+      { capabilities: { resources: {} } },
+    );
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+
+    const { client } = await link(server);
+
+    const controller = new AbortController();
+    controller.abort('already dead');
+
+    await expect(client.listResources({ signal: controller.signal })).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generic on() subscription
+// ---------------------------------------------------------------------------
+
+describe('McpClient.on() generic notification subscription', () => {
+  it('routes server notifications to all registered handlers', async () => {
+    const server = new Server(
+      { name: 'notify-server', version: '0.0.1' },
+      { capabilities: { resources: { listChanged: true } } },
+    );
+    const { client } = await link(server);
+
+    const a = vi.fn();
+    const b = vi.fn();
+    const unregA = client.on(ResourceListChangedNotificationSchema, a);
+    client.on(ResourceListChangedNotificationSchema, b);
+
+    await server.notification({ method: 'notifications/resources/list_changed' });
+
+    await vi.waitFor(() => {
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    unregA();
+    await server.notification({ method: 'notifications/resources/list_changed' });
+
+    await vi.waitFor(() => {
+      expect(b).toHaveBeenCalledTimes(2);
+    });
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not interfere with subscribeResource resource-update fan-out', async () => {
+    const server = new Server(
+      { name: 'res-server', version: '0.0.1' },
+      { capabilities: { resources: { subscribe: true, listChanged: true } } },
+    );
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+    // Accept subscribe / unsubscribe no-ops; see ../fixtures/resources-prompts-server.ts.
+    const { SubscribeRequestSchema, UnsubscribeRequestSchema } = await import(
+      '@modelcontextprotocol/sdk/types.js'
+    );
+    server.setRequestHandler(SubscribeRequestSchema, async () => ({}));
+    server.setRequestHandler(UnsubscribeRequestSchema, async () => ({}));
+
+    const { client } = await link(server);
+
+    const subscribed = vi.fn();
+    const unsub = await client.subscribeResource('mem://doc/x', subscribed);
+
+    // Separately subscribe via the generic API to the same schema. Both
+    // should fire on a resource-updated notification.
+    const { ResourceUpdatedNotificationSchema } = await import(
+      '@modelcontextprotocol/sdk/types.js'
+    );
+    const generic = vi.fn();
+    client.on(ResourceUpdatedNotificationSchema, generic);
+
+    await server.notification({
+      method: 'notifications/resources/updated',
+      params: { uri: 'mem://doc/x' },
+    });
+
+    await vi.waitFor(() => {
+      expect(subscribed).toHaveBeenCalledTimes(1);
+      expect(generic).toHaveBeenCalledTimes(1);
+    });
+
+    await unsub();
+  });
+});

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -9,9 +9,12 @@
  * fan-out, and application-layer handlers for the server-initiated primitives
  * (sampling, elicitation, roots).
  *
- * PR-0.1 shipped resources + prompts. PR-0.2 (this commit) adds sampling,
- * elicitation, roots, and completions. PR-0.3 closes Stage 0 with logging,
- * progress, cancellation, and generic notification routing.
+ * Stage 0 completion as of PR-0.3:
+ *   PR-0.1 — resources + prompts.
+ *   PR-0.2 — sampling + elicitation + roots + completions.
+ *   PR-0.3 — logging, progress, cancellation, generic notification routing,
+ *            per-request options (signal + onProgress + timeout) threaded
+ *            through every client-initiated call.
  *
  * The hypervisor (`./hypervisor.ts`) continues to speak its custom JSON-RPC
  * for tool calls. Stage 1 migrates the hypervisor to route through this
@@ -20,6 +23,8 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { AnyObjectSchema, SchemaOutput } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import {
   type ClientCapabilities,
@@ -32,6 +37,10 @@ import {
   ElicitRequestSchema,
   type ElicitResult,
   ListRootsRequestSchema,
+  type LoggingLevel,
+  type LoggingMessageNotification,
+  LoggingMessageNotificationSchema,
+  type Progress,
   type Prompt,
   type PromptMessage,
   type PromptReference,
@@ -93,10 +102,6 @@ export type SamplingHandler = (
  * asking the client to elicit structured input from the user (form mode) or
  * direct them to a URL (URL mode). The handler is responsible for rendering
  * UI and returning the user's response.
- *
- * Providing this handler advertises the `elicitation` capability (form mode;
- * URL mode is advertised too — callers can return `action: 'decline'` for
- * modes they don't implement).
  */
 export type ElicitationHandler = (params: ElicitRequest['params']) => Promise<ElicitResult>;
 
@@ -109,6 +114,46 @@ export type ElicitationHandler = (params: ElicitRequest['params']) => Promise<El
  * — the client can notify via `notifyRootsListChanged()`).
  */
 export type RootsProvider = () => Root[] | Promise<Root[]>;
+
+// ---------------------------------------------------------------------------
+// Per-request options
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-request options applied to every client-initiated call. Mirrors the
+ * SDK's `RequestOptions` but exposes only the fields we expect consumers to
+ * use (we may add more as Stage 0 / 1 evolve).
+ *
+ * - `signal` — pass an `AbortSignal` to cancel the request mid-flight. When
+ *   aborted the SDK emits `notifications/cancelled` to the server and the
+ *   pending promise rejects with an AbortError.
+ * - `onProgress` — subscribe to per-request progress notifications. The SDK
+ *   automatically correlates `notifications/progress` by the progress token
+ *   and invokes this callback.
+ * - `timeout` — request-level timeout in ms. If exceeded the SDK raises a
+ *   `RequestTimeout` error. Absent = SDK default.
+ * - `resetTimeoutOnProgress` — if true, receiving a progress notification
+ *   resets the timeout clock. Useful for long-running operations.
+ */
+export type McpRequestOptions = {
+  signal?: AbortSignal;
+  onProgress?: (progress: Progress) => void;
+  timeout?: number;
+  resetTimeoutOnProgress?: boolean;
+};
+
+/** Internal: translate our options to the SDK's native shape. */
+function toSdkRequestOptions(options?: McpRequestOptions): RequestOptions | undefined {
+  if (!options) return undefined;
+  const sdkOptions: RequestOptions = {};
+  if (options.signal) sdkOptions.signal = options.signal;
+  if (options.onProgress) sdkOptions.onprogress = options.onProgress;
+  if (options.timeout !== undefined) sdkOptions.timeout = options.timeout;
+  if (options.resetTimeoutOnProgress !== undefined) {
+    sdkOptions.resetTimeoutOnProgress = options.resetTimeoutOnProgress;
+  }
+  return sdkOptions;
+}
 
 // ---------------------------------------------------------------------------
 // Client options
@@ -167,6 +212,9 @@ export type {
   CreateMessageResult,
   ElicitRequest,
   ElicitResult,
+  LoggingLevel,
+  LoggingMessageNotification,
+  Progress,
   Prompt,
   PromptMessage,
   PromptReference,
@@ -193,6 +241,9 @@ export type CompletionReference = PromptReference | ResourceTemplateReference;
 /** The completion result returned by `complete()`. */
 export type Completion = CompleteResult['completion'];
 
+/** Parameters delivered to an `onLog` subscriber. */
+export type LogMessageParams = LoggingMessageNotification['params'];
+
 // ---------------------------------------------------------------------------
 // Capability auto-advertisement
 // ---------------------------------------------------------------------------
@@ -204,7 +255,7 @@ export type Completion = CompleteResult['completion'];
  * Form-mode elicitation is advertised as the default when an elicitation
  * handler is provided (matches the SDK's interpretation of `elicitation: {}`).
  * URL-mode callers who want that surface explicitly can add it — future
- * enhancement; PR-0.2 treats the handler as a single entry point.
+ * enhancement; today the handler is a single entry point.
  */
 function buildCapabilities(options: McpClientOptions): ClientCapabilities {
   const caps: ClientCapabilities = {};
@@ -220,6 +271,9 @@ function buildCapabilities(options: McpClientOptions): ClientCapabilities {
 
 type ListChangedChannel = 'resources' | 'prompts' | 'tools';
 
+// biome-ignore lint/suspicious/noExplicitAny: handler payload type is recovered from the schema
+type NotificationHandler = (notification: any) => void;
+
 export class McpClient {
   private readonly sdk: Client;
   private readonly options: McpClientOptions;
@@ -233,6 +287,14 @@ export class McpClient {
     prompts: new Set(),
     tools: new Set(),
   };
+  /**
+   * Subscribers per notification schema. First `on(schema, handler)` call for
+   * a schema registers a single fan-out handler with the SDK; subsequent
+   * calls just add to the Set. Removing the last subscriber keeps the SDK
+   * handler registered (no public API to unregister by schema) — empty
+   * fan-out is a cheap no-op.
+   */
+  private readonly notificationSubscribers = new Map<AnyObjectSchema, Set<NotificationHandler>>();
 
   constructor(options: McpClientOptions) {
     this.options = options;
@@ -245,9 +307,10 @@ export class McpClient {
       },
     });
 
-    // Fan notifications/resources/updated out to per-URI subscribers. The SDK
-    // calls this handler for every update; we dispatch to interested parties.
-    this.sdk.setNotificationHandler(ResourceUpdatedNotificationSchema, (notification) => {
+    // Route resource-updated notifications through the generic fan-out so the
+    // same `on(ResourceUpdatedNotificationSchema, ...)` subscription API
+    // remains available without overwriting our per-URI subscriber dispatch.
+    this.on(ResourceUpdatedNotificationSchema, (notification) => {
       const uri = notification.params.uri;
       const subscribers = this.resourceSubscribers.get(uri);
       if (!subscribers) return;
@@ -255,8 +318,7 @@ export class McpClient {
         try {
           handler({ uri });
         } catch {
-          // Swallow per-subscriber errors; one bad handler must not disrupt
-          // the others, and the SDK doesn't care either way.
+          // Swallow per-subscriber errors.
         }
       }
     });
@@ -314,17 +376,17 @@ export class McpClient {
   // Resources
   // -------------------------------------------------------------------------
 
-  async listResources(): Promise<Resource[]> {
+  async listResources(options?: McpRequestOptions): Promise<Resource[]> {
     this.assertConnected('listResources');
     this.requireCapability('resources');
-    const result = await this.sdk.listResources();
+    const result = await this.sdk.listResources(undefined, toSdkRequestOptions(options));
     return result.resources;
   }
 
-  async readResource(uri: string): Promise<ResourceContents[]> {
+  async readResource(uri: string, options?: McpRequestOptions): Promise<ResourceContents[]> {
     this.assertConnected('readResource');
     this.requireCapability('resources');
-    const result = await this.sdk.readResource({ uri });
+    const result = await this.sdk.readResource({ uri }, toSdkRequestOptions(options));
     return result.contents;
   }
 
@@ -339,6 +401,7 @@ export class McpClient {
   async subscribeResource(
     uri: string,
     handler: (params: ResourceUpdatedParams) => void,
+    options?: McpRequestOptions,
   ): Promise<() => Promise<void>> {
     this.assertConnected('subscribeResource');
     const caps = this.getServerCapabilities();
@@ -349,7 +412,7 @@ export class McpClient {
     if (!subscribers) {
       subscribers = new Set();
       this.resourceSubscribers.set(uri, subscribers);
-      await this.sdk.subscribeResource({ uri });
+      await this.sdk.subscribeResource({ uri }, toSdkRequestOptions(options));
     }
     subscribers.add(handler);
 
@@ -373,18 +436,22 @@ export class McpClient {
   // Prompts
   // -------------------------------------------------------------------------
 
-  async listPrompts(): Promise<Prompt[]> {
+  async listPrompts(options?: McpRequestOptions): Promise<Prompt[]> {
     this.assertConnected('listPrompts');
     this.requireCapability('prompts');
-    const result = await this.sdk.listPrompts();
+    const result = await this.sdk.listPrompts(undefined, toSdkRequestOptions(options));
     return result.prompts;
   }
 
-  async getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult> {
+  async getPrompt(
+    name: string,
+    args?: Record<string, string>,
+    options?: McpRequestOptions,
+  ): Promise<GetPromptResult> {
     this.assertConnected('getPrompt');
     this.requireCapability('prompts');
     const params = args === undefined ? { name } : { name, arguments: args };
-    const result = await this.sdk.getPrompt(params);
+    const result = await this.sdk.getPrompt(params, toSdkRequestOptions(options));
     return {
       description: result.description,
       messages: result.messages,
@@ -440,21 +507,87 @@ export class McpClient {
   async complete(
     reference: CompletionReference,
     argument: { name: string; value: string },
+    options?: McpRequestOptions,
   ): Promise<Completion> {
     this.assertConnected('complete');
     this.requireCapability('completions');
     const params: CompleteRequest['params'] = { ref: reference, argument };
-    const result = await this.sdk.complete(params);
+    const result = await this.sdk.complete(params, toSdkRequestOptions(options));
     return result.completion;
+  }
+
+  // -------------------------------------------------------------------------
+  // Logging (PR-0.3)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Set the minimum log level the server should emit. Requires the server to
+   * advertise the `logging` capability.
+   */
+  async setLoggingLevel(level: LoggingLevel, options?: McpRequestOptions): Promise<void> {
+    this.assertConnected('setLoggingLevel');
+    this.requireCapability('logging');
+    await this.sdk.setLoggingLevel(level, toSdkRequestOptions(options));
+  }
+
+  /**
+   * Subscribe to server-emitted log messages. Returns an unregister function.
+   *
+   * Implemented on top of the generic `on()` fan-out, so multiple subscribers
+   * coexist cleanly (admin UI, CLI logger, telemetry exporter, …).
+   */
+  onLog(handler: (params: LogMessageParams) => void): () => void {
+    return this.on(LoggingMessageNotificationSchema, (notification) => {
+      handler(notification.params);
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Generic notification subscription (PR-0.3)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Subscribe to arbitrary server notifications by zod schema. First
+   * subscription per schema installs a single SDK handler that fans out to
+   * every registered subscriber; later subscriptions join the existing fan.
+   * Returns an unregister function.
+   *
+   * Typically callers use the purpose-built subscribers (`onLog`,
+   * `onResourcesListChanged`, `subscribeResource`) rather than this. Use
+   * `on()` for schemas the client doesn't yet expose a named subscriber for.
+   */
+  on<T extends AnyObjectSchema>(
+    schema: T,
+    handler: (notification: SchemaOutput<T>) => void,
+  ): () => void {
+    let subscribers = this.notificationSubscribers.get(schema);
+    if (!subscribers) {
+      subscribers = new Set<NotificationHandler>();
+      this.notificationSubscribers.set(schema, subscribers);
+      const fanOut: NotificationHandler = (notification) => {
+        for (const h of subscribers ?? []) {
+          try {
+            h(notification);
+          } catch {
+            // Swallow per-subscriber errors.
+          }
+        }
+      };
+      this.sdk.setNotificationHandler(schema, fanOut);
+    }
+    subscribers.add(handler as NotificationHandler);
+    return () => {
+      subscribers?.delete(handler as NotificationHandler);
+    };
   }
 
   // -------------------------------------------------------------------------
   // Health
   // -------------------------------------------------------------------------
 
-  async ping(): Promise<void> {
+  async ping(options?: McpRequestOptions): Promise<void> {
     this.assertConnected('ping');
-    await this.sdk.ping();
+    await this.sdk.ping(toSdkRequestOptions(options));
   }
 
   // -------------------------------------------------------------------------

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -54,7 +54,7 @@ export {
   McpAuthClaimsSchema,
   validateMcpClaims,
 } from './auth.js';
-// MCP protocol client (Stage 0 — PR-0.1 resources + prompts, PR-0.2 sampling + elicitation + roots + completions)
+// MCP protocol client (Stage 0 complete — PR-0.1 resources + prompts, PR-0.2 sampling + elicitation + roots + completions, PR-0.3 logging + progress + cancellation + generic notifications)
 export {
   type ClientCapabilities,
   type CompleteRequest,
@@ -68,10 +68,15 @@ export {
   type ElicitRequest,
   type ElicitResult,
   type GetPromptResult,
+  type LoggingLevel,
+  type LoggingMessageNotification,
+  type LogMessageParams,
   McpCapabilityError,
   McpClient,
   type McpClientOptions,
   McpNotConnectedError,
+  type McpRequestOptions,
+  type Progress,
   type Prompt,
   type PromptMessage,
   type PromptReference,


### PR DESCRIPTION
## Summary

**Stage 0 closed.** PR-0.3 completes the final slice of Stage 0 — logging, progress, cancellation, and generic notification routing — and wires per-request options (`signal`, `onProgress`, `timeout`, `resetTimeoutOnProgress`) through every client-initiated call. With this PR merged, `@revealui/mcp`'s `McpClient` speaks the full MCP client surface defined by the current spec.

Stage 0 recap:

- [#487](https://github.com/RevealUIStudio/revealui/pull/487) PR-0.1 — resources + prompts (McpClient scaffolding)
- [#488](https://github.com/RevealUIStudio/revealui/pull/488) PR-0.2 — sampling + elicitation + roots + completions
- **PR-0.3 (this PR)** — logging + progress + cancellation + generic notifications

## Changes

### Logging

```ts
await client.setLoggingLevel('warning');
const unregister = client.onLog((msg) => console.log(msg.level, msg.data));
```

### Generic notification subscription

```ts
client.on(CustomNotificationSchema, (notification) => { ... });
```

First subscriber per schema installs a single SDK handler + fan-out; later subscribers join. Returns unregister. Used internally by `onLog` and by the constructor's resource-updated wiring, so external `on(ResourceUpdatedNotificationSchema, …)` calls coexist with `subscribeResource` without overwriting each other.

### Per-request options

Every request method (`listResources`, `readResource`, `listPrompts`, `getPrompt`, `complete`, `ping`, `subscribeResource`, `setLoggingLevel`) now accepts an optional final `McpRequestOptions`:

```ts
const controller = new AbortController();
const result = await client.listResources({
  signal: controller.signal,         // cancel → SDK sends notifications/cancelled
  onProgress: (p) => showProgress(p), // per-request progress callback
  timeout: 30_000,
  resetTimeoutOnProgress: true,       // keep alive as long as progress flows
});
```

No explicit `cancelRequest()` — `AbortSignal` is the web-idiomatic cancellation primitive and the SDK handles wire-level semantics natively.

## Testing

8 new integration cases in `packages/mcp/__tests__/client.transport-primitives.test.ts` via `InMemoryTransport.createLinkedPair()`:

- **Logging** — `setLoggingLevel` round-trip, `onLog` fan-out with multiple subscribers + unregister, `McpCapabilityError` without capability
- **Progress** — server emits `notifications/progress` with the request's auto-generated progress token; client `onProgress` receives all events in order
- **Cancellation** — mid-flight abort rejects the promise; pre-aborted signal rejects immediately
- **Generic `on()`** — fan-out to multiple handlers, unregister leaves others intact, coexistence with `subscribeResource` resource-updated path

MCP total: **155 passing / 5 skipped** (was 147 after PR-0.2).

## Not in this PR

Stage 1 starts: Streamable HTTP transport + dual-mode first-party servers. The transport discriminated union will extend to `{ kind: 'streamable-http', url, ... }`; the 13 first-party servers under `packages/mcp/src/servers/` will ship both stdio and HTTP build targets. See internal docs §6.

## Test plan

- [x] `pnpm --filter @revealui/mcp typecheck` → clean
- [x] `pnpm --filter @revealui/mcp test` → 155 passed, 5 skipped
- [x] `pnpm gate:quick` → PASS (14/14)
- [ ] All 10 required checks green on `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
