### PR TITLE
feat(mcp): OAuth 2.1 client provider (Stage 2 PR-2.1)

### DIFF
--- a/.changeset/mcp-2-1-oauth-client.md
+++ b/.changeset/mcp-2-1-oauth-client.md
@@ -1,0 +1,20 @@
+---
+'@revealui/mcp': minor
+---
+
+Add OAuth 2.1 client support — Stage 2 PR-2.1 of the MCP v1 plan. Remote MCP
+servers can now be authorized end-to-end without hand-rolling the flow.
+
+- `McpOAuthProvider` implements the SDK's `OAuthClientProvider` interface:
+  Authorization Code + PKCE, Dynamic Client Registration (RFC 7591), and
+  automatic refresh with OAuth 2.1 §4.12 refresh-token rotation handled
+  transparently.
+- `Vault` abstracts durable credential storage. `createRevvaultVault()`
+  (default) shells out to the `revvault` CLI and persists under
+  `mcp/<tenant>/<server>/{tokens,client,verifier,discovery}`. `createMemoryVault()`
+  is provided for tests and ephemeral flows.
+- `StreamableHttpTransportOptions.authProvider` wires a provider into
+  `StreamableHTTPClientTransport`; the SDK drives discovery, DCR, PKCE, and
+  refresh from there. `McpClient.finishAuth(code)` delegates to the transport
+  to complete the code-for-token exchange after the user returns from consent.
+- Importable from `@revealui/mcp` (top level) or `@revealui/mcp/oauth`.

--- a/packages/mcp/__tests__/oauth-integration.test.ts
+++ b/packages/mcp/__tests__/oauth-integration.test.ts
@@ -1,0 +1,503 @@
+/**
+ * OAuth 2.1 integration tests (Stage 2 PR-2.1).
+ *
+ * Drives the SDK's top-level `auth()` helper against a hermetic mock
+ * authorization server (real `http.createServer` on an ephemeral port) with
+ * our {@link McpOAuthProvider} attached. Covers:
+ *
+ *   1. First-time authorization with Dynamic Client Registration (RFC 7591),
+ *      PKCE verifier generation, and the `redirectToAuthorization` hand-off.
+ *   2. Authorization code exchange with PKCE — the verifier round-trips through
+ *      the vault and lands in the token request.
+ *   3. Refresh-token rotation (OAuth 2.1 §4.12) — a rotated refresh_token is
+ *      persisted through `saveTokens` verbatim.
+ *   4. Streamable HTTP transport wiring — an `authProvider` with pre-seeded
+ *      tokens produces an `Authorization: Bearer …` header on the MCP wire.
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { auth, refreshAuthorization } from '@modelcontextprotocol/sdk/client/auth.js';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import { createMemoryVault, McpOAuthProvider, type Vault } from '../src/oauth.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+// ---------------------------------------------------------------------------
+// Mock authorization server
+// ---------------------------------------------------------------------------
+
+type AuthCodeGrant = {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope?: string;
+};
+
+interface MockAsState {
+  clients: Map<string, { client_id: string; redirect_uris: string[] }>;
+  issuedCodes: Map<string, AuthCodeGrant>;
+  validRefreshTokens: Set<string>;
+  /** Controls whether the server rotates refresh tokens on refresh (RFC 6749 §5.2 OR OAuth 2.1 §4.12). */
+  rotateRefreshTokens: boolean;
+  /** Events observed, for assertions. */
+  events: Array<{ kind: string; detail?: Record<string, unknown> }>;
+  nextAccessToken: number;
+  nextRefreshToken: number;
+}
+
+type RunningAs = {
+  url: string;
+  state: MockAsState;
+  close(): Promise<void>;
+};
+
+const teardowns: Array<() => Promise<void>> = [];
+
+async function readBody(req: import('node:http').IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseForm(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(body)) out[k] = v;
+  return out;
+}
+
+async function startMockAs(options?: { rotateRefreshTokens?: boolean }): Promise<RunningAs> {
+  const state: MockAsState = {
+    clients: new Map(),
+    issuedCodes: new Map(),
+    validRefreshTokens: new Set(),
+    rotateRefreshTokens: options?.rotateRefreshTokens ?? true,
+    events: [],
+    nextAccessToken: 1,
+    nextRefreshToken: 1,
+  };
+
+  const server = createHttpServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    const baseUrl = `http://${req.headers.host}`;
+    const send = (status: number, body: unknown): void => {
+      res.statusCode = status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(body));
+    };
+
+    try {
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-protected-resource') {
+        state.events.push({ kind: 'resource-metadata' });
+        return send(200, {
+          resource: baseUrl,
+          authorization_servers: [baseUrl],
+        });
+      }
+
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-authorization-server') {
+        state.events.push({ kind: 'as-metadata' });
+        return send(200, {
+          issuer: baseUrl,
+          authorization_endpoint: `${baseUrl}/authorize`,
+          token_endpoint: `${baseUrl}/token`,
+          registration_endpoint: `${baseUrl}/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+          token_endpoint_auth_methods_supported: ['none'],
+        });
+      }
+
+      if (req.method === 'POST' && url.pathname === '/register') {
+        const body = await readBody(req);
+        const metadata = JSON.parse(body) as {
+          redirect_uris: string[];
+          client_name?: string;
+        };
+        const clientId = `client-${state.clients.size + 1}`;
+        state.clients.set(clientId, {
+          client_id: clientId,
+          redirect_uris: metadata.redirect_uris,
+        });
+        state.events.push({ kind: 'register', detail: { clientId } });
+        return send(201, {
+          client_id: clientId,
+          client_id_issued_at: Math.floor(Date.now() / 1000),
+          ...metadata,
+        });
+      }
+
+      if (req.method === 'POST' && url.pathname === '/token') {
+        const form = parseForm(await readBody(req));
+        if (form.grant_type === 'authorization_code') {
+          const grant = state.issuedCodes.get(form.code);
+          if (!grant) return send(400, { error: 'invalid_grant' });
+          // Verify PKCE.
+          const expectedChallenge = await sha256Base64Url(form.code_verifier ?? '');
+          if (grant.codeChallengeMethod !== 'S256' || expectedChallenge !== grant.codeChallenge) {
+            return send(400, { error: 'invalid_grant', error_description: 'PKCE mismatch' });
+          }
+          if (grant.clientId !== form.client_id) {
+            return send(400, { error: 'invalid_client' });
+          }
+          state.issuedCodes.delete(form.code);
+          const access = `access-${state.nextAccessToken++}`;
+          const refresh = `refresh-${state.nextRefreshToken++}`;
+          state.validRefreshTokens.add(refresh);
+          state.events.push({
+            kind: 'token-exchange',
+            detail: { code: form.code, client: form.client_id },
+          });
+          return send(200, {
+            access_token: access,
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: refresh,
+            scope: grant.scope,
+          });
+        }
+
+        if (form.grant_type === 'refresh_token') {
+          const presented = form.refresh_token ?? '';
+          if (!state.validRefreshTokens.has(presented)) {
+            return send(400, { error: 'invalid_grant' });
+          }
+          state.validRefreshTokens.delete(presented);
+          const newAccess = `access-${state.nextAccessToken++}`;
+          const refreshBody: Record<string, unknown> = {
+            access_token: newAccess,
+            token_type: 'Bearer',
+            expires_in: 3600,
+          };
+          if (state.rotateRefreshTokens) {
+            const rotated = `refresh-${state.nextRefreshToken++}`;
+            state.validRefreshTokens.add(rotated);
+            refreshBody.refresh_token = rotated;
+          } else {
+            state.validRefreshTokens.add(presented); // keep old refresh valid
+          }
+          state.events.push({
+            kind: 'refresh',
+            detail: {
+              old: presented,
+              rotated: refreshBody.refresh_token,
+            },
+          });
+          return send(200, refreshBody);
+        }
+
+        return send(400, { error: 'unsupported_grant_type' });
+      }
+
+      return send(404, { error: 'not_found', path: url.pathname });
+    } catch (err) {
+      return send(500, { error: 'server_error', message: String(err) });
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  const close = () =>
+    new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  teardowns.push(close);
+  return { url, state, close };
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const { subtle } = await import('node:crypto');
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Buffer.from(digest)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseClientMetadata = {
+  redirect_uris: ['http://localhost/oauth/callback'],
+  client_name: 'McpOAuthProvider test',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+};
+
+function mkProvider(
+  vault: Vault = createMemoryVault(),
+  overrides?: Partial<ConstructorParameters<typeof McpOAuthProvider>[0]>,
+): McpOAuthProvider {
+  return new McpOAuthProvider({
+    tenant: 'acme',
+    server: 'linear',
+    vault,
+    redirectUrl: 'http://localhost/oauth/callback',
+    clientMetadata: baseClientMetadata,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(async () => {
+  while (teardowns.length) {
+    const fn = teardowns.pop();
+    if (fn) await fn().catch(() => undefined);
+  }
+});
+
+describe('McpOAuthProvider × SDK auth() first-time flow', () => {
+  it('runs discovery, DCR, and redirect — persisting verifier + client info', async () => {
+    const as = await startMockAs();
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+
+    const result = await auth(provider, { serverUrl: as.url });
+
+    expect(result).toBe('REDIRECT');
+
+    // Provider has captured the URL for the caller to navigate to.
+    expect(provider.lastAuthorizationUrl).toBeDefined();
+    const authUrl = provider.lastAuthorizationUrl as URL;
+    expect(authUrl.pathname).toBe('/authorize');
+    expect(authUrl.searchParams.get('response_type')).toBe('code');
+    expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(authUrl.searchParams.get('code_challenge')).toBeTruthy();
+    expect(authUrl.searchParams.get('client_id')).toBe('client-1');
+
+    // DCR and discovery fired against the AS.
+    const kinds = as.state.events.map((e) => e.kind);
+    expect(kinds).toContain('as-metadata');
+    expect(kinds).toContain('register');
+
+    // Client info persisted.
+    const storedClient = await provider.clientInformation();
+    expect(storedClient?.client_id).toBe('client-1');
+
+    // PKCE verifier stored in vault under the documented path.
+    expect(await vault.get('mcp/acme/linear/verifier')).toBeTruthy();
+  });
+
+  it('exchanges an authorization code and stores tokens via saveTokens', async () => {
+    const as = await startMockAs();
+    const provider = mkProvider();
+
+    // Step 1: kick off the flow.
+    expect(await auth(provider, { serverUrl: as.url })).toBe('REDIRECT');
+
+    // Step 2: simulate the user consenting + AS issuing an authorization code.
+    // We hand-register the code against the state the client just built.
+    const authUrl = provider.lastAuthorizationUrl as URL;
+    const codeChallenge = authUrl.searchParams.get('code_challenge') as string;
+    const clientId = authUrl.searchParams.get('client_id') as string;
+    const redirectUri = authUrl.searchParams.get('redirect_uri') as string;
+    const authCode = 'auth-code-abc';
+    as.state.issuedCodes.set(authCode, {
+      code: authCode,
+      clientId,
+      redirectUri,
+      codeChallenge,
+      codeChallengeMethod: 'S256',
+      scope: authUrl.searchParams.get('scope') ?? undefined,
+    });
+
+    // Step 3: the redirect lands with ?code=…; caller invokes auth() again with it.
+    const result = await auth(provider, { serverUrl: as.url, authorizationCode: authCode });
+    expect(result).toBe('AUTHORIZED');
+
+    // Tokens landed in the vault.
+    const tokens = await provider.tokens();
+    expect(tokens?.access_token).toBe('access-1');
+    expect(tokens?.refresh_token).toBe('refresh-1');
+    expect(tokens?.token_type).toBe('Bearer');
+
+    // Token exchange was observed on the AS.
+    expect(as.state.events.find((e) => e.kind === 'token-exchange')).toBeDefined();
+  });
+});
+
+describe('McpOAuthProvider × refresh rotation', () => {
+  it('persists a rotated refresh_token when the AS rotates (OAuth 2.1 §4.12)', async () => {
+    const as = await startMockAs({ rotateRefreshTokens: true });
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+
+    // Pre-seed client info + expired tokens. We set expires_in=0 to force
+    // downstream consumers to treat the access as stale; the refresh flow
+    // does not itself check expiry — it just exchanges the refresh_token.
+    await provider.saveClientInformation({
+      client_id: 'pre-registered',
+      redirect_uris: baseClientMetadata.redirect_uris,
+    });
+    const originalRefresh = 'refresh-original';
+    as.state.validRefreshTokens.add(originalRefresh);
+    await provider.saveTokens({
+      access_token: 'access-stale',
+      token_type: 'Bearer',
+      expires_in: 0,
+      refresh_token: originalRefresh,
+    });
+
+    // Execute the refresh directly via the SDK helper.
+    const newTokens = await refreshAuthorization(as.url, {
+      clientInformation: { client_id: 'pre-registered' },
+      refreshToken: originalRefresh,
+    });
+
+    // Persist through the provider as the SDK transport would.
+    await provider.saveTokens(newTokens);
+
+    const stored = await provider.tokens();
+    expect(stored?.access_token).toBe(newTokens.access_token);
+    expect(stored?.refresh_token).toBeDefined();
+    expect(stored?.refresh_token).not.toBe(originalRefresh);
+
+    // AS rotated, so the old refresh_token is no longer valid.
+    expect(as.state.validRefreshTokens.has(originalRefresh)).toBe(false);
+    expect(as.state.validRefreshTokens.has(stored?.refresh_token as string)).toBe(true);
+  });
+
+  it('keeps the original refresh_token when the AS does not rotate', async () => {
+    const as = await startMockAs({ rotateRefreshTokens: false });
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+
+    await provider.saveClientInformation({
+      client_id: 'pre-registered',
+      redirect_uris: baseClientMetadata.redirect_uris,
+    });
+    const originalRefresh = 'refresh-keep';
+    as.state.validRefreshTokens.add(originalRefresh);
+    await provider.saveTokens({
+      access_token: 'access-stale',
+      token_type: 'Bearer',
+      refresh_token: originalRefresh,
+    });
+
+    const newTokens = await refreshAuthorization(as.url, {
+      clientInformation: { client_id: 'pre-registered' },
+      refreshToken: originalRefresh,
+    });
+    // The SDK preserves the original refresh_token when the AS omits one.
+    await provider.saveTokens(newTokens);
+    const stored = await provider.tokens();
+    expect(stored?.refresh_token).toBe(originalRefresh);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport wiring — the provider is passed through to StreamableHTTPClientTransport
+// and emits Authorization headers on the MCP wire.
+// ---------------------------------------------------------------------------
+
+describe('McpOAuthProvider × StreamableHTTP transport wiring', () => {
+  it('forwards the bearer token from the provider into the MCP request headers', async () => {
+    const seenAuthorizationHeaders: string[] = [];
+
+    // Mock MCP server that records the Authorization header on every request.
+    const handler = createNodeStreamableHttpHandler({
+      createServer: () => {
+        const server = new McpServer(
+          { name: 'auth-wire-fixture', version: '0.0.1' },
+          { capabilities: { resources: {} } },
+        );
+        server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+          resources: [{ uri: 'res://one', name: 'one' }],
+        }));
+        server.setRequestHandler(ReadResourceRequestSchema, async (req) => ({
+          contents: [{ uri: req.params.uri, mimeType: 'text/plain', text: 'ok' }],
+        }));
+        return server;
+      },
+    });
+
+    const httpServer: NodeHttpServer = createHttpServer((req, res) => {
+      seenAuthorizationHeaders.push(String(req.headers.authorization ?? ''));
+      void handler(req, res).catch((err) => {
+        if (!res.headersSent) res.statusCode = 500;
+        res.end(String(err));
+      });
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const { port } = httpServer.address() as AddressInfo;
+    teardowns.push(
+      () =>
+        new Promise((resolve, reject) =>
+          httpServer.close((err) => (err ? reject(err) : resolve())),
+        ),
+    );
+
+    // Provider with pre-seeded, still-valid tokens.
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+    await provider.saveClientInformation({
+      client_id: 'pre-registered',
+      redirect_uris: baseClientMetadata.redirect_uris,
+    });
+    await provider.saveTokens({
+      access_token: 'pre-seeded-access',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'pre-seeded-refresh',
+    });
+
+    const client = new McpClient({
+      clientInfo: { name: 'oauth-wire-test', version: '0.0.0' },
+      transport: {
+        kind: 'streamable-http',
+        url: `http://127.0.0.1:${port}/`,
+        authProvider: provider,
+      },
+    });
+
+    await client.connect();
+    const resources = await client.listResources();
+    await client.close();
+
+    expect(resources).toHaveLength(1);
+    // At least one wire request carried the Bearer header from the provider.
+    expect(seenAuthorizationHeaders.some((h) => h === 'Bearer pre-seeded-access')).toBe(true);
+  });
+
+  it('rejects finishAuth when transport is not streamable-http', async () => {
+    const client = new McpClient({
+      clientInfo: { name: 'test', version: '0.0.0' },
+      transport: {
+        kind: 'stdio',
+        command: 'node',
+        args: ['-e', ';'],
+      },
+    });
+    await expect(client.finishAuth('code-123')).rejects.toThrow(
+      /requires the 'streamable-http' transport/,
+    );
+  });
+
+  it('rejects finishAuth when connect() has not been called', async () => {
+    const provider = mkProvider();
+    const client = new McpClient({
+      clientInfo: { name: 'test', version: '0.0.0' },
+      transport: {
+        kind: 'streamable-http',
+        url: 'http://127.0.0.1:1/',
+        authProvider: provider,
+      },
+    });
+    await expect(client.finishAuth('code-123')).rejects.toThrow(/finishAuth.*before connect/);
+  });
+});

--- a/packages/mcp/__tests__/oauth-provider.test.ts
+++ b/packages/mcp/__tests__/oauth-provider.test.ts
@@ -1,0 +1,255 @@
+/**
+ * OAuth provider unit tests (Stage 2 PR-2.1).
+ *
+ * Verifies the `Vault` contract, the revvault path layout, and the
+ * `McpOAuthProvider`'s round-tripping of tokens, client info, and verifier
+ * through a memory-backed vault. Hermetic — no network, no subprocess.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMemoryVault, McpOAuthProvider, mcpOAuthPaths, type Vault } from '../src/oauth.js';
+
+const TENANT = 'acme';
+const SERVER = 'linear';
+
+const baseClientMetadata = {
+  redirect_uris: ['https://admin.example.com/oauth/callback'],
+  client_name: 'Test Client',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+};
+
+function mkProvider(vault: Vault = createMemoryVault()): McpOAuthProvider {
+  return new McpOAuthProvider({
+    tenant: TENANT,
+    server: SERVER,
+    vault,
+    redirectUrl: 'https://admin.example.com/oauth/callback',
+    clientMetadata: baseClientMetadata,
+  });
+}
+
+describe('mcpOAuthPaths', () => {
+  it('produces the documented revvault layout', () => {
+    expect(mcpOAuthPaths(TENANT, SERVER)).toEqual({
+      tokens: 'mcp/acme/linear/tokens',
+      client: 'mcp/acme/linear/client',
+      verifier: 'mcp/acme/linear/verifier',
+      discovery: 'mcp/acme/linear/discovery',
+    });
+  });
+});
+
+describe('createMemoryVault', () => {
+  it('round-trips values', async () => {
+    const vault = createMemoryVault();
+    expect(await vault.get('foo/bar')).toBeUndefined();
+    await vault.set('foo/bar', 'baz');
+    expect(await vault.get('foo/bar')).toBe('baz');
+    await vault.delete('foo/bar');
+    expect(await vault.get('foo/bar')).toBeUndefined();
+  });
+
+  it('honors the seed map', async () => {
+    const vault = createMemoryVault({ 'foo/bar': 'baz' });
+    expect(await vault.get('foo/bar')).toBe('baz');
+  });
+});
+
+describe('McpOAuthProvider', () => {
+  it('exposes construction-time metadata via getters', () => {
+    const provider = mkProvider();
+    expect(provider.redirectUrl).toBe('https://admin.example.com/oauth/callback');
+    expect(provider.clientMetadata).toEqual(baseClientMetadata);
+  });
+
+  it('state() returns a fresh UUID when no generator is configured', async () => {
+    const provider = mkProvider();
+    const a = await Promise.resolve(provider.state());
+    const b = await Promise.resolve(provider.state());
+    expect(typeof a).toBe('string');
+    expect(a).not.toBe(b);
+  });
+
+  it('state() delegates to the configured generator', async () => {
+    const vault = createMemoryVault();
+    const provider = new McpOAuthProvider({
+      tenant: TENANT,
+      server: SERVER,
+      vault,
+      redirectUrl: 'https://admin.example.com/oauth/callback',
+      clientMetadata: baseClientMetadata,
+      state: () => 'fixed-state',
+    });
+    expect(await provider.state()).toBe('fixed-state');
+  });
+
+  it('tokens() returns undefined when nothing is stored', async () => {
+    const provider = mkProvider();
+    expect(await provider.tokens()).toBeUndefined();
+  });
+
+  it('round-trips OAuth tokens through the vault', async () => {
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+
+    await provider.saveTokens({
+      access_token: 'at-1',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'rt-1',
+      scope: 'mcp:tools mcp:resources',
+    });
+
+    expect(await provider.tokens()).toEqual({
+      access_token: 'at-1',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'rt-1',
+      scope: 'mcp:tools mcp:resources',
+    });
+
+    // Tokens land at the documented path.
+    const raw = await vault.get('mcp/acme/linear/tokens');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).access_token).toBe('at-1');
+  });
+
+  it('persists rotated refresh tokens verbatim (OAuth 2.1 §4.12)', async () => {
+    const provider = mkProvider();
+    await provider.saveTokens({
+      access_token: 'at-1',
+      token_type: 'Bearer',
+      refresh_token: 'rt-original',
+    });
+    await provider.saveTokens({
+      access_token: 'at-2',
+      token_type: 'Bearer',
+      refresh_token: 'rt-rotated',
+    });
+    const stored = await provider.tokens();
+    expect(stored?.access_token).toBe('at-2');
+    expect(stored?.refresh_token).toBe('rt-rotated');
+  });
+
+  it('clientInformation() returns undefined before DCR', async () => {
+    const provider = mkProvider();
+    expect(await provider.clientInformation()).toBeUndefined();
+  });
+
+  it('round-trips DCR client information through the vault', async () => {
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+    const registered = {
+      client_id: 'client-xyz',
+      client_secret: 'secret-123',
+      client_id_issued_at: 1700000000,
+      redirect_uris: ['https://admin.example.com/oauth/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'client_secret_basic',
+    };
+
+    await provider.saveClientInformation(registered);
+
+    expect(await provider.clientInformation()).toEqual(registered);
+    expect(await vault.get('mcp/acme/linear/client')).toBeTruthy();
+  });
+
+  it('round-trips the PKCE code verifier through the vault', async () => {
+    const vault = createMemoryVault();
+    const provider = mkProvider(vault);
+    await provider.saveCodeVerifier('abc123-verifier');
+    expect(await provider.codeVerifier()).toBe('abc123-verifier');
+    expect(await vault.get('mcp/acme/linear/verifier')).toBe('abc123-verifier');
+  });
+
+  it('codeVerifier() throws when the verifier is missing', async () => {
+    const provider = mkProvider();
+    await expect(provider.codeVerifier()).rejects.toThrow(/PKCE code verifier missing/);
+  });
+
+  it('redirectToAuthorization records the URL and invokes onRedirect', async () => {
+    const vault = createMemoryVault();
+    const onRedirect = vi.fn();
+    const provider = new McpOAuthProvider({
+      tenant: TENANT,
+      server: SERVER,
+      vault,
+      redirectUrl: 'https://admin.example.com/oauth/callback',
+      clientMetadata: baseClientMetadata,
+      onRedirect,
+    });
+
+    const url = new URL('https://auth.example.com/authorize?client_id=abc&state=xyz');
+    await provider.redirectToAuthorization(url);
+
+    expect(provider.lastAuthorizationUrl?.toString()).toBe(url.toString());
+    expect(onRedirect).toHaveBeenCalledOnce();
+    expect(onRedirect).toHaveBeenCalledWith(url);
+  });
+
+  it('redirectToAuthorization works without an onRedirect hook', async () => {
+    const provider = mkProvider();
+    const url = new URL('https://auth.example.com/authorize?client_id=abc');
+    await expect(provider.redirectToAuthorization(url)).resolves.toBeUndefined();
+    expect(provider.lastAuthorizationUrl?.toString()).toBe(url.toString());
+  });
+
+  it('invalidateCredentials("all") deletes every path', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens': '{"access_token":"at"}',
+      'mcp/acme/linear/client': '{"client_id":"cid"}',
+      'mcp/acme/linear/verifier': 'ver',
+      'mcp/acme/linear/discovery': '{}',
+    });
+    const provider = mkProvider(vault);
+    await provider.invalidateCredentials('all');
+    expect(await vault.get('mcp/acme/linear/tokens')).toBeUndefined();
+    expect(await vault.get('mcp/acme/linear/client')).toBeUndefined();
+    expect(await vault.get('mcp/acme/linear/verifier')).toBeUndefined();
+    expect(await vault.get('mcp/acme/linear/discovery')).toBeUndefined();
+  });
+
+  it('invalidateCredentials("tokens") only deletes tokens', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens': '{"access_token":"at"}',
+      'mcp/acme/linear/client': '{"client_id":"cid"}',
+      'mcp/acme/linear/verifier': 'ver',
+    });
+    const provider = mkProvider(vault);
+    await provider.invalidateCredentials('tokens');
+    expect(await vault.get('mcp/acme/linear/tokens')).toBeUndefined();
+    expect(await vault.get('mcp/acme/linear/client')).toBe('{"client_id":"cid"}');
+    expect(await vault.get('mcp/acme/linear/verifier')).toBe('ver');
+  });
+
+  it('surfaces JSON parse errors on corrupted stored tokens', async () => {
+    const vault = createMemoryVault({ 'mcp/acme/linear/tokens': 'not-json' });
+    const provider = mkProvider(vault);
+    await expect(provider.tokens()).rejects.toThrow(/Failed to parse stored tokens JSON/);
+  });
+
+  it('scopes state per (tenant, server) so two providers do not collide', async () => {
+    const vault = createMemoryVault();
+    const a = new McpOAuthProvider({
+      tenant: 'acme',
+      server: 'linear',
+      vault,
+      redirectUrl: 'https://admin.example.com/oauth/callback',
+      clientMetadata: baseClientMetadata,
+    });
+    const b = new McpOAuthProvider({
+      tenant: 'acme',
+      server: 'notion',
+      vault,
+      redirectUrl: 'https://admin.example.com/oauth/callback',
+      clientMetadata: baseClientMetadata,
+    });
+    await a.saveTokens({ access_token: 'linear-token', token_type: 'Bearer' });
+    await b.saveTokens({ access_token: 'notion-token', token_type: 'Bearer' });
+    expect((await a.tokens())?.access_token).toBe('linear-token');
+    expect((await b.tokens())?.access_token).toBe('notion-token');
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -70,6 +70,10 @@
     "./streamable-http": {
       "types": "./dist/streamable-http.d.ts",
       "import": "./dist/streamable-http.js"
+    },
+    "./oauth": {
+      "types": "./dist/oauth.d.ts",
+      "import": "./dist/oauth.js"
     }
   },
   "files": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -21,6 +21,7 @@
  * client so transport abstraction (Streamable HTTP) lands cleanly.
  */
 
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import {
@@ -88,9 +89,13 @@ export type CustomTransportOptions = {
  * SSE streaming for progress/notifications, and OAuth 2.1 for authenticated
  * deployments.
  *
- * OAuth wiring lands in Stage 2; this PR (Stage 1) exposes the transport
- * without an `authProvider`. Callers who need auth before Stage 2 can pass
- * their own bearer token via `requestInit.headers`.
+ * Pass `authProvider` to enable OAuth 2.1 (Authorization Code + PKCE,
+ * Dynamic Client Registration, automatic refresh). `@revealui/mcp` ships
+ * `McpOAuthProvider` at `./oauth.js` — construct it with a
+ * `(tenant, server, vault)` triple and a redirect URL, and attach it here.
+ * If `authProvider` is omitted and the server requires auth, the SDK throws
+ * `UnauthorizedError` on connect. Callers who need static bearer-token auth
+ * instead can pass the header via `requestInit.headers`.
  */
 export type StreamableHttpTransportOptions = {
   kind: 'streamable-http';
@@ -105,6 +110,12 @@ export type StreamableHttpTransportOptions = {
   sessionId?: string;
   /** SSE reconnection tuning (delays, retry ceiling). */
   reconnectionOptions?: StreamableHTTPReconnectionOptions;
+  /**
+   * OAuth 2.1 client provider. The SDK invokes discovery, DCR, PKCE, and
+   * refresh flows through this object, persisting state via the provider's
+   * storage methods. See `./oauth.js` for a revvault-backed implementation.
+   */
+  authProvider?: OAuthClientProvider;
 };
 
 export type TransportOptions =
@@ -312,6 +323,12 @@ export class McpClient {
   private readonly sdk: Client;
   private readonly options: McpClientOptions;
   private connected = false;
+  /**
+   * Tracks the Streamable HTTP transport when that kind is in use, so
+   * `finishAuth()` can delegate to it. Set by `createTransport`, cleared
+   * on `close()`.
+   */
+  private httpTransport?: StreamableHTTPClientTransport;
   private readonly resourceSubscribers = new Map<
     string,
     Set<(params: ResourceUpdatedParams) => void>
@@ -398,7 +415,36 @@ export class McpClient {
     if (!this.connected) return;
     await this.sdk.close();
     this.connected = false;
+    this.httpTransport = undefined;
     this.resourceSubscribers.clear();
+  }
+
+  /**
+   * Finalize an OAuth 2.1 authorization flow initiated by an `authProvider`.
+   *
+   * After `connect()` triggers `OAuthClientProvider.redirectToAuthorization`,
+   * the user completes consent at the authorization server and is redirected
+   * back to the caller's callback URL with a `code` query parameter. The
+   * caller passes that `code` here, which delegates to the Streamable HTTP
+   * transport's `finishAuth`: the SDK exchanges the code (with the stored
+   * PKCE verifier) at the token endpoint and persists the resulting token
+   * set via the provider's `saveTokens`. Retry `connect()` afterward.
+   *
+   * Throws if the client is not using the `streamable-http` transport or if
+   * `connect()` has not been called yet (the transport is constructed during
+   * `connect`).
+   */
+  async finishAuth(authorizationCode: string): Promise<void> {
+    if (this.options.transport.kind !== 'streamable-http') {
+      throw new Error(
+        `McpClient.finishAuth() requires the 'streamable-http' transport ` +
+          `(got '${this.options.transport.kind}')`,
+      );
+    }
+    if (!this.httpTransport) {
+      throw new McpNotConnectedError('finishAuth');
+    }
+    await this.httpTransport.finishAuth(authorizationCode);
   }
 
   /** Server capabilities returned by `initialize`. Undefined before connect. */
@@ -647,7 +693,10 @@ export class McpClient {
         if (t.fetch) sdkOptions.fetch = t.fetch;
         if (t.sessionId) sdkOptions.sessionId = t.sessionId;
         if (t.reconnectionOptions) sdkOptions.reconnectionOptions = t.reconnectionOptions;
-        return new StreamableHTTPClientTransport(url, sdkOptions);
+        if (t.authProvider) sdkOptions.authProvider = t.authProvider;
+        const transport = new StreamableHTTPClientTransport(url, sdkOptions);
+        this.httpTransport = transport;
+        return transport;
       }
     }
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -129,6 +129,22 @@ export {
   type MCPTool,
   type NamespacedTool,
 } from './hypervisor.js';
+// OAuth 2.1 client provider (Stage 2 PR-2.1 — revvault-backed credential storage)
+export {
+  createMemoryVault,
+  createRevvaultVault,
+  type McpOAuthPaths,
+  McpOAuthProvider,
+  type McpOAuthProviderOptions,
+  mcpOAuthPaths,
+  type OAuthClientInformation,
+  type OAuthClientInformationFull,
+  type OAuthClientMetadata,
+  type OAuthTokens,
+  RevvaultError,
+  type RevvaultVaultOptions,
+  type Vault,
+} from './oauth.js';
 // Tool pipeline (composition / chaining)
 export {
   executePipeline,

--- a/packages/mcp/src/oauth.ts
+++ b/packages/mcp/src/oauth.ts
@@ -1,0 +1,398 @@
+/**
+ * OAuth 2.1 client provider for `@revealui/mcp`.
+ *
+ * Phase: Stage 2 PR-2.1 of the MCP v1 plan (see
+ * `.jv/docs/mcp-productionization-scope.md`).
+ *
+ * Implements the SDK's `OAuthClientProvider` interface, backed by a pluggable
+ * `Vault` for durable credential storage. The default implementation shells
+ * out to the `revvault` CLI; a memory-backed implementation is exported for
+ * tests and for environments without revvault on the host.
+ *
+ * Storage layout per `(tenant, server)` pair, rooted at `mcp/<tenant>/<server>/`:
+ *   tokens    — OAuthTokens JSON (access + refresh + expiry + token_type + scope)
+ *   client    — DCR client info JSON (client_id + optional client_secret)
+ *   verifier  — PKCE code verifier, opaque string, single-use during redirect
+ *   discovery — cached authorization-server metadata (optional)
+ *
+ * Flow (first-time authorization):
+ *   1. Caller constructs a provider with `{ tenant, server, vault, redirectUrl,
+ *      clientMetadata, onRedirect }` and attaches it to a Streamable HTTP
+ *      transport via `authProvider` on `StreamableHttpTransportOptions`.
+ *   2. On `connect()`, the SDK transport detects missing tokens, runs OAuth
+ *      discovery, performs Dynamic Client Registration (RFC 7591) if
+ *      `saveClientInformation` is implemented, generates a PKCE verifier,
+ *      persists it, and calls `redirectToAuthorization(url)`.
+ *   3. This provider's `redirectToAuthorization` records the URL on
+ *      `lastAuthorizationUrl` and invokes the caller's `onRedirect` hook. The
+ *      caller navigates the user agent (e.g. a Next.js route handler issuing
+ *      an HTTP 302).
+ *   4. After the user authorizes and returns to the callback URL, the caller
+ *      extracts the `code` query parameter and invokes `mcpClient.finishAuth(code)`,
+ *      which delegates to the transport's `finishAuth(code)` — this exchanges
+ *      the code via PKCE and persists tokens via `saveTokens`.
+ *   5. Subsequent `connect()` calls use the stored tokens. Token refresh is
+ *      automatic: the SDK detects expiry, calls the refresh endpoint, and
+ *      calls `saveTokens` with the new token set. OAuth 2.1 §4.12 refresh-token
+ *      rotation is transparent — the rotated refresh_token flows through
+ *      `saveTokens` verbatim.
+ */
+
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+
+// ---------------------------------------------------------------------------
+// Vault interface (pluggable KV for provider state)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal key/value interface the provider needs from its backing store.
+ *
+ * Keys are revvault-style slash-delimited paths (e.g. `mcp/acme/linear/tokens`).
+ * Values are opaque strings; the provider JSON-encodes structured values
+ * before calling `set`.
+ */
+export interface Vault {
+  /** Returns the value at `path`, or `undefined` if not present. */
+  get(path: string): Promise<string | undefined>;
+  /** Stores `value` at `path`, overwriting any prior value. */
+  set(path: string, value: string): Promise<void>;
+  /** Deletes the value at `path`. No-op if not present. */
+  delete(path: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Revvault-backed vault (default)
+// ---------------------------------------------------------------------------
+
+export interface RevvaultVaultOptions {
+  /** Path to the `revvault` binary. Defaults to `~/.local/bin/revvault`. */
+  binPath?: string;
+  /**
+   * Age identity path. Passed via `REVVAULT_IDENTITY` env var. Defaults to
+   * `~/.config/age/keys.txt`, matching revvault's own default.
+   */
+  identityPath?: string;
+  /** Spawn timeout in ms. Defaults to 10_000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Creates a {@link Vault} backed by the `revvault` CLI. Requires `revvault` to
+ * be installed on the host and the age identity to be readable.
+ *
+ * Production default for RevealUI deployments. In CI or test environments
+ * without revvault, prefer {@link createMemoryVault}.
+ */
+export function createRevvaultVault(options: RevvaultVaultOptions = {}): Vault {
+  const binPath = options.binPath ?? join(homedir(), '.local/bin/revvault');
+  const identityPath =
+    options.identityPath ??
+    process.env.REVVAULT_IDENTITY ??
+    join(homedir(), '.config/age/keys.txt');
+  const timeoutMs = options.timeoutMs ?? 10_000;
+
+  const env = { ...process.env, REVVAULT_IDENTITY: identityPath };
+
+  const run = (
+    args: string[],
+    stdin?: string,
+  ): Promise<{ code: number | null; stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(binPath, args, { env, timeout: timeoutMs });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        resolve({ code, stdout, stderr });
+      });
+      if (stdin !== undefined) {
+        child.stdin.end(stdin);
+      } else {
+        child.stdin.end();
+      }
+    });
+
+  return {
+    async get(path) {
+      assertSafePath(path);
+      const { code, stdout, stderr } = await run(['get', '--full', path]);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault get exited ${code}: ${stderr.trim()}`);
+      }
+      if (stdout.length === 0 && /not found/i.test(stderr)) {
+        return undefined;
+      }
+      if (stdout.length === 0) {
+        throw new RevvaultError(`revvault get returned empty output: ${stderr.trim()}`);
+      }
+      return stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+    },
+    async set(path, value) {
+      assertSafePath(path);
+      const { code, stderr } = await run(['set', '--force', path], value);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault set exited ${code}: ${stderr.trim()}`);
+      }
+    },
+    async delete(path) {
+      assertSafePath(path);
+      const { code, stderr } = await run(['delete', '--force', path]);
+      if (code !== 0 && !/not found/i.test(stderr)) {
+        throw new RevvaultError(`revvault delete exited ${code}: ${stderr.trim()}`);
+      }
+    },
+  };
+}
+
+/** Reject shell-metacharacter and traversal patterns in vault paths. */
+function assertSafePath(path: string): void {
+  if (!/^[A-Za-z0-9/_\-.]+$/.test(path)) {
+    throw new RevvaultError(`Vault path contains disallowed characters: ${path}`);
+  }
+  if (path.includes('..') || path.startsWith('/') || path.endsWith('/')) {
+    throw new RevvaultError(`Vault path is not well-formed: ${path}`);
+  }
+}
+
+export class RevvaultError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RevvaultError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory vault (tests / ephemeral flows)
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an in-memory {@link Vault} backed by a `Map`. Intended for tests and
+ * for short-lived processes where persistence is not required.
+ *
+ * An optional `seed` object prepopulates the map.
+ */
+export function createMemoryVault(seed?: Record<string, string>): Vault {
+  const store = new Map<string, string>(seed ? Object.entries(seed) : undefined);
+  return {
+    async get(path) {
+      return store.get(path);
+    },
+    async set(path, value) {
+      store.set(path, value);
+    },
+    async delete(path) {
+      store.delete(path);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Path layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical revvault path layout for MCP OAuth credentials. Exported so admin
+ * tooling and audits can introspect the layout without reimplementing it.
+ */
+export interface McpOAuthPaths {
+  tokens: string;
+  client: string;
+  verifier: string;
+  discovery: string;
+}
+
+/** Build the {@link McpOAuthPaths} for a given `(tenant, server)` pair. */
+export function mcpOAuthPaths(tenant: string, server: string): McpOAuthPaths {
+  const prefix = `mcp/${tenant}/${server}`;
+  return {
+    tokens: `${prefix}/tokens`,
+    client: `${prefix}/client`,
+    verifier: `${prefix}/verifier`,
+    discovery: `${prefix}/discovery`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RevvaultOAuthProvider
+// ---------------------------------------------------------------------------
+
+export interface McpOAuthProviderOptions {
+  /** Tenant identifier. Used as the first path segment in revvault. */
+  tenant: string;
+  /** Server identifier (e.g. `linear`, `notion`). Second path segment. */
+  server: string;
+  /** Backing vault. Use {@link createRevvaultVault} in production. */
+  vault: Vault;
+  /**
+   * URL the authorization server should redirect to after user consent.
+   * This is the public URL of the caller's callback handler.
+   */
+  redirectUrl: string | URL;
+  /**
+   * OAuth client metadata used for Dynamic Client Registration and advertised
+   * to the authorization server. Must include `redirect_uris` covering
+   * `redirectUrl`.
+   */
+  clientMetadata: OAuthClientMetadata;
+  /**
+   * Called when the SDK's `auth()` needs to send the user to the authorization
+   * URL. The caller is responsible for navigating the user agent (e.g. by
+   * issuing an HTTP 302 from a Next.js route handler). The provider also
+   * records the URL on {@link RevvaultOAuthProvider.lastAuthorizationUrl} for
+   * callers that prefer synchronous inspection over a callback.
+   */
+  onRedirect?(authorizationUrl: URL): void | Promise<void>;
+  /**
+   * Generates an opaque OAuth state parameter. Defaults to a `crypto.randomUUID()`.
+   * Callers that want to bind state to session identifiers can override.
+   */
+  state?(): string | Promise<string>;
+}
+
+/**
+ * SDK-compatible OAuth client provider backed by a {@link Vault}. Instances are
+ * scoped to a single `(tenant, server)` pair — construct one per MCP server
+ * the caller intends to authorize against.
+ */
+export class McpOAuthProvider implements OAuthClientProvider {
+  private readonly vault: Vault;
+  private readonly paths: McpOAuthPaths;
+  private readonly _redirectUrl: string | URL;
+  private readonly _clientMetadata: OAuthClientMetadata;
+  private readonly onRedirect?: (url: URL) => void | Promise<void>;
+  private readonly _state?: () => string | Promise<string>;
+
+  /**
+   * The most recent authorization URL the SDK asked us to send the user to.
+   * Populated by {@link redirectToAuthorization}. Callers may read this
+   * synchronously after an `auth()` or `connect()` call that returns
+   * `'REDIRECT'`.
+   */
+  lastAuthorizationUrl?: URL;
+
+  constructor(options: McpOAuthProviderOptions) {
+    this.vault = options.vault;
+    this.paths = mcpOAuthPaths(options.tenant, options.server);
+    this._redirectUrl = options.redirectUrl;
+    this._clientMetadata = options.clientMetadata;
+    this.onRedirect = options.onRedirect;
+    this._state = options.state;
+  }
+
+  // -- OAuthClientProvider (getters) ----------------------------------------
+
+  get redirectUrl(): string | URL {
+    return this._redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return this._clientMetadata;
+  }
+
+  state(): string | Promise<string> {
+    if (this._state) return this._state();
+    return crypto.randomUUID();
+  }
+
+  // -- OAuthClientProvider (client info) ------------------------------------
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const raw = await this.vault.get(this.paths.client);
+    if (raw === undefined) return undefined;
+    return parseJson<OAuthClientInformationMixed>(raw, 'client information');
+  }
+
+  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+    await this.vault.set(this.paths.client, JSON.stringify(info));
+  }
+
+  // -- OAuthClientProvider (tokens) -----------------------------------------
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const raw = await this.vault.get(this.paths.tokens);
+    if (raw === undefined) return undefined;
+    return parseJson<OAuthTokens>(raw, 'tokens');
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.vault.set(this.paths.tokens, JSON.stringify(tokens));
+  }
+
+  // -- OAuthClientProvider (PKCE verifier) ----------------------------------
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    await this.vault.set(this.paths.verifier, codeVerifier);
+  }
+
+  async codeVerifier(): Promise<string> {
+    const value = await this.vault.get(this.paths.verifier);
+    if (value === undefined) {
+      throw new Error(
+        `[@revealui/mcp] PKCE code verifier missing at ${this.paths.verifier}. ` +
+          'The authorization flow must call saveCodeVerifier before finishAuth.',
+      );
+    }
+    return value;
+  }
+
+  // -- OAuthClientProvider (redirect) ---------------------------------------
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    this.lastAuthorizationUrl = authorizationUrl;
+    if (this.onRedirect) {
+      await this.onRedirect(authorizationUrl);
+    }
+  }
+
+  // -- OAuthClientProvider (invalidation) -----------------------------------
+
+  async invalidateCredentials(
+    scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery',
+  ): Promise<void> {
+    const targets: string[] = [];
+    if (scope === 'all' || scope === 'tokens') targets.push(this.paths.tokens);
+    if (scope === 'all' || scope === 'client') targets.push(this.paths.client);
+    if (scope === 'all' || scope === 'verifier') targets.push(this.paths.verifier);
+    if (scope === 'all' || scope === 'discovery') targets.push(this.paths.discovery);
+    await Promise.all(targets.map((path) => this.vault.delete(path)));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseJson<T>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(
+      `[@revealui/mcp] Failed to parse stored ${label} JSON: ${(err as Error).message}`,
+    );
+  }
+}
+
+export type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+};


### PR DESCRIPTION
## Summary

Stage 2 PR-2.1 of the MCP v1 productionization plan. Adds end-to-end OAuth 2.1 support so remote MCP servers can be authorized without callers hand-rolling the flow. Attaches to the Streamable HTTP transport via the SDK's `authProvider` hook shipped in PR-1.1 (#491).

### What ships

- **`McpOAuthProvider`** — implements the SDK's `OAuthClientProvider` interface. Authorization Code + PKCE, Dynamic Client Registration (RFC 7591), automatic refresh with OAuth 2.1 §4.12 refresh-token rotation all handled transparently.
- **`Vault` abstraction** — pluggable credential storage.
  - `createRevvaultVault()` (production default) shells out to the `revvault` CLI and persists under the documented layout: `mcp/<tenant>/<server>/{tokens,client,verifier,discovery}`.
  - `createMemoryVault()` for tests and ephemeral flows.
- **Transport wiring** — `StreamableHttpTransportOptions.authProvider` threads a provider into `StreamableHTTPClientTransport`. `McpClient.finishAuth(code)` delegates to the transport's `finishAuth` to complete the code-for-token exchange after the user returns from consent.
- **Public API** — exports available from `@revealui/mcp` top-level or the new `@revealui/mcp/oauth` subpath.

### Flow (first-time authorization)

1. Caller constructs provider with `{ tenant, server, vault, redirectUrl, clientMetadata, onRedirect }` and attaches to a Streamable HTTP transport.
2. On `connect()`, the SDK detects missing tokens, runs OAuth discovery, performs DCR, generates a PKCE verifier, and calls `redirectToAuthorization(url)`.
3. The provider records the URL on `lastAuthorizationUrl` and invokes the caller's `onRedirect` hook. Caller navigates the user agent (e.g. HTTP 302 from a route handler).
4. After consent, the caller invokes `mcpClient.finishAuth(code)`. SDK exchanges code + PKCE verifier at the token endpoint, persists tokens via `saveTokens`.
5. Subsequent `connect()` uses stored tokens. Refresh is automatic; rotated refresh tokens flow through `saveTokens` verbatim.

### Test coverage

26 new tests (19 unit + 7 integration). `@revealui/mcp` package: **190 passing / 5 skipped** (was 164 / 5 before this PR).

- **Unit** (`oauth-provider.test.ts`): vault contract, path layout, token/client/verifier round-trip, rotated-refresh persistence, `invalidateCredentials` scopes, corrupted-JSON handling, per-`(tenant, server)` scoping.
- **Integration** (`oauth-integration.test.ts`): hermetic mock authorization server on an ephemeral port exercises:
  - Discovery + DCR + PKCE generation + `redirectToAuthorization` hand-off
  - Authorization code exchange with PKCE (code verifier round-trips through the vault into the token request)
  - Refresh-token rotation (OAuth 2.1 §4.12) — rotated `refresh_token` persists correctly; non-rotating AS preserves original
  - Transport wiring — `Authorization: Bearer …` header appears on the MCP wire when provider has tokens

## Stage 2 remainder

- **PR-2.2** — admin UI redirect flow: "connect server" form + callback route handler. Lands on top of this PR.

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally (Biome, audits, boundary, claim-drift, raw-SQL, empty-catch, security, coverage — all ✓)
- [ ] `pnpm --filter @revealui/mcp test` — 190 passing / 5 skipped

## Notes

- No hypervisor changes — that migration is still a deferred Stage 1-adjacent follow-up (822 lines + session management + tenant scoping; own design thread).
- No new server-side OAuth handling — this PR is client-side. RevealUI-hosted servers that want to act as OAuth RS lands separately when that product need appears.
- Local `pnpm gate` showed intermittent flake in `@revealui/core#test` and `@revealui/cache#test` under turbo's 15-way concurrency; both pass cleanly standalone (core: 2608 tests, cache: 256 tests). Pre-existing, unrelated to this PR.
