### PR TITLE
feat(retention): 90d purge for app_logs + error_events (CR8-P3-02 PR1)

### DIFF
--- a/apps/api/src/routes/cron/cleanup.ts
+++ b/apps/api/src/routes/cron/cleanup.ts
@@ -2,8 +2,9 @@
  * Cron: Stale Data Cleanup
  *
  * Deletes expired sessions, rate limits, password reset tokens, magic links,
- * publishes overdue scheduled pages, recovers stuck sagas, and cleans up
- * expired idempotency keys. Piggybacks on the daily cron dispatcher.
+ * publishes overdue scheduled pages, recovers stuck sagas, cleans up expired
+ * idempotency keys, and purges old log rows past the retention window.
+ * Piggybacks on the daily cron dispatcher.
  *
  * Protected by X-Cron-Secret header (defense-in-depth  -  also validated in dispatch.ts).
  */
@@ -11,7 +12,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
-import { cleanupStaleTokens } from '@revealui/db/cleanup';
+import { cleanupOldLogs, cleanupStaleTokens } from '@revealui/db/cleanup';
 import { cleanupExpiredIdempotencyKeys, recoverStaleSagas } from '@revealui/db/saga';
 import { Hono } from 'hono';
 
@@ -87,12 +88,36 @@ app.post('/cleanup', async (c) => {
       logger.error(`[cron-cleanup] Saga recovery/cleanup failed: ${message}`);
     }
 
+    // Log retention purge: app_logs + error_events past the configured window.
+    // Non-fatal — logged and reported but does not fail the cron if it errors.
+    let logsPurged = { appLogs: 0, errorEvents: 0, retentionDays: 0 };
+    try {
+      const logsResult = await cleanupOldLogs();
+      logsPurged = {
+        appLogs: logsResult.appLogs,
+        errorEvents: logsResult.errorEvents,
+        retentionDays: logsResult.retentionDays,
+      };
+      if (logsResult.appLogs > 0 || logsResult.errorEvents > 0) {
+        logger.info('[cron-cleanup] Purged logs past retention window', {
+          appLogs: logsResult.appLogs,
+          errorEvents: logsResult.errorEvents,
+          retentionDays: logsResult.retentionDays,
+          cutoff: logsResult.cutoff.toISOString(),
+        });
+      }
+    } catch (logErr) {
+      const message = logErr instanceof Error ? logErr.message : String(logErr);
+      logger.error(`[cron-cleanup] Log retention purge failed: ${message}`);
+    }
+
     return c.json({
       success: true,
       ...result,
       total,
       recoveredSagas,
       expiredIdempotencyKeys: expiredKeys,
+      logsPurged,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -62,6 +62,15 @@ const optionalSchema = z.object({
   // Cron endpoint authentication
   REVEALUI_CRON_SECRET: secretSchema.optional(),
 
+  // Log retention window for app_logs + error_events (days). Default 90.
+  // Privacy policy commits to a concrete window; see docs/security/.
+  REVEALUI_LOG_RETENTION_DAYS: z.coerce
+    .number()
+    .int()
+    .min(1, 'Must be at least 1 day')
+    .max(3650, 'Must not exceed 3650 days (10 years)')
+    .default(90),
+
   // License key signing (RSA-2048 PEM)
   REVEALUI_LICENSE_PRIVATE_KEY: z.string().optional(),
   REVEALUI_LICENSE_PUBLIC_KEY: z.string().optional(),

--- a/packages/db/src/cleanup/index.ts
+++ b/packages/db/src/cleanup/index.ts
@@ -13,6 +13,12 @@ export {
   cleanupVectorDataForSite,
   configureCleanup,
 } from './cross-db-cleanup.js';
+export {
+  type CleanupLogsOptions,
+  type CleanupLogsResult,
+  cleanupOldLogs,
+  type LogRetentionTable,
+} from './log-retention.js';
 export { cleanupRagDataForSite } from './rag-site-cleanup.js';
 export {
   type CleanupTable,

--- a/packages/db/src/cleanup/log-retention.ts
+++ b/packages/db/src/cleanup/log-retention.ts
@@ -1,0 +1,104 @@
+/**
+ * Log Retention Cleanup
+ *
+ * Purges old rows from `app_logs` and `error_events` past the configured
+ * retention window. Runs daily as part of the consolidated cron dispatcher.
+ *
+ * Retention window comes from `REVEALUI_LOG_RETENTION_DAYS` (default 90).
+ * See docs/security/ for the privacy-policy-facing commitment and
+ * ~/suite/.jv/docs/cr8-p3-02-retention-design.md for the decision record.
+ *
+ * Audit logs (`audit_log`) are intentionally excluded — they are
+ * append-only by design with tamper-evident hash chains, retained
+ * indefinitely for security and compliance purposes (decision D1).
+ */
+
+import { lt } from 'drizzle-orm';
+import { getClient } from '../client/index.js';
+import { appLogs } from '../schema/app-logs.js';
+import { errorEvents } from '../schema/error-events.js';
+
+export type LogRetentionTable = 'appLogs' | 'errorEvents';
+
+export interface CleanupLogsOptions {
+  /** When true, counts rows without deleting (default: false) */
+  dryRun?: boolean;
+  /** Override retention window in days; defaults to REVEALUI_LOG_RETENTION_DAYS env (fallback 90) */
+  retentionDays?: number;
+  /** Limit cleanup to specific tables; defaults to both */
+  tables?: LogRetentionTable[];
+  /** Optional database client override (used by integration tests with PGlite) */
+  db?: ReturnType<typeof getClient>;
+}
+
+export interface CleanupLogsResult {
+  appLogs: number;
+  errorEvents: number;
+  dryRun: boolean;
+  retentionDays: number;
+  cutoff: Date;
+}
+
+const ALL_TABLES: LogRetentionTable[] = ['appLogs', 'errorEvents'];
+const DEFAULT_RETENTION_DAYS = 90;
+
+function resolveRetentionDays(override?: number): number {
+  if (typeof override === 'number') {
+    if (!Number.isInteger(override) || override < 1) {
+      throw new Error(`Invalid retentionDays override: ${override}. Must be a positive integer.`);
+    }
+    return override;
+  }
+  const envValue = process.env.REVEALUI_LOG_RETENTION_DAYS;
+  if (envValue) {
+    const parsed = Number.parseInt(envValue, 10);
+    if (Number.isInteger(parsed) && parsed >= 1) {
+      return parsed;
+    }
+  }
+  return DEFAULT_RETENTION_DAYS;
+}
+
+/**
+ * Deletes (or counts, in dry-run mode) log rows older than the retention window.
+ * Reads POSTGRES_URL / DATABASE_URL from the environment via getClient() unless
+ * an explicit `db` client is provided.
+ */
+export async function cleanupOldLogs(options: CleanupLogsOptions = {}): Promise<CleanupLogsResult> {
+  const { dryRun = false, tables = ALL_TABLES, db: dbOverride } = options;
+  const retentionDays = resolveRetentionDays(options.retentionDays);
+  const db = dbOverride ?? getClient();
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+
+  const result: CleanupLogsResult = {
+    appLogs: 0,
+    errorEvents: 0,
+    dryRun,
+    retentionDays,
+    cutoff,
+  };
+
+  if (tables.includes('appLogs')) {
+    const where = lt(appLogs.timestamp, cutoff);
+    if (dryRun) {
+      const rows = await db.select({ id: appLogs.id }).from(appLogs).where(where);
+      result.appLogs = rows.length;
+    } else {
+      const deleted = await db.delete(appLogs).where(where).returning();
+      result.appLogs = deleted.length;
+    }
+  }
+
+  if (tables.includes('errorEvents')) {
+    const where = lt(errorEvents.timestamp, cutoff);
+    if (dryRun) {
+      const rows = await db.select({ id: errorEvents.id }).from(errorEvents).where(where);
+      result.errorEvents = rows.length;
+    } else {
+      const deleted = await db.delete(errorEvents).where(where).returning();
+      result.errorEvents = deleted.length;
+    }
+  }
+
+  return result;
+}

--- a/packages/db/src/schema/app-logs.ts
+++ b/packages/db/src/schema/app-logs.ts
@@ -4,9 +4,11 @@ import { check, index, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-co
 /**
  * Structured application logs  -  warn and above, all apps.
  *
- * Append-only. No FK constraints (logs outlive users/requests).
- * Written via the DB log transport (packages/db/src/log-transport.ts).
- * Only populated in production; dev logs stay on stdout.
+ * No FK constraints (logs outlive users/requests). Written via the
+ * DB log transport (packages/db/src/log-transport.ts). Only populated
+ * in production; dev logs stay on stdout. Retention: rows older than
+ * REVEALUI_LOG_RETENTION_DAYS (default 90) are purged by the daily
+ * cron — see packages/db/src/cleanup/log-retention.ts.
  */
 export const appLogs = pgTable(
   'app_logs',

--- a/packages/db/src/schema/error-events.ts
+++ b/packages/db/src/schema/error-events.ts
@@ -1,9 +1,10 @@
 /**
  * Error Events Table - Persistent storage for application errors.
  *
- * Append-only table. Captures unhandled errors from admin (client + server)
- * and API. Queryable via the admin dashboard /admin/errors page.
- * Supplemented by Axiom log drain for full log search.
+ * Captures unhandled errors from admin (client + server) and API.
+ * Queryable via the admin dashboard /admin/errors page. Retention:
+ * rows older than REVEALUI_LOG_RETENTION_DAYS (default 90) are purged
+ * by the daily cron — see packages/db/src/cleanup/log-retention.ts.
  */
 
 import { sql } from 'drizzle-orm';

--- a/packages/test/src/integration/database/log-retention.integration.test.ts
+++ b/packages/test/src/integration/database/log-retention.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Integration tests for log retention cleanup (CR8-P3-02 PR1).
+ *
+ * Exercises `cleanupOldLogs()` end-to-end against a PGlite-backed Postgres.
+ * Validates the retention window cutoff, dry-run counting, per-table
+ * scoping, and env-var / override precedence.
+ *
+ * Module: packages/db/src/cleanup/log-retention.ts
+ * Schemas: packages/db/src/schema/app-logs.ts, error-events.ts
+ * Design: ~/suite/.jv/docs/cr8-p3-02-retention-design.md
+ */
+
+import { cleanupOldLogs } from '@revealui/db/cleanup';
+import { appLogs, errorEvents } from '@revealui/db/schema';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
+
+describe('log retention cleanup (CR8-P3-02 PR1)', () => {
+  let testDb: TestDb;
+  // PgliteDatabase is runtime-compatible with the @revealui/db Database union.
+  const asDbOpts = (): { db: never } => ({ db: testDb.drizzle as never });
+
+  const daysAgo = (n: number): Date => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - n);
+    return d;
+  };
+
+  beforeAll(async () => {
+    testDb = await createTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await testDb.close();
+  });
+
+  beforeEach(async () => {
+    await testDb.pglite.exec('DELETE FROM app_logs');
+    await testDb.pglite.exec('DELETE FROM error_events');
+    delete process.env.REVEALUI_LOG_RETENTION_DAYS;
+  });
+
+  afterEach(() => {
+    delete process.env.REVEALUI_LOG_RETENTION_DAYS;
+  });
+
+  it('deletes app_logs older than 90d, keeps newer rows', async () => {
+    await testDb.drizzle.insert(appLogs).values([
+      {
+        id: 'old-1',
+        timestamp: daysAgo(100),
+        level: 'warn',
+        message: 'old 1',
+        app: 'api',
+        environment: 'production',
+      },
+      {
+        id: 'old-2',
+        timestamp: daysAgo(91),
+        level: 'error',
+        message: 'old 2',
+        app: 'admin',
+        environment: 'production',
+      },
+      {
+        id: 'fresh-1',
+        timestamp: daysAgo(89),
+        level: 'warn',
+        message: 'fresh 1',
+        app: 'api',
+        environment: 'production',
+      },
+      {
+        id: 'fresh-2',
+        timestamp: daysAgo(1),
+        level: 'error',
+        message: 'fresh 2',
+        app: 'marketing',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs(asDbOpts());
+
+    expect(result.appLogs).toBe(2);
+    expect(result.errorEvents).toBe(0);
+    expect(result.dryRun).toBe(false);
+    expect(result.retentionDays).toBe(90);
+
+    const remaining = await testDb.pglite.query<{ id: string }>(
+      'SELECT id FROM app_logs ORDER BY id',
+    );
+    expect(remaining.rows.map((r) => r.id)).toEqual(['fresh-1', 'fresh-2']);
+  });
+
+  it('deletes error_events older than 90d, keeps newer rows', async () => {
+    await testDb.drizzle.insert(errorEvents).values([
+      {
+        id: 'err-old',
+        timestamp: daysAgo(120),
+        level: 'error',
+        message: 'ancient error',
+        app: 'api',
+        environment: 'production',
+      },
+      {
+        id: 'err-fresh',
+        timestamp: daysAgo(30),
+        level: 'fatal',
+        message: 'recent error',
+        app: 'admin',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs(asDbOpts());
+
+    expect(result.errorEvents).toBe(1);
+    expect(result.appLogs).toBe(0);
+
+    const remaining = await testDb.pglite.query<{ id: string }>('SELECT id FROM error_events');
+    expect(remaining.rows.map((r) => r.id)).toEqual(['err-fresh']);
+  });
+
+  it('dry-run counts without deleting', async () => {
+    await testDb.drizzle.insert(appLogs).values([
+      {
+        id: 'old',
+        timestamp: daysAgo(200),
+        level: 'warn',
+        message: 'old',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+    await testDb.drizzle.insert(errorEvents).values([
+      {
+        id: 'old-err',
+        timestamp: daysAgo(200),
+        level: 'error',
+        message: 'old err',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs({ ...asDbOpts(), dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.appLogs).toBe(1);
+    expect(result.errorEvents).toBe(1);
+
+    const appRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM app_logs');
+    const errRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM error_events');
+    expect(appRows.rows).toHaveLength(1);
+    expect(errRows.rows).toHaveLength(1);
+  });
+
+  it('honors retentionDays override', async () => {
+    await testDb.drizzle.insert(appLogs).values([
+      {
+        id: 'a-10d',
+        timestamp: daysAgo(10),
+        level: 'warn',
+        message: 'a',
+        app: 'api',
+        environment: 'production',
+      },
+      {
+        id: 'a-3d',
+        timestamp: daysAgo(3),
+        level: 'warn',
+        message: 'a',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs({ ...asDbOpts(), retentionDays: 7 });
+
+    expect(result.retentionDays).toBe(7);
+    expect(result.appLogs).toBe(1);
+
+    const remaining = await testDb.pglite.query<{ id: string }>('SELECT id FROM app_logs');
+    expect(remaining.rows.map((r) => r.id)).toEqual(['a-3d']);
+  });
+
+  it('honors REVEALUI_LOG_RETENTION_DAYS env var when override not provided', async () => {
+    process.env.REVEALUI_LOG_RETENTION_DAYS = '30';
+
+    await testDb.drizzle.insert(appLogs).values([
+      {
+        id: 'env-old',
+        timestamp: daysAgo(45),
+        level: 'warn',
+        message: 'env-old',
+        app: 'api',
+        environment: 'production',
+      },
+      {
+        id: 'env-fresh',
+        timestamp: daysAgo(15),
+        level: 'warn',
+        message: 'env-fresh',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs(asDbOpts());
+
+    expect(result.retentionDays).toBe(30);
+    expect(result.appLogs).toBe(1);
+
+    const remaining = await testDb.pglite.query<{ id: string }>('SELECT id FROM app_logs');
+    expect(remaining.rows.map((r) => r.id)).toEqual(['env-fresh']);
+  });
+
+  it('scopes cleanup to requested tables only', async () => {
+    await testDb.drizzle.insert(appLogs).values([
+      {
+        id: 'app-old',
+        timestamp: daysAgo(100),
+        level: 'warn',
+        message: 'a',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+    await testDb.drizzle.insert(errorEvents).values([
+      {
+        id: 'err-old',
+        timestamp: daysAgo(100),
+        level: 'error',
+        message: 'e',
+        app: 'api',
+        environment: 'production',
+      },
+    ]);
+
+    const result = await cleanupOldLogs({ ...asDbOpts(), tables: ['appLogs'] });
+
+    expect(result.appLogs).toBe(1);
+    expect(result.errorEvents).toBe(0);
+
+    const appRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM app_logs');
+    const errRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM error_events');
+    expect(appRows.rows).toHaveLength(0);
+    expect(errRows.rows).toHaveLength(1);
+  });
+
+  it('rejects invalid retentionDays override', async () => {
+    await expect(cleanupOldLogs({ ...asDbOpts(), retentionDays: 0 })).rejects.toThrow(
+      'Must be a positive integer',
+    );
+
+    await expect(cleanupOldLogs({ ...asDbOpts(), retentionDays: -5 })).rejects.toThrow(
+      'Must be a positive integer',
+    );
+
+    await expect(cleanupOldLogs({ ...asDbOpts(), retentionDays: 1.5 })).rejects.toThrow(
+      'Must be a positive integer',
+    );
+  });
+
+  it('falls back to 90d default when env var is absent or malformed', async () => {
+    process.env.REVEALUI_LOG_RETENTION_DAYS = 'not-a-number';
+
+    const result = await cleanupOldLogs(asDbOpts());
+    expect(result.retentionDays).toBe(90);
+  });
+});


### PR DESCRIPTION
## Summary

Ships **CR8-P3-02 PR1** (of 2) — 90-day retention purge for `app_logs` and `error_events`.

Privacy policy at `apps/marketing/src/app/privacy/page.tsx:39,84` promises server logs are "retained only as long as necessary" with no concrete window. This is the enforcement: rows older than `REVEALUI_LOG_RETENTION_DAYS` (default **90**) are purged by the daily cron dispatcher.

Design decisions live in internal docs (founder-approved 2026-04-22, commit `80c2cfcd1`).

## What's in this PR

- **`packages/db/src/cleanup/log-retention.ts`** — new `cleanupOldLogs()` with `dryRun`, `retentionDays` override, per-table scoping, and `db` override for tests. Read env var with sane fallback to 90d; reject invalid overrides.
- **`packages/config/src/schema.ts`** — `REVEALUI_LOG_RETENTION_DAYS` env var (`z.coerce.number().int().min(1).max(3650).default(90)`).
- **`apps/api/src/routes/cron/cleanup.ts`** — wires `cleanupOldLogs()` into the existing daily cron after the saga + idempotency cleanup block. Non-fatal: errors logged but do not fail the cron run.
- **Schema docstrings** — `app-logs.ts` and `error-events.ts` updated to document the retention window. Also removes an **aspirational, false** `Supplemented by Axiom log drain for full log search` comment from `error-events.ts` — verified zero Axiom configuration in the repo on 2026-04-22 (no `AXIOM` / `@axiomhq` / log-drain refs anywhere in `apps/`, `packages/`, or `vercel.json` files).
- **Integration tests** — `packages/test/src/integration/database/log-retention.integration.test.ts`, 8 PGlite-backed tests covering:
  1. `app_logs` deletion past cutoff
  2. `error_events` deletion past cutoff
  3. Dry-run counts without mutating
  4. `retentionDays` override
  5. `REVEALUI_LOG_RETENTION_DAYS` env var fallback
  6. Per-table `tables` scoping
  7. Invalid override rejection (0, negative, non-integer)
  8. Env var malformed → 90d default

## Out of scope

- **`audit_log`** — stays indefinite (decision D1 in the design doc). It has a tamper-evident hash chain (`signature` / `previousSignature`) and the schema explicitly asserts "no DELETE ever." Purging breaks the chain. Simplest story for SOC 2 readiness; revisit only if table size becomes a problem.
- **`processed_webhook_events`, `jobs` (completed), `webhook_reconciliation`** — these are operational-hygiene purges that ship in **PR2** (separate PR, ~1 hr).
- **Privacy policy text update** — per founder decision, ships in a **separate docs commit** after this lands. Proposed text:
  > Application logs and error events are retained for 90 days. Agent activity audit logs are retained indefinitely for security and compliance purposes.

## Verification

- `pnpm turbo build --filter @revealui/db` green (after building transitive deps)
- `pnpm turbo typecheck --filter api --filter @revealui/db --filter @revealui/config` green (16/16)
- `pnpm exec vitest run --config vitest.integration.config.ts src/integration/database/log-retention.integration.test.ts` — **8/8 pass in 3.14s**
- `pnpm gate:quick` — all phases green locally after Biome fix

## Test plan

- [ ] CI green on this PR (build, unit, integration now running on PRs per [revealui#493](https://github.com/RevealUIStudio/revealui/pull/493)).
- [ ] After merge: open PR2 (operational-hygiene retention) off `test`.
- [ ] After merge: separate docs commit updating `apps/marketing/src/app/privacy/page.tsx` and (optionally) `docs/security/INFORMATION_SECURITY_POLICY.md` with the concrete 90d window.
- [ ] After both merge: flip `CR8-P3-02` checkbox `[ ] → [x]` in internal docs with commit citation.

## Memory alignment

- `feedback_honest_audit_playbook.md` — design doc in internal docs (`cr8-p3-02-retention-design.md`), sanitized public-facing implementation here, CI-wired via cron. Removing the false Axiom comment is the "no leaked findings" discipline.
- `feedback_durable_only.md` — no tactical shortcuts; env var has bounds validation; retention window is concrete and enforceable, not "typically 90 days."
- `feedback_no_auto_merge.md` — manual merge only on green + clean.
