### PR TITLE
feat(api, ai): Stage 5.3 elicitation plumbing + side-channel SSE chunks (A.2b-backend)

### DIFF
--- a/.changeset/mcp-a2b-backend.md
+++ b/.changeset/mcp-a2b-backend.md
@@ -1,0 +1,66 @@
+---
+'@revealui/ai': minor
+'api': minor
+---
+
+A.2b-backend of the post-v1 MCP arc — wire Stage 5.3 elicitation handler
+into agent-stream + emit side-channel SSE chunks for
+sampling/elicitation. The backend plumbing the A.2b-frontend UI will sit
+on top of.
+
+When an MCP server connected to an in-flight `/api/agent-stream` run
+calls `elicitation/create`, the handler now:
+
+1. Writes an `elicitation_request` chunk to the SSE stream with
+   `{ sessionId, elicitationId, requestedSchema, message, namespace }`.
+2. Parks on the in-memory agent-run session registry until a matching
+   `POST /api/agent-stream/elicit` resolves the pending promise.
+3. Returns the user's decision to the MCP server so the tool call can
+   continue.
+
+Sampling requests (wired in A.2a) now also emit a `sampling_request`
+chunk before running the LLM for observability.
+
+**`@revealui/ai`:**
+- Extend `AgentStreamChunk` with three side-channel types:
+  `session_info`, `sampling_request`, `elicitation_request`. Adds
+  `sessionId`, `namespace`, `sampling`, and `elicitation` optional
+  fields to carry side-channel payloads. Runtime-level emission is
+  unchanged — the generator still yields only the core turn events
+  (`text`, `tool_call_start`, `tool_call_result`, `error`, `done`).
+  Side-channel chunks are written directly by route-level handlers.
+
+**`api`:**
+- `apps/api/src/lib/agent-run-sessions.ts` (new) — process-local
+  registry of `(sessionId, elicitationId) → pending Promise<ElicitResult>`.
+  Adapted from Stage 3.4's admin-side `call-sessions.ts`, scoped to
+  agent-run lifecycle rather than per-tool-invocation. Exports:
+  `createAgentRunSession`, `getAgentRunSession`, `awaitElicitationResponse`,
+  `resolveElicitation`, `deleteAgentRunSession` (plus a test-only
+  `_resetAgentRunSessions`).
+- `apps/api/src/routes/agent-stream-elicit.ts` (new) —
+  `POST /api/agent-stream/elicit` endpoint. Body
+  `{ sessionId, elicitationId, action: 'accept'|'decline'|'cancel',
+  content? }`. Enforces `session.userId === c.var.user.id`. 404 on
+  unknown session or elicitation id; 403 on user mismatch; 401 on
+  unauthenticated.
+- `apps/api/src/routes/agent-stream.ts` —
+  - Create `runSession = createAgentRunSession(user.id)` before
+    MCP-client construction; tear down in the streamSSE `finally`.
+  - Declare `streamRef: { current: SSEStreamingApi | undefined }` as a
+    late-binding mutable reference so per-server elicitation/sampling
+    handlers (built before `streamSSE()` starts) can write into the
+    stream once it exists.
+  - Wrap the A.2a sampling handler with a chunk-emit wrapper writing a
+    `sampling_request` chunk before calling the inner handler.
+  - Build a per-server `elicitationHandler` that writes an
+    `elicitation_request` chunk + parks on the run-session registry;
+    falls back to `{ action: 'cancel' }` when the stream isn't yet
+    bound or when the registry entry disappears mid-flight.
+  - First SSE chunk is `session_info` so the client learns the
+    `sessionId` to POST back to `/api/agent-stream/elicit`.
+- `apps/api/src/index.ts` — mount the new route at
+  `/api/agent-stream/elicit` (canonical + `/api/v1/…` alias), before
+  the parent `/api/agent-stream` mount so the trie-based router matches
+  the more-specific prefix first. CSRF (`writeProtected`) applied to
+  the new POST.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -71,6 +71,7 @@ import { a2aRoutes, wellKnownRoutes } from './routes/a2a.js';
 import adminObservabilityRoute from './routes/admin/observability.js';
 import { createAgentCollabRoute } from './routes/agent-collab.js';
 import agentStreamRoute from './routes/agent-stream.js';
+import agentStreamElicitRoute from './routes/agent-stream-elicit.js';
 import agentTasksRoute from './routes/agent-tasks.js';
 import apiKeysRoute from './routes/api-keys.js';
 import authRoute from './routes/auth.js';
@@ -752,6 +753,8 @@ app.post('/api/agent-tasks/*', writeProtected);
 app.post('/api/v1/agent-tasks/*', writeProtected);
 app.post('/api/agent-stream', writeProtected);
 app.post('/api/v1/agent-stream', writeProtected);
+app.post('/api/agent-stream/elicit', writeProtected);
+app.post('/api/v1/agent-stream/elicit', writeProtected);
 app.get('/api/rag/*', writeProtected);
 app.get('/api/v1/rag/*', writeProtected);
 app.post('/api/rag/*', writeProtected);
@@ -1044,6 +1047,12 @@ app.route('/api/webhooks', webhooksRoute);
 app.route('/api/provenance', provenanceRoute);
 app.route('/api/tickets', ticketsRoute);
 app.route('/api/agent-tasks', agentTasksRoute);
+// A.2b: elicitation-response endpoint for in-flight agent runs. Mounted
+// BEFORE the parent `/api/agent-stream` route so Hono's trie-based router
+// matches the more-specific path first. The OpenAPIHono instance for
+// agent-stream is already bound to `/` for its POST streaming handler, so
+// elicit must be a sibling rather than a sub-route.
+app.route('/api/agent-stream/elicit', agentStreamElicitRoute);
 app.route('/api/agent-stream', agentStreamRoute);
 app.route('/api/content', contentRoute);
 app.route('/api/rag', ragIndexRoute);
@@ -1098,6 +1107,7 @@ app.route('/api/v1/webhooks', webhooksRoute);
 app.route('/api/v1/provenance', provenanceRoute);
 app.route('/api/v1/tickets', ticketsRoute);
 app.route('/api/v1/agent-tasks', agentTasksRoute);
+app.route('/api/v1/agent-stream/elicit', agentStreamElicitRoute);
 app.route('/api/v1/agent-stream', agentStreamRoute);
 app.route('/api/v1/content', contentRoute);
 app.route('/api/v1/rag', ragIndexRoute);

--- a/apps/api/src/lib/__tests__/agent-run-sessions.test.ts
+++ b/apps/api/src/lib/__tests__/agent-run-sessions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the process-local agent-run session registry. Hermetic —
+ * no HTTP, no DB, no filesystem. Each `describe` block resets the
+ * registry in a `beforeEach` so sessions from one block don't leak.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetAgentRunSessions,
+  awaitElicitationResponse,
+  createAgentRunSession,
+  deleteAgentRunSession,
+  getAgentRunSession,
+  resolveElicitation,
+} from '../agent-run-sessions.js';
+
+beforeEach(() => {
+  _resetAgentRunSessions();
+});
+
+afterEach(() => {
+  _resetAgentRunSessions();
+});
+
+describe('createAgentRunSession', () => {
+  it('returns a session bound to the supplied user with a unique id', () => {
+    const a = createAgentRunSession('user-1');
+    const b = createAgentRunSession('user-2');
+
+    expect(a.userId).toBe('user-1');
+    expect(b.userId).toBe('user-2');
+    expect(a.sessionId).not.toBe(b.sessionId);
+    expect(a.pending.size).toBe(0);
+    expect(typeof a.createdAt).toBe('number');
+  });
+});
+
+describe('getAgentRunSession', () => {
+  it('returns the session when it exists', () => {
+    const session = createAgentRunSession('user-1');
+    expect(getAgentRunSession(session.sessionId)).toBe(session);
+  });
+
+  it('returns undefined for unknown session ids', () => {
+    expect(getAgentRunSession('not-a-real-session')).toBeUndefined();
+  });
+});
+
+describe('awaitElicitationResponse + resolveElicitation', () => {
+  it('resolves the pending promise when a matching elicit response lands', async () => {
+    const session = createAgentRunSession('user-1');
+    const pending = awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const landed = resolveElicitation(session.sessionId, 'elicit-1', {
+      action: 'accept',
+      content: { ok: true },
+    });
+
+    expect(landed).toBe(true);
+    await expect(pending).resolves.toEqual({
+      action: 'accept',
+      content: { ok: true },
+    });
+  });
+
+  it('returns false when the session is unknown', () => {
+    expect(resolveElicitation('missing-session', 'elicit-1', { action: 'cancel' })).toBe(false);
+  });
+
+  it('returns false when the elicitation id is unknown for an existing session', () => {
+    const session = createAgentRunSession('user-1');
+    expect(resolveElicitation(session.sessionId, 'not-registered', { action: 'cancel' })).toBe(
+      false,
+    );
+  });
+
+  it('drops the pending entry after resolving so a second response 404s', async () => {
+    const session = createAgentRunSession('user-1');
+    const pending = awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    expect(resolveElicitation(session.sessionId, 'elicit-1', { action: 'decline' })).toBe(true);
+    await pending;
+
+    expect(resolveElicitation(session.sessionId, 'elicit-1', { action: 'accept' })).toBe(false);
+  });
+
+  it('resolves with cancel when awaiting on a non-existent session', async () => {
+    const pending = awaitElicitationResponse('phantom-session', 'elicit-1');
+    await expect(pending).resolves.toEqual({ action: 'cancel' });
+  });
+});
+
+describe('deleteAgentRunSession', () => {
+  it('removes the session', () => {
+    const session = createAgentRunSession('user-1');
+    deleteAgentRunSession(session.sessionId);
+    expect(getAgentRunSession(session.sessionId)).toBeUndefined();
+  });
+
+  it('resolves any outstanding elicitation with cancel', async () => {
+    const session = createAgentRunSession('user-1');
+    const a = awaitElicitationResponse(session.sessionId, 'elicit-a');
+    const b = awaitElicitationResponse(session.sessionId, 'elicit-b');
+
+    deleteAgentRunSession(session.sessionId);
+
+    await expect(a).resolves.toEqual({ action: 'cancel' });
+    await expect(b).resolves.toEqual({ action: 'cancel' });
+  });
+
+  it('is a no-op when the session does not exist', () => {
+    expect(() => deleteAgentRunSession('phantom')).not.toThrow();
+  });
+});

--- a/apps/api/src/lib/agent-run-sessions.ts
+++ b/apps/api/src/lib/agent-run-sessions.ts
@@ -1,0 +1,126 @@
+/**
+ * In-memory session registry for streaming agent runs at
+ * `/api/agent-stream` that may trigger MCP `elicitation/create` requests
+ * mid-flight. Lifetime: one entry per active agent-stream request. Entries
+ * are removed explicitly when the stream ends (success, error, disconnect).
+ *
+ * Adapted from Stage 3.4's
+ * [`apps/admin/src/lib/mcp/call-sessions.ts`](../../../admin/src/lib/mcp/call-sessions.ts) —
+ * same design (process-local `Map`, ephemeral, no durability) but scoped
+ * to agent-run flows rather than per-`(tenant, server)` tool-invocation
+ * flows. Two route handlers bridge via this registry:
+ *
+ *   1. `POST /api/agent-stream` registers the session on stream start,
+ *      attaches an `elicitationHandler` to each connected `McpClient`
+ *      that writes an `elicitation_request` SSE chunk and awaits a
+ *      matching POST response.
+ *   2. `POST /api/agent-stream/elicit` reads `{ sessionId, elicitationId,
+ *      action, content? }` from its body, looks up the pending promise,
+ *      and resolves it so the MCP server's `elicitation/create` call
+ *      returns and the agent turn continues.
+ *
+ * State is process-local and intentionally non-durable. If the api process
+ * restarts, in-flight agent runs are cancelled (any unresolved elicitation
+ * handlers reject with `{ action: 'cancel' }`).
+ *
+ * A.2b of the post-v1 MCP arc.
+ */
+
+import type { ElicitResult } from '@revealui/mcp/client';
+
+interface PendingElicitation {
+  id: string;
+  resolve: (result: ElicitResult) => void;
+}
+
+export interface AgentRunSession {
+  sessionId: string;
+  userId: string;
+  createdAt: number;
+  pending: Map<string, PendingElicitation>;
+}
+
+const sessions = new Map<string, AgentRunSession>();
+
+export function createAgentRunSession(userId: string): AgentRunSession {
+  const sessionId = crypto.randomUUID();
+  const session: AgentRunSession = {
+    sessionId,
+    userId,
+    createdAt: Date.now(),
+    pending: new Map(),
+  };
+  sessions.set(sessionId, session);
+  return session;
+}
+
+export function getAgentRunSession(sessionId: string): AgentRunSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export function deleteAgentRunSession(sessionId: string): void {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+  // Reject any outstanding elicitation so the MCP server's handler
+  // unblocks and the client can tear down cleanly.
+  for (const pending of session.pending.values()) {
+    pending.resolve({ action: 'cancel' });
+  }
+  sessions.delete(sessionId);
+}
+
+/**
+ * Register a pending elicitation against an active session. Returns a
+ * Promise that resolves when a matching `elicit` POST lands (or when the
+ * session is deleted, in which case the promise resolves with
+ * `{ action: 'cancel' }`).
+ */
+export function awaitElicitationResponse(
+  sessionId: string,
+  elicitationId: string,
+): Promise<ElicitResult> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return Promise.resolve({ action: 'cancel' });
+  }
+  return new Promise<ElicitResult>((resolve) => {
+    session.pending.set(elicitationId, { id: elicitationId, resolve });
+  });
+}
+
+/**
+ * Resolve a pending elicitation with the admin-supplied response. Returns
+ * `true` if a matching pending request was found + resolved. The caller
+ * (the `/elicit` route) reports 404 on `false`.
+ */
+export function resolveElicitation(
+  sessionId: string,
+  elicitationId: string,
+  result: ElicitResult,
+): boolean {
+  const session = sessions.get(sessionId);
+  if (!session) return false;
+  const pending = session.pending.get(elicitationId);
+  if (!pending) return false;
+  session.pending.delete(elicitationId);
+  pending.resolve(result);
+  return true;
+}
+
+/**
+ * Test-only. Clears the registry — isolates test-to-test state so
+ * neighbor-session data never bleeds across `describe` blocks.
+ *
+ * Exported at module top-level (rather than behind a guard) because the
+ * registry is already process-local + in-memory; there's no production
+ * surface where "clear all sessions" is a legitimate operation. Tests
+ * that touch the registry should call this in `beforeEach`.
+ */
+export function _resetAgentRunSessions(): void {
+  for (const session of sessions.values()) {
+    for (const pending of session.pending.values()) {
+      pending.resolve({ action: 'cancel' });
+    }
+  }
+  sessions.clear();
+}

--- a/apps/api/src/routes/__tests__/agent-stream-elicit.test.ts
+++ b/apps/api/src/routes/__tests__/agent-stream-elicit.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for `POST /api/agent-stream/elicit`. Hermetic — no DB,
+ * no HTTP, no file I/O. Mounts the real route on a fresh Hono app with a
+ * stub auth middleware that seeds `c.var.user`.
+ */
+
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetAgentRunSessions,
+  awaitElicitationResponse,
+  createAgentRunSession,
+} from '../../lib/agent-run-sessions.js';
+import elicitRoute from '../agent-stream-elicit.js';
+
+function createApp(user: { id: string; role: string } | null) {
+  const app = new Hono<{ Variables: { user?: { id: string; role: string } } }>();
+  app.use('*', async (c, next) => {
+    if (user) c.set('user', user);
+    await next();
+  });
+  app.route('/agent-stream/elicit', elicitRoute);
+  return app;
+}
+
+async function postElicit(
+  app: Hono,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request('/agent-stream/elicit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, json };
+}
+
+beforeEach(() => {
+  _resetAgentRunSessions();
+});
+
+afterEach(() => {
+  _resetAgentRunSessions();
+});
+
+describe('POST /agent-stream/elicit', () => {
+  it('resolves a pending elicitation on accept', async () => {
+    const session = createAgentRunSession('user-1');
+    const pending = awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+      content: { answer: 42 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ success: true });
+    await expect(pending).resolves.toEqual({
+      action: 'accept',
+      content: { answer: 42 },
+    });
+  });
+
+  it('resolves a pending elicitation on decline (content dropped)', async () => {
+    const session = createAgentRunSession('user-1');
+    const pending = awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'decline',
+      content: { shouldBeDropped: true },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(pending).resolves.toEqual({ action: 'decline' });
+  });
+
+  it('returns 401 when the caller is unauthenticated', async () => {
+    const session = createAgentRunSession('user-1');
+    awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const app = createApp(null);
+    const res = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.json).toMatchObject({ success: false });
+  });
+
+  it('returns 403 when the session belongs to a different user', async () => {
+    const session = createAgentRunSession('user-1');
+    awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const app = createApp({ id: 'user-2', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.json).toMatchObject({ success: false });
+  });
+
+  it('returns 404 when the session is unknown', async () => {
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: '00000000-0000-4000-8000-000000000000',
+      elicitationId: 'elicit-1',
+      action: 'cancel',
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.json).toMatchObject({ success: false });
+  });
+
+  it('returns 404 when the elicitation id is unknown for an existing session', async () => {
+    const session = createAgentRunSession('user-1');
+    awaitElicitationResponse(session.sessionId, 'registered');
+
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'not-registered',
+      action: 'accept',
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a second POST for the same elicitation id (one-shot)', async () => {
+    const session = createAgentRunSession('user-1');
+    const pending = awaitElicitationResponse(session.sessionId, 'elicit-1');
+
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const first = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+      content: { n: 1 },
+    });
+    const second = await postElicit(app, {
+      sessionId: session.sessionId,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+      content: { n: 2 },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(404);
+    await expect(pending).resolves.toEqual({ action: 'accept', content: { n: 1 } });
+  });
+
+  it('validates body shape (rejects non-uuid sessionId)', async () => {
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: 'not-a-uuid',
+      elicitationId: 'elicit-1',
+      action: 'accept',
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+
+  it('validates body shape (rejects invalid action)', async () => {
+    const app = createApp({ id: 'user-1', role: 'admin' });
+    const res = await postElicit(app, {
+      sessionId: crypto.randomUUID(),
+      elicitationId: 'elicit-1',
+      action: 'invalid',
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});

--- a/apps/api/src/routes/__tests__/agent-stream-success.test.ts
+++ b/apps/api/src/routes/__tests__/agent-stream-success.test.ts
@@ -147,6 +147,23 @@ function parseSse(text: string): SseEvent[] {
   return events;
 }
 
+/**
+ * A.2b emits a `session_info` chunk as the FIRST SSE frame on every
+ * agent-stream response so the client learns the `sessionId` to POST back
+ * to `/api/agent-stream/elicit`. Tests that assert the shape of agent-
+ * generated chunks (`text`, `tool_call_start`, `done`, etc.) use this
+ * helper to strip the session_info prefix; tests that care about the
+ * prefix itself assert on the raw `parseSse` output.
+ */
+function dropSessionInfo(events: SseEvent[]): SseEvent[] {
+  if (events.length === 0) return events;
+  const first = events[0];
+  if (first && first.event === 'session_info') {
+    return events.slice(1);
+  }
+  return events;
+}
+
 /** Get the runtime mock returned for the most recent request. */
 async function getRuntimeMock() {
   const { StreamingAgentRuntime } = await import('@revealui/ai/orchestration/streaming-runtime');
@@ -229,6 +246,35 @@ describe('agent-stream  -  success path (AI modules working)', () => {
     expect(res.headers.get('content-type')).toContain('text/event-stream');
   });
 
+  it('emits a session_info chunk as the FIRST SSE frame (A.2b)', async () => {
+    // The A.2b side-channel contract: the client learns the sessionId from
+    // the leading frame and POSTs elicitation responses to
+    // /api/agent-stream/elicit?sessionId=... — so session_info MUST
+    // precede any other chunks, even when the agent runs to done
+    // immediately.
+    const { StreamingAgentRuntime } = await import('@revealui/ai/orchestration/streaming-runtime');
+    // biome-ignore lint/complexity/useArrowFunction: StreamingAgentRuntime is called with `new`  -  arrow functions cannot be constructors (Vitest 4)
+    vi.mocked(StreamingAgentRuntime).mockImplementation(function () {
+      return {
+        streamTask: vi.fn().mockImplementation(async function* () {
+          yield { type: 'done', result: 'ok' };
+        }),
+      };
+    });
+
+    const app = createApp();
+    const res = await jsonPost(app, '/agent-stream', { instruction: 'noop' });
+    const events = parseSse(await res.text());
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0]!.event).toBe('session_info');
+    const sessionInfo = events[0]!.data as { type: string; sessionId: string };
+    expect(sessionInfo.type).toBe('session_info');
+    expect(sessionInfo.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
   it('emits one SSE frame per chunk with matching event type', async () => {
     const { StreamingAgentRuntime } = await import('@revealui/ai/orchestration/streaming-runtime');
     // biome-ignore lint/complexity/useArrowFunction: StreamingAgentRuntime is called with `new`  -  arrow functions cannot be constructors (Vitest 4)
@@ -246,7 +292,7 @@ describe('agent-stream  -  success path (AI modules working)', () => {
     const res = await jsonPost(app, '/agent-stream', { instruction: 'Say hello' });
 
     expect(res.status).toBe(200);
-    const events = parseSse(await res.text());
+    const events = dropSessionInfo(parseSse(await res.text()));
     expect(events).toHaveLength(3);
     expect(events[0]!.event).toBe('thinking');
     expect(events[1]!.event).toBe('token');
@@ -266,8 +312,8 @@ describe('agent-stream  -  success path (AI modules working)', () => {
     });
 
     const app = createApp();
-    const events = parseSse(
-      await (await jsonPost(app, '/agent-stream', { instruction: 'Hi' })).text(),
+    const events = dropSessionInfo(
+      parseSse(await (await jsonPost(app, '/agent-stream', { instruction: 'Hi' })).text()),
     );
 
     expect(events[0]!.data).toMatchObject({ type: 'token', content: 'Hi', index: 0 });
@@ -290,8 +336,8 @@ describe('agent-stream  -  success path (AI modules working)', () => {
     });
 
     const app = createApp();
-    const events = parseSse(
-      await (await jsonPost(app, '/agent-stream', { instruction: '' })).text(),
+    const events = dropSessionInfo(
+      parseSse(await (await jsonPost(app, '/agent-stream', { instruction: '' })).text()),
     );
 
     expect(events).toHaveLength(2);
@@ -311,8 +357,8 @@ describe('agent-stream  -  success path (AI modules working)', () => {
     });
 
     const app = createApp();
-    const events = parseSse(
-      await (await jsonPost(app, '/agent-stream', { instruction: 'crash' })).text(),
+    const events = dropSessionInfo(
+      parseSse(await (await jsonPost(app, '/agent-stream', { instruction: 'crash' })).text()),
     );
 
     expect(events).toHaveLength(1);

--- a/apps/api/src/routes/agent-stream-elicit.ts
+++ b/apps/api/src/routes/agent-stream-elicit.ts
@@ -1,0 +1,129 @@
+/**
+ * Agent-stream elicitation response endpoint.
+ *
+ * `POST /api/agent-stream/elicit`
+ *
+ * When an MCP server connected to an agent run at `/api/agent-stream`
+ * calls `elicitation/create`, the route's elicitation handler writes an
+ * `elicitation_request` chunk to the SSE stream and parks on a pending
+ * promise keyed on `(sessionId, elicitationId)`. The client POSTs the
+ * user's decision here; this route resolves the pending promise so the
+ * MCP server's request returns and the agent turn continues.
+ *
+ * Auth is required. The session's `userId` must match the caller's
+ * session so one admin can't resolve another admin's elicitation. When
+ * the session was created by a guest-path agent run (no `userId`), any
+ * authenticated admin may resolve — no per-admin scoping to enforce.
+ *
+ * A.2b of the post-v1 MCP arc.
+ */
+
+import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { getAgentRunSession, resolveElicitation } from '../lib/agent-run-sessions.js';
+
+type Variables = {
+  user?: { id: string; role: string };
+};
+
+const app = new OpenAPIHono<{ Variables: Variables }>();
+
+/**
+ * MCP elicitation content is restricted by the spec's `ElicitResult`
+ * schema to primitive values + arrays of strings. No nested objects, no
+ * numbers-as-strings. Matches `@modelcontextprotocol/sdk`'s shape.
+ */
+const ElicitContentValue = z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]);
+
+const ElicitResponseBody = z.object({
+  sessionId: z.string().uuid(),
+  elicitationId: z.string().min(1).max(128),
+  action: z.enum(['accept', 'decline', 'cancel']),
+  content: z.record(z.string(), ElicitContentValue).optional(),
+});
+
+const elicitRoute = createRoute({
+  method: 'post',
+  path: '/',
+  tags: ['agent'],
+  summary: 'Submit an elicitation response for an in-flight agent run',
+  description:
+    'Resolves a pending `elicitation/create` request issued by an MCP server during an agent-stream run. The client provides `{ sessionId, elicitationId, action, content? }`; the server maps the session to the pending handler promise and resolves it.',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: ElicitResponseBody,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(true) }),
+        },
+      },
+      description: 'Elicitation resolved',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(false), error: z.string() }),
+        },
+      },
+      description: 'Authentication required',
+    },
+    403: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(false), error: z.string() }),
+        },
+      },
+      description: 'Session belongs to a different user',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(false), error: z.string() }),
+        },
+      },
+      description: 'No pending elicitation matching the supplied ids',
+    },
+  },
+});
+
+app.openapi(elicitRoute, async (c) => {
+  const user = c.get('user');
+  if (!user) {
+    return c.json({ success: false as const, error: 'Authentication required' }, 401);
+  }
+
+  const body = c.req.valid('json');
+
+  const session = getAgentRunSession(body.sessionId);
+  if (!session) {
+    return c.json(
+      { success: false as const, error: 'No pending elicitation for this session' },
+      404,
+    );
+  }
+  if (session.userId !== user.id) {
+    return c.json({ success: false as const, error: 'Session belongs to a different user' }, 403);
+  }
+
+  const resolved = resolveElicitation(body.sessionId, body.elicitationId, {
+    action: body.action,
+    ...(body.action === 'accept' && body.content ? { content: body.content } : {}),
+  });
+  if (!resolved) {
+    return c.json(
+      { success: false as const, error: 'Elicitation id not found or already resolved' },
+      404,
+    );
+  }
+
+  return c.json({ success: true as const }, 200);
+});
+
+export default app;

--- a/apps/api/src/routes/agent-stream.ts
+++ b/apps/api/src/routes/agent-stream.ts
@@ -11,7 +11,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
-import type { McpClient } from '@revealui/mcp/client';
+import type { ElicitationHandler, McpClient, SamplingHandler } from '@revealui/mcp/client';
 import { createRevvaultVault } from '@revealui/mcp/oauth';
 import {
   buildRemoteMcpClient,
@@ -20,7 +20,12 @@ import {
 } from '@revealui/mcp/remote-client';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
-import { streamSSE } from 'hono/streaming';
+import { type SSEStreamingApi, streamSSE } from 'hono/streaming';
+import {
+  awaitElicitationResponse,
+  createAgentRunSession,
+  deleteAgentRunSession,
+} from '../lib/agent-run-sessions.js';
 import { recordUsageMeter } from '../lib/metering.js';
 import { getEntitlementsFromContext } from '../middleware/entitlements.js';
 
@@ -212,15 +217,23 @@ app.openapi(agentStreamRoute, async (c) => {
 
   const allTools: unknown[] = [...cmsTools, ...codingTools];
 
-  // ─── Stage 5 + 6 integration (A.1) ────────────────────────────────────
+  // ─── Stage 5 + 6 integration (A.1 / A.2a / A.2b) ──────────────────────
   // Connect the tenant's OAuth-authorized MCP servers and merge their
   // tools into `allTools`. Compose a protocol-log sink that fans
   // Stage 6.1 events into the central logger and, when an `accountId`
   // is resolvable from entitlements, into `usage_meters`. Safe
   // fallback: no tenant header → `mcpClients: []`, just the logger sink.
+  //
+  // A.2b adds side-channel SSE chunks for sampling + elicitation so the
+  // `/admin/agents/:id/run` page (A.2b-frontend) can render live:
+  // `streamRef` is a late-binding reference to the SSE stream, captured
+  // here via a shared mutable box so per-server handlers built before
+  // `streamSSE()` starts can write into the stream once it exists.
   const mcpClients: McpClient[] = [];
   const tenant = c.get('tenant')?.id;
   const accountId = getEntitlementsFromContext(c).accountId;
+  const runSession = createAgentRunSession(user.id);
+  const streamRef: { current: SSEStreamingApi | undefined } = { current: undefined };
 
   const loggerSink = aiMod.createCoreLoggerSink();
   const meterSink = accountId
@@ -268,29 +281,98 @@ app.openapi(agentStreamRoute, async (c) => {
 
     for (const server of serverIds) {
       try {
-        // A.2a: Per-server sampling handler so when the MCP server calls
-        // `sampling/create` mid-agent-run, our configured LLM services it.
-        // Same `onEvent` sink as the tool adapters so Stage 6.1 logger +
-        // Stage 6.2 usage_meters capture `mcp.sampling.create` events too.
-        //
-        // Structural cast note: `@revealui/ai`'s `McpSamplingHandler` uses a
-        // simplified message-content shape, while `@revealui/mcp`'s
-        // `SamplingHandler` (fed into the SDK) uses the full
-        // `TextContent | ImageContent | AudioContent | …` union. The two
-        // are runtime-compatible for the text fields the handler actually
-        // reads — the cast documents the known type-system mismatch that
-        // falls out of Stage 5.2's structural-decoupling design. Fixing
-        // it for real means widening `McpSamplingRequestParams.messages[].
-        // content` in `@revealui/ai`; deferred — out of A.2a scope.
-        const samplingHandler = aiMod.createSamplingHandler({
+        // A.2a: base per-server sampling handler. The `as unknown as` cast
+        // documents the known @revealui/ai vs @revealui/mcp SamplingHandler
+        // type mismatch (simplified content shape vs SDK union). See
+        // `.jv/docs/admin-mcp-integration-scope.md` §A.2a for the deferred
+        // real fix (widening `McpSamplingRequestParams.messages[].content`).
+        const innerSamplingHandler = aiMod.createSamplingHandler({
           llm: llmClient as Parameters<typeof aiMod.createSamplingHandler>[0]['llm'],
           allowedModels: samplingAllowedModels,
           defaultModel: samplingDefaultModel,
           namespace: server,
           onEvent,
-        }) as unknown as Parameters<typeof buildRemoteMcpClient>[0]['samplingHandler'];
+        }) as unknown as SamplingHandler;
 
-        const built = await buildRemoteMcpClient({ tenant, server, samplingHandler });
+        // A.2b: wrap the sampling handler with a chunk-emit wrapper so the
+        // UI can render a "sampling in progress" card alongside the event.
+        // Chunk is best-effort — emit errors are swallowed so a stream
+        // write never breaks the underlying MCP handler call.
+        const samplingHandler: SamplingHandler = async (params) => {
+          try {
+            await streamRef.current?.writeSSE({
+              event: 'sampling_request',
+              data: JSON.stringify({
+                type: 'sampling_request',
+                sessionId: runSession.sessionId,
+                namespace: server,
+                sampling: {
+                  model: samplingDefaultModel,
+                  messageCount: params.messages.length,
+                  maxTokens: params.maxTokens,
+                },
+              }),
+            });
+          } catch (emitError) {
+            logger.warn('[agent-stream] sampling_request chunk emit failed', {
+              server,
+              error: emitError instanceof Error ? emitError.message : String(emitError),
+            });
+          }
+          return innerSamplingHandler(params);
+        };
+
+        // A.2b: per-server elicitation handler. When the MCP server calls
+        // `elicitation/create`, write the request to the SSE stream with a
+        // unique elicitationId, then park on the run-session registry
+        // until the client POSTs a response to /api/agent-stream/elicit.
+        // Missing stream = cancel (client never registered, so no UI can
+        // respond); missing session (e.g. after teardown) likewise cancels
+        // via the registry's fallback.
+        //
+        // URL-mode elicitation is auto-declined — the client UI only
+        // supports form mode, and URL mode routes the user-agent to a
+        // server-supplied URL which is a social-engineering risk without
+        // explicit UI that shows the URL and requires a user click. When
+        // URL mode becomes a deliberate product decision, re-enable it
+        // alongside that UI (A.2b-frontend or a follow-up).
+        const elicitationHandler: ElicitationHandler = async (params) => {
+          if ('mode' in params && params.mode === 'url') {
+            return { action: 'decline' };
+          }
+          const elicitationId = crypto.randomUUID();
+          const stream = streamRef.current;
+          if (!stream) return { action: 'cancel' };
+          try {
+            await stream.writeSSE({
+              event: 'elicitation_request',
+              data: JSON.stringify({
+                type: 'elicitation_request',
+                sessionId: runSession.sessionId,
+                namespace: server,
+                elicitation: {
+                  elicitationId,
+                  requestedSchema: params.requestedSchema,
+                  ...(params.message ? { message: params.message } : {}),
+                },
+              }),
+            });
+          } catch (emitError) {
+            logger.warn('[agent-stream] elicitation_request chunk emit failed', {
+              server,
+              error: emitError instanceof Error ? emitError.message : String(emitError),
+            });
+            return { action: 'cancel' };
+          }
+          return awaitElicitationResponse(runSession.sessionId, elicitationId);
+        };
+
+        const built = await buildRemoteMcpClient({
+          tenant,
+          server,
+          samplingHandler,
+          elicitationHandler,
+        });
         await built.client.connect();
         const mcpTools = await aiMod.createToolsFromMcpClient(built.client, {
           namespace: server,
@@ -366,6 +448,20 @@ Workspace: ${workspaceId}`,
     // Clean up on client disconnect
     c.req.raw.signal?.addEventListener('abort', () => controller.abort());
 
+    // A.2b: publish the agent-run session id to the client as the first
+    // chunk so it knows what sessionId to POST to /api/agent-stream/elicit
+    // when an `elicitation_request` chunk lands. Also populates the
+    // late-binding streamRef so the sampling/elicitation handlers built
+    // above can now write side-channel chunks.
+    streamRef.current = stream;
+    await stream.writeSSE({
+      event: 'session_info',
+      data: JSON.stringify({
+        type: 'session_info',
+        sessionId: runSession.sessionId,
+      }),
+    });
+
     try {
       // llmClient is typed as unknown because it comes from dynamically imported Pro packages;
       // the runtime type is LLMClient when present.
@@ -397,6 +493,11 @@ Workspace: ${workspaceId}`,
       for (const client of mcpClients) {
         await client.close().catch(() => undefined);
       }
+      // A.2b: delete the run session. Any still-pending elicitation
+      // handlers resolve with `{ action: 'cancel' }` so the MCP servers
+      // can complete their `elicitation/create` requests cleanly.
+      deleteAgentRunSession(runSession.sessionId);
+      streamRef.current = undefined;
     }
   });
 });

--- a/packages/ai/src/orchestration/streaming-runtime.ts
+++ b/packages/ai/src/orchestration/streaming-runtime.ts
@@ -17,8 +17,40 @@ import { ToolCallDeduplicator } from '../tools/deduplicator.js';
 import type { Agent, Task } from './agent.js';
 import { AgentRuntime, type RuntimeConfig } from './runtime.js';
 
+/**
+ * Chunk types emitted over the agent-stream SSE channel.
+ *
+ * The generator in `StreamingAgentRuntime.streamTask` emits the core turn
+ * events (`text`, `tool_call_start`, `tool_call_result`, `error`, `done`).
+ *
+ * Side-channel events originate outside the generator — route-level
+ * handlers (MCP sampling / elicitation) write them to the SSE stream
+ * directly between turns:
+ *
+ *   - `session_info` — emitted once at stream start with the
+ *     agent-run session id. Clients use the id to POST elicitation
+ *     responses back via `POST /api/agent-stream/elicit`.
+ *   - `sampling_request` — fired when a connected MCP server calls
+ *     `sampling/create`; the handler services the request synchronously
+ *     and emits this chunk for observability.
+ *   - `elicitation_request` — fired when a connected MCP server calls
+ *     `elicitation/create`; the handler pauses waiting for a POST
+ *     response keyed on `(sessionId, elicitationId)`.
+ *
+ * A.2b of the post-v1 MCP arc — the side-channel types are defined here
+ * so the `useAgentStream` consumer + future UI can narrow on them.
+ * A.2b-backend wires the emission; A.2b-frontend renders them.
+ */
 export interface AgentStreamChunk {
-  type: 'text' | 'tool_call_start' | 'tool_call_result' | 'error' | 'done';
+  type:
+    | 'text'
+    | 'tool_call_start'
+    | 'tool_call_result'
+    | 'error'
+    | 'done'
+    | 'session_info'
+    | 'sampling_request'
+    | 'elicitation_request';
   content?: string;
   toolCall?: { name: string; arguments: string };
   toolResult?: ToolResult;
@@ -26,6 +58,29 @@ export interface AgentStreamChunk {
   metadata?: {
     tokensUsed?: number;
     executionTime?: number;
+  };
+  /**
+   * Present on `session_info`, `sampling_request`, `elicitation_request`.
+   * Identifies the agent-run session; clients key elicitation POSTs on
+   * this.
+   */
+  sessionId?: string;
+  /**
+   * Namespace (MCP server id) the side-channel event originated from.
+   * Present on `sampling_request` + `elicitation_request`.
+   */
+  namespace?: string;
+  /** Present on `sampling_request` — requested model + shape. */
+  sampling?: {
+    model: string;
+    messageCount: number;
+    maxTokens: number;
+  };
+  /** Present on `elicitation_request` — form payload. */
+  elicitation?: {
+    elicitationId: string;
+    requestedSchema: unknown;
+    message?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

**A.2b-backend of the post-v1 MCP arc.** Wires Stage 5.3 elicitation handler + side-channel SSE chunks at `/api/agent-stream` so **A.2b-frontend** (next session) can render a `/admin/agents/:id/run` page consuming these events.

When an MCP server connected to an in-flight agent run calls `elicitation/create`, the handler now writes an `elicitation_request` chunk to the SSE stream with `{ sessionId, elicitationId, requestedSchema, message, namespace }` and parks on the in-memory agent-run session registry until a matching `POST /api/agent-stream/elicit` resolves the pending promise. Sampling requests (wired in A.2a) also emit a `sampling_request` chunk before running the LLM for observability.

## What ships

- **`packages/ai/src/orchestration/streaming-runtime.ts`** — extend `AgentStreamChunk` with three side-channel type variants: `session_info`, `sampling_request`, `elicitation_request` + optional `sessionId`, `namespace`, `sampling`, `elicitation` fields. Runtime-level emission unchanged — side-channel chunks are written directly by route-level handlers between turns.
- **`apps/api/src/lib/agent-run-sessions.ts`** (new) — process-local registry of `(sessionId, elicitationId) → pending Promise<ElicitResult>`. Adapted from Stage 3.4's admin-side `call-sessions.ts`.
- **`apps/api/src/lib/__tests__/agent-run-sessions.test.ts`** (new) — 11 unit tests for the registry lifecycle.
- **`apps/api/src/routes/agent-stream-elicit.ts`** (new) — `POST /api/agent-stream/elicit`. Body `{ sessionId: uuid, elicitationId, action: 'accept'|'decline'|'cancel', content? }` with content constrained to MCP spec primitives. Enforces `session.userId === c.var.user.id`.
- **`apps/api/src/routes/__tests__/agent-stream-elicit.test.ts`** (new) — 9 integration tests (accept / decline / 401 / 403 / 404 / one-shot / body validation).
- **`apps/api/src/routes/agent-stream.ts`** — create `runSession` before MCP-client construction; declare `streamRef: { current: SSEStreamingApi | undefined }` late-binding; wrap A.2a sampling handler with a chunk-emit wrapper; build per-server `elicitationHandler` (auto-declines URL mode for safety; form mode writes `elicitation_request` chunk + parks on the registry); first SSE chunk is `session_info`; `finally` closes clients + deletes session.
- **`apps/api/src/routes/__tests__/agent-stream-success.test.ts`** — new `dropSessionInfo` helper + new explicit test `"emits a session_info chunk as the FIRST SSE frame (A.2b)"` + 4 existing tests updated to call `dropSessionInfo`.
- **`apps/api/src/index.ts`** — mount `agentStreamElicitRoute` BEFORE the parent `/api/agent-stream` mount (trie router matches more-specific first); CSRF applied via `writeProtected`.

## Design anchors

Part of the A.2 split decided in internal docs §A.2b:

- A.2a = backend sampling handler ✅ merged (`470084548`)
- **A.2b-backend = this PR** (plumbing + chunk types + session registry + elicit endpoint)
- A.2b-frontend = next PR (`/run` page, UI, `StreamingToolCard` refactor)

## Discipline held

- **URL-mode elicitation auto-declines.** Form mode only for now; URL mode routes the user-agent to a server-supplied URL which is a social-engineering risk without explicit UI that shows the URL and requires a user click. Scope-doc note in the handler comment + deferred to a future PR.
- **Best-effort side-channel.** Stream writes never break the underlying MCP handler call — emit errors are swallowed with a `warn` log; handler falls back to `{ action: 'cancel' }` if the stream isn't bound or emit fails.
- **Structural decoupling held.** No new static imports from `@revealui/ai` in `apps/api`. The `AgentStreamChunk` type extension is in `@revealui/ai` (where the type lives); `apps/api` doesn't import it.
- **Content-value constraint.** Elicit POST body's `content` is typed to MCP's `{ [key]: string | number | boolean | string[] }` spec — no nested objects, caught at zod validation.
- **User-scoped session auth.** `/elicit` enforces `session.userId === c.var.user.id` so one admin can't resolve another admin's elicitation.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — 951/951 pass (type-only change)
- [x] `pnpm --filter @revealui/mcp test` — 221/221 pass (unchanged)
- [x] `pnpm --filter api test` — 2366/2366 pass (+20 new tests + 1 new session_info test + 4 updated tests)
- [x] `pnpm --filter api typecheck` — clean
- [x] `pnpm --filter "api..." build` — clean
- [x] `pnpm validate:boundary` — clean
- [x] Pre-push gate (15 checks) — PASS
- [ ] **Post-merge smoke test** (manual): connect an MCP server that emits `elicitation/create` mid-tool-call; fire an agent run; confirm (a) `session_info` chunk lands first with a valid UUID, (b) `elicitation_request` chunk appears when the server requests input, (c) POSTing `{ sessionId, elicitationId, action: 'accept', content: {...} }` to `/api/agent-stream/elicit` resolves the server's call.

## Follow-ups (NOT in this PR)

- **A.2b-frontend** — `/admin/agents/:id/run` page consuming the new chunk types. Refactors `StreamingToolCard` into a reusable `useToolStream` hook, adds cancel button, elicitation form UI. ~600-800 LOC.
- **URL-mode elicitation** — defer until explicit UI design exists that shows the URL + requires a user click before navigating.
- **End-to-end integration test** exercising the full elicitation round-trip (MCP server → elicitation chunk → client POST → handler resolves). Manual smoke test suffices for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
