### PR TITLE
feat(mcp): content collections as MCP resources (Stage 4.1)

### DIFF
--- a/.changeset/mcp-4-1-content-resources.md
+++ b/.changeset/mcp-4-1-content-resources.md
@@ -1,0 +1,32 @@
+---
+'@revealui/contracts': minor
+'@revealui/mcp': minor
+---
+
+Stage 4.1 of the MCP v1 plan — expose RevealUI content as MCP resources.
+First cut of the content-pipeline-as-resources arc; the admin UI opt-out
+toggle + `revealui://<tenant>/…` URI scheme land with Stage 4.2.
+
+**`@revealui/contracts`:**
+- `CollectionStructure.mcpResource?: boolean` — declarative opt-out for
+  exposing a collection's rows to MCP clients. Default behavior (when
+  absent) is to expose. Added to both the TypeScript interface and the
+  `CollectionStructureSchema` Zod schema.
+
+**`@revealui/mcp`:**
+- `revealui-content` server advertises the `resources` capability.
+- `resources/list` walks a curated default set (`posts`, `pages`,
+  `products`, `media`) and returns one resource per row under the URI
+  scheme `revealui-content://<collection>/<id>`. Partial upstream
+  failure is tolerated — an unavailable collection doesn't blank the
+  rest of the list.
+- `resources/read` parses the URI, fetches the record from
+  `/api/<collection>/<id>`, and returns the JSON verbatim as an
+  `application/json` text block.
+- Malformed URIs + collections outside the default set throw with
+  clear messages.
+
+5 new integration tests (mcp: 195 → 200 passing / 5 skipped). The
+curated default set is the minimum-viable surface — collection-config
+introspection (which consults `mcpResource`) lands with Stage 4.2
+alongside the admin UI toggle.

--- a/packages/contracts/src/admin/structure.ts
+++ b/packages/contracts/src/admin/structure.ts
@@ -758,6 +758,15 @@ export const CollectionStructureSchema = z
     // Default sort
     defaultSort: z.string().optional(),
 
+    /**
+     * Expose this collection's rows as MCP resources via the
+     * `revealui-content` server. Default: `true`. Set to `false` to opt the
+     * collection out of the MCP resource surface (e.g. collections that
+     * contain credentials or PII the agent layer shouldn't see). Stage 4 of
+     * the MCP v1 plan. The admin UI toggle for this lands with Stage 4.2.
+     */
+    mcpResource: z.boolean().optional(),
+
     // Note: access, hooks, endpoints are functions - not validated here
   })
   .passthrough();
@@ -778,6 +787,11 @@ export interface CollectionStructure {
   custom?: Record<string, unknown> | undefined;
   dbName?: string | undefined;
   defaultSort?: string | undefined;
+  /**
+   * Expose this collection's rows as MCP resources via the `revealui-content`
+   * server. Default: `true`. Stage 4 of the MCP v1 plan.
+   */
+  mcpResource?: boolean | undefined;
 }
 
 /**

--- a/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
+++ b/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
@@ -192,6 +192,145 @@ describe('revealui-content factory over Streamable HTTP', () => {
     expect(apiReq?.headers['user-agent']).toBe('RevealUI-MCP/1.0');
   });
 
+  it('advertises the resources capability (Stage 4.1)', async () => {
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'resources-caps-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    expect(client.getServerCapabilities()?.resources).toBeDefined();
+  });
+
+  it('lists content collections as MCP resources', async () => {
+    const mockApi = await startMockApi({
+      '/api/posts': {
+        docs: [
+          { id: 'p1', title: 'First post' },
+          { id: 'p2', title: 'Second post' },
+        ],
+      },
+      '/api/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
+      '/api/products': { docs: [{ id: 'pr1', name: 'Widget' }] },
+      '/api/media': { docs: [{ id: 'm1', filename: 'hero.jpg' }] },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'list-resources-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const resources = await client.listResources();
+    // 2 posts + 1 page + 1 product + 1 media = 5
+    expect(resources).toHaveLength(5);
+    expect(resources.map((r) => r.uri).sort()).toEqual([
+      'revealui-content://media/m1',
+      'revealui-content://pages/pg1',
+      'revealui-content://posts/p1',
+      'revealui-content://posts/p2',
+      'revealui-content://products/pr1',
+    ]);
+    const post = resources.find((r) => r.uri === 'revealui-content://posts/p1');
+    expect(post?.name).toBe('posts/First post');
+    expect(post?.mimeType).toBe('application/json');
+  });
+
+  it('survives partial failure — an unavailable collection does not blank the list', async () => {
+    // /api/pages returns 404 (intentionally omitted); /api/posts returns docs.
+    const mockApi = await startMockApi({
+      '/api/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
+      '/api/products': { docs: [] },
+      '/api/media': { docs: [] },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'partial-fail-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const resources = await client.listResources();
+    expect(resources.map((r) => r.uri)).toEqual(['revealui-content://posts/p1']);
+  });
+
+  it('reads a resource by URI', async () => {
+    const mockApi = await startMockApi({
+      '/api/posts/p1': { id: 'p1', title: 'First post', body: 'hello world' },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'read-resource-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const contents = await client.readResource('revealui-content://posts/p1');
+    expect(contents).toHaveLength(1);
+    expect(contents[0]?.mimeType).toBe('application/json');
+    const parsed = JSON.parse(contents[0]?.text as string);
+    expect(parsed.id).toBe('p1');
+    expect(parsed.title).toBe('First post');
+  });
+
+  it('rejects malformed resource URIs', async () => {
+    process.env.REVEALUI_API_URL = 'http://127.0.0.1:1';
+    process.env.REVEALUI_API_KEY = 'test';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'bad-uri-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    await expect(client.readResource('http://other-scheme/nope')).rejects.toThrow(
+      /Unknown resource URI/,
+    );
+    // Collection not in the default set.
+    await expect(client.readResource('revealui-content://unknown-collection/x')).rejects.toThrow(
+      /not exposed as a resource/,
+    );
+  });
+
   it('returns a tool-level error when credentials are missing', async () => {
     // Ensure no credentials in env for this scenario.
     delete process.env.REVEALUI_API_URL;

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -29,7 +29,11 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   type CallToolRequest,
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  type ReadResourceRequest,
+  ReadResourceRequestSchema,
+  type Resource,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 
@@ -170,6 +174,89 @@ const TOOLS: Tool[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Resource catalog (Stage 4.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Collections that default to being exposed as MCP resources. The admin-side
+ * `mcpResource: false` opt-out on a collection definition (Stage 4.1 contracts
+ * change) will subtract from this set once the admin publishes an
+ * introspection surface (Stage 4.2). For now this is the curated v1 set —
+ * the collections RevealUI treats as first-class content and which every
+ * admin instance has.
+ */
+const DEFAULT_RESOURCEABLE_COLLECTIONS: ReadonlyArray<{
+  slug: string;
+  titleField: string;
+  description: string;
+}> = [
+  { slug: 'posts', titleField: 'title', description: 'Blog posts and articles' },
+  { slug: 'pages', titleField: 'title', description: 'Site pages (marketing, landing, docs)' },
+  { slug: 'products', titleField: 'name', description: 'Catalog products' },
+  { slug: 'media', titleField: 'filename', description: 'Uploaded media assets' },
+];
+
+/** URI scheme for Stage 4.1. Stage 4.2 may extend with a tenant segment. */
+const RESOURCE_URI_PREFIX = 'revealui-content://';
+
+/** Max rows per collection surfaced in a single `resources/list` response. */
+const DEFAULT_RESOURCE_PAGE_SIZE = 50;
+
+interface ContentRow extends Record<string, unknown> {
+  id: string | number;
+}
+
+interface ContentListResponse {
+  docs?: ContentRow[];
+  data?: ContentRow[];
+  items?: ContentRow[];
+}
+
+/** Extract rows from one of several shapes the RevealUI content API uses. */
+function extractDocs(body: unknown): ContentRow[] {
+  if (!body || typeof body !== 'object') return [];
+  const b = body as ContentListResponse & { data?: ContentRow[] | { docs?: ContentRow[] } };
+  if (Array.isArray(b.docs)) return b.docs;
+  if (Array.isArray(b.items)) return b.items;
+  if (Array.isArray(b.data)) return b.data;
+  if (b.data && typeof b.data === 'object' && Array.isArray((b.data as { docs?: unknown }).docs)) {
+    return (b.data as { docs: ContentRow[] }).docs;
+  }
+  return [];
+}
+
+function pickTitle(row: ContentRow, titleField: string): string {
+  const raw = row[titleField];
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return String(row.id);
+}
+
+function resourceForRow(
+  collection: { slug: string; titleField: string; description: string },
+  row: ContentRow,
+): Resource {
+  const id = String(row.id);
+  return {
+    uri: `${RESOURCE_URI_PREFIX}${collection.slug}/${id}`,
+    name: `${collection.slug}/${pickTitle(row, collection.titleField)}`,
+    description: `${collection.description} (id: ${id})`,
+    mimeType: 'application/json',
+  };
+}
+
+function parseResourceUri(uri: string): { collection: string; id: string } | null {
+  if (!uri.startsWith(RESOURCE_URI_PREFIX)) return null;
+  const rest = uri.slice(RESOURCE_URI_PREFIX.length);
+  const slash = rest.indexOf('/');
+  if (slash < 1 || slash === rest.length - 1) return null;
+  const collection = rest.slice(0, slash);
+  const id = rest.slice(slash + 1);
+  if (!/^[a-z][a-z0-9-]*$/.test(collection)) return null;
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) return null;
+  return { collection, id };
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -182,10 +269,77 @@ const TOOLS: Tool[] = [
 export function createRevealuiContentServer(): Server {
   const server = new Server(
     { name: 'revealui-content', version: '1.0.0' },
-    { capabilities: { tools: {} } },
+    { capabilities: { tools: {}, resources: {} } },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+  // -------------------------------------------------------------------------
+  // Resources (Stage 4.1)
+  // -------------------------------------------------------------------------
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
+      /\/$/,
+      '',
+    );
+    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+    if (!(apiUrl && apiKey)) {
+      // Without credentials the server can't enumerate rows; advertise an
+      // empty list rather than erroring — clients still see the resources
+      // capability and can retry once creds are set.
+      return { resources: [] };
+    }
+
+    const resources: Resource[] = [];
+    for (const collection of DEFAULT_RESOURCEABLE_COLLECTIONS) {
+      try {
+        const body = await apiGet(apiUrl, apiKey, `/api/${collection.slug}`, {
+          limit: String(DEFAULT_RESOURCE_PAGE_SIZE),
+          page: '1',
+        });
+        for (const row of extractDocs(body)) {
+          resources.push(resourceForRow(collection, row));
+        }
+      } catch {
+        // empty-catch-ok: an unavailable collection shouldn't blank-out the entire resource list
+      }
+    }
+    return { resources };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
+    const parsed = parseResourceUri(request.params.uri);
+    if (!parsed) {
+      throw new Error(
+        `Unknown resource URI (expected ${RESOURCE_URI_PREFIX}<collection>/<id>): ${request.params.uri}`,
+      );
+    }
+    const collection = DEFAULT_RESOURCEABLE_COLLECTIONS.find((c) => c.slug === parsed.collection);
+    if (!collection) {
+      throw new Error(`Collection is not exposed as a resource: ${parsed.collection}`);
+    }
+
+    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
+      /\/$/,
+      '',
+    );
+    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+    if (!(apiUrl && apiKey)) {
+      throw new Error('REVEALUI_API_URL and REVEALUI_API_KEY must be set');
+    }
+
+    const row = await apiGet(apiUrl, apiKey, `/api/${parsed.collection}/${parsed.id}`);
+    return {
+      contents: [
+        {
+          uri: request.params.uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(row, null, 2),
+        },
+      ],
+    };
+  });
 
   server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
     const startTime = Date.now();


### PR DESCRIPTION
## Summary

Stage 4.1 of the MCP v1 productionization plan — **expose RevealUI content as MCP resources**. First cut of the content-pipeline-as-resources arc. Admin UI opt-out toggle + full `revealui://<tenant>/<collection>/<id>` URI scheme land with Stage 4.2.

### `@revealui/contracts`

- **`CollectionStructure.mcpResource?: boolean`** — declarative opt-out for exposing a collection's rows to MCP clients. Default behavior (field absent): expose. Added to both the TypeScript interface and `CollectionStructureSchema` Zod schema. The admin UI toggle that writes this flag through CollectionConfig lands with PR-4.2.

### `@revealui/mcp` — `revealui-content` factory

- Advertises the `resources` capability alongside `tools`.
- **`resources/list`** walks a curated default set (`posts`, `pages`, `products`, `media`) and returns one resource per row under the URI scheme `revealui-content://<collection>/<id>`. Partial upstream failure is tolerated — an unavailable collection doesn't blank the rest of the list.
- **`resources/read`** parses the URI, fetches the record from `/api/<collection>/<id>`, and returns the JSON verbatim as an `application/json` text block.
- Malformed URIs + collections outside the default set throw with clear messages.

The curated default set (`posts`, `pages`, `products`, `media`) is the minimum-viable surface for Stage 4.1 — these are the collections every RevealUI admin instance has. Stage 4.2 adds dynamic introspection of all collection definitions (respecting `mcpResource: false` opt-out) plus an admin UI toggle.

### Test coverage

5 new integration tests (`@revealui/mcp`: 195 → 200 passing / 5 skipped):

- Resources capability advertised
- Lists content collections as resources (happy path — 5 rows across 4 collections)
- Survives partial failure (404 on one collection doesn't blank the list)
- Reads a resource by URI and returns the record as JSON
- Rejects malformed resource URIs + unknown collections

## Stage 4 remainder

- **4.2** — roots scoped by site/collection, per-collection opt-out toggle in admin UI (integrates with the server catalog from Stage 3.1), refined URI scheme `revealui://<tenant>/<collection>/<id>`, and dynamic introspection that consults `mcpResource: false` to subtract from the exposed set.

## Test plan

- [ ] CI: Quality, Security Gate, Typecheck, Build, Unit Tests, Integration Tests, Drizzle Migrations, Submodule Audit, CodeQL, Dependency Review, Secret Scanning (Gitleaks)
- [ ] Pre-push gate: PASSED locally
- [ ] `pnpm --filter @revealui/mcp test` — 200 passing / 5 skipped
- [ ] `pnpm --filter @revealui/contracts test` — 758 passing (all existing + no regression on CollectionStructure roundtrip)

## Notes

- **Why a curated set instead of walking all CollectionConfigs right now?** The `revealui-content` server runs out-of-process (stdio subprocess or HTTP sidecar). It talks to the RevealUI REST API, not directly to in-process CollectionConfig objects. Full introspection requires a dedicated `/api/mcp/collections` endpoint that enumerates admin-side collection metadata — that's scoped for 4.2 where the admin UI toggle also lives. The curated set covers 100% of default RevealUI installs.
- **URI scheme is `revealui-content://<collection>/<id>`** (not yet `revealui://<tenant>/…`). No tenancy segment in 4.1 — the REST API the factory talks to is already tenant-scoped via the `REVEALUI_API_KEY`. The fuller scheme lands with 4.2's roots work.
- **`mcpResource: false` is wired in contracts but not yet consumed** by the factory — that's 4.2 work. Setting it on a collection today has no runtime effect but the type + Zod schema are in place so admins can adopt the field ahead of the consumer shipping.
