### PR TITLE
ci(integration): run integration tests on all PRs, not main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,14 +222,14 @@ jobs:
           SKIP_ENV_VALIDATION: "true"
 
   # ---------------------------------------------------------------------------
-  # Phase 3a.1: Integration tests (main only — requires DB)
+  # Phase 3a.1: Integration tests (all PRs + push to main — requires DB)
   # ---------------------------------------------------------------------------
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: quality
-    if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

Closes **CR8-P3-01** (MASTER_PLAN §CR-8 Phase 3).

Moves integration tests from `main`-only to run on all PRs. Before this change, PRs targeting `test` (the bulk of them in the `feature/* → test → main` pipeline) skipped integration entirely — migration bugs could land in `test` and only surface at the `test → main` promotion. Now every PR gets integration signal before merge.

## Change

Single-line edit to `.github/workflows/ci.yml:226`:

```diff
- if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+ if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
```

Also updated the section comment to reflect the new trigger set.

## Why this specific gate

- **Runs on**: all PRs (to `test` or `main`) + push to `main` (deploy safety net).
- **Skips**: push to `test`. The preceding PR already validated the merge commit, and the `concurrency` block at `ci.yml:23-25` cancels in-progress runs on rapid merges — so push-to-test integration would duplicate work that often doesn't complete anyway.

## Scope

Only `test-integration`. `coverage` (line 278) and `e2e-smoke` / `e2e-accessibility` / `e2e-visual` (lines 371+) remain `main`-only — those are separate concerns and outside P3-01 scope.

## Test plan

- [ ] CI on this PR runs integration tests (validates the change eats its own dogfood).
- [ ] `test-integration` appears as a check on this PR.
- [ ] Unit, typecheck, build continue to pass.
- [ ] After merge: flip `CR8-P3-01` checkbox `[ ] → [x]` in internal docs with commit citation (separate an internal repo commit).
