### PR TITLE
fix(ci): drop unknown --no-git-checks flag from canary publish

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -91,7 +91,11 @@ jobs:
 
       - name: Publish canary to npm
         if: steps.changesets.outputs.count != '0'
-        run: pnpm changeset publish --tag canary --no-git-checks
+        # --no-git-checks was removed in @changesets/cli 2.x; publish no
+        # longer runs git-state checks (those moved to `changeset version`),
+        # so the flag is both unknown and unneeded. Publishing with
+        # `--tag canary` alone is correct for snapshot releases.
+        run: pnpm changeset publish --tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

`@changesets/cli` 2.31.0 rejects the `--no-git-checks` flag that release-canary.yml was passing to `changeset publish`:

```
Unknown flag for publish: --git-checks
Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
```

Snapshot/canary releases do not create git tags (ephemeral versions, no commits) and the git-state checks that `--no-git-checks` used to skip moved to `changeset version` in 2.x, so the flag is both unknown and unneeded. Publishing with `--tag canary` alone is correct.

## Why this surfaced now

Release Canary has been failing for ~2 days on an earlier step (`changeset version --snapshot canary` rejecting mixed changesets). [#547](https://github.com/RevealUIStudio/revealui/pull/547) and [#551](https://github.com/RevealUIStudio/revealui/pull/551) cleaned that up and wired a CI validator to prevent recurrence. The first canary run after #551 landed (run [24910828166](https://github.com/RevealUIStudio/revealui/actions/runs/24910828166)) made it all the way to the publish step — and surfaced this second, previously-masked failure.

## Test plan

- [ ] CI passes on this PR (no workflow change touches tested code)
- [ ] After merge, next push to `test` triggers Release Canary → `Publish canary to npm` step succeeds → first green canary release in ~2 days
- [ ] Downstream: [#540](https://github.com/RevealUIStudio/revealui/pull/540)'s `Publish canary to npm` check clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
