### PR TITLE
feat(api, mcp): wire Stage 5+6 MCP primitives at /api/agent-stream (A.1)

### DIFF
--- a/.changeset/mcp-a1-backend-wiring.md
+++ b/.changeset/mcp-a1-backend-wiring.md
@@ -1,0 +1,40 @@
+---
+'@revealui/mcp': minor
+'api': minor
+'admin': patch
+---
+
+A.1 of the post-v1 MCP arc — first production consumer of Stage 5 + Stage 6
+primitives at `/api/agent-stream`. `usage_meters` rows now flow for real
+agent runs whose session resolves to a billing account, and MCP protocol
+events land in the central log aggregator.
+
+**`@revealui/mcp`:**
+- New `@revealui/mcp/remote-client` export. Extracts the admin-local
+  `buildRemoteMcpClient` + adds `listConnectedMcpServers(vault, tenant)` so
+  the API app can discover a tenant's OAuth-authorized servers and connect
+  to them without duplicating admin code.
+
+**`api`:**
+- New `apps/api/src/lib/metering.ts` — `recordUsageMeter()` thin writer
+  around `db.insert(usageMeters).values(row).onConflictDoNothing()`.
+  `@revealui/db` stays schema-only.
+- `apps/api/src/routes/agent-stream.ts` resolves the tenant (from
+  `X-Tenant-ID` via `tenantMiddleware`) and the `accountId` (from the
+  global `entitlementMiddleware`), builds `McpClient`s for every
+  OAuth-authorized server the tenant has, merges those tools into the
+  agent's tool list, and composes an `onEvent` sink that fans Stage 6.1
+  protocol events into `createCoreLoggerSink()` plus — when `accountId`
+  is known — `createUsageMeterSink({ accountId, write: recordUsageMeter })`.
+- Safe fallbacks hold the existing behavior when a request has no tenant
+  or no active account membership: empty `mcpClients`, logger-only sink.
+- MCP clients opened during the request are closed in the streamSSE
+  finally so sockets + OAuth-refresh timers don't leak.
+
+**`admin`:**
+- `apps/admin/src/lib/mcp/remote-server-client.ts` becomes a re-export
+  shim pointing at `@revealui/mcp/remote-client`; existing admin route
+  imports keep working untouched.
+- `apps/admin/src/app/api/mcp/remote-servers/route.ts` consumes the
+  shared `listConnectedMcpServers` helper instead of the inline
+  enumeration.

--- a/apps/admin/src/app/api/mcp/remote-servers/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/route.ts
@@ -7,11 +7,14 @@
  * connected; missing tokens count as disconnected (and simply aren't listed
  * here — the catalog UI surfaces the "connect" CTA separately).
  *
- * Stage 3.1 of the MCP v1 plan.
+ * Stage 3.1 of the MCP v1 plan; enumeration logic extracted to
+ * `@revealui/mcp/remote-client` in A.1 of the post-v1 arc so the API app
+ * can reuse it.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { createRevvaultVault } from '@revealui/mcp/oauth';
+import { listConnectedMcpServers } from '@revealui/mcp/remote-client';
 import { type NextRequest, NextResponse } from 'next/server';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
@@ -57,21 +60,13 @@ export async function GET(
   }
 
   const vault = createRevvaultVault();
-  const paths = await vault.list(`mcp/${tenant}/`);
+  const serverIds = await listConnectedMcpServers(vault, tenant);
 
-  // Match `mcp/<tenant>/<server>/tokens` and collect unique server ids.
-  const serverIds = new Set<string>();
-  for (const path of paths) {
-    const segments = path.split('/');
-    if (segments.length === 4 && segments[3] === 'tokens') {
-      const server = segments[2];
-      if (server && IDENTIFIER_RE.test(server)) serverIds.add(server);
-    }
-  }
-
-  const servers: RemoteMcpServerSummary[] = Array.from(serverIds)
-    .sort()
-    .map((server) => ({ tenant, server, connectionState: 'connected' }));
+  const servers: RemoteMcpServerSummary[] = serverIds.map((server) => ({
+    tenant,
+    server,
+    connectionState: 'connected',
+  }));
 
   return NextResponse.json({ servers });
 }

--- a/apps/admin/src/lib/mcp/remote-server-client.ts
+++ b/apps/admin/src/lib/mcp/remote-server-client.ts
@@ -1,127 +1,14 @@
 /**
- * Helper for constructing an `McpClient` against an OAuth-authorized remote
- * MCP server using credentials already persisted in the vault.
- *
- * Callers supply `(tenant, server)`. We read the non-credential meta record
- * (`mcp/<tenant>/<server>/meta`) to recover the server URL, then construct
- * an `McpOAuthProvider` that feeds the streamable-http transport. The
- * returned client is configured but NOT yet connected — callers invoke
- * `connect()` themselves so they can manage teardown.
- *
- * Stage 3.2 of the MCP v1 plan.
+ * Backward-compat shim. The implementation moved to
+ * `@revealui/mcp/remote-client` so the API app can share it with admin
+ * without duplicating OAuth-provider wiring. Existing admin imports keep
+ * working via this re-export.
  */
 
-import { type ElicitationHandler, McpClient } from '@revealui/mcp/client';
-import {
-  createRevvaultVault,
-  McpOAuthProvider,
-  type OAuthClientMetadata,
-  type Vault,
-} from '@revealui/mcp/oauth';
-
-/** Stored alongside tokens by the OAuth callback. */
-export interface RemoteServerMeta {
-  serverUrl: string;
-  connectedAt: string;
-  connectedBy: string;
-}
-
-export class RemoteServerNotConnectedError extends Error {
-  constructor(
-    public readonly tenant: string,
-    public readonly server: string,
-  ) {
-    super(
-      `No OAuth meta found for mcp/${tenant}/${server}. ` +
-        'Re-authorize the server via /admin/mcp/connect.',
-    );
-    this.name = 'RemoteServerNotConnectedError';
-  }
-}
-
-/**
- * Non-authoritative placeholder; the provider reuses the originally-registered
- * client info saved at `mcp/<tenant>/<server>/client`. Only shape is required
- * by the provider constructor.
- */
-const SENTINEL_CLIENT_METADATA: OAuthClientMetadata = {
-  redirect_uris: ['http://localhost/unused'],
-  client_name: 'RevealUI Admin (runtime)',
-  grant_types: ['authorization_code', 'refresh_token'],
-  response_types: ['code'],
-  token_endpoint_auth_method: 'none',
-};
-
-export interface BuildRemoteMcpClientOptions {
-  tenant: string;
-  server: string;
-  /** Injected for tests; defaults to the revvault-backed vault. */
-  vault?: Vault;
-  /** Client name reported during `initialize`. */
-  clientName?: string;
-  /** Client version reported during `initialize`. */
-  clientVersion?: string;
-  /**
-   * Handler invoked when the server sends `elicitation/create`. Registered
-   * on the `McpClient` at construction time so capability advertisement
-   * matches what the caller can actually service.
-   */
-  elicitationHandler?: ElicitationHandler;
-}
-
-export interface BuiltRemoteMcpClient {
-  client: McpClient;
-  meta: RemoteServerMeta;
-}
-
-/**
- * Load OAuth credentials + server URL and return a configured `McpClient`.
- * Throws {@link RemoteServerNotConnectedError} if no meta record exists for
- * the `(tenant, server)` pair.
- */
-export async function buildRemoteMcpClient(
-  options: BuildRemoteMcpClientOptions,
-): Promise<BuiltRemoteMcpClient> {
-  const { tenant, server } = options;
-  const vault = options.vault ?? createRevvaultVault();
-
-  const metaPath = `mcp/${tenant}/${server}/meta`;
-  const rawMeta = await vault.get(metaPath);
-  if (!rawMeta) throw new RemoteServerNotConnectedError(tenant, server);
-  const meta = parseMeta(rawMeta);
-
-  const provider = new McpOAuthProvider({
-    tenant,
-    server,
-    vault,
-    redirectUrl: 'http://localhost/unused',
-    clientMetadata: SENTINEL_CLIENT_METADATA,
-  });
-
-  const client = new McpClient({
-    clientInfo: {
-      name: options.clientName ?? 'revealui-admin',
-      version: options.clientVersion ?? '0.0.0',
-    },
-    transport: {
-      kind: 'streamable-http',
-      url: meta.serverUrl,
-      authProvider: provider,
-    },
-    ...(options.elicitationHandler ? { elicitationHandler: options.elicitationHandler } : {}),
-  });
-
-  return { client, meta };
-}
-
-function parseMeta(raw: string): RemoteServerMeta {
-  const parsed = JSON.parse(raw) as Partial<RemoteServerMeta>;
-  if (
-    typeof parsed.serverUrl !== 'string' ||
-    typeof parsed.connectedAt !== 'string' ||
-    typeof parsed.connectedBy !== 'string'
-  ) {
-    throw new Error('Stored MCP remote-server meta is missing required fields');
-  }
-  return parsed as RemoteServerMeta;
-}
+export {
+  type BuildRemoteMcpClientOptions,
+  type BuiltRemoteMcpClient,
+  buildRemoteMcpClient,
+  type RemoteServerMeta,
+  RemoteServerNotConnectedError,
+} from '@revealui/mcp/remote-client';

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/mcp": "workspace:*",
     "@revealui/openapi": "workspace:*",
     "@sentry/node": "^10.49.0",
     "@vercel/blob": "^2.3.3",

--- a/apps/api/src/lib/__tests__/metering.test.ts
+++ b/apps/api/src/lib/__tests__/metering.test.ts
@@ -1,0 +1,136 @@
+/**
+ * PGlite-backed integration test for `recordUsageMeter`. Exercises the
+ * real SQL path end-to-end — insert validates against schema constraints
+ * (NOT NULL accountId fk, source CHECK, unique idempotencyKey).
+ */
+
+import type { McpUsageMeterRow } from '@revealui/ai';
+import { accounts, usageMeters } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return {
+    ...actual,
+    getClient: () => testDb.drizzle,
+  };
+});
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+async function seedAccount(db: TestDb, id = 'acct_test'): Promise<string> {
+  await db.drizzle.insert(accounts).values({
+    id,
+    name: 'Test Account',
+    slug: `test-${id}`,
+    status: 'active',
+  });
+  return id;
+}
+
+function makeRow(overrides: Partial<McpUsageMeterRow> = {}): McpUsageMeterRow {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    accountId: overrides.accountId ?? 'acct_test',
+    meterName: overrides.meterName ?? 'mcp.tool.call',
+    quantity: overrides.quantity ?? 1,
+    periodStart: overrides.periodStart ?? new Date('2026-04-23T22:00:00Z'),
+    periodEnd: overrides.periodEnd ?? null,
+    source: overrides.source ?? 'agent',
+    idempotencyKey: overrides.idempotencyKey ?? crypto.randomUUID(),
+  };
+}
+
+describe('recordUsageMeter', () => {
+  beforeEach(async () => {
+    testDb = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await testDb.close();
+  });
+
+  it('persists a usage_meters row', async () => {
+    const { recordUsageMeter } = await import('../metering.js');
+    await seedAccount(testDb);
+
+    const row = makeRow({ meterName: 'mcp.tool.call' });
+    await recordUsageMeter(row);
+
+    const persisted = await testDb.drizzle
+      .select()
+      .from(usageMeters)
+      .where(eq(usageMeters.idempotencyKey, row.idempotencyKey));
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      accountId: 'acct_test',
+      meterName: 'mcp.tool.call',
+      quantity: 1,
+      source: 'agent',
+    });
+  });
+
+  it('is idempotent on idempotencyKey (duplicate call keeps one row)', async () => {
+    const { recordUsageMeter } = await import('../metering.js');
+    await seedAccount(testDb);
+
+    const key = 'mcp.tool.call:acct_test:linear:search_issues:1714000000000';
+    const first = makeRow({ idempotencyKey: key, meterName: 'mcp.tool.call' });
+    const second = makeRow({
+      idempotencyKey: key,
+      meterName: 'mcp.tool.call',
+      // New synthetic id — schema allows, but the unique key should still dedupe.
+    });
+
+    await recordUsageMeter(first);
+    await recordUsageMeter(second);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(usageMeters)
+      .where(eq(usageMeters.idempotencyKey, key));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(first.id);
+  });
+
+  it('persists rows for every supported `kind` → `meterName` mapping', async () => {
+    const { recordUsageMeter } = await import('../metering.js');
+    await seedAccount(testDb);
+
+    const kinds: McpUsageMeterRow['meterName'][] = [
+      'mcp.tool.call',
+      'mcp.resource.list',
+      'mcp.resource.read',
+      'mcp.prompt.list',
+      'mcp.prompt.get',
+      'mcp.sampling.create',
+      'mcp.elicitation.create',
+    ];
+
+    for (const meterName of kinds) {
+      await recordUsageMeter(makeRow({ meterName }));
+    }
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(usageMeters)
+      .where(eq(usageMeters.accountId, 'acct_test'));
+    expect(rows.map((r) => r.meterName).sort()).toEqual([...kinds].sort());
+  });
+
+  it('rejects rows whose accountId does not exist (fk violation propagates)', async () => {
+    const { recordUsageMeter } = await import('../metering.js');
+    // Intentionally skip seedAccount — the row references a nonexistent account.
+
+    await expect(recordUsageMeter(makeRow({ accountId: 'acct_missing' }))).rejects.toThrow();
+  });
+});

--- a/apps/api/src/lib/__tests__/metering.test.ts
+++ b/apps/api/src/lib/__tests__/metering.test.ts
@@ -4,8 +4,7 @@
  * (NOT NULL accountId fk, source CHECK, unique idempotencyKey).
  */
 
-import type { McpUsageMeterRow } from '@revealui/ai';
-import { accounts, usageMeters } from '@revealui/db/schema';
+import { accounts, type NewUsageMeter, usageMeters } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -37,7 +36,7 @@ async function seedAccount(db: TestDb, id = 'acct_test'): Promise<string> {
   return id;
 }
 
-function makeRow(overrides: Partial<McpUsageMeterRow> = {}): McpUsageMeterRow {
+function makeRow(overrides: Partial<NewUsageMeter> = {}): NewUsageMeter {
   return {
     id: overrides.id ?? crypto.randomUUID(),
     accountId: overrides.accountId ?? 'acct_test',
@@ -106,7 +105,7 @@ describe('recordUsageMeter', () => {
     const { recordUsageMeter } = await import('../metering.js');
     await seedAccount(testDb);
 
-    const kinds: McpUsageMeterRow['meterName'][] = [
+    const kinds: string[] = [
       'mcp.tool.call',
       'mcp.resource.list',
       'mcp.resource.read',

--- a/apps/api/src/lib/metering.ts
+++ b/apps/api/src/lib/metering.ts
@@ -1,0 +1,34 @@
+/**
+ * Usage-meter writer for apps/api. Persists `usage_meters` rows produced
+ * by `@revealui/ai/createUsageMeterSink` (agent-adapter boundary) and
+ * `@revealui/mcp.MCPHypervisor.setUsageMeterSink()` (hypervisor boundary).
+ *
+ * Design note. `@revealui/db` stays schema-only by convention — no
+ * `writers/` surface. The single concrete insert lives here so agent-side
+ * code has one import target and a uniform place to grow retention,
+ * dedup, or alerting logic once the first usage data lands.
+ *
+ * Per A.1 of the post-v1 MCP arc; see
+ * `.jv/docs/admin-mcp-integration-scope.md` §1.A.1 Q3 for the rationale.
+ */
+
+import type { McpUsageMeterRow } from '@revealui/ai';
+import { getClient } from '@revealui/db';
+import { usageMeters } from '@revealui/db/schema';
+
+/**
+ * Persist a single `usage_meters` row. Idempotent via the unique index on
+ * `idempotency_key` — retries of the same semantic call collapse to a
+ * single row when the caller supplies a stable key. The default generator
+ * in `createUsageMeterSink` uses a fresh UUID per event (no coalescence);
+ * override with a deterministic key whenever retry dedup matters.
+ *
+ * Write failures propagate; both `createUsageMeterSink` and
+ * `MCPHypervisor.setUsageMeterSink` wrap their writer in safe-dispatch so
+ * a thrown error is logged at warn but never breaks the underlying MCP
+ * protocol call.
+ */
+export async function recordUsageMeter(row: McpUsageMeterRow): Promise<void> {
+  const db = getClient();
+  await db.insert(usageMeters).values(row).onConflictDoNothing();
+}

--- a/apps/api/src/lib/metering.ts
+++ b/apps/api/src/lib/metering.ts
@@ -12,9 +12,8 @@
  * `.jv/docs/admin-mcp-integration-scope.md` §1.A.1 Q3 for the rationale.
  */
 
-import type { McpUsageMeterRow } from '@revealui/ai';
 import { getClient } from '@revealui/db';
-import { usageMeters } from '@revealui/db/schema';
+import { type NewUsageMeter, usageMeters } from '@revealui/db/schema';
 
 /**
  * Persist a single `usage_meters` row. Idempotent via the unique index on
@@ -28,7 +27,7 @@ import { usageMeters } from '@revealui/db/schema';
  * a thrown error is logged at warn but never breaks the underlying MCP
  * protocol call.
  */
-export async function recordUsageMeter(row: McpUsageMeterRow): Promise<void> {
+export async function recordUsageMeter(row: NewUsageMeter): Promise<void> {
   const db = getClient();
   await db.insert(usageMeters).values(row).onConflictDoNothing();
 }

--- a/apps/api/src/routes/__tests__/agent-stream-success.test.ts
+++ b/apps/api/src/routes/__tests__/agent-stream-success.test.ts
@@ -59,6 +59,12 @@ vi.mock('hono/streaming', () => ({
 
 vi.mock('@revealui/ai', () => ({
   createLLMClientFromEnv: vi.fn().mockReturnValue({ type: 'env-client' }),
+  // A.1: agent-stream composes Stage 6.1/6.2 sinks + builds MCP tools from
+  // tenant-connected servers. Stub each factory with a harmless
+  // no-op; tests that care about sink behavior set their own spies.
+  createCoreLoggerSink: vi.fn().mockReturnValue(() => {}),
+  createUsageMeterSink: vi.fn().mockReturnValue(() => {}),
+  createToolsFromMcpClient: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@revealui/ai/llm/client', () => ({
@@ -159,8 +165,16 @@ beforeEach(async () => {
   vi.clearAllMocks();
   capturedEvents.length = 0;
 
-  const { createLLMClientFromEnv } = await import('@revealui/ai');
+  const {
+    createLLMClientFromEnv,
+    createCoreLoggerSink,
+    createUsageMeterSink,
+    createToolsFromMcpClient,
+  } = await import('@revealui/ai');
   vi.mocked(createLLMClientFromEnv).mockReturnValue({ type: 'env-client' });
+  vi.mocked(createCoreLoggerSink).mockReturnValue(() => {});
+  vi.mocked(createUsageMeterSink).mockReturnValue(() => {});
+  vi.mocked(createToolsFromMcpClient).mockResolvedValue([]);
 
   const { LLMClient } = await import('@revealui/ai/llm/client');
   // biome-ignore lint/complexity/useArrowFunction: LLMClient is called with `new`  -  arrow functions cannot be constructors (Vitest 4)

--- a/apps/api/src/routes/agent-stream.ts
+++ b/apps/api/src/routes/agent-stream.ts
@@ -10,9 +10,20 @@
  * See packages/ai/src/client/hooks/useAgentStream.ts for the React hook.
  */
 
+import type { McpEventSink } from '@revealui/ai';
+import { logger } from '@revealui/core/observability/logger';
+import type { McpClient } from '@revealui/mcp/client';
+import { createRevvaultVault } from '@revealui/mcp/oauth';
+import {
+  buildRemoteMcpClient,
+  listConnectedMcpServers,
+  RemoteServerNotConnectedError,
+} from '@revealui/mcp/remote-client';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
 import { streamSSE } from 'hono/streaming';
+import { recordUsageMeter } from '../lib/metering.js';
+import { getEntitlementsFromContext } from '../middleware/entitlements.js';
 
 type Variables = {
   tenant?: { id: string };
@@ -200,7 +211,66 @@ app.openapi(agentStreamRoute, async (c) => {
     }
   }
 
-  const allTools = [...cmsTools, ...codingTools];
+  const allTools: unknown[] = [...cmsTools, ...codingTools];
+
+  // ─── Stage 5 + 6 integration (A.1) ────────────────────────────────────
+  // Connect the tenant's OAuth-authorized MCP servers and merge their
+  // tools into `allTools`. Compose a protocol-log sink that fans
+  // Stage 6.1 events into the central logger and, when an `accountId`
+  // is resolvable from entitlements, into `usage_meters`. Safe
+  // fallback: no tenant header → `mcpClients: []`, just the logger sink.
+  const mcpClients: McpClient[] = [];
+  const tenant = c.get('tenant')?.id;
+  const accountId = getEntitlementsFromContext(c).accountId;
+
+  const loggerSink = aiMod.createCoreLoggerSink();
+  const meterSink = accountId
+    ? aiMod.createUsageMeterSink({
+        accountId,
+        write: (row) => recordUsageMeter(row),
+      })
+    : undefined;
+  const onEvent: McpEventSink = meterSink
+    ? (event) => {
+        loggerSink(event);
+        meterSink(event);
+      }
+    : loggerSink;
+
+  if (tenant) {
+    let serverIds: string[] = [];
+    try {
+      serverIds = await listConnectedMcpServers(createRevvaultVault(), tenant);
+    } catch (error) {
+      logger.warn('[agent-stream] failed to list MCP servers for tenant', {
+        tenant,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    for (const server of serverIds) {
+      try {
+        const built = await buildRemoteMcpClient({ tenant, server });
+        await built.client.connect();
+        const mcpTools = await aiMod.createToolsFromMcpClient(built.client, {
+          namespace: server,
+          onEvent,
+        });
+        mcpClients.push(built.client);
+        allTools.push(...mcpTools);
+      } catch (error) {
+        // Per-server isolation — one server failing doesn't break the
+        // whole agent call. Re-auth required is silent (expected).
+        if (!(error instanceof RemoteServerNotConnectedError)) {
+          logger.warn('[agent-stream] failed to connect MCP server', {
+            tenant,
+            server,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
 
   const localDisclaimer = isLocalOnly
     ? '\n\nYou are in free tier mode. You can read and search code but cannot make edits, run commands, or perform git operations. Upgrade to Pro for full coding capabilities.'
@@ -281,6 +351,12 @@ Workspace: ${workspaceId}`,
         }),
         event: 'error',
       });
+    } finally {
+      // Tear down any MCP clients we connected at handler entry so
+      // sockets + OAuth-refresh timers don't leak across requests.
+      for (const client of mcpClients) {
+        await client.close().catch(() => undefined);
+      }
     }
   });
 });

--- a/apps/api/src/routes/agent-stream.ts
+++ b/apps/api/src/routes/agent-stream.ts
@@ -10,7 +10,6 @@
  * See packages/ai/src/client/hooks/useAgentStream.ts for the React hook.
  */
 
-import type { McpEventSink } from '@revealui/ai';
 import { logger } from '@revealui/core/observability/logger';
 import type { McpClient } from '@revealui/mcp/client';
 import { createRevvaultVault } from '@revealui/mcp/oauth';
@@ -230,6 +229,11 @@ app.openapi(agentStreamRoute, async (c) => {
         write: (row) => recordUsageMeter(row),
       })
     : undefined;
+  // Type of the Stage 6.1 event sink, derived from @revealui/ai via
+  // the lazy-imported aiMod so apps/api keeps zero static references to
+  // the optional Pro package (enforced by scripts/validate/boundary.ts).
+  type AiMod = NonNullable<typeof aiMod>;
+  type McpEventSink = ReturnType<AiMod['createCoreLoggerSink']>;
   const onEvent: McpEventSink = meterSink
     ? (event) => {
         loggerSink(event);

--- a/packages/mcp/__tests__/remote-client.test.ts
+++ b/packages/mcp/__tests__/remote-client.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for {@link listConnectedMcpServers}. Uses the in-memory vault
+ * so tests are hermetic — no revvault subprocess, no network.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMemoryVault, RevvaultError } from '../src/oauth.js';
+import { listConnectedMcpServers } from '../src/remote-client.js';
+
+describe('listConnectedMcpServers', () => {
+  it('returns sorted unique server ids from tokens paths', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens': '{}',
+      'mcp/acme/linear/meta': '{}',
+      'mcp/acme/linear/client': '{}',
+      'mcp/acme/github/tokens': '{}',
+      'mcp/acme/github/meta': '{}',
+      'mcp/acme/stripe/tokens': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual(['github', 'linear', 'stripe']);
+  });
+
+  it('returns empty array when no tokens are present for the tenant', async () => {
+    const vault = createMemoryVault({
+      'mcp/other-tenant/linear/tokens': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual([]);
+  });
+
+  it('ignores paths that are not `tokens` blobs', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/meta': '{}',
+      'mcp/acme/linear/client': '{}',
+      'mcp/acme/linear/verifier': 'x',
+      'mcp/acme/linear/discovery': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual([]);
+  });
+
+  it('ignores paths with deeper nesting than `tokens`', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens/extra': '{}',
+      'mcp/acme/linear/tokens': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual(['linear']);
+  });
+
+  it('ignores server ids containing unsafe characters', async () => {
+    // Seed the vault directly with a path that would have been rejected by
+    // `set` — simulates a production vault whose entries predate the
+    // current validation rules, or a vault shared with another client that
+    // writes looser names. The helper should defend against that by
+    // re-validating each discovered server id.
+    const vault = createMemoryVault({
+      'mcp/acme/bad..server/tokens': '{}',
+      'mcp/acme/linear/tokens': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual(['linear']);
+  });
+
+  it('rejects tenant ids that contain disallowed characters', async () => {
+    const vault = createMemoryVault();
+
+    await expect(listConnectedMcpServers(vault, '..')).rejects.toThrow(RevvaultError);
+    await expect(listConnectedMcpServers(vault, 'a/b')).rejects.toThrow(RevvaultError);
+    await expect(listConnectedMcpServers(vault, '')).rejects.toThrow(RevvaultError);
+    await expect(listConnectedMcpServers(vault, 'a'.repeat(65))).rejects.toThrow(RevvaultError);
+  });
+
+  it('accepts tenant ids with all permitted characters', async () => {
+    const vault = createMemoryVault({
+      'mcp/Acme_Corp-1/linear/tokens': '{}',
+    });
+
+    const servers = await listConnectedMcpServers(vault, 'Acme_Corp-1');
+
+    expect(servers).toEqual(['linear']);
+  });
+
+  it('de-duplicates when multiple entries share the same server id', async () => {
+    const vault = createMemoryVault({
+      'mcp/acme/linear/tokens': '{}',
+      // A later write to the same path wouldn't happen in a real vault, but
+      // the enumerator should handle it idempotently regardless.
+    });
+    // Manually inject a duplicate path via the seed to simulate a historic
+    // state; the real-world source for dedup is more like "multiple keys
+    // landing under the same server during retry flows".
+    await vault.set('mcp/acme/linear/tokens', 'overwritten');
+
+    const servers = await listConnectedMcpServers(vault, 'acme');
+
+    expect(servers).toEqual(['linear']);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -78,6 +78,10 @@
     "./client": {
       "types": "./dist/client.d.ts",
       "import": "./dist/client.js"
+    },
+    "./remote-client": {
+      "types": "./dist/remote-client.d.ts",
+      "import": "./dist/remote-client.js"
     }
   },
   "files": [

--- a/packages/mcp/src/remote-client.ts
+++ b/packages/mcp/src/remote-client.ts
@@ -1,0 +1,182 @@
+/**
+ * Remote MCP server client helpers — tenant-scoped discovery + connection.
+ *
+ * Two responsibilities:
+ *
+ *   1. {@link listConnectedMcpServers} — enumerate the servers a tenant has
+ *      an authorized OAuth token for in the vault. Does NOT connect; a pure
+ *      metadata lookup.
+ *
+ *   2. {@link buildRemoteMcpClient} — load the stored server URL + OAuth
+ *      meta for `(tenant, server)` and return a configured {@link McpClient}.
+ *      The client is configured but NOT yet connected — callers invoke
+ *      `connect()` themselves so they can manage teardown.
+ *
+ * Both helpers were originally defined alongside each other in the admin
+ * app: {@link listConnectedMcpServers} as inline logic in the
+ * `/api/mcp/remote-servers` route, {@link buildRemoteMcpClient} as the
+ * admin-local `lib/mcp/remote-server-client.ts`. They moved here so the API
+ * app can use the same path enumeration + client-construction logic without
+ * duplicating admin code.
+ */
+
+import { type ElicitationHandler, McpClient } from './client.js';
+import {
+  createRevvaultVault,
+  McpOAuthProvider,
+  type OAuthClientMetadata,
+  RevvaultError,
+  type Vault,
+} from './oauth.js';
+
+/**
+ * Safe identifier regex for tenant + server IDs. Matches the regex used by
+ * the admin remote-servers route for incoming user input.
+ */
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+// ---------------------------------------------------------------------------
+// Tenant → connected-server discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * List the MCP servers that tenant `tenantId` has authorized OAuth tokens
+ * for in the vault. Enumerates `mcp/<tenantId>/<server>/tokens` entries
+ * and returns the unique server IDs, sorted ascending.
+ *
+ * A server appears here if and only if a successful OAuth flow has landed
+ * a `tokens` blob at that path. Tokens may be expired — refresh/rotation
+ * is the transport's concern via the `OAuthClientProvider` hooks. Callers
+ * should treat this list as "has been authorized at least once" rather
+ * than "is definitely healthy right now".
+ *
+ * @throws {RevvaultError} when the vault `list` call fails or when
+ *   `tenantId` contains characters that would be unsafe to pass to the
+ *   vault.
+ */
+export async function listConnectedMcpServers(vault: Vault, tenantId: string): Promise<string[]> {
+  if (!SAFE_ID_RE.test(tenantId)) {
+    throw new RevvaultError(`tenantId must match /^[A-Za-z0-9_-]{1,64}$/ (got: ${tenantId})`);
+  }
+  const paths = await vault.list(`mcp/${tenantId}/`);
+  const serverIds = new Set<string>();
+  for (const path of paths) {
+    const segments = path.split('/');
+    if (segments.length === 4 && segments[3] === 'tokens') {
+      const server = segments[2];
+      if (server && SAFE_ID_RE.test(server)) serverIds.add(server);
+    }
+  }
+  return Array.from(serverIds).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Per-server client construction
+// ---------------------------------------------------------------------------
+
+/** Stored alongside tokens by the OAuth callback. */
+export interface RemoteServerMeta {
+  serverUrl: string;
+  connectedAt: string;
+  connectedBy: string;
+}
+
+export class RemoteServerNotConnectedError extends Error {
+  constructor(
+    public readonly tenant: string,
+    public readonly server: string,
+  ) {
+    super(
+      `No OAuth meta found for mcp/${tenant}/${server}. ` +
+        'Re-authorize the server via /admin/mcp/connect.',
+    );
+    this.name = 'RemoteServerNotConnectedError';
+  }
+}
+
+/**
+ * Non-authoritative placeholder; the provider reuses the originally-registered
+ * client info saved at `mcp/<tenant>/<server>/client`. Only shape is required
+ * by the provider constructor.
+ */
+const SENTINEL_CLIENT_METADATA: OAuthClientMetadata = {
+  redirect_uris: ['http://localhost/unused'],
+  client_name: 'RevealUI (runtime)',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+};
+
+export interface BuildRemoteMcpClientOptions {
+  tenant: string;
+  server: string;
+  /** Injected for tests; defaults to the revvault-backed vault. */
+  vault?: Vault;
+  /** Client name reported during `initialize`. */
+  clientName?: string;
+  /** Client version reported during `initialize`. */
+  clientVersion?: string;
+  /**
+   * Handler invoked when the server sends `elicitation/create`. Registered
+   * on the `McpClient` at construction time so capability advertisement
+   * matches what the caller can actually service.
+   */
+  elicitationHandler?: ElicitationHandler;
+}
+
+export interface BuiltRemoteMcpClient {
+  client: McpClient;
+  meta: RemoteServerMeta;
+}
+
+/**
+ * Load OAuth credentials + server URL and return a configured `McpClient`.
+ * Throws {@link RemoteServerNotConnectedError} if no meta record exists for
+ * the `(tenant, server)` pair.
+ */
+export async function buildRemoteMcpClient(
+  options: BuildRemoteMcpClientOptions,
+): Promise<BuiltRemoteMcpClient> {
+  const { tenant, server } = options;
+  const vault = options.vault ?? createRevvaultVault();
+
+  const metaPath = `mcp/${tenant}/${server}/meta`;
+  const rawMeta = await vault.get(metaPath);
+  if (!rawMeta) throw new RemoteServerNotConnectedError(tenant, server);
+  const meta = parseMeta(rawMeta);
+
+  const provider = new McpOAuthProvider({
+    tenant,
+    server,
+    vault,
+    redirectUrl: 'http://localhost/unused',
+    clientMetadata: SENTINEL_CLIENT_METADATA,
+  });
+
+  const client = new McpClient({
+    clientInfo: {
+      name: options.clientName ?? 'revealui',
+      version: options.clientVersion ?? '0.0.0',
+    },
+    transport: {
+      kind: 'streamable-http',
+      url: meta.serverUrl,
+      authProvider: provider,
+    },
+    ...(options.elicitationHandler ? { elicitationHandler: options.elicitationHandler } : {}),
+  });
+
+  return { client, meta };
+}
+
+function parseMeta(raw: string): RemoteServerMeta {
+  const parsed = JSON.parse(raw) as Partial<RemoteServerMeta>;
+  if (
+    typeof parsed.serverUrl !== 'string' ||
+    typeof parsed.connectedAt !== 'string' ||
+    typeof parsed.connectedBy !== 'string'
+  ) {
+    throw new Error('Stored MCP remote-server meta is missing required fields');
+  }
+  return parsed as RemoteServerMeta;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@revealui/mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
       '@revealui/openapi':
         specifier: workspace:*
         version: link:../../packages/openapi


### PR DESCRIPTION
## Summary

**A.1 of the post-v1 MCP arc.** First production consumer of Stage 5 + Stage 6 primitives at `/api/agent-stream`:

- Discovers the tenant's OAuth-authorized MCP servers via revvault (shared `listConnectedMcpServers` helper extracted into a new `@revealui/mcp/remote-client` subpath).
- Builds `McpClient`s + surfaces their tools, resources, and prompts on each agent run.
- Emits Stage 6.1 protocol-log events to the central logger.
- Lands `usage_meters` rows via Stage 6.2's `createUsageMeterSink` when the session resolves to a billing `accountId` (via the existing global `entitlementMiddleware`).

Safe fallbacks preserved: requests without a tenant header or an active account membership keep working exactly as before — empty `mcpClients`, logger-only sink.

## What ships

- `packages/mcp/src/remote-client.ts` (new) — exports `listConnectedMcpServers` + moves `buildRemoteMcpClient` from `apps/admin/src/lib/mcp/remote-server-client.ts` (kept as a re-export shim).
- `packages/mcp/__tests__/remote-client.test.ts` (new) — 8 unit tests; `@revealui/mcp` 210 → 218 passing.
- `apps/api/src/lib/metering.ts` (new) — `recordUsageMeter()` thin writer. `@revealui/db` stays schema-only.
- `apps/api/src/lib/__tests__/metering.test.ts` (new) — 4 PGlite-backed integration tests.
- `apps/api/src/routes/agent-stream.ts` — extended around line 248 with the tenant/accountId resolution, MCP client construction, and sink composition. Teardown in streamSSE finally.
- `apps/admin/src/app/api/mcp/remote-servers/route.ts` — consumes the shared helper.

## Design anchors

Closes internal docs §1.A.1. Design questions resolved earlier today with file anchors:

- **Q1:** tenant → server discovery = revvault path enumeration via `@revealui/mcp/oauth.createRevvaultVault().list()`, not a DB table.
- **Q2:** user → `accountId` = already solved by global `entitlementMiddleware` (`apps/api/src/middleware/entitlements.ts:55-117`). Consume `getEntitlementsFromContext(c).accountId`.
- **Q3:** writer = new `apps/api/src/lib/metering.ts`. Shape spec'd in the design doc.

## Discipline held

- **Structural decoupling.** No static imports from `@revealui/ai` in `apps/api` (boundary validator enforces). `McpEventSink` is derived via `ReturnType<NonNullable<typeof aiMod>['createCoreLoggerSink']>` from the dynamic import; `recordUsageMeter` takes `NewUsageMeter` from `@revealui/db/schema` instead of `McpUsageMeterRow`. The shapes are structurally compatible by design (Stage 6.2).
- **Consumer-wired metering.** `@revealui/mcp` still has no `@revealui/db` runtime dep. Each call path wires its own writer.
- **Per-server isolation.** One server failing to connect never breaks the whole agent call — logged + skipped. Re-auth-required (`RemoteServerNotConnectedError`) is silent.
- **No leaked sockets.** `streamSSE` finally closes every connected `McpClient`.

## Test plan

- [x] `pnpm --filter @revealui/mcp test` — 218/218 pass (+8 new)
- [x] `pnpm --filter api test` — 2345/2345 pass (+4 new metering; +16 agent-stream-success tests fixed after mock update)
- [x] `pnpm --filter admin test` — 1592/1592 pass
- [x] `pnpm --filter api typecheck` — clean
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm validate:boundary` — clean
- [x] Pre-push gate (15 checks) — PASS
- [ ] **Post-merge smoke test** (manual): fire an agent run against a real tenant with a connected MCP server; confirm a `usage_meters` row with `meterName='mcp.tool.call'` + `source='agent'` lands, and a `[mcp] mcp.tool.call` entry appears in central logs.

## Follow-ups (NOT in this PR)

- **A.2** — user-visible streaming agent-exec page (`apps/admin`) consuming `/api/agent-stream` SSE, with per-event-type rendering (reuses Stage 3.4 `StreamingToolCard`), elicitation form, cancel button. Wires a sampling handler defaulting to Canonical Inference Snap.
- **A.3** — `usage_meters` dashboards at `/admin/mcp`. Will add a nullable `duration_ms` migration.
- **End-to-end integration test** exercising the full `/api/agent-stream` → MCP adapter → `usage_meters` chain. Skipped here to keep this PR focused; acceptance verification is the post-merge smoke test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
