### PR TITLE
feat(mcp, ai): MCP usage metering — hypervisor + agent-adapter paths (Stage 6.2)

### DIFF
--- a/packages/ai/src/__tests__/tools/mcp-events.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-events.test.ts
@@ -184,3 +184,178 @@ describe('emitMcpEvent', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Stage 6.2 — createUsageMeterSink
+// ---------------------------------------------------------------------------
+
+import { createUsageMeterSink, type McpUsageMeterRow } from '../../tools/mcp-events.js';
+
+describe('createUsageMeterSink', () => {
+  it('writes a usage_meters row with accountId + meterName + defaults', () => {
+    const rows: McpUsageMeterRow[] = [];
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+
+    sink(successEvent());
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row).toMatchObject({
+      accountId: 'acct-123',
+      meterName: 'mcp.tool.call',
+      quantity: 1,
+      periodEnd: null,
+      source: 'agent',
+    });
+    expect(row.id).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(row.idempotencyKey).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(row.periodStart).toBeInstanceOf(Date);
+  });
+
+  it('maps each event kind to the matching meter name', () => {
+    const rows: McpUsageMeterRow[] = [];
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+
+    sink({
+      kind: 'mcp.resource.read',
+      namespace: 'content',
+      uri: 'revealui://posts/1',
+      duration_ms: 3,
+      success: true,
+    });
+    sink({
+      kind: 'mcp.prompt.get',
+      namespace: 'content',
+      promptName: 'greet',
+      duration_ms: 4,
+      success: true,
+    });
+    sink({
+      kind: 'mcp.sampling.create',
+      model: 'gemma3',
+      messageCount: 2,
+      maxTokens: 256,
+      duration_ms: 1200,
+      success: true,
+    });
+    sink({
+      kind: 'mcp.elicitation.create',
+      action: 'accept',
+      fieldCount: 1,
+      duration_ms: 8,
+      success: true,
+    });
+
+    expect(rows.map((r) => r.meterName)).toEqual([
+      'mcp.resource.read',
+      'mcp.prompt.get',
+      'mcp.sampling.create',
+      'mcp.elicitation.create',
+    ]);
+  });
+
+  it('honors custom source label', () => {
+    const rows: McpUsageMeterRow[] = [];
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      source: 'api',
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+    sink(successEvent());
+    expect(rows[0]?.source).toBe('api');
+  });
+
+  it('uses supplied idempotencyKey generator for retry coalescence', () => {
+    const rows: McpUsageMeterRow[] = [];
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      idempotencyKey: (e) => `fixed:${e.kind}`,
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+    sink(successEvent());
+    sink(successEvent());
+    expect(rows[0]?.idempotencyKey).toBe('fixed:mcp.tool.call');
+    expect(rows[1]?.idempotencyKey).toBe('fixed:mcp.tool.call');
+  });
+
+  it('uses supplied id generator', () => {
+    const rows: McpUsageMeterRow[] = [];
+    let counter = 0;
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      id: () => `row-${++counter}`,
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+    sink(successEvent());
+    sink(successEvent());
+    expect(rows[0]?.id).toBe('row-1');
+    expect(rows[1]?.id).toBe('row-2');
+  });
+
+  it('emits a row for failed events too (billing cares about attempts)', () => {
+    const rows: McpUsageMeterRow[] = [];
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      write: (row) => {
+        rows.push(row);
+      },
+    });
+    sink(failureEvent());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.meterName).toBe('mcp.tool.call');
+  });
+
+  it('awaits and swallows rejected async writes without throwing', async () => {
+    const sink = createUsageMeterSink({
+      accountId: 'acct-123',
+      write: async () => {
+        throw new Error('db unavailable');
+      },
+    });
+
+    expect(() => sink(successEvent())).not.toThrow();
+    // Let the rejected microtask settle so logger.warn is observed.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/usage meter write rejected/),
+      expect.objectContaining({ event: 'mcp.tool.call', error: 'db unavailable' }),
+    );
+  });
+
+  it('swallows synchronous write throws via emitMcpEvent when wrapped', () => {
+    // When paired with the adapter's own emitMcpEvent safe-dispatch,
+    // a sink that throws sync never propagates. Here we verify the
+    // integration boundary: emitMcpEvent(sink, event) swallows
+    // throws, and the usage-meter sink constructed here is callable
+    // through that path.
+    const brokenSink = createUsageMeterSink({
+      accountId: 'acct-123',
+      write: () => {
+        throw new Error('sync write boom');
+      },
+    });
+
+    expect(() => emitMcpEvent(brokenSink, successEvent())).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/event sink threw/),
+      expect.objectContaining({ event: 'mcp.tool.call' }),
+    );
+  });
+});

--- a/packages/ai/src/tools/mcp-events.ts
+++ b/packages/ai/src/tools/mcp-events.ts
@@ -207,3 +207,157 @@ export function emitMcpEvent(sink: McpEventSink | undefined, event: McpLogEvent)
     });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Stage 6.2 — usage metering sink
+// ---------------------------------------------------------------------------
+
+/**
+ * Row shape consumed by the sink's `write` callback. Structurally
+ * matches `usage_meters` insert payload in `@revealui/db/schema/accounts`.
+ * Kept as a plain interface here to avoid importing Drizzle's inferred
+ * insert type and to let tests build rows without a db client.
+ */
+export interface McpUsageMeterRow {
+  /** Synthetic primary key. Default: `crypto.randomUUID()`. */
+  id: string;
+  /** Tenant / account fk (NOT NULL on `usage_meters`). */
+  accountId: string;
+  /** Dot-notation meter name: mirrors `McpLogEvent.kind`. */
+  meterName: string;
+  /**
+   * Event count. v1 uses `1` per call (row-per-call pattern); billing
+   * aggregation rolls these up. A larger quantity makes sense only
+   * when the meter represents a volume (tokens, bytes) rather than
+   * a count of events.
+   */
+  quantity: number;
+  /** Timestamp the metered event occurred. */
+  periodStart: Date;
+  /** Reserved for aggregation-mode rows; `null` for per-call rows. */
+  periodEnd: Date | null;
+  /**
+   * Origin label. Per the `usage_meters` CHECK constraint one of
+   * `'system' | 'user' | 'agent' | 'api'`. Defaults to `'agent'`
+   * since this sink consumes agent-runtime protocol events.
+   */
+  source: 'system' | 'user' | 'agent' | 'api';
+  /** Unique key. Backs `uniqueIndex` on `usage_meters`. */
+  idempotencyKey: string;
+}
+
+/**
+ * Consumer-supplied row writer. Typically:
+ * `(row) => db.insert(usageMeters).values(row)`.
+ * Can be sync (throws on error) or async. The sink awaits thenable
+ * results and logs rejections at warn — write failures never propagate
+ * back into the MCP call that produced the event.
+ */
+export type McpUsageMeterWriter = (row: McpUsageMeterRow) => void | Promise<void>;
+
+export interface CreateUsageMeterSinkOptions {
+  /**
+   * Tenant / account id required by the `usage_meters.accountId NOT
+   * NULL fk` constraint. Agent-side adapters are tenant-agnostic by
+   * design — consumer binds the correct account when constructing
+   * the sink, typically one sink per authenticated call path.
+   */
+  accountId: string;
+  /**
+   * Row persistence callback. Structural so consumers can plug in
+   * raw Drizzle, a wrapped client, or a test double.
+   */
+  write: McpUsageMeterWriter;
+  /**
+   * Origin label per `usage_meters.source` check constraint. Default
+   * `'agent'`.
+   */
+  source?: McpUsageMeterRow['source'];
+  /**
+   * Custom idempotency-key generator. Default: fresh
+   * `crypto.randomUUID()` per event (safe; no retry coalescence).
+   * Supply a deterministic generator (e.g. `${requestId}:${e.kind}`)
+   * to collapse duplicate retries of one semantic call to a single
+   * row.
+   */
+  idempotencyKey?: (event: McpLogEvent) => string;
+  /**
+   * Custom row-id generator. Default: fresh UUID. Provided as a hook
+   * for consumers integrating with an existing id scheme.
+   */
+  id?: (event: McpLogEvent) => string;
+}
+
+/**
+ * Map an `McpLogEvent.kind` to a `usage_meters.meterName` string.
+ * One-to-one: the dot-notation kind IS the meter name.
+ *
+ * @internal
+ */
+const METER_NAMES: Readonly<Record<McpLogEvent['kind'], string>> = {
+  'mcp.tool.call': 'mcp.tool.call',
+  'mcp.resource.list': 'mcp.resource.list',
+  'mcp.resource.read': 'mcp.resource.read',
+  'mcp.prompt.list': 'mcp.prompt.list',
+  'mcp.prompt.get': 'mcp.prompt.get',
+  'mcp.sampling.create': 'mcp.sampling.create',
+  'mcp.elicitation.create': 'mcp.elicitation.create',
+};
+
+/**
+ * Build an `McpEventSink` that translates Stage 6.1 protocol log
+ * events into `usage_meters` insert rows (Stage 6.2).
+ *
+ * This is the agent-adapter-lane counterpart to the hypervisor's
+ * `setUsageMeterSink()` in `@revealui/mcp`. Both paths land rows in
+ * the same `usage_meters` table. The agent-adapter path covers the
+ * four boundaries the hypervisor doesn't own
+ * (`resource.list/read`, `prompt.list/get`, `sampling.create`,
+ * `elicitation.create`) plus the agent-side `tool.call` for
+ * `McpClient`-using agents.
+ *
+ * @example
+ * ```typescript
+ * import { usageMeters } from '@revealui/db';
+ * import {
+ *   createToolsFromMcpClient,
+ *   createUsageMeterSink,
+ * } from '@revealui/ai';
+ *
+ * const tools = await createToolsFromMcpClient(client, {
+ *   namespace: 'content',
+ *   onEvent: createUsageMeterSink({
+ *     accountId: session.accountId,
+ *     write: (row) => db.insert(usageMeters).values(row),
+ *   }),
+ * });
+ * ```
+ */
+export function createUsageMeterSink(options: CreateUsageMeterSinkOptions): McpEventSink {
+  const source = options.source ?? 'agent';
+  const genId = options.id ?? (() => crypto.randomUUID());
+  const genKey = options.idempotencyKey ?? (() => crypto.randomUUID());
+
+  return (event) => {
+    const row: McpUsageMeterRow = {
+      id: genId(event),
+      accountId: options.accountId,
+      meterName: METER_NAMES[event.kind],
+      quantity: 1,
+      periodStart: new Date(),
+      periodEnd: null,
+      source,
+      idempotencyKey: genKey(event),
+    };
+
+    const result = options.write(row);
+    if (result && typeof (result as Promise<void>).catch === 'function') {
+      (result as Promise<void>).catch((error) => {
+        logger.warn('[mcp] usage meter write rejected; continuing', {
+          event: event.kind,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+  };
+}

--- a/packages/mcp/src/__tests__/hypervisor.test.ts
+++ b/packages/mcp/src/__tests__/hypervisor.test.ts
@@ -632,4 +632,229 @@ describe('MCPHypervisor', () => {
       }).not.toThrow();
     });
   });
+
+  // ===========================================================================
+  // Stage 6.2 — usage metering sink
+  // ===========================================================================
+
+  describe('setUsageMeterSink() + emitMeter', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('emits mcp.tool.call with success: true + duration on callTool success', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      const sink = vi.fn();
+      hv.setUsageMeterSink(sink);
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', { x: 1 });
+
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await toolPromise;
+
+      expect(sink).toHaveBeenCalledTimes(1);
+      const event = sink.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(event).toMatchObject({
+        kind: 'mcp.tool.call',
+        serverName: 'test-server',
+        toolName: 'do_thing',
+        success: true,
+      });
+      expect(event).not.toHaveProperty('tenantId');
+      expect(event.duration_ms).toBeTypeOf('number');
+      expect(event.duration_ms as number).toBeGreaterThanOrEqual(0);
+    });
+
+    it('emits mcp.tool.call with success: false + error on callTool failure', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      const sink = vi.fn();
+      hv.setUsageMeterSink(sink);
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'failing_tool', {});
+
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(
+          `${JSON.stringify({
+            jsonrpc: '2.0',
+            id: req.id,
+            error: { code: -32000, message: 'server-side failure' },
+          })}\n`,
+        ),
+      );
+
+      await expect(toolPromise).rejects.toThrow(/server-side failure/);
+
+      const event = sink.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(event).toMatchObject({
+        kind: 'mcp.tool.call',
+        serverName: 'test-server',
+        toolName: 'failing_tool',
+        success: false,
+      });
+      expect(event.error).toMatch(/server-side failure/);
+    });
+
+    it('emits with tenantId populated via callToolForTenant', async () => {
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+
+      // Inject a tenant-scoped entry with a running mock process (bypass
+      // startServerForTenant's spawn + credential-resolve path).
+      const tenantEntry = {
+        config: testConfig,
+        process: mockProcess as unknown as import('node:child_process').ChildProcess,
+        tools: [],
+        healthy: true,
+        lastPingAt: null,
+      };
+      (hv as unknown as { tenantServers: Map<string, typeof tenantEntry> }).tenantServers.set(
+        'acct-123:test-server',
+        tenantEntry,
+      );
+      mockProcess.exitCode = null;
+
+      const sink = vi.fn();
+      hv.setUsageMeterSink(sink);
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callToolForTenant('test-server', 'acct-123', 'deploy', {
+        env: 'prod',
+      });
+
+      // Drive the pending request to resolution by reaching into the
+      // private map the hypervisor populated when it wrote the RPC frame.
+      await new Promise((r) => setTimeout(r, 0));
+      const pending = (
+        hv as unknown as {
+          pendingRequests: Map<
+            number,
+            { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }
+          >;
+        }
+      ).pendingRequests;
+      expect(pending.size).toBe(1);
+      const [, first] = Array.from(pending.entries())[0] ?? [];
+      clearTimeout(first?.timer);
+      first?.resolve({ content: [{ type: 'text', text: 'ok' }] });
+
+      await toolPromise;
+
+      const event = sink.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(event).toMatchObject({
+        kind: 'mcp.tool.call',
+        serverName: 'test-server',
+        toolName: 'deploy',
+        tenantId: 'acct-123',
+        success: true,
+      });
+    });
+
+    it('does not emit when no sink is registered', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      // No setUsageMeterSink call — should be a no-op.
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await expect(toolPromise).resolves.toBeDefined();
+    });
+
+    it('setUsageMeterSink(null) disables a previously-installed sink', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      const sink = vi.fn();
+      hv.setUsageMeterSink(sink);
+      hv.setUsageMeterSink(null);
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+      await toolPromise;
+
+      expect(sink).not.toHaveBeenCalled();
+    });
+
+    it('swallows synchronous sink exceptions without breaking the call', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      hv.setUsageMeterSink(() => {
+        throw new Error('sink broken');
+      });
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      // Call should still resolve successfully; the underlying result is not
+      // affected by the failing sink.
+      await expect(toolPromise).resolves.toBeDefined();
+    });
+
+    it('swallows rejected async sink promises without breaking the call', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      hv.setUsageMeterSink(async () => {
+        throw new Error('async sink failed');
+      });
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+      const req = JSON.parse((mockProcess.stdin.write.mock.calls[0]?.[0] as string).trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await expect(toolPromise).resolves.toBeDefined();
+    });
+  });
 });

--- a/packages/mcp/src/hypervisor.ts
+++ b/packages/mcp/src/hypervisor.ts
@@ -17,6 +17,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { registerCleanupHandler } from '@revealui/core/monitoring';
 import { logger } from '@revealui/core/observability/logger';
+import type { McpMeterEvent, McpMeterSink } from './metering.js';
 
 // =============================================================================
 // Types
@@ -138,6 +139,7 @@ export class MCPHypervisor {
   /** Tenant-scoped server instances: key = `${tenantId}:${serverName}` */
   private tenantServers: Map<string, ServerEntry> = new Map();
   private credentialResolver: MCPCredentialResolver | null = null;
+  private meterSink: McpMeterSink | null = null;
   private requestCounter = 0;
   private pendingRequests: Map<
     number,
@@ -453,22 +455,39 @@ export class MCPHypervisor {
         arguments: args,
       });
 
+      const durationMs = Date.now() - startTime;
       logger.info('[MCPHypervisor] Tool complete', {
         event: 'mcp.tool.complete',
         server: serverName,
         tool: toolName,
         success: true,
-        durationMs: Date.now() - startTime,
+        durationMs: durationMs,
+      });
+      this.emitMeter({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        duration_ms: durationMs,
+        success: true,
       });
 
       return result;
     } catch (error) {
+      const durationMs = Date.now() - startTime;
       logger.info('[MCPHypervisor] Tool failed', {
         event: 'mcp.tool.complete',
         server: serverName,
         tool: toolName,
         success: false,
-        durationMs: Date.now() - startTime,
+        durationMs: durationMs,
+      });
+      this.emitMeter({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        duration_ms: durationMs,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
       });
       throw error;
     }
@@ -499,6 +518,49 @@ export class MCPHypervisor {
    */
   setCredentialResolver(resolver: MCPCredentialResolver): void {
     this.credentialResolver = resolver;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Usage metering (Stage 6.2)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Install a consumer-wired metering sink. Fires exactly once per
+   * tool-call boundary (success or failure) with an `McpMeterEvent`.
+   * Sinks may be sync or async — invocation is fire-and-forget; sink
+   * errors are logged at warn and never propagate into the call path.
+   *
+   * See `./metering.ts` for the event shape. Pass `null` to disable.
+   */
+  setUsageMeterSink(sink: McpMeterSink | null): void {
+    this.meterSink = sink;
+  }
+
+  /**
+   * Fire the consumer-wired metering sink. Swallows errors so
+   * observability can never corrupt a successful tool call.
+   *
+   * @internal
+   */
+  private emitMeter(event: McpMeterEvent): void {
+    const sink = this.meterSink;
+    if (!sink) return;
+    try {
+      const result = sink(event);
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch((error) => {
+          logger.warn('[MCPHypervisor] usage meter sink rejected; continuing', {
+            event: event.kind,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+    } catch (error) {
+      logger.warn('[MCPHypervisor] usage meter sink threw; continuing', {
+        event: event.kind,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -673,24 +735,43 @@ export class MCPHypervisor {
         entry.process?.stdin?.write(`${JSON.stringify(request)}\n`);
       });
 
+      const durationMs = Date.now() - startTime;
       logger.info('[MCPHypervisor] Tenant tool complete', {
         event: 'mcp.tool.complete',
         server: serverName,
         tool: toolName,
         tenant: tenantId,
         success: true,
-        durationMs: Date.now() - startTime,
+        durationMs: durationMs,
+      });
+      this.emitMeter({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        tenantId,
+        duration_ms: durationMs,
+        success: true,
       });
 
       return result;
     } catch (error) {
+      const durationMs = Date.now() - startTime;
       logger.info('[MCPHypervisor] Tenant tool failed', {
         event: 'mcp.tool.complete',
         server: serverName,
         tool: toolName,
         tenant: tenantId,
         success: false,
-        durationMs: Date.now() - startTime,
+        durationMs: durationMs,
+      });
+      this.emitMeter({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        tenantId,
+        duration_ms: durationMs,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
       });
       throw error;
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -131,6 +131,8 @@ export {
   type MCPTool,
   type NamespacedTool,
 } from './hypervisor.js';
+// Usage metering (Stage 6.2 — tool-call boundary hook, consumer-wired sink)
+export type { McpMeterEvent, McpMeterSink } from './metering.js';
 // OAuth 2.1 client provider (Stage 2 PR-2.1 — revvault-backed credential storage)
 export {
   createMemoryVault,

--- a/packages/mcp/src/metering.ts
+++ b/packages/mcp/src/metering.ts
@@ -1,0 +1,60 @@
+/**
+ * MCP hypervisor usage metering — consumer-wired sink for tool-call boundary.
+ *
+ * Stage 6.2 of the MCP v1 plan. The hypervisor fires a structured
+ * `McpMeterEvent` once per tool call (success or failure) to a sink the
+ * consumer supplies. Consumers translate the event into whatever their
+ * downstream billing / audit layer expects — typically a row in
+ * `usage_meters` (see `@revealui/db` schema).
+ *
+ * Only the `mcp.tool.call` boundary is metered here: that's the single
+ * MCP primitive the hypervisor actually owns today (JSON-RPC
+ * `tools/call`). The other four boundaries (resource reads, prompt
+ * lookups, sampling, elicitation) live in `@revealui/ai`'s MCP adapter
+ * and are metered there via `createUsageMeterSink()` over Stage 6.1's
+ * `McpEventSink`. Both paths converge on the same `usage_meters`
+ * table.
+ *
+ * Why a sink instead of a direct db write? `@revealui/mcp` has no
+ * `@revealui/db` runtime dependency — the same structural-decoupling
+ * discipline Stage 5 held between `@revealui/ai` and `@revealui/mcp`.
+ * Consumers (admin app, agent runtime) wire the sink with their own
+ * db handle + tenant-to-account mapping at construction time.
+ */
+
+/**
+ * Event payload fired once per hypervisor tool-call boundary.
+ */
+export interface McpMeterEvent {
+  /**
+   * Boundary discriminator. Stage 6.2 only emits `'mcp.tool.call'`
+   * from the hypervisor; the union is reserved for future additions
+   * if/when the hypervisor migration to `McpClient` lands and it
+   * starts owning more boundaries.
+   */
+  kind: 'mcp.tool.call';
+  /** Registered server name (unprefixed). */
+  serverName: string;
+  /** Tool name (no `@@mcp_<server>__` prefix). */
+  toolName: string;
+  /**
+   * Tenant identifier when the call went through
+   * `callToolForTenant`; `undefined` for non-tenant `callTool` calls
+   * (local / singleton registry path).
+   */
+  tenantId?: string;
+  /** Wall-clock duration from entry to exit in milliseconds. */
+  duration_ms: number;
+  /** `true` when the JSON-RPC call resolved; `false` on throw / timeout. */
+  success: boolean;
+  /** Server-reported error message on failure. Omitted on success. */
+  error?: string;
+}
+
+/**
+ * Consumer-wired metering sink. Called exactly once per metered
+ * boundary. Either synchronous or async — the hypervisor does not
+ * await; sink errors are swallowed so observability cannot break the
+ * underlying call.
+ */
+export type McpMeterSink = (event: McpMeterEvent) => void | Promise<void>;


### PR DESCRIPTION
## Summary

Stage 6.2 of internal docs — usage metering via two composable paths that converge on the existing `usage_meters` table in `@revealui/db`. **Closes v1** when merged.

## The two paths

Ground-truth inspection showed the hypervisor only owns 1 of the 5 boundaries the scope doc's "candidates" list implied. Split shape:

### Hypervisor path — `@revealui/mcp`

`MCPHypervisor` grows `setUsageMeterSink(sink | null)`. Fires `McpMeterEvent` once per `callTool` / `callToolForTenant` with `{ kind: 'mcp.tool.call', serverName, toolName, tenantId?, duration_ms, success, error? }`. Covers the one boundary the hypervisor actually owns today (JSON-RPC `tools/call`).

New module: `packages/mcp/src/metering.ts` — defines `McpMeterEvent` + `McpMeterSink` types only; no runtime behavior.

### Agent-adapter path — `@revealui/ai`

`createUsageMeterSink({ accountId, write, source?, idempotencyKey?, id? })` in `packages/ai/src/tools/mcp-events.ts` translates Stage 6.1 `McpLogEvent`s into `usage_meters` insert rows. Covers the four boundaries the hypervisor doesn't own — `resource.list/read`, `prompt.list/get`, `sampling.create`, `elicitation.create` — plus the agent-side `tool.call` for `McpClient`-using agents.

## Structural-decoupling posture

- `@revealui/mcp` still has no `@revealui/db` runtime dep. The sink is a callback; consumer plugs in a db client.
- Agent-side sink accepts `write: (row) => void | Promise<void>` — any db client shape works (raw Drizzle, wrapped, test double).
- Agent adapter stays tenant-agnostic. Consumer binds `accountId` at sink construction.
- Both sinks swallow thrown / rejected writes (logged at warn, MCP call unaffected).

## Design calls

- **Default `idempotencyKey` + `id` use `crypto.randomUUID()`** — safe, never collides, no retry coalescence. Consumers override with deterministic generators (e.g. `${requestId}:${kind}`) to collapse duplicates.
- **`quantity: 1` per call** — row-per-call pattern; billing aggregation rolls these up. Larger quantity only when the meter represents volume (tokens, bytes).
- **`source` defaults to `'agent'`** — per `usage_meters.source` CHECK constraint (`'system' | 'user' | 'agent' | 'api'`). Consumer can override for `'api'`-originated or `'user'`-originated paths.
- **Meter names are 1:1 with event kinds** (`mcp.tool.call`, `mcp.resource.read`, ...). Both paths write to the same taxonomy.

## Changes

- `packages/mcp/src/metering.ts` (new, ~60 LOC) — event/sink types.
- `packages/mcp/src/hypervisor.ts` — `meterSink` field, `setUsageMeterSink()` setter, `emitMeter()` safe-dispatch; wired into `callTool` + `callToolForTenant` at success + error branches.
- `packages/mcp/src/index.ts` — export `McpMeterEvent` + `McpMeterSink` types.
- `packages/ai/src/tools/mcp-events.ts` — `McpUsageMeterRow`, `McpUsageMeterWriter`, `CreateUsageMeterSinkOptions`, `createUsageMeterSink()`, internal `METER_NAMES` map.

## Tests

- `@revealui/mcp`: **203 → 210 passing** (+7 hypervisor metering tests — success emission, failure emission, tenant-id population, no-sink default, `null` disable, sync throw swallow, async reject swallow).
- `@revealui/ai`: **938 → 951 passing** (+8 sink tests — default row shape, meter-name mapping across all 5 event kinds, custom source / id / idempotencyKey, row-on-failure, async write reject, sync throw via `emitMcpEvent`).
- Typecheck + biome clean across both packages (1 pre-existing `countSchemaFields` warn from Stage 5.3 unrelated).

## Test plan

- [x] `pnpm --filter @revealui/mcp test` — 210 pass, 5 skipped, 14 files
- [x] `pnpm --filter @revealui/ai test` — 951 pass, 63 files
- [x] `pnpm --filter @revealui/mcp --filter @revealui/ai typecheck` — clean
- [x] `pnpm --filter @revealui/mcp --filter @revealui/ai lint` — clean for this diff
- [x] `pnpm turbo build --filter @revealui/ai --filter @revealui/mcp` — 11/11

## Deferred

- **Hypervisor migration to `McpClient`** — still the strategic follow-on. When it lands, the hypervisor will own all 5 boundaries natively and the agent-adapter sink path becomes its consumer (composition, not replacement).
- **Stripe wiring** — v1.1 marketplace concern per scope doc §5.5.
- **Admin UI dashboards** — per-meter histograms / latency charts on the admin `/admin/mcp` page. Their own design thread.

Closes Stage 6.2 and v1 of the MCP productionization plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
