### PR TITLE
feat(ai): resources + prompts as agent meta-tools (Stage 5.1b, re-open of #511)

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -81,9 +81,38 @@ const runtime = new AgentRuntime({
 ```
 
 Tools from each client are namespaced as `mcp_<name>__<toolName>` so multiple
-clients coexist without collisions. Stage 5.1b will extend this path with
-resources + prompts; Stage 5.2 adds recursive sampling through the agent's
-LLM provider.
+clients coexist without collisions.
+
+### Resources + prompts (Stage 5.1b)
+
+When an MCP client advertises resources and/or prompts, the adapter
+additionally emits per-server meta-tools so the agent can read them on
+demand without any bespoke wiring:
+
+| Meta-tool | Calls | Returns |
+|---|---|---|
+| `mcp_<ns>__list_resources` | `client.listResources()` | `[{ uri, name?, description?, mimeType? }, …]` |
+| `mcp_<ns>__read_resource({ uri })` | `client.readResource(uri)` | resource contents; text parts flattened into the `content` field for token-efficient LLM context |
+| `mcp_<ns>__list_prompts` | `client.listPrompts()` | `[{ name, description?, arguments? }, …]` |
+| `mcp_<ns>__get_prompt({ name, args? })` | `client.getPrompt(name, args)` | `{ description?, messages }`; text messages flattened to `<role>: <text>` |
+
+All four are opt-out via `include` on `createToolsFromMcpClient()`. Meta-tools
+are silently skipped when the client doesn't implement the underlying
+method (e.g. servers that don't advertise the resources capability).
+
+```typescript
+// Include every primitive (default)
+const tools = await createToolsFromMcpClient(client, { namespace: 'content' })
+
+// Tools only, skip the resources/prompts meta-tools
+const toolsOnly = await createToolsFromMcpClient(client, {
+  namespace: 'content',
+  include: { tools: true, resources: false, prompts: false },
+})
+```
+
+Stage 5.2 will add recursive sampling (server → agent's LLM provider);
+Stage 5.3 surfaces elicitation + progress + cancellation in agent UI.
 
 The legacy `mcpToolSource` path (hypervisor-backed) still works and is
 kept for backwards compatibility, but new integrations should prefer the

--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -11,6 +11,10 @@ import {
   createToolsFromMcpClient,
   type McpCallToolResultLike,
   type McpClientLike,
+  type McpGetPromptResultLike,
+  type McpPromptDescriptor,
+  type McpResourceContentLike,
+  type McpResourceDescriptor,
   type McpToolDescriptor,
 } from '../../tools/mcp-adapter.js';
 
@@ -21,6 +25,29 @@ function makeClient(
   return {
     listTools: vi.fn().mockResolvedValue(descriptors),
     callTool: vi.fn(async (name, args) => callHandler(name, args)),
+  };
+}
+
+interface FullClientOptions {
+  tools?: McpToolDescriptor[];
+  resources?: McpResourceDescriptor[];
+  resourceContents?: Record<string, ReadonlyArray<McpResourceContentLike>>;
+  prompts?: McpPromptDescriptor[];
+  promptResults?: Record<string, McpGetPromptResultLike>;
+}
+
+function makeFullClient(opts: FullClientOptions): McpClientLike {
+  return {
+    listTools: vi.fn().mockResolvedValue(opts.tools ?? []),
+    callTool: vi.fn().mockResolvedValue({ content: [] }),
+    listResources: vi.fn().mockResolvedValue(opts.resources ?? []),
+    readResource: vi.fn(async (uri: string) => opts.resourceContents?.[uri] ?? []),
+    listPrompts: vi.fn().mockResolvedValue(opts.prompts ?? []),
+    getPrompt: vi.fn(async (name: string) => {
+      const result = opts.promptResults?.[name];
+      if (!result) throw new Error(`prompt not found: ${name}`);
+      return result;
+    }),
   };
 }
 
@@ -212,5 +239,263 @@ describe('createToolsFromMcpClient', () => {
       category: 'content-mcp',
     });
     expect(tools[0]?.getMetadata?.().category).toBe('content-mcp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stage 5.1b — resource + prompt meta-tools
+// ---------------------------------------------------------------------------
+
+describe('createToolsFromMcpClient — resources (Stage 5.1b)', () => {
+  it('emits list_resources + read_resource meta-tools when the client supports resources', async () => {
+    const client = makeFullClient({
+      resources: [
+        { uri: 'revealui-content://posts/1', name: 'posts/Post 1', mimeType: 'application/json' },
+      ],
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('mcp_content__list_resources');
+    expect(names).toContain('mcp_content__read_resource');
+  });
+
+  it('list_resources returns the descriptors verbatim', async () => {
+    const descriptors: McpResourceDescriptor[] = [
+      { uri: 'revealui-content://posts/1', name: 'Post 1' },
+      { uri: 'revealui-content://pages/home', name: 'Home' },
+    ];
+    const client = makeFullClient({ resources: descriptors });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+    const listTool = tools.find((t) => t.name === 'mcp_content__list_resources');
+    const result = await listTool?.execute({});
+
+    expect(result?.success).toBe(true);
+    expect(result?.data).toEqual(descriptors);
+  });
+
+  it('read_resource fetches contents by URI and joins text parts into `content`', async () => {
+    const client = makeFullClient({
+      resourceContents: {
+        'revealui-content://posts/1': [
+          { uri: 'revealui-content://posts/1', text: 'First paragraph.', mimeType: 'text/plain' },
+          { uri: 'revealui-content://posts/1', text: 'Second paragraph.', mimeType: 'text/plain' },
+        ],
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+    const readTool = tools.find((t) => t.name === 'mcp_content__read_resource');
+    const result = await readTool?.execute({ uri: 'revealui-content://posts/1' });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBe('First paragraph.\n\nSecond paragraph.');
+    expect(Array.isArray(result?.data)).toBe(true);
+  });
+
+  it('read_resource omits `content` flattening when any part is binary (blob)', async () => {
+    const client = makeFullClient({
+      resourceContents: {
+        'revealui-content://media/1': [
+          { uri: 'revealui-content://media/1', blob: 'base64data==', mimeType: 'image/png' },
+        ],
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'content' });
+    const readTool = tools.find((t) => t.name === 'mcp_content__read_resource');
+    const result = await readTool?.execute({ uri: 'revealui-content://media/1' });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBeUndefined();
+    expect(Array.isArray(result?.data)).toBe(true);
+  });
+
+  it('skips resource meta-tools when include.resources is false', async () => {
+    const client = makeFullClient({ resources: [{ uri: 'x://y', name: 'y' }] });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      include: { resources: false },
+    });
+    expect(tools.some((t) => t.name === 'mcp_srv__list_resources')).toBe(false);
+    expect(tools.some((t) => t.name === 'mcp_srv__read_resource')).toBe(false);
+  });
+
+  it('skips resource meta-tools silently when the client does not implement them', async () => {
+    const client: McpClientLike = {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+      // no listResources / readResource
+    };
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'minimal' });
+    expect(tools.some((t) => t.name === 'mcp_minimal__list_resources')).toBe(false);
+    expect(tools.some((t) => t.name === 'mcp_minimal__read_resource')).toBe(false);
+  });
+
+  it('surfaces read_resource transport errors as failed ToolResult', async () => {
+    const client = makeFullClient({});
+    client.readResource = vi.fn().mockRejectedValue(new Error('transport closed'));
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const readTool = tools.find((t) => t.name === 'mcp_srv__read_resource');
+    const result = await readTool?.execute({ uri: 'x://y' });
+
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe('transport closed');
+  });
+});
+
+describe('createToolsFromMcpClient — prompts (Stage 5.1b)', () => {
+  it('emits list_prompts + get_prompt meta-tools when the client supports prompts', async () => {
+    const client = makeFullClient({
+      prompts: [{ name: 'rewrite', description: 'Rewrite input for clarity' }],
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('mcp_srv__list_prompts');
+    expect(names).toContain('mcp_srv__get_prompt');
+  });
+
+  it('list_prompts returns the descriptors verbatim', async () => {
+    const descriptors: McpPromptDescriptor[] = [
+      {
+        name: 'summarize',
+        description: 'Summarize a long document',
+        arguments: [{ name: 'text', required: true }],
+      },
+    ];
+    const client = makeFullClient({ prompts: descriptors });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const listTool = tools.find((t) => t.name === 'mcp_srv__list_prompts');
+    const result = await listTool?.execute({});
+
+    expect(result?.success).toBe(true);
+    expect(result?.data).toEqual(descriptors);
+  });
+
+  it('get_prompt flattens text messages into `content`', async () => {
+    const client = makeFullClient({
+      promptResults: {
+        rewrite: {
+          description: 'Rewrite helper',
+          messages: [
+            { role: 'user', content: { type: 'text', text: 'Please rewrite:' } },
+            { role: 'user', content: { type: 'text', text: 'Hello world.' } },
+          ],
+        },
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+    const result = await getTool?.execute({ name: 'rewrite' });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBe('user: Please rewrite:\n\nuser: Hello world.');
+  });
+
+  it('get_prompt handles string-content messages (not just typed-text)', async () => {
+    const client = makeFullClient({
+      promptResults: {
+        greet: {
+          messages: [{ role: 'assistant', content: 'Hi there' }],
+        },
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+    const result = await getTool?.execute({ name: 'greet' });
+
+    expect(result?.success).toBe(true);
+    expect(result?.content).toBe('assistant: Hi there');
+  });
+
+  it('get_prompt forwards args to the client', async () => {
+    const getPromptSpy = vi.fn(async () => ({ messages: [] }));
+    const client: McpClientLike = {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+      listPrompts: vi.fn().mockResolvedValue([{ name: 'greet' }]),
+      getPrompt: getPromptSpy,
+    };
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+    await getTool?.execute({ name: 'greet', args: { user: 'alice', style: 'formal' } });
+
+    expect(getPromptSpy).toHaveBeenCalledWith('greet', { user: 'alice', style: 'formal' });
+  });
+
+  it('get_prompt rejects non-string argument values (per MCP spec)', async () => {
+    const client = makeFullClient({ promptResults: { greet: { messages: [] } } });
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+
+    // args.style is a number — zod validation should reject before the call
+    await expect(
+      getTool?.execute({ name: 'greet', args: { style: 42 as unknown as string } }),
+    ).rejects.toThrow();
+  });
+
+  it('skips prompt meta-tools when include.prompts is false', async () => {
+    const client = makeFullClient({ prompts: [{ name: 'greet' }] });
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      include: { prompts: false },
+    });
+    expect(tools.some((t) => t.name === 'mcp_srv__list_prompts')).toBe(false);
+    expect(tools.some((t) => t.name === 'mcp_srv__get_prompt')).toBe(false);
+  });
+
+  it('skips prompt meta-tools silently when the client does not implement them', async () => {
+    const client: McpClientLike = {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+      // no listPrompts / getPrompt
+    };
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'minimal' });
+    expect(tools.some((t) => t.name === 'mcp_minimal__list_prompts')).toBe(false);
+    expect(tools.some((t) => t.name === 'mcp_minimal__get_prompt')).toBe(false);
+  });
+});
+
+describe('createToolsFromMcpClient — include flag combinations', () => {
+  it('include.tools: false skips server tools but keeps resources + prompts', async () => {
+    const client = makeFullClient({
+      tools: [{ name: 'list_sites', inputSchema: { type: 'object', properties: {} } }],
+      resources: [{ uri: 'x://y', name: 'y' }],
+      prompts: [{ name: 'greet' }],
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      include: { tools: false },
+    });
+    expect(tools.some((t) => t.name === 'mcp_srv__list_sites')).toBe(false);
+    expect(tools.some((t) => t.name === 'mcp_srv__list_resources')).toBe(true);
+    expect(tools.some((t) => t.name === 'mcp_srv__list_prompts')).toBe(true);
+  });
+
+  it('emits all three surfaces by default (tools + resources + prompts)', async () => {
+    const client = makeFullClient({
+      tools: [{ name: 'echo', inputSchema: { type: 'object', properties: {} } }],
+      resources: [{ uri: 'x://y', name: 'y' }],
+      prompts: [{ name: 'greet' }],
+    });
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('mcp_srv__echo');
+    expect(names).toContain('mcp_srv__list_resources');
+    expect(names).toContain('mcp_srv__read_resource');
+    expect(names).toContain('mcp_srv__list_prompts');
+    expect(names).toContain('mcp_srv__get_prompt');
   });
 });

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -73,6 +73,23 @@ export interface McpClientLike {
     args?: Record<string, unknown>,
     options?: unknown,
   ): Promise<McpCallToolResultLike>;
+  /**
+   * Resources (Stage 5.1b). Optional: when absent on the client, the
+   * adapter skips emitting resource meta-tools for the server regardless
+   * of `include.resources`.
+   */
+  listResources?(options?: unknown): Promise<ReadonlyArray<McpResourceDescriptor>>;
+  readResource?(uri: string, options?: unknown): Promise<ReadonlyArray<McpResourceContentLike>>;
+  /**
+   * Prompts (Stage 5.1b). Optional: when absent, prompt meta-tools are
+   * skipped for the server.
+   */
+  listPrompts?(options?: unknown): Promise<ReadonlyArray<McpPromptDescriptor>>;
+  getPrompt?(
+    name: string,
+    args?: Record<string, string>,
+    options?: unknown,
+  ): Promise<McpGetPromptResultLike>;
 }
 
 /** Subset of the spec `Tool` shape needed for agent-side discovery. */
@@ -89,6 +106,42 @@ export interface McpCallToolResultLike {
   structuredContent?: unknown;
 }
 
+/** Subset of the spec `Resource` shape needed for listing. */
+export interface McpResourceDescriptor {
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+}
+
+/** One element of `readResource`'s response — either a text or a blob content part. */
+export interface McpResourceContentLike {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+}
+
+/** Subset of the spec `Prompt` shape needed for listing. */
+export interface McpPromptDescriptor {
+  name: string;
+  description?: string;
+  arguments?: ReadonlyArray<{
+    name: string;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+/** Subset of the spec `GetPromptResult` shape. */
+export interface McpGetPromptResultLike {
+  description?: string;
+  messages: ReadonlyArray<{
+    role: 'user' | 'assistant' | string;
+    content: unknown;
+  }>;
+}
+
 export interface CreateToolsFromMcpClientOptions {
   /**
    * Namespace (typically the server's identifier) prepended to each tool
@@ -101,6 +154,24 @@ export interface CreateToolsFromMcpClientOptions {
    * Defaults to `'mcp'`.
    */
   category?: string;
+  /**
+   * Which MCP primitives to expose to the agent as tools (Stage 5.1b).
+   *
+   * - `tools` (default `true`): wrap every server tool.
+   * - `resources` (default `true`): emit two meta-tools per namespace —
+   *   `mcp_<ns>__list_resources` and `mcp_<ns>__read_resource({ uri })`.
+   *   Skipped silently when the client doesn't expose `listResources` /
+   *   `readResource`.
+   * - `prompts` (default `true`): emit two meta-tools per namespace —
+   *   `mcp_<ns>__list_prompts` and `mcp_<ns>__get_prompt({ name, args? })`.
+   *   Skipped silently when the client doesn't expose `listPrompts` /
+   *   `getPrompt`.
+   */
+  include?: {
+    tools?: boolean;
+    resources?: boolean;
+    prompts?: boolean;
+  };
 }
 
 /**
@@ -137,50 +208,242 @@ export async function createToolsFromMcpClient(
     );
   }
 
-  const descriptors = await client.listTools();
   const category = options.category ?? 'mcp';
+  const includeTools = options.include?.tools !== false;
+  const includeResources = options.include?.resources !== false;
+  const includePrompts = options.include?.prompts !== false;
 
-  return descriptors.map((descriptor): Tool => {
-    const zodSchema = jsonSchemaObjectToZod(descriptor.inputSchema);
-    const namespacedName = `mcp_${options.namespace}__${descriptor.name}`;
+  const tools: Tool[] = [];
 
-    return {
-      name: namespacedName,
-      label: descriptor.name,
-      description: descriptor.description ?? `${options.namespace}: ${descriptor.name}`,
-      parameters: zodSchema,
+  // --- Server tools (Stage 5.1a) -----------------------------------------
+  if (includeTools) {
+    const descriptors = await client.listTools();
+    for (const descriptor of descriptors) {
+      tools.push(buildServerTool(client, descriptor, options.namespace, category));
+    }
+  }
 
-      async execute(params: unknown): Promise<ToolResult> {
-        const validated = zodSchema.parse(params);
-        try {
-          const result = await client.callTool(
-            descriptor.name,
-            validated as Record<string, unknown>,
-          );
-          if (result.isError) {
-            return {
-              success: false,
-              error: extractErrorText(result),
-            };
-          }
-          const payload = result.structuredContent ?? result.content;
-          return {
-            success: true,
-            data: serializeMCPResult(payload),
-          };
-        } catch (error) {
-          return {
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          };
+  // --- Resource meta-tools (Stage 5.1b) ----------------------------------
+  if (includeResources && client.listResources && client.readResource) {
+    tools.push(buildListResourcesTool(client, options.namespace, category));
+    tools.push(buildReadResourceTool(client, options.namespace, category));
+  }
+
+  // --- Prompt meta-tools (Stage 5.1b) ------------------------------------
+  if (includePrompts && client.listPrompts && client.getPrompt) {
+    tools.push(buildListPromptsTool(client, options.namespace, category));
+    tools.push(buildGetPromptTool(client, options.namespace, category));
+  }
+
+  return tools;
+}
+
+function buildServerTool(
+  client: McpClientLike,
+  descriptor: McpToolDescriptor,
+  namespace: string,
+  category: string,
+): Tool {
+  const zodSchema = jsonSchemaObjectToZod(descriptor.inputSchema);
+  const namespacedName = `mcp_${namespace}__${descriptor.name}`;
+  return {
+    name: namespacedName,
+    label: descriptor.name,
+    description: descriptor.description ?? `${namespace}: ${descriptor.name}`,
+    parameters: zodSchema,
+
+    async execute(params: unknown): Promise<ToolResult> {
+      const validated = zodSchema.parse(params);
+      try {
+        const result = await client.callTool(descriptor.name, validated as Record<string, unknown>);
+        if (result.isError) {
+          return { success: false, error: extractErrorText(result) };
         }
-      },
+        const payload = result.structuredContent ?? result.content;
+        return { success: true, data: serializeMCPResult(payload) };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
 
-      getMetadata() {
-        return { category, version: '1.0.0', mcpNamespace: options.namespace };
-      },
-    };
+    getMetadata() {
+      return { category, version: '1.0.0', mcpNamespace: namespace };
+    },
+  };
+}
+
+function buildListResourcesTool(client: McpClientLike, namespace: string, category: string): Tool {
+  return {
+    name: `mcp_${namespace}__list_resources`,
+    label: 'list_resources',
+    description: `List resources exposed by the ${namespace} MCP server. Returns an array of { uri, name, description?, mimeType? }.`,
+    parameters: z.object({}),
+
+    async execute(): Promise<ToolResult> {
+      try {
+        const resources = (await client.listResources?.()) ?? [];
+        return { success: true, data: serializeMCPResult(resources) };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    getMetadata() {
+      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'resources' };
+    },
+  };
+}
+
+function buildReadResourceTool(client: McpClientLike, namespace: string, category: string): Tool {
+  const paramsSchema = z.object({
+    uri: z.string().min(1).describe('Resource URI to read (e.g. revealui-content://posts/abc)'),
   });
+  return {
+    name: `mcp_${namespace}__read_resource`,
+    label: 'read_resource',
+    description: `Read a resource by URI from the ${namespace} MCP server. Returns the resource contents (text parts flattened to a joined string when possible).`,
+    parameters: paramsSchema,
+
+    async execute(params: unknown): Promise<ToolResult> {
+      const { uri } = paramsSchema.parse(params);
+      try {
+        const contents = (await client.readResource?.(uri)) ?? [];
+        const joinedText = flattenResourceText(contents);
+        const base: ToolResult = {
+          success: true,
+          data: serializeMCPResult(contents),
+        };
+        return joinedText !== undefined ? { ...base, content: joinedText } : base;
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    getMetadata() {
+      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'resources' };
+    },
+  };
+}
+
+function buildListPromptsTool(client: McpClientLike, namespace: string, category: string): Tool {
+  return {
+    name: `mcp_${namespace}__list_prompts`,
+    label: 'list_prompts',
+    description: `List prompts exposed by the ${namespace} MCP server. Returns an array of { name, description?, arguments? }.`,
+    parameters: z.object({}),
+
+    async execute(): Promise<ToolResult> {
+      try {
+        const prompts = (await client.listPrompts?.()) ?? [];
+        return { success: true, data: serializeMCPResult(prompts) };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    getMetadata() {
+      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'prompts' };
+    },
+  };
+}
+
+function buildGetPromptTool(client: McpClientLike, namespace: string, category: string): Tool {
+  const paramsSchema = z.object({
+    name: z.string().min(1).describe('Prompt name to retrieve'),
+    args: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Prompt arguments as a string-valued map (per MCP spec)'),
+  });
+  return {
+    name: `mcp_${namespace}__get_prompt`,
+    label: 'get_prompt',
+    description: `Get a resolved prompt from the ${namespace} MCP server. Returns { description?, messages } — messages is an array of { role, content }.`,
+    parameters: paramsSchema,
+
+    async execute(params: unknown): Promise<ToolResult> {
+      const { name, args } = paramsSchema.parse(params);
+      try {
+        const result = await client.getPrompt?.(name, args);
+        if (!result) {
+          return { success: false, error: 'client does not implement getPrompt' };
+        }
+        const joinedText = flattenPromptMessages(result.messages);
+        const base: ToolResult = {
+          success: true,
+          data: serializeMCPResult(result),
+        };
+        return joinedText !== undefined ? { ...base, content: joinedText } : base;
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    getMetadata() {
+      return { category, version: '1.0.0', mcpNamespace: namespace, kind: 'prompts' };
+    },
+  };
+}
+
+/**
+ * Collapse an array of resource contents to a single text string when every
+ * part carries text. Returns `undefined` if any part is binary (blob) or has
+ * no text, signaling the caller that a token-efficient summary isn't
+ * available — in which case the full `data` array still carries everything.
+ */
+function flattenResourceText(contents: ReadonlyArray<McpResourceContentLike>): string | undefined {
+  if (contents.length === 0) return undefined;
+  const parts: string[] = [];
+  for (const part of contents) {
+    if (typeof part.text === 'string') {
+      parts.push(part.text);
+    } else {
+      return undefined;
+    }
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Collapse a prompt's message array to a single text summary in
+ * `<role>: <text>` format. Returns `undefined` when any message has a
+ * non-text content shape (image, resource reference, …).
+ */
+function flattenPromptMessages(
+  messages: ReadonlyArray<{ role: string; content: unknown }>,
+): string | undefined {
+  if (messages.length === 0) return undefined;
+  const lines: string[] = [];
+  for (const msg of messages) {
+    const text = extractMessageText(msg.content);
+    if (text === undefined) return undefined;
+    lines.push(`${msg.role}: ${text}`);
+  }
+  return lines.join('\n\n');
+}
+
+function extractMessageText(content: unknown): string | undefined {
+  if (typeof content === 'string') return content;
+  if (content && typeof content === 'object') {
+    const c = content as { type?: string; text?: string };
+    if (c.type === 'text' && typeof c.text === 'string') return c.text;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

> **Note:** Re-open of [#511](https://github.com/RevealUIStudio/revealui/pull/511) targeting `test` directly. The original closed automatically when its base branch (`feat/mcp-stage-5-1a-agent-mcpclient`) was deleted on Stage 5.1a merge. Same diff, same tests, same semantics.

Extends the agent's MCP adapter (shipped in 5.1a via [#508](https://github.com/RevealUIStudio/revealui/pull/508)) with first-class access to resources and prompts — agents can now read `revealui-content://...` resources mid-conversation and invoke MCP prompts via standard tool calls, no bespoke wiring.

### New meta-tools per MCP client namespace

| Meta-tool | Wraps | Purpose |
|---|---|---|
| `mcp_<ns>__list_resources` | `client.listResources()` | Enumerate available resources |
| `mcp_<ns>__read_resource({ uri })` | `client.readResource(uri)` | Fetch resource contents |
| `mcp_<ns>__list_prompts` | `client.listPrompts()` | Enumerate prompt templates |
| `mcp_<ns>__get_prompt({ name, args? })` | `client.getPrompt(name, args)` | Resolve a prompt template |

### Token-efficient LLM context

- `read_resource` joins text-only contents into `ToolResult.content` (what the LLM sees); full structured contents remain in `data`.
- `get_prompt` flattens text messages to `<role>: <text>\n\n…` in `content`; binary/image message parts skip flattening so `data` is authoritative.

### Configurability

`CreateToolsFromMcpClientOptions` gains `include: { tools?, resources?, prompts? }`. All default to `true`. Meta-tools are **silently skipped** when the underlying client method is absent — minimal structural stubs keep working.

### Decoupling preserved

- `McpClientLike` extended with four **optional** methods.
- No `@revealui/mcp` dep added to `@revealui/ai/package.json`.
- Prompt argument shape is `Record<string, string>` per spec; zod rejects non-string values.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — **881 / 881 passing** when this first shipped (+17 new adapter tests).
- [x] `pnpm --filter @revealui/ai typecheck` — clean.
- [ ] CI — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
