### PR TITLE
fix(deps): bump uuid to >=14.0.0 via pnpm override (Dependabot #28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
       "srvx": ">=0.11.13",
       "smol-toml": ">=1.6.1",
       "jsdom": "29.0.1",
+      "uuid": ">=14.0.0",
       "@revealui/config": "workspace:*",
       "@revealui/contracts": "workspace:*",
       "@revealui/db": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ overrides:
   srvx: '>=0.11.13'
   smol-toml: '>=1.6.1'
   jsdom: 29.0.1
+  uuid: '>=14.0.0'
   '@revealui/config': workspace:*
   '@revealui/contracts': workspace:*
   '@revealui/db': workspace:*
@@ -8804,8 +8805,8 @@ packages:
   uuid-parse@1.1.0:
     resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -14480,7 +14481,7 @@ snapshots:
   hyperid@3.3.0:
     dependencies:
       buffer: 5.7.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       uuid-parse: 1.1.0
 
   iceberg-js@0.8.1: {}
@@ -16843,7 +16844,7 @@ snapshots:
 
   uuid-parse@1.1.0: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

Closes Dependabot alert [#28](https://github.com/RevealUIStudio/revealui/security/dependabot/28) ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) — "Missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided", medium severity, patched in `uuid@14.0.0`.

Adds `"uuid": ">=14.0.0"` to the root `pnpm.overrides` block. One-line fix.

## Ground truth

Single transitive chain (dev-only):

```
revealui (dev)
  └─ autocannon@8.0.0
     └─ hyperid@3.3.0
        └─ uuid@8.3.2  →  uuid@14.0.0 after override
```

Before: `uuid@8.3.2` (vulnerable, < 14.0.0).
After: `uuid@14.0.0` (single resolution; `pnpm why uuid` confirms).

## Verification

- `pnpm install` — 30.9s clean, no peer-dep warnings.
- `pnpm why uuid` — single resolution chain, only `uuid@14.0.0` in the tree.
- `./node_modules/.bin/autocannon --help` — exits 0, usage text renders. `hyperid` loads cleanly against `uuid@14` despite the major bump (v8→v14). The `hyperid` → `uuid` code path uses `v4()` which has been stable across majors.
- Pre-push gate — 15/15 quality checks PASS (Biome, audits, validation, Pro license, claim drift, migration journal, raw-SQL, empty-catch, security, coverage — all green).

## Scope

Dev-only. `autocannon` is a load-testing CLI, not in the production runtime. No production-bundle impact.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm why uuid` shows only `uuid@14.0.0`
- [x] `autocannon --help` exits 0 (hyperid loads cleanly against v14)
- [x] Pre-push quality gate PASS
- [ ] CI full gate + integration tests green on PR
