### PR TITLE
docs(roadmap): link Agent Marketplace to tracker #526

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,8 +129,8 @@ Give users the ability to interact with an AI agent directly from the admin dash
 
 ### Mid-Term (Q3 2026)
 
-#### Agent Marketplace
-A registry where developers can publish and discover MCP servers and AI agent capabilities. Revenue share model (80% developer / 20% platform).
+#### Agent Marketplace — [#526](https://github.com/RevealUIStudio/revealui/issues/526)
+A registry where developers can publish and discover MCP servers and AI agent capabilities. Revenue share model (80% developer / 20% platform). _Currently: MCP Server Marketplace (Phase 5.5) and RevMarket autonomous-agent layer (Phase 5.16) are both substantially built — schemas, API routes, admin UI, Stripe Connect payouts, x402 payment middleware, developer docs — but x402 is disabled by default and live charging is gated on §CR-8 A-grade achievement and Stripe live-mode switch._
 
 #### Multi-User Collaboration — [#514](https://github.com/RevealUIStudio/revealui/issues/514)
 Real-time multi-user editing powered by ElectricSQL. Currently basic shape subscriptions and Yjs CRDT foundation exist (experimental). Full conflict resolution, presence indicators, and collaborative workflows are planned.


### PR DESCRIPTION
## Summary

Links `docs/ROADMAP.md` §Mid-Term Agent Marketplace heading to new umbrella tracker [#526](https://github.com/RevealUIStudio/revealui/issues/526), following the #514/#515/#516 precedent from the 2026-04-23 round-2 batch (revealui#517).

CR-9 P1-05 round-3 continuation — remaining ROADMAP future-tense markers.

## Scope

Single-file edit: `docs/ROADMAP.md` lines 132-133.

**Before:**
```
#### Agent Marketplace
A registry where developers can publish and discover MCP servers and AI agent capabilities. Revenue share model (80% developer / 20% platform).
```

**After:**
```
#### Agent Marketplace — [#526]
A registry ... 20% platform). _Currently: MCP Server Marketplace (Phase 5.5) and RevMarket autonomous-agent layer (Phase 5.16) are both substantially built — schemas, API routes, admin UI, Stripe Connect payouts, x402 payment middleware, developer docs — but x402 is disabled by default and live charging is gated on §CR-8 A-grade achievement and Stripe live-mode switch._
```

No other edits.

## Why the reality-anchor note

Ground-truth survey showed the Agent Marketplace is not greenfield. Substantial code already exists on both surfaces:

- `packages/db/src/schema/marketplace.ts` (Phase 5.5 MCP Marketplace tables)
- `packages/db/src/schema/revmarket.ts` (Phase 5.16 RevMarket agent tables)
- `apps/api/src/routes/marketplace.ts` + `/cron/marketplace-payouts.ts`
- `apps/api/src/middleware/x402.ts` (disabled by default via `X402_ENABLED=false`)
- `apps/admin/src/app/(backend)/admin/marketplace/` (publish, analytics, earnings, tasks pages)
- `apps/marketing/src/app/marketplace/page.tsx`
- `docs/MARKETPLACE.md` (458 lines of developer-facing docs)
- MASTER_PLAN §Phase 5.16 records Phase A–D complete (card publishing, task submission + auto-match, result delivery, billing integration)

Leaving the blurb as plain future-tense ("planned" / "registry where developers can publish...") would misrepresent the state. The reality-anchor sentence tells readers "it's built, launch-gated on charge-readiness + Stripe live" — which is the accurate shape. Matches the #514/#515/#516 precedent where each reality-anchor sentence in ROADMAP.md names the existing partial implementation.

## Tracker scope (#526)

Umbrella covering both MCP Server Marketplace (Phase 5.5) and RevMarket (Phase 5.16) surfaces, since they share:

- Payment rails (Stripe Connect + x402 USDC-on-Base)
- Payout plumbing (batched weekly transfers)
- Charge-readiness gates (§CR-8 A-grade blocker revealui#431)
- Live-mode switch (post-LLC Stripe live)

Tracker body covers: scope, two-surface distinction, existing work (schemas/routes/admin/docs enumerated), 5 acceptance-criteria buckets (A charge-readiness / B MCP marketplace v1.1 / C RevMarket v1.1 / D x402 payment rails / E 2027+ pricing direction), progress tracker, scope guardrails (not a plugin store / not a crypto trading surface / not a code-review replacement / etc.), dependencies + blockers table, references.

## Verification

- [x] Ground-truth verified before authoring — every "existing work" claim in #526 cross-referenced against actual files in the repo + MASTER_PLAN §5.16
- [x] No code changes; zero runtime risk
- [x] Claim-drift scanner (`scripts/validate/claim-drift.ts`) `FUTURE_TENSE_PATTERN` only matches parenthesized markers — this PR adds zero new parens so no CI surprise expected (same scanner behavior as revealui#517)
- [x] Zero file overlap with MCP session's Stage 6.2 lane (`packages/mcp/src/hypervisor*` + `@revealui/db` usage_meters) per workboard coord note

## Test plan

- [ ] CI passes (15/15 green; E2E skips expected on chore branch)
- [ ] Tracker #526 renders cleanly on GitHub
- [ ] ROADMAP.md heading link resolves to #526 on github.com

## References

- Precedent: revealui#517 (CR-9 P1-05 round-2 batch, 2026-04-23)
- Sibling trackers: [#514 Multi-User Collab](https://github.com/RevealUIStudio/revealui/issues/514), [#515 Forge-tier parity](https://github.com/RevealUIStudio/revealui/issues/515), [#516 SOC2 Type II](https://github.com/RevealUIStudio/revealui/issues/516), [#451 Planned-rows umbrella](https://github.com/RevealUIStudio/revealui/issues/451)
- Handoff: internal docs §7 recommended-first-task
