### PR TITLE
docs(roadmap): link Ecosystem Integration to umbrella tracker #528

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,11 +115,11 @@ Give users the ability to interact with an AI agent directly from the admin dash
 - API reference for all packages
 - Collection cookbook with common patterns
 
-#### Ecosystem Integration
+#### Ecosystem Integration — [#528](https://github.com/RevealUIStudio/revealui/issues/528)
 - RevVault desktop app integration in Studio _(already built: `VaultPanel.tsx` connects via Tauri to RevVault)_
-- RevVault rotation engine as a Pro feature  -  automated credential lifecycle management
-- RevKit agent coordination protocol extraction as `@revealui/workboard`  -  MIT standalone package
-- Unified ecosystem messaging across marketing, docs, and pricing surfaces
+- RevVault rotation engine as a Pro feature  -  automated credential lifecycle management. _Currently: 5 interactive rotation shell scripts ship at `~/suite/.jv/scripts/rotation/` (neon, revealui-secret, stripe-webhook, probe-current-values, probe-mcp-api-key); Rust workspace at `~/suite/revvault/` ready to absorb them as a first-class subsystem._
+- RevKit agent coordination protocol extraction as `@revealui/workboard`  -  MIT standalone package. _Currently: implementation lives inside `@revealui/harnesses` (FSL-1.1-MIT Pro) at `packages/harnesses/src/workboard/`; extraction brings it in line with the PRO.md declaration that RevKit agent coordination is MIT-free._
+- Unified ecosystem messaging across marketing, docs, and pricing surfaces _(drift-control work, not a new feature)_
 
 #### Developer Experience
 - `create-revealui` template improvements (more starters, better defaults)


### PR DESCRIPTION
## Summary

Links `docs/ROADMAP.md` §Near-Term Ecosystem Integration heading to new umbrella tracker [#528](https://github.com/RevealUIStudio/revealui/issues/528) and adds reality-anchor notes under each of the three planned sub-bullets.

CR-9 P1-05 round-4 continuation — remaining ROADMAP future-tense markers.

## Scope

Single-file edit: `docs/ROADMAP.md` lines 118-122.

**Heading:** `#### Ecosystem Integration` → `#### Ecosystem Integration — [#528]`

**Sub-bullets** (existing bullet 119 unchanged; bullets 120-122 get reality-anchor italics):

- RevVault rotation engine: notes the 5 interactive shell scripts already shipped at internal docs (`rotate-neon.sh`, `rotate-revealui-secret.sh`, `rotate-stripe-webhook.sh`, `probe-current-values-live.sh`, `probe-mcp-api-key.sh` per internal docs commit 68205c32f from 2026-04-22), and notes the Rust workspace at `~/suite/revvault/` is ready to absorb them as a first-class subsystem.
- `@revealui/workboard`: notes the implementation currently lives inside `@revealui/harnesses` (FSL-1.1-MIT Pro) at `packages/harnesses/src/workboard/`, and extraction brings it in line with the PRO.md declaration that RevKit agent coordination is MIT-free.
- Unified ecosystem messaging: flagged as drift-control work, not a new feature.

No other edits.

## Why reality-anchor notes on sub-bullets (this time)

The Ecosystem Integration heading has 4 bullets — one cross-referencing existing work (VaultPanel.tsx in Studio) + 3 forward-looking. The forward-looking bullets each pointed at substantial existing context that would be opaque to a first-time reader:

1. RevVault rotation engine: shell scripts + design doc + execution plan + runbook already exist; reader should know the "existing ramp" shape before treating this as a greenfield item.
2. `@revealui/workboard`: PRO.md already declares RevKit-coordination as MIT-free; the extraction bullet makes that declaration *actually true*. Worth naming the current mismatch so a reader understands the motivation.
3. Unified messaging: easy to misread as a marketing campaign. Naming it "drift-control work" prevents scope creep.

Matches the pattern used on revealui#517 (round-2) and revealui#527 (round-3): italicized `_Currently: ..._` or `_(drift-control work, not a new feature)_` clauses that anchor the bullet to current state.

## Tracker scope (#528)

Umbrella covering the three planned Ecosystem Integration sub-surfaces, matching the #515 Forge-tier umbrella precedent (single heading-level tracker, multiple sub-sections).

Structure:
- **Section A — RevVault rotation engine as Pro feature.** Existing work enumerated (5 shell scripts + rotation-landscape design doc + execution plan + rotation runbook + PRO.md tier declaration). 9 acceptance criteria: Rust rotation subsystem port, adapter model, coordinated multi-secret rotation with rollback, Pro-tier license gate, automatic scheduling, audit trail, dry-run parity, test fixtures, shell-script retirement path.
- **Section B — `@revealui/workboard` extraction.** Existing location + files enumerated; PRO.md-declaration vs reality gap named. 8 acceptance criteria: new MIT package at `packages/workboard/`, clean API surface, zero Pro dependencies, independent tests, cross-consumer migration, LICENSE/README, changeset starting at 0.1.0, PRO.md consistency verification.
- **Section C — Unified ecosystem messaging.** Surfaces in scope (marketing, docs, pricing, README, admin onboarding, blog drafts, package READMEs, RevealCoin whitepaper). 7 acceptance criteria: canonical "What is RevealUI?" doc, tier-name consistency, feature-availability matrix consistency, claim-drift scanner coverage extension, Suite products list consistency (build on 2026-04-10 CR7-16 audit), blog-draft triage, "Last updated" stamp refresh.
- Scope guardrails: not a RevVault redesign / not a RevKit rebrand / not a marketing campaign / not a Studio feature / not a cross-repo refactor / not a charge-gate item.
- Dependencies + blockers table naming Revvault-MCP-path-decision, Pro-tier license parity (already shipped — reusable), claim-drift scanner, CR9-P1-01 drift discipline as upstream.
- Sibling-tracker cross-refs: #451 (Suite Planned-rows), #514/#515/#516/#526 (CR9-P1-05 umbrella precedents).

Cross-referenced already-built work (VaultPanel.tsx at `revdev/apps/studio/src/components/vault/VaultPanel.tsx`) verified before authoring.

## Verification

- [x] Ground-truth verified — every "existing work" claim in #528 cross-referenced against actual files (revvault crates, internal docs rotation scripts, harnesses/src/workboard tree, PRO.md tier declarations, VaultPanel.tsx presence)
- [x] No code changes; zero runtime risk
- [x] Claim-drift scanner parenthesized-marker pattern: PR adds zero new parens, only italicized prose — same safety as #517 / #527
- [x] Zero file overlap with MCP session's Stage 6.2 lane (`packages/mcp/src/hypervisor*` + `@revealui/db` usage_meters) per workboard

## Test plan

- [ ] CI passes (15/15 green; E2E skips expected on chore branch)
- [ ] Tracker #528 renders cleanly on GitHub
- [ ] ROADMAP.md heading link resolves to #528

## References

- Precedents: revealui#517 (round-2 batch), revealui#527 (round-3 Agent Marketplace)
- Sibling trackers: [#514](https://github.com/RevealUIStudio/revealui/issues/514) / [#515](https://github.com/RevealUIStudio/revealui/issues/515) / [#516](https://github.com/RevealUIStudio/revealui/issues/516) / [#526](https://github.com/RevealUIStudio/revealui/issues/526)
- Cross-ref: internal docs, internal docs
