### PR TITLE
docs(pro,marketing): public Fair Source licensing explainer

### DIFF
--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -81,7 +81,12 @@ const faqs = [
   {
     question: 'What does "full source code access" mean?',
     answer:
-      'You get the complete RevealUI source code, including all apps and packages. You can modify, extend, and deploy it however you need. All paid tiers include priority updates and commercial package access.',
+      'You get the complete RevealUI source code — every app and package is published in the public monorepo. Infrastructure packages (@revealui/core, auth, db, contracts, security, utils, config, cache, resilience, openapi, sync, mcp) are MIT-licensed. The two Pro packages (@revealui/ai, @revealui/harnesses) ship under Fair Source (FSL-1.1-MIT): source is visible, commercial use is permitted except for building a directly competing developer platform, and each release automatically converts to plain MIT two years after publication. All paid tiers add runtime entitlements (license validation, feature gates, priority updates) on top of that source access — nothing is hidden behind a closed binary.',
+  },
+  {
+    question: 'What is Fair Source (FSL-1.1-MIT)?',
+    answer:
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -20,6 +20,7 @@ Per-user or perpetual licenses can still exist for narrowly scoped products, but
 - [Overview](#overview)
 - [Commercial Model](#commercial-model)
 - [What Pro Includes](#what-pro-includes)
+- [Licensing (Fair Source + MIT)](#licensing-fair-source--mit)
 - [MCP Setup](#mcp-setup)
 - [MCP Servers](#mcp-servers)
 - [Getting API Keys](#getting-api-keys)
@@ -95,6 +96,23 @@ RevealUI is part of a four-project ecosystem. Each project has features distribu
 | RevealCoin x402 agent payments | | | | Yes |
 
 The MIT-licensed components (RevVault CLI, RevKit agent coordination) are free forever. Commercial features (desktop app, rotation engine, provisioning, x402 payments) require the corresponding tier.
+
+## Licensing (Fair Source + MIT)
+
+RevealUI publishes every package to npm from the same public repo. There are two source licenses in play:
+
+- **OSS packages (MIT):** `@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/security`, `@revealui/utils`, `@revealui/config`, `@revealui/cache`, `@revealui/resilience`, `@revealui/openapi`, `@revealui/sync`, `@revealui/mcp`, and the rest of the public infrastructure. Use them however you want — commercial products, forks, SaaS, whatever.
+- **Pro packages (Fair Source, FSL-1.1-MIT):** `@revealui/ai` and `@revealui/harnesses`. Source-visible in the public repo, installable from npm like any other package, with one legal constraint: you can't build a product that competes directly with RevealUI on top of them. Two years after each release the license on that release automatically converts to plain MIT. FSL-1.1 is the same license used by Sentry, GitButler, and Keygen.
+
+**What this means in practice:**
+
+- You get full source access to the Pro packages for audit, security review, bug reports, and self-service debugging. No "black box" you have to trust.
+- You can use the Pro packages commercially as long as your product isn't a substantially similar developer platform competing with RevealUI. Building a SaaS product on top of the AI primitives, agents, editors, harnesses, or MCP marketplace is fine. Publishing a competing "platform software sold at the account or workspace level" isn't.
+- Every Pro release has a scheduled MIT-conversion date two years out. You can see the history in the package's changelog, and today's FSL source becomes tomorrow's MIT source.
+
+The Pro tier gate isn't enforced by the license — it's enforced at runtime by license validation (`initializeLicense()`, 6-layer middleware, `checkAIFeatureGate()` at every Pro API entry point). The license JWTs are RS256-signed; the check can't be bypassed by forking the source. FSL is the legal backstop; runtime enforcement is the real protection.
+
+For full decision context: [ADR-003: Fair Source Licensing](./architecture/ADR-003-fair-source-licensing.md). Root-level `LICENSE` (MIT) and `LICENSE.FSL` describe the terms verbatim.
 
 ## MCP Setup
 


### PR DESCRIPTION
## Summary

The 2026-04-23 audit flagged that our Pro packages moved to Fair Source (FSL-1.1-MIT) per [ADR-003](docs/architecture/ADR-003-fair-source-licensing.md) on 2026-04-08, but the customer-facing narrative never caught up. Customers have no public page explaining:

- That Pro packages are source-visible (not closed binaries)
- What the FSL-1.1-MIT non-compete clause actually permits
- That each Pro release MIT-converts two years after publication
- How the runtime license gate (RS256 JWTs, 6-layer middleware) differs from and backs up the source license

This PR adds that narrative in two places — one for developers reading the PRO guide, one for prospective customers on the marketing pricing page.

### Changes

**`docs/PRO.md`** — new `## Licensing (Fair Source + MIT)` section between "Ecosystem Features by Tier" and "MCP Setup". Also added to the Table of Contents.

Covers:
- Which packages are MIT (13+ infrastructure packages, explicitly named)
- Which are FSL-1.1-MIT (`@revealui/ai`, `@revealui/harnesses`) and what that means
- Three "in practice" bullets on source audit / commercial use / MIT conversion
- How the runtime enforcement relates to the legal license (FSL = backstop; JWT check = real protection)
- Link into ADR-003 for full decision context

**`apps/marketing/src/app/pricing/page.tsx`** — two FAQ updates:
- Rewrote the existing "What does full source code access mean?" answer to name MIT + FSL explicitly and describe the conversion cadence
- Added a new FAQ entry "What is Fair Source (FSL-1.1-MIT)?" that explains the model to a customer who's never heard of FSL, including the non-compete scope and the Sentry/GitButler/Keygen precedent

Both follow the existing FAQ voice (second-person, concrete, no internal vocabulary).

### Not touched (flagged for follow-up)

- Package-level READMEs for `@revealui/ai` and `@revealui/harnesses` — they could each carry a compact FSL banner. Holding off until after this PR so we can point to the PRO.md section as canonical.
- `LICENSE.FSL` file at repo root — already exists per ADR-003 and is referenced from the new section.

**Source:** internal docs § revealui — public/customer-facing, Missing entry: "Fair Source explainer for customers"`.

## Test plan
- [ ] `pnpm --filter marketing build` green (FAQ array edit only)
- [ ] `pnpm --filter marketing test` green (faq-count or pricing-data tests may need adjusting for the new FAQ entry — check `apps/marketing/src/app/pricing/__tests__/pricing-data.test.ts`)
- [ ] Preview the rendered `/pricing` page and confirm the new FAQ renders cleanly + the rewritten "full source code access" entry reads well
- [ ] Skim `docs/PRO.md` in rendered docs app — verify TOC anchor `#licensing-fair-source--mit` resolves (double-dash from `+`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
