### PR TITLE
chore(docs,config): retire Resend/SMTP paths from public env templates and docs

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -52,10 +52,15 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 CORS_ORIGIN=https://admin.yourdomain.com,https://www.yourdomain.com
 
 # -----------------------------------------------------------------------------
-# Email — Resend (REQUIRED for waitlist, password reset, notifications)
+# Email — Gmail REST API via Google Workspace service account (REQUIRED for
+# waitlist notifications, password reset, and recovery flows).
+# Resend / SMTP / nodemailer paths were removed 2026-04-09 (PR #227).
 # -----------------------------------------------------------------------------
-RESEND_API_KEY=
-# RESEND_FROM_EMAIL=noreply@yourdomain.com
+GOOGLE_SERVICE_ACCOUNT_EMAIL=sa@<project>.iam.gserviceaccount.com
+# GOOGLE_PRIVATE_KEY: PKCS8 PEM from the service account JSON. When pasted into
+# a .env file, literal newlines must be escaped as `\n` so the shell preserves them.
+GOOGLE_PRIVATE_KEY=<paste-service-account-pkcs8-pem-with-newlines-escaped-as-literal-backslash-n>
+EMAIL_FROM=noreply@yourdomain.com
 
 # -----------------------------------------------------------------------------
 # OAuth Providers (optional — enable the ones you need)

--- a/.env.template
+++ b/.env.template
@@ -131,10 +131,14 @@ NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID=price_xxxxxxxxxxxxxxxxxxxxxxxx
 REVEALUI_LICENSE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 REVEALUI_LICENSE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
 
-# Email provider (Resend — required for password reset emails)
-# Get from: https://resend.com → Settings → API Keys
-RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-RESEND_FROM_EMAIL=noreply@yourdomain.com
+# Email provider — Gmail REST API via Google Workspace service account
+# (required for password reset, verification, and recovery flows).
+# Resend / SMTP / nodemailer paths were removed 2026-04-09 (PR #227).
+# Setup: create a service account, enable domain-wide delegation, set
+# EMAIL_FROM to a Workspace user that holds the delegation.
+GOOGLE_SERVICE_ACCOUNT_EMAIL=sa@<project>.iam.gserviceaccount.com
+GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n<escaped-pem>\n-----END PRIVATE KEY-----\n"
+EMAIL_FROM=noreply@yourdomain.com
 
 # Email address to notify when someone joins the waitlist
 # Optional - waitlist notifications are silently skipped if unset

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -125,11 +125,13 @@ NEXT_PRIVATE_REVEALUI_REVALIDATION_KEY=your-revalidation-key-min-32-chars
 
 # -----------------------------------------------------------------------------
 # Email (optional — for transactional emails)
-# Priority: Gmail REST API > Resend > SMTP > Mock
+# Provider: Gmail REST API via Google Workspace service account.
+# Resend / SMTP / nodemailer paths were removed 2026-04-09 (PR #227).
+# Without the Gmail env vars, admin falls back to a mock transport in dev.
 # -----------------------------------------------------------------------------
-# SMTP_HOST=smtp.example.com
-# SMTP_USER=smtp-user@example.com
-# SMTP_PASS=your-smtp-password
+# GOOGLE_SERVICE_ACCOUNT_EMAIL=sa@project.iam.gserviceaccount.com
+# GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# EMAIL_FROM=noreply@revealui.com
 
 # -----------------------------------------------------------------------------
 # AI / LLM (optional — required for /api/chat and AI agent features)

--- a/apps/admin/.env.production.template
+++ b/apps/admin/.env.production.template
@@ -45,12 +45,17 @@ REVEALUI_API_URL=https://api.revealui.com
 NEXT_PUBLIC_API_URL=https://api.revealui.com
 
 # -----------------------------------------------------------------------------
-# Email — Resend (required for password reset)
-# Resend Dashboard: API Keys → Sender scope key
-# From address must be verified in Resend.
+# Email — Gmail REST API via Google Workspace service account (required for
+# password reset, verification, and recovery flows).
+# Resend / SMTP / nodemailer paths were removed 2026-04-09 (PR #227).
+# Setup: create a service account, grant domain-wide delegation, set the
+# from-address to a Workspace user with delegation.
 # -----------------------------------------------------------------------------
-RESEND_API_KEY=re_<your-resend-api-key>
-RESEND_FROM_EMAIL=noreply@revealui.com
+GOOGLE_SERVICE_ACCOUNT_EMAIL=sa@<your-project>.iam.gserviceaccount.com
+# GOOGLE_PRIVATE_KEY: PKCS8 PEM from the service account JSON. Literal newlines
+# inside the PEM must be escaped as `\n` so the shell preserves them when loading.
+GOOGLE_PRIVATE_KEY=<paste-service-account-pkcs8-pem-with-newlines-escaped-as-literal-backslash-n>
+EMAIL_FROM=noreply@revealui.com
 
 # -----------------------------------------------------------------------------
 # Stripe — Client-side (required for billing page)

--- a/apps/admin/src/app/api/auth/recovery/request/route.ts
+++ b/apps/admin/src/app/api/auth/recovery/request/route.ts
@@ -57,7 +57,7 @@ async function requestHandler(request: NextRequest): Promise<NextResponse> {
     if (user) {
       const { token } = await createMagicLink(user.id);
 
-      // Send recovery email via configured provider (Resend/SMTP/mock)
+      // Send recovery email via Gmail REST API (or mock in dev without creds)
       const emailResult = await sendRecoveryEmail(email, token);
 
       if (!emailResult.success) {

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -117,16 +117,12 @@ WS_BASE_URL=ws://localhost:3004
 
 # -----------------------------------------------------------------------------
 # Email (transactional emails — password reset, recovery, etc.)
-# Priority: Gmail REST API > Resend
+# Provider: Gmail REST API via Google Workspace service account.
+# Resend / SMTP / nodemailer paths were removed 2026-04-09 (PR #227).
 # -----------------------------------------------------------------------------
-# Gmail REST API (preferred — edge-compatible, free with Google Workspace)
 # GOOGLE_SERVICE_ACCOUNT_EMAIL=sa@project.iam.gserviceaccount.com
 # GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 # EMAIL_FROM=noreply@revealui.com
-
-# Resend (fallback)
-# RESEND_API_KEY=re_xxxxxxxxxxxx
-# RESEND_FROM_EMAIL=noreply@revealui.com
 
 # -----------------------------------------------------------------------------
 # Stripe


### PR DESCRIPTION
## Summary

Retire the `Resend` / SMTP / nodemailer paths from developer-facing docs and env templates. The swap to Gmail REST API via Google Workspace service account landed **2026-04-09 in PR #227** and the runtime code no longer reads `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, or any `SMTP_*` env var (grep-confirmed: 0 `.ts` hits in the repo). The surviving references were all documentation / config templates, which mislead developers into provisioning the wrong integration.

### Changes

- **`apps/marketing/README.md`** — LeadCapture + `/api/waitlist` narrative now says "Gmail API founder notifications"; the "Environment Variables" block swaps `RESEND_API_KEY` for `GOOGLE_SERVICE_ACCOUNT_EMAIL` / `GOOGLE_PRIVATE_KEY` / `EMAIL_FROM`. Also fixes one stray `CMS admin UI` → `admin UI` reference while we're here.
- **`apps/api/.env.example`** — drop the `Resend (fallback)` block; keep the Gmail block and clarify it's the only provider.
- **`apps/admin/.env.production.template`** — production template was still marking `RESEND_API_KEY` as REQUIRED. Replaced with Gmail service-account variables (still marked REQUIRED for password-reset/verification/recovery).
- **`apps/admin/.env.example`** — drop `SMTP_HOST` / `SMTP_USER` / `SMTP_PASS`; clarify mock transport is the dev-without-creds fallback.
- **`.env.template`** + **`.env.production.example`** — swap top-level Resend env vars for Gmail service-account vars.
- **`docs/ENVIRONMENT-VARIABLES-GUIDE.md`** — quick-reference table row + full env-var table rows updated (Gmail triplet with descriptions that flag the retired Resend path).
- **`apps/api/src/routes/cron/billing-readiness.ts:8`** — JSDoc comment "Gmail or Resend" → "Gmail REST API".
- **`apps/admin/src/app/api/auth/recovery/request/route.ts:60`** — inline comment "Resend/SMTP/mock" → "Gmail REST API (or mock in dev without creds)".

### Not touched in this PR (follow-ups)

These still reference Resend legitimately and would need separate thought:
- `.github/workflows/deploy.yml:330` — CI check that grep-scans Vercel env output for `RESEND_API_KEY`. Leaving until someone confirms whether to delete the check or leave it as a drift-detector.
- `docs/CREDENTIAL-ROTATION-RUNBOOK.md` — rotation cadence table still lists `RESEND_API_KEY`. Historical rotation log; cleaning this is its own audit.
- `docker-compose.forge.yml`, `infrastructure/k8s/secrets.yaml.example` — pass-through env blocks in deploy scaffolding.
- `docs/SECRETS.md` — Resend paths already removed in [revealui #538](https://github.com/RevealUIStudio/revealui/pull/538).

**Source:** internal docs § revealui — public/customer-facing`.

## Test plan
- [ ] `pnpm typecheck` green
- [ ] `pnpm --filter marketing build` green (README change only affects markdown)
- [ ] `pnpm --filter api build` + `pnpm --filter admin build` green (comment + template changes only)
- [ ] Deploy preview: verify `/api/waitlist` still works end-to-end from a fresh branch env (Gmail creds needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
