### PR TITLE
feat(admin): elicitation + progress + log stream (Stage 3.4)

### DIFF
--- a/.changeset/mcp-3-4-elicitation-progress-logs.md
+++ b/.changeset/mcp-3-4-elicitation-progress-logs.md
@@ -1,0 +1,47 @@
+---
+'admin': minor
+---
+
+Stage 3.4 of the MCP v1 plan — closes Stage 3. Adds the three server-push
+surfaces to the inspector: inline elicitation forms, progress bars with
+cancel, and a live log stream viewer.
+
+**Routes:**
+- `POST /api/mcp/remote-servers/[server]/call-tool-stream` — SSE streaming
+  tool invoker. Emits `session`, `log`, `progress`, `elicitation`,
+  `result`, and `error` events as they happen. Aborting the fetch
+  forwards an AbortSignal to the SDK transport, which emits
+  `notifications/cancelled` on the wire.
+- `POST /api/mcp/remote-servers/[server]/elicitation-respond` — resolves
+  a pending `elicitation/create` request on an active streaming session.
+  Body: `{ sessionId, elicitationId, action: 'accept'|'decline'|'cancel',
+  content? }`. One-shot; session-ownership bound.
+- `GET /api/mcp/remote-servers/[server]/log-stream?tenant=X&level=info` —
+  opens a long-lived SSE connection that sets the remote server's log
+  level and forwards every `notifications/message` to the browser.
+
+**Internals:**
+- `lib/mcp/call-sessions.ts` — in-memory session registry bridging the
+  streaming route (which creates a session + registers pending
+  elicitations) to the respond route (which looks them up by session id
+  and resolves the matching promise). Tears down cleanly on client
+  disconnect — every outstanding elicitation is auto-cancelled.
+- `buildRemoteMcpClient({ …, elicitationHandler })` option on the admin
+  helper.
+
+**UI:**
+- `/admin/mcp/inspect` Tools tab now uses `StreamingToolCard`: surfaces
+  a progress bar during the call, a cancel button, an inline
+  elicitation form rendered from the server's `requestedSchema`, and a
+  collapsible per-call log panel. Tools that don't emit progress or
+  elicitation work unchanged — the final result simply arrives with no
+  prior events.
+- New **Logs** tab (fourth in the inspector) — live-tails
+  `notifications/message` from the server with a level selector, cap
+  of 500 entries, and start/stop/clear controls.
+
+**Stage 2 + 3 complete** with this PR. Remaining MCP v1 stages: 4
+(content pipeline as MCP resources), 5 (agent runtime consumes full
+protocol), 6 (protocol-level observability + usage metering).
+
+14 new tests (admin: 1571 → 1585 passing / 10 skipped).

--- a/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx
@@ -1,25 +1,32 @@
 /**
  * MCP — Server Inspector (/admin/mcp/inspect?tenant=X&server=Y)
  *
- * Stage 3.2 + 3.3. Tabbed inspector for an OAuth-authorized remote MCP
- * server:
- *   - Tools (3.2)     — `inputSchema` → form → invoke → result.
- *   - Resources (3.3) — list + read-only preview pane.
- *   - Prompts (3.3)   — list + completion-aware argument form → resolve.
- *
- * Reads `?tenant=` and `?server=` from the URL; the top-level "tools" fetch
- * is always the anchor (it also returns `serverUrl` for the header).
- *
- * Elicitation / progress / log streaming lands in Stage 3.4.
+ * Stage 3.2 + 3.3 + 3.4. Tabbed inspector for an OAuth-authorized remote
+ * MCP server:
+ *   - Tools (3.2+3.4)     — `inputSchema` → form → invoke → streaming
+ *                           result with progress bar + cancel button +
+ *                           inline elicitation form + per-call log panel.
+ *   - Resources (3.3)     — list + read-only preview pane.
+ *   - Prompts (3.3)       — list + completion-aware argument form → resolve.
+ *   - Logs (3.4)          — live-tail `notifications/message` stream.
  */
 
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { LogsPanel } from '@/lib/components/mcp/logs-panel';
 import { PromptsPanel } from '@/lib/components/mcp/prompts-panel';
 import { ResourcesPanel } from '@/lib/components/mcp/resources-panel';
+import { StreamingToolCard } from '@/lib/components/mcp/streaming-tool-card';
 
-type InspectorTab = 'tools' | 'resources' | 'prompts';
+type InspectorTab = 'tools' | 'resources' | 'prompts' | 'logs';
+
+interface JsonSchemaProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+}
 
 interface Tool {
   name: string;
@@ -29,18 +36,6 @@ interface Tool {
     properties?: Record<string, JsonSchemaProperty>;
     required?: string[];
   };
-}
-
-interface JsonSchemaProperty {
-  type?: string;
-  description?: string;
-  enum?: unknown[];
-  default?: unknown;
-}
-
-interface CallToolResult {
-  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-  isError?: boolean;
 }
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
@@ -132,7 +127,7 @@ export default function InspectMcpServerPage() {
       {/* Tabs */}
       <div className="border-b border-zinc-800 bg-zinc-900/70">
         <nav className="mx-auto flex max-w-5xl gap-1 px-6" aria-label="Inspector surfaces">
-          {(['tools', 'resources', 'prompts'] as InspectorTab[]).map((t) => (
+          {(['tools', 'resources', 'prompts', 'logs'] as InspectorTab[]).map((t) => (
             <button
               key={t}
               type="button"
@@ -182,7 +177,7 @@ export default function InspectMcpServerPage() {
 
             <div className="space-y-4">
               {tools.map((tool) => (
-                <ToolCard key={tool.name} tool={tool} tenant={tenant} server={server} />
+                <StreamingToolCard key={tool.name} tool={tool} tenant={tenant} server={server} />
               ))}
             </div>
           </>
@@ -190,207 +185,7 @@ export default function InspectMcpServerPage() {
 
         {activeTab === 'resources' && <ResourcesPanel tenant={tenant} server={server} />}
         {activeTab === 'prompts' && <PromptsPanel tenant={tenant} server={server} />}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tool card — form + invoker
-// ---------------------------------------------------------------------------
-
-interface ToolCardProps {
-  tool: Tool;
-  tenant: string;
-  server: string;
-}
-
-function ToolCard({ tool, tenant, server }: ToolCardProps) {
-  const properties = useMemo(() => tool.inputSchema?.properties ?? {}, [tool.inputSchema]);
-  const required = useMemo(() => new Set(tool.inputSchema?.required ?? []), [tool.inputSchema]);
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<CallToolResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
-    if (raw === '') return undefined;
-    switch (prop.type) {
-      case 'number':
-      case 'integer': {
-        const n = Number(raw);
-        return Number.isFinite(n) ? n : raw;
-      }
-      case 'boolean':
-        return raw === 'true';
-      case 'object':
-      case 'array':
-        return JSON.parse(raw);
-      default:
-        return raw;
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitting(true);
-    setResult(null);
-    setError(null);
-    try {
-      const args: Record<string, unknown> = {};
-      for (const [key, prop] of Object.entries(properties)) {
-        const raw = values[key] ?? '';
-        const parsed = parseValue(prop, raw);
-        if (parsed !== undefined) args[key] = parsed;
-      }
-      const res = await fetch(`/api/mcp/remote-servers/${encodeURIComponent(server)}/call-tool`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ tenant, name: tool.name, arguments: args }),
-      });
-      // empty-catch-ok: non-JSON error body — res.status is surfaced below
-      const body = (await res.json().catch(() => ({}))) as {
-        result?: CallToolResult;
-        error?: string;
-        detail?: string;
-      };
-      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
-      setResult(body.result ?? null);
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
-      <summary className="flex cursor-pointer items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="font-mono text-sm font-semibold text-white">{tool.name}</div>
-          {tool.description && (
-            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{tool.description}</div>
-          )}
-        </div>
-        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
-      </summary>
-
-      <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
-        {Object.keys(properties).length === 0 && (
-          <p className="text-xs text-zinc-500">
-            This tool takes no input. Click <span className="font-medium">Invoke</span> to call it.
-          </p>
-        )}
-        {Object.entries(properties).map(([key, prop]) => (
-          <ArgumentField
-            key={key}
-            name={key}
-            prop={prop}
-            required={required.has(key)}
-            value={values[key] ?? ''}
-            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
-          />
-        ))}
-
-        <div className="flex items-center gap-3 pt-2">
-          <button
-            type="submit"
-            disabled={submitting}
-            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? 'Invoking…' : 'Invoke'}
-          </button>
-          {error && <span className="text-xs text-red-400">{error}</span>}
-        </div>
-      </form>
-
-      {result && <ToolResult result={result} />}
-    </details>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Argument field
-// ---------------------------------------------------------------------------
-
-interface ArgumentFieldProps {
-  name: string;
-  prop: JsonSchemaProperty;
-  required: boolean;
-  value: string;
-  onChange: (value: string) => void;
-}
-
-function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
-  const inputId = `arg-${name}`;
-  const placeholder =
-    prop.default !== undefined
-      ? `default: ${JSON.stringify(prop.default)}`
-      : prop.type === 'object' || prop.type === 'array'
-        ? 'JSON value'
-        : (prop.type ?? 'string');
-
-  return (
-    <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
-        {name}
-        {required && <span className="ml-1 text-red-400">*</span>}
-        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
-      </label>
-      {prop.enum && prop.enum.length > 0 ? (
-        <select
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        >
-          <option value="">—</option>
-          {prop.enum.map((opt) => (
-            <option key={String(opt)} value={String(opt)}>
-              {String(opt)}
-            </option>
-          ))}
-        </select>
-      ) : (
-        <input
-          id={inputId}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          required={required}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        />
-      )}
-      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tool result display
-// ---------------------------------------------------------------------------
-
-function ToolResult({ result }: { result: CallToolResult }) {
-  return (
-    <div
-      className={`mt-4 rounded-md border p-3 text-xs ${
-        result.isError
-          ? 'border-red-800 bg-red-900/20 text-red-300'
-          : 'border-emerald-900 bg-emerald-900/10 text-emerald-200'
-      }`}
-    >
-      <div className="mb-2 font-medium">{result.isError ? 'Tool returned an error' : 'Result'}</div>
-      <div className="space-y-2">
-        {result.content.map((block, idx) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: blocks have no id
-          <pre key={idx} className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px]">
-            {block.type === 'text'
-              ? (block.text ?? '')
-              : `[${block.type}${block.mimeType ? ` ${block.mimeType}` : ''}]`}
-          </pre>
-        ))}
+        {activeTab === 'logs' && <LogsPanel tenant={tenant} server={server} />}
       </div>
     </div>
   );

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/elicitation-respond-route.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/elicitation-respond-route.test.ts
@@ -1,0 +1,183 @@
+/**
+ * elicitation-respond route tests (Stage 3.4).
+ *
+ * Covers session ownership, pending-elicitation lookup, and action
+ * normalization. Streaming + call-tool integration is exercised separately
+ * — this file focuses on the validation surface of the respond endpoint.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  awaitElicitationResponse,
+  createCallSession,
+  deleteCallSession,
+} from '@/lib/mcp/call-sessions';
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(url, {
+    headers: { cookie: 'session=test' },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  mockGetSession.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/mcp/remote-servers/[server]/elicitation-respond', () => {
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }) as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects malformed sessionId / elicitationId', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({ sessionId: 'not-a-uuid', elicitationId: 'x', action: 'accept' }),
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unknown action', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../elicitation-respond/route.js');
+    const session = createCallSession('u1');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          elicitationId: '00000000-0000-0000-0000-000000000000',
+          action: 'bogus',
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+    deleteCallSession(session.sessionId);
+  });
+
+  it('returns 404 when the session is gone', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: '11111111-1111-1111-1111-111111111111',
+          elicitationId: '22222222-2222-2222-2222-222222222222',
+          action: 'cancel',
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when the session owner is a different admin', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'eve', role: 'admin' } });
+    const session = createCallSession('alice');
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          elicitationId: '22222222-2222-2222-2222-222222222222',
+          action: 'cancel',
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(403);
+    deleteCallSession(session.sessionId);
+  });
+
+  it('resolves the pending elicitation with accept + content', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const session = createCallSession('u1');
+    const elicitationId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const pending = awaitElicitationResponse(session.sessionId, elicitationId);
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          elicitationId,
+          action: 'accept',
+          content: { name: 'alice', count: 3 },
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    await expect(pending).resolves.toEqual({
+      action: 'accept',
+      content: { name: 'alice', count: 3 },
+    });
+    deleteCallSession(session.sessionId);
+  });
+
+  it('rejects accept without a plain-object content', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const session = createCallSession('u1');
+    const elicitationId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    void awaitElicitationResponse(session.sessionId, elicitationId);
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          elicitationId,
+          action: 'accept',
+          content: [1, 2, 3],
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+    deleteCallSession(session.sessionId);
+  });
+
+  it('accepts decline/cancel with no content', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const session = createCallSession('u1');
+    const elicitationId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const pending = awaitElicitationResponse(session.sessionId, elicitationId);
+    const { POST } = await import('../elicitation-respond/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/elicitation-respond', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          elicitationId,
+          action: 'decline',
+        }),
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    await expect(pending).resolves.toEqual({ action: 'decline' });
+    deleteCallSession(session.sessionId);
+  });
+});

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/call-tool-stream/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/call-tool-stream/route.ts
@@ -1,0 +1,217 @@
+/**
+ * MCP streaming tool invoke — POST /api/mcp/remote-servers/[server]/call-tool-stream
+ *
+ * Streams progress notifications, log messages, elicitation requests, and
+ * the final `CallToolResult` back to the browser as Server-Sent Events.
+ * Companion routes:
+ *   - `POST .../elicitation-respond` resolves a pending elicitation.
+ *   - Aborting the fetch on the client side forwards an AbortSignal through
+ *     the SDK transport, which emits `notifications/cancelled` on the wire.
+ *
+ * SSE event shapes (all emitted as `data: <json>\n\n`):
+ *   { type: 'session',     sessionId: string }
+ *   { type: 'log',         level, data, logger? }
+ *   { type: 'progress',    progress: number, total?: number, message?: string }
+ *   { type: 'elicitation', id: string, message: string, requestedSchema: object }
+ *   { type: 'result',      result: CallToolResult }
+ *   { type: 'error',       error: string, detail?: string }
+ *
+ * The stream always closes with exactly one of `result` or `error`.
+ *
+ * Stage 3.4 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { McpCapabilityError } from '@revealui/mcp/client';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import {
+  awaitElicitationResponse,
+  createCallSession,
+  deleteCallSession,
+} from '@/lib/mcp/call-sessions';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+type SseEvent =
+  | { type: 'session'; sessionId: string }
+  | { type: 'log'; level: string; data: unknown; logger?: string }
+  | { type: 'progress'; progress: number; total?: number; message?: string }
+  | { type: 'elicitation'; id: string; message: string; requestedSchema: unknown }
+  | { type: 'result'; result: unknown }
+  | { type: 'error'; error: string; detail?: string };
+
+function encodeEvent(event: SseEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<Response> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  let body: { tenant?: unknown; name?: unknown; arguments?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+  const { tenant, name } = body;
+  if (typeof tenant !== 'string' || !IDENTIFIER_RE.test(tenant)) {
+    return NextResponse.json(
+      { error: 'body.tenant must be a string matching /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (typeof name !== 'string' || name.length === 0 || name.length > 256) {
+    return NextResponse.json(
+      { error: 'body.name must be a non-empty string (≤256 chars)' },
+      { status: 400 },
+    );
+  }
+  let args: Record<string, unknown> | undefined;
+  if (body.arguments !== undefined) {
+    if (
+      typeof body.arguments !== 'object' ||
+      body.arguments === null ||
+      Array.isArray(body.arguments)
+    ) {
+      return NextResponse.json(
+        { error: 'body.arguments must be a plain object when provided' },
+        { status: 400 },
+      );
+    }
+    args = body.arguments as Record<string, unknown>;
+  }
+
+  // Build the streaming response. The rest of the handler runs inside the
+  // ReadableStream's start() so events are emitted as they happen.
+  const session = createCallSession(authSession.user.id);
+  const encoder = new TextEncoder();
+  const abortCtrl = new AbortController();
+  request.signal.addEventListener('abort', () => abortCtrl.abort(), { once: true });
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (event: SseEvent): void => {
+        try {
+          controller.enqueue(encoder.encode(encodeEvent(event)));
+        } catch {
+          // empty-catch-ok: controller already closed — nothing to do
+        }
+      };
+
+      write({ type: 'session', sessionId: session.sessionId });
+
+      let built: Awaited<ReturnType<typeof buildRemoteMcpClient>> | undefined;
+      let unsubscribeLog: (() => void) | undefined;
+      try {
+        built = await buildRemoteMcpClient({
+          tenant: tenant as string,
+          server,
+          elicitationHandler: async (params) => {
+            // URL-mode elicitation (out-of-band consent flows) isn't yet
+            // supported by the inspector — decline so the server can fall
+            // back. Form-mode with an inline `requestedSchema` is the
+            // common case and renders natively below.
+            if ((params as { mode?: string }).mode === 'url') {
+              return { action: 'decline' };
+            }
+            const requestedSchema = (
+              params as {
+                requestedSchema?: unknown;
+              }
+            ).requestedSchema;
+            const elicitationId = crypto.randomUUID();
+            write({
+              type: 'elicitation',
+              id: elicitationId,
+              message: params.message,
+              requestedSchema,
+            });
+            return awaitElicitationResponse(session.sessionId, elicitationId);
+          },
+        });
+
+        await built.client.connect();
+
+        unsubscribeLog = built.client.onLog((logParams) => {
+          write({
+            type: 'log',
+            level: logParams.level,
+            data: logParams.data,
+            ...(logParams.logger ? { logger: logParams.logger } : {}),
+          });
+        });
+
+        const result = await built.client.callTool(name as string, args, {
+          signal: abortCtrl.signal,
+          onProgress: (p) => {
+            write({
+              type: 'progress',
+              progress: p.progress,
+              ...(p.total !== undefined ? { total: p.total } : {}),
+              ...(p.message !== undefined ? { message: p.message } : {}),
+            });
+          },
+        });
+
+        write({ type: 'result', result });
+      } catch (err) {
+        if (abortCtrl.signal.aborted) {
+          write({ type: 'error', error: 'cancelled' });
+        } else if (err instanceof RemoteServerNotConnectedError) {
+          write({ type: 'error', error: 'not_connected', detail: err.message });
+        } else if (err instanceof McpCapabilityError) {
+          write({ type: 'error', error: 'capability_missing', detail: err.message });
+        } else {
+          write({
+            type: 'error',
+            error: 'mcp_call_failed',
+            detail: (err as Error).message.slice(0, 200),
+          });
+        }
+      } finally {
+        unsubscribeLog?.();
+        if (built) {
+          await built.client.close().catch(() => undefined); // empty-catch-ok: best-effort teardown
+        }
+        deleteCallSession(session.sessionId);
+        try {
+          controller.close();
+        } catch {
+          // empty-catch-ok: already closed (e.g. client disconnected)
+        }
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    },
+  });
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/elicitation-respond/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/elicitation-respond/route.ts
@@ -1,0 +1,110 @@
+/**
+ * MCP elicitation response — POST /api/mcp/remote-servers/[server]/elicitation-respond
+ *
+ * Resolves a pending elicitation request on an active `call-tool-stream`
+ * session. The streaming invoker emits an `{ type: 'elicitation', id, … }`
+ * event when the remote server calls `elicitation/create`; the admin UI
+ * renders a form, collects the user's response, and POSTs back here.
+ *
+ * Body:
+ * ```
+ * {
+ *   sessionId: string,
+ *   elicitationId: string,
+ *   action: 'accept' | 'decline' | 'cancel',
+ *   content?: Record<string, unknown>
+ * }
+ * ```
+ *
+ * Returns 200 on success; 404 if no matching pending elicitation exists
+ * (stale sessionId, or the admin responded twice, or the stream already
+ * ended).
+ *
+ * Stage 3.4 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import type { ElicitResult } from '@revealui/mcp/client';
+import { type NextRequest, NextResponse } from 'next/server';
+import { getCallSession, resolveElicitation } from '@/lib/mcp/call-sessions';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<{ resolved: true } | { error: string; detail?: string }>> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: {
+    sessionId?: unknown;
+    elicitationId?: unknown;
+    action?: unknown;
+    content?: unknown;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const { sessionId, elicitationId, action } = body;
+  if (typeof sessionId !== 'string' || !UUID_RE.test(sessionId)) {
+    return NextResponse.json({ error: 'body.sessionId must be a UUID' }, { status: 400 });
+  }
+  if (typeof elicitationId !== 'string' || !UUID_RE.test(elicitationId)) {
+    return NextResponse.json({ error: 'body.elicitationId must be a UUID' }, { status: 400 });
+  }
+  if (action !== 'accept' && action !== 'decline' && action !== 'cancel') {
+    return NextResponse.json(
+      { error: "body.action must be 'accept' | 'decline' | 'cancel'" },
+      { status: 400 },
+    );
+  }
+
+  // Bind responses to the session owner. Prevents a different admin from
+  // closing out another admin's open elicitation.
+  const session = getCallSession(sessionId);
+  if (!session) {
+    return NextResponse.json(
+      { error: 'session_expired', detail: 'The streaming session is no longer active.' },
+      { status: 404 },
+    );
+  }
+  if (session.userId !== authSession.user.id) {
+    return NextResponse.json({ error: 'session_owner_mismatch' }, { status: 403 });
+  }
+
+  let result: ElicitResult;
+  if (action === 'accept') {
+    const rawContent = body.content;
+    if (typeof rawContent !== 'object' || rawContent === null || Array.isArray(rawContent)) {
+      return NextResponse.json(
+        { error: "body.content must be a plain object when action === 'accept'" },
+        { status: 400 },
+      );
+    }
+    result = {
+      action: 'accept',
+      content: rawContent as Record<string, string | number | boolean | string[]>,
+    };
+  } else {
+    result = { action };
+  }
+
+  const resolved = resolveElicitation(sessionId, elicitationId, result);
+  if (!resolved) {
+    return NextResponse.json(
+      { error: 'unknown_elicitation', detail: 'No matching pending elicitation.' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ resolved: true });
+}

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/log-stream/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/log-stream/route.ts
@@ -1,0 +1,157 @@
+/**
+ * MCP log stream — GET /api/mcp/remote-servers/[server]/log-stream?tenant=X&level=info
+ *
+ * Opens a long-lived SSE connection to a remote MCP server, registers a
+ * log listener, and streams `notifications/message` events back to the
+ * browser as they arrive. Closing the HTTP connection (or aborting the
+ * fetch on the client side) closes the MCP connection and stops streaming.
+ *
+ * SSE event shape: `data: { type: 'log', level, data, logger? }\n\n`.
+ * An initial `{ type: 'ready' }` signals the connection is live.
+ *
+ * Supported `level` values: debug, info, notice, warning, error, critical,
+ * alert, emergency. Defaults to `info`.
+ *
+ * Stage 3.4 of the MCP v1 plan.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { type LoggingLevel, McpCapabilityError } from '@revealui/mcp/client';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import {
+  buildRemoteMcpClient,
+  RemoteServerNotConnectedError,
+} from '@/lib/mcp/remote-server-client';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const ALLOWED_LEVELS: LoggingLevel[] = [
+  'debug',
+  'info',
+  'notice',
+  'warning',
+  'error',
+  'critical',
+  'alert',
+  'emergency',
+];
+
+function parseLevel(value: string | null): LoggingLevel {
+  if (value && (ALLOWED_LEVELS as string[]).includes(value)) return value as LoggingLevel;
+  return 'info';
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ server: string }> },
+): Promise<Response> {
+  const authSession = await getSession(request.headers, extractRequestContext(request));
+  if (!authSession) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (authSession.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { server } = await context.params;
+  const url = new URL(request.url);
+  const tenant = url.searchParams.get('tenant');
+  const level = parseLevel(url.searchParams.get('level'));
+
+  if (!(tenant && IDENTIFIER_RE.test(tenant))) {
+    return NextResponse.json(
+      { error: 'tenant query parameter must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+  if (!IDENTIFIER_RE.test(server)) {
+    return NextResponse.json(
+      { error: 'server path segment must match /^[A-Za-z0-9_-]{1,64}$/' },
+      { status: 400 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const write = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    event: Record<string, unknown>,
+  ): void => {
+    try {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+    } catch {
+      // empty-catch-ok: controller already closed — nothing to do
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let built: Awaited<ReturnType<typeof buildRemoteMcpClient>> | undefined;
+      let unsubscribe: (() => void) | undefined;
+
+      const abort = () => {
+        unsubscribe?.();
+        if (built) {
+          void built.client.close().catch(() => undefined); // empty-catch-ok: best-effort teardown
+        }
+        try {
+          controller.close();
+        } catch {
+          // empty-catch-ok: already closed
+        }
+      };
+      request.signal.addEventListener('abort', abort, { once: true });
+
+      try {
+        built = await buildRemoteMcpClient({ tenant, server });
+        await built.client.connect();
+
+        unsubscribe = built.client.onLog((logParams) => {
+          write(controller, {
+            type: 'log',
+            level: logParams.level,
+            data: logParams.data,
+            ...(logParams.logger ? { logger: logParams.logger } : {}),
+          });
+        });
+
+        await built.client.setLoggingLevel(level);
+        write(controller, { type: 'ready', level });
+
+        // Hold the stream open. The registered `abort` listener + the client
+        // disconnecting tear it down. We intentionally never resolve this
+        // Promise under normal operation.
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      } catch (err) {
+        if (err instanceof RemoteServerNotConnectedError) {
+          write(controller, { type: 'error', error: 'not_connected', detail: err.message });
+        } else if (err instanceof McpCapabilityError) {
+          write(controller, {
+            type: 'error',
+            error: 'capability_missing',
+            detail: err.message,
+          });
+        } else if (!request.signal.aborted) {
+          write(controller, {
+            type: 'error',
+            error: 'mcp_call_failed',
+            detail: (err as Error).message.slice(0, 200),
+          });
+        }
+      } finally {
+        abort();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    },
+  });
+}

--- a/apps/admin/src/lib/components/mcp/logs-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/logs-panel.tsx
@@ -1,0 +1,242 @@
+/**
+ * Logs panel for `/admin/mcp/inspect` (Stage 3.4).
+ *
+ * Opens a long-lived SSE connection to the remote MCP server's log stream
+ * (`/api/mcp/remote-servers/[server]/log-stream`) and renders every
+ * `notifications/message` event as it arrives. Admin can pick a level
+ * (which the server filters on) and clear the buffer.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface LogEntry {
+  level: string;
+  data: unknown;
+  logger?: string;
+  at: number;
+}
+
+type Level = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+
+const LEVELS: Level[] = [
+  'debug',
+  'info',
+  'notice',
+  'warning',
+  'error',
+  'critical',
+  'alert',
+  'emergency',
+];
+
+interface LogsPanelProps {
+  tenant: string;
+  server: string;
+}
+
+export function LogsPanel({ tenant, server }: LogsPanelProps) {
+  const [level, setLevel] = useState<Level>('info');
+  const [state, setState] = useState<'idle' | 'connecting' | 'streaming' | 'error'>('idle');
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState('idle');
+  }, []);
+
+  const start = useCallback(async () => {
+    stop();
+    setEntries([]);
+    setMessage(null);
+    setState('connecting');
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch(
+        `/api/mcp/remote-servers/${encodeURIComponent(server)}/log-stream?tenant=${encodeURIComponent(tenant)}&level=${level}`,
+        { credentials: 'include', signal: controller.signal },
+      );
+      if (!(res.ok && res.body)) {
+        // empty-catch-ok: non-JSON error body — surface res.status below
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          detail?: string;
+        };
+        throw new Error(body.detail ?? body.error ?? `HTTP ${res.status}`);
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let idx = buffer.indexOf('\n\n');
+        while (idx !== -1) {
+          const rawEvent = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+          const dataLine = rawEvent
+            .split('\n')
+            .find((l) => l.startsWith('data:'))
+            ?.slice(5)
+            .trim();
+          if (dataLine) {
+            try {
+              const parsed = JSON.parse(dataLine) as
+                | { type: 'ready'; level: Level }
+                | { type: 'log'; level: string; data: unknown; logger?: string }
+                | { type: 'error'; error: string; detail?: string };
+              if (parsed.type === 'ready') {
+                setState('streaming');
+              } else if (parsed.type === 'log') {
+                setEntries((existing) => {
+                  const next = [
+                    ...existing,
+                    {
+                      level: parsed.level,
+                      data: parsed.data,
+                      logger: parsed.logger,
+                      at: Date.now(),
+                    },
+                  ];
+                  // Cap buffer to the most recent 500 entries.
+                  return next.length > 500 ? next.slice(-500) : next;
+                });
+              } else if (parsed.type === 'error') {
+                setMessage(parsed.detail ?? parsed.error);
+                setState('error');
+              }
+            } catch {
+              // empty-catch-ok: malformed line — ignore and continue streaming
+            }
+          }
+          idx = buffer.indexOf('\n\n');
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setMessage((err as Error).message);
+        setState('error');
+      } else {
+        setState('idle');
+      }
+    }
+  }, [tenant, server, level, stop]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+        <label htmlFor="log-level" className="text-xs font-medium text-zinc-300">
+          Level
+        </label>
+        <select
+          id="log-level"
+          value={level}
+          onChange={(e) => setLevel(e.target.value as Level)}
+          disabled={state === 'streaming' || state === 'connecting'}
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 font-mono text-xs text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+        >
+          {LEVELS.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+        {state === 'streaming' || state === 'connecting' ? (
+          <button
+            type="button"
+            onClick={stop}
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+          >
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void start()}
+            className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Start
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setEntries([])}
+          disabled={entries.length === 0}
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Clear
+        </button>
+        <div className="ml-auto text-xs text-zinc-500">
+          {state === 'streaming' && (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" /> streaming
+            </span>
+          )}
+          {state === 'connecting' && <span>connecting…</span>}
+          {state === 'error' && <span className="text-red-400">error</span>}
+          {state === 'idle' && <span>idle</span>}
+          <span className="ml-3">{entries.length} entries</span>
+        </div>
+      </div>
+
+      {message && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+        >
+          {message}
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
+          No log messages yet. Click <span className="font-medium text-zinc-300">Start</span> to
+          subscribe.
+        </div>
+      ) : (
+        <ul className="max-h-[60vh] space-y-0.5 overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 font-mono text-[11px]">
+          {entries.map((entry) => (
+            <li key={entry.at} className="text-zinc-200">
+              <span className="mr-2 text-zinc-500">
+                [{new Date(entry.at).toISOString().slice(11, 19)}]
+              </span>
+              <span className={levelColor(entry.level)}>{entry.level}</span>
+              {entry.logger && <span className="ml-1 text-zinc-500">({entry.logger})</span>}{' '}
+              {typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function levelColor(level: string): string {
+  switch (level) {
+    case 'error':
+    case 'critical':
+    case 'alert':
+    case 'emergency':
+      return 'text-red-400';
+    case 'warning':
+      return 'text-yellow-400';
+    case 'notice':
+    case 'info':
+      return 'text-emerald-400';
+    default:
+      return 'text-zinc-400';
+  }
+}

--- a/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
+++ b/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
@@ -1,0 +1,588 @@
+/**
+ * Streaming tool invoker card (Stage 3.4).
+ *
+ * Replaces the Stage 3.2 request/response `ToolCard` with an SSE-driven
+ * invoker that surfaces:
+ *
+ *   - Progress bar, fed by `notifications/progress` from the server.
+ *   - Cancel button, which aborts the fetch → the SDK transport emits
+ *     `notifications/cancelled` on the wire.
+ *   - Inline elicitation form, rendered from the server's
+ *     `requestedSchema`. Response goes back via
+ *     `/api/mcp/remote-servers/<server>/elicitation-respond`.
+ *   - Live per-call log panel (protocol-level `notifications/message`).
+ *   - Final `CallToolResult` on success; structured error on failure.
+ *
+ * Tool calls that don't emit progress or elicitation still work — those
+ * event types simply never arrive and the UI shows only the final result.
+ */
+
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Tool {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    type?: string;
+    properties?: Record<string, JsonSchemaProperty>;
+    required?: string[];
+  };
+}
+
+interface JsonSchemaProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+}
+
+interface CallToolResult {
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  isError?: boolean;
+}
+
+interface LogEntry {
+  level: string;
+  data: unknown;
+  logger?: string;
+  at: number;
+}
+
+interface ElicitationRequest {
+  id: string;
+  message: string;
+  requestedSchema: {
+    type?: string;
+    properties?: Record<string, JsonSchemaProperty>;
+    required?: string[];
+  };
+}
+
+type SseEvent =
+  | { type: 'session'; sessionId: string }
+  | { type: 'log'; level: string; data: unknown; logger?: string }
+  | { type: 'progress'; progress: number; total?: number; message?: string }
+  | { type: 'elicitation'; id: string; message: string; requestedSchema: unknown }
+  | { type: 'result'; result: CallToolResult }
+  | { type: 'error'; error: string; detail?: string };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface StreamingToolCardProps {
+  tool: Tool;
+  tenant: string;
+  server: string;
+}
+
+export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardProps) {
+  const properties = useMemo(() => tool.inputSchema?.properties ?? {}, [tool.inputSchema]);
+  const required = useMemo(() => new Set(tool.inputSchema?.required ?? []), [tool.inputSchema]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [invoking, setInvoking] = useState(false);
+  const [progress, setProgress] = useState<{
+    progress: number;
+    total?: number;
+    message?: string;
+  } | null>(null);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [pendingElicitation, setPendingElicitation] = useState<ElicitationRequest | null>(null);
+  const [result, setResult] = useState<CallToolResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
+    if (raw === '') return undefined;
+    switch (prop.type) {
+      case 'number':
+      case 'integer': {
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : raw;
+      }
+      case 'boolean':
+        return raw === 'true';
+      case 'object':
+      case 'array':
+        return JSON.parse(raw);
+      default:
+        return raw;
+    }
+  };
+
+  const resetState = () => {
+    setProgress(null);
+    setLogs([]);
+    setPendingElicitation(null);
+    setResult(null);
+    setError(null);
+    sessionIdRef.current = null;
+  };
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const consumeStream = async (body: ReadableStream<Uint8Array>): Promise<void> => {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx = buffer.indexOf('\n\n');
+      while (idx !== -1) {
+        const rawEvent = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const dataLine = rawEvent
+          .split('\n')
+          .find((l) => l.startsWith('data:'))
+          ?.slice(5)
+          .trim();
+        if (dataLine) {
+          try {
+            const parsed = JSON.parse(dataLine) as SseEvent;
+            applyEvent(parsed);
+          } catch {
+            // empty-catch-ok: malformed line — ignore and continue streaming
+          }
+        }
+        idx = buffer.indexOf('\n\n');
+      }
+    }
+  };
+
+  const applyEvent = (event: SseEvent): void => {
+    switch (event.type) {
+      case 'session':
+        sessionIdRef.current = event.sessionId;
+        break;
+      case 'log':
+        setLogs((existing) => [
+          ...existing,
+          {
+            level: event.level,
+            data: event.data,
+            logger: event.logger,
+            at: Date.now(),
+          },
+        ]);
+        break;
+      case 'progress':
+        setProgress({
+          progress: event.progress,
+          total: event.total,
+          message: event.message,
+        });
+        break;
+      case 'elicitation':
+        setPendingElicitation({
+          id: event.id,
+          message: event.message,
+          requestedSchema: (event.requestedSchema ?? {}) as ElicitationRequest['requestedSchema'],
+        });
+        break;
+      case 'result':
+        setResult(event.result);
+        break;
+      case 'error':
+        setError(event.detail ? `${event.error}: ${event.detail}` : event.error);
+        break;
+    }
+  };
+
+  const submitElicitation = async (
+    action: 'accept' | 'decline' | 'cancel',
+    content?: Record<string, unknown>,
+  ): Promise<void> => {
+    const elicitation = pendingElicitation;
+    const sessionId = sessionIdRef.current;
+    if (!(elicitation && sessionId)) return;
+    setPendingElicitation(null);
+    await fetch(`/api/mcp/remote-servers/${encodeURIComponent(server)}/elicitation-respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        sessionId,
+        elicitationId: elicitation.id,
+        action,
+        ...(action === 'accept' && content ? { content } : {}),
+      }),
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    resetState();
+    setInvoking(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const args: Record<string, unknown> = {};
+      for (const [key, prop] of Object.entries(properties)) {
+        const raw = values[key] ?? '';
+        const parsed = parseValue(prop, raw);
+        if (parsed !== undefined) args[key] = parsed;
+      }
+      const res = await fetch(
+        `/api/mcp/remote-servers/${encodeURIComponent(server)}/call-tool-stream`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          signal: controller.signal,
+          body: JSON.stringify({ tenant, name: tool.name, arguments: args }),
+        },
+      );
+      if (!(res.ok && res.body)) {
+        // empty-catch-ok: non-JSON error body — surface res.status below
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          detail?: string;
+        };
+        throw new Error(body.detail ?? body.error ?? `HTTP ${res.status}`);
+      }
+      await consumeStream(res.body);
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        setError('cancelled');
+      } else {
+        setError((err as Error).message);
+      }
+    } finally {
+      setInvoking(false);
+      abortRef.current = null;
+    }
+  };
+
+  return (
+    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+      <summary className="flex cursor-pointer items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-sm font-semibold text-white">{tool.name}</div>
+          {tool.description && (
+            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{tool.description}</div>
+          )}
+        </div>
+        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
+      </summary>
+
+      <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
+        {Object.keys(properties).length === 0 && (
+          <p className="text-xs text-zinc-500">
+            This tool takes no input. Click <span className="font-medium">Invoke</span> to call it.
+          </p>
+        )}
+        {Object.entries(properties).map(([key, prop]) => (
+          <ArgumentField
+            key={key}
+            name={key}
+            prop={prop}
+            required={required.has(key)}
+            value={values[key] ?? ''}
+            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
+          />
+        ))}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={invoking}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {invoking ? 'Invoking…' : 'Invoke'}
+          </button>
+          {invoking && (
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+
+      {progress && <ProgressDisplay progress={progress} />}
+      {pendingElicitation && (
+        <ElicitationForm elicitation={pendingElicitation} onSubmit={submitElicitation} />
+      )}
+      {logs.length > 0 && <LogPanel logs={logs} />}
+      {result && <ToolResult result={result} />}
+      {error && (
+        <div className="mt-4 rounded-md border border-red-800 bg-red-900/20 p-3 text-xs text-red-300">
+          {error}
+        </div>
+      )}
+    </details>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Argument field (mirrors the Stage 3.2 version)
+// ---------------------------------------------------------------------------
+
+interface ArgumentFieldProps {
+  name: string;
+  prop: JsonSchemaProperty;
+  required: boolean;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
+  const inputId = `arg-${name}`;
+  const placeholder =
+    prop.default !== undefined
+      ? `default: ${JSON.stringify(prop.default)}`
+      : prop.type === 'object' || prop.type === 'array'
+        ? 'JSON value'
+        : (prop.type ?? 'string');
+
+  return (
+    <div>
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+        {name}
+        {required && <span className="ml-1 text-red-400">*</span>}
+        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
+      </label>
+      {prop.enum && prop.enum.length > 0 ? (
+        <select
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        >
+          <option value="">—</option>
+          {prop.enum.map((opt) => (
+            <option key={String(opt)} value={String(opt)}>
+              {String(opt)}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        />
+      )}
+      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Progress bar
+// ---------------------------------------------------------------------------
+
+function ProgressDisplay({
+  progress,
+}: {
+  progress: { progress: number; total?: number; message?: string };
+}) {
+  const pct =
+    progress.total && progress.total > 0
+      ? Math.min(100, Math.round((progress.progress / progress.total) * 100))
+      : undefined;
+  return (
+    <div className="mt-4 rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+      <div className="mb-1.5 flex items-center justify-between text-[10px] text-zinc-400">
+        <span>{progress.message ?? 'Progress'}</span>
+        <span className="font-mono">
+          {pct !== undefined
+            ? `${pct}%`
+            : `${progress.progress}${progress.total !== undefined ? ` / ${progress.total}` : ''}`}
+        </span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-zinc-800">
+        <div
+          className="h-full bg-emerald-500 transition-all duration-200"
+          style={
+            pct !== undefined ? { width: `${pct}%` } : { width: '33%', opacity: 0.6 } // indeterminate fallback
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Elicitation form — renders the server's requestedSchema inline
+// ---------------------------------------------------------------------------
+
+interface ElicitationFormProps {
+  elicitation: ElicitationRequest;
+  onSubmit: (
+    action: 'accept' | 'decline' | 'cancel',
+    content?: Record<string, unknown>,
+  ) => Promise<void>;
+}
+
+function ElicitationForm({ elicitation, onSubmit }: ElicitationFormProps) {
+  const schema = elicitation.requestedSchema ?? {};
+  const properties = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
+    if (raw === '') return undefined;
+    switch (prop.type) {
+      case 'number':
+      case 'integer': {
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : raw;
+      }
+      case 'boolean':
+        return raw === 'true';
+      default:
+        return raw;
+    }
+  };
+
+  const handleAccept = (e: React.FormEvent) => {
+    e.preventDefault();
+    const content: Record<string, unknown> = {};
+    for (const [key, prop] of Object.entries(properties)) {
+      const raw = values[key] ?? '';
+      const parsed = parseValue(prop, raw);
+      if (parsed !== undefined) content[key] = parsed;
+    }
+    void onSubmit('accept', content);
+  };
+
+  return (
+    <form
+      onSubmit={handleAccept}
+      className="mt-4 rounded-md border border-blue-800 bg-blue-900/10 p-3"
+    >
+      <div className="mb-3 flex items-center gap-2 text-xs">
+        <span className="rounded-full bg-blue-500/20 px-2 py-0.5 font-medium text-blue-300">
+          Server request
+        </span>
+        <span className="text-blue-200">{elicitation.message}</span>
+      </div>
+      <div className="space-y-3">
+        {Object.entries(properties).map(([key, prop]) => (
+          <ArgumentField
+            key={key}
+            name={key}
+            prop={prop}
+            required={required.has(key)}
+            value={values[key] ?? ''}
+            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
+          />
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="submit"
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => void onSubmit('decline')}
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          onClick={() => void onSubmit('cancel')}
+          className="rounded-md border border-red-800 bg-red-900/20 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-900/40"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Log panel (per-call, collapsible)
+// ---------------------------------------------------------------------------
+
+function LogPanel({ logs }: { logs: LogEntry[] }) {
+  return (
+    <details className="mt-4 rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+      <summary className="cursor-pointer text-xs text-zinc-400">
+        Logs <span className="text-zinc-500">({logs.length})</span>
+      </summary>
+      <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto font-mono text-[11px]">
+        {logs.map((entry) => (
+          <li key={entry.at} className="text-zinc-200">
+            <span className="mr-2 text-zinc-500">
+              [{new Date(entry.at).toISOString().slice(11, 19)}]
+            </span>
+            <span className={levelColor(entry.level)}>{entry.level}</span>
+            {entry.logger && <span className="ml-1 text-zinc-500">({entry.logger})</span>}{' '}
+            {typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data)}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+function levelColor(level: string): string {
+  switch (level) {
+    case 'error':
+    case 'critical':
+    case 'alert':
+    case 'emergency':
+      return 'text-red-400';
+    case 'warning':
+      return 'text-yellow-400';
+    case 'notice':
+    case 'info':
+      return 'text-emerald-400';
+    default:
+      return 'text-zinc-400';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result display (mirrors Stage 3.2)
+// ---------------------------------------------------------------------------
+
+function ToolResult({ result }: { result: CallToolResult }) {
+  return (
+    <div
+      className={`mt-4 rounded-md border p-3 text-xs ${
+        result.isError
+          ? 'border-red-800 bg-red-900/20 text-red-300'
+          : 'border-emerald-900 bg-emerald-900/10 text-emerald-200'
+      }`}
+    >
+      <div className="mb-2 font-medium">{result.isError ? 'Tool returned an error' : 'Result'}</div>
+      <div className="space-y-2">
+        {result.content.map((block, idx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: blocks have no id
+          <pre key={idx} className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px]">
+            {block.type === 'text'
+              ? (block.text ?? '')
+              : `[${block.type}${block.mimeType ? ` ${block.mimeType}` : ''}]`}
+          </pre>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/mcp/__tests__/call-sessions.test.ts
+++ b/apps/admin/src/lib/mcp/__tests__/call-sessions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * call-sessions unit tests (Stage 3.4).
+ *
+ * Exercises the in-memory session registry that bridges the streaming
+ * call-tool route and the elicitation-respond route.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  awaitElicitationResponse,
+  createCallSession,
+  deleteCallSession,
+  getCallSession,
+  resolveElicitation,
+} from '../call-sessions';
+
+describe('call-sessions', () => {
+  it('createCallSession registers a retrievable session', () => {
+    const session = createCallSession('admin-1');
+    expect(session.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(session.userId).toBe('admin-1');
+    expect(getCallSession(session.sessionId)).toBe(session);
+    deleteCallSession(session.sessionId);
+  });
+
+  it('awaitElicitationResponse resolves when resolveElicitation is called with a match', async () => {
+    const session = createCallSession('admin-1');
+    const elicitationId = 'e-1';
+    const pending = awaitElicitationResponse(session.sessionId, elicitationId);
+    const resolved = resolveElicitation(session.sessionId, elicitationId, {
+      action: 'accept',
+      content: { name: 'alice' },
+    });
+    expect(resolved).toBe(true);
+    await expect(pending).resolves.toEqual({
+      action: 'accept',
+      content: { name: 'alice' },
+    });
+    deleteCallSession(session.sessionId);
+  });
+
+  it('resolveElicitation returns false when no matching pending exists', () => {
+    const session = createCallSession('admin-1');
+    expect(resolveElicitation(session.sessionId, 'nope', { action: 'cancel' })).toBe(false);
+    deleteCallSession(session.sessionId);
+  });
+
+  it('deleteCallSession cancels every outstanding elicitation', async () => {
+    const session = createCallSession('admin-1');
+    const a = awaitElicitationResponse(session.sessionId, 'e-a');
+    const b = awaitElicitationResponse(session.sessionId, 'e-b');
+    deleteCallSession(session.sessionId);
+    await expect(a).resolves.toEqual({ action: 'cancel' });
+    await expect(b).resolves.toEqual({ action: 'cancel' });
+    expect(getCallSession(session.sessionId)).toBeUndefined();
+  });
+
+  it('awaitElicitationResponse for an unknown session resolves with cancel', async () => {
+    await expect(
+      awaitElicitationResponse('00000000-0000-0000-0000-000000000000', 'e-x'),
+    ).resolves.toEqual({ action: 'cancel' });
+  });
+
+  it('resolveElicitation is single-use — a second call for the same id returns false', () => {
+    const session = createCallSession('admin-1');
+    void awaitElicitationResponse(session.sessionId, 'e-1');
+    expect(resolveElicitation(session.sessionId, 'e-1', { action: 'accept', content: {} })).toBe(
+      true,
+    );
+    expect(resolveElicitation(session.sessionId, 'e-1', { action: 'accept', content: {} })).toBe(
+      false,
+    );
+    deleteCallSession(session.sessionId);
+  });
+});

--- a/apps/admin/src/lib/mcp/call-sessions.ts
+++ b/apps/admin/src/lib/mcp/call-sessions.ts
@@ -1,0 +1,103 @@
+/**
+ * In-memory session registry for streaming MCP tool calls that may request
+ * elicitation mid-flight. Lifetime: one entry per active `call-tool-stream`
+ * request. Entries are automatically removed when the stream ends (success,
+ * error, or client disconnect).
+ *
+ * A `CallSession` bridges two route handlers:
+ *
+ *   1. `POST .../call-tool-stream` registers the session, attaches an
+ *      `elicitationHandler` that creates a `PendingElicitation` entry, and
+ *      writes `{ type: 'elicitation', id, requestedSchema, message }` to
+ *      the SSE stream. The handler returns a Promise that resolves once
+ *      the admin submits a response.
+ *
+ *   2. `POST .../elicitation-respond` reads `{ sessionId, elicitationId,
+ *      action, content? }` from its body, looks up the matching pending
+ *      promise, and resolves it so the tool call can continue.
+ *
+ * State is process-local and intentionally non-durable — streaming MCP
+ * tool calls are ephemeral; if the admin process restarts, in-flight
+ * sessions are cancelled.
+ *
+ * Stage 3.4 of the MCP v1 plan.
+ */
+
+import type { ElicitResult } from '@revealui/mcp/client';
+
+interface PendingElicitation {
+  id: string;
+  resolve: (result: ElicitResult) => void;
+}
+
+export interface CallSession {
+  sessionId: string;
+  userId: string;
+  createdAt: number;
+  pending: Map<string, PendingElicitation>;
+}
+
+const sessions = new Map<string, CallSession>();
+
+export function createCallSession(userId: string): CallSession {
+  const sessionId = crypto.randomUUID();
+  const session: CallSession = {
+    sessionId,
+    userId,
+    createdAt: Date.now(),
+    pending: new Map(),
+  };
+  sessions.set(sessionId, session);
+  return session;
+}
+
+export function getCallSession(sessionId: string): CallSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export function deleteCallSession(sessionId: string): void {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+  // Reject any outstanding elicitation to unblock the MCP call's
+  // `elicitationHandler` so it can tear down cleanly.
+  for (const pending of session.pending.values()) {
+    pending.resolve({ action: 'cancel' });
+  }
+  sessions.delete(sessionId);
+}
+
+/**
+ * Register a pending elicitation against an active session. Returns a
+ * Promise that resolves when a matching `elicitation-respond` call lands.
+ */
+export function awaitElicitationResponse(
+  sessionId: string,
+  elicitationId: string,
+): Promise<ElicitResult> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return Promise.resolve({ action: 'cancel' });
+  }
+  return new Promise<ElicitResult>((resolve) => {
+    session.pending.set(elicitationId, { id: elicitationId, resolve });
+  });
+}
+
+/**
+ * Resolve a pending elicitation with the admin-supplied response. Returns
+ * `true` if a matching pending request was found. The caller (the
+ * elicitation-respond route) reports 404 on `false`.
+ */
+export function resolveElicitation(
+  sessionId: string,
+  elicitationId: string,
+  result: ElicitResult,
+): boolean {
+  const session = sessions.get(sessionId);
+  if (!session) return false;
+  const pending = session.pending.get(elicitationId);
+  if (!pending) return false;
+  session.pending.delete(elicitationId);
+  pending.resolve(result);
+  return true;
+}

--- a/apps/admin/src/lib/mcp/remote-server-client.ts
+++ b/apps/admin/src/lib/mcp/remote-server-client.ts
@@ -11,7 +11,7 @@
  * Stage 3.2 of the MCP v1 plan.
  */
 
-import { McpClient } from '@revealui/mcp/client';
+import { type ElicitationHandler, McpClient } from '@revealui/mcp/client';
 import {
   createRevvaultVault,
   McpOAuthProvider,
@@ -61,6 +61,12 @@ export interface BuildRemoteMcpClientOptions {
   clientName?: string;
   /** Client version reported during `initialize`. */
   clientVersion?: string;
+  /**
+   * Handler invoked when the server sends `elicitation/create`. Registered
+   * on the `McpClient` at construction time so capability advertisement
+   * matches what the caller can actually service.
+   */
+  elicitationHandler?: ElicitationHandler;
 }
 
 export interface BuiltRemoteMcpClient {
@@ -102,6 +108,7 @@ export async function buildRemoteMcpClient(
       url: meta.serverUrl,
       authProvider: provider,
     },
+    ...(options.elicitationHandler ? { elicitationHandler: options.elicitationHandler } : {}),
   });
 
   return { client, meta };


### PR DESCRIPTION
## Summary

Stage 3.4 of the MCP v1 productionization plan — **closes Stage 3**. Adds the three server-push surfaces to the inspector: inline elicitation forms, progress bars with cancel, and a live log stream viewer. With this PR merged, the admin has a full-protocol surface for OAuth-authorized remote MCP servers: tools, resources, prompts, completions, elicitation, progress, cancellation, and logs.

### Three new routes

- **`POST /api/mcp/remote-servers/[server]/call-tool-stream`** — SSE-streaming tool invoker. Emits `session`, `log`, `progress`, `elicitation`, `result`, and `error` events over the course of a single call. Aborting the fetch forwards an `AbortSignal` to the SDK transport, which emits `notifications/cancelled` on the wire and tears down.
- **`POST /api/mcp/remote-servers/[server]/elicitation-respond`** — resolves a pending `elicitation/create` request on an active streaming session. Body: `{ sessionId, elicitationId, action: 'accept'|'decline'|'cancel', content? }`. One-shot; session-ownership bound.
- **`GET /api/mcp/remote-servers/[server]/log-stream?tenant=X&level=info`** — long-lived SSE that sets the remote server's log level and forwards every `notifications/message` event to the browser. Closing the HTTP connection closes the MCP connection.

### Internals

- **`lib/mcp/call-sessions.ts`** — in-memory session registry bridging the streaming call-tool route (which creates a session + registers pending elicitations) to the respond route (which looks them up and resolves the matching promise). Tears down cleanly on client disconnect; every outstanding elicitation is auto-cancelled.
- **`buildRemoteMcpClient({ …, elicitationHandler })`** passthrough so short-lived clients can service `elicitation/create`.

### UI

- **Tools tab** now uses `StreamingToolCard` — surfaces a progress bar during the call, a cancel button, an inline elicitation form rendered from the server's `requestedSchema`, and a collapsible per-call log panel. Tools that don't emit progress or elicitation work unchanged: the final result simply arrives with no prior events.
- **New Logs tab** (fourth in the inspector nav) — live-tails `notifications/message` from the server with a level selector, a 500-entry buffer cap, and start/stop/clear controls.
- URL-mode elicitation (out-of-band consent flows) is declined automatically — form-mode with an inline `requestedSchema` is the common case and renders natively.

### Test coverage

14 new tests (admin: 1571 → 1585 passing / 10 skipped):

- **`call-sessions`** (6 unit tests): registration, resolve happy-path, unknown-match, auto-cancel on session delete, unknown-session graceful fallback, single-use guarantee.
- **`elicitation-respond` route** (8 integration tests): 401/403 gating, malformed IDs, unknown action, expired session, cross-admin ownership mismatch, accept + content forwarded, accept requires plain-object content, decline with no content.

## Stage 3 complete

With this PR merged, the full Stage 3 admin UI surface is shipped:

- ✅ 3.1 Server catalog + disconnect
- ✅ 3.2 Tool browser + ad-hoc invoker
- ✅ 3.3 Resource browser + prompt picker + completion-aware inputs
- ✅ 3.4 Elicitation forms + progress + cancel + log stream

Remaining MCP v1 stages:
- **Stage 4** — content pipeline as MCP resources (collections auto-exposed under `revealui://<tenant>/<collection>/<id>`, per-collection `mcpResource` opt-out)
- **Stage 5** — agent runtime consumes full protocol (`@revealui/ai` orchestrator uses `McpClient` directly; recursive sampling routes through agent's LLM)
- **Stage 6** — protocol-level observability + usage metering (events into RevealUI observability; rows in `usage-meters`)

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally
- [ ] `pnpm --filter admin test` — 1585 passing / 10 skipped
- [ ] `pnpm --filter admin typecheck` — clean
- [ ] `pnpm --filter "admin..." build` — clean

## Notes

- **Session state is process-local** — if the admin Next.js process restarts, any in-flight streaming call is torn down and in-progress elicitations are auto-cancelled. Fine for v1; distributed session state lands when/if admin moves to a multi-replica deploy.
- **Vercel streaming limits apply** — Vercel's serverless runtime caps streaming function duration. For long-running tool calls or log streams, expect the connection to drop at the platform's max-duration boundary. Hobby: 10s; Pro: 60s; Enterprise: higher. Self-hosted has no such cap.
- **Elicitation URL-mode is declined** — the MCP spec allows `elicitation/create` with `mode: 'url'` for out-of-band consent flows (e.g. delegated OAuth). Inspector auto-declines; form-mode is the common case and renders natively.
- **No new `@revealui/mcp` changes** — the client surface (`elicitationHandler`, `onProgress`, `onLog`, AbortSignal) was already shipped in Stages 0 + 2.
