### PR TITLE
feat(admin): resource browser + prompt picker (Stage 3.3)

### DIFF
--- a/.changeset/mcp-3-3-resources-prompts.md
+++ b/.changeset/mcp-3-3-resources-prompts.md
@@ -1,0 +1,16 @@
+---
+'admin': minor
+---
+
+Stage 3.3 of the MCP v1 plan — resource browser, prompt picker, and
+completion-aware prompt argument inputs. Builds on Stages 2, 3.1, and 3.2.
+
+- Four new per-server routes:
+  - `GET /api/mcp/remote-servers/[server]/resources?tenant=X` — list resources.
+  - `GET /api/mcp/remote-servers/[server]/resource?tenant=X&uri=...` — read a single resource; returns the full `ResourceContents[]` (text + blob blocks).
+  - `GET /api/mcp/remote-servers/[server]/prompts?tenant=X` — list prompts.
+  - `POST /api/mcp/remote-servers/[server]/get-prompt` — resolve a prompt with string-valued arguments; returns the full `GetPromptResult`.
+- `/admin/mcp/inspect` gets tabbed navigation — **Tools** (3.2) / **Resources** / **Prompts**. The Tools panel is unchanged.
+- **Resources tab:** master-detail layout with a resource list on the left and a read-only preview pane on the right. Text blocks render in a monospace viewer; binary blobs surface their mime type + base64 size without decoding.
+- **Prompts tab:** collapsible cards with a resolve form per prompt. Argument inputs are **completion-aware** — as the user types, a 200ms-debounced POST to `/complete` (shipped in PR-3.2) fetches server-side suggestions and feeds them into a native `<datalist>`. First real consumer of the completions plumbing.
+- 11 new route tests (admin: 1560 → 1571). Adversarial inputs, capability errors, transport teardown all covered.

--- a/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
@@ -1,25 +1,25 @@
 /**
  * MCP — Server Inspector (/admin/mcp/inspect?tenant=X&server=Y)
  *
- * Stage 3.2 of the MCP v1 plan. Tool browser + ad-hoc invoker for an
- * OAuth-authorized remote MCP server.
+ * Stage 3.2 + 3.3. Tabbed inspector for an OAuth-authorized remote MCP
+ * server:
+ *   - Tools (3.2)     — `inputSchema` → form → invoke → result.
+ *   - Resources (3.3) — list + read-only preview pane.
+ *   - Prompts (3.3)   — list + completion-aware argument form → resolve.
  *
- * Flow:
- *   1. Reads `?tenant=` and `?server=` from the URL.
- *   2. Fetches `GET /api/mcp/remote-servers/<server>/tools?tenant=<tenant>`.
- *   3. Renders each tool as a collapsible card with an argument form
- *      derived from `Tool.inputSchema` (best-effort — arbitrary JSON strings
- *      for non-trivial schemas).
- *   4. On submit, POSTs `/api/mcp/remote-servers/<server>/call-tool` and
- *      displays the `CallToolResult` content blocks inline.
+ * Reads `?tenant=` and `?server=` from the URL; the top-level "tools" fetch
+ * is always the anchor (it also returns `serverUrl` for the header).
  *
- * Resource/prompt browsing (which would consume the completions handler)
- * lands in Stage 3.3.
+ * Elicitation / progress / log streaming lands in Stage 3.4.
  */
 
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PromptsPanel } from '@/lib/components/mcp/prompts-panel';
+import { ResourcesPanel } from '@/lib/components/mcp/resources-panel';
+
+type InspectorTab = 'tools' | 'resources' | 'prompts';
 
 interface Tool {
   name: string;
@@ -58,6 +58,7 @@ export default function InspectMcpServerPage() {
   const tenant = useSearchParam('tenant');
   const server = useSearchParam('server');
 
+  const [activeTab, setActiveTab] = useState<InspectorTab>('tools');
   const [tools, setTools] = useState<Tool[]>([]);
   const [serverUrl, setServerUrl] = useState<string | null>(null);
   const [state, setState] = useState<LoadState>('idle');
@@ -128,38 +129,67 @@ export default function InspectMcpServerPage() {
         )}
       </div>
 
-      <div className="mx-auto max-w-5xl p-6">
-        {message && (
-          <div
-            role="alert"
-            className={`mb-6 rounded-lg border p-3 text-sm ${
-              state === 'error'
-                ? 'border-red-800 bg-red-900/20 text-red-300'
-                : 'border-zinc-800 bg-zinc-900/50 text-zinc-300'
-            }`}
-          >
-            {message}
-          </div>
-        )}
-
-        {state === 'loading' && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
-            Loading tools…
-          </div>
-        )}
-
-        {state === 'ready' && tools.length === 0 && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
-            This server doesn&rsquo;t advertise any tools, or the{' '}
-            <span className="font-mono text-zinc-400">tools</span> capability isn&rsquo;t declared.
-          </div>
-        )}
-
-        <div className="space-y-4">
-          {tools.map((tool) => (
-            <ToolCard key={tool.name} tool={tool} tenant={tenant} server={server} />
+      {/* Tabs */}
+      <div className="border-b border-zinc-800 bg-zinc-900/70">
+        <nav className="mx-auto flex max-w-5xl gap-1 px-6" aria-label="Inspector surfaces">
+          {(['tools', 'resources', 'prompts'] as InspectorTab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setActiveTab(t)}
+              className={`-mb-px border-b-2 px-3 py-2 text-sm capitalize transition-colors ${
+                activeTab === t
+                  ? 'border-emerald-500 text-emerald-300'
+                  : 'border-transparent text-zinc-400 hover:text-zinc-200'
+              }`}
+              aria-current={activeTab === t ? 'page' : undefined}
+            >
+              {t}
+            </button>
           ))}
-        </div>
+        </nav>
+      </div>
+
+      <div className="mx-auto max-w-5xl p-6">
+        {activeTab === 'tools' && (
+          <>
+            {message && (
+              <div
+                role="alert"
+                className={`mb-6 rounded-lg border p-3 text-sm ${
+                  state === 'error'
+                    ? 'border-red-800 bg-red-900/20 text-red-300'
+                    : 'border-zinc-800 bg-zinc-900/50 text-zinc-300'
+                }`}
+              >
+                {message}
+              </div>
+            )}
+
+            {state === 'loading' && (
+              <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                Loading tools…
+              </div>
+            )}
+
+            {state === 'ready' && tools.length === 0 && (
+              <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                This server doesn&rsquo;t advertise any tools, or the{' '}
+                <span className="font-mono text-zinc-400">tools</span> capability isn&rsquo;t
+                declared.
+              </div>
+            )}
+
+            <div className="space-y-4">
+              {tools.map((tool) => (
+                <ToolCard key={tool.name} tool={tool} tenant={tenant} server={server} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {activeTab === 'resources' && <ResourcesPanel tenant={tenant} server={server} />}
+        {activeTab === 'prompts' && <PromptsPanel tenant={tenant} server={server} />}
       </div>
     </div>
   );

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Resources + Prompts route tests (Stage 3.3).
+ *
+ * Four new per-server routes land in this PR:
+ *   - GET  .../resources
+ *   - GET  .../resource?uri=...
+ *   - GET  .../prompts
+ *   - POST .../get-prompt
+ *
+ * `buildRemoteMcpClient` is stubbed (same pattern as the tool-routes test)
+ * so we can assert argument forwarding, error propagation, and transport
+ * teardown without spinning up a real MCP server. Real-wire coverage lives
+ * in `packages/mcp/__tests__/client.integration.test.ts`.
+ */
+
+import { McpCapabilityError } from '@revealui/mcp/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// -- Fake client ------------------------------------------------------------
+
+class FakeMcpClient {
+  connectCalls = 0;
+  closeCalls = 0;
+  listResourcesImpl: () => Promise<unknown[]> = async () => [];
+  readResourceImpl: (uri: string) => Promise<unknown[]> = async () => [];
+  listPromptsImpl: () => Promise<unknown[]> = async () => [];
+  getPromptImpl: (name: string, args?: unknown) => Promise<unknown> = async () => ({
+    messages: [],
+  });
+
+  async connect(): Promise<void> {
+    this.connectCalls++;
+  }
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+  async listResources(): Promise<unknown[]> {
+    return this.listResourcesImpl();
+  }
+  async readResource(uri: string): Promise<unknown[]> {
+    return this.readResourceImpl(uri);
+  }
+  async listPrompts(): Promise<unknown[]> {
+    return this.listPromptsImpl();
+  }
+  async getPrompt(name: string, args?: unknown): Promise<unknown> {
+    return this.getPromptImpl(name, args);
+  }
+}
+
+const fakeClients: FakeMcpClient[] = [];
+
+const mockBuild = vi.fn(async (_opts: { tenant: string; server: string }) => {
+  const client = new FakeMcpClient();
+  fakeClients.push(client);
+  return { client, meta: { serverUrl: 'http://remote.test/mcp' } };
+});
+
+vi.mock('@/lib/mcp/remote-server-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/mcp/remote-server-client')>(
+    '@/lib/mcp/remote-server-client',
+  );
+  return {
+    ...actual,
+    buildRemoteMcpClient: (opts: { tenant: string; server: string }) => mockBuild(opts),
+  };
+});
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(url, {
+    headers: { cookie: 'session=test' },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  mockGetSession.mockReset();
+  mockBuild.mockClear();
+  fakeClients.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /resources
+// ---------------------------------------------------------------------------
+
+describe('GET /api/mcp/remote-servers/[server]/resources', () => {
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../resources/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/resources?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when tenant is missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../resources/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/resources') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 412 when the server does not advertise the resources capability', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.listResourcesImpl = async () => {
+        throw new McpCapabilityError('resources');
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { GET } = await import('../resources/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/resources?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(412);
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+
+  it('connects, lists resources, and closes the transport', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.listResourcesImpl = async () => [
+        { uri: 'revealui://acme/posts/1', name: 'First post' },
+      ];
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { GET } = await import('../resources/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/resources?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resources: Array<{ uri: string }> };
+    expect(body.resources).toHaveLength(1);
+    expect(body.resources[0]?.uri).toBe('revealui://acme/posts/1');
+    expect(fakeClients[0]?.connectCalls).toBe(1);
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /resource?uri=...
+// ---------------------------------------------------------------------------
+
+describe('GET /api/mcp/remote-servers/[server]/resource', () => {
+  it('returns 400 when uri is missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../resource/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/resource?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards uri to readResource and returns contents', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedUri: string | undefined;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.readResourceImpl = async (uri) => {
+        observedUri = uri;
+        return [{ uri, mimeType: 'text/plain', text: 'hello from post' }];
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const uri = 'revealui://acme/posts/1';
+    const { GET } = await import('../resource/route.js');
+    const res = await GET(
+      makeRequest(
+        `http://admin.test/api/mcp/remote-servers/linear/resource?tenant=acme&uri=${encodeURIComponent(uri)}`,
+      ) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      contents: Array<{ uri: string; text: string; mimeType: string }>;
+    };
+    expect(observedUri).toBe(uri);
+    expect(body.contents[0]?.text).toBe('hello from post');
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /prompts
+// ---------------------------------------------------------------------------
+
+describe('GET /api/mcp/remote-servers/[server]/prompts', () => {
+  it('connects, lists prompts, and closes the transport', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.listPromptsImpl = async () => [
+        {
+          name: 'summarize',
+          description: 'Summarize a topic',
+          arguments: [{ name: 'topic', required: true }],
+        },
+      ];
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { GET } = await import('../prompts/route.js');
+    const res = await GET(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/prompts?tenant=acme') as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompts: Array<{ name: string }> };
+    expect(body.prompts.map((p) => p.name)).toEqual(['summarize']);
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /get-prompt
+// ---------------------------------------------------------------------------
+
+describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
+  it('returns 400 when body.name is missing', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-string argument values (MCP prompt args are string-valued)', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          name: 'summarize',
+          arguments: { topic: 42 },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards name + arguments and returns the GetPromptResult', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedName: string | undefined;
+    let observedArgs: unknown;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.getPromptImpl = async (name, args) => {
+        observedName = name;
+        observedArgs = args;
+        return {
+          description: 'resolved',
+          messages: [
+            {
+              role: 'user' as const,
+              content: { type: 'text', text: 'hello' },
+            },
+          ],
+        };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          name: 'summarize',
+          arguments: { topic: 'OAuth 2.1' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { messages: Array<{ content: { text: string } }> };
+    };
+    expect(observedName).toBe('summarize');
+    expect(observedArgs).toEqual({ topic: 'OAuth 2.1' });
+    expect(body.result.messages[0]?.content.text).toBe('hello');
+    expect(fakeClients[0]?.closeCalls).toBe(1);
+  });
+
+  it('accepts get-prompt with no arguments', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedArgs: unknown = 'not-seen';
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.getPromptImpl = async (_name, args) => {
+        observedArgs = args;
+        return { messages: [] };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({ tenant: 'acme', name: 'greeting' }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(observedArgs).toBeUndefined();
+  });
+});

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP get-prompt — POST /api/mcp/remote-servers/[server]/get-prompt
+ *
+ * Resolves a prompt on a connected remote MCP server with the given
+ * string-valued arguments. Returns the full `GetPromptResult` — the
+ * `messages` array is what a client LLM would consume.
+ *
+ * Body:
+ * ```
+ * { tenant: string, name: string, arguments?: Record<string, string> }
+ * ```
+ *
+ * Per the MCP spec, prompt arguments are strings (not arbitrary JSON
+ * values). This is enforced here — non-string values surface as HTTP 400.
+ *
+ * Stage 3.3 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { type GetPromptResult, McpCapabilityError } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ result: GetPromptResult } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let body: { tenant?: unknown; name?: unknown; arguments?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const { tenant, name } = body;
+  if (typeof tenant !== 'string' || !IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'body.tenant must be a string matching /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (typeof name !== 'string' || name.length === 0 || name.length > 256) {
+    return NextResponse.json(
+      { error: 'body.name must be a non-empty string (≤256 chars)' },
+      { status: 400 },
+    );
+  }
+
+  let args: Record<string, string> | undefined;
+  if (body.arguments !== undefined) {
+    if (
+      typeof body.arguments !== 'object' ||
+      body.arguments === null ||
+      Array.isArray(body.arguments)
+    ) {
+      return NextResponse.json(
+        { error: 'body.arguments must be a plain object of string values when provided' },
+        { status: 400 },
+      );
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body.arguments as Record<string, unknown>)) {
+      if (typeof v !== 'string') {
+        return NextResponse.json(
+          {
+            error: `body.arguments.${k} must be a string (MCP prompt arguments are string-valued)`,
+          },
+          { status: 400 },
+        );
+      }
+      out[k] = v;
+    }
+    args = out;
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const result = await built.client.getPrompt(name, args);
+    return NextResponse.json({ result });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/prompts/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/prompts/route.ts
@@ -1,0 +1,80 @@
+/**
+ * MCP prompts list — GET /api/mcp/remote-servers/[server]/prompts?tenant=X
+ *
+ * Connects to an OAuth-authorized remote MCP server and returns the list
+ * of prompts it advertises. Requires the `prompts` capability.
+ *
+ * Stage 3.3 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { McpCapabilityError, type Prompt } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ prompts: Prompt[] } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  const tenant = new URL(request.url).searchParams.get('tenant');
+
+  if (!(tenant && IDENTIFIER_RE.test(tenant))) {
+    return NextResponse.json(
+      { error: 'tenant query parameter must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const prompts = await built.client.listPrompts();
+    return NextResponse.json({ prompts });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/resource/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/resource/route.ts
@@ -1,0 +1,92 @@
+/**
+ * MCP resource read — GET /api/mcp/remote-servers/[server]/resource?tenant=X&uri=...
+ *
+ * Fetches the contents of a single resource from a connected remote MCP
+ * server. Returns the SDK's `ResourceContents[]` shape verbatim — each
+ * block is either `{ uri, mimeType?, text }` or `{ uri, mimeType?, blob }`
+ * (base64). The admin preview pane renders text blocks in a monospace
+ * viewer and surfaces mime-type chips for binary blobs.
+ *
+ * Stage 3.3 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { McpCapabilityError, type ResourceContents } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_URI_LENGTH = 2048;
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ contents: ResourceContents[] } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  const url = new URL(request.url);
+  const tenant = url.searchParams.get('tenant');
+  const uri = url.searchParams.get('uri');
+
+  if (!(tenant && IDENTIFIER_RE.test(tenant))) {
+    return NextResponse.json(
+      { error: 'tenant query parameter must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!uri || uri.length > MAX_URI_LENGTH) {
+    return NextResponse.json(
+      { error: `uri query parameter is required (≤${MAX_URI_LENGTH} chars)` },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const contents = await built.client.readResource(uri);
+    return NextResponse.json({ contents });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/resources/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/resources/route.ts
@@ -1,0 +1,81 @@
+/**
+ * MCP resources list — GET /api/mcp/remote-servers/[server]/resources?tenant=X
+ *
+ * Connects to an OAuth-authorized remote MCP server and returns the list
+ * of resources it advertises. Short-lived: the client is torn down after
+ * the call. Requires the server to advertise the `resources` capability.
+ *
+ * Stage 3.3 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { McpCapabilityError, type Resource } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<NextResponse<{ resources: Resource[] } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  const tenant = new URL(request.url).searchParams.get('tenant');
+
+  if (!(tenant && IDENTIFIER_RE.test(tenant))) {
+    return NextResponse.json(
+      { error: 'tenant query parameter must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let built: Awaited<ReturnType<typeof buildRemoteMcpClient>>;
+  try {
+    built = await buildRemoteMcpClient({ tenant, server });
+  } catch (err) {
+    if (err instanceof RemoteServerNotConnectedError) {
+      return NextResponse.json({ error: 'not_connected', detail: err.message }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: 'meta_load_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await built.client.connect();
+    const resources = await built.client.listResources();
+    return NextResponse.json({ resources });
+  } catch (err) {
+    if (err instanceof McpCapabilityError) {
+      return NextResponse.json(
+        { error: 'capability_missing', detail: err.message },
+        { status: 412 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'mcp_call_failed', detail: (err as Error).message.slice(0, 200) },
+      { status: 502 },
+    );
+  } finally {
+    await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort transport teardown
+  }
+}

--- a/apps/admin/src/lib/components/mcp/prompts-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/prompts-panel.tsx
@@ -1,0 +1,317 @@
+/**
+ * Prompts panel for `/admin/mcp/inspect` (Stage 3.3).
+ *
+ * Lists prompts advertised by a connected remote MCP server. Each prompt
+ * can be resolved by filling in its string-valued arguments and submitting;
+ * inputs are completion-aware — as the user types we POST the partial
+ * value to `/complete` with a `ref/prompt` reference to fetch server-side
+ * suggestions.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface PromptArgument {
+  name: string;
+  description?: string;
+  required?: boolean;
+}
+
+interface Prompt {
+  name: string;
+  description?: string;
+  arguments?: PromptArgument[];
+}
+
+interface PromptMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: { type: string; text?: string; data?: string; mimeType?: string };
+}
+
+interface GetPromptResult {
+  description?: string;
+  messages: PromptMessage[];
+}
+
+interface PromptsPanelProps {
+  tenant: string;
+  server: string;
+}
+
+export function PromptsPanel({ tenant, server }: PromptsPanelProps) {
+  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [state, setState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadPrompts = useCallback(async () => {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch(
+        `/api/mcp/remote-servers/${encodeURIComponent(server)}/prompts?tenant=${encodeURIComponent(tenant)}`,
+        { credentials: 'include' },
+      );
+      // empty-catch-ok: non-JSON error body — res.status surfaces below
+      const body = (await res.json().catch(() => ({}))) as {
+        prompts?: Prompt[];
+        error?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setPrompts(body.prompts ?? []);
+      setState('ready');
+    } catch (err) {
+      setState('error');
+      setMessage(`Failed to load prompts: ${(err as Error).message}`);
+    }
+  }, [tenant, server]);
+
+  useEffect(() => {
+    void loadPrompts();
+  }, [loadPrompts]);
+
+  return (
+    <div className="space-y-4">
+      {message && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+        >
+          {message}
+        </div>
+      )}
+      {state === 'loading' && (
+        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+          Loading prompts…
+        </div>
+      )}
+      {state === 'ready' && prompts.length === 0 && (
+        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+          No prompts advertised.
+        </div>
+      )}
+      {prompts.map((prompt) => (
+        <PromptCard key={prompt.name} prompt={prompt} tenant={tenant} server={server} />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Prompt card — form + resolver
+// ---------------------------------------------------------------------------
+
+interface PromptCardProps {
+  prompt: Prompt;
+  tenant: string;
+  server: string;
+}
+
+function PromptCard({ prompt, tenant, server }: PromptCardProps) {
+  const args = useMemo(() => prompt.arguments ?? [], [prompt.arguments]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<GetPromptResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setResult(null);
+    setError(null);
+    try {
+      const resolved: Record<string, string> = {};
+      for (const a of args) {
+        const v = values[a.name];
+        if (v !== undefined && v !== '') resolved[a.name] = v;
+      }
+      const res = await fetch(`/api/mcp/remote-servers/${encodeURIComponent(server)}/get-prompt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tenant, name: prompt.name, arguments: resolved }),
+      });
+      // empty-catch-ok: non-JSON error body — res.status surfaces below
+      const body = (await res.json().catch(() => ({}))) as {
+        result?: GetPromptResult;
+        error?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setResult(body.result ?? null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+      <summary className="flex cursor-pointer items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-sm font-semibold text-white">{prompt.name}</div>
+          {prompt.description && (
+            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{prompt.description}</div>
+          )}
+        </div>
+        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
+      </summary>
+
+      <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
+        {args.length === 0 && (
+          <p className="text-xs text-zinc-500">
+            This prompt takes no arguments. Click <span className="font-medium">Resolve</span> to
+            fetch its messages.
+          </p>
+        )}
+        {args.map((arg) => (
+          <PromptArgumentField
+            key={arg.name}
+            arg={arg}
+            prompt={prompt.name}
+            tenant={tenant}
+            server={server}
+            value={values[arg.name] ?? ''}
+            onChange={(value) => setValues((v) => ({ ...v, [arg.name]: value }))}
+          />
+        ))}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? 'Resolving…' : 'Resolve'}
+          </button>
+          {error && <span className="text-xs text-red-400">{error}</span>}
+        </div>
+      </form>
+
+      {result && <PromptResult result={result} />}
+    </details>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Argument field — completion-aware (fetches server-side suggestions)
+// ---------------------------------------------------------------------------
+
+interface PromptArgumentFieldProps {
+  arg: PromptArgument;
+  prompt: string;
+  tenant: string;
+  server: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function PromptArgumentField({
+  arg,
+  prompt,
+  tenant,
+  server,
+  value,
+  onChange,
+}: PromptArgumentFieldProps) {
+  const inputId = `prompt-arg-${prompt}-${arg.name}`;
+  const listId = `${inputId}-suggestions`;
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (value.length === 0) {
+      setSuggestions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/mcp/remote-servers/${encodeURIComponent(server)}/complete`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({
+                tenant,
+                ref: { type: 'ref/prompt', name: prompt },
+                argument: { name: arg.name, value },
+              }),
+            },
+          );
+          if (!res.ok) return;
+          // empty-catch-ok: non-JSON body means no suggestions — just leave the list empty
+          const body = (await res.json().catch(() => ({}))) as {
+            completion?: { values?: string[] };
+          };
+          setSuggestions(body.completion?.values ?? []);
+        } catch {
+          // empty-catch-ok: completions are a best-effort UX enhancement; a network blip shouldn't crash the form
+          setSuggestions([]);
+        }
+      })();
+    }, 200);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [value, prompt, arg.name, tenant, server]);
+
+  return (
+    <div>
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+        {arg.name}
+        {arg.required && <span className="ml-1 text-red-400">*</span>}
+      </label>
+      <input
+        id={inputId}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        list={suggestions.length > 0 ? listId : undefined}
+        required={arg.required}
+        autoComplete="off"
+        className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+      />
+      {suggestions.length > 0 && (
+        <datalist id={listId}>
+          {suggestions.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+      )}
+      {arg.description && <p className="mt-1 text-[11px] text-zinc-500">{arg.description}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Prompt result display
+// ---------------------------------------------------------------------------
+
+function PromptResult({ result }: { result: GetPromptResult }) {
+  return (
+    <div className="mt-4 space-y-3">
+      {result.description && (
+        <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3 text-xs text-zinc-400">
+          {result.description}
+        </div>
+      )}
+      {result.messages.map((msg, idx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: messages have no id
+        <div key={idx} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+          <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-wide text-zinc-500">
+            <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-zinc-300">{msg.role}</span>
+            <span className="text-zinc-600">{msg.content.type}</span>
+          </div>
+          <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+            {msg.content.type === 'text'
+              ? (msg.content.text ?? '')
+              : `[${msg.content.type}${msg.content.mimeType ? ` ${msg.content.mimeType}` : ''}]`}
+          </pre>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/lib/components/mcp/resources-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/resources-panel.tsx
@@ -1,0 +1,191 @@
+/**
+ * Resources panel for `/admin/mcp/inspect` (Stage 3.3).
+ *
+ * Lists resources advertised by a connected remote MCP server and, on row
+ * click, fetches the contents via `readResource` and renders a read-only
+ * preview pane. Text blocks render as monospace; binary blobs surface
+ * their mime-type with a size chip.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface Resource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+interface ResourceContent {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+}
+
+interface ResourcesPanelProps {
+  tenant: string;
+  server: string;
+}
+
+export function ResourcesPanel({ tenant, server }: ResourcesPanelProps) {
+  const [resources, setResources] = useState<Resource[]>([]);
+  const [state, setState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+  const [selectedUri, setSelectedUri] = useState<string | null>(null);
+  const [contents, setContents] = useState<ResourceContent[] | null>(null);
+  const [previewState, setPreviewState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const loadResources = useCallback(async () => {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch(
+        `/api/mcp/remote-servers/${encodeURIComponent(server)}/resources?tenant=${encodeURIComponent(tenant)}`,
+        { credentials: 'include' },
+      );
+      // empty-catch-ok: non-JSON error body — res.status surfaces below
+      const body = (await res.json().catch(() => ({}))) as {
+        resources?: Resource[];
+        error?: string;
+      };
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      setResources(body.resources ?? []);
+      setState('ready');
+    } catch (err) {
+      setState('error');
+      setMessage(`Failed to load resources: ${(err as Error).message}`);
+    }
+  }, [tenant, server]);
+
+  useEffect(() => {
+    void loadResources();
+  }, [loadResources]);
+
+  const handleSelect = useCallback(
+    async (uri: string) => {
+      setSelectedUri(uri);
+      setContents(null);
+      setPreviewError(null);
+      setPreviewState('loading');
+      try {
+        const res = await fetch(
+          `/api/mcp/remote-servers/${encodeURIComponent(server)}/resource?tenant=${encodeURIComponent(tenant)}&uri=${encodeURIComponent(uri)}`,
+          { credentials: 'include' },
+        );
+        // empty-catch-ok: non-JSON error body — res.status surfaces below
+        const body = (await res.json().catch(() => ({}))) as {
+          contents?: ResourceContent[];
+          error?: string;
+        };
+        if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+        setContents(body.contents ?? []);
+        setPreviewState('ready');
+      } catch (err) {
+        setPreviewError((err as Error).message);
+        setPreviewState('error');
+      }
+    },
+    [tenant, server],
+  );
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+      <div>
+        {message && (
+          <div
+            role="alert"
+            className="mb-3 rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+          >
+            {message}
+          </div>
+        )}
+        {state === 'loading' && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+            Loading…
+          </div>
+        )}
+        {state === 'ready' && resources.length === 0 && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+            No resources advertised.
+          </div>
+        )}
+        {resources.length > 0 && (
+          <ul className="divide-y divide-zinc-800 overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/50">
+            {resources.map((r) => {
+              const selected = r.uri === selectedUri;
+              return (
+                <li key={r.uri}>
+                  <button
+                    type="button"
+                    onClick={() => void handleSelect(r.uri)}
+                    className={`block w-full px-3 py-2 text-left transition-colors ${
+                      selected
+                        ? 'bg-emerald-900/20 text-emerald-200'
+                        : 'text-zinc-300 hover:bg-zinc-800/60'
+                    }`}
+                  >
+                    <div className="truncate font-mono text-xs">{r.name || r.uri}</div>
+                    <div className="mt-0.5 truncate text-[10px] text-zinc-500">{r.uri}</div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        {!selectedUri && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
+            Select a resource to preview its contents.
+          </div>
+        )}
+        {selectedUri && previewState === 'loading' && (
+          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
+            Loading preview…
+          </div>
+        )}
+        {selectedUri && previewState === 'error' && (
+          <div className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300">
+            {previewError}
+          </div>
+        )}
+        {selectedUri && previewState === 'ready' && contents && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-zinc-800 bg-zinc-900/50 px-3 py-2 font-mono text-[10px] text-zinc-500">
+              {selectedUri}
+            </div>
+            {contents.length === 0 && (
+              <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-900/30 p-3 text-center text-xs text-zinc-500">
+                (empty)
+              </div>
+            )}
+            {contents.map((block, idx) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: content blocks have no id
+              <div key={idx} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+                <div className="mb-2 text-[10px] text-zinc-500">
+                  {block.mimeType ??
+                    (block.text !== undefined ? 'text/plain' : 'application/octet-stream')}
+                  {block.blob && ` · ${block.blob.length} base64 chars`}
+                </div>
+                {block.text !== undefined ? (
+                  <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+                    {block.text}
+                  </pre>
+                ) : (
+                  <div className="font-mono text-[11px] text-zinc-500">
+                    (binary content — not rendered in preview)
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stage 3.3 of the MCP v1 productionization plan — **resource browser + prompt picker + read-only resource preview** for OAuth-authorized remote MCP servers. Builds on Stages 2 + 3.1 + 3.2. Only Stage 3.4 (elicitation, progress, logs) remains to close the admin UI surface.

### Four new per-server routes

- **`GET /api/mcp/remote-servers/[server]/resources?tenant=X`** — lists `Resource[]` advertised by the server. Requires `resources` capability; 412 otherwise.
- **`GET /api/mcp/remote-servers/[server]/resource?tenant=X&uri=...`** — reads a single resource. Returns `ResourceContents[]` verbatim — text blocks with `text`, binary with base64 `blob`. `uri` is a required query param capped at 2048 chars.
- **`GET /api/mcp/remote-servers/[server]/prompts?tenant=X`** — lists `Prompt[]`. Requires `prompts` capability.
- **`POST /api/mcp/remote-servers/[server]/get-prompt`** — body `{ tenant, name, arguments? }`. Returns the full `GetPromptResult` (messages + optional description). **Enforces that `arguments` values are strings** — per the MCP spec, prompt arguments are string-valued, not arbitrary JSON.

### `/admin/mcp/inspect` — tabbed nav

- **Tools** (3.2, unchanged) · **Resources** (new) · **Prompts** (new)
- **Resources tab** — master-detail layout. Left column: resource list with name + URI. Right pane: read-only preview. Text blocks render in a monospace viewer; binary blobs surface mime-type + base64 size without attempting to decode.
- **Prompts tab** — collapsible cards per prompt with a resolve form. **Argument inputs are completion-aware**: a 200ms-debounced POST to `/complete` (shipped in PR-3.2, [#501](https://github.com/RevealUIStudio/revealui/pull/501)) feeds server-side suggestions into a native `<datalist>`. First real consumer of the completions plumbing.

### Test coverage

11 new route tests (admin: 1560 → 1571 passing / 10 skipped):

- **Resources** (4 tests): 401 without session; 400 when tenant missing; 412 on `McpCapabilityError`; happy-path list + transport teardown.
- **Resource read** (2 tests): 400 when `uri` missing; forward uri to `readResource`, return contents.
- **Prompts list** (1 test): happy-path list + transport teardown.
- **Get-prompt** (4 tests): 400 when name missing; 400 on non-string argument values; happy-path resolve + forwarded args; no-arguments case (`arguments` field absent).

## Stage 3 remainder

- **3.4** — elicitation forms (inline), progress bars + cancel button, live log stream viewer. Last piece to close Stage 3.

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally
- [ ] `pnpm --filter admin test` — 1571 passing / 10 skipped
- [ ] `pnpm --filter admin typecheck` — clean
- [ ] `pnpm --filter "admin..." build` — clean

## Notes

- No `@revealui/mcp` changes. The client surface (`McpClient.listResources`, `readResource`, `listPrompts`, `getPrompt`, `complete`) was already shipped in Stage 0 (PR-0.1 / PR-0.2).
- Completions tab is limited to `ref/prompt` consumption — resource-template completions are surfaced by the server over the same route but aren't yet wired in the UI (no resource-template URIs in-product yet; lands with Stage 4 content-pipeline work).
- Prompt argument resolution is minimal: string inputs only, no rich typing. Enum suggestions would require extending the prompt spec — parked for post-v1.
