### PR TITLE
feat(ai): agent runtime adopts standard MCP client (Stage 5.1a)

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -8,12 +8,86 @@ AI system for RevealUI - memory, LLM, orchestration, and tools.
 ## Features
 
 - **Memory System**: CRDT-based persistent memory (Working, Episodic, Semantic)
-- **LLM Integration**: Provider abstractions for Anthropic, GROQ, Ollama, and more
+- **LLM Integration**: Provider abstractions for Anthropic, GROQ, Ollama, Canonical Inference Snaps, and more
 - **Agent Orchestration**: Runtime and execution engine for AI agents
-- **Tool Calling**: Tool registry and execution system
+- **Tool Calling**: Tool registry + standard-MCP-client integration (Stage 5.1a)
 - **Vector Search**: Semantic search with pgvector
 - **Type-safe**: Full TypeScript support
 - **Performant**: Optimized for low-latency operations
+
+## Reference stack (Ubuntu)
+
+The recommended on-prem / on-device stack pairs `@revealui/ai` with a
+**Canonical Inference Snap** for local LLM inference:
+
+```
+@revealui/ai (this package)
+   │
+   ├── agent runtime + tool-calling loop
+   │
+   ├── MCP client → @revealui/mcp/client → tools/resources/prompts from MCP servers
+   │
+   └── LLM provider → OpenAI-compatible HTTP → localhost:<port>/v1
+                                                    ▲
+                                                    │
+                                         Canonical Inference Snap
+                                         (DeepSeek R1, Qwen 2.5 VL,
+                                          Gemma 3, Nemotron Nano —
+                                          silicon-optimized on Intel/
+                                          Ampere/NVIDIA/NPU)
+```
+
+Quick setup:
+
+```bash
+sudo snap install gemma3               # or deepseek-r1, qwen-vl, etc.
+gemma3 set http.port=9090
+gemma3 status                          # confirms base URL
+```
+
+```typescript
+import { InferenceSnapsProvider, LLMClient } from '@revealui/ai'
+
+const provider = new InferenceSnapsProvider({
+  baseURL: 'http://localhost:9090/v1',
+  model: 'gemma3',
+})
+
+const client = new LLMClient({ provider })
+```
+
+Cloud providers (Anthropic, OpenAI, GROQ) remain supported; the local
+inference path is the documented default for self-hosted deployments.
+
+## MCP tool integration
+
+Standard MCP servers plug into the agent runtime as tool sources. Construct
+an `McpClient` (from `@revealui/mcp/client`), connect it, and pass it to
+`AgentRuntime`:
+
+```typescript
+import { McpClient } from '@revealui/mcp/client'
+import { AgentRuntime } from '@revealui/ai'
+
+const contentClient = new McpClient({
+  clientInfo: { name: 'my-agent', version: '1.0.0' },
+  transport: { kind: 'streamable-http', url: 'https://admin.example.com/api/mcp/content' },
+})
+await contentClient.connect()
+
+const runtime = new AgentRuntime({
+  mcpClients: [{ name: 'content', client: contentClient }],
+})
+```
+
+Tools from each client are namespaced as `mcp_<name>__<toolName>` so multiple
+clients coexist without collisions. Stage 5.1b will extend this path with
+resources + prompts; Stage 5.2 adds recursive sampling through the agent's
+LLM provider.
+
+The legacy `mcpToolSource` path (hypervisor-backed) still works and is
+kept for backwards compatibility, but new integrations should prefer the
+`mcpClients` path.
 
 ## Installation
 

--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Stage 5.1a — tests for `createToolsFromMcpClient`.
+ *
+ * Uses a structural stub that matches the `McpClientLike` shape, so these
+ * tests run without importing `@revealui/mcp` (preserving the package-level
+ * decoupling decision).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createToolsFromMcpClient,
+  type McpCallToolResultLike,
+  type McpClientLike,
+  type McpToolDescriptor,
+} from '../../tools/mcp-adapter.js';
+
+function makeClient(
+  descriptors: McpToolDescriptor[],
+  callHandler: (name: string, args?: Record<string, unknown>) => Promise<McpCallToolResultLike>,
+): McpClientLike {
+  return {
+    listTools: vi.fn().mockResolvedValue(descriptors),
+    callTool: vi.fn(async (name, args) => callHandler(name, args)),
+  };
+}
+
+describe('createToolsFromMcpClient', () => {
+  it('rejects empty namespace', async () => {
+    const client = makeClient([], async () => ({ content: [] }));
+    await expect(createToolsFromMcpClient(client, { namespace: '' })).rejects.toThrow(/namespace/);
+  });
+
+  it('rejects namespace with disallowed characters', async () => {
+    const client = makeClient([], async () => ({ content: [] }));
+    await expect(createToolsFromMcpClient(client, { namespace: 'bad.chars' })).rejects.toThrow(
+      /namespace/,
+    );
+    await expect(createToolsFromMcpClient(client, { namespace: '../etc' })).rejects.toThrow(
+      /namespace/,
+    );
+  });
+
+  it('wraps every MCP tool descriptor into a Tool with namespaced name', async () => {
+    const client = makeClient(
+      [
+        {
+          name: 'list_items',
+          description: 'List items in a collection',
+          inputSchema: {
+            type: 'object',
+            properties: { collection: { type: 'string' } },
+            required: ['collection'],
+          },
+        },
+        {
+          name: 'get_item',
+          inputSchema: { type: 'object', properties: { id: { type: 'string' } } },
+        },
+      ],
+      async () => ({ content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]?.name).toBe('mcp_content__list_items');
+    expect(tools[0]?.label).toBe('list_items');
+    expect(tools[0]?.description).toBe('List items in a collection');
+    expect(tools[1]?.name).toBe('mcp_content__get_item');
+    // Description falls back to "<namespace>: <toolName>" when server omits one.
+    expect(tools[1]?.description).toBe('content: get_item');
+  });
+
+  it('dispatches a successful call through the MCP client', async () => {
+    const callHandler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: { status: 'done' },
+    });
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      callHandler,
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(callHandler).toHaveBeenCalledWith('noop', {});
+    expect(result).toEqual({
+      success: true,
+      data: { status: 'done' },
+    });
+  });
+
+  it('falls back to content array when structuredContent is absent', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({
+        content: [{ type: 'text', text: 'hello' }],
+      }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(true);
+    expect(Array.isArray(result?.data)).toBe(true);
+  });
+
+  it('maps isError: true to a failed ToolResult with the text content', async () => {
+    const client = makeClient(
+      [{ name: 'broken', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({
+        isError: true,
+        content: [
+          { type: 'text', text: 'Collection not found: foo' },
+          { type: 'text', text: 'Retry with a valid slug' },
+        ],
+      }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe('Collection not found: foo\nRetry with a valid slug');
+  });
+
+  it('surfaces a default message when isError: true but content has no text parts', async () => {
+    const client = makeClient(
+      [{ name: 'broken', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ isError: true, content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toMatch(/no detail/i);
+  });
+
+  it('maps thrown exceptions into a failed ToolResult', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => {
+        throw new Error('transport closed');
+      },
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe('transport closed');
+  });
+
+  it('validates parameters against the zod schema derived from inputSchema', async () => {
+    const client = makeClient(
+      [
+        {
+          name: 'greet',
+          inputSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      ],
+      async () => ({ content: [{ type: 'text', text: 'hi' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+
+    // Missing required parameter — zod throws inside execute, which we don't catch there.
+    await expect(tools[0]?.execute({})).rejects.toThrow();
+  });
+
+  it('tolerates malformed inputSchema by defaulting to a permissive object schema', async () => {
+    const client = makeClient(
+      [
+        // inputSchema is not an object — real-world servers occasionally send junk
+        { name: 'weird', inputSchema: null as unknown as object },
+      ],
+      async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(true);
+  });
+
+  it('sets metadata with the namespace and default category', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+    const meta = tools[0]?.getMetadata?.();
+    expect(meta?.category).toBe('mcp');
+    expect(meta?.mcpNamespace).toBe('content');
+  });
+
+  it('honors a custom category', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'content',
+      category: 'content-mcp',
+    });
+    expect(tools[0]?.getMetadata?.().category).toBe('content-mcp');
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -79,6 +79,7 @@ export * from './ingestion/index.js';
 export * from './llm/client.js';
 export * from './llm/provider-health.js';
 export * from './llm/providers/base.js';
+export * from './llm/providers/inference-snaps.js';
 export * from './llm/providers/openai-compat.js';
 export * from './llm/token-counter.js';
 export * from './llm/workspace-provider-config.js';

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -12,8 +12,8 @@ import { estimateCost } from '../llm/token-counter.js';
 import type { AgentSkillProvider } from '../skills/integration/agent-skill-provider.js';
 import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
 import { ToolCallDeduplicator } from '../tools/deduplicator.js';
-import type { MCPToolSource } from '../tools/mcp-adapter.js';
-import { discoverMCPTools } from '../tools/mcp-adapter.js';
+import type { MCPToolSource, McpClientLike } from '../tools/mcp-adapter.js';
+import { createToolsFromMcpClient, discoverMCPTools } from '../tools/mcp-adapter.js';
 import { createWebSearchTool } from '../tools/web/duck-duck-go.js';
 import type { Agent, AgentResult, Task } from './agent.js';
 
@@ -58,8 +58,34 @@ export interface RuntimeConfig {
    * Optional MCP Hypervisor (or any MCPToolSource). When provided, tools from
    * all healthy MCP servers are merged into the agent's tool set before each
    * task execution. Pass an MCPHypervisor from @revealui/mcp.
+   *
+   * @deprecated Prefer `mcpClients` (Stage 5.1a). The hypervisor path doesn't
+   *   expose the full MCP protocol surface (resources, prompts, sampling,
+   *   elicitation). Standard `McpClient` instances do. This field stays for
+   *   backwards compatibility and will keep working until a future major.
    */
   mcpToolSource?: MCPToolSource;
+  /**
+   * Optional set of standard MCP clients (Stage 5.1a). When provided, each
+   * client's tools are listed and merged into the agent's tool set before
+   * each task. Tool names are namespaced as `mcp_<name>__<toolName>` so
+   * multiple clients can coexist without collisions. Consumers construct the
+   * client (stdio / Streamable HTTP + OAuth) and pre-connect it before
+   * passing it here. The runtime does NOT own client lifecycle.
+   *
+   * @example
+   * ```typescript
+   * import { McpClient } from '@revealui/mcp/client';
+   *
+   * const contentClient = new McpClient({ ... });
+   * await contentClient.connect();
+   *
+   * const runtime = new AgentRuntime({
+   *   mcpClients: [{ name: 'content', client: contentClient }],
+   * });
+   * ```
+   */
+  mcpClients?: ReadonlyArray<{ name: string; client: McpClientLike }>;
   /**
    * Optional skill provider. When set, activated skills are injected into the
    * system prompt before the first LLM call, giving the agent contextual
@@ -105,6 +131,7 @@ export class AgentRuntime {
       maxRetries: config.maxRetries ?? 3,
       enableCache: config.enableCache ?? true, // Enable by default for cost savings
       mcpToolSource: config.mcpToolSource,
+      mcpClients: config.mcpClients,
       skillProvider: config.skillProvider,
       thinkingLevel: config.thinkingLevel,
       modelTier: config.modelTier,
@@ -158,8 +185,23 @@ export class AgentRuntime {
     let totalTokens = 0;
     let totalCostUsd = 0;
 
-    // Merge MCP-discovered tools (from healthy servers) into the agent's tool set
-    const mcpTools = this.config.mcpToolSource ? discoverMCPTools(this.config.mcpToolSource) : [];
+    // Merge MCP-discovered tools into the agent's tool set. Two paths:
+    //   - Standard `McpClient` instances (Stage 5.1a, preferred)
+    //   - `MCPToolSource` / hypervisor (legacy, deprecated but supported)
+    const mcpTools: Tool[] = [];
+    if (this.config.mcpToolSource) {
+      mcpTools.push(...discoverMCPTools(this.config.mcpToolSource));
+    }
+    if (this.config.mcpClients && this.config.mcpClients.length > 0) {
+      for (const { name, client } of this.config.mcpClients) {
+        try {
+          const fromClient = await createToolsFromMcpClient(client, { namespace: name });
+          mcpTools.push(...fromClient);
+        } catch {
+          // empty-catch-ok: an unhealthy MCP client shouldn't fail the whole task — other clients + base tools still apply
+        }
+      }
+    }
 
     // Swap in a custom WebSearchProvider if the agent config specifies one (P4-3)
     const customProvider = agent.config?.webSearchProvider;

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -1,7 +1,24 @@
 /**
  * MCP Tool Adapter
  *
- * Bridges MCP (Model Context Protocol) servers to the tool system
+ * Bridges MCP (Model Context Protocol) servers to the tool system.
+ *
+ * Two paths:
+ *
+ *   1. **Standard MCP client** (Stage 5.1a, preferred) — consumers construct an
+ *      `McpClient` from `@revealui/mcp/client` against stdio or Streamable HTTP,
+ *      and pass it to `createToolsFromMcpClient()` (or to `AgentRuntime` via
+ *      `mcpClients`). This is the full-protocol path: future stages will extend
+ *      this to resources, prompts, sampling, elicitation, etc.
+ *
+ *   2. **Hypervisor** (legacy, pre-5.1a) — consumers pass an `MCPHypervisor` (or
+ *      any `MCPToolSource`) to `discoverMCPTools()`. Kept for backwards compat;
+ *      deprecated in favor of path (1). The hypervisor still owns server-side
+ *      subprocess + tenant-scoping concerns and isn't going away.
+ *
+ * Both paths are deliberately **structurally typed** — `@revealui/ai` has no
+ * runtime dependency on `@revealui/mcp`. Consumers satisfy the shapes
+ * `McpClientLike` / `MCPToolSource` with whichever client they construct.
  */
 
 import { z } from 'zod/v4';
@@ -25,10 +42,163 @@ export interface MCPClient {
 /**
  * Interface for an MCP tool source (e.g. MCPHypervisor from @revealui/mcp).
  * Using an interface here keeps @revealui/ai decoupled from @revealui/mcp.
+ *
+ * @deprecated Prefer `McpClientLike` + `createToolsFromMcpClient()` (Stage 5.1a).
+ *   The hypervisor path doesn't expose the full MCP protocol surface (resources,
+ *   prompts, sampling, elicitation). The typed-client path does.
  */
 export interface MCPToolSource {
   getAllTools(): Array<{ namespacedName: string; serverName: string; tool: MCPTool }>;
   callTool(serverName: string, toolName: string, args: unknown): Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 5.1a — standard MCP client path
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural shape of an `McpClient` from `@revealui/mcp/client`. Declared
+ * here (rather than imported) to keep `@revealui/ai` decoupled from
+ * `@revealui/mcp` at the type level. Consumers pass any object whose
+ * `listTools()` + `callTool()` methods match — the real `McpClient`
+ * structurally satisfies this shape.
+ *
+ * Returns / options are loose-typed to the spec-relevant bits; the real
+ * `McpClient` returns richer SDK types which we don't need for tool dispatch.
+ */
+export interface McpClientLike {
+  listTools(options?: unknown): Promise<ReadonlyArray<McpToolDescriptor>>;
+  callTool(
+    name: string,
+    args?: Record<string, unknown>,
+    options?: unknown,
+  ): Promise<McpCallToolResultLike>;
+}
+
+/** Subset of the spec `Tool` shape needed for agent-side discovery. */
+export interface McpToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+}
+
+/** Subset of the spec `CallToolResult` shape. */
+export interface McpCallToolResultLike {
+  content: ReadonlyArray<unknown>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}
+
+export interface CreateToolsFromMcpClientOptions {
+  /**
+   * Namespace (typically the server's identifier) prepended to each tool
+   * name so collisions across multiple MCP clients are impossible.
+   * Output tool name: `mcp_<namespace>__<toolName>`.
+   */
+  namespace: string;
+  /**
+   * Optional category tag used for tool-level telemetry + UI grouping.
+   * Defaults to `'mcp'`.
+   */
+  category?: string;
+}
+
+/**
+ * Connect the agent's tool registry to a standard MCP client. Lists tools
+ * from the MCP server and returns agent-side `Tool` instances that dispatch
+ * calls back through the client. Safe to call multiple times per server —
+ * each invocation re-reads the current tool list.
+ *
+ * @example
+ * ```typescript
+ * import { McpClient } from '@revealui/mcp/client';
+ * import { createToolsFromMcpClient } from '@revealui/ai';
+ *
+ * const client = new McpClient({
+ *   clientInfo: { name: 'my-agent', version: '1.0.0' },
+ *   transport: { kind: 'streamable-http', url: 'https://example.com/mcp' },
+ * });
+ * await client.connect();
+ *
+ * const tools = await createToolsFromMcpClient(client, {
+ *   namespace: 'example-server',
+ * });
+ *
+ * agent.tools.push(...tools);
+ * ```
+ */
+export async function createToolsFromMcpClient(
+  client: McpClientLike,
+  options: CreateToolsFromMcpClientOptions,
+): Promise<Tool[]> {
+  if (!(options.namespace && /^[a-zA-Z0-9_-]+$/.test(options.namespace))) {
+    throw new Error(
+      `createToolsFromMcpClient: namespace must be a non-empty string of [a-zA-Z0-9_-], got ${JSON.stringify(options.namespace)}`,
+    );
+  }
+
+  const descriptors = await client.listTools();
+  const category = options.category ?? 'mcp';
+
+  return descriptors.map((descriptor): Tool => {
+    const zodSchema = jsonSchemaObjectToZod(descriptor.inputSchema);
+    const namespacedName = `mcp_${options.namespace}__${descriptor.name}`;
+
+    return {
+      name: namespacedName,
+      label: descriptor.name,
+      description: descriptor.description ?? `${options.namespace}: ${descriptor.name}`,
+      parameters: zodSchema,
+
+      async execute(params: unknown): Promise<ToolResult> {
+        const validated = zodSchema.parse(params);
+        try {
+          const result = await client.callTool(
+            descriptor.name,
+            validated as Record<string, unknown>,
+          );
+          if (result.isError) {
+            return {
+              success: false,
+              error: extractErrorText(result),
+            };
+          }
+          const payload = result.structuredContent ?? result.content;
+          return {
+            success: true,
+            data: serializeMCPResult(payload),
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+
+      getMetadata() {
+        return { category, version: '1.0.0', mcpNamespace: options.namespace };
+      },
+    };
+  });
+}
+
+/**
+ * Extract a human-readable error string from an MCP `CallToolResult` that
+ * came back with `isError: true`. Servers put the error detail in `content`
+ * per spec; we concatenate any text parts.
+ */
+function extractErrorText(result: McpCallToolResultLike): string {
+  const texts: string[] = [];
+  for (const part of result.content) {
+    if (part && typeof part === 'object') {
+      const p = part as { type?: string; text?: string };
+      if (p.type === 'text' && typeof p.text === 'string') {
+        texts.push(p.text);
+      }
+    }
+  }
+  return texts.length > 0 ? texts.join('\n') : 'Tool reported error (no detail)';
 }
 
 /**
@@ -144,6 +314,34 @@ export function discoverMCPTools(source: MCPToolSource): Tool[] {
     };
 
     return agentTool;
+  });
+}
+
+/**
+ * Narrow an untyped `inputSchema` from a spec `Tool` into the shape
+ * `jsonSchemaToZod` understands, then delegate. Falls back to a permissive
+ * `z.object({})` when the input is malformed so tool discovery never hard-fails
+ * on a misbehaving server.
+ */
+function jsonSchemaObjectToZod(raw: unknown): z.ZodSchema {
+  if (!(raw && typeof raw === 'object')) return z.object({});
+  const s = raw as {
+    type?: unknown;
+    properties?: unknown;
+    required?: unknown;
+  };
+  if (s.type !== 'object') return z.object({});
+  const properties =
+    s.properties && typeof s.properties === 'object'
+      ? (s.properties as Record<string, unknown>)
+      : undefined;
+  const required = Array.isArray(s.required)
+    ? (s.required.filter((r) => typeof r === 'string') as string[])
+    : undefined;
+  return jsonSchemaToZod({
+    type: 'object',
+    ...(properties !== undefined ? { properties } : {}),
+    ...(required !== undefined ? { required } : {}),
   });
 }
 


### PR DESCRIPTION
## Summary

Open **Stage 5** of the MCP v1 plan. `@revealui/ai`'s agent runtime gains a first-class path for consuming MCP servers via standard `McpClient` instances (tools-only in this PR; resources + prompts follow in 5.1b). The hypervisor path stays intact for backwards compatibility.

- **New `createToolsFromMcpClient(client, { namespace })`** in `packages/ai/src/tools/mcp-adapter.ts` — lists tools from a connected MCP client, wraps each into the agent's `Tool` shape, namespaces as `mcp_<namespace>__<toolName>`. `isError: true` maps to a failed `ToolResult` with concatenated error text.
- **New `AgentRuntimeConfig.mcpClients`** option — array of `{ name, client }` entries merged into the agent's tool set at each task. Individual client failures tolerated.
- **`InferenceSnapsProvider`** top-level exported (was internal-only). Canonical Inference Snap is the documented Ubuntu reference provider.
- **Decoupling preserved.** No `@revealui/mcp` dep added to `@revealui/ai/package.json`. Consumers construct their own `McpClient` and pass it; the agent types it structurally via `McpClientLike`.
- **`mcpToolSource` / `discoverMCPTools`** marked `@deprecated` in JSDoc, kept working — strangler-fig retention per the scope doc. No API breaks.

## Why this sequencing

Stage 5.1a is deliberately tools-only. The full protocol surface (resources + prompts + sampling + elicitation) lands across 5.1b, 5.2, 5.3 — each a focused PR with its own user-facing payoff. The hypervisor migration (Stage 1-adjacent, 822 LOC) stays deferred and is NOT touched here: each first-party server erodes hypervisor responsibility as it ports to dual-mode (Stage 1 continuation). Framing documented in internal docs §6 Stage 5.

## Canonical Inference Snap reference stack

README documents the Ubuntu reference chain:

```
@revealui/ai  ──MCP──▶ @revealui/mcp/client  ──HTTP/stdio──▶  MCP servers
     │
     └── LLM ──▶ OpenAI-compatible HTTP ──▶ localhost:<port>/v1 ──▶ Canonical Inference Snap
                                                                    (DeepSeek R1, Qwen 2.5 VL,
                                                                     Gemma 3, Nemotron Nano)
```

Cloud providers (Anthropic/OpenAI/GROQ) remain supported; local inference is the documented default for self-hosted deployments.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — **864 / 864 passing** (+12 new adapter tests)
- [x] `pnpm --filter @revealui/ai typecheck` — clean
- [x] `pnpm exec biome check` — clean (after import-sort fix)
- [ ] Full CI — pending

## Not touched

- Streaming runtime (pre-existing gap: never merged MCP tools; out of scope)
- Hypervisor internals (stays as-is by design; strangler-fig erosion)
- `@revealui/mcp` (agent package remains runtime-independent of it)

## Next (tracked in scope doc)

- **5.1b** — resources + prompts in agent flow
- **5.2** — recursive sampling (server → agent's LLM provider)
- **5.3** — elicitation + progress + cancellation in agent UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
