### PR TITLE
docs(roadmap): link Developer Experience to umbrella tracker #535

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,11 +121,11 @@ Give users the ability to interact with an AI agent directly from the admin dash
 - RevKit agent coordination protocol extraction as `@revealui/workboard`  -  MIT standalone package. _Currently: implementation lives inside `@revealui/harnesses` (FSL-1.1-MIT Pro) at `packages/harnesses/src/workboard/`; extraction brings it in line with the PRO.md declaration that RevKit agent coordination is MIT-free._
 - Unified ecosystem messaging across marketing, docs, and pricing surfaces _(drift-control work, not a new feature)_
 
-#### Developer Experience
-- `create-revealui` template improvements (more starters, better defaults)
-- Hot module reload improvements for admin development
-- Better error messages and debugging output
-- Plugin system documentation
+#### Developer Experience — [#535](https://github.com/RevealUIStudio/revealui/issues/535)
+- `create-revealui` template improvements (more starters, better defaults). _Currently: `@revealui/cli` ships 4 templates (`basic-blog`, `e-commerce`, `portfolio`, `starter`) at `packages/cli/templates/`; bullet covers template audit + one new opinionated-SaaS starter + smoother prompts + post-init onboarding._
+- Hot module reload improvements for admin development. _Currently: admin runs Next.js 16 with Turbopack configured; bullet covers baseline measurement + collection-definition HMR + RichText plugin HMR + dev-startup optimization._
+- Better error messages and debugging output. _Currently: `packages/core/src/error-handling/` ships boundaries + reporter + fallbacks + Sentry wired per §CR-8 Phase 1; bullet covers user-facing error audit + opaque → actionable rewrites + structured `DEBUG=revealui:*` namespaces + API error-envelope consistency._
+- Plugin system documentation. _Currently: Plugin API lives at `packages/core/src/types/plugins.ts` with 3 first-party plugins (`form-builder`, `nested-docs`, `redirects`) but no dedicated `docs/PLUGINS.md`; bullet closes that documentation gap._
 
 ### Mid-Term (Q3 2026)
 


### PR DESCRIPTION
## Summary

Links `docs/ROADMAP.md` §Near-Term Developer Experience heading to new umbrella tracker [#535](https://github.com/RevealUIStudio/revealui/issues/535) and adds reality-anchor italics under each of the four planned sub-bullets.

CR-9 P1-05 round-5 continuation — remaining ROADMAP future-tense markers.

## Scope

Single-file edit: `docs/ROADMAP.md` lines 124-128.

**Heading:** `#### Developer Experience` → `#### Developer Experience — [#535]`

**Sub-bullets** (each gets a `_Currently: ..._` italic naming existing work + the gap):

- `create-revealui` template improvements — names 4 existing templates (`basic-blog`, `e-commerce`, `portfolio`, `starter`) at `packages/cli/templates/`; bullet covers template audit + new opinionated-SaaS starter + smoother prompts + post-init onboarding.
- Admin HMR — names Next.js 16 + Turbopack already configured; bullet covers baseline measurement + collection-definition/RichText-plugin HMR + dev-startup time reduction.
- Error messages + debugging — names `packages/core/src/error-handling/` (boundaries + reporter + fallbacks) + Sentry wired per §CR-8 Phase 1; bullet covers user-facing error audit + opaque-to-actionable rewrites + structured `DEBUG=revealui:*` namespaces + API error-envelope consistency.
- Plugin system docs — names the Plugin API at `packages/core/src/types/plugins.ts` + 3 first-party plugins (`form-builder`, `nested-docs`, `redirects`) + the **missing** `docs/PLUGINS.md`; bullet closes that documentation gap.

No other edits.

## Tracker scope (#535)

Umbrella covering 4 planned DX sub-surfaces, matching the #515 / #528 multi-section umbrella precedent.

Structure:
- **Section A — `create-revealui` template improvements.** Existing state enumerated (v0.5.5 wrapper + v0.7.0 CLI with 4 templates + full codemod/installer runtime). 7 acceptance criteria: template audit, one new opinionated-SaaS starter, smoother default-ful prompts, polished post-init onboarding, template README consistency, CI validation, changeset version bump.
- **Section B — Admin HMR improvements.** Existing state enumerated (Next.js 16.2.4 + Turbopack). 7 acceptance criteria: baseline measurement (before optimizing), collection-definition HMR, schema-driven regeneration, RichText plugin HMR, dev-startup reduction, dev-log noise cleanup, `docs/guides/admin-dev.md`.
- **Section C — Better errors + debugging.** Existing state enumerated (full error-handling module + Sentry already wired per §CR-8 Phase 1). 7 acceptance criteria: user-facing error audit, opaque-to-actionable rewrites (top 20), dev-mode stack filtering, structured `DEBUG` namespaces in 3 hotspots, API error envelope consistency + enforcing test, admin toast format with error code + copy button, `docs/guides/errors-and-debugging.md`.
- **Section D — Plugin system docs.** Existing state named + documentation gap called out. 7 acceptance criteria: authoritative `docs/PLUGINS.md`, first-party plugin reference docs, plugin API stability declaration, runnable example, `docs/INDEX.md` + `README.md` cross-links, `packages/core/src/plugins/README.md`, plugin-authoring convention notes.
- Scope guardrails: not a CLI rebuild / not a Next.js upgrade / not a Sentry rework / not a plugin-API redesign / not open-ended DX / not a charge-gate.
- Dependencies table acknowledging Sentry already shipped (reusable for Section C baseline), Turbopack stable (no Section B block), plugin API de-facto stable (Section D declares it, not block).

## Why reality-anchor italics on each sub-bullet

Same reasoning as #529 (Ecosystem Integration). Each DX bullet points at substantial existing infrastructure — reader needs to see the "existing ramp" before treating the item as greenfield. Plugin system especially: code exists, *docs* don't — naming that mismatch prevents scope creep into API redesign.

## Verification

- [x] Ground-truth verified — every "existing work" claim in #535 cross-referenced against actual files (`packages/cli/templates/{basic-blog,e-commerce,portfolio,starter}/`, `packages/cli/package.json` v0.7.0, `packages/create-revealui/package.json` v0.5.5, `apps/admin/next.config.*` Turbopack block, `packages/core/src/error-handling/` README + modules, `packages/core/src/types/plugins.ts` Plugin type, `packages/core/src/plugins/{form-builder,nested-docs,redirects}.ts`)
- [x] Confirmed absence of `docs/PLUGINS.md` or equivalent via `ls docs/` + grep
- [x] No code changes; zero runtime risk
- [x] Claim-drift scanner parenthesized-marker pattern: PR adds zero new parens, only italicized prose — same safety as #517 / #527 / #529
- [x] Zero file overlap with MCP session's lane — MCP v1 closed 2026-04-23 at Stage 6.2 (`5360a8203`); lane is quiet

## Test plan

- [ ] CI passes (15/15 green; E2E skips expected on chore branch)
- [ ] Tracker #535 renders cleanly on GitHub
- [ ] ROADMAP.md heading link resolves to #535

## References

- Precedents: revealui#517 (round-2), revealui#527 (round-3 Agent Marketplace), revealui#529 (round-4 Ecosystem Integration)
- Sibling trackers: [#514](https://github.com/RevealUIStudio/revealui/issues/514) / [#515](https://github.com/RevealUIStudio/revealui/issues/515) / [#516](https://github.com/RevealUIStudio/revealui/issues/516) / [#526](https://github.com/RevealUIStudio/revealui/issues/526) / [#528](https://github.com/RevealUIStudio/revealui/issues/528)
- §CR-8 Phase 1 Sentry wiring: prior reference for Section C
