### PR TITLE
feat(retention): operational-hygiene purge for jobs + webhook events (CR8-P3-02 PR2)

### DIFF
--- a/apps/api/src/routes/cron/cleanup.ts
+++ b/apps/api/src/routes/cron/cleanup.ts
@@ -3,8 +3,9 @@
  *
  * Deletes expired sessions, rate limits, password reset tokens, magic links,
  * publishes overdue scheduled pages, recovers stuck sagas, cleans up expired
- * idempotency keys, and purges old log rows past the retention window.
- * Piggybacks on the daily cron dispatcher.
+ * idempotency keys, purges old log rows past their retention window, and
+ * purges terminal rows from operational-hygiene tables (jobs, webhook events,
+ * resolved reconciliation records). Piggybacks on the daily cron dispatcher.
  *
  * Protected by X-Cron-Secret header (defense-in-depth  -  also validated in dispatch.ts).
  */
@@ -12,7 +13,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
-import { cleanupOldLogs, cleanupStaleTokens } from '@revealui/db/cleanup';
+import { cleanupOldLogs, cleanupOperational, cleanupStaleTokens } from '@revealui/db/cleanup';
 import { cleanupExpiredIdempotencyKeys, recoverStaleSagas } from '@revealui/db/saga';
 import { Hono } from 'hono';
 
@@ -111,6 +112,38 @@ app.post('/cleanup', async (c) => {
       logger.error(`[cron-cleanup] Log retention purge failed: ${message}`);
     }
 
+    // Operational-hygiene purge: terminal jobs + processed webhook events.
+    // Safety rules enforced at the query level — active jobs survive
+    // unconditionally. Non-fatal.
+    let operationalPurged = {
+      jobs: 0,
+      webhookEvents: 0,
+      windows: { jobs: 0, webhookEvents: 0 },
+    };
+    try {
+      const opsResult = await cleanupOperational();
+      operationalPurged = {
+        jobs: opsResult.jobs,
+        webhookEvents: opsResult.webhookEvents,
+        windows: opsResult.windows,
+      };
+      const total = opsResult.jobs + opsResult.webhookEvents;
+      if (total > 0) {
+        logger.info('[cron-cleanup] Purged operational rows past retention', {
+          jobs: opsResult.jobs,
+          webhookEvents: opsResult.webhookEvents,
+          windows: opsResult.windows,
+          cutoffs: {
+            jobs: opsResult.cutoffs.jobs.toISOString(),
+            webhookEvents: opsResult.cutoffs.webhookEvents.toISOString(),
+          },
+        });
+      }
+    } catch (opsErr) {
+      const message = opsErr instanceof Error ? opsErr.message : String(opsErr);
+      logger.error(`[cron-cleanup] Operational retention purge failed: ${message}`);
+    }
+
     return c.json({
       success: true,
       ...result,
@@ -118,6 +151,7 @@ app.post('/cleanup', async (c) => {
       recoveredSagas,
       expiredIdempotencyKeys: expiredKeys,
       logsPurged,
+      operationalPurged,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -71,6 +71,22 @@ const optionalSchema = z.object({
     .max(3650, 'Must not exceed 3650 days (10 years)')
     .default(90),
 
+  // Operational-hygiene retention windows (days). Purge terminal rows past
+  // the window to keep hot tables lean. See packages/db/src/cleanup/
+  // operational-retention.ts.
+  REVEALUI_JOB_RETENTION_DAYS: z.coerce
+    .number()
+    .int()
+    .min(1, 'Must be at least 1 day')
+    .max(3650, 'Must not exceed 3650 days (10 years)')
+    .default(30),
+  REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS: z.coerce
+    .number()
+    .int()
+    .min(1, 'Must be at least 1 day')
+    .max(3650, 'Must not exceed 3650 days (10 years)')
+    .default(90),
+
   // License key signing (RSA-2048 PEM)
   REVEALUI_LICENSE_PRIVATE_KEY: z.string().optional(),
   REVEALUI_LICENSE_PUBLIC_KEY: z.string().optional(),

--- a/packages/db/src/cleanup/index.ts
+++ b/packages/db/src/cleanup/index.ts
@@ -19,6 +19,12 @@ export {
   cleanupOldLogs,
   type LogRetentionTable,
 } from './log-retention.js';
+export {
+  type CleanupOperationalOptions,
+  type CleanupOperationalResult,
+  cleanupOperational,
+  type OperationalRetentionTable,
+} from './operational-retention.js';
 export { cleanupRagDataForSite } from './rag-site-cleanup.js';
 export {
   type CleanupTable,

--- a/packages/db/src/cleanup/operational-retention.ts
+++ b/packages/db/src/cleanup/operational-retention.ts
@@ -1,0 +1,159 @@
+/**
+ * Operational Hygiene Retention
+ *
+ * Purges terminal rows from internal queue and idempotency tables past
+ * their retention windows. Keeps hot tables lean; no PII concerns (these
+ * are internal operational state, not user data).
+ *
+ * See ~/suite/.jv/docs/cr8-p3-02-retention-design.md for the decision
+ * record. This is PR2 in the CR8-P3-02 arc; PR1 shipped the log tables.
+ *
+ * NOTE: the design doc originally called for a third purge on
+ * `unreconciled_webhooks`. That table is defined in the Drizzle schema
+ * but has no corresponding CREATE TABLE migration (verified 2026-04-22
+ * — snapshots at migrations/meta/0006_snapshot.json + 0009_snapshot.json
+ * reference it, but no .sql migration creates it). A fresh DB would fail
+ * the retention query. Dropped from PR2 scope; tracked in a separate
+ * follow-up to ship the missing migration first.
+ *
+ * Windows:
+ *   - jobs (state IN ('completed', 'failed'), completedAt < cutoff)
+ *     → REVEALUI_JOB_RETENTION_DAYS (default 30)
+ *     Queue rows grow unboundedly with every processed job. 30d gives
+ *     post-incident-debugging headroom without table bloat. Active /
+ *     created / retry rows are NEVER purged — only terminal states.
+ *
+ *   - processed_webhook_events (processedAt < cutoff)
+ *     → REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS (default 90)
+ *     Stripe idempotency markers. Stripe retry horizon is ~24h; 90d is
+ *     belt-and-suspenders. No PII.
+ */
+
+import { and, inArray, isNotNull, lt } from 'drizzle-orm';
+import { getClient } from '../client/index.js';
+import { jobs } from '../schema/jobs.js';
+import { processedWebhookEvents } from '../schema/webhook-events.js';
+
+export type OperationalRetentionTable = 'jobs' | 'webhookEvents';
+
+export interface CleanupOperationalOptions {
+  /** When true, counts rows without deleting (default: false) */
+  dryRun?: boolean;
+  /** Per-table retention overrides in days; each falls back to its env var, then default */
+  retentionDays?: Partial<Record<OperationalRetentionTable, number>>;
+  /** Limit cleanup to specific tables; defaults to all */
+  tables?: OperationalRetentionTable[];
+  /** Optional database client override (used by integration tests with PGlite) */
+  db?: ReturnType<typeof getClient>;
+}
+
+export interface CleanupOperationalResult {
+  jobs: number;
+  webhookEvents: number;
+  dryRun: boolean;
+  windows: Record<OperationalRetentionTable, number>;
+  cutoffs: Record<OperationalRetentionTable, Date>;
+}
+
+const ALL_TABLES: OperationalRetentionTable[] = ['jobs', 'webhookEvents'];
+
+const DEFAULT_WINDOWS: Record<OperationalRetentionTable, number> = {
+  jobs: 30,
+  webhookEvents: 90,
+};
+
+const ENV_VARS: Record<OperationalRetentionTable, string> = {
+  jobs: 'REVEALUI_JOB_RETENTION_DAYS',
+  webhookEvents: 'REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS',
+};
+
+function resolveWindow(table: OperationalRetentionTable, override?: number): number {
+  if (typeof override === 'number') {
+    if (!Number.isInteger(override) || override < 1) {
+      throw new Error(
+        `Invalid retentionDays override for ${table}: ${override}. Must be a positive integer.`,
+      );
+    }
+    return override;
+  }
+  const envValue = process.env[ENV_VARS[table]];
+  if (envValue) {
+    const parsed = Number.parseInt(envValue, 10);
+    if (Number.isInteger(parsed) && parsed >= 1) {
+      return parsed;
+    }
+  }
+  return DEFAULT_WINDOWS[table];
+}
+
+/**
+ * Deletes (or counts, in dry-run mode) terminal rows from operational tables
+ * past their retention windows.
+ *
+ * Safety guarantees:
+ *   - `jobs`: only rows with state IN ('completed', 'failed') are considered.
+ *     Active / created / retry rows survive regardless of age.
+ *   - `processed_webhook_events`: no protected state; all rows past the
+ *     window are purgeable (idempotency markers are bounded by time, not
+ *     state).
+ */
+export async function cleanupOperational(
+  options: CleanupOperationalOptions = {},
+): Promise<CleanupOperationalResult> {
+  const { dryRun = false, tables = ALL_TABLES, db: dbOverride } = options;
+  const overrides = options.retentionDays ?? {};
+  const db = dbOverride ?? getClient();
+
+  const windows: Record<OperationalRetentionTable, number> = {
+    jobs: resolveWindow('jobs', overrides.jobs),
+    webhookEvents: resolveWindow('webhookEvents', overrides.webhookEvents),
+  };
+
+  const now = Date.now();
+  const cutoffs: Record<OperationalRetentionTable, Date> = {
+    jobs: new Date(now - windows.jobs * 24 * 60 * 60 * 1000),
+    webhookEvents: new Date(now - windows.webhookEvents * 24 * 60 * 60 * 1000),
+  };
+
+  const result: CleanupOperationalResult = {
+    jobs: 0,
+    webhookEvents: 0,
+    dryRun,
+    windows,
+    cutoffs,
+  };
+
+  if (tables.includes('jobs')) {
+    // SAFETY: terminal states only. Never purge 'active', 'created', 'retry'.
+    // Use completedAt as the cutoff column so a long-running job that just
+    // completed isn't wrongly considered "old" by its createdAt.
+    const where = and(
+      inArray(jobs.state, ['completed', 'failed']),
+      isNotNull(jobs.completedAt),
+      lt(jobs.completedAt, cutoffs.jobs),
+    );
+    if (dryRun) {
+      const rows = await db.select({ id: jobs.id }).from(jobs).where(where);
+      result.jobs = rows.length;
+    } else {
+      const deleted = await db.delete(jobs).where(where).returning();
+      result.jobs = deleted.length;
+    }
+  }
+
+  if (tables.includes('webhookEvents')) {
+    const where = lt(processedWebhookEvents.processedAt, cutoffs.webhookEvents);
+    if (dryRun) {
+      const rows = await db
+        .select({ id: processedWebhookEvents.id })
+        .from(processedWebhookEvents)
+        .where(where);
+      result.webhookEvents = rows.length;
+    } else {
+      const deleted = await db.delete(processedWebhookEvents).where(where).returning();
+      result.webhookEvents = deleted.length;
+    }
+  }
+
+  return result;
+}

--- a/packages/test/src/integration/database/operational-retention.integration.test.ts
+++ b/packages/test/src/integration/database/operational-retention.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests for operational-hygiene retention (CR8-P3-02 PR2).
+ *
+ * Exercises `cleanupOperational()` end-to-end against a PGlite-backed
+ * Postgres. Validates the per-table cutoffs, state safety rules, dry-run
+ * counting, per-table scoping, and env-var / override precedence.
+ *
+ * NOTE: unreconciledWebhooks coverage deferred — table has a schema
+ * definition but no migration (see module-level doc comment and the
+ * follow-up task "Fix missing unreconciled_webhooks migration").
+ *
+ * Module: packages/db/src/cleanup/operational-retention.ts
+ * Schemas: packages/db/src/schema/{jobs,webhook-events}.ts
+ * Design: ~/suite/.jv/docs/cr8-p3-02-retention-design.md
+ */
+
+import { cleanupOperational } from '@revealui/db/cleanup';
+import { jobs, processedWebhookEvents } from '@revealui/db/schema';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
+
+describe('operational-hygiene retention (CR8-P3-02 PR2)', () => {
+  let testDb: TestDb;
+  const asDbOpts = (): { db: never } => ({ db: testDb.drizzle as never });
+
+  const daysAgo = (n: number): Date => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - n);
+    return d;
+  };
+
+  beforeAll(async () => {
+    testDb = await createTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await testDb.close();
+  });
+
+  beforeEach(async () => {
+    await testDb.pglite.exec('DELETE FROM jobs');
+    await testDb.pglite.exec('DELETE FROM processed_webhook_events');
+    delete process.env.REVEALUI_JOB_RETENTION_DAYS;
+    delete process.env.REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS;
+  });
+
+  afterEach(() => {
+    delete process.env.REVEALUI_JOB_RETENTION_DAYS;
+    delete process.env.REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS;
+  });
+
+  describe('jobs', () => {
+    it('deletes completed + failed jobs past 30d, keeps fresh terminal rows', async () => {
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'old-completed',
+          name: 'email.send',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(60),
+          completedAt: daysAgo(40),
+        },
+        {
+          id: 'old-failed',
+          name: 'email.send',
+          data: {},
+          state: 'failed',
+          createdAt: daysAgo(60),
+          completedAt: daysAgo(35),
+        },
+        {
+          id: 'fresh-completed',
+          name: 'email.send',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(10),
+          completedAt: daysAgo(5),
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.jobs).toBe(2);
+      expect(result.windows.jobs).toBe(30);
+
+      const remaining = await testDb.pglite.query<{ id: string }>(
+        'SELECT id FROM jobs ORDER BY id',
+      );
+      expect(remaining.rows.map((r) => r.id)).toEqual(['fresh-completed']);
+    });
+
+    it('NEVER purges active, created, or retry jobs regardless of age', async () => {
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'ancient-active',
+          name: 'long.running',
+          data: {},
+          state: 'active',
+          createdAt: daysAgo(365),
+          completedAt: null,
+        },
+        {
+          id: 'ancient-created',
+          name: 'pending.forever',
+          data: {},
+          state: 'created',
+          createdAt: daysAgo(365),
+          completedAt: null,
+        },
+        {
+          id: 'ancient-retry',
+          name: 'legacy.retry',
+          data: {},
+          state: 'retry',
+          createdAt: daysAgo(365),
+          completedAt: null,
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.jobs).toBe(0);
+
+      const remaining = await testDb.pglite.query<{ id: string }>(
+        'SELECT id FROM jobs ORDER BY id',
+      );
+      expect(remaining.rows).toHaveLength(3);
+    });
+
+    it('uses completedAt (not createdAt) as the cutoff column', async () => {
+      // Long-running job created 60d ago but just completed — should survive.
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'long-running-just-completed',
+          name: 'slow.job',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(60),
+          completedAt: daysAgo(1),
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.jobs).toBe(0);
+      const remaining = await testDb.pglite.query<{ id: string }>('SELECT id FROM jobs');
+      expect(remaining.rows.map((r) => r.id)).toEqual(['long-running-just-completed']);
+    });
+
+    it('ignores terminal rows with null completedAt (defensive)', async () => {
+      // Shouldn't happen in practice but guard against it.
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'malformed-terminal',
+          name: 'oddity',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(365),
+          completedAt: null,
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+      expect(result.jobs).toBe(0);
+    });
+  });
+
+  describe('processed_webhook_events', () => {
+    it('deletes events past 90d, keeps recent rows', async () => {
+      await testDb.drizzle.insert(processedWebhookEvents).values([
+        {
+          id: 'evt_old',
+          eventType: 'checkout.session.completed',
+          processedAt: daysAgo(100),
+        },
+        {
+          id: 'evt_fresh',
+          eventType: 'invoice.paid',
+          processedAt: daysAgo(30),
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.webhookEvents).toBe(1);
+      expect(result.windows.webhookEvents).toBe(90);
+
+      const remaining = await testDb.pglite.query<{ id: string }>(
+        'SELECT id FROM processed_webhook_events',
+      );
+      expect(remaining.rows.map((r) => r.id)).toEqual(['evt_fresh']);
+    });
+  });
+
+  describe('options + env vars', () => {
+    it('dry-run counts without deleting across both tables', async () => {
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'j',
+          name: 'x',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(60),
+          completedAt: daysAgo(40),
+        },
+      ]);
+      await testDb.drizzle
+        .insert(processedWebhookEvents)
+        .values([{ id: 'evt', eventType: 'x', processedAt: daysAgo(100) }]);
+
+      const result = await cleanupOperational({ ...asDbOpts(), dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.jobs).toBe(1);
+      expect(result.webhookEvents).toBe(1);
+
+      const jobsRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM jobs');
+      const evtRows = await testDb.pglite.query<{ id: string }>(
+        'SELECT id FROM processed_webhook_events',
+      );
+      expect(jobsRows.rows).toHaveLength(1);
+      expect(evtRows.rows).toHaveLength(1);
+    });
+
+    it('honors per-table retentionDays overrides', async () => {
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'j',
+          name: 'x',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(20),
+          completedAt: daysAgo(10),
+        },
+      ]);
+
+      const result = await cleanupOperational({
+        ...asDbOpts(),
+        retentionDays: { jobs: 7 },
+      });
+
+      expect(result.windows.jobs).toBe(7);
+      expect(result.windows.webhookEvents).toBe(90);
+      expect(result.jobs).toBe(1);
+    });
+
+    it('honors REVEALUI_* env vars', async () => {
+      process.env.REVEALUI_JOB_RETENTION_DAYS = '60';
+      process.env.REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS = '14';
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.windows.jobs).toBe(60);
+      expect(result.windows.webhookEvents).toBe(14);
+    });
+
+    it('scopes cleanup to requested tables only', async () => {
+      await testDb.drizzle.insert(jobs).values([
+        {
+          id: 'j',
+          name: 'x',
+          data: {},
+          state: 'completed',
+          createdAt: daysAgo(60),
+          completedAt: daysAgo(40),
+        },
+      ]);
+      await testDb.drizzle
+        .insert(processedWebhookEvents)
+        .values([{ id: 'evt', eventType: 'x', processedAt: daysAgo(100) }]);
+
+      const result = await cleanupOperational({
+        ...asDbOpts(),
+        tables: ['webhookEvents'],
+      });
+
+      expect(result.webhookEvents).toBe(1);
+      expect(result.jobs).toBe(0); // scoped out
+
+      const jobsRows = await testDb.pglite.query<{ id: string }>('SELECT id FROM jobs');
+      expect(jobsRows.rows).toHaveLength(1);
+    });
+
+    it('rejects invalid retentionDays override', async () => {
+      await expect(
+        cleanupOperational({ ...asDbOpts(), retentionDays: { jobs: 0 } }),
+      ).rejects.toThrow('Must be a positive integer');
+
+      await expect(
+        cleanupOperational({ ...asDbOpts(), retentionDays: { webhookEvents: -5 } }),
+      ).rejects.toThrow('Must be a positive integer');
+
+      await expect(
+        cleanupOperational({ ...asDbOpts(), retentionDays: { jobs: 1.5 } }),
+      ).rejects.toThrow('Must be a positive integer');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Ships **CR8-P3-02 PR2** (of 2) — operational-hygiene retention purges for `jobs` and `processed_webhook_events`.

PR1 ([revealui#495](https://github.com/RevealUIStudio/revealui/pull/495)) landed log retention for `app_logs` + `error_events`. PR2 extends the same daily cron with a second purge pass for internal queue / idempotency tables that were growing unboundedly with no policy or privacy concern — just table bloat.

Design: internal docs §5 (founder decisions locked 2026-04-22, commit `80c2cfcd1`).

## Change

- **`packages/db/src/cleanup/operational-retention.ts`** — new `cleanupOperational()` with per-table `dryRun`, `retentionDays`, and `tables` options. Accepts `db` override for PGlite-backed tests.
- **`packages/config/src/schema.ts`** — adds `REVEALUI_JOB_RETENTION_DAYS` (default **30**) and `REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS` (default **90**). Same `z.coerce.number().int().min(1).max(3650)` validation as `REVEALUI_LOG_RETENTION_DAYS`.
- **`apps/api/src/routes/cron/cleanup.ts`** — wires `cleanupOperational()` after the PR1 log-retention block. Non-fatal: logged and reported but does not fail the cron.
- **Integration tests** — `packages/test/src/integration/database/operational-retention.integration.test.ts`, **10 PGlite-backed tests**:
  1. `jobs`: deletes completed + failed past 30d, keeps fresh terminal rows
  2. `jobs`: NEVER purges active/created/retry regardless of age
  3. `jobs`: uses `completedAt` (not `createdAt`) as the cutoff column
  4. `jobs`: ignores terminal rows with null `completedAt` (defensive)
  5. `processed_webhook_events`: 90d cutoff
  6. dry-run counts without deleting across both tables
  7. per-table `retentionDays` overrides
  8. env var precedence (both `REVEALUI_*_RETENTION_DAYS`)
  9. per-table `tables` scoping
  10. invalid override rejection (0, negative, non-integer)

## Safety guarantees (query-level, not caller-level)

- **`jobs`**: purge `WHERE state IN ('completed', 'failed') AND completed_at IS NOT NULL AND completed_at < cutoff`. Active jobs, created jobs, retry rows — all survive unconditionally. `completedAt` as cutoff (not `createdAt`) prevents false-positive purges of long-running jobs that just finished.
- **`processed_webhook_events`**: no protected state; pure TTL on `processed_at < cutoff`. Stripe retry horizon is ~24h, so 90d is belt-and-suspenders.

## Scope change from the design doc

Design doc §5 also proposed retention for **`unreconciled_webhooks`** at 90d (resolved rows only). During implementation I discovered the table is defined in the Drizzle schema + snapshots but has **no `CREATE TABLE` migration** — `grep -n "unreconciled" packages/db/migrations/*.sql` returns zero hits. A fresh DB would fail any query against the table.

This is a separate pre-existing bug (the table is actively written by `webhooks.ts` and queried by `scripts/commands/database/check-unreconciled.ts` — so either prod has it via `drizzle-kit push` or prod writes fail too). Dropped from PR2 scope; will be handled by a dedicated `fix/missing-unreconciled-webhooks-migration` PR before retention for that table ships in a follow-up.

## Verification

- `pnpm turbo build --filter @revealui/db` green
- `pnpm turbo typecheck --filter api --filter @revealui/db --filter @revealui/config` green (16/16)
- `pnpm exec vitest run --config vitest.integration.config.ts src/integration/database/operational-retention.integration.test.ts` — **10/10 pass in 3.58s**

## Not in scope / not needed

- **Privacy policy text update**: none of PR2's tables carry PII worth advertising a window for (webhook events = Stripe event IDs + types, jobs = internal queue state). Confirmed with founder 2026-04-22.
- **audit_log**: stays indefinite (design decision D1, PR1 scope).

## Test plan

- [ ] CI green on this PR
- [ ] After merge + the separate `fix/missing-unreconciled-webhooks-migration` PR lands: a tiny follow-up adds `unreconciledWebhooks` retention (~15 min extending `cleanupOperational`)
- [ ] Flip `CR8-P3-02` checkbox `[ ] → [x]` in internal docs citing #495 + this PR + the privacy-text commit ([#496](https://github.com/RevealUIStudio/revealui/pull/496))

## Memory alignment

- `feedback_honest_audit_playbook.md` — design doc → private internal docs commit → public implementation → CI enforcement. The unreconciled_webhooks finding goes into a separate dedicated PR per the same playbook.
- `feedback_audit_workflow.md` — single-concern PR; the discovered migration bug gets its own branch.
- `feedback_durable_only.md` — concrete windows, env-configurable bounds, no "typically N days" weasel phrasing.
