### PR TITLE
feat(api, mcp): Stage 5.2 sampling handler at /api/agent-stream (A.2a)

### DIFF
--- a/.changeset/mcp-a2a-sampling-handler.md
+++ b/.changeset/mcp-a2a-sampling-handler.md
@@ -1,0 +1,26 @@
+---
+'@revealui/mcp': minor
+'api': patch
+---
+
+A.2a of the post-v1 MCP arc — wire Stage 5.2 sampling handler into agent-stream.
+
+When an OAuth-authorized MCP server connected to an agent run at
+`/api/agent-stream` requests `sampling/create`, the handler now routes the
+request through the configured LLM (defaulting to Canonical Inference Snap
+via `INFERENCE_SNAPS_BASE_URL` env precedence). Model-hint allowlist guards
+against servers routing us to expensive models.
+
+**`@revealui/mcp`:**
+- `BuildRemoteMcpClientOptions.samplingHandler?: SamplingHandler` — new
+  pass-through slot on `buildRemoteMcpClient` that forwards to the
+  `McpClient` constructor (the slot already existed on `McpClient`; A.2a
+  exposes it to callers via `@revealui/mcp/remote-client`).
+
+**`api`:**
+- `apps/api/src/routes/agent-stream.ts` — per connected MCP server, build
+  a sampling handler via `aiMod.createSamplingHandler({ llm: llmClient,
+  allowedModels, defaultModel, namespace: server, onEvent })` and pass
+  to `buildRemoteMcpClient`. Same `onEvent` sink as A.1's tool adapters,
+  so Stage 6.1 logger + Stage 6.2 `usage_meters` capture
+  `mcp.sampling.create` events alongside tool calls.

--- a/apps/api/src/routes/agent-stream.ts
+++ b/apps/api/src/routes/agent-stream.ts
@@ -252,9 +252,45 @@ app.openapi(agentStreamRoute, async (c) => {
       });
     }
 
+    // A.2a: Sampling handler allowlist. MCP servers may request any model
+    // via `modelPreferences.hints`; we filter those hints to this list so
+    // servers can't silently route us to expensive models. Models outside
+    // the list fall back to `defaultModel`. Conservative set — extend when
+    // specific models are validated + cost-bounded.
+    const samplingAllowedModels = [
+      'gemma3',
+      'gemma3:e2b',
+      'gemma3:e4b',
+      'deepseek-r1',
+      'qwen3',
+    ] as const;
+    const samplingDefaultModel = process.env.LLM_MODEL ?? 'gemma3';
+
     for (const server of serverIds) {
       try {
-        const built = await buildRemoteMcpClient({ tenant, server });
+        // A.2a: Per-server sampling handler so when the MCP server calls
+        // `sampling/create` mid-agent-run, our configured LLM services it.
+        // Same `onEvent` sink as the tool adapters so Stage 6.1 logger +
+        // Stage 6.2 usage_meters capture `mcp.sampling.create` events too.
+        //
+        // Structural cast note: `@revealui/ai`'s `McpSamplingHandler` uses a
+        // simplified message-content shape, while `@revealui/mcp`'s
+        // `SamplingHandler` (fed into the SDK) uses the full
+        // `TextContent | ImageContent | AudioContent | …` union. The two
+        // are runtime-compatible for the text fields the handler actually
+        // reads — the cast documents the known type-system mismatch that
+        // falls out of Stage 5.2's structural-decoupling design. Fixing
+        // it for real means widening `McpSamplingRequestParams.messages[].
+        // content` in `@revealui/ai`; deferred — out of A.2a scope.
+        const samplingHandler = aiMod.createSamplingHandler({
+          llm: llmClient as Parameters<typeof aiMod.createSamplingHandler>[0]['llm'],
+          allowedModels: samplingAllowedModels,
+          defaultModel: samplingDefaultModel,
+          namespace: server,
+          onEvent,
+        }) as unknown as Parameters<typeof buildRemoteMcpClient>[0]['samplingHandler'];
+
+        const built = await buildRemoteMcpClient({ tenant, server, samplingHandler });
         await built.client.connect();
         const mcpTools = await aiMod.createToolsFromMcpClient(built.client, {
           namespace: server,

--- a/packages/mcp/__tests__/remote-client.test.ts
+++ b/packages/mcp/__tests__/remote-client.test.ts
@@ -1,11 +1,24 @@
 /**
- * Unit tests for {@link listConnectedMcpServers}. Uses the in-memory vault
- * so tests are hermetic — no revvault subprocess, no network.
+ * Unit tests for {@link listConnectedMcpServers} and the
+ * {@link buildRemoteMcpClient} options-to-`McpClient` plumbing. Uses the
+ * in-memory vault so tests are hermetic — no revvault subprocess, no
+ * network.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createMemoryVault, RevvaultError } from '../src/oauth.js';
-import { listConnectedMcpServers } from '../src/remote-client.js';
+import { buildRemoteMcpClient, listConnectedMcpServers } from '../src/remote-client.js';
+
+// Mock McpClient constructor so buildRemoteMcpClient tests can inspect the
+// options passed through without actually opening a transport.
+vi.mock('../src/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/client.js')>('../src/client.js');
+  const McpClientMock = vi.fn();
+  return {
+    ...actual,
+    McpClient: McpClientMock,
+  };
+});
 
 describe('listConnectedMcpServers', () => {
   it('returns sorted unique server ids from tokens paths', async () => {
@@ -106,5 +119,59 @@ describe('listConnectedMcpServers', () => {
     const servers = await listConnectedMcpServers(vault, 'acme');
 
     expect(servers).toEqual(['linear']);
+  });
+});
+
+describe('buildRemoteMcpClient', () => {
+  const META = JSON.stringify({
+    serverUrl: 'https://mcp.example.com',
+    connectedAt: '2026-04-24T00:00:00.000Z',
+    connectedBy: 'user-123',
+  });
+
+  async function importFreshClient() {
+    // vi.mock hoists; re-import the mocked constructor so per-test setup can
+    // clear its call history without teardown affecting other suites.
+    const { McpClient } = await import('../src/client.js');
+    return vi.mocked(McpClient);
+  }
+
+  it('passes samplingHandler through to the McpClient constructor (A.2a)', async () => {
+    const McpClientMock = await importFreshClient();
+    McpClientMock.mockClear();
+
+    const vault = createMemoryVault({ 'mcp/acme/linear/meta': META });
+    const samplingHandler = vi.fn();
+    await buildRemoteMcpClient({ tenant: 'acme', server: 'linear', vault, samplingHandler });
+
+    expect(McpClientMock).toHaveBeenCalledTimes(1);
+    const opts = McpClientMock.mock.calls[0]?.[0];
+    expect(opts?.samplingHandler).toBe(samplingHandler);
+    expect(opts?.elicitationHandler).toBeUndefined();
+  });
+
+  it('passes elicitationHandler through to the McpClient constructor', async () => {
+    const McpClientMock = await importFreshClient();
+    McpClientMock.mockClear();
+
+    const vault = createMemoryVault({ 'mcp/acme/linear/meta': META });
+    const elicitationHandler = vi.fn();
+    await buildRemoteMcpClient({ tenant: 'acme', server: 'linear', vault, elicitationHandler });
+
+    const opts = McpClientMock.mock.calls[0]?.[0];
+    expect(opts?.elicitationHandler).toBe(elicitationHandler);
+    expect(opts?.samplingHandler).toBeUndefined();
+  });
+
+  it('omits both handlers from the McpClient options when neither is supplied', async () => {
+    const McpClientMock = await importFreshClient();
+    McpClientMock.mockClear();
+
+    const vault = createMemoryVault({ 'mcp/acme/linear/meta': META });
+    await buildRemoteMcpClient({ tenant: 'acme', server: 'linear', vault });
+
+    const opts = McpClientMock.mock.calls[0]?.[0];
+    expect(opts?.samplingHandler).toBeUndefined();
+    expect(opts?.elicitationHandler).toBeUndefined();
   });
 });

--- a/packages/mcp/src/remote-client.ts
+++ b/packages/mcp/src/remote-client.ts
@@ -20,7 +20,7 @@
  * duplicating admin code.
  */
 
-import { type ElicitationHandler, McpClient } from './client.js';
+import { type ElicitationHandler, McpClient, type SamplingHandler } from './client.js';
 import {
   createRevvaultVault,
   McpOAuthProvider,
@@ -122,6 +122,15 @@ export interface BuildRemoteMcpClientOptions {
    * matches what the caller can actually service.
    */
   elicitationHandler?: ElicitationHandler;
+  /**
+   * Handler invoked when the server sends `sampling/create`. Registered
+   * on the `McpClient` at construction time so capability advertisement
+   * matches what the caller can actually service. Typically built via
+   * `createSamplingHandler` from `@revealui/ai`, which routes the request
+   * through the caller's configured LLM with an optional model allowlist
+   * for cost safety.
+   */
+  samplingHandler?: SamplingHandler;
 }
 
 export interface BuiltRemoteMcpClient {
@@ -164,6 +173,7 @@ export async function buildRemoteMcpClient(
       authProvider: provider,
     },
     ...(options.elicitationHandler ? { elicitationHandler: options.elicitationHandler } : {}),
+    ...(options.samplingHandler ? { samplingHandler: options.samplingHandler } : {}),
   });
 
   return { client, meta };


### PR DESCRIPTION
## Summary

**A.2a of the post-v1 MCP arc.** Wires Stage 5.2 sampling handler into the production `/api/agent-stream` code path so when a connected MCP server calls `sampling/create` mid-agent-run, our configured LLM services it.

Canonical Inference Snap is the default provider via the existing `createLLMClientFromEnv` env precedence (`INFERENCE_SNAPS_BASE_URL` → `GROQ_API_KEY` → `OLLAMA_BASE_URL`). Model-hint allowlist guards against servers routing us to expensive models. Same `onEvent` sink as A.1's tool adapters, so Stage 6.1 logger + Stage 6.2 `usage_meters` capture `mcp.sampling.create` events alongside tool calls — zero extra observability wiring.

## What ships

- `packages/mcp/src/remote-client.ts` — add optional `samplingHandler?: SamplingHandler` to `BuildRemoteMcpClientOptions`; pass-through to the `McpClient` constructor (slot already existed at [`packages/mcp/src/client.ts:215`](../blob/test/packages/mcp/src/client.ts#L215)).
- `packages/mcp/__tests__/remote-client.test.ts` — 3 new plumbing tests (samplingHandler passes through / elicitationHandler passes through / both omitted when neither supplied). Uses `vi.mock('../src/client.js')` to inspect constructor options without opening a transport. 218 → 221 passing.
- `apps/api/src/routes/agent-stream.ts` — per connected MCP server, build a sampling handler via `aiMod.createSamplingHandler({ llm, allowedModels, defaultModel, namespace, onEvent })` and pass to `buildRemoteMcpClient`. Allowlist: `['gemma3', 'gemma3:e2b', 'gemma3:e4b', 'deepseek-r1', 'qwen3']`. Default model: `process.env.LLM_MODEL ?? 'gemma3'`.

## Design anchors

Part of the A.2 split decided during the 2026-04-24 post-A.1 survey (see internal docs §A.2a). Original A.2 scope (~500 LOC, UI-heavy) didn't account for the `AgentStreamChunk` type extensions + runtime `emit` plumbing needed before the UI can render sampling/elicitation chunks. Split:

- **A.2a (this PR, ~145 LOC):** backend sampling handler. No UI, no new chunk types. Sampling happens silently but observably (logger + meters).
- **A.2b (next PR, ~800 LOC):** streaming agent-exec page at `/admin/agents/[id]/run`, elicitation POST endpoint + session registry, new chunk types, `useToolStream` hook extraction.

## Structural-decoupling note

`@revealui/ai`'s `McpSamplingHandler` uses a simplified message-content shape (`content: { type: string; text?; data?; mimeType? }`) while `@revealui/mcp`'s `SamplingHandler` uses the SDK's full union (`TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource | …`). The two are runtime-compatible for the text fields the handler actually reads, but not structurally assignable. An explicit `as unknown as` cast in `agent-stream.ts` documents the known type-system mismatch that falls out of Stage 5.2's structural-decoupling design. Real fix (widening `McpSamplingRequestParams.messages[].content` in `@revealui/ai`) is out of A.2a scope.

## Test plan

- [x] `pnpm --filter @revealui/mcp test` — 221/221 pass (+3 new)
- [x] `pnpm --filter api test` — 2345/2345 pass (unchanged)
- [x] `pnpm --filter api typecheck` — clean
- [x] `pnpm --filter "@revealui/mcp..." build` — clean
- [x] `pnpm validate:boundary` — clean
- [x] Pre-push gate (15 checks) — PASS
- [ ] **Post-merge smoke test** (manual): connect an MCP server that exercises `sampling/create` mid-tool-call to a tenant; fire an agent run; confirm `[mcp] mcp.sampling.create` entries in central logs and a `usage_meters` row with `meterName='mcp.sampling.create'` + `source='agent'` when the session resolves an `accountId`.

## Follow-ups (NOT in this PR)

- **A.2b** — streaming agent-exec page consuming `/api/agent-stream` SSE with per-event-type rendering (reuses Stage 3.4 `StreamingToolCard` via extracted `useToolStream` hook), elicitation forms, cancel button. Adds `sampling_request` + `elicitation_request` chunk types to `AgentStreamChunk`, a process-local session registry adapted from Stage 3.4's `call-sessions.ts`, and a `POST /api/agent-stream/elicit` endpoint.
- **Widen `McpSamplingRequestParams.messages[].content`** in `@revealui/ai` so the `as unknown as` cast can go away.
- **End-to-end integration test** exercising the full `/api/agent-stream` → MCP server `sampling/create` → LLM → back chain. Skipped here; same defense-in-depth deferral as A.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
