### PR TITLE
fix(db): add missing unreconciled_webhooks migration (0010)

### DIFF
--- a/packages/db/migrations/0010_unreconciled_webhooks.sql
+++ b/packages/db/migrations/0010_unreconciled_webhooks.sql
@@ -1,0 +1,39 @@
+-- Hand-written migration for the `unreconciled_webhooks` table.
+--
+-- CONTEXT: The table is defined in `packages/db/src/schema/webhook-reconciliation.ts`
+-- and appears in the Drizzle snapshots at `meta/0006_snapshot.json` and
+-- `meta/0009_snapshot.json`, but had NO corresponding `.sql` migration in
+-- 0000–0009 (verified 2026-04-22 via `grep -n "unreconciled" migrations/*.sql`
+-- → zero hits). The table is actively written by `apps/api/src/routes/webhooks.ts`
+-- and queried by `scripts/commands/database/check-unreconciled.ts`, so
+-- production likely has it via an ad-hoc `drizzle-kit push` at some point.
+-- A freshly-migrated environment (new deploy, PGlite test DB) would fail
+-- these writes with `relation "unreconciled_webhooks" does not exist`.
+--
+-- IDEMPOTENCY: All DDL uses `IF NOT EXISTS` so this migration is safe to
+-- apply against a production DB that already has the table. On a fresh DB
+-- it creates the table + indexes from scratch.
+--
+-- See ~/suite/.jv/docs/cr8-p3-02-retention-design.md for the discovery
+-- context (was found while scoping the operational-hygiene retention work).
+
+CREATE TABLE IF NOT EXISTS "unreconciled_webhooks" (
+	"event_id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"customer_id" text,
+	"stripe_object_id" text,
+	"object_type" text,
+	"error_trace" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"resolved_by" text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "unreconciled_webhooks_customer_id_idx"
+	ON "unreconciled_webhooks" USING btree ("customer_id");
+--> statement-breakpoint
+-- Partial index: only unresolved rows. Makes "find all open reconciliation
+-- records" cheap as the table grows — the cron query hits this index.
+CREATE INDEX IF NOT EXISTS "unreconciled_webhooks_unresolved_idx"
+	ON "unreconciled_webhooks" USING btree ("created_at")
+	WHERE "resolved_at" IS NULL;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -38,6 +38,12 @@
       "rationale": "Hand-written ALTER TABLE on jobs adding locked_by/locked_until/last_error columns plus a partial index on (locked_until) WHERE state = 'active'. CR8-P2-01 phase A — durable work queue visibility-timeout semantics. drizzle-kit can model the columns but not the partial-index predicate (WHERE clause inside CREATE INDEX IF NOT EXISTS), and the ADD COLUMN statements are wrapped in IF NOT EXISTS for idempotent re-apply. Companion Drizzle schema update at packages/db/src/schema/jobs.ts adds the columns + partial index for type-safety; callers query via Drizzle, not raw SQL.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as 0003: snapshot regeneration via `pnpm --filter @revealui/db db:generate` against a clean DB once the shared-facts/yjs/shared-memory debt is worked through. Deferred to keep phase A scoped."
+    },
+    {
+      "tag": "0010_unreconciled_webhooks",
+      "rationale": "Hand-written CREATE TABLE + indexes for the `unreconciled_webhooks` table. The table was defined in packages/db/src/schema/webhook-reconciliation.ts and already appears in the Drizzle snapshots at meta/0006_snapshot.json and meta/0009_snapshot.json, but NO .sql migration ever created it (verified 2026-04-22: grep -n 'unreconciled' migrations/*.sql → zero hits). Production likely has the table from an ad-hoc drizzle-kit push at some point (webhooks.ts writes to it at runtime; if prod didn't have it, webhook processing would be failing). Migration uses CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS so it is safe to apply against both fresh DBs (creates it) and prod (no-op). Partial index `unreconciled_webhooks_unresolved_idx` on (created_at) WHERE resolved_at IS NULL is not expressible in Drizzle's schema DSL beyond the .where() modifier.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Snapshot already captures the table (meta/0006_snapshot.json + meta/0009_snapshot.json reference it). Missing snapshot for this tag specifically because it's a retroactive catch-up for an unmigrated table; the canonical snapshot state is the 0009 snapshot. Full snapshot regen deferred to the general snapshot-debt backfill tracked alongside 0003/0004/0005/0008."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777084800000,
       "tag": "0009_mcp_document_operations",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777171200000,
+      "tag": "0010_unreconciled_webhooks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/test/src/integration/database/unreconciled-webhooks-migration.integration.test.ts
+++ b/packages/test/src/integration/database/unreconciled-webhooks-migration.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration test for the unreconciled_webhooks migration (0010).
+ *
+ * Verifies that the freshly-migrated DB has the table and that the
+ * partial index is correctly scoped to `WHERE resolved_at IS NULL`.
+ *
+ * Migration: packages/db/migrations/0010_unreconciled_webhooks.sql
+ * Schema: packages/db/src/schema/webhook-reconciliation.ts
+ *
+ * Context: the table was present in the Drizzle schema + snapshots but
+ * had no .sql migration. Fresh DBs (test / new deploys) would fail any
+ * query against it. This test runs against PGlite via the createTestDb
+ * harness which applies all migrations in order — if the migration is
+ * missing or broken, this test fails at harness setup.
+ */
+
+import { unreconciledWebhooks } from '@revealui/db/schema';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
+
+describe('unreconciled_webhooks migration (0010)', () => {
+  let testDb: TestDb;
+
+  beforeAll(async () => {
+    testDb = await createTestDb();
+  }, 30_000);
+
+  afterAll(async () => {
+    await testDb.close();
+  });
+
+  it('creates the unreconciled_webhooks table', async () => {
+    const result = await testDb.pglite.query<{ table_name: string }>(
+      "SELECT table_name FROM information_schema.tables WHERE table_name = 'unreconciled_webhooks'",
+    );
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it('has all expected columns with correct types', async () => {
+    const result = await testDb.pglite.query<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+    }>(
+      "SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = 'unreconciled_webhooks' ORDER BY column_name",
+    );
+    const columns = Object.fromEntries(
+      result.rows.map((r) => [
+        r.column_name,
+        { type: r.data_type, nullable: r.is_nullable === 'YES' },
+      ]),
+    );
+
+    expect(columns).toMatchObject({
+      event_id: { nullable: false },
+      event_type: { nullable: false },
+      customer_id: { nullable: true },
+      stripe_object_id: { nullable: true },
+      object_type: { nullable: true },
+      error_trace: { nullable: false },
+      created_at: { nullable: false },
+      resolved_at: { nullable: true },
+      resolved_by: { nullable: true },
+    });
+  });
+
+  it('has the partial index scoped to unresolved rows', async () => {
+    const result = await testDb.pglite.query<{
+      indexname: string;
+      indexdef: string;
+    }>(
+      "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'unreconciled_webhooks' AND indexname = 'unreconciled_webhooks_unresolved_idx'",
+    );
+    expect(result.rows).toHaveLength(1);
+    // Partial-index predicate preserved.
+    expect(result.rows[0]?.indexdef).toMatch(/WHERE .*resolved_at.*IS NULL/i);
+  });
+
+  it('accepts inserts via Drizzle', async () => {
+    await testDb.drizzle.insert(unreconciledWebhooks).values({
+      eventId: 'evt_test_1',
+      eventType: 'checkout.session.completed',
+      errorTrace: 'test trace',
+    });
+
+    const rows = await testDb.pglite.query<{ event_id: string }>(
+      "SELECT event_id FROM unreconciled_webhooks WHERE event_id = 'evt_test_1'",
+    );
+    expect(rows.rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Schema-vs-migration drift fix: adds the missing `CREATE TABLE unreconciled_webhooks` migration.

## Discovery

Found while scoping **CR8-P3-02 PR2** ([revealui#499](https://github.com/RevealUIStudio/revealui/pull/499)). The retention query against `unreconciledWebhooks` failed in PGlite with `relation "unreconciled_webhooks" does not exist`. Investigation:

```
$ grep -n 'unreconciled' packages/db/migrations/*.sql
(empty)

$ ls packages/db/migrations/meta/*.json | xargs grep -l unreconciled_webhooks
packages/db/migrations/meta/0006_snapshot.json
packages/db/migrations/meta/0009_snapshot.json
```

The table is defined in [packages/db/src/schema/webhook-reconciliation.ts](packages/db/src/schema/webhook-reconciliation.ts) and the Drizzle snapshots reference it — but no `.sql` migration ever creates it.

## Runtime impact

The table is actively written by:
- [apps/api/src/routes/webhooks.ts](apps/api/src/routes/webhooks.ts) — inserts on failed Stripe webhook reconciliation
- [scripts/commands/database/check-unreconciled.ts](scripts/commands/database/check-unreconciled.ts) — reads for admin alerting

Production **likely has the table** from an ad-hoc `drizzle-kit push` at some point (otherwise webhook reconciliation writes would be failing in prod). But any fresh DB — new deploy, PGlite test DB, local reset — fails immediately on the first write.

## Fix

`packages/db/migrations/0010_unreconciled_webhooks.sql` with idempotent DDL:

```sql
CREATE TABLE IF NOT EXISTS "unreconciled_webhooks" ( ... );
CREATE INDEX IF NOT EXISTS "unreconciled_webhooks_customer_id_idx" ...;
CREATE INDEX IF NOT EXISTS "unreconciled_webhooks_unresolved_idx"
	ON "unreconciled_webhooks" USING btree ("created_at")
	WHERE "resolved_at" IS NULL;
```

Safe to apply against:
- **Fresh DBs** → creates table + both indexes
- **Production** (already has the table) → no-op

Journal updated at `meta/_journal.json` with `idx: 10`. `_custom.json` entry added with full rationale per validator convention.

## Verification

- **Migration-journal validator**: `pnpm tsx scripts/validate/migration-journal.ts` → `11 SQL files, 11 journal entries, all checks passed`
- **Integration test** ([packages/test/src/integration/database/unreconciled-webhooks-migration.integration.test.ts](packages/test/src/integration/database/unreconciled-webhooks-migration.integration.test.ts)): 4/4 pass in 6.4s — table exists, all columns + nullability correct, partial index predicate preserved (`WHERE resolved_at IS NULL`), Drizzle inserts succeed

## Unblocks

Once merged, a tiny follow-up PR adds `unreconciled_webhooks` retention to `cleanupOperational()` ([revealui#499](https://github.com/RevealUIStudio/revealui/pull/499)) — extending the existing module with the third table that was dropped from PR2 scope due to this bug.

## Test plan

- [ ] CI green on this PR
- [ ] Integration tests pass (new test + any existing webhook_reconciliation tests that now have a migrated table)
- [ ] After merge: extend `cleanupOperational()` with `unreconciledWebhooks` retention (safety: only resolved rows, 90d) in a separate small PR

## Memory alignment

- `feedback_audit_workflow.md` — branch-per-audit-item; this is a dedicated single-concern PR. Did NOT fold into PR2.
- `feedback_honest_audit_playbook.md` — concrete finding (missing migration), concrete fix (idempotent DDL + test), measurable outcome (integration test asserts the table exists post-migration).
- `feedback_durable_only.md` — no tactical shortcuts; `CREATE TABLE IF NOT EXISTS` is the durable fix that works on both prod and fresh DBs.
