### PR TITLE
feat(validate): catch mixed-changeset frontmatter at PR time + cleanup

### DIFF
--- a/.changeset/mcp-a2a-sampling-handler.md
+++ b/.changeset/mcp-a2a-sampling-handler.md
@@ -1,6 +1,5 @@
 ---
 '@revealui/mcp': minor
-'api': patch
 ---
 
 A.2a of the post-v1 MCP arc — wire Stage 5.2 sampling handler into agent-stream.

--- a/.changeset/mcp-a2b-backend.md
+++ b/.changeset/mcp-a2b-backend.md
@@ -1,6 +1,5 @@
 ---
 '@revealui/ai': minor
-'api': minor
 ---
 
 A.2b-backend of the post-v1 MCP arc — wire Stage 5.3 elicitation handler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
       - name: Empty-catch validation (hard fail)
         run: pnpm validate:empty-catch
 
+      - name: Changeset validation (hard fail)
+        # Catches mixed ignored+non-ignored changeset frontmatter BEFORE
+        # merge, instead of discovering the same rejection later inside
+        # release-canary.yml when it is already on test.
+        run: pnpm validate:changesets
+
   # ---------------------------------------------------------------------------
   # Phase 1.5: Drizzle migration apply (all branches)
   #

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
+    "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:raw-sql": "tsx scripts/validate/raw-sql.ts"

--- a/scripts/validate/mixed-changesets.ts
+++ b/scripts/validate/mixed-changesets.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+
+/**
+ * Mixed-Changeset Validator
+ *
+ * Changesets CLI hard-fails with "Found mixed changeset" when a single
+ * .changeset/*.md file lists BOTH an ignored package (api, admin, docs,
+ * marketing, test, revealcoin, @revealui/scripts, @revealui/dev — per
+ * .changeset/config.json `ignore` array) AND a non-ignored package
+ * (e.g., @revealui/mcp, @revealui/ai, @revealui/core).
+ *
+ * That failure happens deep inside the Release Canary workflow, long
+ * after the offending PR has merged to `test`. By the time canary
+ * fails, every subsequent push is already blocked from publishing,
+ * and the fix requires a separate cleanup PR.
+ *
+ * This validator runs in the `quality` CI job on every PR, before
+ * anything merges. It catches the exact same `getRelevantChangesets`
+ * rejection pre-merge, with an error message that points the author
+ * at the fix.
+ *
+ * Precedent: commit 19a5c73ff (PR #547, 2026-04-24) cleaned up three
+ * mixed changesets (mcp-3-1, mcp-3-2, mcp-a1) that had been shipping
+ * broken canary runs for 9 consecutive test pushes. Two more mixed
+ * changesets (mcp-a2a, mcp-a2b) landed afterward despite the
+ * precedent. The shape of the failure is recurring and worth
+ * enforcing at PR time, not discovering at canary time.
+ *
+ * Exit codes:
+ *   0 — all changesets are clean
+ *   1 — one or more mixed changesets detected
+ *   2 — config/parse error
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const CHANGESET_DIR = join(REPO_ROOT, '.changeset');
+const CONFIG_PATH = join(CHANGESET_DIR, 'config.json');
+
+interface ChangesetConfig {
+  ignore?: string[];
+}
+
+interface MixedFinding {
+  file: string;
+  ignored: string[];
+  nonIgnored: string[];
+}
+
+/** Structured stdout/stderr output — scripts/** cannot use the console object. */
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+function err(line: string): void {
+  process.stderr.write(`${line}\n`);
+}
+
+function loadIgnoreList(): string[] {
+  let raw: string;
+  try {
+    raw = readFileSync(CONFIG_PATH, 'utf8');
+  } catch (e) {
+    err(`[mixed-changesets] FATAL: could not read ${CONFIG_PATH}: ${String(e)}`);
+    process.exit(2);
+  }
+  let config: ChangesetConfig;
+  try {
+    config = JSON.parse(raw) as ChangesetConfig;
+  } catch (e) {
+    err(`[mixed-changesets] FATAL: could not parse ${CONFIG_PATH}: ${String(e)}`);
+    process.exit(2);
+  }
+  return config.ignore ?? [];
+}
+
+/**
+ * Parse the YAML frontmatter of a changeset .md file and return the list
+ * of package names declared there. Handles both single-quoted and
+ * double-quoted package names. Skips files without a frontmatter block.
+ */
+function extractFrontmatterPackages(content: string): string[] {
+  const match = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!match) {
+    return [];
+  }
+  const frontmatter = match[1] ?? '';
+  const packages: string[] = [];
+  for (const line of frontmatter.split('\n')) {
+    // matches: 'pkg': level OR "pkg": level
+    const pkgMatch = /^\s*['"]([^'"]+)['"]\s*:\s*\w+/.exec(line);
+    if (pkgMatch?.[1]) {
+      packages.push(pkgMatch[1]);
+    }
+  }
+  return packages;
+}
+
+function scanChangesets(ignoreList: string[]): MixedFinding[] {
+  const ignoreSet = new Set(ignoreList);
+  let entries: string[];
+  try {
+    entries = readdirSync(CHANGESET_DIR);
+  } catch (e) {
+    err(`[mixed-changesets] FATAL: could not read ${CHANGESET_DIR}: ${String(e)}`);
+    process.exit(2);
+  }
+
+  const findings: MixedFinding[] = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.md') || entry === 'README.md') {
+      continue;
+    }
+    const filePath = join(CHANGESET_DIR, entry);
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf8');
+    } catch (e) {
+      err(`[mixed-changesets] WARN: could not read ${filePath}: ${String(e)}`);
+      continue;
+    }
+
+    const packages = extractFrontmatterPackages(content);
+    if (packages.length < 2) {
+      // A single-package changeset can't be mixed; a zero-package file
+      // is malformed but is a separate concern.
+      continue;
+    }
+
+    const ignored: string[] = [];
+    const nonIgnored: string[] = [];
+    for (const pkg of packages) {
+      if (ignoreSet.has(pkg)) {
+        ignored.push(pkg);
+      } else {
+        nonIgnored.push(pkg);
+      }
+    }
+
+    if (ignored.length > 0 && nonIgnored.length > 0) {
+      findings.push({ file: entry, ignored, nonIgnored });
+    }
+  }
+
+  return findings;
+}
+
+function main(): void {
+  const ignoreList = loadIgnoreList();
+  const findings = scanChangesets(ignoreList);
+
+  if (findings.length === 0) {
+    out('[mixed-changesets] OK: no mixed ignored+non-ignored changesets found.');
+    process.exit(0);
+  }
+
+  err('[mixed-changesets] FAIL: the changesets CLI rejects any changeset that');
+  err('                      lists BOTH an ignored package and a non-ignored one.');
+  err('                      Fix each offender by removing the ignored-package');
+  err('                      entries from the frontmatter (keep the body text');
+  err('                      describing the wider change — it becomes part of the');
+  err('                      non-ignored package’s changelog anyway).');
+  err('');
+  err(`Ignored packages per .changeset/config.json: ${ignoreList.join(', ')}`);
+  err('');
+  for (const finding of findings) {
+    err(`  .changeset/${finding.file}`);
+    err(`    ignored:     ${finding.ignored.join(', ')}`);
+    err(`    non-ignored: ${finding.nonIgnored.join(', ')}`);
+    err('');
+  }
+  err(`Found ${findings.length} mixed changeset${findings.length === 1 ? '' : 's'}.`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

**Two-part durable fix for the recurring mixed-changeset canary break.**

### Part 1 — Cleanup (immediate #540 unblock)

Changesets CLI rejects any `.changeset/*.md` with mixed ignored + non-ignored packages in frontmatter. Two of these landed on `test` after [#547](https://github.com/RevealUIStudio/revealui/pull/547) cleaned up the first batch (`mcp-3-1`, `mcp-3-2`, `mcp-a1`):

| File | Before | After |
|------|--------|-------|
| `.changeset/mcp-a2a-sampling-handler.md` | `@revealui/mcp` + `api` | `@revealui/mcp` |
| `.changeset/mcp-a2b-backend.md` | `@revealui/ai` + `api` | `@revealui/ai` |

Body text preserved — `@revealui/mcp` and `@revealui/ai` changelogs still describe the adjacent `api` work. Dropping the ignored-package entry is cosmetic (ignored packages never get version-bumped regardless), but it's what the CLI requires to stop hard-failing.

### Part 2 — Durable enforcement (this won't happen again)

**New validator: `scripts/validate/mixed-changesets.ts`** (~150 LOC)

- Reads `.changeset/config.json` for the authoritative `ignore` list
- Parses YAML frontmatter of every `.changeset/*.md` (skips `README.md`)
- Flags any changeset with BOTH ignored and non-ignored packages
- Exits `1` with an actionable error naming each offender + the fix
- Exits `2` on config/parse errors (distinguishable from the intentional `1`)

**Wired into `quality` CI job** (`.github/workflows/ci.yml`), right after `validate:empty-catch`. PRs that introduce a mixed changeset now fail the Quality gate before merge, with an error pointing at the fix. No more discovery-at-canary-time.

**npm script**: `pnpm validate:changesets` — matches the existing `validate:*` convention.

## Why this is durable

Before this PR, the failure mode was:
1. Agent writes a feat PR covering a non-ignored package + touching an ignored one (api/admin).
2. They generate a changeset listing both packages.
3. PR passes Quality (changesets CLI isn't run at PR time).
4. PR merges to `test`.
5. `release-canary.yml` fires on push to test → `changeset version --snapshot canary` step fails → canary release broken.
6. Every subsequent push to `test` also fails canary until someone opens a cleanup PR.

Precedent of the cost:
- **2026-04-23**: 9 consecutive canary failures on `test` before #547 cleaned up 3 mixed changesets.
- **2026-04-24 (today, post-#547)**: 2 more mixed changesets landed (`mcp-a2a`, `mcp-a2b`), re-breaking canary immediately.

After this PR: the check runs at PR time, in the same Quality phase as the other validators (`validate:structure`, `validate:boundary`, `validate:claims`, `validate:migrations`, `validate:raw-sql`, `validate:empty-catch`). Mixed changesets fail Quality → PR can't merge → `test` never sees them → canary stays green.

## Test plan

- [ ] CI Quality passes (including the new `validate:changesets` step)
- [ ] Once merged: `pnpm validate:changesets` exits 0 on `test`
- [ ] Release Canary on next `test` push goes green (first time in two days)
- [ ] Downstream: [#540](https://github.com/RevealUIStudio/revealui/pull/540) test→main promotion's canary failure clears after this merges

## Not included

- Not wired into `release-canary.yml` itself — by the time canary runs, CI has already gated the PR. Redundant.
- Doesn't change `.changeset/config.json` — the `ignore` list is already correct; the bug was authors ignoring it.
- Doesn't try to auto-fix mixed changesets — the fix (drop ignored-package lines) is trivial once surfaced, and the body text often has enough context to be worth preserving, which is a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
