### PR TITLE
feat(ai): MCP protocol log channel (Stage 6.1)

### DIFF
--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -615,3 +615,219 @@ describe('createToolsFromMcpClient — include flag combinations', () => {
     expect(names).toContain('mcp_srv__get_prompt');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Stage 6.1 — onEvent observability hook
+// ---------------------------------------------------------------------------
+
+describe('createToolsFromMcpClient — onEvent', () => {
+  it('emits mcp.tool.call with success: true + duration + toolName on happy path', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    await tools[0]?.execute({});
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.tool.call',
+      namespace: 'srv',
+      toolName: 'noop',
+      success: true,
+    });
+    expect(typeof events[0]?.duration_ms).toBe('number');
+    expect(events[0]?.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits mcp.tool.call with success: false on isError result (error text propagated)', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ isError: true, content: [{ type: 'text', text: 'server rejected' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const result = await tools[0]?.execute({});
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.tool.call',
+      success: false,
+      error: 'server rejected',
+    });
+    expect(result).toEqual({ success: false, error: 'server rejected' });
+  });
+
+  it('emits mcp.tool.call with success: false on thrown errors', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeClient(
+      [{ name: 'flaky', inputSchema: { type: 'object', properties: {} } }],
+      async () => {
+        throw new Error('transport broke');
+      },
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    await tools[0]?.execute({});
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.tool.call',
+      success: false,
+      error: 'transport broke',
+    });
+  });
+
+  it('emits mcp.resource.list with resourceCount', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeFullClient({
+      resources: [
+        { uri: 'x://1', name: 'one' },
+        { uri: 'x://2', name: 'two' },
+      ],
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const listTool = tools.find((t) => t.name === 'mcp_srv__list_resources');
+    await listTool?.execute({});
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.resource.list',
+      namespace: 'srv',
+      success: true,
+      resourceCount: 2,
+    });
+  });
+
+  it('emits mcp.resource.read with the requested URI', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeFullClient({
+      resources: [{ uri: 'x://hello', name: 'hello' }],
+      resourceContents: { 'x://hello': [{ uri: 'x://hello', text: 'contents' }] },
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const readTool = tools.find((t) => t.name === 'mcp_srv__read_resource');
+    await readTool?.execute({ uri: 'x://hello' });
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.resource.read',
+      namespace: 'srv',
+      uri: 'x://hello',
+      success: true,
+    });
+  });
+
+  it('emits mcp.prompt.list with promptCount', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeFullClient({
+      prompts: [{ name: 'greet' }, { name: 'summarize' }, { name: 'classify' }],
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const listTool = tools.find((t) => t.name === 'mcp_srv__list_prompts');
+    await listTool?.execute({});
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.prompt.list',
+      namespace: 'srv',
+      success: true,
+      promptCount: 3,
+    });
+  });
+
+  it('emits mcp.prompt.get with promptName', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeFullClient({
+      prompts: [{ name: 'greet' }],
+      promptResults: {
+        greet: { messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }] },
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+    await getTool?.execute({ name: 'greet' });
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.prompt.get',
+      namespace: 'srv',
+      promptName: 'greet',
+      success: true,
+    });
+  });
+
+  it('emits mcp.prompt.get with success: false when the server errors', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const client = makeFullClient({
+      prompts: [{ name: 'greet' }],
+      // promptResults is empty → getPrompt throws "prompt not found"
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    const getTool = tools.find((t) => t.name === 'mcp_srv__get_prompt');
+    await getTool?.execute({ name: 'greet' });
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.prompt.get',
+      promptName: 'greet',
+      success: false,
+    });
+    expect(events[0]?.error).toMatch(/prompt not found/);
+  });
+
+  it('works without onEvent — no emission, no throw', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+    expect(result?.success).toBe(true);
+  });
+
+  it('continues when the sink throws (does not break the underlying call)', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+    const sink = vi.fn(() => {
+      throw new Error('sink broken');
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onEvent: sink,
+    });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(true);
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai/src/__tests__/tools/mcp-elicitation.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-elicitation.test.ts
@@ -183,3 +183,110 @@ describe('createElicitationHandler — observability', () => {
     expect(events[0]).toMatchObject({ mode: 'url' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Stage 6.1 — onEvent observability hook
+// ---------------------------------------------------------------------------
+
+describe('createElicitationHandler — onEvent', () => {
+  it('emits mcp.elicitation.create with action: "accept" on user accept', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'accept', content: { confirm: true } }),
+      namespace: 'content',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    await handler(makeParams());
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.elicitation.create',
+      namespace: 'content',
+      action: 'accept',
+      fieldCount: 1,
+      success: true,
+    });
+    expect(typeof events[0]?.duration_ms).toBe('number');
+  });
+
+  it('emits action: "decline" when the user declines', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'decline' }),
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    await handler(makeParams());
+    expect(events[0]).toMatchObject({ action: 'decline', success: true });
+  });
+
+  it('emits action: "cancel" when the user cancels', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'cancel' }),
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    await handler(makeParams());
+    expect(events[0]).toMatchObject({ action: 'cancel', success: true });
+  });
+
+  it('emits action: "decline" + success: true on URL-mode auto-decline', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => {
+        throw new Error('should not be called');
+      },
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    await handler(makeParams({ mode: 'url' }));
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.elicitation.create',
+      action: 'decline',
+      mode: 'url',
+      success: true,
+    });
+  });
+
+  it('emits action: "cancel" when the timeout fires', async () => {
+    vi.useFakeTimers();
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: () => new Promise(() => {}),
+      timeoutMs: 100,
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    const promise = handler(makeParams());
+    await vi.advanceTimersByTimeAsync(101);
+    await promise;
+
+    expect(events[0]).toMatchObject({ action: 'cancel', success: true });
+  });
+
+  it('emits action: "cancel" when onElicit throws (error is mapped to cancel)', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createElicitationHandler({
+      onElicit: async () => {
+        throw new Error('UI crashed');
+      },
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    await handler(makeParams());
+
+    // The action is 'cancel' because the error→cancel mapping wrapped the
+    // thrown error before we emitted. success remains true — the handler
+    // completed successfully, returning a valid spec result.
+    expect(events[0]).toMatchObject({ action: 'cancel', success: true });
+  });
+
+  it('is silent without onEvent', async () => {
+    const handler = createElicitationHandler({
+      onElicit: async () => ({ action: 'accept' }),
+    });
+    const result = await handler(makeParams());
+    expect(result.action).toBe('accept');
+  });
+});

--- a/packages/ai/src/__tests__/tools/mcp-events.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-events.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Stage 6.1 — tests for `mcp-events` (protocol log channel primitives).
+ *
+ * The event types themselves are pure structural shapes and don't need
+ * dedicated tests. This file covers the two runtime helpers:
+ *   - `createCoreLoggerSink()` — routes events to
+ *     `@revealui/core/observability/logger` at the right level.
+ *   - `emitMcpEvent()` — internal safe-dispatch helper used by the
+ *     adapter / sampling / elicitation modules.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCoreLoggerSink, emitMcpEvent, type McpLogEvent } from '../../tools/mcp-events.js';
+
+const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger,
+  createLogger: vi.fn(() => logger),
+}));
+
+beforeEach(() => {
+  logger.debug.mockClear();
+  logger.info.mockClear();
+  logger.warn.mockClear();
+  logger.error.mockClear();
+});
+
+function successEvent(): McpLogEvent {
+  return {
+    kind: 'mcp.tool.call',
+    namespace: 'content',
+    toolName: 'list_items',
+    duration_ms: 42,
+    success: true,
+  };
+}
+
+function failureEvent(): McpLogEvent {
+  return {
+    kind: 'mcp.tool.call',
+    namespace: 'content',
+    toolName: 'list_items',
+    duration_ms: 7,
+    success: false,
+    error: 'boom',
+  };
+}
+
+describe('createCoreLoggerSink', () => {
+  it('routes successful events to logger.info by default', () => {
+    const sink = createCoreLoggerSink();
+    sink(successEvent());
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    const [message, payload] = logger.info.mock.calls[0] ?? [];
+    expect(message).toBe('[mcp] mcp.tool.call');
+    expect(payload).toMatchObject({
+      event: 'mcp.tool.call',
+      namespace: 'content',
+      toolName: 'list_items',
+      duration_ms: 42,
+      success: true,
+    });
+    // `kind` is hoisted to the payload's `event` field (so ingestion can
+    // filter on a single scalar), not duplicated on the payload itself.
+    expect(payload).not.toHaveProperty('kind');
+  });
+
+  it('routes failed events to logger.warn regardless of successLevel', () => {
+    const sink = createCoreLoggerSink({ successLevel: 'debug' });
+    sink(failureEvent());
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    const [message, payload] = logger.warn.mock.calls[0] ?? [];
+    expect(message).toBe('[mcp] mcp.tool.call');
+    expect(payload).toMatchObject({
+      event: 'mcp.tool.call',
+      success: false,
+      error: 'boom',
+    });
+  });
+
+  it('drops successful events to logger.debug when successLevel: "debug"', () => {
+    const sink = createCoreLoggerSink({ successLevel: 'debug' });
+    sink(successEvent());
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('preserves event-specific fields for each kind', () => {
+    const sink = createCoreLoggerSink();
+    sink({
+      kind: 'mcp.resource.read',
+      namespace: 'content',
+      uri: 'revealui://posts/123',
+      duration_ms: 11,
+      success: true,
+    });
+    sink({
+      kind: 'mcp.sampling.create',
+      model: 'gemma3',
+      messageCount: 3,
+      maxTokens: 512,
+      duration_ms: 2001,
+      success: true,
+    });
+    sink({
+      kind: 'mcp.elicitation.create',
+      action: 'accept',
+      fieldCount: 2,
+      duration_ms: 9,
+      success: true,
+    });
+
+    expect(logger.info).toHaveBeenCalledTimes(3);
+    const payloads = logger.info.mock.calls.map((call) => call[1]);
+    expect(payloads[0]).toMatchObject({ event: 'mcp.resource.read', uri: 'revealui://posts/123' });
+    expect(payloads[1]).toMatchObject({
+      event: 'mcp.sampling.create',
+      model: 'gemma3',
+      messageCount: 3,
+      maxTokens: 512,
+    });
+    expect(payloads[2]).toMatchObject({
+      event: 'mcp.elicitation.create',
+      action: 'accept',
+      fieldCount: 2,
+    });
+  });
+});
+
+describe('emitMcpEvent', () => {
+  it('is a no-op when sink is undefined', () => {
+    expect(() => emitMcpEvent(undefined, successEvent())).not.toThrow();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('invokes the sink with the event verbatim', () => {
+    const sink = vi.fn();
+    const event = successEvent();
+    emitMcpEvent(sink, event);
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(event);
+  });
+
+  it('swallows sink exceptions and logs a warning', () => {
+    const sink = vi.fn(() => {
+      throw new Error('sink is broken');
+    });
+    expect(() => emitMcpEvent(sink, successEvent())).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message, payload] = logger.warn.mock.calls[0] ?? [];
+    expect(message).toMatch(/event sink threw/);
+    expect(payload).toMatchObject({
+      event: 'mcp.tool.call',
+      error: 'sink is broken',
+    });
+  });
+
+  it('handles non-Error throws from the sink', () => {
+    const sink = vi.fn(() => {
+      throw 'string error';
+    });
+    expect(() => emitMcpEvent(sink, successEvent())).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        error: 'string error',
+      }),
+    );
+  });
+});

--- a/packages/ai/src/__tests__/tools/mcp-sampling.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-sampling.test.ts
@@ -271,3 +271,83 @@ describe('createSamplingHandler — observability + errors', () => {
     await expect(handler(makeParams())).rejects.toThrow('rate limited');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Stage 6.1 — onEvent observability hook
+// ---------------------------------------------------------------------------
+
+describe('createSamplingHandler — onEvent', () => {
+  it('emits mcp.sampling.create on success with model, counts, and namespace', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const llm = makeLLM();
+    const handler = createSamplingHandler({
+      llm,
+      defaultModel: 'gemma3',
+      namespace: 'content',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    await handler(
+      makeParams({
+        messages: [
+          { role: 'user', content: { type: 'text', text: 'one' } },
+          { role: 'assistant', content: { type: 'text', text: 'two' } },
+        ],
+        maxTokens: 1024,
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.sampling.create',
+      namespace: 'content',
+      model: 'gemma3',
+      messageCount: 2,
+      maxTokens: 1024,
+      success: true,
+    });
+    expect(typeof events[0]?.duration_ms).toBe('number');
+  });
+
+  it('omits namespace when none was configured on the handler', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createSamplingHandler({
+      llm: makeLLM(),
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+    await handler(makeParams());
+
+    expect(events[0]).not.toHaveProperty('namespace');
+  });
+
+  it('emits mcp.sampling.create with success: false on LLM errors and rethrows', async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const llm: SamplingLLM = {
+      chat: vi.fn(async () => {
+        throw new Error('rate limited');
+      }),
+    };
+    const handler = createSamplingHandler({
+      llm,
+      defaultModel: 'gemma3',
+      onEvent: (e) => events.push(e as unknown as Record<string, unknown>),
+    });
+
+    await expect(handler(makeParams())).rejects.toThrow('rate limited');
+
+    expect(events[0]).toMatchObject({
+      kind: 'mcp.sampling.create',
+      model: 'gemma3',
+      success: false,
+      error: 'rate limited',
+    });
+  });
+
+  it('is silent without onEvent', async () => {
+    // No observable effect beyond not-throwing; but we verify the handler
+    // still resolves normally with no sink attached.
+    const handler = createSamplingHandler({ llm: makeLLM() });
+    const result = await handler(makeParams());
+    expect(result.role).toBe('assistant');
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -103,6 +103,7 @@ export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';
 export * from './tools/mcp-adapter.js';
 export * from './tools/mcp-elicitation.js';
+export * from './tools/mcp-events.js';
 export * from './tools/mcp-sampling.js';
 export * from './tools/memory/index.js';
 export * from './tools/registry.js';

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -23,6 +23,7 @@
 
 import { z } from 'zod/v4';
 import type { Tool, ToolResult } from './base.js';
+import { emitMcpEvent, type McpEventSink } from './mcp-events.js';
 
 export interface MCPTool {
   name: string;
@@ -187,6 +188,15 @@ export interface CreateToolsFromMcpClientOptions {
    * agent run. Resource/prompt meta-tools also receive the signal.
    */
   signal?: AbortSignal;
+  /**
+   * Protocol-level observability sink (Stage 6.1). Fires exactly once
+   * per tool / resource / prompt call with a structured summary
+   * (`namespace`, operation, `duration_ms`, `success`, `error?`). See
+   * `./mcp-events.ts` for the event shapes and `createCoreLoggerSink()`
+   * for the default routing to `@revealui/core/observability/logger`.
+   * Safe to pass a throwing sink — adapter swallows sink errors.
+   */
+  onEvent?: McpEventSink;
 }
 
 /** Spec-shaped `Progress` notification subset. */
@@ -252,6 +262,7 @@ export async function createToolsFromMcpClient(
     category,
     ...(options.onProgress !== undefined ? { onProgress: options.onProgress } : {}),
     ...(options.signal !== undefined ? { signal: options.signal } : {}),
+    ...(options.onEvent !== undefined ? { onEvent: options.onEvent } : {}),
   };
 
   const tools: Tool[] = [];
@@ -290,6 +301,7 @@ interface BuildToolContext {
   category: string;
   onProgress?: (event: McpProgressEvent) => void;
   signal?: AbortSignal;
+  onEvent?: McpEventSink;
 }
 
 /**
@@ -325,6 +337,7 @@ function buildServerTool(
 
     async execute(params: unknown): Promise<ToolResult> {
       const validated = zodSchema.parse(params);
+      const started = Date.now();
       try {
         const result = await client.callTool(
           descriptor.name,
@@ -332,15 +345,37 @@ function buildServerTool(
           buildRequestOptions(ctx, descriptor.name),
         );
         if (result.isError) {
-          return { success: false, error: extractErrorText(result) };
+          const errorText = extractErrorText(result);
+          emitMcpEvent(ctx.onEvent, {
+            kind: 'mcp.tool.call',
+            namespace: ctx.namespace,
+            toolName: descriptor.name,
+            duration_ms: Date.now() - started,
+            success: false,
+            error: errorText,
+          });
+          return { success: false, error: errorText };
         }
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.tool.call',
+          namespace: ctx.namespace,
+          toolName: descriptor.name,
+          duration_ms: Date.now() - started,
+          success: true,
+        });
         const payload = result.structuredContent ?? result.content;
         return { success: true, data: serializeMCPResult(payload) };
       } catch (error) {
-        return {
+        const message = error instanceof Error ? error.message : String(error);
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.tool.call',
+          namespace: ctx.namespace,
+          toolName: descriptor.name,
+          duration_ms: Date.now() - started,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
+          error: message,
+        });
+        return { success: false, error: message };
       }
     },
 
@@ -358,15 +393,28 @@ function buildListResourcesTool(client: McpClientLike, ctx: BuildToolContext): T
     parameters: z.object({}),
 
     async execute(): Promise<ToolResult> {
+      const started = Date.now();
       try {
         const resources =
           (await client.listResources?.(buildRequestOptions(ctx, 'list_resources'))) ?? [];
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.resource.list',
+          namespace: ctx.namespace,
+          duration_ms: Date.now() - started,
+          success: true,
+          resourceCount: resources.length,
+        });
         return { success: true, data: serializeMCPResult(resources) };
       } catch (error) {
-        return {
+        const message = error instanceof Error ? error.message : String(error);
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.resource.list',
+          namespace: ctx.namespace,
+          duration_ms: Date.now() - started,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
+          error: message,
+        });
+        return { success: false, error: message };
       }
     },
 
@@ -393,9 +441,17 @@ function buildReadResourceTool(client: McpClientLike, ctx: BuildToolContext): To
 
     async execute(params: unknown): Promise<ToolResult> {
       const { uri } = paramsSchema.parse(params);
+      const started = Date.now();
       try {
         const contents =
           (await client.readResource?.(uri, buildRequestOptions(ctx, 'read_resource'))) ?? [];
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.resource.read',
+          namespace: ctx.namespace,
+          uri,
+          duration_ms: Date.now() - started,
+          success: true,
+        });
         const joinedText = flattenResourceText(contents);
         const base: ToolResult = {
           success: true,
@@ -403,10 +459,16 @@ function buildReadResourceTool(client: McpClientLike, ctx: BuildToolContext): To
         };
         return joinedText !== undefined ? { ...base, content: joinedText } : base;
       } catch (error) {
-        return {
+        const message = error instanceof Error ? error.message : String(error);
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.resource.read',
+          namespace: ctx.namespace,
+          uri,
+          duration_ms: Date.now() - started,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
+          error: message,
+        });
+        return { success: false, error: message };
       }
     },
 
@@ -429,15 +491,28 @@ function buildListPromptsTool(client: McpClientLike, ctx: BuildToolContext): Too
     parameters: z.object({}),
 
     async execute(): Promise<ToolResult> {
+      const started = Date.now();
       try {
         const prompts =
           (await client.listPrompts?.(buildRequestOptions(ctx, 'list_prompts'))) ?? [];
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.prompt.list',
+          namespace: ctx.namespace,
+          duration_ms: Date.now() - started,
+          success: true,
+          promptCount: prompts.length,
+        });
         return { success: true, data: serializeMCPResult(prompts) };
       } catch (error) {
-        return {
+        const message = error instanceof Error ? error.message : String(error);
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.prompt.list',
+          namespace: ctx.namespace,
+          duration_ms: Date.now() - started,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
+          error: message,
+        });
+        return { success: false, error: message };
       }
     },
 
@@ -468,11 +543,28 @@ function buildGetPromptTool(client: McpClientLike, ctx: BuildToolContext): Tool 
 
     async execute(params: unknown): Promise<ToolResult> {
       const { name, args } = paramsSchema.parse(params);
+      const started = Date.now();
       try {
         const result = await client.getPrompt?.(name, args, buildRequestOptions(ctx, 'get_prompt'));
         if (!result) {
-          return { success: false, error: 'client does not implement getPrompt' };
+          const msg = 'client does not implement getPrompt';
+          emitMcpEvent(ctx.onEvent, {
+            kind: 'mcp.prompt.get',
+            namespace: ctx.namespace,
+            promptName: name,
+            duration_ms: Date.now() - started,
+            success: false,
+            error: msg,
+          });
+          return { success: false, error: msg };
         }
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.prompt.get',
+          namespace: ctx.namespace,
+          promptName: name,
+          duration_ms: Date.now() - started,
+          success: true,
+        });
         const joinedText = flattenPromptMessages(result.messages);
         const base: ToolResult = {
           success: true,
@@ -480,10 +572,16 @@ function buildGetPromptTool(client: McpClientLike, ctx: BuildToolContext): Tool 
         };
         return joinedText !== undefined ? { ...base, content: joinedText } : base;
       } catch (error) {
-        return {
+        const message = error instanceof Error ? error.message : String(error);
+        emitMcpEvent(ctx.onEvent, {
+          kind: 'mcp.prompt.get',
+          namespace: ctx.namespace,
+          promptName: name,
+          duration_ms: Date.now() - started,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
+          error: message,
+        });
+        return { success: false, error: message };
       }
     },
 

--- a/packages/ai/src/tools/mcp-elicitation.ts
+++ b/packages/ai/src/tools/mcp-elicitation.ts
@@ -51,6 +51,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { emitMcpEvent, type McpEventSink } from './mcp-events.js';
 
 // ---------------------------------------------------------------------------
 // Structural MCP spec types (subset)
@@ -117,19 +118,46 @@ export interface CreateElicitationHandlerOptions {
    * message + field count. Useful for audit trails.
    */
   onElicitationRequest?: (info: { message: string; fieldCount: number; mode?: string }) => void;
+  /**
+   * Protocol-level observability sink (Stage 6.1). Fires once per
+   * `elicitation/create` call (after the handler decides — whether
+   * the user accepted, declined, cancelled, url-mode auto-declined,
+   * or the timeout fired) with `{ kind: 'mcp.elicitation.create',
+   * action, fieldCount, mode?, duration_ms, success }`. URL-mode
+   * auto-decline + timeout-cancel both emit `success: true` — they
+   * are legitimate handler outcomes, not failures. Only thrown errors
+   * report `success: false`.
+   */
+  onEvent?: McpEventSink;
+  /**
+   * Optional server identifier included in emitted events. Leave unset
+   * when the handler is shared across multiple servers.
+   */
+  namespace?: string;
 }
 
 export function createElicitationHandler(
   options: CreateElicitationHandlerOptions,
 ): McpElicitationHandler {
-  const { onElicit, timeoutMs, allowUrlMode, onElicitationRequest } = options;
+  const { onElicit, timeoutMs, allowUrlMode, onElicitationRequest, onEvent, namespace } = options;
 
   return async (params: McpElicitRequestParams): Promise<McpElicitResult> => {
+    const fieldCount = countSchemaFields(params.requestedSchema);
+    const started = Date.now();
+
     if (params.mode === 'url' && !allowUrlMode) {
+      emitMcpEvent(onEvent, {
+        kind: 'mcp.elicitation.create',
+        ...(namespace !== undefined ? { namespace } : {}),
+        action: 'decline',
+        fieldCount,
+        ...(params.mode !== undefined ? { mode: params.mode } : {}),
+        duration_ms: Date.now() - started,
+        success: true,
+      });
       return { action: 'decline' };
     }
 
-    const fieldCount = countSchemaFields(params.requestedSchema);
     onElicitationRequest?.({
       message: params.message,
       fieldCount,
@@ -137,6 +165,7 @@ export function createElicitationHandler(
     });
 
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let result: McpElicitResult;
     try {
       const userResponse = onElicit(params).catch((error) => {
         // Errors inside the consumer's UI callback → cancel (not decline —
@@ -149,19 +178,30 @@ export function createElicitationHandler(
       });
 
       if (timeoutMs === undefined || timeoutMs <= 0) {
-        return await userResponse;
+        result = await userResponse;
+      } else {
+        const timeoutPromise = new Promise<McpElicitResult>((resolve) => {
+          timeoutHandle = setTimeout(() => {
+            resolve({ action: 'cancel' });
+          }, timeoutMs);
+        });
+        result = await Promise.race([userResponse, timeoutPromise]);
       }
-
-      const timeoutPromise = new Promise<McpElicitResult>((resolve) => {
-        timeoutHandle = setTimeout(() => {
-          resolve({ action: 'cancel' });
-        }, timeoutMs);
-      });
-
-      return await Promise.race([userResponse, timeoutPromise]);
     } finally {
       if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
     }
+
+    emitMcpEvent(onEvent, {
+      kind: 'mcp.elicitation.create',
+      ...(namespace !== undefined ? { namespace } : {}),
+      action: result.action,
+      fieldCount,
+      ...(params.mode !== undefined ? { mode: params.mode } : {}),
+      duration_ms: Date.now() - started,
+      success: true,
+    });
+
+    return result;
   };
 }
 

--- a/packages/ai/src/tools/mcp-events.ts
+++ b/packages/ai/src/tools/mcp-events.ts
@@ -1,0 +1,209 @@
+/**
+ * MCP protocol log channel — structured events per server-to-client call
+ * (Stage 6.1 of the MCP v1 plan).
+ *
+ * Stage 5 shipped the full agent-side MCP protocol surface
+ * (tools + resources + prompts + sampling + elicitation + progress +
+ * cancellation). Stage 6.1 adds observability: every adapter in
+ * `@revealui/ai/tools/mcp-*` grows an `onEvent?: McpEventSink` hook that
+ * fires once per protocol call with a structured summary. Consumers wire
+ * the sink to whatever aggregator they run — typically
+ * `@revealui/core/observability/logger` via `createCoreLoggerSink()`.
+ *
+ * Instrumentation lives at the agent-adapter layer by design. The
+ * hypervisor is a separate lane (Stage 6.2 lands `usage_meters` rows
+ * there, where `accountId` is in scope). Agent adapters are intentionally
+ * tenant-agnostic, so events carry no `accountId` field — the consumer
+ * adds tenant context in their sink wrapper if they need it for routing.
+ *
+ * PII note
+ * --------
+ * Errors surfaced by the server can legitimately contain user-identifying
+ * strings (e.g. "user 'alice@example.com' not found"). `error` is passed
+ * through to the sink verbatim. If your deployment's observability layer
+ * is subject to PII constraints, wrap the sink with a redactor
+ * (`redactLogContext` from `@revealui/security`) before passing it in.
+ *
+ * Params / args / content bodies are **not** included in events —
+ * observability is summary-grained by default to avoid accidentally
+ * logging credentials, prompts, or document contents.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+
+// ---------------------------------------------------------------------------
+// Event shapes
+// ---------------------------------------------------------------------------
+
+/** Common fields every MCP protocol-log event carries. */
+interface McpEventBase {
+  /**
+   * Wall-clock duration of the call in milliseconds, measured from
+   * handler entry to handler exit (success or failure). Includes the
+   * full round-trip across the transport plus any zod validation.
+   */
+  duration_ms: number;
+  /** `true` when the call completed without throwing and without `isError`. */
+  success: boolean;
+  /**
+   * Server-reported error text on failure (from `CallToolResult.content`
+   * when `isError: true`, or from `error.message` when the call threw).
+   * Omitted when `success: true`. May contain PII — see module docs.
+   */
+  error?: string;
+}
+
+export interface McpToolCallEvent extends McpEventBase {
+  kind: 'mcp.tool.call';
+  /** Server identifier the tool belongs to. */
+  namespace: string;
+  /** Tool name WITHOUT the `mcp_<namespace>__` adapter prefix. */
+  toolName: string;
+}
+
+export interface McpResourceListEvent extends McpEventBase {
+  kind: 'mcp.resource.list';
+  namespace: string;
+  /** Number of resources returned (omitted on failure). */
+  resourceCount?: number;
+}
+
+export interface McpResourceReadEvent extends McpEventBase {
+  kind: 'mcp.resource.read';
+  namespace: string;
+  /** Resource URI that was read. May be sensitive — see module docs. */
+  uri: string;
+}
+
+export interface McpPromptListEvent extends McpEventBase {
+  kind: 'mcp.prompt.list';
+  namespace: string;
+  /** Number of prompts returned (omitted on failure). */
+  promptCount?: number;
+}
+
+export interface McpPromptGetEvent extends McpEventBase {
+  kind: 'mcp.prompt.get';
+  namespace: string;
+  /** Prompt name that was requested. */
+  promptName: string;
+}
+
+export interface McpSamplingCreateEvent extends McpEventBase {
+  kind: 'mcp.sampling.create';
+  /**
+   * Server identifier when the consumer attached one at handler
+   * construction via `createSamplingHandler({ namespace })`. Absent
+   * when the handler is wired to a shared `McpClient` that fans out
+   * to multiple servers — in that case the consumer's sink wrapper
+   * can fill it in from call-site context.
+   */
+  namespace?: string;
+  /** Model label reported back to the server in `result.model`. */
+  model: string;
+  messageCount: number;
+  maxTokens: number;
+}
+
+export interface McpElicitationCreateEvent extends McpEventBase {
+  kind: 'mcp.elicitation.create';
+  /** Server identifier when provided to `createElicitationHandler`. */
+  namespace?: string;
+  /** User's decision — `'accept' | 'decline' | 'cancel'`. */
+  action: 'accept' | 'decline' | 'cancel';
+  /** Number of fields in the requested schema. */
+  fieldCount: number;
+  /** Elicitation mode as declared by the server (`'form'`, `'url'`, …). */
+  mode?: string;
+}
+
+export type McpLogEvent =
+  | McpToolCallEvent
+  | McpResourceListEvent
+  | McpResourceReadEvent
+  | McpPromptListEvent
+  | McpPromptGetEvent
+  | McpSamplingCreateEvent
+  | McpElicitationCreateEvent;
+
+/**
+ * Consumer-wired observability sink. Called exactly once per protocol
+ * call. Must not throw — the adapter swallows sink-thrown errors
+ * internally, but a well-behaved sink returns quickly and cleanly.
+ */
+export type McpEventSink = (event: McpLogEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Default sink — routes events to @revealui/core/observability/logger
+// ---------------------------------------------------------------------------
+
+export interface CreateCoreLoggerSinkOptions {
+  /**
+   * Minimum level for successful events. Default `'info'`. Set to
+   * `'debug'` to drop successful-call volume from info-level ingestion.
+   * Failed calls are always emitted at `'warn'` regardless.
+   */
+  successLevel?: 'debug' | 'info';
+}
+
+/**
+ * Build an `McpEventSink` that fans events into the central log
+ * aggregator via `@revealui/core/observability/logger`. This is the
+ * recommended default for in-process consumers (admin app, API, agent
+ * orchestration). Out-of-process consumers (CLI, remote inspector)
+ * typically construct a custom sink that forwards to their own transport.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createToolsFromMcpClient,
+ *   createCoreLoggerSink,
+ * } from '@revealui/ai';
+ *
+ * const onEvent = createCoreLoggerSink();
+ *
+ * const tools = await createToolsFromMcpClient(client, {
+ *   namespace: 'my-server',
+ *   onEvent,
+ * });
+ * ```
+ */
+export function createCoreLoggerSink(options: CreateCoreLoggerSinkOptions = {}): McpEventSink {
+  const successLevel = options.successLevel ?? 'info';
+  return (event) => {
+    const { kind, ...rest } = event;
+    const payload = { event: kind, ...rest };
+    if (!event.success) {
+      logger.warn(`[mcp] ${kind}`, payload);
+      return;
+    }
+    if (successLevel === 'debug') {
+      logger.debug(`[mcp] ${kind}`, payload);
+    } else {
+      logger.info(`[mcp] ${kind}`, payload);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper — shared across mcp-adapter / mcp-sampling / mcp-elicitation
+// ---------------------------------------------------------------------------
+
+/**
+ * Invoke a sink, swallowing any thrown error. A misbehaving sink must
+ * never break the underlying MCP call — observability is best-effort.
+ * Logs the sink failure at warn so the regression is still visible.
+ *
+ * @internal
+ */
+export function emitMcpEvent(sink: McpEventSink | undefined, event: McpLogEvent): void {
+  if (!sink) return;
+  try {
+    sink(event);
+  } catch (error) {
+    logger.warn('[mcp] event sink threw; continuing', {
+      event: event.kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/ai/src/tools/mcp-sampling.ts
+++ b/packages/ai/src/tools/mcp-sampling.ts
@@ -44,6 +44,7 @@
  */
 
 import type { LLMChatOptions, LLMResponse, Message } from '../llm/providers/base.js';
+import { emitMcpEvent, type McpEventSink } from './mcp-events.js';
 
 // ---------------------------------------------------------------------------
 // Structural LLM shape
@@ -154,10 +155,26 @@ export interface CreateSamplingHandlerOptions {
     maxTokens: number;
     systemPrompt?: string;
   }) => void;
+  /**
+   * Protocol-level observability sink (Stage 6.1). Fires once per
+   * `sampling/createMessage` call (after the LLM responds, or on
+   * failure) with `{ kind: 'mcp.sampling.create', model, messageCount,
+   * maxTokens, duration_ms, success, error? }`. Set `namespace` when
+   * the handler is attached to a single-server `McpClient` so events
+   * can be grouped in the aggregator.
+   */
+  onEvent?: McpEventSink;
+  /**
+   * Optional server identifier included in emitted events. Leave unset
+   * when the handler is shared across multiple servers — consumer's
+   * sink wrapper can fill in namespace from call-site context.
+   */
+  namespace?: string;
 }
 
 export function createSamplingHandler(options: CreateSamplingHandlerOptions): McpSamplingHandler {
-  const { llm, allowedModels, defaultModel, selectModel, onSamplingRequest } = options;
+  const { llm, allowedModels, defaultModel, selectModel, onSamplingRequest, onEvent, namespace } =
+    options;
 
   return async (params: McpSamplingRequestParams): Promise<McpSamplingResult> => {
     const model = resolveModel(params.modelPreferences?.hints, {
@@ -185,21 +202,46 @@ export function createSamplingHandler(options: CreateSamplingHandlerOptions): Mc
       ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
     };
 
-    const response = await llm.chat(messages, chatOptions);
+    const started = Date.now();
+    try {
+      const response = await llm.chat(messages, chatOptions);
 
-    const stopReason = mapFinishReason(response.finishReason);
-    const result: McpSamplingResult = {
-      model: reportedModel,
-      role: 'assistant',
-      content: {
-        type: 'text',
-        text: response.content,
-      },
-    };
-    if (stopReason !== undefined) {
-      result.stopReason = stopReason;
+      emitMcpEvent(onEvent, {
+        kind: 'mcp.sampling.create',
+        ...(namespace !== undefined ? { namespace } : {}),
+        model: reportedModel,
+        messageCount: params.messages.length,
+        maxTokens: params.maxTokens,
+        duration_ms: Date.now() - started,
+        success: true,
+      });
+
+      const stopReason = mapFinishReason(response.finishReason);
+      const result: McpSamplingResult = {
+        model: reportedModel,
+        role: 'assistant',
+        content: {
+          type: 'text',
+          text: response.content,
+        },
+      };
+      if (stopReason !== undefined) {
+        result.stopReason = stopReason;
+      }
+      return result;
+    } catch (error) {
+      emitMcpEvent(onEvent, {
+        kind: 'mcp.sampling.create',
+        ...(namespace !== undefined ? { namespace } : {}),
+        model: reportedModel,
+        messageCount: params.messages.length,
+        maxTokens: params.maxTokens,
+        duration_ms: Date.now() - started,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
-    return result;
   };
 }
 


### PR DESCRIPTION
## Summary

Stage 6.1 of internal docs — protocol log channel at the agent-adapter layer. Structured events per server-to-client MCP call (tool / resource / prompt / sampling / elicitation) land in the central log aggregator via a consumer-wired sink.

Each of the five agent-side adapter surfaces emits one event at end-of-call with `{ namespace, duration_ms, success, error? }` plus kind-specific fields. Consumers wire the sink at factory construction time — `createCoreLoggerSink()` routes to `@revealui/core/observability/logger` by default (info for success, warn for failure).

## Why agent-adapter instead of hypervisor

Stage 6 has two lanes:

- **6.1 (this PR) — protocol log channel → agent-adapter layer.** Adapters are intentionally tenant-agnostic; emitting structured events here preserves the Stage 5 structural-typing discipline with `@revealui/mcp` and gives the consumer full control over where events route.
- **6.2 (next PR) — usage_meters rows → hypervisor layer.** Metering requires `accountId` (NOT NULL fk on `usage_meters`). The hypervisor already has tenant context; the agent adapter structurally shouldn't.

## Changes

- New `packages/ai/src/tools/mcp-events.ts`:
  - `McpLogEvent` discriminated union: `mcp.tool.call`, `mcp.resource.list`, `mcp.resource.read`, `mcp.prompt.list`, `mcp.prompt.get`, `mcp.sampling.create`, `mcp.elicitation.create`
  - `McpEventSink` type
  - `createCoreLoggerSink({ successLevel? })` helper — info/warn routing with optional debug-level drop
  - `emitMcpEvent()` internal safe-dispatch (swallows sink exceptions + logs warn)
- `createToolsFromMcpClient` grows `onEvent?: McpEventSink`, threaded through `BuildToolContext` to all 5 tool builders (server tool, list_resources, read_resource, list_prompts, get_prompt)
- `createSamplingHandler` grows `onEvent` + `namespace`. Emits on success (after LLM chat resolves) and on failure (before rethrow)
- `createElicitationHandler` grows `onEvent` + `namespace`. Emits on every terminal action — accept, decline, cancel, URL-mode auto-decline, timeout-cancel, error-to-cancel
- Exports added to `packages/ai/src/index.ts`

## Structural-decoupling posture

- No runtime dep on `@revealui/mcp` added. Hook + event types live in `@revealui/ai`; consumer wires the sink.
- `@revealui/core/observability/logger` import follows the established pattern (a2a, memory/preferences, skills, mcp-elicitation.ts:53 already imports from the same path).
- Params, args, content bodies are NOT included in events — summary-grained to avoid accidentally logging credentials / prompts / document contents.
- Tenant-agnostic by design. `accountId` is Stage 6.2's concern.

## Tests

`@revealui/ai`: **914 → 938 passing** (+24 tests).

- New `mcp-events.test.ts` (8 tests) — sink routing per level, event-specific field preservation, emit safety (undefined sink no-op, sink-exception swallow).
- `mcp-client-adapter.test.ts` +10 — event emission for each of the 5 tool shapes (including happy path, isError, thrown error, sink-exception-safe).
- `mcp-sampling.test.ts` +4 — success + failure paths, namespace absent when unconfigured, silent without sink.
- `mcp-elicitation.test.ts` +7 — accept / decline / cancel / URL-auto-decline / timeout-cancel / error-to-cancel / silent-without-sink.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — 938 passing, 5 skipped, 62 test files pass
- [x] `pnpm --filter @revealui/ai typecheck` — clean
- [x] `pnpm --filter @revealui/ai lint` — clean for this PR's changes (one pre-existing warn in `countSchemaFields` from Stage 5.3 unrelated to this diff)
- [x] `pnpm turbo build --filter @revealui/ai` — 10/10 tasks

## Deferred

- **Stage 6.2** (usage_meters rows at hypervisor boundaries) — separate PR.
- **Event ingestion UI** — admin dashboards for per-namespace tool-call histograms, latency charts, etc. Stage 5.1 inspector (admin `/admin/mcp` page) is the natural home but belongs in its own design thread alongside Stage 6.2.

Closes Stage 6.1 of the MCP productionization v1 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
