### PR TITLE
chore(docs): soften drift-prone claims in CLAUDE.md (CR9-P1-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) |
 | @revealui/db | Drizzle ORM schema (81 tables), dual-DB (Neon + Supabase) |
 | @revealui/auth | Session auth, password reset, rate limiting |
-| @revealui/presentation | 57 native UI components (Tailwind v4, zero external UI deps  -  only clsx + CVA) |
+| @revealui/presentation | Native UI components in `packages/presentation/src/components/` (Tailwind v4, zero external UI deps  -  only clsx + CVA) |
 | @revealui/router | Lightweight file-based router with SSR |
 | @revealui/config | Type-safe env config (Zod + lazy Proxy) |
 | @revealui/utils | Logger, DB helpers, validation |
@@ -170,11 +170,11 @@ Schemas are in `packages/db/src/schema/`. Use Drizzle ORM for queries. Dual-data
 - Database tests use PGlite (in-memory PostgreSQL)
 
 ## Build & Security Status
-- 30 workspaces build and typecheck clean
+- All workspaces build and typecheck clean (run `pnpm build` and `pnpm typecheck:all`)
 - Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
-- 36 pnpm overrides enforce minimum safe versions for transitive deps
+- Pinned overrides enforce minimum safe versions for transitive deps (see `pnpm.overrides` block in root `package.json`)
 - React 19.2.4 (CVE-2025-55182 React2Shell patched)
-- 0 GitHub CodeQL alerts, 0 Dependabot alerts (as of 2026-04-12)
+- GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; open warnings tracked in [revealui#509](https://github.com/RevealUIStudio/revealui/issues/509)
 - AST-based code-pattern analyzer: execSync injection, TOCTOU, ReDoS (ret parser + contracts schemas)
 - Pre-push gate runs affected tests on protected branches
 - Run `pnpm audit:any` and `pnpm audit:console` for current any/console counts (warn-only)
@@ -201,7 +201,7 @@ Biome, boundary, claim-drift, typecheck, tests, and build all block pushes. Audi
 - Rich text: isSafeUrl() blocks javascript:/vbscript:/data: in Lexical link/image rendering
 - Webhook rate limiting: 100 req/min on /api/webhooks
 - Cross-DB cleanup: `@revealui/db/cleanup` for orphaned Supabase data after site deletion
-- RBAC + ABAC policy engine in core (58 enforcement tests prove role isolation)
+- RBAC + ABAC policy engine in core (enforcement tests in `packages/core/src/__tests__/auth/` and `packages/core/src/collections/operations/__tests__/access-enforcement.test.ts` prove role isolation)
 - GDPR compliance framework (consent, deletion, anonymization)
 - AI memory validation: prototype pollution prevention, depth/size limits
 - CI: CodeQL, Gitleaks, dependency auditing, secret scanning (security-audit.yml, consolidated)


### PR DESCRIPTION
## Summary

- Replace drift-prone specific counts in `CLAUDE.md` with source-path pointers or first-class pnpm-command pointers, matching the in-file precedent from [revealui#440](https://github.com/RevealUIStudio/revealui/pull/440) (CR9-P1-01).
- Line 177 updated to reflect current security posture: Dependabot still 0 open (#28 closed via [revealui#506](https://github.com/RevealUIStudio/revealui/pull/506)), but 8 CodeQL warnings are now open and tracked in [revealui#509](https://github.com/RevealUIStudio/revealui/issues/509) for triage.
- Line 178 (AST-based analyzer claim) verified defensible and left intact — `packages/contracts/src/security/ret-ast.ts` and `rule-registry.ts` confirmed present with the 4 claimed rule classes.

## Changes

- **Line 55** `57 native UI components` → source-path pointer to `packages/presentation/src/components/`
- **Line 173** `30 workspaces build and typecheck clean` → `pnpm build` + `pnpm typecheck:all` pointer (count dropped)
- **Line 175** `36 pnpm overrides` → pointer to `pnpm.overrides` block in root `package.json` (count dropped)
- **Line 177** `0 CodeQL alerts, 0 Dependabot alerts (as of 2026-04-12)` → `monitored via the Security tab; open warnings tracked in revealui#509`
- **Line 204** `58 enforcement tests` → source-path pointers to `packages/core/src/__tests__/auth/` + `access-enforcement.test.ts` (count dropped)

Line 53 (`81 tables`) deliberately left as-is — CR9-P1-06 converged on that number and it is stable. Line 176 (`React 19.2.4`) left as-is — specific-version pin matters for the CVE-2025-55182 reference.

## Test plan

- [x] Pre-push `pnpm gate:quick` passed locally.
- [x] `git diff` shows 5 insertions, 5 deletions in `CLAUDE.md` only.
- [ ] CI green on `chore/claude-md-drift-sweep`.
- [ ] Merge on CLEAN + green.
- [ ] After merge: update MASTER_PLAN §CR-9 P1-01 closure entry to note the CLAUDE.md sweep + tracker issue.

## Notes

- This PR intentionally does not close the 8 CodeQL warnings. Those are tracked in [revealui#509](https://github.com/RevealUIStudio/revealui/issues/509) for owner triage (fix vs dismiss vs accept-as-known per rule class).
- Zero code changes. Zero test changes. Docs surface only.
