### PR TITLE
chore(docs,marketing): retire Resend references after Gmail migration

### DIFF
--- a/apps/api/src/routes/cron/billing-readiness.ts
+++ b/apps/api/src/routes/cron/billing-readiness.ts
@@ -5,7 +5,7 @@
  * 1. All expected Stripe price env vars are set
  * 2. REVEALUI_LICENSE_PRIVATE_KEY is present (for license JWT generation)
  * 3. Billing catalog DB rows exist for all tiers
- * 4. Email provider configured (warning only  -  Gmail or Resend)
+ * 4. Email provider configured (warning only  -  Gmail API via Google Workspace service account)
  *
  * Sends an alert email to REVEALUI_ALERT_EMAIL on any failure.
  * Runs daily at 06:00 UTC (configured in vercel.json).

--- a/apps/marketing/README.md
+++ b/apps/marketing/README.md
@@ -9,8 +9,8 @@ Marketing site for RevealUI  -  agentic business runtime. Users, content, produc
 - Hero: "Build your business, not your boilerplate." + five primitives subtitle
 - ValueProposition: "Stop stitching tools together"  -  Own Your Stack, AI Agents Built In, Production Stack Included
 - SocialProof: six capability cards
-- LeadCapture: waitlist form with DB-backed storage and Resend email notifications
-- ProductMockup: illustrated browser chrome of the CMS admin UI
+- LeadCapture: waitlist form (posts to RevealUI API; storage and email handled server-side via Gmail API)
+- ProductMockup: illustrated browser chrome of the admin UI
 
 ## Development
 
@@ -27,14 +27,16 @@ The ignoreCommand skips builds when no `apps/marketing/**` files changed.
 
 ## Environment Variables
 
+The marketing site has no server-side secrets  -  it proxies form submissions to the RevealUI API, which handles storage and email.
+
 ```env
-RESEND_API_KEY=          # Waitlist founder notification emails (Resend)
-DATABASE_URL=            # NeonDB connection string (waitlist storage)
+NEXT_PUBLIC_API_URL=     # RevealUI API base (default: https://api.revealui.com)
+NEXT_PUBLIC_ADMIN_URL=   # RevealUI admin URL (default: https://admin.revealui.com)
 ```
 
 ## API
 
-- `POST /api/waitlist`  -  Add email to waitlist (DB-backed, rate-limited, Resend notification)
+- `POST /api/waitlist`  -  Proxies waitlist signup to the RevealUI API (rate-limited; API handles storage + email)
 - `GET /api/waitlist`  -  410 Gone (removed for GDPR)
 
 ## Routes
@@ -57,7 +59,7 @@ The marketing site should present RevealUI as:
 ## Key Components
 
 - `src/components/HeroSection.tsx`  -  Headline + CTA + ProductMockup
-- `src/components/ProductMockup.tsx`  -  Illustrated CMS admin UI (browser chrome)
+- `src/components/ProductMockup.tsx`  -  Illustrated admin UI (browser chrome)
 - `src/components/ValueProposition.tsx`  -  Three-column feature section
 - `src/components/SocialProof.tsx`  -  Six capability cards
 - `src/components/LeadCapture.tsx`  -  Waitlist form

--- a/docs/ENVIRONMENT-VARIABLES-GUIDE.md
+++ b/docs/ENVIRONMENT-VARIABLES-GUIDE.md
@@ -87,7 +87,7 @@ pnpm dev
 | **For payments** | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | When testing checkout, subscriptions, or billing |
 | **For uploads** | `BLOB_READ_WRITE_TOKEN` | When testing media uploads |
 | **For AI** | `LLM_PROVIDER`, `OLLAMA_BASE_URL` or `INFERENCE_SNAPS_BASE_URL` | When testing AI agent features |
-| **For email** | `RESEND_API_KEY`, `RESEND_FROM_EMAIL` | When testing password reset or waitlist emails |
+| **For email** | `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `EMAIL_FROM` | When testing password reset or waitlist emails (Gmail API via Google Workspace service account) |
 | **For sync** | `NEXT_PUBLIC_ELECTRIC_SERVICE_URL`, `ELECTRIC_SERVICE_URL` | When testing real-time sync features |
 | **For monitoring** | `NEXT_PUBLIC_SENTRY_DSN` | Recommended for staging and production |
 
@@ -170,8 +170,10 @@ During Next.js builds, set `SKIP_ENV_VALIDATION=true` to defer validation to run
 | `VERCEL_CLIENT_SECRET` | No | None | Vercel OAuth App client secret. | HIGH (server-only) | admin |
 | `OAUTH_ADMIN_EMAILS` | No | None | Comma-separated email allowlist for OAuth admin access. Leave empty to allow any authenticated OAuth account. | MEDIUM | admin |
 | `NEXT_PUBLIC_APP_URL` | No | `NEXT_PUBLIC_SERVER_URL` | Base URL for constructing OAuth redirect URIs. | LOW (client-safe) | admin |
-| `RESEND_API_KEY` | No | None | Resend API key for transactional emails (password reset, waitlist notifications). | HIGH (server-only) | admin, api |
-| `RESEND_FROM_EMAIL` | No | None | Sender address for transactional emails. | LOW | admin, api |
+| `GOOGLE_SERVICE_ACCOUNT_EMAIL` | No | None | Google Workspace service-account email with domain-wide delegation for Gmail API. Used for transactional emails (password reset, waitlist notifications). | HIGH (server-only) | admin, api |
+| `GOOGLE_PRIVATE_KEY` | No | None | Google Workspace service-account private key (PEM). Paired with `GOOGLE_SERVICE_ACCOUNT_EMAIL`. | HIGH (server-only) | admin, api |
+| `EMAIL_FROM` | No | `noreply@revealui.com` | Sender address for transactional emails. Must match a domain the Gmail service account can send as. | LOW | admin, api |
+| `EMAIL_REPLY_TO` | No | None | Optional reply-to address for transactional emails. | LOW | admin, api |
 | `REVEALUI_WAITLIST_NOTIFY_EMAIL` | No | None | Email address to notify on waitlist signups. Silently skipped if unset. | LOW | marketing |
 | `REVEALUI_SUPPORT_EMAIL` | No | `support@revealui.com` | Support contact shown in transactional emails sent to customers. | LOW | admin, api |
 


### PR DESCRIPTION
## Summary

Retires `RESEND_API_KEY` references from customer-facing docs + marketing README + one API docstring. Email provider swapped from Resend to Gmail API (Google Workspace service account) on 2026-04-09; these docs didn't catch up.

Drive-by: one `CMS admin UI` → `admin UI` fix in `apps/marketing/README.md` (per 2026-04-09 rename) since the file is already being touched.

Source: 2026-04-23 suite messaging-drift audit PR #2 scope.

## Scope

- **`apps/marketing/README.md`** — `RESEND_API_KEY` + stale `DATABASE_URL` dropped from the Environment Variables block. Marketing has no server-side secrets — it proxies to the API. Documents `NEXT_PUBLIC_API_URL` + `NEXT_PUBLIC_ADMIN_URL` as the actual configurable vars.
- **`docs/ENVIRONMENT-VARIABLES-GUIDE.md`** — swaps Resend rows for the actual Gmail env vars read by `apps/api/src/lib/email.ts`: `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `EMAIL_FROM`, `EMAIL_REPLY_TO`.
- **`apps/api/src/routes/cron/billing-readiness.ts`** — docstring line 8 said "Gmail or Resend" but the cron only checks `hasGmail` at line 191; docstring updated to match code.

## Not in scope

Internal docs (`docs/SECRETS.md`, `TROUBLESHOOTING.md`, `TYPE-SYSTEM-RULES.md`, `monorepo.md`, `THIRD_PARTY_LICENSES.md`) landing separately via `chore/audit-drift-internal-docs` by a parallel session. Zero file overlap between the two PRs.

`docs/CREDENTIAL-ROTATION-RUNBOOK.md` still has `RESEND_API_KEY` in its 90-day rotation table + `revealui/env/services` vault path — that's rotation-runbook scope, separate cleanup.

## Test plan

- [x] `pnpm gate:quick` green (15/15 checks: Biome, any-audit, console-audit, structure, boundary, version-policy, catalog, docs-import-drift, pro-license, claim-drift, migration-journal, raw-SQL, empty-catch, security-audit, coverage)
- [ ] Full CI green on PR
- [ ] Manual verification: `apps/marketing/README.md` renders clean on GitHub
- [ ] Manual verification: `docs/ENVIRONMENT-VARIABLES-GUIDE.md` env-var table renders clean
- [ ] Manual verification: email cron `billing-readiness.ts` still compiles (only a docstring changed, but include in smoke test)
