### PR TITLE
feat(ai): elicitation + progress + cancellation (Stage 5.3, closes Stage 5)

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -111,7 +111,60 @@ const toolsOnly = await createToolsFromMcpClient(client, {
 })
 ```
 
-Stage 5.3 surfaces elicitation + progress + cancellation in agent UI.
+### Elicitation, progress, cancellation (Stage 5.3)
+
+MCP servers can ask the user for structured input mid-flow
+(`elicitation/create`), report progress on long-running tool calls, and
+respect cancellation. `@revealui/ai` wires all three through consumer
+callbacks — the agent package stays UI-agnostic:
+
+```typescript
+import { McpClient } from '@revealui/mcp/client'
+import { createElicitationHandler, createToolsFromMcpClient } from '@revealui/ai'
+
+const controller = new AbortController() // wire to a UI cancel button
+
+const client = new McpClient({
+  clientInfo: { name: 'my-agent', version: '1.0.0' },
+  transport: { kind: 'streamable-http', url: '…' },
+  elicitationHandler: createElicitationHandler({
+    onElicit: async ({ message, requestedSchema }) => {
+      const form = await showFormDialog({ title: message, schema: requestedSchema })
+      if (!form) return { action: 'cancel' }
+      return { action: 'accept', content: form.values }
+    },
+    timeoutMs: 60_000,         // auto-cancel if no response
+    // allowUrlMode: false      // default — URL-mode auto-declines
+  }),
+})
+await client.connect()
+
+const tools = await createToolsFromMcpClient(client, {
+  namespace: 'content',
+  signal: controller.signal,    // cancel all MCP RPC when aborted
+  onProgress: (event) => {      // per-tool-call progress events
+    progressBar.update(event.toolName, event.progress.progress, event.progress.total)
+  },
+})
+```
+
+**Elicitation safety:**
+- `mode: 'url'` (out-of-band consent) is auto-declined unless
+  `allowUrlMode: true`. URL-mode is a phishing vector when users can't
+  easily verify the target domain.
+- `timeoutMs` auto-cancels (not declines) when no response arrives.
+  Useful in headless automation.
+- Errors thrown inside `onElicit` map to `{ action: 'cancel' }` — the
+  server sees a clean non-response, not a crashed protocol.
+
+**Progress events** are forwarded from the server's
+`notifications/progress` stream with the namespace + tool name stamped
+for multi-client attribution. Resource + prompt meta-tools also emit
+(via their own `notifications/progress` flows).
+
+**Cancellation** uses the MCP spec's `notifications/cancelled` — aborting
+the `AbortSignal` propagates to in-flight RPC calls on the wire, so
+long-running operations stop instead of just being ignored.
 
 ### Recursive sampling (Stage 5.2)
 

--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -429,7 +429,13 @@ describe('createToolsFromMcpClient — prompts (Stage 5.1b)', () => {
     const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
     await getTool?.execute({ name: 'greet', args: { user: 'alice', style: 'formal' } });
 
-    expect(getPromptSpy).toHaveBeenCalledWith('greet', { user: 'alice', style: 'formal' });
+    // The adapter always passes a third `options` argument; it's `undefined` when
+    // onProgress + signal are both absent (Stage 5.3 wiring).
+    expect(getPromptSpy).toHaveBeenCalledWith(
+      'greet',
+      { user: 'alice', style: 'formal' },
+      undefined,
+    );
   });
 
   it('get_prompt rejects non-string argument values (per MCP spec)', async () => {
@@ -463,6 +469,116 @@ describe('createToolsFromMcpClient — prompts (Stage 5.1b)', () => {
     const tools = await createToolsFromMcpClient(client, { namespace: 'minimal' });
     expect(tools.some((t) => t.name === 'mcp_minimal__list_prompts')).toBe(false);
     expect(tools.some((t) => t.name === 'mcp_minimal__get_prompt')).toBe(false);
+  });
+});
+
+describe('createToolsFromMcpClient — progress + signal (Stage 5.3)', () => {
+  it('forwards onProgress to server tool calls with namespace + toolName context', async () => {
+    const events: unknown[] = [];
+    const client = makeClient(
+      [{ name: 'long_op', inputSchema: { type: 'object', properties: {} } }],
+      async (_name, _args) => ({ content: [] }),
+    );
+    // Simulate the SDK calling onProgress mid-request.
+    client.callTool = vi.fn(async (_name, _args, options) => {
+      const onProgress = (options as { onProgress?: (p: unknown) => void } | undefined)?.onProgress;
+      onProgress?.({ progress: 25, total: 100, message: 'working' });
+      onProgress?.({ progress: 75, total: 100 });
+      return { content: [] };
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onProgress: (event) => events.push(event),
+    });
+    await tools[0]?.execute({});
+
+    expect(events).toEqual([
+      {
+        namespace: 'srv',
+        toolName: 'long_op',
+        progress: { progress: 25, total: 100, message: 'working' },
+      },
+      {
+        namespace: 'srv',
+        toolName: 'long_op',
+        progress: { progress: 75, total: 100 },
+      },
+    ]);
+  });
+
+  it('forwards signal to server tool calls', async () => {
+    const captured: Array<unknown> = [];
+    const client = makeClient(
+      [{ name: 'op', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+    client.callTool = vi.fn(async (_name, _args, options) => {
+      captured.push(options);
+      return { content: [] };
+    });
+    const controller = new AbortController();
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      signal: controller.signal,
+    });
+    await tools[0]?.execute({});
+
+    const firstCall = captured[0] as { signal?: AbortSignal } | undefined;
+    expect(firstCall?.signal).toBe(controller.signal);
+  });
+
+  it('passes undefined request options when neither onProgress nor signal is set', async () => {
+    const captured: Array<unknown> = [];
+    const client = makeClient(
+      [{ name: 'op', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+    client.callTool = vi.fn(async (_name, _args, options) => {
+      captured.push(options);
+      return { content: [] };
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    await tools[0]?.execute({});
+
+    // Undefined, not an empty object — keeps the RPC frame clean.
+    expect(captured[0]).toBeUndefined();
+  });
+
+  it('forwards onProgress + signal to resource + prompt meta-tools as well', async () => {
+    const events: unknown[] = [];
+    const listResourceCalls: unknown[] = [];
+    const readResourceCalls: unknown[] = [];
+    const client: McpClientLike = {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+      listResources: vi.fn(async (options) => {
+        listResourceCalls.push(options);
+        return [];
+      }),
+      readResource: vi.fn(async (_uri, options) => {
+        readResourceCalls.push(options);
+        return [];
+      }),
+    };
+    const controller = new AbortController();
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      signal: controller.signal,
+      onProgress: (e) => events.push(e),
+    });
+    const listTool = tools.find((t) => t.name === 'mcp_srv__list_resources');
+    const readTool = tools.find((t) => t.name === 'mcp_srv__read_resource');
+    await listTool?.execute({});
+    await readTool?.execute({ uri: 'x://y' });
+
+    const listOpts = listResourceCalls[0] as { signal?: AbortSignal };
+    const readOpts = readResourceCalls[0] as { signal?: AbortSignal };
+    expect(listOpts.signal).toBe(controller.signal);
+    expect(readOpts.signal).toBe(controller.signal);
   });
 });
 

--- a/packages/ai/src/__tests__/tools/mcp-elicitation.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-elicitation.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Stage 5.3 — tests for `createElicitationHandler`.
+ *
+ * Covers URL-mode auto-decline, timeout behavior, error-to-cancel
+ * mapping, observability, and the happy path through the consumer's
+ * onElicit callback.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createElicitationHandler,
+  type McpElicitRequestParams,
+  type McpElicitResult,
+} from '../../tools/mcp-elicitation.js';
+
+function makeParams(overrides: Partial<McpElicitRequestParams> = {}): McpElicitRequestParams {
+  return {
+    message: 'Please confirm the action.',
+    requestedSchema: {
+      type: 'object',
+      properties: { confirm: { type: 'boolean' } },
+      required: ['confirm'],
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createElicitationHandler — happy path', () => {
+  it('invokes onElicit and returns the user response verbatim', async () => {
+    const onElicit = vi.fn(
+      async (): Promise<McpElicitResult> => ({ action: 'accept', content: { confirm: true } }),
+    );
+    const handler = createElicitationHandler({ onElicit });
+    const params = makeParams();
+
+    const result = await handler(params);
+
+    expect(onElicit).toHaveBeenCalledWith(params);
+    expect(result).toEqual({ action: 'accept', content: { confirm: true } });
+  });
+
+  it('passes decline + cancel responses through verbatim', async () => {
+    const handler = createElicitationHandler({
+      onElicit: async (params) => {
+        if (params.message.includes('cancel')) return { action: 'cancel' };
+        return { action: 'decline' };
+      },
+    });
+
+    expect((await handler(makeParams({ message: 'please cancel' }))).action).toBe('cancel');
+    expect((await handler(makeParams({ message: 'please decline' }))).action).toBe('decline');
+  });
+});
+
+describe('createElicitationHandler — URL mode', () => {
+  it('auto-declines mode: "url" requests by default', async () => {
+    const onElicit = vi.fn();
+    const handler = createElicitationHandler({ onElicit });
+
+    const result = await handler(makeParams({ mode: 'url' }));
+
+    expect(result).toEqual({ action: 'decline' });
+    expect(onElicit).not.toHaveBeenCalled();
+  });
+
+  it('allows url mode when allowUrlMode is true', async () => {
+    const onElicit = vi.fn(
+      async (): Promise<McpElicitResult> => ({ action: 'accept', content: { ok: true } }),
+    );
+    const handler = createElicitationHandler({ onElicit, allowUrlMode: true });
+
+    const result = await handler(makeParams({ mode: 'url' }));
+
+    expect(onElicit).toHaveBeenCalledTimes(1);
+    expect(result.action).toBe('accept');
+  });
+
+  it('lets through form mode normally regardless of allowUrlMode', async () => {
+    const onElicit = vi.fn(async (): Promise<McpElicitResult> => ({ action: 'accept' }));
+    const handler = createElicitationHandler({ onElicit });
+
+    await handler(makeParams({ mode: 'form' }));
+
+    expect(onElicit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createElicitationHandler — timeout', () => {
+  it('cancels when the user does not respond within timeoutMs', async () => {
+    vi.useFakeTimers();
+    const handler = createElicitationHandler({
+      onElicit: () => new Promise(() => undefined), // never resolves
+      timeoutMs: 1_000,
+    });
+
+    const resultPromise = handler(makeParams());
+    await vi.advanceTimersByTimeAsync(1_001);
+    const result = await resultPromise;
+
+    expect(result).toEqual({ action: 'cancel' });
+  });
+
+  it('returns the user response if it arrives before the timeout', async () => {
+    vi.useFakeTimers();
+    const handler = createElicitationHandler({
+      onElicit: async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        return { action: 'accept', content: { ok: true } };
+      },
+      timeoutMs: 1_000,
+    });
+
+    const resultPromise = handler(makeParams());
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await resultPromise;
+
+    expect(result).toEqual({ action: 'accept', content: { ok: true } });
+  });
+
+  it('disables timeout when timeoutMs is undefined or 0', async () => {
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'accept' }),
+      timeoutMs: 0,
+    });
+    const result = await handler(makeParams());
+    expect(result.action).toBe('accept');
+  });
+});
+
+describe('createElicitationHandler — error handling', () => {
+  it('maps thrown errors from onElicit to { action: "cancel" }', async () => {
+    const handler = createElicitationHandler({
+      onElicit: async () => {
+        throw new Error('UI unmounted');
+      },
+    });
+
+    const result = await handler(makeParams());
+
+    expect(result).toEqual({ action: 'cancel' });
+  });
+});
+
+describe('createElicitationHandler — observability', () => {
+  it('invokes onElicitationRequest with message + fieldCount before onElicit', async () => {
+    const events: unknown[] = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'accept' }),
+      onElicitationRequest: (info) => events.push(info),
+    });
+
+    await handler(
+      makeParams({
+        message: 'pick one',
+        requestedSchema: {
+          type: 'object',
+          properties: { a: {}, b: {}, c: {} },
+        },
+      }),
+    );
+
+    expect(events).toEqual([{ message: 'pick one', fieldCount: 3 }]);
+  });
+
+  it('includes mode in the observability event when provided', async () => {
+    const events: unknown[] = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'accept' }),
+      allowUrlMode: true,
+      onElicitationRequest: (info) => events.push(info),
+    });
+
+    await handler(makeParams({ mode: 'url' }));
+
+    expect(events[0]).toMatchObject({ mode: 'url' });
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -102,6 +102,7 @@ export * from './tools/base.js';
 export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';
 export * from './tools/mcp-adapter.js';
+export * from './tools/mcp-elicitation.js';
 export * from './tools/mcp-sampling.js';
 export * from './tools/memory/index.js';
 export * from './tools/registry.js';

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -172,6 +172,41 @@ export interface CreateToolsFromMcpClientOptions {
     resources?: boolean;
     prompts?: boolean;
   };
+  /**
+   * Progress observability hook (Stage 5.3). Every server tool call made
+   * through the wrapped `Tool.execute()` forwards per-request progress
+   * notifications here. Resource + prompt meta-tools don't emit
+   * progress (they're single-shot lookups).
+   */
+  onProgress?: (event: McpProgressEvent) => void;
+  /**
+   * Optional `AbortSignal` forwarded to every server tool call (Stage
+   * 5.3). When the signal aborts, in-flight MCP RPC calls are
+   * cancelled via `notifications/cancelled` per the MCP spec. Useful
+   * for wiring a consumer-facing cancel button into an active
+   * agent run. Resource/prompt meta-tools also receive the signal.
+   */
+  signal?: AbortSignal;
+}
+
+/** Spec-shaped `Progress` notification subset. */
+export interface McpProgressLike {
+  /** Monotonically increasing progress token value. */
+  progress: number;
+  /** Total expected units of work, when the server knows it. */
+  total?: number;
+  /** Human-readable status message. */
+  message?: string;
+}
+
+/** Event payload forwarded to `onProgress`. */
+export interface McpProgressEvent {
+  /** Namespace the tool belongs to (for multi-client agents). */
+  namespace: string;
+  /** Wrapped tool name that emitted the event (without the `mcp_<ns>__` prefix). */
+  toolName: string;
+  /** Progress payload as reported by the server. */
+  progress: McpProgressLike;
 }
 
 /**
@@ -212,6 +247,12 @@ export async function createToolsFromMcpClient(
   const includeTools = options.include?.tools !== false;
   const includeResources = options.include?.resources !== false;
   const includePrompts = options.include?.prompts !== false;
+  const ctx: BuildToolContext = {
+    namespace: options.namespace,
+    category,
+    ...(options.onProgress !== undefined ? { onProgress: options.onProgress } : {}),
+    ...(options.signal !== undefined ? { signal: options.signal } : {}),
+  };
 
   const tools: Tool[] = [];
 
@@ -219,43 +260,77 @@ export async function createToolsFromMcpClient(
   if (includeTools) {
     const descriptors = await client.listTools();
     for (const descriptor of descriptors) {
-      tools.push(buildServerTool(client, descriptor, options.namespace, category));
+      tools.push(buildServerTool(client, descriptor, ctx));
     }
   }
 
   // --- Resource meta-tools (Stage 5.1b) ----------------------------------
   if (includeResources && client.listResources && client.readResource) {
-    tools.push(buildListResourcesTool(client, options.namespace, category));
-    tools.push(buildReadResourceTool(client, options.namespace, category));
+    tools.push(buildListResourcesTool(client, ctx));
+    tools.push(buildReadResourceTool(client, ctx));
   }
 
   // --- Prompt meta-tools (Stage 5.1b) ------------------------------------
   if (includePrompts && client.listPrompts && client.getPrompt) {
-    tools.push(buildListPromptsTool(client, options.namespace, category));
-    tools.push(buildGetPromptTool(client, options.namespace, category));
+    tools.push(buildListPromptsTool(client, ctx));
+    tools.push(buildGetPromptTool(client, ctx));
   }
 
   return tools;
 }
 
+/**
+ * Internal context bundled per-`createToolsFromMcpClient` call and
+ * handed to every `build*Tool` helper. Keeps the signature manageable
+ * once options grow beyond name + category (Stage 5.3 added progress +
+ * signal threading).
+ */
+interface BuildToolContext {
+  namespace: string;
+  category: string;
+  onProgress?: (event: McpProgressEvent) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Build the request-options object passed to `client.callTool()` /
+ * `readResource()` / etc. Wraps the ctx's `onProgress` with the
+ * specific tool name + namespace so every emitted event is attributable.
+ */
+function buildRequestOptions(
+  ctx: BuildToolContext,
+  toolName: string,
+): { onProgress?: (progress: McpProgressLike) => void; signal?: AbortSignal } | undefined {
+  const opts: { onProgress?: (progress: McpProgressLike) => void; signal?: AbortSignal } = {};
+  if (ctx.onProgress) {
+    const emit = ctx.onProgress;
+    opts.onProgress = (progress) => emit({ namespace: ctx.namespace, toolName, progress });
+  }
+  if (ctx.signal) opts.signal = ctx.signal;
+  return opts.onProgress || opts.signal ? opts : undefined;
+}
+
 function buildServerTool(
   client: McpClientLike,
   descriptor: McpToolDescriptor,
-  namespace: string,
-  category: string,
+  ctx: BuildToolContext,
 ): Tool {
   const zodSchema = jsonSchemaObjectToZod(descriptor.inputSchema);
-  const namespacedName = `mcp_${namespace}__${descriptor.name}`;
+  const namespacedName = `mcp_${ctx.namespace}__${descriptor.name}`;
   return {
     name: namespacedName,
     label: descriptor.name,
-    description: descriptor.description ?? `${namespace}: ${descriptor.name}`,
+    description: descriptor.description ?? `${ctx.namespace}: ${descriptor.name}`,
     parameters: zodSchema,
 
     async execute(params: unknown): Promise<ToolResult> {
       const validated = zodSchema.parse(params);
       try {
-        const result = await client.callTool(descriptor.name, validated as Record<string, unknown>);
+        const result = await client.callTool(
+          descriptor.name,
+          validated as Record<string, unknown>,
+          buildRequestOptions(ctx, descriptor.name),
+        );
         if (result.isError) {
           return { success: false, error: extractErrorText(result) };
         }
@@ -270,21 +345,22 @@ function buildServerTool(
     },
 
     getMetadata() {
-      return { category, version: '1.0.0', mcpNamespace: namespace };
+      return { category: ctx.category, version: '1.0.0', mcpNamespace: ctx.namespace };
     },
   };
 }
 
-function buildListResourcesTool(client: McpClientLike, namespace: string, category: string): Tool {
+function buildListResourcesTool(client: McpClientLike, ctx: BuildToolContext): Tool {
   return {
-    name: `mcp_${namespace}__list_resources`,
+    name: `mcp_${ctx.namespace}__list_resources`,
     label: 'list_resources',
-    description: `List resources exposed by the ${namespace} MCP server. Returns an array of { uri, name, description?, mimeType? }.`,
+    description: `List resources exposed by the ${ctx.namespace} MCP server. Returns an array of { uri, name, description?, mimeType? }.`,
     parameters: z.object({}),
 
     async execute(): Promise<ToolResult> {
       try {
-        const resources = (await client.listResources?.()) ?? [];
+        const resources =
+          (await client.listResources?.(buildRequestOptions(ctx, 'list_resources'))) ?? [];
         return { success: true, data: serializeMCPResult(resources) };
       } catch (error) {
         return {
@@ -295,25 +371,31 @@ function buildListResourcesTool(client: McpClientLike, namespace: string, catego
     },
 
     getMetadata() {
-      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'resources' };
+      return {
+        category: ctx.category,
+        version: '1.0.0',
+        mcpNamespace: ctx.namespace,
+        kind: 'resources',
+      };
     },
   };
 }
 
-function buildReadResourceTool(client: McpClientLike, namespace: string, category: string): Tool {
+function buildReadResourceTool(client: McpClientLike, ctx: BuildToolContext): Tool {
   const paramsSchema = z.object({
     uri: z.string().min(1).describe('Resource URI to read (e.g. revealui-content://posts/abc)'),
   });
   return {
-    name: `mcp_${namespace}__read_resource`,
+    name: `mcp_${ctx.namespace}__read_resource`,
     label: 'read_resource',
-    description: `Read a resource by URI from the ${namespace} MCP server. Returns the resource contents (text parts flattened to a joined string when possible).`,
+    description: `Read a resource by URI from the ${ctx.namespace} MCP server. Returns the resource contents (text parts flattened to a joined string when possible).`,
     parameters: paramsSchema,
 
     async execute(params: unknown): Promise<ToolResult> {
       const { uri } = paramsSchema.parse(params);
       try {
-        const contents = (await client.readResource?.(uri)) ?? [];
+        const contents =
+          (await client.readResource?.(uri, buildRequestOptions(ctx, 'read_resource'))) ?? [];
         const joinedText = flattenResourceText(contents);
         const base: ToolResult = {
           success: true,
@@ -329,21 +411,27 @@ function buildReadResourceTool(client: McpClientLike, namespace: string, categor
     },
 
     getMetadata() {
-      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'resources' };
+      return {
+        category: ctx.category,
+        version: '1.0.0',
+        mcpNamespace: ctx.namespace,
+        kind: 'resources',
+      };
     },
   };
 }
 
-function buildListPromptsTool(client: McpClientLike, namespace: string, category: string): Tool {
+function buildListPromptsTool(client: McpClientLike, ctx: BuildToolContext): Tool {
   return {
-    name: `mcp_${namespace}__list_prompts`,
+    name: `mcp_${ctx.namespace}__list_prompts`,
     label: 'list_prompts',
-    description: `List prompts exposed by the ${namespace} MCP server. Returns an array of { name, description?, arguments? }.`,
+    description: `List prompts exposed by the ${ctx.namespace} MCP server. Returns an array of { name, description?, arguments? }.`,
     parameters: z.object({}),
 
     async execute(): Promise<ToolResult> {
       try {
-        const prompts = (await client.listPrompts?.()) ?? [];
+        const prompts =
+          (await client.listPrompts?.(buildRequestOptions(ctx, 'list_prompts'))) ?? [];
         return { success: true, data: serializeMCPResult(prompts) };
       } catch (error) {
         return {
@@ -354,12 +442,17 @@ function buildListPromptsTool(client: McpClientLike, namespace: string, category
     },
 
     getMetadata() {
-      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'prompts' };
+      return {
+        category: ctx.category,
+        version: '1.0.0',
+        mcpNamespace: ctx.namespace,
+        kind: 'prompts',
+      };
     },
   };
 }
 
-function buildGetPromptTool(client: McpClientLike, namespace: string, category: string): Tool {
+function buildGetPromptTool(client: McpClientLike, ctx: BuildToolContext): Tool {
   const paramsSchema = z.object({
     name: z.string().min(1).describe('Prompt name to retrieve'),
     args: z
@@ -368,15 +461,15 @@ function buildGetPromptTool(client: McpClientLike, namespace: string, category: 
       .describe('Prompt arguments as a string-valued map (per MCP spec)'),
   });
   return {
-    name: `mcp_${namespace}__get_prompt`,
+    name: `mcp_${ctx.namespace}__get_prompt`,
     label: 'get_prompt',
-    description: `Get a resolved prompt from the ${namespace} MCP server. Returns { description?, messages } — messages is an array of { role, content }.`,
+    description: `Get a resolved prompt from the ${ctx.namespace} MCP server. Returns { description?, messages } — messages is an array of { role, content }.`,
     parameters: paramsSchema,
 
     async execute(params: unknown): Promise<ToolResult> {
       const { name, args } = paramsSchema.parse(params);
       try {
-        const result = await client.getPrompt?.(name, args);
+        const result = await client.getPrompt?.(name, args, buildRequestOptions(ctx, 'get_prompt'));
         if (!result) {
           return { success: false, error: 'client does not implement getPrompt' };
         }
@@ -395,7 +488,12 @@ function buildGetPromptTool(client: McpClientLike, namespace: string, category: 
     },
 
     getMetadata() {
-      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'prompts' };
+      return {
+        category: ctx.category,
+        version: '1.0.0',
+        mcpNamespace: ctx.namespace,
+        kind: 'prompts',
+      };
     },
   };
 }

--- a/packages/ai/src/tools/mcp-elicitation.ts
+++ b/packages/ai/src/tools/mcp-elicitation.ts
@@ -1,0 +1,172 @@
+/**
+ * MCP Elicitation — route server `elicitation/create` requests through
+ * a consumer-provided UI callback (Stage 5.3 of the MCP v1 plan).
+ *
+ * The MCP spec defines `elicitation/create` as a server-to-client
+ * request: a server asks the client to collect structured input from
+ * the user mid-flow (form inputs, confirmations, auth prompts). The
+ * agent runtime is NOT the right place to decide what UI to show —
+ * each consumer (admin inspector, agent execution panel, CLI tool,
+ * Slack bot, …) renders in its own idiom. This module exposes
+ * `createElicitationHandler({ onElicit })` — a thin factory that
+ * wraps the consumer's async UI callback into the structural handler
+ * shape that `McpClient` from `@revealui/mcp/client` expects.
+ *
+ * Safety defaults
+ * ---------------
+ * - Servers that request **URL mode** (out-of-band consent via a
+ *   separate browser tab) are auto-declined unless `allowUrlMode: true`
+ *   is passed. URL mode is a phishing vector when the user can't
+ *   easily verify what domain they're on — admin inspector (Stage 3.4)
+ *   takes the same posture; agent runtime matches for consistency.
+ * - Optional `timeoutMs` auto-declines after the deadline. Useful in
+ *   headless automation where no human is at the keyboard.
+ * - Thrown errors inside `onElicit` are converted to `{ action:
+ *   'cancel' }` rather than propagating — servers should see a clean
+ *   decline, not a protocol error the UI crashed on.
+ *
+ * As with the rest of the MCP-adapter surface, this module uses
+ * structural typing to stay decoupled from `@revealui/mcp` — the real
+ * `ElicitationHandler` from `@revealui/mcp/client` structurally
+ * satisfies the `McpElicitationHandler` shape exported here.
+ *
+ * @example
+ * ```typescript
+ * import { McpClient } from '@revealui/mcp/client';
+ * import { createElicitationHandler } from '@revealui/ai';
+ *
+ * const client = new McpClient({
+ *   clientInfo: { name: 'my-agent', version: '1.0.0' },
+ *   transport: { kind: 'streamable-http', url: '…' },
+ *   elicitationHandler: createElicitationHandler({
+ *     onElicit: async ({ message, requestedSchema }) => {
+ *       const form = await showFormDialog({ title: message, schema: requestedSchema });
+ *       if (!form) return { action: 'cancel' };
+ *       return { action: 'accept', content: form.values };
+ *     },
+ *     timeoutMs: 60_000,
+ *   }),
+ * });
+ * ```
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+
+// ---------------------------------------------------------------------------
+// Structural MCP spec types (subset)
+// ---------------------------------------------------------------------------
+
+/** Parameters of an `elicitation/create` request (spec-shaped subset). */
+export interface McpElicitRequestParams {
+  /**
+   * Elicitation mode. Currently the spec defines `'form'` (inline form
+   * fields) as the only named value; future modes (e.g. `'url'` for
+   * out-of-band consent) may appear. Undefined = `'form'`.
+   */
+  mode?: string;
+  /** User-facing prompt message. */
+  message: string;
+  /** JSON Schema describing the fields to collect. */
+  requestedSchema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: ReadonlyArray<string>;
+  };
+}
+
+/** Allowed values for `ElicitResult.content` per the MCP spec. */
+export type McpElicitContentValue = string | number | boolean | ReadonlyArray<string>;
+
+/** Result of an `elicitation/create` request (spec-shaped subset). */
+export interface McpElicitResult {
+  action: 'accept' | 'decline' | 'cancel';
+  content?: Record<string, McpElicitContentValue>;
+}
+
+/** Structural shape of the handler — matches `ElicitationHandler` from `@revealui/mcp/client`. */
+export type McpElicitationHandler = (params: McpElicitRequestParams) => Promise<McpElicitResult>;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateElicitationHandlerOptions {
+  /**
+   * Consumer-supplied async callback that renders UI and collects the
+   * response. Receives the spec-shaped request params; returns a
+   * spec-shaped result. The factory handles URL-mode auto-decline,
+   * timeouts, and error-to-cancel mapping around this callback.
+   */
+  onElicit: (params: McpElicitRequestParams) => Promise<McpElicitResult>;
+  /**
+   * Auto-decline deadline in milliseconds. When set and no response
+   * arrives within the window, the handler returns `{ action: 'cancel' }`
+   * (not `'decline'` — the timeout wasn't a user decision). Set to
+   * `undefined` / omit to wait indefinitely.
+   */
+  timeoutMs?: number;
+  /**
+   * Accept `mode: 'url'` elicitation requests (out-of-band consent via
+   * a separate browser tab). Default `false` — URL-mode requests are
+   * auto-declined for safety. Flip to `true` only if the consumer's
+   * UI renders a verifiable domain-check + explicit user approval.
+   */
+  allowUrlMode?: boolean;
+  /**
+   * Observability hook. Fires before `onElicit` is invoked with the
+   * message + field count. Useful for audit trails.
+   */
+  onElicitationRequest?: (info: { message: string; fieldCount: number; mode?: string }) => void;
+}
+
+export function createElicitationHandler(
+  options: CreateElicitationHandlerOptions,
+): McpElicitationHandler {
+  const { onElicit, timeoutMs, allowUrlMode, onElicitationRequest } = options;
+
+  return async (params: McpElicitRequestParams): Promise<McpElicitResult> => {
+    if (params.mode === 'url' && !allowUrlMode) {
+      return { action: 'decline' };
+    }
+
+    const fieldCount = countSchemaFields(params.requestedSchema);
+    onElicitationRequest?.({
+      message: params.message,
+      fieldCount,
+      ...(params.mode !== undefined ? { mode: params.mode } : {}),
+    });
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const userResponse = onElicit(params).catch((error) => {
+        // Errors inside the consumer's UI callback → cancel (not decline —
+        // the server should see a clean "didn't happen", not a
+        // misrepresented "user said no").
+        logger.warn('[createElicitationHandler] onElicit threw; returning cancel', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { action: 'cancel' } as McpElicitResult;
+      });
+
+      if (timeoutMs === undefined || timeoutMs <= 0) {
+        return await userResponse;
+      }
+
+      const timeoutPromise = new Promise<McpElicitResult>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          resolve({ action: 'cancel' });
+        }, timeoutMs);
+      });
+
+      return await Promise.race([userResponse, timeoutPromise]);
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+    }
+  };
+}
+
+/** Count the declared fields on a `requestedSchema.properties` record. */
+function countSchemaFields(schema: McpElicitRequestParams['requestedSchema']): number {
+  if (!(schema && schema.properties && typeof schema.properties === 'object')) return 0;
+  return Object.keys(schema.properties).length;
+}


### PR DESCRIPTION
## Summary

**Closes Stage 5.** Stacked on [revealui#512](https://github.com/RevealUIStudio/revealui/pull/512). Lands the last three server-to-client primitives — elicitation, progress, cancellation — as consumer-callback helpers matching the 5.1a/b/5.2 pattern. The agent package stays UI-agnostic; each consumer (admin inspector, agent execution panel, CLI, Slack bot, …) wires its own UI around the callbacks.

### What shipped

**`createElicitationHandler({ onElicit, timeoutMs?, allowUrlMode?, onElicitationRequest? })`** (new `packages/ai/src/tools/mcp-elicitation.ts`)

| Safety surface | Default |
|---|---|
| `mode: 'url'` requests (out-of-band consent; phishing vector) | Auto-decline. Flip via `allowUrlMode: true` only when UI renders domain verification. |
| `timeoutMs` | Undefined (wait forever). When set, auto-cancels after the deadline. |
| Errors inside `onElicit` | Map to `{ action: 'cancel' }` — server sees clean non-response, not a protocol crash. |
| Warn logging | Via `@revealui/core/observability/logger`, not `console.*`. |

**Progress + cancellation on `createToolsFromMcpClient`:**

| Option | Wires to |
|---|---|
| `onProgress: (event) => void` | Every server tool call + resource/prompt meta-tool. Event includes `{ namespace, toolName, progress: { progress, total?, message? } }` so multi-client agents can attribute events correctly. |
| `signal: AbortSignal` | Forwarded to every MCP RPC. Aborting emits `notifications/cancelled` on the wire per the spec — long-running ops actually stop, not just get ignored. |

Internal refactor: `build*Tool` helpers now take a `BuildToolContext = { namespace, category, onProgress?, signal? }` instead of positional `(namespace, category)`. Grows cleanly when options expand.

### What this unlocks

Combined with 5.1a + 5.1b + 5.2, the agent now covers every server-to-client MCP interaction:
- Tools (5.1a)
- Resources + prompts (5.1b)
- Sampling (5.2)
- Elicitation + progress + cancellation (5.3)

Any consumer — admin agent panel, CLI REPL, marketplace-sandbox runner — gets the full protocol surface by wiring their UI callbacks.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — **914 / 914 passing** (+11 elicitation, +4 adapter progress/signal).
- [x] `pnpm --filter @revealui/ai typecheck` — clean.
- [x] Pre-push gate — green (after fixing a `console.warn → logger.warn` violation the gate caught).
- [ ] CI — pending.

## Not touched

- Agent runtime streaming path (pre-existing gap — no MCP tool merging today; out of scope)
- Hypervisor internals (strangler-fig erosion per scope doc)
- `@revealui/mcp` (agent package remains runtime-independent)
- Session-persistent elicitation state (per-call scope in 5.3; session recall is separate)

## Stage 5 is closed

This PR completes the four-PR Stage 5 arc: #508, #511, #512, this.

**Next (v1): Stage 6** — protocol-level observability + usage metering (2 PRs). Structured events per call into RevealUI observability; usage metering rows at every hypervisor boundary. Stripe wiring deferred to v1.1 (marketplace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
