### PR TITLE
feat(retention): unreconciled_webhooks 90d retention (CR8-P3-02 follow-up)

### DIFF
--- a/apps/api/src/routes/cron/cleanup.ts
+++ b/apps/api/src/routes/cron/cleanup.ts
@@ -112,30 +112,35 @@ app.post('/cleanup', async (c) => {
       logger.error(`[cron-cleanup] Log retention purge failed: ${message}`);
     }
 
-    // Operational-hygiene purge: terminal jobs + processed webhook events.
-    // Safety rules enforced at the query level — active jobs survive
+    // Operational-hygiene purge: terminal jobs, processed webhook events,
+    // resolved reconciliation records. Safety rules enforced at the query
+    // level — active jobs and unresolved reconciliation rows survive
     // unconditionally. Non-fatal.
     let operationalPurged = {
       jobs: 0,
       webhookEvents: 0,
-      windows: { jobs: 0, webhookEvents: 0 },
+      unreconciledWebhooks: 0,
+      windows: { jobs: 0, webhookEvents: 0, unreconciledWebhooks: 0 },
     };
     try {
       const opsResult = await cleanupOperational();
       operationalPurged = {
         jobs: opsResult.jobs,
         webhookEvents: opsResult.webhookEvents,
+        unreconciledWebhooks: opsResult.unreconciledWebhooks,
         windows: opsResult.windows,
       };
-      const total = opsResult.jobs + opsResult.webhookEvents;
+      const total = opsResult.jobs + opsResult.webhookEvents + opsResult.unreconciledWebhooks;
       if (total > 0) {
         logger.info('[cron-cleanup] Purged operational rows past retention', {
           jobs: opsResult.jobs,
           webhookEvents: opsResult.webhookEvents,
+          unreconciledWebhooks: opsResult.unreconciledWebhooks,
           windows: opsResult.windows,
           cutoffs: {
             jobs: opsResult.cutoffs.jobs.toISOString(),
             webhookEvents: opsResult.cutoffs.webhookEvents.toISOString(),
+            unreconciledWebhooks: opsResult.cutoffs.unreconciledWebhooks.toISOString(),
           },
         });
       }

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -86,6 +86,13 @@ const optionalSchema = z.object({
     .min(1, 'Must be at least 1 day')
     .max(3650, 'Must not exceed 3650 days (10 years)')
     .default(90),
+  // Resolved rows only — unresolved (open customer-payment bugs) never purged.
+  REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS: z.coerce
+    .number()
+    .int()
+    .min(1, 'Must be at least 1 day')
+    .max(3650, 'Must not exceed 3650 days (10 years)')
+    .default(90),
 
   // License key signing (RSA-2048 PEM)
   REVEALUI_LICENSE_PRIVATE_KEY: z.string().optional(),

--- a/packages/db/src/cleanup/operational-retention.ts
+++ b/packages/db/src/cleanup/operational-retention.ts
@@ -1,20 +1,17 @@
 /**
  * Operational Hygiene Retention
  *
- * Purges terminal rows from internal queue and idempotency tables past
- * their retention windows. Keeps hot tables lean; no PII concerns (these
- * are internal operational state, not user data).
+ * Purges terminal rows from internal queue / idempotency / reconciliation
+ * tables past their retention windows. Keeps hot tables lean; no PII
+ * concerns (these are internal operational state, not user data).
  *
  * See ~/suite/.jv/docs/cr8-p3-02-retention-design.md for the decision
- * record. This is PR2 in the CR8-P3-02 arc; PR1 shipped the log tables.
- *
- * NOTE: the design doc originally called for a third purge on
- * `unreconciled_webhooks`. That table is defined in the Drizzle schema
- * but has no corresponding CREATE TABLE migration (verified 2026-04-22
- * — snapshots at migrations/meta/0006_snapshot.json + 0009_snapshot.json
- * reference it, but no .sql migration creates it). A fresh DB would fail
- * the retention query. Dropped from PR2 scope; tracked in a separate
- * follow-up to ship the missing migration first.
+ * record. Part of the CR8-P3-02 arc:
+ *   - PR1 (revealui#495): app_logs + error_events retention
+ *   - PR2 (revealui#499): jobs + processed_webhook_events retention
+ *   - fix  (revealui#500): missing unreconciled_webhooks migration (0010)
+ *   - this PR: extends PR2 with unreconciled_webhooks retention now that
+ *     the migration is in place.
  *
  * Windows:
  *   - jobs (state IN ('completed', 'failed'), completedAt < cutoff)
@@ -27,14 +24,21 @@
  *     → REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS (default 90)
  *     Stripe idempotency markers. Stripe retry horizon is ~24h; 90d is
  *     belt-and-suspenders. No PII.
+ *
+ *   - unreconciled_webhooks (resolvedAt IS NOT NULL AND resolvedAt < cutoff)
+ *     → REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS (default 90)
+ *     SAFETY: only purges resolved rows. Unresolved rows represent open
+ *     customer-payment-fulfillment bugs and MUST persist until manually
+ *     reconciled. resolvedAt=NULL rows are skipped unconditionally.
  */
 
 import { and, inArray, isNotNull, lt } from 'drizzle-orm';
 import { getClient } from '../client/index.js';
 import { jobs } from '../schema/jobs.js';
 import { processedWebhookEvents } from '../schema/webhook-events.js';
+import { unreconciledWebhooks } from '../schema/webhook-reconciliation.js';
 
-export type OperationalRetentionTable = 'jobs' | 'webhookEvents';
+export type OperationalRetentionTable = 'jobs' | 'webhookEvents' | 'unreconciledWebhooks';
 
 export interface CleanupOperationalOptions {
   /** When true, counts rows without deleting (default: false) */
@@ -50,21 +54,24 @@ export interface CleanupOperationalOptions {
 export interface CleanupOperationalResult {
   jobs: number;
   webhookEvents: number;
+  unreconciledWebhooks: number;
   dryRun: boolean;
   windows: Record<OperationalRetentionTable, number>;
   cutoffs: Record<OperationalRetentionTable, Date>;
 }
 
-const ALL_TABLES: OperationalRetentionTable[] = ['jobs', 'webhookEvents'];
+const ALL_TABLES: OperationalRetentionTable[] = ['jobs', 'webhookEvents', 'unreconciledWebhooks'];
 
 const DEFAULT_WINDOWS: Record<OperationalRetentionTable, number> = {
   jobs: 30,
   webhookEvents: 90,
+  unreconciledWebhooks: 90,
 };
 
 const ENV_VARS: Record<OperationalRetentionTable, string> = {
   jobs: 'REVEALUI_JOB_RETENTION_DAYS',
   webhookEvents: 'REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS',
+  unreconciledWebhooks: 'REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS',
 };
 
 function resolveWindow(table: OperationalRetentionTable, override?: number): number {
@@ -96,6 +103,8 @@ function resolveWindow(table: OperationalRetentionTable, override?: number): num
  *   - `processed_webhook_events`: no protected state; all rows past the
  *     window are purgeable (idempotency markers are bounded by time, not
  *     state).
+ *   - `unreconciled_webhooks`: only rows with resolvedAt IS NOT NULL are
+ *     considered. Open reconciliation work is never silently purged.
  */
 export async function cleanupOperational(
   options: CleanupOperationalOptions = {},
@@ -107,17 +116,20 @@ export async function cleanupOperational(
   const windows: Record<OperationalRetentionTable, number> = {
     jobs: resolveWindow('jobs', overrides.jobs),
     webhookEvents: resolveWindow('webhookEvents', overrides.webhookEvents),
+    unreconciledWebhooks: resolveWindow('unreconciledWebhooks', overrides.unreconciledWebhooks),
   };
 
   const now = Date.now();
   const cutoffs: Record<OperationalRetentionTable, Date> = {
     jobs: new Date(now - windows.jobs * 24 * 60 * 60 * 1000),
     webhookEvents: new Date(now - windows.webhookEvents * 24 * 60 * 60 * 1000),
+    unreconciledWebhooks: new Date(now - windows.unreconciledWebhooks * 24 * 60 * 60 * 1000),
   };
 
   const result: CleanupOperationalResult = {
     jobs: 0,
     webhookEvents: 0,
+    unreconciledWebhooks: 0,
     dryRun,
     windows,
     cutoffs,
@@ -152,6 +164,24 @@ export async function cleanupOperational(
     } else {
       const deleted = await db.delete(processedWebhookEvents).where(where).returning();
       result.webhookEvents = deleted.length;
+    }
+  }
+
+  if (tables.includes('unreconciledWebhooks')) {
+    // SAFETY: only resolved rows. Unresolved = open customer-payment bug.
+    const where = and(
+      isNotNull(unreconciledWebhooks.resolvedAt),
+      lt(unreconciledWebhooks.resolvedAt, cutoffs.unreconciledWebhooks),
+    );
+    if (dryRun) {
+      const rows = await db
+        .select({ eventId: unreconciledWebhooks.eventId })
+        .from(unreconciledWebhooks)
+        .where(where);
+      result.unreconciledWebhooks = rows.length;
+    } else {
+      const deleted = await db.delete(unreconciledWebhooks).where(where).returning();
+      result.unreconciledWebhooks = deleted.length;
     }
   }
 

--- a/packages/test/src/integration/database/operational-retention.integration.test.ts
+++ b/packages/test/src/integration/database/operational-retention.integration.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { cleanupOperational } from '@revealui/db/cleanup';
-import { jobs, processedWebhookEvents } from '@revealui/db/schema';
+import { jobs, processedWebhookEvents, unreconciledWebhooks } from '@revealui/db/schema';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createTestDb, type TestDb } from '../../utils/drizzle-test-db.js';
 
@@ -40,13 +40,16 @@ describe('operational-hygiene retention (CR8-P3-02 PR2)', () => {
   beforeEach(async () => {
     await testDb.pglite.exec('DELETE FROM jobs');
     await testDb.pglite.exec('DELETE FROM processed_webhook_events');
+    await testDb.pglite.exec('DELETE FROM unreconciled_webhooks');
     delete process.env.REVEALUI_JOB_RETENTION_DAYS;
     delete process.env.REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS;
+    delete process.env.REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS;
   });
 
   afterEach(() => {
     delete process.env.REVEALUI_JOB_RETENTION_DAYS;
     delete process.env.REVEALUI_WEBHOOK_EVENT_RETENTION_DAYS;
+    delete process.env.REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS;
   });
 
   describe('jobs', () => {
@@ -189,6 +192,72 @@ describe('operational-hygiene retention (CR8-P3-02 PR2)', () => {
         'SELECT id FROM processed_webhook_events',
       );
       expect(remaining.rows.map((r) => r.id)).toEqual(['evt_fresh']);
+    });
+  });
+
+  describe('unreconciled_webhooks', () => {
+    it('deletes RESOLVED rows past 90d, keeps unresolved rows forever', async () => {
+      await testDb.drizzle.insert(unreconciledWebhooks).values([
+        {
+          eventId: 'evt_old_resolved',
+          eventType: 'checkout.session.completed',
+          errorTrace: 'stripe timeout',
+          createdAt: daysAgo(200),
+          resolvedAt: daysAgo(100),
+          resolvedBy: 'cron',
+        },
+        {
+          eventId: 'evt_ancient_unresolved',
+          eventType: 'invoice.payment_failed',
+          errorTrace: 'customer unreachable',
+          createdAt: daysAgo(365),
+          resolvedAt: null,
+          resolvedBy: null,
+        },
+        {
+          eventId: 'evt_fresh_resolved',
+          eventType: 'customer.subscription.updated',
+          errorTrace: 'race condition',
+          createdAt: daysAgo(30),
+          resolvedAt: daysAgo(10),
+          resolvedBy: 'admin@revealui.com',
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+
+      expect(result.unreconciledWebhooks).toBe(1);
+      expect(result.windows.unreconciledWebhooks).toBe(90);
+
+      const remaining = await testDb.pglite.query<{ event_id: string }>(
+        'SELECT event_id FROM unreconciled_webhooks ORDER BY event_id',
+      );
+      // ancient-unresolved MUST survive; fresh-resolved survives by window.
+      expect(remaining.rows.map((r) => r.event_id)).toEqual([
+        'evt_ancient_unresolved',
+        'evt_fresh_resolved',
+      ]);
+    });
+
+    it('NEVER purges unresolved rows regardless of age (safety)', async () => {
+      await testDb.drizzle.insert(unreconciledWebhooks).values([
+        {
+          eventId: 'evt_eternal_bug',
+          eventType: 'checkout.session.completed',
+          errorTrace: 'unhandled payment',
+          createdAt: daysAgo(10_000),
+          resolvedAt: null,
+          resolvedBy: null,
+        },
+      ]);
+
+      const result = await cleanupOperational(asDbOpts());
+      expect(result.unreconciledWebhooks).toBe(0);
+
+      const remaining = await testDb.pglite.query<{ event_id: string }>(
+        'SELECT event_id FROM unreconciled_webhooks',
+      );
+      expect(remaining.rows).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary

**Completes the CR8-P3-02 retention arc.** Adds the third (and final) operational-hygiene purge: `unreconciled_webhooks` 90d retention for resolved rows only.

Unblocked by [revealui#500](https://github.com/RevealUIStudio/revealui/pull/500) (merged `9c2e70118`) which shipped the missing `unreconciled_webhooks` CREATE TABLE migration discovered during PR2 scoping.

## CR8-P3-02 arc recap

| PR | Commit | What |
|---|---|---|
| [#495](https://github.com/RevealUIStudio/revealui/pull/495) | `f8eeb668b` | PR1 — `app_logs` + `error_events` 90d retention (code) |
| [#496](https://github.com/RevealUIStudio/revealui/pull/496) | `d51ec28ad` | Privacy-policy concrete windows + CI-enforced text assertion |
| [#499](https://github.com/RevealUIStudio/revealui/pull/499) | `6468e5e37` | PR2 — `jobs` 30d + `processed_webhook_events` 90d |
| [#500](https://github.com/RevealUIStudio/revealui/pull/500) | `9c2e70118` | fix — missing `unreconciled_webhooks` migration (0010) |
| **this PR** | — | **unreconciled_webhooks 90d retention (completes the arc)** |

## Change

- **`packages/config/src/schema.ts`** — `REVEALUI_WEBHOOK_RECONCILIATION_RETENTION_DAYS` (coerced int, 1..3650, default **90**).
- **`packages/db/src/cleanup/operational-retention.ts`** — re-adds the `unreconciledWebhooks` entry that was dropped from PR2 when the missing migration was discovered. Query: `and(isNotNull(unreconciledWebhooks.resolvedAt), lt(unreconciledWebhooks.resolvedAt, cutoffs.unreconciledWebhooks))`. Module docstring updated with the full arc reference.
- **`apps/api/src/routes/cron/cleanup.ts`** — extends `operationalPurged` shape + log output to include the third table.
- **Integration tests** — 2 new tests in the existing `operational-retention.integration.test.ts`:
  1. Deletes RESOLVED rows past 90d, keeps unresolved (10,000d old) + fresh resolved (10d)
  2. NEVER purges unresolved rows regardless of age — 10,000d unresolved survives unconditionally

## Safety guarantee

The one that matters: `resolvedAt IS NULL` rows represent **open customer-payment-fulfillment bugs**. They must persist until manually reconciled. Query-level enforcement via `isNotNull(unreconciledWebhooks.resolvedAt)` in the `WHERE`. Test `NEVER purges unresolved rows regardless of age (safety)` proves this: seeds a 10,000-day-old unresolved row, runs cleanup, asserts the row survives.

## Verification

- `pnpm turbo build --filter @revealui/db` green
- `pnpm turbo typecheck --filter api --filter @revealui/db --filter @revealui/config` green (16/16)
- `pnpm exec vitest run src/integration/database/operational-retention.integration.test.ts` — **12/12 pass in 3.03s** (10 existing + 2 new)
- `pnpm gate:quick` green after Biome fix

## Test plan

- [ ] CI green on this PR (integration tests must pass now that the table exists via #500)
- [ ] After merge: flip `CR8-P3-02` checkbox `[ ] → [x]` in internal docs citing all 5 commits (#495, #496, #499, #500, this)
- [ ] Optional: close the design doc at internal docs with a "STATUS: COMPLETE" header

## Memory alignment

- `feedback_audit_workflow.md` — dedicated PRs; this is a small single-concern follow-up that completes the arc without muddying the prior three PRs.
- `feedback_durable_only.md` — safety rule enforced at the query level (not caller discipline), concrete env-configurable window.
- `feedback_honest_audit_playbook.md` — the whole arc: design doc → founder decisions → implementation → policy text → CI enforcement. Every row of design doc §5 now has corresponding code + test.
