### PR TITLE
feat(mcp): dynamic collection introspection + admin UI (Stage 4.2)

### DIFF
--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -3,7 +3,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getSharedCMSConfig } from '@revealui/config/revealui';
-import type { CollectionConfig, Field } from '@revealui/contracts/admin';
+import type { Field } from '@revealui/contracts/admin';
 import type { RevealUIField, RevealUIInstance } from '@revealui/core';
 import {
   BoldFeature,
@@ -23,24 +23,7 @@ import {
 } from '@revealui/core';
 import { en } from '@revealui/core/admin/i18n/en';
 import sharp from 'sharp';
-// Import shared configuration from @revealui/config
-import Banners from '@/lib/collections/Banners';
-import Cards from '@/lib/collections/Cards';
-import Categories from '@/lib/collections/Categories';
-import Contents from '@/lib/collections/Contents';
-import { Conversations } from '@/lib/collections/Conversations';
-import Events from '@/lib/collections/Events';
-import Heros from '@/lib/collections/Heros';
-import Layouts from '@/lib/collections/Layouts';
-import { Media } from '@/lib/collections/Media';
-import { Orders } from '@/lib/collections/Orders';
-import { Pages } from '@/lib/collections/Pages/index';
-import { Posts } from '@/lib/collections/Posts';
-import Prices from '@/lib/collections/Prices';
-import Products from '@/lib/collections/Products';
-import Subscriptions from '@/lib/collections/Subscriptions';
-import Tags from '@/lib/collections/Tags';
-import { Tenants } from '@/lib/collections/Tenants';
+import { allCollections } from '@/lib/collections/registry';
 import Users from '@/lib/collections/Users';
 import { createTypedCollectionStorage } from '@/lib/db/typedCollectionStorage';
 import { Footer, Header, Settings } from '@/lib/globals';
@@ -247,27 +230,7 @@ export default buildConfig({
       },
     }),
   ],
-  collections: [
-    Users,
-    Tenants,
-    Pages,
-    Media,
-    Layouts,
-    Contents,
-    Categories,
-    Tags,
-    Events,
-    Cards,
-    Heros,
-    Products,
-    Prices,
-    Orders,
-    Posts,
-    Subscriptions,
-    Banners,
-    Conversations,
-    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous collection array requires invariant generic
-  ] as CollectionConfig<any>[],
+  collections: allCollections,
   // Programmatically create first user on initialization if none exists
   onInit: async (instance: unknown) => {
     const revealui = instance as RevealUIInstance;

--- a/apps/admin/src/app/(backend)/admin/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/page.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
+import type { CollectionMcpSummary } from '@/lib/mcp/collections';
 
 interface RemoteServerSummary {
   tenant: string;
@@ -28,6 +29,7 @@ export default function McpCatalogPage() {
   const [activeTenant, setActiveTenant] = useState<string | null>(null);
   const [builtins, setBuiltins] = useState<McpServerInfo[]>([]);
   const [remotes, setRemotes] = useState<RemoteServerSummary[]>([]);
+  const [collections, setCollections] = useState<CollectionMcpSummary[]>([]);
   const [state, setState] = useState<LoadState>('idle');
   const [message, setMessage] = useState<string | null>(null);
 
@@ -42,6 +44,26 @@ export default function McpCatalogPage() {
         if (!cancelled) setBuiltins(data.servers ?? []);
       } catch (err) {
         if (!cancelled) setMessage(`Failed to load built-in servers: ${(err as Error).message}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load MCP content-exposure map on mount (tenant-agnostic in v1).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/mcp/collections', { credentials: 'include' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { collections: CollectionMcpSummary[] };
+        if (!cancelled) setCollections(data.collections ?? []);
+      } catch (err) {
+        if (!cancelled) {
+          setMessage(`Failed to load collection exposure: ${(err as Error).message}`);
+        }
       }
     })();
     return () => {
@@ -217,6 +239,57 @@ export default function McpCatalogPage() {
                         >
                           Disconnect
                         </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {/* Content exposure (tenant-agnostic in v1) */}
+        <section className="mb-10">
+          <h2 className="mb-1 text-lg font-medium text-white">
+            Content exposure{' '}
+            <span className="text-sm font-normal text-zinc-500">({collections.length})</span>
+          </h2>
+          <p className="mb-3 text-xs text-zinc-500">
+            Collections exposed to MCP clients as resources via the{' '}
+            <span className="font-mono text-zinc-400">revealui-content</span> server. Opt a
+            collection out by setting{' '}
+            <span className="font-mono text-zinc-400">mcpResource: false</span> in its
+            CollectionConfig.
+          </p>
+          {collections.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+              Loading collection exposure…
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-zinc-800">
+              <table className="w-full text-sm">
+                <thead className="bg-zinc-900/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Slug</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Label</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Exposure</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {collections.map((c) => (
+                    <tr key={c.slug} className="border-t border-zinc-800/50">
+                      <td className="px-4 py-3 font-mono text-zinc-300">{c.slug}</td>
+                      <td className="px-4 py-3 text-zinc-400">{c.labelPlural ?? c.label}</td>
+                      <td className="px-4 py-3">
+                        {c.mcpResource ? (
+                          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                            exposed
+                          </span>
+                        ) : (
+                          <span className="rounded-full bg-zinc-700/40 px-2 py-0.5 text-xs font-medium text-zinc-400">
+                            hidden
+                          </span>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/apps/admin/src/app/api/mcp/collections/__tests__/collections-route.test.ts
+++ b/apps/admin/src/app/api/mcp/collections/__tests__/collections-route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * MCP collections introspection route tests (Stage 4.2).
+ *
+ * Exercises `GET /api/mcp/collections` — auth gating (session + bearer),
+ * summary shape, and `mcpResource` default/opt-out resolution.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the collection registry with a small, controlled set so the test
+// doesn't depend on the real admin config (which imports the entire world).
+vi.mock('@/lib/collections/registry', () => ({
+  allCollections: [
+    {
+      slug: 'posts',
+      labels: { singular: 'Post', plural: 'Posts' },
+      fields: [],
+    },
+    {
+      slug: 'users',
+      labels: { singular: 'User', plural: 'Users' },
+      mcpResource: false,
+      fields: [],
+    },
+    {
+      slug: 'user-preferences',
+      fields: [],
+    },
+  ],
+}));
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+function makeRequest(init?: RequestInit): Request {
+  return new Request('http://admin.test/api/mcp/collections', {
+    headers: { cookie: 'session=test' },
+    ...init,
+  });
+}
+
+const originalApiKey = process.env.REVEALUI_API_KEY;
+
+beforeEach(() => {
+  mockGetSession.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  if (originalApiKey !== undefined) process.env.REVEALUI_API_KEY = originalApiKey;
+  else delete process.env.REVEALUI_API_KEY;
+});
+
+describe('GET /api/mcp/collections', () => {
+  it('returns 401 without a session or bearer token', async () => {
+    delete process.env.REVEALUI_API_KEY;
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../route.js');
+    const res = await GET(makeRequest() as never);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin sessions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'user' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(makeRequest() as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the collection list for admin sessions', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(makeRequest() as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collections: Array<Record<string, unknown>> };
+    expect(body.collections).toHaveLength(3);
+  });
+
+  it('accepts a bearer token matching REVEALUI_API_KEY without a session', async () => {
+    process.env.REVEALUI_API_KEY = 'secret-service-key';
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest({
+        headers: { authorization: 'Bearer secret-service-key' },
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bearer token that does not match REVEALUI_API_KEY', async () => {
+    process.env.REVEALUI_API_KEY = 'secret-service-key';
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest({
+        headers: { authorization: 'Bearer wrong-key' },
+      }) as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects bearer auth when REVEALUI_API_KEY is not configured', async () => {
+    delete process.env.REVEALUI_API_KEY;
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import('../route.js');
+    const res = await GET(
+      makeRequest({
+        headers: { authorization: 'Bearer anything' },
+      }) as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('resolves mcpResource: default true when absent, explicit false when opted out', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { GET } = await import('../route.js');
+    const res = await GET(makeRequest() as never);
+    const body = (await res.json()) as {
+      collections: Array<{
+        slug: string;
+        mcpResource: boolean;
+        label: string;
+        labelPlural?: string;
+      }>;
+    };
+
+    const posts = body.collections.find((c) => c.slug === 'posts');
+    expect(posts?.mcpResource).toBe(true);
+    expect(posts?.label).toBe('Post');
+    expect(posts?.labelPlural).toBe('Posts');
+
+    const users = body.collections.find((c) => c.slug === 'users');
+    expect(users?.mcpResource).toBe(false);
+    expect(users?.label).toBe('User');
+
+    const prefs = body.collections.find((c) => c.slug === 'user-preferences');
+    expect(prefs?.mcpResource).toBe(true);
+    expect(prefs?.label).toBe('User Preferences');
+    expect(prefs?.labelPlural).toBeUndefined();
+  });
+});

--- a/apps/admin/src/app/api/mcp/collections/route.ts
+++ b/apps/admin/src/app/api/mcp/collections/route.ts
@@ -1,0 +1,59 @@
+/**
+ * MCP Collections Registry — GET /api/mcp/collections
+ *
+ * Stage 4.2 of the MCP v1 plan. Enumerates every CollectionConfig registered
+ * with the admin instance and returns a summary that includes the resolved
+ * `mcpResource` flag (default `true` when absent — see Stage 4.1 contract).
+ *
+ * Consumers:
+ *   - The `revealui-content` MCP server factory uses this to decide which
+ *     collections to advertise as MCP resources. Curated `posts/pages/
+ *     products/media` fallback still applies in standalone stdio mode when
+ *     the admin endpoint is unreachable or credentials are not configured.
+ *   - The `/admin/mcp` page renders the list (both exposed and hidden) in a
+ *     read-only "Content exposure" section.
+ *
+ * Auth: accepts either an authenticated admin session (UI consumer) or a
+ * `Authorization: Bearer <REVEALUI_API_KEY>` header whose value matches the
+ * admin's configured `REVEALUI_API_KEY` env var (factory / out-of-process
+ * consumer). Comparison is constant-time to avoid timing leaks.
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import { allCollections } from '@/lib/collections/registry';
+import { resolveCollectionMcpSummary } from '@/lib/mcp/collections';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+/** Constant-time compare for bearer-token auth. */
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+}
+
+function hasValidBearerToken(request: NextRequest): boolean {
+  const header = request.headers.get('authorization');
+  if (!header) return false;
+  const match = header.match(/^Bearer\s+(.+)$/);
+  if (!match) return false;
+  const provided = match[1];
+  const expected = process.env.REVEALUI_API_KEY;
+  if (!(expected && expected.length > 0 && provided)) return false;
+  return safeCompare(provided, expected);
+}
+
+export async function GET(request: NextRequest) {
+  if (!hasValidBearerToken(request)) {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (session.user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+
+  const collections = allCollections.map((c) => resolveCollectionMcpSummary(c));
+  return NextResponse.json({ collections });
+}

--- a/apps/admin/src/lib/collections/Users/index.ts
+++ b/apps/admin/src/lib/collections/Users/index.ts
@@ -7,6 +7,7 @@ import { loginAfterCreate, recordLastLoggedInTenant } from '@/lib/hooks/index';
 const Users: RevealCollectionConfig<User> = {
   slug: 'users',
   timestamps: true,
+  mcpResource: false,
   admin: {
     useAsTitle: 'email',
     defaultColumns: ['email'],

--- a/apps/admin/src/lib/collections/registry.ts
+++ b/apps/admin/src/lib/collections/registry.ts
@@ -1,0 +1,55 @@
+/**
+ * Canonical collection registry for the admin app.
+ *
+ * Single source of truth for which CollectionConfig objects are registered
+ * with the admin instance. Consumed by:
+ *   - `apps/admin/revealui.config.ts` — passes `allCollections` into
+ *     `buildConfig({ collections })`.
+ *   - `apps/admin/src/app/api/mcp/collections/route.ts` — enumerates
+ *     collections to the MCP resource surface (Stage 4.2).
+ *
+ * Add new collections here; both the admin runtime and the MCP resource
+ * introspection surface pick them up automatically.
+ */
+
+import type { CollectionConfig } from '@revealui/contracts/admin';
+import Banners from './Banners';
+import Cards from './Cards';
+import Categories from './Categories';
+import Contents from './Contents';
+import { Conversations } from './Conversations';
+import Events from './Events';
+import Heros from './Heros';
+import Layouts from './Layouts';
+import { Media } from './Media';
+import { Orders } from './Orders';
+import { Pages } from './Pages/index';
+import { Posts } from './Posts';
+import Prices from './Prices';
+import Products from './Products';
+import Subscriptions from './Subscriptions';
+import Tags from './Tags';
+import { Tenants } from './Tenants';
+import Users from './Users';
+
+export const allCollections = [
+  Users,
+  Tenants,
+  Pages,
+  Media,
+  Layouts,
+  Contents,
+  Categories,
+  Tags,
+  Events,
+  Cards,
+  Heros,
+  Products,
+  Prices,
+  Orders,
+  Posts,
+  Subscriptions,
+  Banners,
+  Conversations,
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous collection array requires invariant generic
+] as CollectionConfig<any>[];

--- a/apps/admin/src/lib/mcp/collections.ts
+++ b/apps/admin/src/lib/mcp/collections.ts
@@ -1,0 +1,67 @@
+/**
+ * MCP collection introspection — summary shape + resolver.
+ *
+ * Stage 4.2 of the MCP v1 plan. `/api/mcp/collections` returns an array of
+ * `CollectionMcpSummary` by walking every registered CollectionConfig and
+ * applying `resolveCollectionMcpSummary()`. Downstream consumers:
+ *
+ *   - `revealui-content` MCP server factory — filters on `mcpResource: true`
+ *     to decide which collections to advertise as resources.
+ *   - `/admin/mcp` page — renders the list (exposed + hidden) as the
+ *     read-only "Content exposure" section.
+ */
+
+import type { CollectionConfig } from '@revealui/contracts/admin';
+
+export interface CollectionMcpSummary {
+  /** Collection slug (e.g. `posts`, `pages`). */
+  slug: string;
+  /** Human-readable singular label (e.g. `Post`). */
+  label: string;
+  /** Human-readable plural label when the admin provides one. */
+  labelPlural?: string;
+  /**
+   * Resolved MCP-resource flag. `true` when the collection is exposed to
+   * MCP clients; `false` when opted out via `mcpResource: false` on the
+   * CollectionStructure. Absent on the source config resolves to `true`
+   * (default behavior per Stage 4.1 contract).
+   */
+  mcpResource: boolean;
+}
+
+/**
+ * Title-case a kebab-case slug. Used as a fallback when the collection
+ * doesn't declare explicit labels — `user-preferences` → `User Preferences`.
+ */
+export function titleCaseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => (w.length === 0 ? w : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
+
+/**
+ * Project a CollectionConfig into the MCP-facing summary shape.
+ *
+ * Input is typed loosely (`CollectionConfig<any>`) because the heterogeneous
+ * admin registry uses an invariant generic.
+ */
+export function resolveCollectionMcpSummary(
+  // biome-ignore lint/suspicious/noExplicitAny: registry holds heterogeneous collections
+  collection: CollectionConfig<any>,
+): CollectionMcpSummary {
+  const singular =
+    typeof collection.labels?.singular === 'string' && collection.labels.singular.length > 0
+      ? collection.labels.singular
+      : undefined;
+  const plural =
+    typeof collection.labels?.plural === 'string' && collection.labels.plural.length > 0
+      ? collection.labels.plural
+      : undefined;
+  return {
+    slug: collection.slug,
+    label: singular ?? titleCaseSlug(collection.slug),
+    labelPlural: plural,
+    mcpResource: collection.mcpResource !== false,
+  };
+}

--- a/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
+++ b/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
@@ -13,7 +13,11 @@ import { createServer as createHttpServer, type Server as NodeHttpServer } from 
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { McpClient } from '../src/client.js';
-import { createRevealuiContentServer } from '../src/servers/factories/revealui-content.js';
+import {
+  type CollectionMcpSummary,
+  type CreateRevealuiContentServerOptions,
+  createRevealuiContentServer,
+} from '../src/servers/factories/revealui-content.js';
 import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
 
 // ---------------------------------------------------------------------------
@@ -67,9 +71,9 @@ async function startMockApi(responses: Record<string, unknown>): Promise<MockApi
 
 type McpHandle = { url: string; close: () => Promise<void> };
 
-async function startMcpHttp(): Promise<McpHandle> {
+async function startMcpHttp(options?: CreateRevealuiContentServerOptions): Promise<McpHandle> {
   const handler = createNodeStreamableHttpHandler({
-    createServer: createRevealuiContentServer,
+    createServer: () => createRevealuiContentServer(options),
     enableJsonResponse: true,
   });
   const httpServer: NodeHttpServer = createHttpServer((req, res) => {
@@ -329,6 +333,121 @@ describe('revealui-content factory over Streamable HTTP', () => {
     await expect(client.readResource('revealui-content://unknown-collection/x')).rejects.toThrow(
       /not exposed as a resource/,
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Stage 4.2 — dynamic collection introspection
+  // -------------------------------------------------------------------------
+
+  it('respects mcpResource: false when introspecting via HTTP', async () => {
+    // /api/mcp/collections returns two collections; one opts out.
+    const mockApi = await startMockApi({
+      '/api/mcp/collections': {
+        collections: [
+          { slug: 'posts', label: 'Post', labelPlural: 'Posts', mcpResource: true },
+          { slug: 'users', label: 'User', labelPlural: 'Users', mcpResource: false },
+        ],
+      },
+      '/api/posts': { docs: [{ id: 'p1', title: 'First post' }] },
+      // Even though /api/users would return docs, mcpResource: false should
+      // prevent the factory from even asking for them.
+      '/api/users': { docs: [{ id: 'u1', email: 'user@example.com' }] },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'dynamic-introspect-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const resources = await client.listResources();
+    expect(resources.map((r) => r.uri)).toEqual(['revealui-content://posts/p1']);
+
+    // Factory should have asked for collections once and posts once, but
+    // never users (opted out at the summary layer).
+    expect(mockApi.requests.some((r) => r.path === '/api/mcp/collections')).toBe(true);
+    expect(mockApi.requests.some((r) => r.path === '/api/posts')).toBe(true);
+    expect(mockApi.requests.some((r) => r.path === '/api/users')).toBe(false);
+  });
+
+  it('injected collectionsProvider takes precedence over HTTP introspection', async () => {
+    // The mock exposes BOTH an introspection endpoint AND specific data,
+    // but the provider overrides the introspected list with a different
+    // shape. The factory should respect the provider and not hit the HTTP
+    // introspection endpoint at all.
+    const mockApi = await startMockApi({
+      '/api/mcp/collections': {
+        collections: [{ slug: 'posts', label: 'Post', labelPlural: 'Posts', mcpResource: true }],
+      },
+      '/api/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const provider = async (): Promise<CollectionMcpSummary[]> => [
+      { slug: 'pages', label: 'Page', labelPlural: 'Pages', mcpResource: true },
+    ];
+
+    const mcp = await startMcpHttp({ collectionsProvider: provider });
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'provider-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const resources = await client.listResources();
+    expect(resources.map((r) => r.uri)).toEqual(['revealui-content://pages/pg1']);
+    // Provider took precedence — the HTTP introspection endpoint should not
+    // have been consulted.
+    expect(mockApi.requests.some((r) => r.path === '/api/mcp/collections')).toBe(false);
+  });
+
+  it('falls back to curated set when neither provider nor HTTP introspection is available', async () => {
+    // Mock returns 404 for /api/mcp/collections (not in responses), so
+    // HTTP introspection fails. The curated set (posts/pages/products/
+    // media) must still drive resource enumeration.
+    const mockApi = await startMockApi({
+      '/api/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
+      '/api/pages': { docs: [] },
+      '/api/products': { docs: [] },
+      '/api/media': { docs: [] },
+    });
+    teardowns.push(mockApi.close);
+    process.env.REVEALUI_API_URL = mockApi.url;
+    process.env.REVEALUI_API_KEY = 'test-api-key';
+
+    const mcp = await startMcpHttp();
+    teardowns.push(mcp.close);
+
+    const client = new McpClient({
+      clientInfo: { name: 'curated-fallback-test', version: '0.0.1' },
+      transport: { kind: 'streamable-http', url: mcp.url },
+    });
+    await client.connect();
+    teardowns.push(async () => {
+      await client.close();
+    });
+
+    const resources = await client.listResources();
+    expect(resources.map((r) => r.uri)).toEqual(['revealui-content://posts/p1']);
+    // Factory tried the introspection endpoint and gracefully fell back.
+    const introspectAttempt = mockApi.requests.find((r) => r.path === '/api/mcp/collections');
+    expect(introspectAttempt).toBeDefined();
   });
 
   it('returns a tool-level error when credentials are missing', async () => {

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -14,15 +14,22 @@
  *   revealui_list_users         — list users (admin only)
  *   revealui_site_stats         — per-site user + content counts
  *
+ * Resources (Stage 4.1 + 4.2): every CollectionConfig with `mcpResource !==
+ * false` is surfaced as an MCP resource under `revealui-content://<slug>/
+ * <id>`. The factory resolves the effective set via three tiers:
+ *
+ *   1. Injected `collectionsProvider` — in-process consumers (admin, agent
+ *      runtime) pass a function that reads directly from the admin registry.
+ *   2. HTTP introspection — fetches `${REVEALUI_API_URL}/api/mcp/collections`
+ *      with the configured API key. Used by out-of-process consumers that
+ *      can reach a running admin.
+ *   3. Curated fallback — `posts`, `pages`, `products`, `media` with
+ *      well-known title fields. Used when neither 1 nor 2 is available
+ *      (airgapped dev, admin offline, credentials missing).
+ *
  * Credentials are supplied by the hypervisor (or HTTP launcher wrapper)
  * via `setCredentials()`. Falls back to `REVEALUI_API_URL` +
  * `REVEALUI_API_KEY` env vars when no override is set.
- *
- * This file is the template 12 remaining first-party servers will follow:
- *   1. Extract a `create<Name>Server()` factory here
- *   2. Make `<name>.ts` a thin stdio launcher that consumes the factory
- *   3. Consumers (admin, agent runtime) import the factory directly for
- *      HTTP hosting via `createNodeStreamableHttpHandler`.
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -56,6 +63,15 @@ let _credentialOverrides: Record<string, string> = {};
  */
 export function setCredentials(creds: Record<string, string>): void {
   _credentialOverrides = creds;
+}
+
+function resolveCredentials(): { apiUrl?: string; apiKey?: string } {
+  const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
+    /\/$/,
+    '',
+  );
+  const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+  return { apiUrl, apiKey };
 }
 
 // ---------------------------------------------------------------------------
@@ -174,29 +190,71 @@ const TOOLS: Tool[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Resource catalog (Stage 4.1)
+// Resource catalog (Stage 4.1 + 4.2)
 // ---------------------------------------------------------------------------
 
 /**
- * Collections that default to being exposed as MCP resources. The admin-side
- * `mcpResource: false` opt-out on a collection definition (Stage 4.1 contracts
- * change) will subtract from this set once the admin publishes an
- * introspection surface (Stage 4.2). For now this is the curated v1 set —
- * the collections RevealUI treats as first-class content and which every
- * admin instance has.
+ * MCP-facing summary of a content collection. Wire-compatible with the shape
+ * returned by `GET /api/mcp/collections` on the admin app.
  */
-const DEFAULT_RESOURCEABLE_COLLECTIONS: ReadonlyArray<{
+export interface CollectionMcpSummary {
+  /** Collection slug. */
   slug: string;
-  titleField: string;
-  description: string;
-}> = [
-  { slug: 'posts', titleField: 'title', description: 'Blog posts and articles' },
-  { slug: 'pages', titleField: 'title', description: 'Site pages (marketing, landing, docs)' },
-  { slug: 'products', titleField: 'name', description: 'Catalog products' },
-  { slug: 'media', titleField: 'filename', description: 'Uploaded media assets' },
+  /** Human-readable singular label (e.g. `Post`). */
+  label: string;
+  /** Human-readable plural label, when known. */
+  labelPlural?: string;
+  /**
+   * Resolved MCP-resource flag. Only collections with `mcpResource: true`
+   * are surfaced as resources.
+   */
+  mcpResource: boolean;
+}
+
+/**
+ * Injection point for in-process consumers. Returning `null` signals the
+ * factory to try the next tier (HTTP, then curated).
+ */
+export type CollectionsProvider = () => Promise<CollectionMcpSummary[] | null>;
+
+export interface CreateRevealuiContentServerOptions {
+  /**
+   * Optional provider used to resolve the list of collections exposed as
+   * MCP resources. When provided, skips HTTP introspection. In-process
+   * admin or agent-runtime consumers wire this to read the registry
+   * directly; out-of-process subprocess consumers leave it unset.
+   */
+  collectionsProvider?: CollectionsProvider;
+}
+
+/**
+ * Curated fallback used when neither an injected provider nor HTTP
+ * introspection is available. These four collections exist in every admin
+ * instance shipped today and have stable well-known title fields.
+ */
+const CURATED_FALLBACK: ReadonlyArray<CollectionMcpSummary> = [
+  { slug: 'posts', label: 'Post', labelPlural: 'Posts', mcpResource: true },
+  { slug: 'pages', label: 'Page', labelPlural: 'Pages', mcpResource: true },
+  { slug: 'products', label: 'Product', labelPlural: 'Products', mcpResource: true },
+  { slug: 'media', label: 'Media', mcpResource: true },
 ];
 
-/** URI scheme for Stage 4.1. Stage 4.2 may extend with a tenant segment. */
+/**
+ * Well-known title-field overrides by slug. Collections listed here pick
+ * their title from the named field; unknown collections fall back to a
+ * cascade (`title` → `name` → `filename` → `label` → id).
+ */
+const TITLE_FIELD_OVERRIDES: Record<string, string> = {
+  posts: 'title',
+  pages: 'title',
+  products: 'name',
+  media: 'filename',
+};
+
+const TITLE_FIELD_CASCADE = ['title', 'name', 'filename', 'label'] as const;
+
+/** URI scheme for Stage 4.1. Stage 4.2 leaves this stable; a `revealui://
+ *  <tenant>/<collection>/<id>` variant is parked for a future design call. */
 const RESOURCE_URI_PREFIX = 'revealui-content://';
 
 /** Max rows per collection surfaced in a single `resources/list` response. */
@@ -225,21 +283,26 @@ function extractDocs(body: unknown): ContentRow[] {
   return [];
 }
 
-function pickTitle(row: ContentRow, titleField: string): string {
-  const raw = row[titleField];
-  if (typeof raw === 'string' && raw.length > 0) return raw;
+function pickTitle(row: ContentRow, collectionSlug: string): string {
+  const override = TITLE_FIELD_OVERRIDES[collectionSlug];
+  if (override) {
+    const raw = row[override];
+    if (typeof raw === 'string' && raw.length > 0) return raw;
+  }
+  for (const field of TITLE_FIELD_CASCADE) {
+    const raw = row[field];
+    if (typeof raw === 'string' && raw.length > 0) return raw;
+  }
   return String(row.id);
 }
 
-function resourceForRow(
-  collection: { slug: string; titleField: string; description: string },
-  row: ContentRow,
-): Resource {
+function resourceForRow(summary: CollectionMcpSummary, row: ContentRow): Resource {
   const id = String(row.id);
+  const description = summary.labelPlural ?? `${summary.label} collection`;
   return {
-    uri: `${RESOURCE_URI_PREFIX}${collection.slug}/${id}`,
-    name: `${collection.slug}/${pickTitle(row, collection.titleField)}`,
-    description: `${collection.description} (id: ${id})`,
+    uri: `${RESOURCE_URI_PREFIX}${summary.slug}/${id}`,
+    name: `${summary.slug}/${pickTitle(row, summary.slug)}`,
+    description: `${description} (id: ${id})`,
     mimeType: 'application/json',
   };
 }
@@ -256,6 +319,43 @@ function parseResourceUri(uri: string): { collection: string; id: string } | nul
   return { collection, id };
 }
 
+/**
+ * Fetch collection summaries from the admin introspection endpoint.
+ * Returns `null` on any failure (network, non-200, malformed body) —
+ * callers fall back to the curated set.
+ */
+async function fetchCollectionsFromAdmin(
+  apiUrl: string,
+  apiKey: string,
+): Promise<CollectionMcpSummary[] | null> {
+  try {
+    const res = await fetch(`${apiUrl}/api/mcp/collections`, {
+      headers: apiHeaders(apiKey),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { collections?: unknown };
+    if (!Array.isArray(body.collections)) return null;
+    const out: CollectionMcpSummary[] = [];
+    for (const raw of body.collections) {
+      if (!raw || typeof raw !== 'object') continue;
+      const r = raw as Partial<CollectionMcpSummary>;
+      if (typeof r.slug !== 'string' || r.slug.length === 0) continue;
+      if (typeof r.label !== 'string' || r.label.length === 0) continue;
+      if (typeof r.mcpResource !== 'boolean') continue;
+      out.push({
+        slug: r.slug,
+        label: r.label,
+        labelPlural: typeof r.labelPlural === 'string' ? r.labelPlural : undefined,
+        mcpResource: r.mcpResource,
+      });
+    }
+    return out;
+    // empty-catch-ok: network/auth/schema errors fall back to curated set
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -266,24 +366,52 @@ function parseResourceUri(uri: string): { collection: string; id: string } | nul
  * request handlers registered. Dual-mode launchers (stdio, Streamable HTTP)
  * consume this factory; the factory itself is transport-agnostic.
  */
-export function createRevealuiContentServer(): Server {
+export function createRevealuiContentServer(options?: CreateRevealuiContentServerOptions): Server {
   const server = new Server(
     { name: 'revealui-content', version: '1.0.0' },
     { capabilities: { tools: {}, resources: {} } },
   );
 
+  // Per-server memoization: resolve the effective collection set once and
+  // reuse across `resources/list` + `resources/read` for the lifetime of the
+  // server instance. Avoids double-fetching on every read.
+  let cachedCollections: CollectionMcpSummary[] | null = null;
+
+  async function resolveCollections(): Promise<CollectionMcpSummary[]> {
+    if (cachedCollections) return cachedCollections;
+
+    // Tier 1: injected provider (in-process consumers).
+    if (options?.collectionsProvider) {
+      const fromProvider = await options.collectionsProvider().catch(() => null);
+      if (fromProvider) {
+        cachedCollections = fromProvider.filter((c) => c.mcpResource);
+        return cachedCollections;
+      }
+    }
+
+    // Tier 2: HTTP introspection against admin.
+    const { apiUrl, apiKey } = resolveCredentials();
+    if (apiUrl && apiKey) {
+      const fromHttp = await fetchCollectionsFromAdmin(apiUrl, apiKey);
+      if (fromHttp) {
+        cachedCollections = fromHttp.filter((c) => c.mcpResource);
+        return cachedCollections;
+      }
+    }
+
+    // Tier 3: curated fallback.
+    cachedCollections = [...CURATED_FALLBACK];
+    return cachedCollections;
+  }
+
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 
   // -------------------------------------------------------------------------
-  // Resources (Stage 4.1)
+  // Resources (Stage 4.1 + 4.2)
   // -------------------------------------------------------------------------
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
-      /\/$/,
-      '',
-    );
-    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+    const { apiUrl, apiKey } = resolveCredentials();
     if (!(apiUrl && apiKey)) {
       // Without credentials the server can't enumerate rows; advertise an
       // empty list rather than erroring — clients still see the resources
@@ -291,8 +419,9 @@ export function createRevealuiContentServer(): Server {
       return { resources: [] };
     }
 
+    const collections = await resolveCollections();
     const resources: Resource[] = [];
-    for (const collection of DEFAULT_RESOURCEABLE_COLLECTIONS) {
+    for (const collection of collections) {
       try {
         const body = await apiGet(apiUrl, apiKey, `/api/${collection.slug}`, {
           limit: String(DEFAULT_RESOURCE_PAGE_SIZE),
@@ -315,16 +444,13 @@ export function createRevealuiContentServer(): Server {
         `Unknown resource URI (expected ${RESOURCE_URI_PREFIX}<collection>/<id>): ${request.params.uri}`,
       );
     }
-    const collection = DEFAULT_RESOURCEABLE_COLLECTIONS.find((c) => c.slug === parsed.collection);
+    const collections = await resolveCollections();
+    const collection = collections.find((c) => c.slug === parsed.collection);
     if (!collection) {
       throw new Error(`Collection is not exposed as a resource: ${parsed.collection}`);
     }
 
-    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
-      /\/$/,
-      '',
-    );
-    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+    const { apiUrl, apiKey } = resolveCredentials();
     if (!(apiUrl && apiKey)) {
       throw new Error('REVEALUI_API_URL and REVEALUI_API_KEY must be set');
     }
@@ -345,11 +471,7 @@ export function createRevealuiContentServer(): Server {
     const startTime = Date.now();
     const toolName = request.params.name;
 
-    const apiUrl = (_credentialOverrides.REVEALUI_API_URL ?? process.env.REVEALUI_API_URL)?.replace(
-      /\/$/,
-      '',
-    );
-    const apiKey = _credentialOverrides.REVEALUI_API_KEY ?? process.env.REVEALUI_API_KEY;
+    const { apiUrl, apiKey } = resolveCredentials();
 
     if (!(apiUrl && apiKey)) {
       return {


### PR DESCRIPTION
## Summary

- Close **Stage 4** of the MCP v1 plan. `@revealui/mcp` content-resource exposure goes from a curated 4-collection hardcode to dynamic introspection over every registered `CollectionConfig`, while the stdio subprocess path retains the curated fallback for airgapped / no-admin scenarios.
- New **`GET /api/mcp/collections`** endpoint — admin session OR `Authorization: Bearer $REVEALUI_API_KEY` — returns `{slug, label, labelPlural?, mcpResource: boolean}[]`.
- **`createRevealuiContentServer(options?)`** now resolves collections in three tiers: injected `collectionsProvider` → HTTP introspection → curated fallback. Per-server memoization; `mcpResource: false` filtering at the summary layer prevents any data fetch for opted-out collections.
- **`/admin/mcp`** gains a read-only "Content exposure" section; no interactive toggle (deferred — needs persistence layer, separate design call).
- **`Users`** opts out via `mcpResource: false` as the canonical PII-opt-out example. No behavior change for curated stdio consumers.
- New `apps/admin/src/lib/collections/registry.ts` is the single source of truth shared between `revealui.config.ts` and the new endpoint.

Scope doc + MASTER_PLAN §5.18 updated in an internal repo.

## Test plan

- [x] `pnpm --filter @revealui/mcp test` — **203 / 208 passing** (+3 new factory integration tests: HTTP introspection honors `mcpResource: false`, injected provider takes precedence, curated fallback on 404)
- [x] `pnpm exec vitest run src/app/api/mcp/collections` in `apps/admin` — **7 / 7 passing** (auth gating, bearer-token auth, `mcpResource` resolution default/opt-out/title-case fallback)
- [ ] Full admin suite (`pnpm --filter admin test`) — local env has pre-existing `vite:import-analysis` flake on `@revealui/mcp/oauth` subpath resolution that also reproduces on clean `origin/test`; CI will validate
- [ ] Manual smoke: admin sign-in → `/admin/mcp` → verify Content exposure section shows 18 rows with `Users` as `hidden` and everything else as `exposed`

## Deferred (tracked in scope doc)

- Interactive per-collection toggle — needs new table or settings record; separate design call
- `revealui://<tenant>/<collection>/<id>` URI scheme — tenant isn't obvious to the stdio factory today; design call
- Roots scoped by site/collection — folded into Stage 5 agent runtime work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
