### PR TITLE
feat(mcp): Streamable HTTP transport (Stage 1 PR-1.1)

### DIFF
--- a/.changeset/mcp-1-1-streamable-http-transport.md
+++ b/.changeset/mcp-1-1-streamable-http-transport.md
@@ -1,0 +1,70 @@
+---
+'@revealui/mcp': minor
+---
+
+Add Streamable HTTP transport support — Stage 1 PR-1.1 of the MCP v1 plan. Opens the door to remote MCP servers (admin-as-client, agent-runtime-as-client, and in v1.1 the RevMarket third-party marketplace).
+
+### Client-side
+
+`McpClient`'s transport discriminated union extends with:
+
+```ts
+new McpClient({
+  clientInfo: { name, version },
+  transport: {
+    kind: 'streamable-http',
+    url: 'https://example.com/mcp',
+    requestInit,        // optional Fetch RequestInit (headers, credentials, …)
+    fetch,              // optional custom fetch
+    sessionId,          // optional resumption token
+    reconnectionOptions,// SSE reconnection tuning
+  },
+});
+```
+
+Wires through to the SDK's `StreamableHTTPClientTransport`. No OAuth wiring yet — Stage 2 adds `authProvider`. Callers who need bearer-token auth before then can pass `Authorization` via `requestInit.headers`.
+
+### Server-side
+
+New subpath export `@revealui/mcp/streamable-http` exposes `createNodeStreamableHttpHandler(options)`. Returns a Node `(req, res) => Promise<void>` handler that:
+
+- Allocates a fresh `Server` + `StreamableHTTPServerTransport` pair per new session (via the caller-provided `createServer()` factory)
+- Routes subsequent requests by `Mcp-Session-Id` header to the matching session's transport
+- Cleans up on session termination
+- Optional `onSessionInitialized` / `onSessionClosed` callbacks
+- Dispatch-level options: `sessionIdGenerator`, `allowedHosts`, `allowedOrigins`, `enableJsonResponse`
+
+The SDK's `StreamableHTTPServerTransport` is a one-session-per-instance primitive (see `this.sessionId` in its implementation). The external `Map<sessionId, { server, transport }>` this helper maintains is what makes multi-client deployments work.
+
+```ts
+import { createServer as createHttpServer } from 'node:http';
+import { createNodeStreamableHttpHandler } from '@revealui/mcp/streamable-http';
+
+const handler = createNodeStreamableHttpHandler({
+  createServer: () => makeRevealUiContentServer(),
+  onSessionInitialized: (id) => logger.info({ sessionId: id }, 'MCP session opened'),
+});
+
+createHttpServer(handler).listen(3000);
+```
+
+### Testing
+
+6 new integration cases in `packages/mcp/__tests__/streamable-http.integration.test.ts` against a real `http.createServer` on an ephemeral port:
+
+- Initialize → listResources → readResource round-trip via HTTP
+- Server capabilities propagated through initialize
+- Two concurrent clients get independent session state (fresh Server per session)
+- `onSessionInitialized` fires with a well-formed session UUID
+- Non-initialize POST without session → 400 "Session ID required"
+- POST with unknown session → 400 "Unknown session ID"
+
+MCP total: **161 passing / 5 skipped** (was 155 after Stage 0).
+
+### Not in this PR
+
+- **Web-Standard (Fetch API) handler** — for Next.js App Router / Cloudflare Workers / Deno / Bun. Same session-routing logic, different request primitive. Targeted for a follow-up in Stage 1.
+- **PR-1.2 — dual-mode first-party servers.** Today's 13 first-party MCP servers under `packages/mcp/src/servers/` ship stdio-only. PR-1.2 makes them build both stdio (dev / Claude Code) and HTTP (admin / agent-runtime) targets.
+- **OAuth 2.1** — Stage 2.
+
+See `.jv/docs/mcp-productionization-scope.md` for the full v1 plan.

--- a/packages/mcp/__tests__/streamable-http.integration.test.ts
+++ b/packages/mcp/__tests__/streamable-http.integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Streamable HTTP integration tests (Stage 1 PR-1.1).
+ *
+ * Exercises the full wire protocol: `McpClient` with the `streamable-http`
+ * transport hitting a real `http.createServer` instance running the
+ * `createNodeStreamableHttpHandler` helper. Sessions allocated + routed via
+ * the external Map, Initialize → resources round-trip, isolated session
+ * state verified across concurrent clients.
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type RunningServer = {
+  url: string;
+  close(): Promise<void>;
+};
+
+const teardowns: Array<() => Promise<void>> = [];
+
+async function startServer(
+  mkServer: () => McpServer,
+  options?: { enableJsonResponse?: boolean },
+): Promise<RunningServer> {
+  const handler = createNodeStreamableHttpHandler({
+    createServer: mkServer,
+    enableJsonResponse: options?.enableJsonResponse,
+  });
+  const httpServer: NodeHttpServer = createHttpServer((req, res) => {
+    void handler(req, res).catch((err) => {
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+      }
+      res.end(JSON.stringify({ error: String(err) }));
+    });
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}/`;
+  const close = () =>
+    new Promise<void>((resolve, reject) =>
+      httpServer.close((err) => (err ? reject(err) : resolve())),
+    );
+  teardowns.push(close);
+  return { url, close };
+}
+
+function makeResourceServer(
+  resources: Array<{ uri: string; name: string; text: string }>,
+): () => McpServer {
+  return () => {
+    const server = new McpServer(
+      { name: 'streamable-http-fixture', version: '0.0.1' },
+      { capabilities: { resources: {} } },
+    );
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: resources.map(({ uri, name }) => ({ uri, name, mimeType: 'text/plain' })),
+    }));
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const found = resources.find((r) => r.uri === request.params.uri);
+      if (!found) throw new Error(`Resource not found: ${request.params.uri}`);
+      return { contents: [{ uri: found.uri, mimeType: 'text/plain', text: found.text }] };
+    });
+    return server;
+  };
+}
+
+afterEach(async () => {
+  while (teardowns.length > 0) {
+    const teardown = teardowns.pop();
+    if (teardown) await teardown().catch(() => undefined);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Basic round-trip
+// ---------------------------------------------------------------------------
+
+describe('Streamable HTTP transport (basic round-trip)', () => {
+  it('initializes, lists, and reads resources through real HTTP', async () => {
+    const running = await startServer(
+      makeResourceServer([
+        { uri: 'mem://alpha', name: 'Alpha', text: 'Contents of alpha' },
+        { uri: 'mem://beta', name: 'Beta', text: 'Contents of beta' },
+      ]),
+      { enableJsonResponse: true },
+    );
+
+    const client = new McpClient({
+      clientInfo: { name: 'streamable-http-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: running.url },
+    });
+    await client.connect();
+
+    const resources = await client.listResources();
+    expect(resources.map((r) => r.uri).sort()).toEqual(['mem://alpha', 'mem://beta']);
+
+    const contents = await client.readResource('mem://alpha');
+    expect(contents).toHaveLength(1);
+    expect(contents[0]?.text).toBe('Contents of alpha');
+
+    await client.close();
+  });
+
+  it('advertises the server capabilities negotiated over HTTP', async () => {
+    const running = await startServer(
+      makeResourceServer([{ uri: 'mem://x', name: 'X', text: 'x' }]),
+      { enableJsonResponse: true },
+    );
+
+    const client = new McpClient({
+      clientInfo: { name: 'caps-http', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: running.url },
+    });
+    await client.connect();
+    expect(client.getServerCapabilities()?.resources).toBeDefined();
+    await client.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session isolation
+// ---------------------------------------------------------------------------
+
+describe('Streamable HTTP transport (session isolation)', () => {
+  it('allocates independent session state per concurrent client', async () => {
+    // Each new server instance sees its own resources-list — shared across
+    // clients only via the handler's session map, not across sessions.
+    const seenClients: string[] = [];
+    const createServer = () => {
+      const id = `session-${seenClients.length}`;
+      seenClients.push(id);
+      const server = new McpServer(
+        { name: 'per-session', version: '0.0.1' },
+        { capabilities: { resources: {} } },
+      );
+      server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+        resources: [{ uri: `mem://${id}`, name: id, mimeType: 'text/plain' }],
+      }));
+      server.setRequestHandler(ReadResourceRequestSchema, async () => ({
+        contents: [],
+      }));
+      return server;
+    };
+
+    const running = await startServer(createServer, { enableJsonResponse: true });
+
+    const clientA = new McpClient({
+      clientInfo: { name: 'A', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: running.url },
+    });
+    const clientB = new McpClient({
+      clientInfo: { name: 'B', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: running.url },
+    });
+
+    await Promise.all([clientA.connect(), clientB.connect()]);
+
+    const [aRes, bRes] = await Promise.all([clientA.listResources(), clientB.listResources()]);
+
+    // Each client got its own session, so the per-session `id` differs.
+    expect(aRes).toHaveLength(1);
+    expect(bRes).toHaveLength(1);
+    expect(aRes[0]?.uri).not.toBe(bRes[0]?.uri);
+    expect(seenClients).toHaveLength(2);
+
+    await Promise.all([clientA.close(), clientB.close()]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session lifecycle callbacks
+// ---------------------------------------------------------------------------
+
+describe('Streamable HTTP transport (session lifecycle)', () => {
+  it('fires onSessionInitialized when a new session is created', async () => {
+    const opened: string[] = [];
+
+    const handler = createNodeStreamableHttpHandler({
+      createServer: makeResourceServer([]),
+      enableJsonResponse: true,
+      onSessionInitialized: (id) => {
+        opened.push(id);
+      },
+    });
+
+    const httpServer = createHttpServer((req, res) => {
+      void handler(req, res).catch(() => res.end());
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const { port } = httpServer.address() as AddressInfo;
+    const url = `http://127.0.0.1:${port}/`;
+    teardowns.push(
+      () =>
+        new Promise<void>((resolve, reject) =>
+          httpServer.close((err) => (err ? reject(err) : resolve())),
+        ),
+    );
+
+    const client = new McpClient({
+      clientInfo: { name: 'lifecycle', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url },
+    });
+    await client.connect();
+    // Exercise the session once so the server fully initializes.
+    await client.listResources();
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toMatch(/[0-9a-f-]{36}/i);
+
+    await client.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe('Streamable HTTP transport (error paths)', () => {
+  it('rejects non-initialize POST without a session header', async () => {
+    const running = await startServer(makeResourceServer([]), { enableJsonResponse: true });
+
+    const res = await fetch(running.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/list',
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { message?: string } };
+    expect(json.error?.message).toBe('Session ID required');
+  });
+
+  it('rejects POST with an unknown session header', async () => {
+    const running = await startServer(makeResourceServer([]), { enableJsonResponse: true });
+
+    const res = await fetch(running.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        'mcp-session-id': 'not-a-real-session',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/list',
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { message?: string } };
+    expect(json.error?.message).toBe('Unknown session ID');
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -66,6 +66,10 @@
     "./auth": {
       "types": "./dist/auth.d.ts",
       "import": "./dist/auth.js"
+    },
+    "./streamable-http": {
+      "types": "./dist/streamable-http.d.ts",
+      "import": "./dist/streamable-http.js"
     }
   },
   "files": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -23,6 +23,11 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+  type StreamableHTTPReconnectionOptions,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { AnyObjectSchema, SchemaOutput } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
@@ -71,14 +76,43 @@ export type StdioTransportOptions = {
 /**
  * Inject a pre-built SDK `Transport`. Intended for tests (`InMemoryTransport`)
  * and for experimental transports not yet first-classed in this discriminator.
- * Stage 1 adds `{ kind: 'streamable-http'; ... }`.
  */
 export type CustomTransportOptions = {
   kind: 'custom';
   transport: Transport;
 };
 
-export type TransportOptions = StdioTransportOptions | CustomTransportOptions;
+/**
+ * Talk MCP over the spec's Streamable HTTP transport. The preferred remote
+ * transport as of the 2025 spec revision — supports request/response JSON,
+ * SSE streaming for progress/notifications, and OAuth 2.1 for authenticated
+ * deployments.
+ *
+ * OAuth wiring lands in Stage 2; this PR (Stage 1) exposes the transport
+ * without an `authProvider`. Callers who need auth before Stage 2 can pass
+ * their own bearer token via `requestInit.headers`.
+ */
+export type StreamableHttpTransportOptions = {
+  kind: 'streamable-http';
+  /** MCP endpoint URL (e.g. `https://example.com/mcp`). */
+  url: string | URL;
+  /** Fetch `RequestInit` applied to every outgoing request. Use this for
+   *  headers, credentials, custom signals, etc. */
+  requestInit?: RequestInit;
+  /** Override `fetch`. Defaults to global `fetch`. */
+  fetch?: typeof fetch;
+  /** Reuse a server-issued session ID (e.g. for reconnection). */
+  sessionId?: string;
+  /** SSE reconnection tuning (delays, retry ceiling). */
+  reconnectionOptions?: StreamableHTTPReconnectionOptions;
+};
+
+export type TransportOptions =
+  | StdioTransportOptions
+  | CustomTransportOptions
+  | StreamableHttpTransportOptions;
+
+export type { StreamableHTTPClientTransportOptions, StreamableHTTPReconnectionOptions };
 
 // ---------------------------------------------------------------------------
 // Application-layer handlers for server-initiated requests
@@ -606,6 +640,15 @@ export class McpClient {
         });
       case 'custom':
         return t.transport;
+      case 'streamable-http': {
+        const url = t.url instanceof URL ? t.url : new URL(t.url);
+        const sdkOptions: StreamableHTTPClientTransportOptions = {};
+        if (t.requestInit) sdkOptions.requestInit = t.requestInit;
+        if (t.fetch) sdkOptions.fetch = t.fetch;
+        if (t.sessionId) sdkOptions.sessionId = t.sessionId;
+        if (t.reconnectionOptions) sdkOptions.reconnectionOptions = t.reconnectionOptions;
+        return new StreamableHTTPClientTransport(url, sdkOptions);
+      }
     }
   }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -54,7 +54,7 @@ export {
   McpAuthClaimsSchema,
   validateMcpClaims,
 } from './auth.js';
-// MCP protocol client (Stage 0 complete — PR-0.1 resources + prompts, PR-0.2 sampling + elicitation + roots + completions, PR-0.3 logging + progress + cancellation + generic notifications)
+// MCP protocol client (Stage 0 complete; Stage 1 PR-1.1 adds Streamable HTTP transport)
 export {
   type ClientCapabilities,
   type CompleteRequest,
@@ -89,6 +89,9 @@ export {
   type SamplingHandler,
   type ServerCapabilities,
   type StdioTransportOptions,
+  type StreamableHTTPClientTransportOptions,
+  type StreamableHTTPReconnectionOptions,
+  type StreamableHttpTransportOptions,
   type TransportOptions,
 } from './client.js';
 // Configuration
@@ -168,6 +171,12 @@ export { launchPlaywrightMcp } from './servers/playwright.js';
 export { launchStripeMcp } from './servers/stripe.js';
 export { launchSupabaseMcp } from './servers/supabase.js';
 export { launchVercelMcp } from './servers/vercel.js';
+// Streamable HTTP server-side helper (Stage 1 PR-1.1)
+export {
+  createNodeStreamableHttpHandler,
+  type StreamableHttpHandler,
+  type StreamableHttpHandlerOptions,
+} from './streamable-http.js';
 // Telemetry (structured observability events)
 export {
   type McpEvent,

--- a/packages/mcp/src/streamable-http.ts
+++ b/packages/mcp/src/streamable-http.ts
@@ -1,0 +1,186 @@
+/**
+ * Streamable HTTP server helper for `@revealui/mcp` (Stage 1 PR-1.1).
+ *
+ * Wraps `@modelcontextprotocol/sdk`'s `StreamableHTTPServerTransport` with
+ * session routing: one `MCP Server` + transport pair per concurrent client,
+ * identified by the `Mcp-Session-Id` header. Initialize requests without a
+ * session header allocate a new server via `createServer()`; subsequent
+ * requests route to the matching session.
+ *
+ * Returns a Node `(req, res) => Promise<void>` handler suitable for use with
+ * `http.createServer`, Express, Fastify, or any framework that exposes the
+ * raw Node request/response pair. A Web-Standard (Request → Response)
+ * variant can layer on top later — the session-routing logic is independent
+ * of the concrete transport flavour.
+ *
+ * The SDK's `StreamableHTTPServerTransport` is a one-session-per-instance
+ * primitive (see the `this.sessionId` field in its implementation). That's
+ * why we maintain an external `Map<sessionId, { server, transport }>` and
+ * not rely on a single transport to multiplex.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  StreamableHTTPServerTransport,
+  type StreamableHTTPServerTransportOptions,
+} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ---------------------------------------------------------------------------
+// Public options + types
+// ---------------------------------------------------------------------------
+
+export type StreamableHttpHandlerOptions = {
+  /**
+   * Called once per new session — returns a fresh `Server` instance to
+   * connect to the session's transport. Keep this function pure; do not
+   * share Server instances across sessions.
+   */
+  createServer: () => Server | Promise<Server>;
+
+  /** Generate session IDs. Default: `crypto.randomUUID()`. */
+  sessionIdGenerator?: () => string;
+
+  /** Called when a new session is initialized. */
+  onSessionInitialized?: (sessionId: string) => void | Promise<void>;
+
+  /** Called when a session is terminated (DELETE or transport close). */
+  onSessionClosed?: (sessionId: string) => void | Promise<void>;
+
+  /**
+   * Allowed `Origin` headers for DNS rebinding protection. If set, requests
+   * with other origins are rejected. Mirrors the SDK's option.
+   */
+  allowedOrigins?: string[];
+
+  /**
+   * Allowed `Host` headers for DNS rebinding protection. If set, requests
+   * with other hosts are rejected.
+   */
+  allowedHosts?: string[];
+
+  /**
+   * If true, responses are raw JSON instead of SSE streams. Useful for
+   * deployments that can't hold open long-lived connections (many
+   * serverless request/response platforms). Default: false.
+   */
+  enableJsonResponse?: boolean;
+};
+
+export type StreamableHttpHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
+type SessionEntry = {
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+};
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Node HTTP request handler that routes MCP Streamable HTTP traffic
+ * to per-session `Server` + `Transport` pairs, allocating new sessions on
+ * InitializeRequest and reusing them on follow-up requests via the
+ * `Mcp-Session-Id` header.
+ *
+ * ```ts
+ * import { createServer as createHttpServer } from 'node:http';
+ * import { createNodeStreamableHttpHandler } from '@revealui/mcp/streamable-http';
+ *
+ * const mcpHandler = createNodeStreamableHttpHandler({
+ *   createServer: () => makeMyMcpServer(),
+ * });
+ *
+ * createHttpServer(mcpHandler).listen(3000);
+ * ```
+ */
+export function createNodeStreamableHttpHandler(
+  options: StreamableHttpHandlerOptions,
+): StreamableHttpHandler {
+  const sessions = new Map<string, SessionEntry>();
+  const generateSessionId = options.sessionIdGenerator ?? (() => randomUUID());
+
+  return async function mcpStreamableHttpHandler(req, res) {
+    const body = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    const rawSession = req.headers['mcp-session-id'];
+    const sessionId = typeof rawSession === 'string' ? rawSession : undefined;
+
+    // Existing session — delegate to its transport.
+    if (sessionId) {
+      const entry = sessions.get(sessionId);
+      if (entry) {
+        await entry.transport.handleRequest(req, res, body);
+        return;
+      }
+      // Known-bad session header — let the transport produce the 404.
+      // Fall through to fresh-session handling, which will reject
+      // non-init requests.
+    }
+
+    // No session header: only an Initialize request may start a new session.
+    if (!sessionId && req.method === 'POST' && isInitializeRequest(body)) {
+      await handleNewSession(body);
+      return;
+    }
+
+    sendJsonError(res, 400, sessionId ? 'Unknown session ID' : 'Session ID required');
+    return;
+
+    async function handleNewSession(parsedBody: unknown): Promise<void> {
+      const server = await options.createServer();
+
+      const transportOptions: StreamableHTTPServerTransportOptions = {
+        sessionIdGenerator: generateSessionId,
+        enableJsonResponse: options.enableJsonResponse,
+        allowedHosts: options.allowedHosts,
+        allowedOrigins: options.allowedOrigins,
+        onsessioninitialized: async (id: string) => {
+          sessions.set(id, { server, transport });
+          await options.onSessionInitialized?.(id);
+        },
+        onsessionclosed: async (id: string) => {
+          sessions.delete(id);
+          await options.onSessionClosed?.(id);
+        },
+      };
+      const transport = new StreamableHTTPServerTransport(transportOptions);
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  if (chunks.length === 0) return undefined;
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function sendJsonError(res: ServerResponse, status: number, message: string): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32000, message },
+      id: null,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Stage 1 PR-1.1 of the MCP v1 plan. Opens the MCP client to remote servers via the spec's Streamable HTTP transport — the preferred wire protocol as of the 2025 spec revision. Unlocks admin-as-client, agent-runtime-as-client (Stage 5), and downstream the RevMarket third-party marketplace (v1.1).

## Client-side

`McpClient`'s transport discriminated union extends with:

```ts
new McpClient({
  clientInfo: { name, version },
  transport: {
    kind: 'streamable-http',
    url: 'https://example.com/mcp',
    requestInit,         // optional Fetch RequestInit
    fetch,               // optional custom fetch
    sessionId,           // optional resumption token
    reconnectionOptions, // SSE reconnection tuning
  },
});
```

Wires through to the SDK's `StreamableHTTPClientTransport`. OAuth 2.1 wiring lands in Stage 2; callers needing bearer auth before then can pass `Authorization` via `requestInit.headers`.

## Server-side

New subpath export `@revealui/mcp/streamable-http` exposes `createNodeStreamableHttpHandler` — a Node `(req, res) => Promise<void>` handler that routes MCP traffic to per-session Server + Transport pairs via the `Mcp-Session-Id` header:

```ts
import { createServer as createHttpServer } from 'node:http';
import { createNodeStreamableHttpHandler } from '@revealui/mcp/streamable-http';

const handler = createNodeStreamableHttpHandler({
  createServer: () => makeRevealUiContentServer(),
  onSessionInitialized: (id) => logger.info({ sessionId: id }, 'MCP session opened'),
});

createHttpServer(handler).listen(3000);
```

**Why an external session map:** the SDK's `StreamableHTTPServerTransport` is a one-session-per-instance primitive (see its `this.sessionId` field). To handle multiple concurrent clients, the handler maintains `Map<sessionId, { server, transport }>` and routes by header.

Protocol rules:
- Non-initialize POST without session header → **400 "Session ID required"**
- POST with unknown session header → **400 "Unknown session ID"**
- InitializeRequest → allocates new session via `createServer()` factory; subsequent requests route to that session

Options: `sessionIdGenerator`, `onSessionInitialized`, `onSessionClosed`, `allowedHosts` / `allowedOrigins` (DNS rebinding protection), `enableJsonResponse` (for deployments that can't hold open SSE).

## Testing

6 new integration cases in `packages/mcp/__tests__/streamable-http.integration.test.ts` against a real `http.createServer` on an ephemeral port:

- Initialize → `listResources` → `readResource` round-trip via HTTP
- Server capabilities propagated through initialize
- Two concurrent clients get independent session state (fresh Server per session)
- `onSessionInitialized` fires with a well-formed UUID
- Non-initialize POST without session → 400
- POST with unknown session → 400

MCP total: **161 passing / 5 skipped** (was 155 after Stage 0).

## Not in this PR

- **Web-Standard (Fetch API) handler** for Next.js App Router / Cloudflare Workers / Deno / Bun. Same session-routing logic, different primitive — layers onto this cleanly. Targeted as a follow-up in Stage 1.
- **PR-1.2** — dual-mode first-party servers. The 13 first-party MCP servers under `packages/mcp/src/servers/` ship stdio-only today; PR-1.2 makes them emit both stdio (dev / Claude Code) and HTTP (admin / agent runtime) targets.
- **OAuth 2.1** — Stage 2.

See internal docs for the full v1 plan.

## Test plan

- [x] `pnpm --filter @revealui/mcp typecheck` → clean
- [x] `pnpm --filter @revealui/mcp test` → 161 passed, 5 skipped
- [x] `pnpm gate:quick` → PASS (15/15)
- [ ] All 10 required checks green on `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
