### PR TITLE
fix(api,docs): retire RVUI in customer-facing strings; RVC is the on-chain ticker

### DIFF
--- a/apps/api/src/middleware/__tests__/x402.test.ts
+++ b/apps/api/src/middleware/__tests__/x402.test.ts
@@ -386,7 +386,9 @@ describe('RVUI payment discovery', () => {
     expect(rvuiMethod.scheme).toBe('solana-spl');
     expect(rvuiMethod.network).toBe('solana:devnet');
     expect(rvuiMethod.payTo).toBe('SolanaTestWallet123');
-    expect(rvuiMethod.extra).toEqual({ name: 'RVUI', version: '1', discount: '20%' });
+    // extra.name is the customer-facing on-chain ticker (RVC), distinct from
+    // the internal RVUI_* env vars + variable names (Kingdom taxonomy split).
+    expect(rvuiMethod.extra).toEqual({ name: 'RVC', version: '1', discount: '20%' });
   });
 
   it('applies 20% discount to RVUI price', () => {

--- a/apps/api/src/middleware/x402.ts
+++ b/apps/api/src/middleware/x402.ts
@@ -212,13 +212,13 @@ export function buildPaymentRequired(resource: string, customPrice?: string): Pa
       network: config.rvuiNetwork,
       maxAmountRequired: toRvuiAtomicUnits(discountedPrice),
       resource,
-      description: `RevealUI agent task — ${discountedPrice} USD in RVUI (20% discount)`,
+      description: `RevealUI agent task — ${discountedPrice} USD in RVC (20% discount)`,
       mimeType: 'application/json',
       outputSchema: {},
       payTo: config.rvuiReceivingAddress,
       maxTimeoutSeconds: config.maxTimeoutSeconds,
       asset: config.rvuiAsset,
-      extra: { name: 'RVUI', version: '1', discount: '20%' },
+      extra: { name: 'RVC', version: '1', discount: '20%' },
     });
   }
 
@@ -372,12 +372,12 @@ export function buildPaymentMethods(baseUrl: string): Record<string, unknown> | 
       network: config.rvuiNetwork,
       maxAmountRequired: toRvuiAtomicUnits(discountedPrice),
       resource: `${baseUrl}/api/agent-stream`,
-      description: `RevealUI agent task — ${discountedPrice} USD in RVUI (20% discount)`,
+      description: `RevealUI agent task — ${discountedPrice} USD in RVC (20% discount)`,
       mimeType: 'application/json',
       payTo: config.rvuiReceivingAddress,
       maxTimeoutSeconds: config.maxTimeoutSeconds,
       asset: config.rvuiAsset,
-      extra: { name: 'RVUI', version: '1', discount: '20%' },
+      extra: { name: 'RVC', version: '1', discount: '20%' },
     });
   }
 

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -994,7 +994,9 @@ Creates a Stripe refund for a payment intent or charge. Admin-only. Full or part
 
 **Pay for subscription with RevealCoin**
 
-Verifies an on-chain RVUI payment transaction and activates the subscription tier. Applies the 15% RVUI discount. Requires wallet address and transaction signature.
+Verifies an on-chain RVC (RevealCoin) payment transaction and activates the subscription tier. Applies the 15% RVC discount. Requires wallet address and transaction signature.
+
+> **Note:** The route path `/api/billing/rvui-payment` uses the internal project codename (`$RVUI`). The on-chain token symbol is **RVC**. Both refer to the same token.
 
 **Request body** (JSON)
 
@@ -1217,7 +1219,9 @@ Creates a Stripe refund for a payment intent or charge. Admin-only. Full or part
 
 **Pay for subscription with RevealCoin**
 
-Verifies an on-chain RVUI payment transaction and activates the subscription tier. Applies the 15% RVUI discount. Requires wallet address and transaction signature.
+Verifies an on-chain RVC (RevealCoin) payment transaction and activates the subscription tier. Applies the 15% RVC discount. Requires wallet address and transaction signature.
+
+> **Note:** The route path uses the internal project codename (`$RVUI`). The on-chain token symbol is **RVC**.
 
 **Request body** (JSON)
 


### PR DESCRIPTION
## Summary

The 2026-04-23 audit flagged ticker ambiguity: MASTER_PLAN / Session_Opener / memory say `$RVUI`; revealcoin UI + whitepaper + `SECURITY.md` say `RVC`. After investigation, the two are **complementary, not contradictory**:

- **`$RVUI`** = internal project codename. Kingdom-taxonomy label ("Crown ($RVUI token)"), code identifiers (`RVUI_*` constants, `rvuiEnabled`, `rvuiReceivingAddress`, `rvuiAsset`), env vars (`RVUI_PAYMENTS_ENABLED`), route paths (`/api/billing/rvui-payment`), function names (`toRvuiAtomicUnits`). **Safe to keep everywhere internal.**
- **`RVC`** = on-chain Token-2022 symbol, declared in the mint metadata, immutable without re-issuing the token. **The only ticker customers see.**

This PR fixes the handful of places where the internal codename leaked into customer-facing strings.

### Changes

**`apps/api/src/middleware/x402.ts`** (two call sites, one for `buildPaymentRequiredResponse`, one for `buildAgentStreamPaymentChallenge`):

- `description: 'RevealUI agent task — ${discountedPrice} USD in RVUI (20% discount)'` → `...in RVC...`
- `extra: { name: 'RVUI', version: '1', discount: '20%' }` → `{ name: 'RVC', ... }`. The `extra.name` field is part of the [x402 protocol response](https://www.x402.org/) returned to paying agents / wallet UIs — surfacing `RVUI` there would confuse anyone holding the token under its real symbol.

**`docs/api/rest-api/README.md`** (two `rvui-payment` route docs, `/api/billing/rvui-payment` and `/api/v1/billing/rvui-payment`):

- Route blurb now describes the on-chain asset as `RVC (RevealCoin)` rather than `RVUI`.
- Added a footnote: "The route path `/api/billing/rvui-payment` uses the internal project codename (`$RVUI`). The on-chain token symbol is RVC. Both refer to the same token." — so developers seeing the URL don't think it's a stale route.

### Not touched, by design

- **Route paths** (`/api/billing/rvui-payment`) — internal URL; stable API surface.
- **Env vars** (`RVUI_PAYMENTS_ENABLED`) — internal infra.
- **Config field names** (`rvuiEnabled`, `rvuiReceivingAddress`, `rvuiAsset`) — internal code identifiers.
- **Kingdom taxonomy** in internal docs, `MASTER_PLAN.md` — explicitly internal-only vocabulary per the Session Opener itself.
- **`@revealui/services/revealcoin/client.ts`** — internal service; its `RVUI` references describe the internal-codename context and don't reach customers.
- **`e2e/billing-checkout.e2e.ts`**, **`docs/SECRETS.md:31`**, **`docs/checklists/stripe-checkout-verification.md`**, **`docs/DOCUMENTATION_ASSESSMENT.md`** — internal test/ops docs.

### Follow-up (not in this PR)

After this lands, a short memory entry documenting the `$RVUI` (internal) vs `RVC` (external) split will keep future sessions from rediscovering the question every time. I'll propose that as a one-line addition to the user's auto-memory once you're happy with this resolution.

**Source:** internal docs § revealcoin ticker ambiguity`.

## Test plan
- [ ] `pnpm --filter api typecheck` green
- [ ] `pnpm --filter api build` green
- [ ] Eyeball the `buildPaymentRequiredResponse` + `buildAgentStreamPaymentChallenge` outputs (x402 response bodies) — both `description` and `extra.name` should say `RVC`
- [ ] `docs/api/rest-api/README.md` renders cleanly — RVC-with-codename-footnote reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
