### PR TITLE
fix(revealcoin): pre-launch honesty on landing hero and roadmap

### DIFF
--- a/apps/revealcoin/src/components/HeroSection.tsx
+++ b/apps/revealcoin/src/components/HeroSection.tsx
@@ -40,8 +40,8 @@ export function HeroSection() {
           color="violet"
           className="mb-6 gap-2 rounded-full px-4 py-1.5 ring-1 ring-violet-200/80"
         >
-          <span className="h-1.5 w-1.5 rounded-full bg-violet-500 animate-pulse" />
-          Live on Solana Mainnet
+          <span className="h-1.5 w-1.5 rounded-full bg-violet-500" />
+          Deployed on Solana Mainnet · Pre-launch
         </Badge>
 
         <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl hero-stagger">
@@ -58,6 +58,17 @@ export function HeroSection() {
           Utility payments, governance voting, and ecosystem rewards - built on Solana Token-2022
           with {TOTAL_SUPPLY_DISPLAY} fixed supply.
         </p>
+
+        {/* Pre-launch disclaimer — token deployed but gated */}
+        <div className="mx-auto mt-6 max-w-2xl rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-left text-sm text-amber-900">
+          <p className="font-semibold">Public trading is not yet live.</p>
+          <p className="mt-1 leading-relaxed">
+            The token is deployed on mainnet, but distribution and Raydium liquidity are gated
+            behind two pre-launch commitments: on-chain vesting migration (replacing the current
+            custodial vesting model) and multi-sig on the mint authority. Watch the roadmap below
+            for progress on both.
+          </p>
+        </div>
 
         {/* Supply symbolism */}
         <div className="mt-6 inline-flex items-center gap-3 rounded-xl bg-gray-950 px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-white/10">

--- a/apps/revealcoin/src/components/RoadmapSection.tsx
+++ b/apps/revealcoin/src/components/RoadmapSection.tsx
@@ -1,8 +1,17 @@
-const milestones = [
+type MilestoneStatus = 'current' | 'upcoming' | 'complete';
+
+interface Milestone {
+  phase: string;
+  title: string;
+  status: MilestoneStatus;
+  items: string[];
+}
+
+const milestones: Milestone[] = [
   {
     phase: 'Phase 0',
     title: 'Foundation',
-    status: 'current' as const,
+    status: 'current',
     items: [
       'Token-2022 mint deployed',
       'Allocations defined + custody-enforced vesting',
@@ -14,7 +23,7 @@ const milestones = [
   {
     phase: 'Phase 1',
     title: 'Public Distribution',
-    status: 'upcoming' as const,
+    status: 'upcoming',
     items: [
       'Gated on: on-chain vesting + multi-sig complete',
       'Initial liquidity seeding',
@@ -24,13 +33,13 @@ const milestones = [
   {
     phase: 'Phase 2',
     title: 'Liquidity & Trading',
-    status: 'upcoming' as const,
+    status: 'upcoming',
     items: ['Raydium CPMM pool creation', 'Jupiter aggregator listing', 'Price oracle (TWAP)'],
   },
   {
     phase: 'Phase 3',
     title: 'Marketplace Integration',
-    status: 'upcoming' as const,
+    status: 'upcoming',
     items: [
       'RVC payments in RevealUI marketplace',
       'x402 micropayment protocol',
@@ -40,7 +49,7 @@ const milestones = [
   {
     phase: 'Phase 4',
     title: 'Governance',
-    status: 'upcoming' as const,
+    status: 'upcoming',
     items: [
       'Proposal creation & voting',
       'Treasury spend visibility',

--- a/apps/revealcoin/src/components/RoadmapSection.tsx
+++ b/apps/revealcoin/src/components/RoadmapSection.tsx
@@ -1,19 +1,30 @@
 const milestones = [
   {
-    phase: 'Phase 1',
-    title: 'Token Launch',
-    status: 'complete' as const,
+    phase: 'Phase 0',
+    title: 'Foundation',
+    status: 'current' as const,
     items: [
       'Token-2022 mint deployed',
-      'Full supply distributed to allocations',
-      'Vesting custody enforced',
+      'Allocations defined + custody-enforced vesting',
       'Metadata on Arweave',
+      'On-chain vesting migration (in design)',
+      'Multi-sig on mint authority (pending)',
+    ],
+  },
+  {
+    phase: 'Phase 1',
+    title: 'Public Distribution',
+    status: 'upcoming' as const,
+    items: [
+      'Gated on: on-chain vesting + multi-sig complete',
+      'Initial liquidity seeding',
+      'Community channels + public communication',
     ],
   },
   {
     phase: 'Phase 2',
     title: 'Liquidity & Trading',
-    status: 'current' as const,
+    status: 'upcoming' as const,
     items: ['Raydium CPMM pool creation', 'Jupiter aggregator listing', 'Price oracle (TWAP)'],
   },
   {


### PR DESCRIPTION
## Summary

The 2026-04-23 audit caught the revealcoin landing page overclaiming. The token is deployed on Solana mainnet (2026-03-26), but two pre-launch commitments gate public distribution and Raydium pool creation:

1. On-chain vesting migration (replacing the current custodial model)
2. Multi-sig on the mint authority

Neither is shipped. The landing page was signalling otherwise via (a) a pulsing "Live on Solana Mainnet" badge that reads like "currently trading", (b) a roadmap that marked Phase 1 "Token Launch" as `complete` with "Full supply distributed to allocations", and (c) Phase 2 "Liquidity & Trading" as `current` with a pulsing animation — while the pool doesn't exist yet.

### Changes

**`apps/revealcoin/src/components/HeroSection.tsx`**
- Badge text: `Live on Solana Mainnet` → `Deployed on Solana Mainnet · Pre-launch`. Removed the `animate-pulse` class on the indicator dot — pulsing signals active/live status that doesn't match reality.
- Added an amber disclaimer panel below the subtitle that names the two gating commitments in plain language and points readers at the roadmap for progress.

**`apps/revealcoin/src/components/RoadmapSection.tsx`** — restructured the phases to match the whitepaper + README, which both describe the state accurately:
- **Phase 0 — Foundation (current):** mint deployed, allocations defined, custody-enforced vesting, Arweave metadata done; on-chain vesting migration + multi-sig still pending.
- **Phase 1 — Public Distribution (upcoming):** gated on the Phase 0 commitments; initial liquidity seeding + community channels.
- **Phase 2 — Liquidity & Trading (upcoming):** Raydium CPMM pool, Jupiter listing, TWAP oracle (content unchanged; status downgraded from `current` to `upcoming`).
- Phases 3 + 4 (Marketplace, Governance) unchanged.

No ticker changes in this PR. The landing page currently says `RVC` throughout; the `$RVUI` vs `RVC` normalization decision is a separate concern that applies suite-wide and is out of scope here.

**Source:** internal docs § revealcoin`.

## Test plan
- [ ] `pnpm --filter revealcoin build` green
- [ ] `pnpm --filter revealcoin test` green (no Hero/Roadmap test files exist; the components render inside the page smoke test if one exists)
- [ ] Preview deploy: eyeball the hero + roadmap on `revealui.com/revealcoin` (or the preview URL) — the badge and disclaimer should read as honest pre-launch state, and the roadmap should show Phase 0 as current with both gating items called out
- [ ] Screen-reader check: disclaimer color contrast is within WCAG AA on amber-50 / amber-900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
