### PR TITLE
feat(mcp): server catalog + disconnect (Stage 3.1)

### DIFF
--- a/.changeset/mcp-3-1-server-catalog.md
+++ b/.changeset/mcp-3-1-server-catalog.md
@@ -1,0 +1,27 @@
+---
+'@revealui/mcp': minor
+'admin': minor
+---
+
+Stage 3.1 of the MCP v1 plan — admin-side server catalog for OAuth-authorized
+remote servers plus a disconnect action.
+
+**`@revealui/mcp`:**
+- `Vault.list(prefix)` on the core interface. Returns every path under
+  `prefix`. `createRevvaultVault()` shells out to `revvault list <prefix>`
+  and parses line-oriented output; `createMemoryVault()` implements the
+  same semantics over its `Map`. Enables catalog tooling to enumerate
+  configured servers without an out-of-band registry.
+
+**admin:**
+- `GET /api/mcp/remote-servers?tenant=X` — enumerates OAuth-authorized
+  servers for a tenant by walking `mcp/<tenant>/<server>/tokens`. Returns
+  `{ tenant, server, connectionState: 'connected' }[]`. Reserved tenant
+  segments (e.g. `oauth`) are rejected.
+- `POST /api/mcp/remote-servers/[server]/disconnect` — revokes every
+  credential path for `(tenant, server)` via
+  `McpOAuthProvider.invalidateCredentials('all')`. Idempotent.
+- `/admin/mcp` — server catalog page. Lists built-in servers (shared
+  endpoint with `/admin/agents` MCP tab) plus remote servers for the
+  entered tenant, with disconnect action and a "Connect new server"
+  link to the existing `/admin/mcp/connect` flow.

--- a/apps/admin/src/app/(backend)/admin/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/page.tsx
@@ -1,0 +1,244 @@
+/**
+ * MCP — Server Catalog (/admin/mcp)
+ *
+ * Stage 3.1 of the MCP v1 plan. Lists both built-in MCP servers (driven by
+ * `/api/mcp/servers`, the existing endpoint shared with the `/admin/agents`
+ * MCP tab) and OAuth-authorized remote servers for the active tenant
+ * (driven by the new `/api/mcp/remote-servers?tenant=X`).
+ *
+ * Scope is intentionally thin: list, connect (link to `/admin/mcp/connect`),
+ * disconnect. Tool/resource/prompt browsing lands in Stage 3.2–3.4.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
+
+interface RemoteServerSummary {
+  tenant: string;
+  server: string;
+  connectionState: 'connected';
+}
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+export default function McpCatalogPage() {
+  const [tenant, setTenant] = useState<string>('');
+  const [activeTenant, setActiveTenant] = useState<string | null>(null);
+  const [builtins, setBuiltins] = useState<McpServerInfo[]>([]);
+  const [remotes, setRemotes] = useState<RemoteServerSummary[]>([]);
+  const [state, setState] = useState<LoadState>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Load built-in servers on mount (tenant-agnostic).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/mcp/servers', { credentials: 'include' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { servers: McpServerInfo[] };
+        if (!cancelled) setBuiltins(data.servers ?? []);
+      } catch (err) {
+        if (!cancelled) setMessage(`Failed to load built-in servers: ${(err as Error).message}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadRemotes = useCallback(async (tenantId: string) => {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/mcp/remote-servers?tenant=${encodeURIComponent(tenantId)}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }; // empty-catch-ok: non-JSON error body — res.status is surfaced below
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as { servers: RemoteServerSummary[] };
+      setRemotes(data.servers ?? []);
+      setState('ready');
+    } catch (err) {
+      setState('error');
+      setMessage(`Failed to load remote servers: ${(err as Error).message}`);
+    }
+  }, []);
+
+  const handleLoadTenant = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = tenant.trim();
+    if (!trimmed) return;
+    setActiveTenant(trimmed);
+    void loadRemotes(trimmed);
+  };
+
+  const handleDisconnect = async (server: string) => {
+    if (!activeTenant) return;
+    if (
+      !confirm(`Revoke OAuth credentials for ${activeTenant}/${server}? This cannot be undone.`)
+    ) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/mcp/remote-servers/${encodeURIComponent(server)}/disconnect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tenant: activeTenant }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }; // empty-catch-ok: non-JSON error body — res.status is surfaced below
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setMessage(`Disconnected ${activeTenant}/${server}.`);
+      await loadRemotes(activeTenant);
+    } catch (err) {
+      setMessage(`Disconnect failed: ${(err as Error).message}`);
+    }
+  };
+
+  return (
+    <div className="min-h-screen">
+      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-white">MCP Server Catalog</h1>
+            <p className="mt-0.5 text-sm text-zinc-400">
+              Built-in servers and OAuth-authorized remote servers per tenant
+            </p>
+          </div>
+          <a
+            href="/admin/mcp/connect"
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Connect new server
+          </a>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl p-6">
+        {message && (
+          <div
+            role="status"
+            className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300"
+          >
+            {message}
+          </div>
+        )}
+
+        {/* Tenant scope selector */}
+        <form
+          onSubmit={handleLoadTenant}
+          className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+        >
+          <label htmlFor="tenant-input" className="mb-1.5 block text-sm font-medium text-zinc-300">
+            Tenant
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              id="tenant-input"
+              name="tenant"
+              type="text"
+              value={tenant}
+              onChange={(e) => setTenant(e.target.value)}
+              pattern="[A-Za-z0-9_-]{1,64}"
+              placeholder="acme"
+              className="w-64 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+            <button
+              type="submit"
+              disabled={!tenant.trim() || state === 'loading'}
+              className="rounded-md bg-zinc-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {state === 'loading' ? 'Loading…' : 'Load'}
+            </button>
+            {activeTenant && state === 'ready' && (
+              <span className="text-xs text-zinc-500">
+                Showing remote servers for{' '}
+                <span className="font-mono text-zinc-400">{activeTenant}</span>
+              </span>
+            )}
+          </div>
+        </form>
+
+        {/* Remote servers (per tenant) */}
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-medium text-white">
+            Remote servers{' '}
+            <span className="text-sm font-normal text-zinc-500">
+              {activeTenant ? `(${activeTenant})` : '(select a tenant)'}
+            </span>
+          </h2>
+          {activeTenant && state === 'ready' && remotes.length === 0 && (
+            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+              No remote servers connected for{' '}
+              <span className="font-mono text-zinc-400">{activeTenant}</span>. Click{' '}
+              <span className="font-medium text-zinc-300">Connect new server</span> to authorize
+              one.
+            </div>
+          )}
+          {remotes.length > 0 && (
+            <div className="overflow-hidden rounded-lg border border-zinc-800">
+              <table className="w-full text-sm">
+                <thead className="bg-zinc-900/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Server</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Tenant</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">State</th>
+                    <th className="px-4 py-3 text-right font-medium text-zinc-400">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {remotes.map((r) => (
+                    <tr key={`${r.tenant}/${r.server}`} className="border-t border-zinc-800/50">
+                      <td className="px-4 py-3 font-mono text-zinc-300">{r.server}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-zinc-500">{r.tenant}</td>
+                      <td className="px-4 py-3">
+                        <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                          {r.connectionState}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => void handleDisconnect(r.server)}
+                          className="text-xs font-medium text-red-400 hover:text-red-300"
+                        >
+                          Disconnect
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {/* Built-in servers (tenant-agnostic) */}
+        <section>
+          <h2 className="mb-3 text-lg font-medium text-white">
+            Built-in servers{' '}
+            <span className="text-sm font-normal text-zinc-500">({builtins.length})</span>
+          </h2>
+          {builtins.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+              Loading built-in servers…
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {builtins.map((server) => (
+                <McpServerCard key={server.id} server={server} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/api/mcp/oauth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/oauth/__tests__/oauth-routes.test.ts
@@ -27,6 +27,8 @@ vi.mock('@revealui/mcp/oauth', async () => {
     delete: async (p: string): Promise<void> => {
       vaultStore.delete(p);
     },
+    list: async (prefix: string): Promise<string[]> =>
+      Array.from(vaultStore.keys()).filter((k) => k.startsWith(prefix)),
   };
   return {
     ...actual,

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/disconnect/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/disconnect/route.ts
@@ -1,0 +1,81 @@
+/**
+ * MCP server disconnect — POST /api/mcp/remote-servers/[server]/disconnect
+ *
+ * Revokes the OAuth credentials stored for `(tenant, server)` by delegating
+ * to `McpOAuthProvider.invalidateCredentials('all')`. Removes tokens, client
+ * registration, PKCE verifier, and cached discovery state. Idempotent —
+ * calling on an already-disconnected server is a no-op.
+ *
+ * Body: `{ "tenant": "<tenant-id>" }`
+ *
+ * Stage 3.1 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import {
+  createRevvaultVault,
+  McpOAuthProvider,
+  type OAuthClientMetadata,
+} from '@revealui/mcp/oauth';
+import { type NextRequest, NextResponse } from 'next/server';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+// Placeholder metadata — only needed to satisfy the provider constructor;
+// `invalidateCredentials` does not depend on it.
+const SENTINEL_CLIENT_METADATA: OAuthClientMetadata = {
+  redirect_uris: ['http://localhost/unused'],
+  client_name: 'RevealUI Admin (disconnect)',
+  grant_types: ['authorization_code'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+};
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ disconnected: true } | { error: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  if (!(server && IDENTIFIER_RE.test(server))) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let body: { tenant?: unknown };
+  try {
+    body = (await request.json()) as { tenant?: unknown };
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+  const tenant = body.tenant;
+  if (typeof tenant !== 'string' || !IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'tenant must be a string matching /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  const vault = createRevvaultVault();
+  const provider = new McpOAuthProvider({
+    tenant,
+    server,
+    vault,
+    redirectUrl: 'http://localhost/unused',
+    clientMetadata: SENTINEL_CLIENT_METADATA,
+  });
+
+  await provider.invalidateCredentials('all');
+
+  return NextResponse.json({ disconnected: true });
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/__tests__/remote-servers-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/__tests__/remote-servers-routes.test.ts
@@ -1,0 +1,255 @@
+/**
+ * MCP remote-server catalog route tests (Stage 3.1).
+ *
+ * Exercises:
+ *   - GET /api/mcp/remote-servers?tenant=X — enumerates OAuth-authorized
+ *     remote servers by walking `mcp/<tenant>/<server>/tokens` in the vault.
+ *   - POST /api/mcp/remote-servers/[server]/disconnect — revokes every
+ *     credential path for `(tenant, server)`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const vaultStore = new Map<string, string>();
+
+vi.mock('@revealui/mcp/oauth', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/mcp/oauth')>('@revealui/mcp/oauth');
+  const sharedVault = {
+    get: async (p: string): Promise<string | undefined> => vaultStore.get(p),
+    set: async (p: string, v: string): Promise<void> => {
+      vaultStore.set(p, v);
+    },
+    delete: async (p: string): Promise<void> => {
+      vaultStore.delete(p);
+    },
+    list: async (prefix: string): Promise<string[]> =>
+      Array.from(vaultStore.keys()).filter((k) => k.startsWith(prefix)),
+  };
+  return {
+    ...actual,
+    createRevvaultVault: () => sharedVault,
+  };
+});
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(url, {
+    headers: { cookie: 'session=test' },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  vaultStore.clear();
+  mockGetSession.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/mcp/remote-servers?tenant=X
+// ---------------------------------------------------------------------------
+
+describe('GET /api/mcp/remote-servers', () => {
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=acme') as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin sessions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'user' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=acme') as never,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when tenant query param is missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(makeRequest('http://admin.test/api/mcp/remote-servers') as never);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 on malformed tenant ids', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=../etc') as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when tenant is a reserved segment (oauth)', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=oauth') as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns an empty list when the tenant has no servers', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=acme') as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { servers: unknown[] };
+    expect(body.servers).toEqual([]);
+  });
+
+  it('lists servers whose tokens path exists under the tenant prefix', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    vaultStore.set('mcp/acme/linear/tokens', '{"access_token":"at"}');
+    vaultStore.set('mcp/acme/linear/client', '{"client_id":"cid"}');
+    vaultStore.set('mcp/acme/notion/tokens', '{"access_token":"at"}');
+    // Different tenant — should NOT surface under acme.
+    vaultStore.set('mcp/other/stripe/tokens', '{"access_token":"at"}');
+    // Unrelated pending record — should NOT be listed.
+    vaultStore.set('mcp/oauth/pending/some-state', '{}');
+
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=acme') as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      servers: Array<{ tenant: string; server: string; connectionState: string }>;
+    };
+    expect(body.servers).toEqual([
+      { tenant: 'acme', server: 'linear', connectionState: 'connected' },
+      { tenant: 'acme', server: 'notion', connectionState: 'connected' },
+    ]);
+  });
+
+  it('ignores malformed server identifiers', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    vaultStore.set('mcp/acme/linear/tokens', '{"access_token":"at"}');
+    // Adversarial — `..` should fail the IDENTIFIER_RE check
+    vaultStore.set('mcp/acme/../oops/tokens', '{}');
+
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers?tenant=acme') as never,
+    );
+    const body = (await res.json()) as {
+      servers: Array<{ server: string }>;
+    };
+    expect(body.servers.map((s) => s.server)).toEqual(['linear']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/mcp/remote-servers/[server]/disconnect
+// ---------------------------------------------------------------------------
+
+describe('POST /api/mcp/remote-servers/[server]/disconnect', () => {
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin sessions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'user' } });
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when the server path segment is malformed', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/bad..one/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'bad..one' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body tenant is missing or malformed', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: '../bad' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes every credential path for (tenant, server)', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    vaultStore.set('mcp/acme/linear/tokens', '{"access_token":"at"}');
+    vaultStore.set('mcp/acme/linear/client', '{"client_id":"cid"}');
+    vaultStore.set('mcp/acme/linear/verifier', 'verifier-123');
+    vaultStore.set('mcp/acme/linear/discovery', '{}');
+    // Sibling server — MUST be preserved.
+    vaultStore.set('mcp/acme/notion/tokens', '{"access_token":"at"}');
+
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+
+    expect(vaultStore.has('mcp/acme/linear/tokens')).toBe(false);
+    expect(vaultStore.has('mcp/acme/linear/client')).toBe(false);
+    expect(vaultStore.has('mcp/acme/linear/verifier')).toBe(false);
+    expect(vaultStore.has('mcp/acme/linear/discovery')).toBe(false);
+    // Notion untouched.
+    expect(vaultStore.has('mcp/acme/notion/tokens')).toBe(true);
+  });
+
+  it('is idempotent — disconnecting an already-disconnected server returns 200', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../[server]/disconnect/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/disconnect', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/admin/src/app/api/mcp/remote-servers/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/route.ts
@@ -1,0 +1,77 @@
+/**
+ * MCP remote servers — GET /api/mcp/remote-servers?tenant=X
+ *
+ * Lists the OAuth-authorized remote MCP servers for a given tenant.
+ * Enumerates `mcp/<tenant>/<server>/tokens` in the backing vault and returns
+ * the corresponding `{ tenant, server }` pairs. Connected tokens count as
+ * connected; missing tokens count as disconnected (and simply aren't listed
+ * here — the catalog UI surfaces the "connect" CTA separately).
+ *
+ * Stage 3.1 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { createRevvaultVault } from '@revealui/mcp/oauth';
+import { type NextRequest, NextResponse } from 'next/server';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Revvault paths that live directly under `mcp/` but are NOT
+ * tenants — reserved for the package's own bookkeeping. Keep in sync
+ * with the path layout documented in `@revealui/mcp/oauth`.
+ */
+const RESERVED_TENANT_SEGMENTS = new Set(['oauth']);
+
+export interface RemoteMcpServerSummary {
+  tenant: string;
+  server: string;
+  connectionState: 'connected';
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<{ servers: RemoteMcpServerSummary[] } | { error: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const requestUrl = new URL(request.url);
+  const tenant = requestUrl.searchParams.get('tenant');
+  if (!tenant) {
+    return NextResponse.json({ error: 'tenant query parameter is required' }, { status: 400 });
+  }
+  if (!IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'tenant must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (RESERVED_TENANT_SEGMENTS.has(tenant)) {
+    return NextResponse.json({ error: `'${tenant}' is reserved` }, { status: 400 });
+  }
+
+  const vault = createRevvaultVault();
+  const paths = await vault.list(`mcp/${tenant}/`);
+
+  // Match `mcp/<tenant>/<server>/tokens` and collect unique server ids.
+  const serverIds = new Set<string>();
+  for (const path of paths) {
+    const segments = path.split('/');
+    if (segments.length === 4 && segments[3] === 'tokens') {
+      const server = segments[2];
+      if (server && IDENTIFIER_RE.test(server)) serverIds.add(server);
+    }
+  }
+
+  const servers: RemoteMcpServerSummary[] = Array.from(serverIds)
+    .sort()
+    .map((server) => ({ tenant, server, connectionState: 'connected' }));
+
+  return NextResponse.json({ servers });
+}

--- a/packages/mcp/__tests__/oauth-provider.test.ts
+++ b/packages/mcp/__tests__/oauth-provider.test.ts
@@ -55,6 +55,24 @@ describe('createMemoryVault', () => {
     const vault = createMemoryVault({ 'foo/bar': 'baz' });
     expect(await vault.get('foo/bar')).toBe('baz');
   });
+
+  it('list(prefix) returns every key under the prefix', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens': 'a',
+      'mcp/acme/linear/client': 'b',
+      'mcp/acme/notion/tokens': 'c',
+      'mcp/other/stripe/tokens': 'd',
+      'unrelated/key': 'e',
+    });
+    const acme = await vault.list('mcp/acme/');
+    expect(acme.sort()).toEqual([
+      'mcp/acme/linear/client',
+      'mcp/acme/linear/tokens',
+      'mcp/acme/notion/tokens',
+    ]);
+    expect(await vault.list('mcp/')).toHaveLength(4);
+    expect(await vault.list('nope/')).toEqual([]);
+  });
 });
 
 describe('McpOAuthProvider', () => {

--- a/packages/mcp/src/oauth.ts
+++ b/packages/mcp/src/oauth.ts
@@ -68,6 +68,14 @@ export interface Vault {
   set(path: string, value: string): Promise<void>;
   /** Deletes the value at `path`. No-op if not present. */
   delete(path: string): Promise<void>;
+  /**
+   * Lists every path that starts with `prefix`. Returns an empty array when
+   * no matches exist. The return order is implementation-defined.
+   *
+   * Used by admin catalog tooling to enumerate configured servers without
+   * requiring an out-of-band registry.
+   */
+  list(prefix: string): Promise<string[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +167,19 @@ export function createRevvaultVault(options: RevvaultVaultOptions = {}): Vault {
         throw new RevvaultError(`revvault delete exited ${code}: ${stderr.trim()}`);
       }
     },
+    async list(prefix) {
+      assertSafePrefix(prefix);
+      const { code, stdout, stderr } = await run(['list', prefix]);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault list exited ${code}: ${stderr.trim()}`);
+      }
+      // `revvault list` emits one path per line. Empty / informational output
+      // (e.g. `No secrets found.`) returns an empty array.
+      return stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && line.startsWith(prefix));
+    },
   };
 }
 
@@ -169,6 +190,16 @@ function assertSafePath(path: string): void {
   }
   if (path.includes('..') || path.startsWith('/') || path.endsWith('/')) {
     throw new RevvaultError(`Vault path is not well-formed: ${path}`);
+  }
+}
+
+/** Same rules as {@link assertSafePath} but allows the trailing slash of a prefix. */
+function assertSafePrefix(prefix: string): void {
+  if (!/^[A-Za-z0-9/_\-.]+$/.test(prefix)) {
+    throw new RevvaultError(`Vault prefix contains disallowed characters: ${prefix}`);
+  }
+  if (prefix.includes('..') || prefix.startsWith('/')) {
+    throw new RevvaultError(`Vault prefix is not well-formed: ${prefix}`);
   }
 }
 
@@ -200,6 +231,13 @@ export function createMemoryVault(seed?: Record<string, string>): Vault {
     },
     async delete(path) {
       store.delete(path);
+    },
+    async list(prefix) {
+      const out: string[] = [];
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) out.push(key);
+      }
+      return out;
     },
   };
 }


### PR DESCRIPTION
## Summary

Stage 3.1 of the MCP v1 productionization plan — admin-side server catalog and disconnect action for OAuth-authorized remote MCP servers. Builds on Stage 2 ([#494](https://github.com/RevealUIStudio/revealui/pull/494), [#497](https://github.com/RevealUIStudio/revealui/pull/497)).

### `@revealui/mcp`

- **`Vault.list(prefix)`** on the core interface. `createRevvaultVault()` shells out to `revvault list <prefix>` and parses line-oriented output; `createMemoryVault()` implements the same semantics over its `Map`. Unlocks catalog tooling to enumerate configured servers without an out-of-band registry.

### admin

- **`GET /api/mcp/remote-servers?tenant=X`** — enumerates OAuth-authorized servers for a tenant by walking `mcp/<tenant>/<server>/tokens` in the vault. Returns `{ tenant, server, connectionState: 'connected' }[]`. Rejects reserved tenant segments (e.g. `oauth`) and malformed identifiers.
- **`POST /api/mcp/remote-servers/[server]/disconnect`** — body `{ tenant }`. Revokes every credential path (`tokens`, `client`, `verifier`, `discovery`) for `(tenant, server)` via `McpOAuthProvider.invalidateCredentials('all')`. Idempotent.
- **`/admin/mcp`** — catalog page. Lists built-in servers (shared `/api/mcp/servers` endpoint with the `/admin/agents` MCP tab) plus remote servers for the entered tenant, with per-row **Disconnect** action and a **Connect new server** link to the existing `/admin/mcp/connect` flow (from PR-2.2).

### Scope boundary

Intentionally thin for Stage 3.1: list + disconnect + link to connect. Tool browser + ad-hoc invoker, resource browser, prompt picker, and elicitation forms land in Stages 3.2–3.4 per the scope doc.

### Test coverage

14 new tests (admin: 1532 → 1546 passing / 10 skipped; `@revealui/mcp`: 190 → 191 passing / 5 skipped):

- **Remote-servers GET** (8 tests): 401, 403, missing tenant, malformed tenant, reserved tenant, empty result, enumeration with cross-tenant isolation, malformed-server filtering (adversarial `..` segment)
- **Disconnect POST** (6 tests): 401, 403, malformed server path, malformed body tenant, credential-path deletion with sibling-server isolation, idempotency
- **`@revealui/mcp`** (1 test): `Vault.list()` on the in-memory impl with prefix isolation

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally (Biome, audits, boundary, claim-drift, raw-SQL, empty-catch, security, coverage — all ✓)
- [ ] `pnpm --filter admin test` — 1546 passing / 10 skipped
- [ ] `pnpm --filter @revealui/mcp test` — 191 passing / 5 skipped
- [ ] `pnpm --filter admin typecheck` — clean
- [ ] `pnpm --filter "admin..." build` — clean

## Notes

- The existing `/admin/agents` MCP tab is untouched — that panel continues to consume the tenant-agnostic `/api/mcp/servers` endpoint. The new `/admin/mcp` page is the anchor for future Stage 3 work (tool browser, resource browser, etc.).
- No `Connect new server` pre-fill yet — the form still accepts free-form input. A catalog-of-known-servers seed list is a v1.1 RevMarket concern.
- **`serverUrl` of connected remote servers is not yet surfaced.** It's captured only in the ephemeral pending record during the OAuth flow; persisting it alongside tokens is a small follow-up that lets the catalog show the URL (deferred to avoid scope creep on 3.1).
