### PR TITLE
feat(mcp): dual-mode revealui-content template (Stage 1 PR-1.2)

### DIFF
--- a/.changeset/mcp-1-2-dual-mode-revealui-content.md
+++ b/.changeset/mcp-1-2-dual-mode-revealui-content.md
@@ -1,0 +1,44 @@
+---
+'@revealui/mcp': minor
+---
+
+Establish the Stage 1 PR-1.2 dual-mode template by refactoring `revealui-content` — the first of 13 first-party MCP servers — to be transport-agnostic. The remaining 12 servers port to the same shape in follow-up PRs.
+
+### Pattern
+
+Each first-party server splits into two files:
+
+| File | Role |
+|---|---|
+| `servers/factories/<name>.ts` (new) | Exports `create<Name>Server(): Server` + `setCredentials(creds)`. Pure factory, no transport coupling. |
+| `servers/<name>.ts` (refactored) | Thin stdio launcher. Imports the factory, connects to `StdioServerTransport`, runs as subprocess. Shebang preserved; hypervisor `spawn()` pipeline unchanged. |
+
+Consumers who need HTTP hosting (admin dashboard, agent runtime, the future Streamable HTTP binary launcher) import the factory directly and wrap it via `createNodeStreamableHttpHandler` from `@revealui/mcp/streamable-http` (PR-1.1).
+
+### This PR ships
+
+- **`packages/mcp/src/servers/factories/revealui-content.ts`** — new. Owns the 5 tools (`revealui_list_sites`, `revealui_list_content`, `revealui_get_content`, `revealui_list_users`, `revealui_site_stats`), credential override mechanism, and REST-proxy helpers. Lives under `servers/factories/` so the `claim-drift` validator's MCP server counter (which reads only the top-level `servers/` directory) doesn't mis-count shared infrastructure as a standalone server.
+- **`packages/mcp/src/servers/revealui-content.ts`** — refactored from 314 → 37 lines. Still the canonical stdio entry point. Re-exports `setCredentials` for hypervisor compatibility.
+- **`createRevealuiContentServer` + `setRevealuiContentCredentials`** exported from `@revealui/mcp` top-level. External consumers can instantiate + wire credentials without importing from an internal path.
+
+### Testing
+
+3 new integration cases in `packages/mcp/__tests__/revealui-content-factory.integration.test.ts` — factory + `createNodeStreamableHttpHandler` + real HTTP server + `McpClient` + mock upstream REST API:
+
+- Client initializes + discovers the `tools` capability over HTTP
+- Tool call proxies through: `McpClient → HTTP handler → factory-created Server → mock REST API`; result body + `_meta` propagated correctly; mock API sees the `Authorization: Bearer …` header
+- Missing credentials → tool returns structured error (`isError: true`) with the canonical "REVEALUI_API_URL and REVEALUI_API_KEY must be set" message
+
+MCP total: **164 passing / 5 skipped** (was 161 after PR-1.1).
+
+### Follow-ups
+
+The remaining 12 first-party servers port to this pattern in subsequent PRs — same shape per server:
+
+1. Move the Server instance + handlers into `<name>-factory.ts`, exposing `create<Name>Server()`
+2. Reduce `<name>.ts` to ~35 lines (stdio-only shell)
+3. Export factory from `@revealui/mcp`
+
+Servers pending port: `code-validator`, `neon`, `next-devtools`, `playwright`, `revealui-email`, `revealui-memory`, `revealui-stripe`, `stripe`, `supabase`, `vercel`, `vultr-test`, `_email-provider`.
+
+See `.jv/docs/mcp-productionization-scope.md` for the full v1 plan.

--- a/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
+++ b/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Dual-mode integration test for the `revealui-content` MCP server.
+ *
+ * Proves the Stage 1 PR-1.2 pattern end-to-end: the server factory
+ * (`createRevealuiContentServer`) drops into `createNodeStreamableHttpHandler`
+ * unchanged, an HTTP `McpClient` discovers the tool surface, and a tool call
+ * proxies through to a mocked REST API. Once this pattern is stable, the
+ * remaining 12 first-party servers under `packages/mcp/src/servers/` port to
+ * the same shape in follow-up PRs.
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import { createRevealuiContentServer } from '../src/servers/factories/revealui-content.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+// ---------------------------------------------------------------------------
+// Mock RevealUI REST API (the upstream the server's tools call)
+// ---------------------------------------------------------------------------
+
+type MockApiHandle = {
+  url: string;
+  requests: Array<{ method: string; path: string; headers: Record<string, string> }>;
+  close: () => Promise<void>;
+};
+
+async function startMockApi(responses: Record<string, unknown>): Promise<MockApiHandle> {
+  const requests: MockApiHandle['requests'] = [];
+  const server = createHttpServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const path = url.pathname;
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (typeof v === 'string') headers[k] = v;
+    }
+    requests.push({ method: req.method ?? 'GET', path, headers });
+
+    const body = responses[path];
+    if (body === undefined) {
+      res.statusCode = 404;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ error: 'Not Found', path }));
+      return;
+    }
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  return {
+    url,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Harness: MCP server in-process via HTTP transport
+// ---------------------------------------------------------------------------
+
+type McpHandle = { url: string; close: () => Promise<void> };
+
+async function startMcpHttp(): Promise<McpHandle> {
+  const handler = createNodeStreamableHttpHandler({
+    createServer: createRevealuiContentServer,
+    enableJsonResponse: true,
+  });
+  const httpServer: NodeHttpServer = createHttpServer((req, res) => {
+    void handler(req, res).catch(() => {
+      if (!res.headersSent) res.statusCode = 500;
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test state
+// ---------------------------------------------------------------------------
+
+const teardowns: Array<() => Promise<void>> = [];
+const originalApiUrl = process.env.REVEALUI_API_URL;
+const originalApiKey = process.env.REVEALUI_API_KEY;
+
+afterEach(async () => {
+  while (teardowns.length > 0) {
+    const t = teardowns.pop();
+    if (t) await t().catch(() => undefined);
+  }
+  // Restore env vars mutated by tests.
+  if (originalApiUrl !== undefined) process.env.REVEALUI_API_URL = originalApiUrl;
+  else delete process.env.REVEALUI_API_URL;
+  if (originalApiKey !== undefined) process.env.REVEALUI_API_KEY = originalApiKey;
+  else delete process.env.REVEALUI_API_KEY;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('revealui-content factory over Streamable HTTP', () => {
+  it('lists the 5 documented tools via the HTTP transport', async () => {
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'dual-mode-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    // Tool listing goes through the sdk Client directly — no McpClient
+    // high-level wrapper for tools yet (hypervisor owns that; Stage 1.x
+    // migrates the hypervisor to route through McpClient). Read the raw
+    // result via a request-level call is out of scope; instead verify
+    // through the server's resources capability handshake.
+    const caps = client.getServerCapabilities();
+    expect(caps?.tools).toBeDefined();
+  });
+
+  it('proxies a tool call through the MCP HTTP transport to a mocked RevealUI API', async () => {
+    const mockApi = await startMockApi({
+      '/api/sites': {
+        sites: [
+          { id: 'site_1', name: 'Demo Site', createdAt: '2026-04-22T00:00:00Z' },
+          { id: 'site_2', name: 'Another Site', createdAt: '2026-04-22T01:00:00Z' },
+        ],
+        total: 2,
+      },
+    });
+    teardowns.push(mockApi.close);
+
+    // Factory falls back to env vars when no setCredentials() override.
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'tool-call-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    // Tool invocation goes through the SDK's client.callTool (not yet
+    // surfaced on McpClient's own facade — that's Stage 1.x / Stage 5 work).
+    // We access it via the internal SDK reference for now.
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into private SDK field for coverage
+    const sdkClient = (client as any).sdk;
+    const result = await sdkClient.callTool({
+      name: 'revealui_list_sites',
+      arguments: { limit: 10, page: 1 },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(Array.isArray(result.content)).toBe(true);
+    const first = result.content[0];
+    expect(first.type).toBe('text');
+
+    const parsed = JSON.parse(first.text);
+    expect(parsed.data.sites).toHaveLength(2);
+    expect(parsed.data.sites[0].id).toBe('site_1');
+    expect(parsed._meta.server).toBe('revealui-content');
+    expect(parsed._meta.tool).toBe('revealui_list_sites');
+
+    // Mock API must have been called with the correct headers.
+    const apiReq = mockApi.requests.find((r) => r.path === '/api/sites');
+    expect(apiReq).toBeDefined();
+    expect(apiReq?.headers.authorization).toBe('Bearer test-api-key');
+    expect(apiReq?.headers['user-agent']).toBe('RevealUI-MCP/1.0');
+  });
+
+  it('returns a tool-level error when credentials are missing', async () => {
+    // Ensure no credentials in env for this scenario.
+    delete process.env.REVEALUI_API_URL;
+    delete process.env.REVEALUI_API_KEY;
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'no-creds-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    const sdkClient = (client as any).sdk;
+    const result = await sdkClient.callTool({
+      name: 'revealui_list_sites',
+      arguments: { limit: 5 },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text as string;
+    expect(text).toMatch(/REVEALUI_API_URL and REVEALUI_API_KEY/);
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -164,6 +164,11 @@ export {
   StripeAdapter,
   VercelAdapter,
 } from './servers/adapter.js';
+// First-party server factories (Stage 1 PR-1.2 — dual-mode template)
+export {
+  createRevealuiContentServer,
+  setCredentials as setRevealuiContentCredentials,
+} from './servers/factories/revealui-content.js';
 // Server launchers
 export { launchNeonMcp } from './servers/neon.js';
 export { launchNextDevtoolsMcp } from './servers/next-devtools.js';

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -1,0 +1,326 @@
+/**
+ * Factory for the `revealui-content` MCP server.
+ *
+ * Dual-mode template (Stage 1 PR-1.2 of the MCP v1 plan): this module owns
+ * the Server construction + request-handler wiring, decoupled from any
+ * transport. The stdio launcher at `./revealui-content.ts` and a future HTTP
+ * launcher both consume `createRevealuiContentServer()` to ensure a single
+ * source of truth for the tool surface.
+ *
+ * Tools exposed:
+ *   revealui_list_sites         — list all sites in the RevealUI instance
+ *   revealui_list_content       — list content entries for a site/collection
+ *   revealui_get_content        — fetch a single content entry by ID
+ *   revealui_list_users         — list users (admin only)
+ *   revealui_site_stats         — per-site user + content counts
+ *
+ * Credentials are supplied by the hypervisor (or HTTP launcher wrapper)
+ * via `setCredentials()`. Falls back to `REVEALUI_API_URL` +
+ * `REVEALUI_API_KEY` env vars when no override is set.
+ *
+ * This file is the template 12 remaining first-party servers will follow:
+ *   1. Extract a `create<Name>Server()` factory here
+ *   2. Make `<name>.ts` a thin stdio launcher that consumes the factory
+ *   3. Consumers (admin, agent runtime) import the factory directly for
+ *      HTTP hosting via `createNodeStreamableHttpHandler`.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ---------------------------------------------------------------------------
+// Credential overrides (set by hypervisor / HTTP launcher)
+// ---------------------------------------------------------------------------
+
+let _credentialOverrides: Record<string, string> = {};
+
+/**
+ * Set credential overrides for this server. Called by the hypervisor with
+ * resolved tenant credentials (or by an HTTP launcher before handing the
+ * server to the handler).
+ *
+ * Credentials set here are process-global (module-level state). Multi-tenant
+ * HTTP deployments that need per-session credentials should either:
+ *   (a) instantiate the server inside `createServer` per call, passing the
+ *       credentials into closure scope, OR
+ *   (b) use the hypervisor's tenant-scoped credential resolver.
+ */
+export function setCredentials(creds: Record<string, string>): void {
+  _credentialOverrides = creds;
+}
+
+// ---------------------------------------------------------------------------
+// API helpers (shared across tool handlers)
+// ---------------------------------------------------------------------------
+
+function apiHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'RevealUI-MCP/1.0',
+  };
+}
+
+async function apiGet(
+  baseUrl: string,
+  apiKey: string,
+  path: string,
+  params?: Record<string, string>,
+): Promise<unknown> {
+  const url = new URL(`${baseUrl}${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString(), { headers: apiHeaders(apiKey) });
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(
+      (body as { error?: string; message?: string }).error ??
+        (body as { message?: string }).message ??
+        `API ${res.status}`,
+    );
+  }
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const TOOLS: Tool[] = [
+  {
+    name: 'revealui_list_sites',
+    description: 'List all sites registered in the RevealUI instance.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Max results to return (default: 20)', default: 20 },
+        page: {
+          type: 'number',
+          description: 'Page number for pagination (default: 1)',
+          default: 1,
+        },
+      },
+    },
+  },
+  {
+    name: 'revealui_list_content',
+    description:
+      'List content entries for a site from a given collection (e.g. posts, pages, products).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: { type: 'string', description: 'Site ID to query content from' },
+        collection: {
+          type: 'string',
+          description: 'Collection slug (e.g. "posts", "pages", "products")',
+        },
+        limit: { type: 'number', description: 'Max results (default: 20)', default: 20 },
+        page: { type: 'number', description: 'Page number (default: 1)', default: 1 },
+        status: { type: 'string', description: 'Filter by status: published, draft, archived' },
+      },
+      required: ['collection'],
+    },
+  },
+  {
+    name: 'revealui_get_content',
+    description: 'Fetch a single content entry by its ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        collection: { type: 'string', description: 'Collection slug (e.g. "posts")' },
+        id: { type: 'string', description: 'Content entry ID' },
+      },
+      required: ['collection', 'id'],
+    },
+  },
+  {
+    name: 'revealui_list_users',
+    description:
+      'List users registered in RevealUI. Requires admin API key. ' +
+      'Returns email, role, and account status.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: { type: 'string', description: 'Filter users by site ID' },
+        limit: { type: 'number', description: 'Max results (default: 20)', default: 20 },
+        page: { type: 'number', description: 'Page number (default: 1)', default: 1 },
+      },
+    },
+  },
+  {
+    name: 'revealui_site_stats',
+    description:
+      'Get aggregate stats for a RevealUI site: user count, content count per collection, and license tier.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: {
+          type: 'string',
+          description: 'Site ID to fetch stats for (omit for global stats)',
+        },
+      },
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh `revealui-content` MCP Server instance. Safe to call
+ * multiple times — each call returns an independent Server with its own
+ * request handlers registered. Dual-mode launchers (stdio, Streamable HTTP)
+ * consume this factory; the factory itself is transport-agnostic.
+ */
+export function createRevealuiContentServer(): Server {
+  const server = new Server(
+    { name: 'revealui-content', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    const startTime = Date.now();
+    const toolName = request.params.name;
+
+    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
+      /\/$/,
+      '',
+    );
+    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+
+    if (!(apiUrl && apiKey)) {
+      return {
+        content: [
+          { type: 'text', text: 'Error: REVEALUI_API_URL and REVEALUI_API_KEY must be set' },
+        ],
+        isError: true,
+      };
+    }
+
+    try {
+      let data: unknown;
+
+      switch (toolName) {
+        case 'revealui_list_sites': {
+          const { limit = 20, page = 1 } = request.params.arguments as {
+            limit?: number;
+            page?: number;
+          };
+          data = await apiGet(apiUrl, apiKey, '/api/sites', {
+            limit: String(limit),
+            page: String(page),
+          });
+          break;
+        }
+
+        case 'revealui_list_content': {
+          const {
+            site_id,
+            collection,
+            limit = 20,
+            page = 1,
+            status,
+          } = request.params.arguments as {
+            site_id?: string;
+            collection: string;
+            limit?: number;
+            page?: number;
+            status?: string;
+          };
+          const params: Record<string, string> = {
+            limit: String(limit),
+            page: String(page),
+          };
+          if (site_id) params.siteId = site_id;
+          if (status) params.status = status;
+
+          data = await apiGet(apiUrl, apiKey, `/api/${collection}`, params);
+          break;
+        }
+
+        case 'revealui_get_content': {
+          const { collection, id } = request.params.arguments as {
+            collection: string;
+            id: string;
+          };
+          data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
+          break;
+        }
+
+        case 'revealui_list_users': {
+          const {
+            site_id,
+            limit = 20,
+            page = 1,
+          } = request.params.arguments as {
+            site_id?: string;
+            limit?: number;
+            page?: number;
+          };
+          const params: Record<string, string> = {
+            limit: String(limit),
+            page: String(page),
+          };
+          if (site_id) params.siteId = site_id;
+
+          data = await apiGet(apiUrl, apiKey, '/api/users', params);
+          break;
+        }
+
+        case 'revealui_site_stats': {
+          const { site_id } = request.params.arguments as { site_id?: string };
+          const params: Record<string, string> = {};
+          if (site_id) params.siteId = site_id;
+
+          data = await apiGet(apiUrl, apiKey, '/api/health', params);
+          break;
+        }
+
+        default:
+          return {
+            content: [{ type: 'text', text: `Error: Unknown tool: ${toolName}` }],
+            isError: true,
+          };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                data,
+                _meta: {
+                  durationMs: Date.now() - startTime,
+                  server: 'revealui-content',
+                  tool: toolName,
+                  timestamp: new Date().toISOString(),
+                },
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [
+          { type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/packages/mcp/src/servers/revealui-content.ts
+++ b/packages/mcp/src/servers/revealui-content.ts
@@ -1,308 +1,34 @@
 #!/usr/bin/env node
 
 /**
- * RevealUI Content MCP Server
+ * RevealUI Content MCP Server — stdio launcher.
  *
- * Model Context Protocol server that gives AI agents read/write access to
- * RevealUI admin content via the RevealUI REST API. Useful for agents that need
- * to query site data, list content, manage users, or inspect deployment state.
+ * Thin wrapper around `createRevealuiContentServer()` (see
+ * `./revealui-content-factory.ts` for the tool surface). This file exists
+ * purely to run the server as a stdio subprocess — the canonical deployment
+ * for local dev, Claude Code integration, and the hypervisor's
+ * `spawn()`-based tool-discovery pipeline.
  *
- * Environment:
- *   REVEALUI_API_URL      -  Base URL of the RevealUI API (e.g. https://api.mysite.com)
- *   REVEALUI_API_KEY      -  API key for authenticating with the RevealUI API
+ * For HTTP / serverless / in-process deployment, import the factory
+ * directly and wrap it via `createNodeStreamableHttpHandler` from
+ * `@revealui/mcp/streamable-http`.
  *
- * Tools:
- *   revealui_list_sites         -  List all sites in the RevealUI instance
- *   revealui_list_content       -  List content entries for a site and collection
- *   revealui_get_content        -  Fetch a single content entry by ID
- *   revealui_list_users         -  List users (admin only)
- *   revealui_site_stats         -  Get user + content counts for a site
+ * Re-exports `setCredentials` for hypervisor compatibility — existing
+ * tenant-scoped credential resolution continues to work unchanged.
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  type CallToolRequest,
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  type Tool,
-} from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '@revealui/core/observability/logger';
 import { checkMcpLicense } from '../index.js';
+import { createRevealuiContentServer } from './factories/revealui-content.js';
 
-// ---------------------------------------------------------------------------
-// Credential overrides (set by Hypervisor before tool invocations)
-// ---------------------------------------------------------------------------
+export { setCredentials } from './factories/revealui-content.js';
 
-let _credentialOverrides: Record<string, string> = {};
-
-/**
- * Set credential overrides for this server.
- * Called by the Hypervisor with resolved tenant credentials.
- */
-export function setCredentials(creds: Record<string, string>): void {
-  _credentialOverrides = creds;
-}
-
-// ---------------------------------------------------------------------------
-// API helpers
-// ---------------------------------------------------------------------------
-
-function apiHeaders(apiKey: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${apiKey}`,
-    'Content-Type': 'application/json',
-    'User-Agent': 'RevealUI-MCP/1.0',
-  };
-}
-
-async function apiGet(
-  baseUrl: string,
-  apiKey: string,
-  path: string,
-  params?: Record<string, string>,
-) {
-  const url = new URL(`${baseUrl}${path}`);
-  if (params) {
-    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
-  }
-  const res = await fetch(url.toString(), { headers: apiHeaders(apiKey) });
-  const body = await res.json();
-  if (!res.ok) {
-    throw new Error(
-      (body as { error?: string; message?: string }).error ??
-        (body as { message?: string }).message ??
-        `API ${res.status}`,
-    );
-  }
-  return body;
-}
-
-// ---------------------------------------------------------------------------
-// Server
-// ---------------------------------------------------------------------------
-
-const server = new Server(
-  { name: 'revealui-content', version: '1.0.0' },
-  { capabilities: { tools: {} } },
-);
-
-const TOOLS: Tool[] = [
-  {
-    name: 'revealui_list_sites',
-    description: 'List all sites registered in the RevealUI instance.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        limit: { type: 'number', description: 'Max results to return (default: 20)', default: 20 },
-        page: {
-          type: 'number',
-          description: 'Page number for pagination (default: 1)',
-          default: 1,
-        },
-      },
-    },
-  },
-  {
-    name: 'revealui_list_content',
-    description:
-      'List content entries for a site from a given collection (e.g. posts, pages, products).',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        site_id: { type: 'string', description: 'Site ID to query content from' },
-        collection: {
-          type: 'string',
-          description: 'Collection slug (e.g. "posts", "pages", "products")',
-        },
-        limit: { type: 'number', description: 'Max results (default: 20)', default: 20 },
-        page: { type: 'number', description: 'Page number (default: 1)', default: 1 },
-        status: { type: 'string', description: 'Filter by status: published, draft, archived' },
-      },
-      required: ['collection'],
-    },
-  },
-  {
-    name: 'revealui_get_content',
-    description: 'Fetch a single content entry by its ID.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        collection: { type: 'string', description: 'Collection slug (e.g. "posts")' },
-        id: { type: 'string', description: 'Content entry ID' },
-      },
-      required: ['collection', 'id'],
-    },
-  },
-  {
-    name: 'revealui_list_users',
-    description:
-      'List users registered in RevealUI. Requires admin API key. ' +
-      'Returns email, role, and account status.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        site_id: { type: 'string', description: 'Filter users by site ID' },
-        limit: { type: 'number', description: 'Max results (default: 20)', default: 20 },
-        page: { type: 'number', description: 'Page number (default: 1)', default: 1 },
-      },
-    },
-  },
-  {
-    name: 'revealui_site_stats',
-    description:
-      'Get aggregate stats for a RevealUI site: user count, content count per collection, and license tier.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        site_id: {
-          type: 'string',
-          description: 'Site ID to fetch stats for (omit for global stats)',
-        },
-      },
-    },
-  },
-];
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
-
-server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
-  const startTime = Date.now();
-  const toolName = request.params.name;
-
-  const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
-    /\/$/,
-    '',
-  );
-  const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
-
-  if (!(apiUrl && apiKey)) {
-    return {
-      content: [{ type: 'text', text: 'Error: REVEALUI_API_URL and REVEALUI_API_KEY must be set' }],
-      isError: true,
-    };
-  }
-
-  try {
-    let data: unknown;
-
-    switch (toolName) {
-      case 'revealui_list_sites': {
-        const { limit = 20, page = 1 } = request.params.arguments as {
-          limit?: number;
-          page?: number;
-        };
-        data = await apiGet(apiUrl, apiKey, '/api/sites', {
-          limit: String(limit),
-          page: String(page),
-        });
-        break;
-      }
-
-      case 'revealui_list_content': {
-        const {
-          site_id,
-          collection,
-          limit = 20,
-          page = 1,
-          status,
-        } = request.params.arguments as {
-          site_id?: string;
-          collection: string;
-          limit?: number;
-          page?: number;
-          status?: string;
-        };
-        const params: Record<string, string> = {
-          limit: String(limit),
-          page: String(page),
-        };
-        if (site_id) params.siteId = site_id;
-        if (status) params.status = status;
-
-        data = await apiGet(apiUrl, apiKey, `/api/${collection}`, params);
-        break;
-      }
-
-      case 'revealui_get_content': {
-        const { collection, id } = request.params.arguments as {
-          collection: string;
-          id: string;
-        };
-        data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
-        break;
-      }
-
-      case 'revealui_list_users': {
-        const {
-          site_id,
-          limit = 20,
-          page = 1,
-        } = request.params.arguments as {
-          site_id?: string;
-          limit?: number;
-          page?: number;
-        };
-        const params: Record<string, string> = {
-          limit: String(limit),
-          page: String(page),
-        };
-        if (site_id) params.siteId = site_id;
-
-        data = await apiGet(apiUrl, apiKey, '/api/users', params);
-        break;
-      }
-
-      case 'revealui_site_stats': {
-        const { site_id } = request.params.arguments as { site_id?: string };
-        const params: Record<string, string> = {};
-        if (site_id) params.siteId = site_id;
-
-        data = await apiGet(apiUrl, apiKey, '/api/health', params);
-        break;
-      }
-
-      default:
-        return {
-          content: [{ type: 'text', text: `Error: Unknown tool: ${toolName}` }],
-          isError: true,
-        };
-    }
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(
-            {
-              data,
-              _meta: {
-                durationMs: Date.now() - startTime,
-                server: 'revealui-content',
-                tool: toolName,
-                timestamp: new Date().toISOString(),
-              },
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
-  } catch (err) {
-    return {
-      content: [
-        { type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` },
-      ],
-      isError: true,
-    };
-  }
-});
-
-async function main() {
+async function main(): Promise<void> {
   if (!(await checkMcpLicense())) {
     process.exit(1);
   }
+  const server = createRevealuiContentServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }


### PR DESCRIPTION
## Summary

Stage 1 PR-1.2 of the MCP v1 plan. Refactors the first of 13 first-party MCP servers into **transport-agnostic** form — establishing the template the remaining 12 servers port to in subsequent PRs.

Builds on [#491](https://github.com/RevealUIStudio/revealui/pull/491) (Streamable HTTP transport): the factory pattern this PR introduces is what lets existing stdio-launched servers also be hosted over HTTP via `createNodeStreamableHttpHandler` without code duplication.

## Pattern

Each server splits into two files:

| Path | Role |
|---|---|
| **`servers/factories/<name>.ts`** (new dir) | Exports `create<Name>Server()` + `setCredentials()`. Pure factory, no transport coupling. Lives under `factories/` so the claim-drift validator's MCP-server counter (which only reads the top-level `servers/` directory) doesn't mis-count shared infrastructure as a standalone server. |
| **`servers/<name>.ts`** (refactored) | Thin stdio launcher. Imports the factory, connects to `StdioServerTransport`, runs as subprocess. Shebang preserved; hypervisor `spawn()` pipeline unchanged. |

Consumers needing HTTP hosting (admin, agent runtime) import the factory directly and wrap it via `createNodeStreamableHttpHandler` from `@revealui/mcp/streamable-http`.

## Changes

- **`packages/mcp/src/servers/factories/revealui-content.ts`** (new) — owns the 5 tools (`revealui_list_sites`, `revealui_list_content`, `revealui_get_content`, `revealui_list_users`, `revealui_site_stats`), credential override mechanism, and REST-proxy helpers.
- **`packages/mcp/src/servers/revealui-content.ts`** — refactored from 314 → 37 lines. Still the canonical stdio subprocess entry. Re-exports `setCredentials` for hypervisor compatibility.
- **Exports** from `@revealui/mcp`: `createRevealuiContentServer`, `setRevealuiContentCredentials`.

## Testing

3 new integration cases in `packages/mcp/__tests__/revealui-content-factory.integration.test.ts` — factory + `createNodeStreamableHttpHandler` + real HTTP server + `McpClient` + mock upstream REST API:

- Client initializes + discovers the `tools` capability over HTTP
- Tool call proxies through: `McpClient → HTTP handler → factory-created Server → mock REST API`; result body + `_meta` propagated correctly; mock API sees the `Authorization: Bearer …` header
- Missing credentials → tool returns `isError: true` with the canonical message

MCP total: **164 passing / 5 skipped** (was 161 after PR-1.1).

## Follow-ups

The remaining 12 first-party servers port to this pattern in subsequent PRs — same shape per server:

- `code-validator`, `neon`, `next-devtools`, `playwright`
- `revealui-email`, `revealui-memory`, `revealui-stripe`
- `stripe`, `supabase`, `vercel`, `vultr-test`, `_email-provider`

Each port is:
1. Move Server construction + handlers into `factories/<name>.ts`, exposing `create<Name>Server()`
2. Reduce `<name>.ts` to ~35 lines (stdio-only shell)
3. Export factory from `@revealui/mcp`

## Test plan

- [x] `pnpm --filter @revealui/mcp typecheck` → clean
- [x] `pnpm --filter @revealui/mcp test` → 164 passed, 5 skipped
- [x] `pnpm gate:quick` → PASS (15/15)
- [ ] All 10 required checks green on `test`

See internal docs for the full v1 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
