### PR TITLE
feat(admin): MCP OAuth connect flow (Stage 2 PR-2.2)

### DIFF
--- a/.changeset/mcp-2-2-admin-oauth-ui.md
+++ b/.changeset/mcp-2-2-admin-oauth-ui.md
@@ -1,0 +1,20 @@
+---
+'admin': minor
+---
+
+Add the admin-side OAuth 2.1 connect flow for remote MCP servers — Stage 2
+PR-2.2 of the MCP v1 plan. Pairs with the client-side provider shipped in
+PR-2.1 (#494).
+
+- `GET /api/mcp/oauth/initiate` — runs SDK discovery + Dynamic Client
+  Registration + PKCE against the target server, stores a pending record in
+  revvault keyed by the authorization state, and 302-redirects to the
+  authorization URL.
+- `GET /api/mcp/oauth/callback` — finalizes the flow: looks up the pending
+  record, validates session + TTL (10 min) + one-shot consumption, exchanges
+  the code for tokens, and redirects back to `/admin/mcp/connect` with a
+  `connected=` or `error=` indicator.
+- `/admin/mcp/connect` — minimal generic form (tenant, server, serverUrl).
+  No per-server branding; polished per-server UX lands with RevMarket (v1.1).
+- `@revealui/mcp` added as a regular dependency of `admin` (previously only
+  a peer); OAuth routes import from `@revealui/mcp/oauth`.

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,6 +11,7 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/mcp": "workspace:*",
     "@revealui/paywall": "workspace:*",
     "@revealui/presentation": "workspace:*",
     "@revealui/setup": "workspace:*",

--- a/apps/admin/src/app/(backend)/admin/mcp/connect/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/connect/page.tsx
@@ -1,0 +1,172 @@
+/**
+ * MCP — Connect Server (/admin/mcp/connect)
+ *
+ * Minimal admin UI for initiating an OAuth 2.1 flow against a remote MCP
+ * server. Submits a GET to `/api/mcp/oauth/initiate`, which runs discovery,
+ * Dynamic Client Registration, and PKCE, then 302-redirects the user to the
+ * authorization server. After consent, the user lands back here with either
+ * `?connected=<server>` or `?error=<reason>`.
+ *
+ * Generic flow per Stage 2 PR-2.2: no per-server branding. Polished per-server
+ * UX lands with RevMarket in v1.1. Token storage is handled by the API layer
+ * via the revvault-backed `McpOAuthProvider`.
+ */
+
+type SearchParamValue = string | string[] | undefined;
+
+function firstString(value: SearchParamValue): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+type PageSearchParams = Promise<Record<string, SearchParamValue>>;
+
+export default async function ConnectMcpServerPage({
+  searchParams,
+}: {
+  searchParams: PageSearchParams;
+}) {
+  const params = await searchParams;
+  const connected = firstString(params.connected);
+  const error = firstString(params.error);
+  const detail = firstString(params.detail);
+  const serverFromResult = firstString(params.server);
+
+  return (
+    <div className="min-h-screen">
+      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <h1 className="text-xl font-semibold text-white">Connect MCP Server</h1>
+        <p className="mt-0.5 text-sm text-zinc-400">
+          Authorize a remote Model Context Protocol server via OAuth 2.1
+        </p>
+      </div>
+
+      <div className="mx-auto max-w-2xl p-6">
+        {connected && (
+          <div
+            role="status"
+            className="mb-6 rounded-lg border border-emerald-800 bg-emerald-900/20 p-4 text-sm text-emerald-300"
+          >
+            Connected to <span className="font-mono font-semibold">{connected}</span>. Tokens are
+            stored in revvault under{' '}
+            <span className="font-mono">mcp/&lt;tenant&gt;/{connected}/tokens</span>.
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-6 rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-300"
+          >
+            <div className="font-semibold">
+              Authorization failed{serverFromResult ? ` for ${serverFromResult}` : ''}
+            </div>
+            <div className="mt-1 text-xs text-red-400">
+              <span className="font-mono">{error}</span>
+              {detail ? <span className="ml-2 text-red-500">— {detail}</span> : null}
+            </div>
+          </div>
+        )}
+
+        <form
+          method="GET"
+          action="/api/mcp/oauth/initiate"
+          className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-6"
+        >
+          <div className="grid gap-4">
+            <div>
+              <label htmlFor="tenant" className="mb-1.5 block text-sm font-medium text-zinc-300">
+                Tenant
+              </label>
+              <input
+                id="tenant"
+                name="tenant"
+                type="text"
+                required
+                pattern="[A-Za-z0-9_-]{1,64}"
+                placeholder="acme"
+                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                Identifier under which tokens are scoped in revvault. Alphanumeric, underscore,
+                hyphen.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="server" className="mb-1.5 block text-sm font-medium text-zinc-300">
+                Server name
+              </label>
+              <input
+                id="server"
+                name="server"
+                type="text"
+                required
+                pattern="[A-Za-z0-9_-]{1,64}"
+                placeholder="linear"
+                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                Short identifier for this MCP server. Used as the revvault path segment.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="serverUrl" className="mb-1.5 block text-sm font-medium text-zinc-300">
+                Server URL
+              </label>
+              <input
+                id="serverUrl"
+                name="serverUrl"
+                type="url"
+                required
+                placeholder="https://mcp.example.com"
+                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                The MCP server&rsquo;s base URL. Must be HTTPS in production (localhost allowed for
+                dev).
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6 flex items-center gap-3">
+            <button
+              type="submit"
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-zinc-900"
+            >
+              Authorize
+            </button>
+            <span className="text-xs text-zinc-500">
+              You&rsquo;ll be redirected to the server&rsquo;s consent screen.
+            </span>
+          </div>
+        </form>
+
+        <div className="mt-8 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
+          <h3 className="text-sm font-medium text-zinc-300">How it works</h3>
+          <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs text-zinc-500">
+            <li>
+              The server discovers OAuth metadata via RFC 9728 / RFC 8414 well-known endpoints.
+            </li>
+            <li>
+              If the server supports Dynamic Client Registration (RFC 7591), a client is registered
+              on the fly.
+            </li>
+            <li>
+              A PKCE verifier is generated and stored, then you&rsquo;re redirected to the
+              authorization endpoint.
+            </li>
+            <li>
+              After consent, the callback exchanges the code for tokens and persists them in
+              revvault.
+            </li>
+            <li>
+              Refresh rotation is handled automatically by the MCP client on subsequent connections.
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/api/mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/oauth/__tests__/oauth-routes.test.ts
@@ -1,0 +1,421 @@
+/**
+ * MCP OAuth route tests (Stage 2 PR-2.2).
+ *
+ * Exercises the full initiate → callback round-trip end-to-end against a
+ * hermetic mock authorization server. The revvault-backed vault is swapped
+ * for a shared in-memory vault via `vi.mock` so we can:
+ *   - confirm the initiate handler stores a pending record keyed by state
+ *   - confirm the callback handler resolves + deletes that record
+ *   - confirm tokens land at `mcp/<tenant>/<server>/tokens` after the flow
+ */
+
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// -- Shared in-memory vault swapped in for the revvault-backed default --
+
+const vaultStore = new Map<string, string>();
+
+vi.mock('@revealui/mcp/oauth', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/mcp/oauth')>('@revealui/mcp/oauth');
+  const sharedVault = {
+    get: async (p: string): Promise<string | undefined> => vaultStore.get(p),
+    set: async (p: string, v: string): Promise<void> => {
+      vaultStore.set(p, v);
+    },
+    delete: async (p: string): Promise<void> => {
+      vaultStore.delete(p);
+    },
+  };
+  return {
+    ...actual,
+    createRevvaultVault: () => sharedVault,
+  };
+});
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+// -- Hermetic mock authorization server (same shape as packages/mcp tests) --
+
+type AuthCodeGrant = {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  state: string;
+};
+
+interface MockAsState {
+  clients: Map<string, { client_id: string; redirect_uris: string[] }>;
+  issuedCodes: Map<string, AuthCodeGrant>;
+  validRefreshTokens: Set<string>;
+  nextAccessToken: number;
+  nextRefreshToken: number;
+}
+
+type RunningAs = {
+  url: string;
+  state: MockAsState;
+  close(): Promise<void>;
+};
+
+const teardowns: Array<() => Promise<void>> = [];
+
+async function readBody(req: import('node:http').IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseForm(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(body)) out[k] = v;
+  return out;
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const { subtle } = await import('node:crypto');
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Buffer.from(digest)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+async function startMockAs(): Promise<RunningAs> {
+  const state: MockAsState = {
+    clients: new Map(),
+    issuedCodes: new Map(),
+    validRefreshTokens: new Set(),
+    nextAccessToken: 1,
+    nextRefreshToken: 1,
+  };
+
+  const server = createHttpServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    const baseUrl = `http://${req.headers.host}`;
+    const send = (status: number, body: unknown): void => {
+      res.statusCode = status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(body));
+    };
+
+    try {
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-protected-resource') {
+        return send(200, { resource: baseUrl, authorization_servers: [baseUrl] });
+      }
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-authorization-server') {
+        return send(200, {
+          issuer: baseUrl,
+          authorization_endpoint: `${baseUrl}/authorize`,
+          token_endpoint: `${baseUrl}/token`,
+          registration_endpoint: `${baseUrl}/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+          token_endpoint_auth_methods_supported: ['none'],
+        });
+      }
+      if (req.method === 'POST' && url.pathname === '/register') {
+        const body = await readBody(req);
+        const metadata = JSON.parse(body) as { redirect_uris: string[]; client_name?: string };
+        const clientId = `client-${state.clients.size + 1}`;
+        state.clients.set(clientId, {
+          client_id: clientId,
+          redirect_uris: metadata.redirect_uris,
+        });
+        return send(201, {
+          client_id: clientId,
+          client_id_issued_at: Math.floor(Date.now() / 1000),
+          ...metadata,
+        });
+      }
+      if (req.method === 'POST' && url.pathname === '/token') {
+        const form = parseForm(await readBody(req));
+        if (form.grant_type === 'authorization_code') {
+          const code = form.code ?? '';
+          const grant = state.issuedCodes.get(code);
+          if (!grant) return send(400, { error: 'invalid_grant' });
+          const expectedChallenge = await sha256Base64Url(form.code_verifier ?? '');
+          if (
+            grant.codeChallengeMethod !== 'S256' ||
+            expectedChallenge !== grant.codeChallenge ||
+            grant.clientId !== form.client_id
+          ) {
+            return send(400, { error: 'invalid_grant' });
+          }
+          state.issuedCodes.delete(code);
+          const access = `access-${state.nextAccessToken++}`;
+          const refresh = `refresh-${state.nextRefreshToken++}`;
+          state.validRefreshTokens.add(refresh);
+          return send(200, {
+            access_token: access,
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: refresh,
+          });
+        }
+        return send(400, { error: 'unsupported_grant_type' });
+      }
+      return send(404, { error: 'not_found' });
+    } catch (err) {
+      return send(500, { error: String(err) });
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  const close = () =>
+    new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  teardowns.push(close);
+  return { url, state, close };
+}
+
+function makeRequest(url: string): Request {
+  return new Request(url, { headers: { cookie: 'session=test' } });
+}
+
+// -- Tests ------------------------------------------------------------------
+
+beforeEach(() => {
+  vaultStore.clear();
+  mockGetSession.mockReset();
+});
+
+afterEach(async () => {
+  while (teardowns.length) {
+    const fn = teardowns.pop();
+    if (fn) await fn().catch(() => undefined);
+  }
+});
+
+describe('GET /api/mcp/oauth/initiate', () => {
+  it('returns 401 when the caller is not authenticated', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(
+      makeRequest(
+        'http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=linear&serverUrl=https://example.com',
+      ) as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin users', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'user' } });
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(
+      makeRequest(
+        'http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=linear&serverUrl=https://example.com',
+      ) as never,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when tenant/server/serverUrl are missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(makeRequest('http://admin.test/api/mcp/oauth/initiate') as never);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when tenant/server contain disallowed characters', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(
+      makeRequest(
+        'http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=../etc/passwd&serverUrl=https://example.com',
+      ) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when serverUrl is not https (except localhost)', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(
+      makeRequest(
+        'http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=linear&serverUrl=http://malicious.example.com',
+      ) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('runs discovery + DCR and redirects to the authorization URL', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    const as = await startMockAs();
+
+    const { GET } = await import('../initiate/route.js');
+    const res = await GET(
+      makeRequest(
+        `http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=linear&serverUrl=${encodeURIComponent(as.url)}`,
+      ) as never,
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location');
+    expect(location).toBeTruthy();
+    const loc = new URL(location as string);
+    expect(loc.origin).toBe(as.url);
+    expect(loc.pathname).toBe('/authorize');
+    expect(loc.searchParams.get('response_type')).toBe('code');
+    expect(loc.searchParams.get('code_challenge_method')).toBe('S256');
+    const state = loc.searchParams.get('state');
+    expect(state).toBeTruthy();
+
+    // Pending record landed in the shared in-memory vault under the expected key.
+    const raw = vaultStore.get(`mcp/oauth/pending/${state}`);
+    expect(raw).toBeTruthy();
+    const pending = JSON.parse(raw as string);
+    expect(pending.tenant).toBe('acme');
+    expect(pending.server).toBe('linear');
+    expect(pending.userId).toBe('admin-1');
+    expect(pending.serverUrl).toBe(`${as.url}/`);
+
+    // DCR ran against the mock AS.
+    expect(as.state.clients.size).toBe(1);
+  });
+});
+
+describe('GET /api/mcp/oauth/callback', () => {
+  it('redirects to /admin/mcp/connect?error=invalid_or_expired_state when state is unknown', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    const { GET } = await import('../callback/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/oauth/callback?code=abc&state=unknown') as never,
+    );
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location') as string);
+    expect(location.pathname).toBe('/admin/mcp/connect');
+    expect(location.searchParams.get('error')).toBe('invalid_or_expired_state');
+  });
+
+  it('rejects when the session user does not match the pending record', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'eve', role: 'admin' } });
+    vaultStore.set(
+      'mcp/oauth/pending/state-xyz',
+      JSON.stringify({
+        tenant: 'acme',
+        server: 'linear',
+        serverUrl: 'http://127.0.0.1/',
+        userId: 'admin-1',
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    const { GET } = await import('../callback/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/oauth/callback?code=abc&state=state-xyz') as never,
+    );
+    const location = new URL(res.headers.get('location') as string);
+    expect(location.searchParams.get('error')).toBe('session_mismatch');
+    // Pending record is consumed one-shot regardless of outcome.
+    expect(vaultStore.get('mcp/oauth/pending/state-xyz')).toBeUndefined();
+  });
+
+  it('rejects when the pending record is older than the TTL', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    const createdAt = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    vaultStore.set(
+      'mcp/oauth/pending/state-old',
+      JSON.stringify({
+        tenant: 'acme',
+        server: 'linear',
+        serverUrl: 'http://127.0.0.1/',
+        userId: 'admin-1',
+        createdAt,
+      }),
+    );
+    const { GET } = await import('../callback/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/oauth/callback?code=abc&state=state-old') as never,
+    );
+    const location = new URL(res.headers.get('location') as string);
+    expect(location.searchParams.get('error')).toBe('pending_expired');
+  });
+
+  it('propagates AS errors into the result page', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    vaultStore.set(
+      'mcp/oauth/pending/state-err',
+      JSON.stringify({
+        tenant: 'acme',
+        server: 'linear',
+        serverUrl: 'http://127.0.0.1/',
+        userId: 'admin-1',
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    const { GET } = await import('../callback/route.js');
+    const res = await GET(
+      makeRequest(
+        'http://admin.test/api/mcp/oauth/callback?state=state-err&error=access_denied',
+      ) as never,
+    );
+    const location = new URL(res.headers.get('location') as string);
+    expect(location.searchParams.get('error')).toBe('access_denied');
+    expect(location.searchParams.get('server')).toBe('linear');
+  });
+
+  it('full round-trip: initiate then callback lands tokens in the vault', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    const as = await startMockAs();
+
+    // 1. Initiate — runs DCR + builds authorization URL + writes pending record.
+    const { GET: initiateGET } = await import('../initiate/route.js');
+    const initRes = await initiateGET(
+      makeRequest(
+        `http://admin.test/api/mcp/oauth/initiate?tenant=acme&server=linear&serverUrl=${encodeURIComponent(as.url)}`,
+      ) as never,
+    );
+    expect(initRes.status).toBe(302);
+    const authUrl = new URL(initRes.headers.get('location') as string);
+    const state = authUrl.searchParams.get('state') as string;
+    const codeChallenge = authUrl.searchParams.get('code_challenge') as string;
+    const clientId = authUrl.searchParams.get('client_id') as string;
+    const redirectUri = authUrl.searchParams.get('redirect_uri') as string;
+
+    // 2. Simulate the AS issuing an authorization code after user consent.
+    const authCode = 'auth-code-12345';
+    as.state.issuedCodes.set(authCode, {
+      code: authCode,
+      clientId,
+      redirectUri,
+      codeChallenge,
+      codeChallengeMethod: 'S256',
+      state,
+    });
+
+    // 3. Callback — exchanges code for tokens, clears pending record, 302 to result page.
+    const { GET: callbackGET } = await import('../callback/route.js');
+    const cbRes = await callbackGET(
+      makeRequest(
+        `http://admin.test/api/mcp/oauth/callback?code=${authCode}&state=${state}`,
+      ) as never,
+    );
+    expect(cbRes.status).toBe(302);
+    const result = new URL(cbRes.headers.get('location') as string);
+    expect(result.pathname).toBe('/admin/mcp/connect');
+    expect(result.searchParams.get('connected')).toBe('linear');
+
+    // Tokens landed under the documented layout.
+    const tokensRaw = vaultStore.get('mcp/acme/linear/tokens');
+    expect(tokensRaw).toBeTruthy();
+    const tokens = JSON.parse(tokensRaw as string);
+    expect(tokens.access_token).toMatch(/^access-/);
+    expect(tokens.refresh_token).toMatch(/^refresh-/);
+
+    // Pending record deleted (one-shot).
+    expect(vaultStore.get(`mcp/oauth/pending/${state}`)).toBeUndefined();
+  });
+});

--- a/apps/admin/src/app/api/mcp/oauth/callback/route.ts
+++ b/apps/admin/src/app/api/mcp/oauth/callback/route.ts
@@ -1,0 +1,152 @@
+/**
+ * MCP OAuth callback — GET /api/mcp/oauth/callback
+ *
+ * Finalizes an OAuth 2.1 flow started by `../initiate/route.ts`. The
+ * authorization server redirects the user here with `?code=...&state=...` (or
+ * `?error=...` on rejection). We resolve the pending record in revvault by
+ * state, rebuild the `McpOAuthProvider` with the same (tenant, server) pair,
+ * and run the token exchange via the SDK's `auth()` helper. Tokens land in
+ * `mcp/<tenant>/<server>/tokens` via the provider's `saveTokens`.
+ *
+ * On success: 302 to `/admin/mcp/connect?connected=<server>`.
+ * On error:   302 to `/admin/mcp/connect?error=<reason>&server=<server>`.
+ *
+ * Stage 2 PR-2.2 of the MCP v1 plan.
+ */
+
+import { auth } from '@modelcontextprotocol/sdk/client/auth.js';
+import { getSession } from '@revealui/auth/server';
+import {
+  createRevvaultVault,
+  McpOAuthProvider,
+  type OAuthClientMetadata,
+} from '@revealui/mcp/oauth';
+import { type NextRequest, NextResponse } from 'next/server';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const PENDING_PATH_PREFIX = 'mcp/oauth/pending';
+const RESULT_PAGE = '/admin/mcp/connect';
+/** Reject pending records older than this — authorization code TTL is ~minutes per OAuth 2.1 §4.1.2. */
+const PENDING_MAX_AGE_MS = 10 * 60 * 1000;
+
+interface PendingRecord {
+  tenant: string;
+  server: string;
+  serverUrl: string;
+  userId: string;
+  createdAt: string;
+}
+
+function resultUrl(origin: string, params: Record<string, string>): string {
+  const url = new URL(RESULT_PAGE, origin);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return url.toString();
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const requestUrl = new URL(request.url);
+  const params = requestUrl.searchParams;
+  const origin = requestUrl.origin;
+  const state = params.get('state');
+  const code = params.get('code');
+  const asError = params.get('error');
+
+  if (!state) {
+    return NextResponse.redirect(resultUrl(origin, { error: 'missing_state' }), 302);
+  }
+
+  const vault = createRevvaultVault();
+  const pendingPath = `${PENDING_PATH_PREFIX}/${state}`;
+
+  const raw = await vault.get(pendingPath);
+  if (!raw) {
+    return NextResponse.redirect(resultUrl(origin, { error: 'invalid_or_expired_state' }), 302);
+  }
+
+  // One-shot: always delete the pending record, whether this call succeeds or
+  // fails. Prevents replay and keeps the store from filling with orphans.
+  await vault.delete(pendingPath).catch(() => undefined);
+
+  let pending: PendingRecord;
+  try {
+    pending = JSON.parse(raw) as PendingRecord;
+  } catch {
+    return NextResponse.redirect(resultUrl(origin, { error: 'corrupted_pending_record' }), 302);
+  }
+
+  if (pending.userId !== authSession.user.id) {
+    return NextResponse.redirect(resultUrl(origin, { error: 'session_mismatch' }), 302);
+  }
+
+  const age = Date.now() - Date.parse(pending.createdAt);
+  if (!Number.isFinite(age) || age > PENDING_MAX_AGE_MS) {
+    return NextResponse.redirect(resultUrl(origin, { error: 'pending_expired' }), 302);
+  }
+
+  if (asError) {
+    return NextResponse.redirect(
+      resultUrl(origin, { error: asError, server: pending.server }),
+      302,
+    );
+  }
+  if (!code) {
+    return NextResponse.redirect(
+      resultUrl(origin, { error: 'missing_code', server: pending.server }),
+      302,
+    );
+  }
+
+  const callbackUrl = new URL('/api/mcp/oauth/callback', origin).toString();
+  const clientMetadata: OAuthClientMetadata = {
+    redirect_uris: [callbackUrl],
+    client_name: 'RevealUI Admin',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+
+  const provider = new McpOAuthProvider({
+    tenant: pending.tenant,
+    server: pending.server,
+    vault,
+    redirectUrl: callbackUrl,
+    clientMetadata,
+    state: () => state,
+  });
+
+  try {
+    const result = await auth(provider, {
+      serverUrl: pending.serverUrl,
+      authorizationCode: code,
+    });
+    if (result !== 'AUTHORIZED') {
+      return NextResponse.redirect(
+        resultUrl(origin, {
+          error: 'token_exchange_incomplete',
+          server: pending.server,
+          detail: String(result),
+        }),
+        302,
+      );
+    }
+  } catch (err) {
+    return NextResponse.redirect(
+      resultUrl(origin, {
+        error: 'token_exchange_failed',
+        server: pending.server,
+        detail: (err as Error).message.slice(0, 200),
+      }),
+      302,
+    );
+  }
+
+  return NextResponse.redirect(resultUrl(origin, { connected: pending.server }), 302);
+}

--- a/apps/admin/src/app/api/mcp/oauth/initiate/route.ts
+++ b/apps/admin/src/app/api/mcp/oauth/initiate/route.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP OAuth initiate — GET /api/mcp/oauth/initiate
+ *
+ * Kicks off the OAuth 2.1 authorization flow for a remote MCP server.
+ * Runs SDK discovery + DCR + PKCE against the target server via
+ * `McpOAuthProvider`, stores a pending-flow record in revvault keyed by the
+ * authorization state, and 302-redirects the user to the authorization URL.
+ *
+ * Query params:
+ *   tenant    — tenant identifier (first revvault path segment)
+ *   server    — server identifier (second segment; e.g. `linear`, `notion`)
+ *   serverUrl — the MCP server's base URL (e.g. `https://mcp.linear.app`)
+ *
+ * On return from the authorization server, the user lands at
+ * `/api/mcp/oauth/callback` (see `../callback/route.ts`), which finalizes the
+ * token exchange.
+ *
+ * Stage 2 PR-2.2 of the MCP v1 plan. See
+ * `.jv/docs/mcp-productionization-scope.md`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { auth } from '@modelcontextprotocol/sdk/client/auth.js';
+import { getSession } from '@revealui/auth/server';
+import {
+  createRevvaultVault,
+  McpOAuthProvider,
+  type OAuthClientMetadata,
+} from '@revealui/mcp/oauth';
+import { type NextRequest, NextResponse } from 'next/server';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const PENDING_PATH_PREFIX = 'mcp/oauth/pending';
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+interface PendingRecord {
+  tenant: string;
+  server: string;
+  serverUrl: string;
+  userId: string;
+  createdAt: string;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const requestUrl = new URL(request.url);
+  const params = requestUrl.searchParams;
+  const tenant = params.get('tenant');
+  const server = params.get('server');
+  const serverUrlRaw = params.get('serverUrl');
+
+  if (!(tenant && server && serverUrlRaw)) {
+    return NextResponse.json(
+      { error: 'tenant, server, and serverUrl query parameters are required' },
+      { status: 400 },
+    );
+  }
+  if (!(IDENTIFIER_RE.test(tenant) && IDENTIFIER_RE.test(server))) {
+    return NextResponse.json(
+      { error: 'tenant and server must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let serverUrl: URL;
+  try {
+    serverUrl = new URL(serverUrlRaw);
+  } catch {
+    return NextResponse.json({ error: 'serverUrl is not a valid URL' }, { status: 400 });
+  }
+  if (
+    serverUrl.protocol !== 'https:' &&
+    serverUrl.hostname !== 'localhost' &&
+    serverUrl.hostname !== '127.0.0.1'
+  ) {
+    return NextResponse.json(
+      { error: 'serverUrl must use https: (localhost allowed for development)' },
+      { status: 400 },
+    );
+  }
+
+  const callbackUrl = new URL('/api/mcp/oauth/callback', requestUrl.origin).toString();
+  const state = randomUUID();
+
+  const vault = createRevvaultVault();
+
+  const pending: PendingRecord = {
+    tenant,
+    server,
+    serverUrl: serverUrl.toString(),
+    userId: authSession.user.id,
+    createdAt: new Date().toISOString(),
+  };
+  await vault.set(`${PENDING_PATH_PREFIX}/${state}`, JSON.stringify(pending));
+
+  const clientMetadata: OAuthClientMetadata = {
+    redirect_uris: [callbackUrl],
+    client_name: 'RevealUI Admin',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+
+  const provider = new McpOAuthProvider({
+    tenant,
+    server,
+    vault,
+    redirectUrl: callbackUrl,
+    clientMetadata,
+    state: () => state,
+  });
+
+  const result = await auth(provider, { serverUrl });
+
+  if (result !== 'REDIRECT' || !provider.lastAuthorizationUrl) {
+    await vault.delete(`${PENDING_PATH_PREFIX}/${state}`).catch(() => undefined);
+    return NextResponse.json(
+      {
+        error: 'OAuth flow did not produce a redirect',
+        detail: `auth() returned ${result}; lastAuthorizationUrl is ${
+          provider.lastAuthorizationUrl ? 'set' : 'unset'
+        }`,
+      },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.redirect(provider.lastAuthorizationUrl.toString(), 302);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@revealui/mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
       '@revealui/paywall':
         specifier: workspace:*
         version: link:../../packages/paywall


### PR DESCRIPTION
## Summary

Stage 2 PR-2.2 of the MCP v1 productionization plan — the admin-side OAuth 2.1 flow for remote MCP servers. Pairs with the client provider shipped in [PR-2.1 (#494)](https://github.com/RevealUIStudio/revealui/pull/494) to close Stage 2.

### What ships

- **`GET /api/mcp/oauth/initiate`** — runs SDK discovery + Dynamic Client Registration + PKCE against the target server via `McpOAuthProvider`, stores a pending-flow record in revvault keyed by the authorization state, and 302-redirects to the authorization URL.
- **`GET /api/mcp/oauth/callback`** — finalizes the flow. Resolves the pending record, validates session + TTL (10 min) + one-shot consumption, exchanges the code for tokens (SDK's `auth()` with `authorizationCode`), and 302-redirects to `/admin/mcp/connect` with `connected=<server>` or `error=<reason>`.
- **`/admin/mcp/connect`** — minimal generic server component form (tenant, server, serverUrl inputs). No per-server branding; polished UX lands with RevMarket (v1.1) per the scope doc.
- **`@revealui/mcp`** now a regular (non-peer) dependency of the admin app; OAuth routes import from `@revealui/mcp/oauth`.

### State/security model

- Pending records land at `mcp/oauth/pending/<state-uuid>` in revvault. `state` is a `crypto.randomUUID()` injected into the provider via `state: () => ...`, echoed back by the AS on callback.
- **One-shot consumption** — the pending record is deleted on every callback, pass or fail. Prevents replay and keeps the store tidy.
- **Session binding** — callback verifies `pending.userId === authSession.user.id`. CSRF-safe without a separate signing key because state is unguessable AND must match a valid revvault record AND session must match.
- **TTL** — pending records older than 10 min are rejected (OAuth 2.1 §4.1.2 authorization-code TTL envelope).
- **Input validation** — `tenant` and `server` must match `/^[A-Za-z0-9_-]{1,64}$/`; `serverUrl` must be HTTPS (localhost/127.0.0.1 allowed for dev).

### Test coverage

9 new route tests (admin: 1523 → 1532 passing / 10 skipped). Hermetic mock authorization server on an ephemeral port covers:

- 401 / 403 auth gating
- 400 on missing/invalid params
- 400 on path-traversal-shaped identifiers
- 400 on non-HTTPS `serverUrl`
- Full initiate flow: discovery + DCR runs, pending record lands in revvault, 302 points at authorization URL with PKCE + state + client_id
- Callback: invalid state → error redirect; session-mismatch → error + pending consumed; expired pending → error; AS error propagation
- **Full round-trip**: initiate → simulate consent → callback exchanges code → tokens land at `mcp/<tenant>/<server>/tokens`, pending record deleted

### Stage 2 closure

With this PR merged, Stage 2 (OAuth 2.1 for remote MCP servers) is complete:
- PR-2.1: client-side provider + transport wiring + revvault credential storage
- PR-2.2: admin-side initiate/callback UX

Next logical piece is Stage 3 (Admin UI surface — 4 PRs: server catalog, tool browser, resource/prompt pickers, elicitation forms).

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally (Biome, audits, boundary, claim-drift, raw-SQL, empty-catch, security, coverage — all ✓)
- [ ] `pnpm --filter admin test` — 1532 passing / 10 skipped
- [ ] `pnpm --filter admin typecheck` — clean
- [ ] `pnpm --filter admin... build` — clean

## Notes

- The vault is the revvault-backed default. Tests swap it via `vi.mock` for a shared in-memory vault so assertions can inspect written records without a revvault binary on the CI host.
- The mock AS pattern (ephemeral `http.createServer`) mirrors the one used in `packages/mcp/__tests__/oauth-integration.test.ts` from PR-2.1.
- No admin-sidebar link yet — the page is reachable by URL for now. A catalog entry lands with Stage 3.1 (server catalog).
