### PR TITLE
chore(docs): internal-docs drift sweep from 2026-04-23 audit

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -54,13 +54,12 @@ revealui/dev/stripe/webhook-secret
 revealui/dev/stripe/publishable-key      # pk_test_*
 revealui/dev/revealui-secret             # JWT/session, ≥32 chars
 revealui/dev/revealui-admin-api-key      # API admin auth
-revealui/dev/resend/api-key              # email service
-revealui/dev/resend/from-email           # sender address
 revealui/dev/blob/read-write-token       # Vercel Blob file uploads
 revealui/dev/google/client-id            # OAuth SSO
 revealui/dev/google/client-secret
-revealui/dev/google/service-account-email # Gmail email provider
-revealui/dev/google/private-key
+revealui/dev/google/service-account-email # Gmail API email provider (service account)
+revealui/dev/google/service-account-from # From address (Workspace user w/ domain-wide delegation)
+revealui/dev/google/private-key          # Gmail API service-account PKCS8 PEM
 revealui/dev/github/client-id            # OAuth SSO
 revealui/dev/github/client-secret
 revealui/dev/admin/bootstrap/email       # CLI admin bootstrap
@@ -85,13 +84,12 @@ revealui/prod/vercel/api-token
 revealui/prod/revealui-secret
 revealui/prod/revealui-cron-secret
 revealui/prod/revealui-admin-api-key
-revealui/prod/resend/api-key
-revealui/prod/resend/from-email
 revealui/prod/blob/read-write-token
-revealui/prod/google/client-id
+revealui/prod/google/client-id           # OAuth SSO
 revealui/prod/google/client-secret
-revealui/prod/google/service-account-email
-revealui/prod/google/private-key
+revealui/prod/google/service-account-email # Gmail API email provider (service account)
+revealui/prod/google/service-account-from # From address (Workspace user w/ domain-wide delegation)
+revealui/prod/google/private-key         # Gmail API service-account PKCS8 PEM
 revealui/prod/github/client-id
 revealui/prod/github/client-secret
 revealui/prod/sentry/auth-token          # CI/CD error tracking

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -16,7 +16,6 @@ This document lists all third-party dependencies used in the RevealUI Framework 
 **License Distribution**:
 - MIT: 45+ packages (90%+)
 - Apache-2.0: 3+ packages
-- BSD-3-Clause: 2+ packages
 - ISC: 1+ packages
 - 0BSD: 1+ packages
 
@@ -57,10 +56,6 @@ This document lists all third-party dependencies used in the RevealUI Framework 
 - **@vercel/analytics** v1.3.1 - Vercel Analytics
 - **@vercel/speed-insights** v1.1.0 - Vercel Speed Insights
 - **@vercel/web-vitals** v1.0.0 - Vercel Web Vitals
-
-### BSD-3-Clause Licensed
-- **@types/jest** v29.5.14 - TypeScript definitions for Jest
-- **@types/testing-library__jest-dom** v6.0.0 - TypeScript definitions for jest-dom
 
 ### 0BSD Licensed
 - **tsx** v4.19.2 - TypeScript execution and REPL for node.js

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -194,7 +194,7 @@ Comprehensive troubleshooting guide for common RevealUI issues.
 
 2. **Check pnpm version**
    ```bash
-   pnpm --version  # Should be 9.14.2+
+   pnpm --version  # Should be 10+
    ```
 
 3. **Verify workspace configuration**

--- a/docs/TYPE-SYSTEM-RULES.md
+++ b/docs/TYPE-SYSTEM-RULES.md
@@ -160,7 +160,7 @@ import type { CollectionMetadata } from '@revealui/ai/tools/admin'
 
 ### Automated Checks
 
-1. **ESLint Rule**: `@typescript-eslint/consistent-type-imports`
+1. **Biome rule**: `style/useImportType` (equivalent of `@typescript-eslint/consistent-type-imports`)
    - Enforces `import type` syntax
    - Catches missing type imports
 
@@ -168,7 +168,7 @@ import type { CollectionMetadata } from '@revealui/ai/tools/admin'
    - Prevents `any` types
    - Requires explicit types
 
-3. **Custom ESLint Rule** (Planned): `revealui/no-inline-types`
+3. **Custom Biome rule** (planned): `revealui/no-inline-types`
    - Detects inline object types in annotations
    - Suggests contract type imports
 
@@ -375,7 +375,7 @@ If you find code violating these rules:
 
 Planned tooling:
 - `pnpm ops migrate:inline-types` - Detect and suggest replacements
-- ESLint auto-fix for simple cases
+- Biome auto-fix for simple cases (once the custom rule lands)
 - Codemod for common patterns
 
 ---
@@ -444,7 +444,7 @@ const temp: { id: string } = getTempData()
 
 - ✅ Linting rules configured (Biome)
 - ✅ Pre-commit hooks active
-- 🚧 Custom ESLint rule (planned)
+- 🚧 Custom Biome rule (planned)
 - 🚧 Automated migration tool (planned)
 - ✅ Code review checklist updated
 

--- a/docs/agent-rules/monorepo.md
+++ b/docs/agent-rules/monorepo.md
@@ -45,7 +45,7 @@
 
 ## Publishing
 - OSS packages: `publishConfig.access: "public"`, MIT license
-- Pro packages: `"private": true` (not published to npm)
+- Pro packages (`@revealui/ai`, `@revealui/harnesses`): `publishConfig.access: "public"`, Fair Source (FSL-1.1-MIT) — published to npm, source in-repo, converts to MIT two years after each release (see `docs/architecture/ADR-003-fair-source-licensing.md`)
 - Use changesets for versioning: `pnpm changeset` → `pnpm changeset:version` → `pnpm changeset:publish`
 
 ## Import Conventions


### PR DESCRIPTION
## Summary

Five internal-docs drift fixes from the 2026-04-23 suite-wide messaging audit. All five are contained to `docs/` — no source-code, test, or public-surface changes.

### 1. `docs/agent-rules/monorepo.md` — Pro packages are Fair Source, not private

Publishing rule said Pro packages have `"private": true` and aren't published to npm. Reality per `docs/PUBLISHING.md:90-91` and `docs/architecture/ADR-003-fair-source-licensing.md`: `@revealui/ai` and `@revealui/harnesses` are published to npm under **Fair Source (FSL-1.1-MIT)** — source in-repo, converts to MIT two years after each release. Updated the rule so new-package scaffolding guidance matches reality.

### 2. `docs/SECRETS.md` — Retire Resend secret paths, surface Gmail service-account paths

`revealui/dev/resend/*` and `revealui/prod/resend/*` entries remained in the secrets inventory after Resend was removed on 2026-04-09 (PR #227). Gmail API via Google Workspace is the email provider now — added explicit service-account + from-address paths (`google/service-account-email`, `google/service-account-from`, `google/private-key`) and removed the four Resend paths.

### 3. `docs/TROUBLESHOOTING.md` — pnpm 9 → 10

"Should be 9.14.2+" → "Should be 10+", matching `docs/QUICK_START.md`, `docs/BUILD_YOUR_BUSINESS.md`, and the Nix flake's actual pnpm pin.

### 4. `docs/TYPE-SYSTEM-RULES.md` — ESLint refs → Biome

Biome is the sole linter. The doc referenced `@typescript-eslint/consistent-type-imports`, "Custom ESLint Rule (Planned)", "ESLint auto-fix for simple cases", and "🚧 Custom ESLint rule (planned)". Rewrote:

- Real rule → Biome equivalent (`style/useImportType`)
- Planned custom rule → "Custom Biome rule (planned)"
- Auto-fix aspiration → Biome auto-fix

### 5. `docs/THIRD_PARTY_LICENSES.md` — drop dead `@types/jest` entries

`@types/jest` v29.5.14 and `@types/testing-library__jest-dom` v6.0.0 were listed as BSD-3-Clause dependencies. A repo-wide scan (excluding `node_modules`) finds **no own-repo package.json referencing either** — they're dead from an earlier Jest iteration before the Vitest migration. Removed both entries and the now-empty BSD-3-Clause subsection. License Distribution summary updated to drop the BSD-3-Clause count.

**Note — broader staleness (follow-up, not in this PR):** `THIRD_PARTY_LICENSES.md` is hand-maintained and contains many outdated version pins (`next@15.5.5`, `@types/react@18.3.12`, `@vercel/blob@0.25.0` vs installed `2.3.3`, `zod@3.24.1`, etc.). Regenerating from the lockfile is a separate concern; this PR only removes the two entries flagged as drift.

**Source:** internal docs § revealui — internal docs`.

## Test plan
- [ ] `pnpm typecheck` green (no code touched, should be a no-op)
- [ ] Markdown/link validators still pass
- [ ] Skim the diff — nothing surprising in the Gmail path naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)
