### PR TITLE
feat(ai): default inference-snaps baseURL to http://localhost:9090/v1

### DIFF
--- a/.changeset/ai-inference-snaps-default-url.md
+++ b/.changeset/ai-inference-snaps-default-url.md
@@ -1,0 +1,11 @@
+---
+'@revealui/ai': minor
+---
+
+`createLLMClientFromEnv()` now ships a default `baseURL` for the `inference-snaps` provider — `http://localhost:9090/v1`, matching Canonical's standard Inference Snap port — so a user who sets `LLM_PROVIDER=inference-snaps` but omits `INFERENCE_SNAPS_BASE_URL` hits the local snap without further configuration. Existing deployments that already set `INFERENCE_SNAPS_BASE_URL` are unchanged (env override still wins). Mirrors the existing Ollama default (`http://localhost:11434`).
+
+Also:
+- JSDoc now lists `inference-snaps → gemma3` alongside Ollama and Groq in the "Provider defaults" block and names Canonical Inference Snaps as the reference local provider on Ubuntu.
+- The "No LLM provider configured" error message now leads with `INFERENCE_SNAPS_BASE_URL` before Ollama and Groq, with a pointer to the provider module's install docs.
+
+Fulfills the Canonical-Inference-Snap-as-reference-provider Stage 5.1/5.2 goal ("ship a documented preset out of the box"). No behavior change for explicit `INFERENCE_SNAPS_BASE_URL` users; no change to auto-detection precedence (still `INFERENCE_SNAPS → GROQ → OLLAMA`).

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -521,9 +521,14 @@ export class LLMClient {
  *
  * All providers use OpenAI-compatible APIs. No proprietary provider SDKs.
  *
+ * Canonical Inference Snaps is the reference local provider on Ubuntu — offline,
+ * silicon-optimized, no API key required. See `providers/inference-snaps.ts` for
+ * install docs (`sudo snap install gemma3`, etc.).
+ *
  * Provider defaults:
- *   groq   → qwen/qwen3-32b
- *   ollama → gemma4:e2b
+ *   inference-snaps → gemma3       (base URL defaults to http://localhost:9090/v1)
+ *   groq            → qwen/qwen3-32b
+ *   ollama          → gemma4:e2b   (base URL defaults to http://localhost:11434)
  */
 export function createLLMClientFromEnv(): LLMClient {
   // Auto-detect provider when LLM_PROVIDER is not explicitly set
@@ -538,8 +543,11 @@ export function createLLMClientFromEnv(): LLMClient {
     provider = 'ollama';
   } else {
     throw new Error(
-      'No LLM provider configured. Set one of: OLLAMA_BASE_URL (local Ollama), ' +
-        'INFERENCE_SNAPS_BASE_URL (local snap), GROQ_API_KEY (cloud). ' +
+      'No LLM provider configured. Set one of: ' +
+        'INFERENCE_SNAPS_BASE_URL (local Canonical Inference Snap; see ' +
+        'packages/ai/src/llm/providers/inference-snaps.ts for install), ' +
+        'OLLAMA_BASE_URL (local Ollama), ' +
+        'GROQ_API_KEY (cloud). ' +
         'Alternatively, set LLM_PROVIDER explicitly.',
     );
   }
@@ -566,7 +574,9 @@ export function createLLMClientFromEnv(): LLMClient {
     defaultModel = 'gemma4:e2b';
   } else if (provider === 'inference-snaps') {
     apiKey = 'inference-snaps'; // inference-snaps ignores the API key
-    baseURL = process.env.INFERENCE_SNAPS_BASE_URL;
+    // Defaults to Canonical's Inference Snap local service on port 9090; override
+    // via INFERENCE_SNAPS_BASE_URL when the snap listens on a non-default port.
+    baseURL = process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1';
     defaultModel = 'gemma3';
   }
 


### PR DESCRIPTION
## Summary

- `createLLMClientFromEnv()` now ships a default `baseURL` for the `inference-snaps` provider — `http://localhost:9090/v1` — so `LLM_PROVIDER=inference-snaps` without `INFERENCE_SNAPS_BASE_URL` hits the local Canonical Inference Snap automatically. Mirrors the existing Ollama `http://localhost:11434` default.
- JSDoc: adds `inference-snaps → gemma3` to the "Provider defaults" block and names Canonical Inference Snaps as the reference local provider on Ubuntu.
- Error message ("No LLM provider configured"): leads with `INFERENCE_SNAPS_BASE_URL` (was listed third) and points to `packages/ai/src/llm/providers/inference-snaps.ts` for install docs.

Fulfills the Canonical-Inference-Snap-as-reference-provider Stage 5.1/5.2 goal ("ship a documented preset out of the box"). Env overrides still win; auto-detect precedence (`INFERENCE_SNAPS → GROQ → OLLAMA`) is unchanged.

## Test plan

- [ ] CI Quality + Typecheck green on `test` base
- [ ] CI Coverage: no regressions in `@revealui/ai`
- [ ] Existing deployments with `INFERENCE_SNAPS_BASE_URL` set: unchanged (env takes precedence via `??`)
- [ ] Spot-check the "No LLM provider" error text once the canary publishes

## Coordination

- Lane: `packages/ai/src/llm/client.ts` + 1 new changeset file. Zero overlap with mcp-a2b-backend WIP (`streaming-runtime.ts`, `mcp-sampling.ts`), audit-drift PRs (#541-#545), or PR #547 changesets.
- Cut from `origin/test@068cc4387` (post-#544 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
