### PR TITLE
feat(mcp): tool browser + ad-hoc invoker (Stage 3.2)

### DIFF
--- a/.changeset/mcp-3-2-tool-browser.md
+++ b/.changeset/mcp-3-2-tool-browser.md
@@ -1,0 +1,39 @@
+---
+'@revealui/mcp': minor
+'admin': minor
+---
+
+Stage 3.2 of the MCP v1 plan — tool browser + ad-hoc invoker for connected
+remote MCP servers. Builds on Stages 2 + 3.1.
+
+**`@revealui/mcp`:**
+- `McpClient.listTools()` and `callTool(name, arguments?)` — full-protocol
+  tool coverage, following the Stage 0 pattern (capability-gated,
+  per-request options threaded through). Tool failures surface in-band
+  (`isError: true, content: [...]`) rather than throwing — transport-level
+  failures still throw. Stage 0 deliberately skipped tools because the
+  hypervisor handled stdio tool calls through its own JSON-RPC; Stage 3.2
+  needs them for remote HTTP servers.
+- `Tool` and `CallToolResult` types exported.
+- New `@revealui/mcp/client` subpath export — admin/edge consumers can
+  import the client surface without pulling in the stdio launcher scripts
+  that auto-execute and call `checkMcpLicense()` during bundling.
+
+**admin:**
+- OAuth callback now writes a non-credential meta record at
+  `mcp/<tenant>/<server>/meta` (`serverUrl` + `connectedAt` + `connectedBy`)
+  so subsequent tool calls know where to connect. Best-effort — tokens
+  remain the load-bearing state.
+- `lib/mcp/remote-server-client.ts` — helper that rebuilds an `McpClient`
+  from stored credentials for a given `(tenant, server)`.
+- Three new per-server routes:
+  - `GET /api/mcp/remote-servers/[server]/tools?tenant=X` — lists tools.
+  - `POST /api/mcp/remote-servers/[server]/call-tool` — invokes a tool.
+  - `POST /api/mcp/remote-servers/[server]/complete` — prompt / resource
+    argument completions (the completions protocol is for prompts +
+    resource templates, not tool arguments).
+- `/admin/mcp/inspect?tenant=X&server=Y` — tool browser page. Renders each
+  tool's `inputSchema` as a form (best-effort: strings, numbers, booleans,
+  enums, JSON for complex types), invokes the tool, displays the
+  `CallToolResult` content blocks.
+- Catalog page (`/admin/mcp`) gets a per-row "Inspect" link.

--- a/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
@@ -1,0 +1,367 @@
+/**
+ * MCP — Server Inspector (/admin/mcp/inspect?tenant=X&server=Y)
+ *
+ * Stage 3.2 of the MCP v1 plan. Tool browser + ad-hoc invoker for an
+ * OAuth-authorized remote MCP server.
+ *
+ * Flow:
+ *   1. Reads `?tenant=` and `?server=` from the URL.
+ *   2. Fetches `GET /api/mcp/remote-servers/<server>/tools?tenant=<tenant>`.
+ *   3. Renders each tool as a collapsible card with an argument form
+ *      derived from `Tool.inputSchema` (best-effort — arbitrary JSON strings
+ *      for non-trivial schemas).
+ *   4. On submit, POSTs `/api/mcp/remote-servers/<server>/call-tool` and
+ *      displays the `CallToolResult` content blocks inline.
+ *
+ * Resource/prompt browsing (which would consume the completions handler)
+ * lands in Stage 3.3.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface Tool {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    type?: string;
+    properties?: Record<string, JsonSchemaProperty>;
+    required?: string[];
+  };
+}
+
+interface JsonSchemaProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+}
+
+interface CallToolResult {
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  isError?: boolean;
+}
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+function useSearchParam(key: string): string | null {
+  const [value, setValue] = useState<string | null>(null);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setValue(params.get(key));
+  }, [key]);
+  return value;
+}
+
+export default function InspectMcpServerPage() {
+  const tenant = useSearchParam('tenant');
+  const server = useSearchParam('server');
+
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [serverUrl, setServerUrl] = useState<string | null>(null);
+  const [state, setState] = useState<LoadState>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadTools = useCallback(async () => {
+    if (!(tenant && server)) return;
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch(
+        `/api/mcp/remote-servers/${encodeURIComponent(server)}/tools?tenant=${encodeURIComponent(tenant)}`,
+        { credentials: 'include' },
+      );
+      // empty-catch-ok: non-JSON error body — res.status is surfaced below
+      const body = (await res.json().catch(() => ({}))) as {
+        tools?: Tool[];
+        serverUrl?: string;
+        error?: string;
+        detail?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setTools(body.tools ?? []);
+      setServerUrl(body.serverUrl ?? null);
+      setState('ready');
+    } catch (err) {
+      setState('error');
+      setMessage(`Failed to load tools: ${(err as Error).message}`);
+    }
+  }, [tenant, server]);
+
+  useEffect(() => {
+    if (tenant && server) void loadTools();
+  }, [tenant, server, loadTools]);
+
+  if (!(tenant && server)) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <div className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-300">
+          Missing <span className="font-mono">tenant</span> or{' '}
+          <span className="font-mono">server</span> query parameter. Navigate from{' '}
+          <a href="/admin/mcp" className="underline">
+            /admin/mcp
+          </a>
+          .
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="flex items-center gap-3">
+          <a href="/admin/mcp" className="text-sm text-zinc-400 hover:text-zinc-200">
+            ← Catalog
+          </a>
+          <span className="text-zinc-600">/</span>
+          <h1 className="text-xl font-semibold text-white">
+            <span className="font-mono text-zinc-400">{tenant}</span>{' '}
+            <span className="text-zinc-600">/</span> <span className="font-mono">{server}</span>
+          </h1>
+        </div>
+        {serverUrl && (
+          <p className="mt-1 text-xs text-zinc-500">
+            {serverUrl} · {tools.length} {tools.length === 1 ? 'tool' : 'tools'}
+          </p>
+        )}
+      </div>
+
+      <div className="mx-auto max-w-5xl p-6">
+        {message && (
+          <div
+            role="alert"
+            className={`mb-6 rounded-lg border p-3 text-sm ${
+              state === 'error'
+                ? 'border-red-800 bg-red-900/20 text-red-300'
+                : 'border-zinc-800 bg-zinc-900/50 text-zinc-300'
+            }`}
+          >
+            {message}
+          </div>
+        )}
+
+        {state === 'loading' && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+            Loading tools…
+          </div>
+        )}
+
+        {state === 'ready' && tools.length === 0 && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+            This server doesn&rsquo;t advertise any tools, or the{' '}
+            <span className="font-mono text-zinc-400">tools</span> capability isn&rsquo;t declared.
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {tools.map((tool) => (
+            <ToolCard key={tool.name} tool={tool} tenant={tenant} server={server} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tool card — form + invoker
+// ---------------------------------------------------------------------------
+
+interface ToolCardProps {
+  tool: Tool;
+  tenant: string;
+  server: string;
+}
+
+function ToolCard({ tool, tenant, server }: ToolCardProps) {
+  const properties = useMemo(() => tool.inputSchema?.properties ?? {}, [tool.inputSchema]);
+  const required = useMemo(() => new Set(tool.inputSchema?.required ?? []), [tool.inputSchema]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<CallToolResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
+    if (raw === '') return undefined;
+    switch (prop.type) {
+      case 'number':
+      case 'integer': {
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : raw;
+      }
+      case 'boolean':
+        return raw === 'true';
+      case 'object':
+      case 'array':
+        return JSON.parse(raw);
+      default:
+        return raw;
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setResult(null);
+    setError(null);
+    try {
+      const args: Record<string, unknown> = {};
+      for (const [key, prop] of Object.entries(properties)) {
+        const raw = values[key] ?? '';
+        const parsed = parseValue(prop, raw);
+        if (parsed !== undefined) args[key] = parsed;
+      }
+      const res = await fetch(`/api/mcp/remote-servers/${encodeURIComponent(server)}/call-tool`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tenant, name: tool.name, arguments: args }),
+      });
+      // empty-catch-ok: non-JSON error body — res.status is surfaced below
+      const body = (await res.json().catch(() => ({}))) as {
+        result?: CallToolResult;
+        error?: string;
+        detail?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setResult(body.result ?? null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+      <summary className="flex cursor-pointer items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-sm font-semibold text-white">{tool.name}</div>
+          {tool.description && (
+            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{tool.description}</div>
+          )}
+        </div>
+        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
+      </summary>
+
+      <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
+        {Object.keys(properties).length === 0 && (
+          <p className="text-xs text-zinc-500">
+            This tool takes no input. Click <span className="font-medium">Invoke</span> to call it.
+          </p>
+        )}
+        {Object.entries(properties).map(([key, prop]) => (
+          <ArgumentField
+            key={key}
+            name={key}
+            prop={prop}
+            required={required.has(key)}
+            value={values[key] ?? ''}
+            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
+          />
+        ))}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? 'Invoking…' : 'Invoke'}
+          </button>
+          {error && <span className="text-xs text-red-400">{error}</span>}
+        </div>
+      </form>
+
+      {result && <ToolResult result={result} />}
+    </details>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Argument field
+// ---------------------------------------------------------------------------
+
+interface ArgumentFieldProps {
+  name: string;
+  prop: JsonSchemaProperty;
+  required: boolean;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
+  const inputId = `arg-${name}`;
+  const placeholder =
+    prop.default !== undefined
+      ? `default: ${JSON.stringify(prop.default)}`
+      : prop.type === 'object' || prop.type === 'array'
+        ? 'JSON value'
+        : (prop.type ?? 'string');
+
+  return (
+    <div>
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+        {name}
+        {required && <span className="ml-1 text-red-400">*</span>}
+        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
+      </label>
+      {prop.enum && prop.enum.length > 0 ? (
+        <select
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        >
+          <option value="">—</option>
+          {prop.enum.map((opt) => (
+            <option key={String(opt)} value={String(opt)}>
+              {String(opt)}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        />
+      )}
+      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tool result display
+// ---------------------------------------------------------------------------
+
+function ToolResult({ result }: { result: CallToolResult }) {
+  return (
+    <div
+      className={`mt-4 rounded-md border p-3 text-xs ${
+        result.isError
+          ? 'border-red-800 bg-red-900/20 text-red-300'
+          : 'border-emerald-900 bg-emerald-900/10 text-emerald-200'
+      }`}
+    >
+      <div className="mb-2 font-medium">{result.isError ? 'Tool returned an error' : 'Result'}</div>
+      <div className="space-y-2">
+        {result.content.map((block, idx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: blocks have no id
+          <pre key={idx} className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px]">
+            {block.type === 'text'
+              ? (block.text ?? '')
+              : `[${block.type}${block.mimeType ? ` ${block.mimeType}` : ''}]`}
+          </pre>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(backend)/admin/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/page.tsx
@@ -203,7 +203,13 @@ export default function McpCatalogPage() {
                           {r.connectionState}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-right">
+                      <td className="flex items-center justify-end gap-3 px-4 py-3 text-right">
+                        <a
+                          href={`/admin/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
+                          className="text-xs font-medium text-emerald-400 hover:text-emerald-300"
+                        >
+                          Inspect
+                        </a>
                         <button
                           type="button"
                           onClick={() => void handleDisconnect(r.server)}

--- a/apps/admin/src/app/api/mcp/oauth/callback/route.ts
+++ b/apps/admin/src/app/api/mcp/oauth/callback/route.ts
@@ -148,5 +148,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  // Persist non-credential metadata for downstream admin tooling (tool browser,
+  // server catalog detail pages). Consumers read from this same path via
+  // `lib/mcp/remote-server-client.ts`. If this write fails we still consider
+  // the authorization successful — the user can reconnect to rehydrate meta.
+  const meta = {
+    serverUrl: pending.serverUrl,
+    connectedAt: new Date().toISOString(),
+    connectedBy: authSession.user.id,
+  };
+  await vault
+    .set(`mcp/${pending.tenant}/${pending.server}/meta`, JSON.stringify(meta))
+    .catch(() => undefined); // empty-catch-ok: meta is best-effort — tokens are the load-bearing state
+
   return NextResponse.redirect(resultUrl(origin, { connected: pending.server }), 302);
 }

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/tool-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/tool-routes.test.ts
@@ -1,0 +1,393 @@
+/**
+ * MCP tool-browser route tests (Stage 3.2).
+ *
+ * Exercises the three new per-server routes:
+ *   - GET   /api/mcp/remote-servers/[server]/tools
+ *   - POST  /api/mcp/remote-servers/[server]/call-tool
+ *   - POST  /api/mcp/remote-servers/[server]/complete
+ *
+ * `buildRemoteMcpClient` is stubbed to return a fake client so we can
+ * assert the routes forward arguments correctly, propagate capability
+ * errors, and always close the transport. Real HTTP + McpClient coverage
+ * lives in `packages/mcp/__tests__/client.tools.test.ts` and the existing
+ * OAuth + Streamable HTTP integration tests.
+ */
+
+import { McpCapabilityError } from '@revealui/mcp/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// -- Mocks ------------------------------------------------------------------
+
+class FakeMcpClient {
+  connectCalls = 0;
+  closeCalls = 0;
+  listToolsImpl: () => Promise<unknown[]> = async () => [];
+  callToolImpl: (name: string, args?: unknown) => Promise<unknown> = async () => ({
+    content: [],
+  });
+  completeImpl: (ref: unknown, arg: unknown) => Promise<unknown> = async () => ({
+    values: [],
+  });
+
+  async connect(): Promise<void> {
+    this.connectCalls++;
+  }
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+  async listTools(): Promise<unknown[]> {
+    return this.listToolsImpl();
+  }
+  async callTool(name: string, args?: unknown): Promise<unknown> {
+    return this.callToolImpl(name, args);
+  }
+  async complete(ref: unknown, arg: unknown): Promise<unknown> {
+    return this.completeImpl(ref, arg);
+  }
+}
+
+const fakeClients: FakeMcpClient[] = [];
+let nextBuildThrows: Error | null = null;
+
+const mockBuild = vi.fn(async (_opts: { tenant: string; server: string }) => {
+  if (nextBuildThrows) {
+    const err = nextBuildThrows;
+    nextBuildThrows = null;
+    throw err;
+  }
+  const client = new FakeMcpClient();
+  fakeClients.push(client);
+  return { client, meta: { serverUrl: 'http://remote.test/mcp' } };
+});
+
+vi.mock('@/lib/mcp/remote-server-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/mcp/remote-server-client')>(
+    '@/lib/mcp/remote-server-client',
+  );
+  return {
+    ...actual,
+    buildRemoteMcpClient: (opts: { tenant: string; server: string }) => mockBuild(opts),
+  };
+});
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(url, {
+    headers: { cookie: 'session=test' },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  mockGetSession.mockReset();
+  mockBuild.mockClear();
+  fakeClients.length = 0;
+  nextBuildThrows = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/mcp/remote-servers/[server]/tools
+// ---------------------------------------------------------------------------
+
+describe('GET /api/mcp/remote-servers/[server]/tools', () => {
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin sessions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'user' } });
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 on missing or malformed tenant', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the server has no stored OAuth meta', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const actual = await vi.importActual<typeof import('@/lib/mcp/remote-server-client')>(
+      '@/lib/mcp/remote-server-client',
+    );
+    nextBuildThrows = new actual.RemoteServerNotConnectedError('acme', 'linear');
+
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('not_connected');
+  });
+
+  it('returns 412 when the server does not advertise the tools capability', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.listToolsImpl = async () => {
+        throw new McpCapabilityError('tools');
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(412);
+    // Transport was still closed despite the error.
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+
+  it('connects, lists tools, and always closes the transport', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.listToolsImpl = async () => [
+        { name: 'echo', description: 'Echoes input', inputSchema: { type: 'object' } },
+      ];
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { GET } = await import('../tools/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/tools?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tools: Array<{ name: string }>; serverUrl: string };
+    expect(body.tools.map((t) => t.name)).toEqual(['echo']);
+    expect(body.serverUrl).toBe('http://remote.test/mcp');
+    expect(fakeClients[0]?.connectCalls).toBe(1);
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/mcp/remote-servers/[server]/call-tool
+// ---------------------------------------------------------------------------
+
+describe('POST /api/mcp/remote-servers/[server]/call-tool', () => {
+  it('returns 400 when body.arguments is not a plain object', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../call-tool/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/call-tool', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme', name: 'echo', arguments: [1, 2, 3] }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body.name is missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../call-tool/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/call-tool', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards name + arguments to callTool and returns the result', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedName: string | undefined;
+    let observedArgs: unknown;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.callToolImpl = async (name, args) => {
+        observedName = name;
+        observedArgs = args;
+        return { content: [{ type: 'text', text: 'ok' }] };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { POST } = await import('../call-tool/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/call-tool', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          name: 'echo',
+          arguments: { text: 'hello' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+    expect(body.result.content[0]?.text).toBe('ok');
+    expect(observedName).toBe('echo');
+    expect(observedArgs).toEqual({ text: 'hello' });
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+
+  it('returns 502 on transport/call failures', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.callToolImpl = async () => {
+        throw new Error('wire exploded');
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { POST } = await import('../call-tool/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/call-tool', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme', name: 'echo', arguments: {} }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(502);
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/mcp/remote-servers/[server]/complete
+// ---------------------------------------------------------------------------
+
+describe('POST /api/mcp/remote-servers/[server]/complete', () => {
+  it('rejects body.ref when type is not recognized', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../complete/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/complete', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          ref: { type: 'ref/unknown', name: 'x' },
+          argument: { name: 'arg', value: '' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects body.argument when shape is wrong', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../complete/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/complete', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          ref: { type: 'ref/prompt', name: 'summarize' },
+          argument: { name: 'arg' }, // missing value
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards prompt-ref completions and returns suggestions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedRef: unknown;
+    let observedArg: unknown;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.completeImpl = async (ref, arg) => {
+        observedRef = ref;
+        observedArg = arg;
+        return { values: ['apple', 'apricot'], hasMore: false };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { POST } = await import('../complete/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/complete', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          ref: { type: 'ref/prompt', name: 'summarize' },
+          argument: { name: 'topic', value: 'ap' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { completion: { values: string[] } };
+    expect(body.completion.values).toEqual(['apple', 'apricot']);
+    expect(observedRef).toEqual({ type: 'ref/prompt', name: 'summarize' });
+    expect(observedArg).toEqual({ name: 'topic', value: 'ap' });
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+
+  it('accepts resource-template references', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedRef: unknown;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.completeImpl = async (ref) => {
+        observedRef = ref;
+        return { values: [] };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+
+    const { POST } = await import('../complete/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/complete', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          ref: { type: 'ref/resource', uri: 'revealui://acme/posts/{id}' },
+          argument: { name: 'id', value: '1' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(observedRef).toEqual({
+      type: 'ref/resource',
+      uri: 'revealui://acme/posts/{id}',
+    });
+  });
+});

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/call-tool/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/call-tool/route.ts
@@ -1,0 +1,109 @@
+/**
+ * MCP call-tool — POST /api/mcp/remote-servers/[server]/call-tool
+ *
+ * Invokes a tool on a connected remote MCP server. Body:
+ * `{ tenant: string, name: string, arguments?: Record<string, unknown> }`.
+ * Returns the full SDK `CallToolResult` — tool failures surface in-band
+ * (`isError: true, content: [...]`), not as HTTP errors.
+ *
+ * Stage 3.2 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { type CallToolResult, McpCapabilityError } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ result: CallToolResult } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let body: { tenant?: unknown; name?: unknown; arguments?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const { tenant, name } = body;
+  if (typeof tenant !== 'string' || !IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'body.tenant must be a string matching /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (typeof name !== 'string' || name.length === 0 || name.length > 256) {
+    return NextResponse.json(
+      { error: 'body.name must be a non-empty string (≤256 chars)' },
+      { status: 400 },
+    );
+  }
+  const args =
+    body.arguments === undefined
+      ? undefined
+      : typeof body.arguments === 'object' &&
+          body.arguments !== null &&
+          !Array.isArray(body.arguments)
+        ? (body.arguments as Record<string, unknown>)
+        : null;
+  if (args === null) {
+    return NextResponse.json(
+      { error: 'body.arguments must be a plain object when provided' },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const result = await built.client.callTool(name, args);
+    return NextResponse.json({ result });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/complete/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/complete/route.ts
@@ -1,0 +1,143 @@
+/**
+ * MCP argument completions — POST /api/mcp/remote-servers/[server]/complete
+ *
+ * Proxies `completions/complete` to a remote MCP server for argument
+ * autocompletion on a prompt or resource-template reference. Body:
+ * ```
+ * {
+ *   tenant: string,
+ *   ref: { type: 'ref/prompt', name: string }
+ *      | { type: 'ref/resource', uri: string },
+ *   argument: { name: string, value: string }
+ * }
+ * ```
+ *
+ * Feeds the admin's argument-completion-aware inputs per Stage 3.2. Note:
+ * the MCP completions protocol is for prompts + resource templates, not for
+ * tool arguments — tools surface their schema via `Tool.inputSchema`.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { type Completion, McpCapabilityError } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+type ParsedRef = { type: 'ref/prompt'; name: string } | { type: 'ref/resource'; uri: string };
+
+function parseRef(input: unknown): ParsedRef | null {
+  if (typeof input !== 'object' || input === null) return null;
+  const ref = input as { type?: unknown; name?: unknown; uri?: unknown };
+  if (ref.type === 'ref/prompt') {
+    if (typeof ref.name !== 'string' || ref.name.length === 0) return null;
+    return { type: 'ref/prompt', name: ref.name };
+  }
+  if (ref.type === 'ref/resource') {
+    if (typeof ref.uri !== 'string' || ref.uri.length === 0) return null;
+    return { type: 'ref/resource', uri: ref.uri };
+  }
+  return null;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ completion: Completion } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let body: { tenant?: unknown; ref?: unknown; argument?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const { tenant } = body;
+  if (typeof tenant !== 'string' || !IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'body.tenant must be a string matching /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  const ref = parseRef(body.ref);
+  if (!ref) {
+    return NextResponse.json(
+      {
+        error: "body.ref must be { type: 'ref/prompt', name } or { type: 'ref/resource', uri }",
+      },
+      { status: 400 },
+    );
+  }
+  const argInput = body.argument;
+  if (typeof argInput !== 'object' || argInput === null) {
+    return NextResponse.json(
+      { error: 'body.argument must be { name: string, value: string }' },
+      { status: 400 },
+    );
+  }
+  const argument = argInput as { name?: unknown; value?: unknown };
+  if (
+    typeof argument.name !== 'string' ||
+    argument.name.length === 0 ||
+    typeof argument.value !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'body.argument.name must be a non-empty string; body.argument.value a string' },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const completion = await built.client.complete(ref, {
+      name: argument.name,
+      value: argument.value,
+    });
+    return NextResponse.json({ completion });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/tools/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/tools/route.ts
@@ -1,0 +1,82 @@
+/**
+ * MCP tools list — GET /api/mcp/remote-servers/[server]/tools?tenant=X
+ *
+ * Connects to an OAuth-authorized remote MCP server and returns the list of
+ * tools it advertises. Short-lived: the client is torn down after the call.
+ *
+ * Stage 3.2 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { McpCapabilityError, type Tool } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<
+  NextResponse<{ tools: Tool[]; serverUrl: string } | { error: string; detail?: string }>
+> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  const tenant = new URL(request.url).searchParams.get('tenant');
+
+  if (!(tenant && IDENTIFIER_RE.test(tenant))) {
+    return NextResponse.json(
+      { error: 'tenant query parameter must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const tools = await built.client.listTools();
+    return NextResponse.json({ tools, serverUrl: built.meta.serverUrl });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/lib/mcp/remote-server-client.ts
+++ b/apps/admin/src/lib/mcp/remote-server-client.ts
@@ -1,0 +1,120 @@
+/**
+ * Helper for constructing an `McpClient` against an OAuth-authorized remote
+ * MCP server using credentials already persisted in the vault.
+ *
+ * Callers supply `(tenant, server)`. We read the non-credential meta record
+ * (`mcp/<tenant>/<server>/meta`) to recover the server URL, then construct
+ * an `McpOAuthProvider` that feeds the streamable-http transport. The
+ * returned client is configured but NOT yet connected — callers invoke
+ * `connect()` themselves so they can manage teardown.
+ *
+ * Stage 3.2 of the MCP v1 plan.
+ */
+
+import { McpClient } from '@revealui/mcp/client';
+import {
+  createRevvaultVault,
+  McpOAuthProvider,
+  type OAuthClientMetadata,
+  type Vault,
+} from '@revealui/mcp/oauth';
+
+/** Stored alongside tokens by the OAuth callback. */
+export interface RemoteServerMeta {
+  serverUrl: string;
+  connectedAt: string;
+  connectedBy: string;
+}
+
+export class RemoteServerNotConnectedError extends Error {
+  constructor(
+    public readonly tenant: string,
+    public readonly server: string,
+  ) {
+    super(
+      `No OAuth meta found for mcp/${tenant}/${server}. ` +
+        'Re-authorize the server via /admin/mcp/connect.',
+    );
+    this.name = 'RemoteServerNotConnectedError';
+  }
+}
+
+/**
+ * Non-authoritative placeholder; the provider reuses the originally-registered
+ * client info saved at `mcp/<tenant>/<server>/client`. Only shape is required
+ * by the provider constructor.
+ */
+const SENTINEL_CLIENT_METADATA: OAuthClientMetadata = {
+  redirect_uris: ['http://localhost/unused'],
+  client_name: 'RevealUI Admin (runtime)',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+};
+
+export interface BuildRemoteMcpClientOptions {
+  tenant: string;
+  server: string;
+  /** Injected for tests; defaults to the revvault-backed vault. */
+  vault?: Vault;
+  /** Client name reported during `initialize`. */
+  clientName?: string;
+  /** Client version reported during `initialize`. */
+  clientVersion?: string;
+}
+
+export interface BuiltRemoteMcpClient {
+  client: McpClient;
+  meta: RemoteServerMeta;
+}
+
+/**
+ * Load OAuth credentials + server URL and return a configured `McpClient`.
+ * Throws {@link RemoteServerNotConnectedError} if no meta record exists for
+ * the `(tenant, server)` pair.
+ */
+export async function buildRemoteMcpClient(
+  options: BuildRemoteMcpClientOptions,
+): Promise<BuiltRemoteMcpClient> {
+  const { tenant, server } = options;
+  const vault = options.vault ?? createRevvaultVault();
+
+  const metaPath = `mcp/${tenant}/${server}/meta`;
+  const rawMeta = await vault.get(metaPath);
+  if (!rawMeta) throw new RemoteServerNotConnectedError(tenant, server);
+  const meta = parseMeta(rawMeta);
+
+  const provider = new McpOAuthProvider({
+    tenant,
+    server,
+    vault,
+    redirectUrl: 'http://localhost/unused',
+    clientMetadata: SENTINEL_CLIENT_METADATA,
+  });
+
+  const client = new McpClient({
+    clientInfo: {
+      name: options.clientName ?? 'revealui-admin',
+      version: options.clientVersion ?? '0.0.0',
+    },
+    transport: {
+      kind: 'streamable-http',
+      url: meta.serverUrl,
+      authProvider: provider,
+    },
+  });
+
+  return { client, meta };
+}
+
+function parseMeta(raw: string): RemoteServerMeta {
+  const parsed = JSON.parse(raw) as Partial<RemoteServerMeta>;
+  if (
+    typeof parsed.serverUrl !== 'string' ||
+    typeof parsed.connectedAt !== 'string' ||
+    typeof parsed.connectedBy !== 'string'
+  ) {
+    throw new Error('Stored MCP remote-server meta is missing required fields');
+  }
+  return parsed as RemoteServerMeta;
+}

--- a/packages/mcp/__tests__/client.tools.test.ts
+++ b/packages/mcp/__tests__/client.tools.test.ts
@@ -1,0 +1,122 @@
+/**
+ * McpClient tools coverage (Stage 3.2).
+ *
+ * Tools were deliberately out of Stage 0 — the hypervisor handled stdio tool
+ * calls through its custom JSON-RPC. Stage 3.2 adds `listTools` and
+ * `callTool` to the full-protocol client so the admin tool browser works
+ * against remote Streamable-HTTP servers.
+ */
+
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpCapabilityError, McpClient } from '../src/client.js';
+
+function makeToolsFixture() {
+  const server = new Server(
+    { name: 'tools-fixture', version: '0.0.1' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'echo',
+        description: 'Echoes the input text',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'Text to echo' },
+          },
+          required: ['text'],
+        },
+      },
+      {
+        name: 'fail',
+        description: 'Always returns an error',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (req.params.name === 'echo') {
+      const args = (req.params.arguments ?? {}) as { text?: string };
+      return {
+        content: [{ type: 'text', text: `echo: ${args.text ?? ''}` }],
+      };
+    }
+    if (req.params.name === 'fail') {
+      return {
+        content: [{ type: 'text', text: 'tool failed on purpose' }],
+        isError: true,
+      };
+    }
+    throw new Error(`unknown tool: ${req.params.name}`);
+  });
+
+  return server;
+}
+
+async function connectedClient(): Promise<McpClient> {
+  const server = makeToolsFixture();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new McpClient({
+    clientInfo: { name: 'tools-test', version: '0.0.0' },
+    transport: { kind: 'custom', transport: clientTransport },
+  });
+  await client.connect();
+  return client;
+}
+
+describe('McpClient tools', () => {
+  let client: McpClient | undefined;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = undefined;
+    }
+  });
+
+  it('listTools returns the server-advertised tools', async () => {
+    client = await connectedClient();
+    const tools = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(['echo', 'fail']);
+    expect(tools.find((t) => t.name === 'echo')?.inputSchema?.required).toEqual(['text']);
+  });
+
+  it('callTool echoes structured arguments and returns a content array', async () => {
+    client = await connectedClient();
+    const result = await client.callTool('echo', { text: 'hello' });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toMatchObject({ type: 'text', text: 'echo: hello' });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('surfaces tool failures in-band via isError rather than throwing', async () => {
+    client = await connectedClient();
+    const result = await client.callTool('fail');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({ type: 'text' });
+  });
+
+  it('throws McpCapabilityError when the server does not advertise tools', async () => {
+    const server = new Server(
+      { name: 'no-tools', version: '0.0.1' },
+      { capabilities: {} }, // no tools capability
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new McpClient({
+      clientInfo: { name: 'tools-test', version: '0.0.0' },
+      transport: { kind: 'custom', transport: clientTransport },
+    });
+    await client.connect();
+
+    await expect(client.listTools()).rejects.toBeInstanceOf(McpCapabilityError);
+    await expect(client.callTool('any')).rejects.toBeInstanceOf(McpCapabilityError);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -74,6 +74,10 @@
     "./oauth": {
       "types": "./dist/oauth.d.ts",
       "import": "./dist/oauth.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js"
     }
   },
   "files": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -33,6 +33,7 @@ import type { AnyObjectSchema, SchemaOutput } from '@modelcontextprotocol/sdk/se
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import {
+  type CallToolResult,
   type ClientCapabilities,
   type CompleteRequest,
   type CompleteResult,
@@ -56,6 +57,7 @@ import {
   ResourceUpdatedNotificationSchema,
   type Root,
   type ServerCapabilities,
+  type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 
 // ---------------------------------------------------------------------------
@@ -250,6 +252,7 @@ export class McpNotConnectedError extends Error {
 // ---------------------------------------------------------------------------
 
 export type {
+  CallToolResult,
   ClientCapabilities,
   CompleteRequest,
   CompleteResult,
@@ -268,6 +271,7 @@ export type {
   ResourceTemplateReference,
   Root,
   ServerCapabilities,
+  Tool,
 };
 
 /** Parameters delivered to a `subscribeResource` handler. */
@@ -510,6 +514,50 @@ export class McpClient {
         }
       }
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompts
+  // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // Tools
+  // -------------------------------------------------------------------------
+
+  /**
+   * Enumerate tools the server exposes. Requires the server to advertise the
+   * `tools` capability.
+   *
+   * Returns the SDK's `Tool` shape unchanged — name, description, input JSON
+   * Schema (as `inputSchema`), and any spec-defined annotations.
+   */
+  async listTools(options?: McpRequestOptions): Promise<Tool[]> {
+    this.assertConnected('listTools');
+    this.requireCapability('tools');
+    const result = await this.sdk.listTools(undefined, toSdkRequestOptions(options));
+    return result.tools;
+  }
+
+  /**
+   * Invoke a tool by name with the supplied structured arguments. Requires
+   * the server to advertise `tools`. Returns the full SDK `CallToolResult`
+   * (structured content + isError flag + optional `_meta`).
+   *
+   * Tool failures surface as `{ isError: true, content: [...] }` rather than
+   * thrown exceptions — the server is explicitly asked to communicate tool
+   * errors in-band per the MCP spec. Transport-level failures still throw.
+   */
+  async callTool(
+    name: string,
+    args?: Record<string, unknown>,
+    options?: McpRequestOptions,
+  ): Promise<CallToolResult> {
+    this.assertConnected('callTool');
+    this.requireCapability('tools');
+    const params: { name: string; arguments?: Record<string, unknown> } = { name };
+    if (args !== undefined) params.arguments = args;
+    const result = await this.sdk.callTool(params, undefined, toSdkRequestOptions(options));
+    return result as CallToolResult;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -56,6 +56,7 @@ export {
 } from './auth.js';
 // MCP protocol client (Stage 0 complete; Stage 1 PR-1.1 adds Streamable HTTP transport)
 export {
+  type CallToolResult,
   type ClientCapabilities,
   type CompleteRequest,
   type CompleteResult,
@@ -92,6 +93,7 @@ export {
   type StreamableHTTPClientTransportOptions,
   type StreamableHTTPReconnectionOptions,
   type StreamableHttpTransportOptions,
+  type Tool,
   type TransportOptions,
 } from './client.js';
 // Configuration


### PR DESCRIPTION
## Summary

Stage 3.2 of the MCP v1 productionization plan — **tool browser + ad-hoc invoker** for OAuth-authorized remote MCP servers. Builds on Stages 2 + 3.1. Resource/prompt browsing (3.3) and elicitation/progress/logs (3.4) remain open.

### `@revealui/mcp`

- **`McpClient.listTools()`** and **`callTool(name, arguments?)`** — capability-gated, per-request options threaded through, tool failures surface in-band (`isError: true, content: [...]`) rather than thrown. Stage 0 deliberately skipped tools because the hypervisor handled stdio tool calls through its own JSON-RPC; 3.2 needs them for remote Streamable-HTTP servers.
- **`Tool`** and **`CallToolResult`** types exported.
- **New `@revealui/mcp/client` subpath export** — admin/edge consumers can import the client surface without transitively pulling in the stdio launcher scripts (`servers/neon.ts`, `servers/next-devtools.ts`, …) whose self-executing `main()` calls `checkMcpLicense()` during bundling. Fixes a latent build failure exposed by this PR's admin-side imports.

### admin

- **OAuth callback** now writes a non-credential meta record at `mcp/<tenant>/<server>/meta` with `{ serverUrl, connectedAt, connectedBy }` after successful token exchange. Tokens remain the load-bearing state — the meta write is best-effort.
- **`lib/mcp/remote-server-client.ts`** — `buildRemoteMcpClient({ tenant, server })` helper that rebuilds an `McpClient` against a connected remote server using credentials + meta already in the vault. Returns `{ client, meta }`; throws `RemoteServerNotConnectedError` when meta is missing.
- **Three new per-server routes**:
  - `GET /api/mcp/remote-servers/[server]/tools?tenant=X` — lists tools + returns `serverUrl`. 404 if not connected; 412 if the server doesn't advertise `tools`.
  - `POST /api/mcp/remote-servers/[server]/call-tool` — body `{ tenant, name, arguments? }`. Returns the full `CallToolResult`; transport failures → 502.
  - `POST /api/mcp/remote-servers/[server]/complete` — body `{ tenant, ref, argument }`. Handles both `ref/prompt` and `ref/resource` references per the MCP completions spec (tool arguments use `Tool.inputSchema`, not completions).
- **`/admin/mcp/inspect?tenant=X&server=Y`** — tool browser page. Renders each tool's `inputSchema` as a form (strings, numbers, booleans, enums, JSON for complex types), invokes the tool, displays `CallToolResult` content blocks inline.
- **Catalog page** (`/admin/mcp`) — adds a per-row "Inspect" link alongside "Disconnect".

### Security / correctness

- Every route gates on admin session + role check.
- `tenant` and `server` must match `/^[A-Za-z0-9_-]{1,64}$/`; adversarial identifiers rejected.
- Route handlers always close the MCP transport in `finally`, even when the call throws.
- Meta write is best-effort; a failed write doesn't break the OAuth flow — the admin can reconnect to rehydrate.

### Test coverage

18 new tests (`@revealui/mcp`: 191 → 195; admin: 1546 → 1560):

- **`@revealui/mcp`** (4 tests): `listTools` round-trip; `callTool` structured-argument echo; in-band `isError` handling; `McpCapabilityError` when `tools` not advertised.
- **admin** (14 tests): 401/403 gating on all three routes; 400 on missing tenant/name/malformed body; 404 when meta is missing (`RemoteServerNotConnectedError`); 412 on `McpCapabilityError`; happy-path round-trip for each route; transport always closed on failure.

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally
- [ ] `pnpm --filter @revealui/mcp test` — 195 passing / 5 skipped
- [ ] `pnpm --filter admin test` — 1560 passing / 10 skipped
- [ ] `pnpm --filter admin typecheck` — clean
- [ ] `pnpm --filter "admin..." build` — clean

## Stage 3 remainder

- **3.3** — resource browser + prompt picker + read-only resource preview pane (consumes the completions route shipped here)
- **3.4** — elicitation forms (inline), progress bars + cancel button, live log stream viewer

## Notes

- **`@revealui/mcp/client` subpath import is now recommended** for any consumer that doesn't need the stdio launchers. The top-level `@revealui/mcp` import continues to work but bundles in the `launch*Mcp` functions whose self-executing `main()` is the root cause of the license-check error that would otherwise surface during Next.js turbopack bundling.
- **Legacy-connected servers** (authorized before this PR) won't have a meta record; they'll return 404 from the tool routes. The admin can reconnect via `/admin/mcp/connect` to rehydrate meta. No data loss — tokens are untouched.
- Completions are wired through on the server side and route; the tool browser UI doesn't yet consume them (tool arguments use `inputSchema`, not completions). Stage 3.3's prompt picker will be the first real consumer.
