### PR TITLE
feat(admin, ai): /admin/agents/[id]/run page + extracted ElicitationForm (A.2b-frontend)

### DIFF
--- a/.changeset/mcp-a2b-frontend.md
+++ b/.changeset/mcp-a2b-frontend.md
@@ -1,0 +1,64 @@
+---
+'@revealui/ai': minor
+'admin': minor
+---
+
+A.2b-frontend of the post-v1 MCP arc — first user-visible Stage 5 surface.
+
+New `/admin/agents/[agentId]/run` page consumes the `/api/agent-stream`
+SSE backend (A.1 + A.2a + A.2b-backend) and renders chunks live: tool
+calls, sampling requests, and inline elicitation forms. Mid-run when a
+connected MCP server requests user input via `elicitation/create`, the
+page renders an inline form derived from `requestedSchema` and POSTs the
+response to `/api/agent-stream/elicit` (A.2b-backend's endpoint).
+
+**`@revealui/ai`:**
+- Extend `useAgentStream` (`packages/ai/src/client/hooks/useAgentStream.ts`)
+  with the three side-channel chunk types from A.2b-backend (`session_info`,
+  `sampling_request`, `elicitation_request`) plus the optional payload
+  fields (`sessionId`, `namespace`, `sampling`, `elicitation`).
+- Track `sessionId` in hook state when the leading `session_info` chunk
+  arrives. Track outstanding form-mode elicitation requests in
+  `pendingElicitations` (a `PendingElicitation[]`).
+- New `submitElicitation(elicitationId, action, content?)` method —
+  POSTs to `/api/agent-stream/elicit` with the resolved `sessionId` +
+  removes the entry from `pendingElicitations` on success. Throws if
+  called before `start()` resolves a sessionId, or if the server
+  returns non-2xx.
+- Pure `applyChunk(state, chunk)` reducer extracted for test-friendliness
+  + exported as `_applyChunkForTesting`. Pending elicitations are
+  cleared on `done`/`error` so stale forms don't sit on screen after the
+  stream tears down.
+- 12 new tests covering the chunk reducer + the submitElicitation
+  round-trip + error paths. `@revealui/ai` 951 → 963 passing.
+
+**`admin`:**
+- New page `apps/admin/src/app/(backend)/admin/agents/[agentId]/run/page.tsx`.
+  Submit-an-instruction form, status bar (streaming/idle/error +
+  sessionId + chunk count), pending-elicitations stack rendered as
+  inline forms, accumulated `text` panel, full event log with
+  per-event-type rows. Cancel button uses `useAgentStream.abort`. Reset
+  clears state for a fresh run.
+- Extracted `ElicitationForm` + `ArgumentField` from Stage 3.4's
+  `StreamingToolCard` into a new shared component
+  `apps/admin/src/lib/components/mcp/elicitation-form.tsx`. The form
+  now accepts a flat `(message, requestedSchema, onSubmit)` shape so
+  it's reusable across the inspector flow and the agent-run flow.
+  `StreamingToolCard` updated to import the extracted component;
+  zero behavior change for the inspector. The Stage 3.4 inspector
+  tests stay green.
+- Added a "Watch live ↗" link button to the Task Tester card on the
+  agent detail page (`page.tsx`), routing to the new `/run` page.
+  `TaskTester` itself unchanged — coexists as a polling A2A fallback.
+
+**Discipline notes:**
+- Boundary validation continues to pass — admin imports `useAgentStream`
+  via the `@revealui/ai/client/hooks/useAgentStream` subpath which is
+  already the existing module path; no new static imports of
+  `@revealui/ai` from admin code.
+- `pendingElicitations` is cleared on `done` and `error` so a stream
+  teardown can't leave a phantom form on screen — matches the
+  registry's `deleteAgentRunSession` cancel-on-cleanup semantics.
+- Malformed `requestedSchema` (e.g. missing `properties`) degrades to
+  an empty-fields form rather than a render error; user can still
+  decline/cancel.

--- a/.changeset/mcp-a2b-frontend.md
+++ b/.changeset/mcp-a2b-frontend.md
@@ -1,6 +1,5 @@
 ---
 '@revealui/ai': minor
-'admin': minor
 ---
 
 A.2b-frontend of the post-v1 MCP arc — first user-visible Stage 5 surface.

--- a/apps/admin/src/app/(backend)/admin/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/agents/[agentId]/page.tsx
@@ -423,9 +423,18 @@ export default function AgentDetailPage({ params }: PageProps) {
               {/* Right: Task tester + history */}
               <div className="flex flex-col gap-6">
                 <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-zinc-500">
-                    Task Tester
-                  </h2>
+                  <div className="mb-4 flex items-center justify-between gap-2">
+                    <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-500">
+                      Task Tester
+                    </h2>
+                    <a
+                      href={`/admin/agents/${encodeURIComponent(agentId)}/run`}
+                      className="rounded-md border border-emerald-700 bg-emerald-900/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-900/40"
+                      title="Stream agent execution live (Stage 5 surface)"
+                    >
+                      Watch live ↗
+                    </a>
+                  </div>
                   <TaskTester
                     agentId={agentId}
                     agentName={card.name}

--- a/apps/admin/src/app/(backend)/admin/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/agents/[agentId]/run/page.tsx
@@ -1,0 +1,329 @@
+/**
+ * Streaming agent execution page.
+ *
+ * `GET /admin/agents/[agentId]/run` — first user-visible Stage 5 surface
+ * (A.2b-frontend of the post-v1 MCP arc). Submits an instruction to
+ * `/api/agent-stream`, consumes the SSE response via `useAgentStream`,
+ * and renders the chunk stream live: tool calls, sampling requests, and
+ * inline elicitation forms.
+ *
+ * The polling `TaskTester` on the agent detail page stays as a fallback
+ * — A.2b-frontend adds a "Watch live" link there that routes here. A.4+
+ * may deprecate `TaskTester` once this page is proven.
+ */
+
+'use client';
+
+import { Breadcrumb } from '@revealui/presentation/client';
+import Link from 'next/link';
+import { use, useState } from 'react';
+import { LicenseGate } from '@/lib/components/LicenseGate';
+import { ElicitationForm, type ElicitationSchema } from '@/lib/components/mcp/elicitation-form';
+import { type AgentStreamChunk, useAgentStream } from '@/lib/hooks/useAgentStream';
+
+interface PageProps {
+  params: Promise<{ agentId: string }>;
+}
+
+export default function AgentRunPage({ params }: PageProps) {
+  const { agentId } = use(params);
+  const [instruction, setInstruction] = useState('');
+  const [mode, setMode] = useState<'admin' | 'coding'>('admin');
+  const stream = useAgentStream();
+
+  const handleStart = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = instruction.trim();
+    if (!trimmed) return;
+    void stream.start({ instruction: trimmed, mode });
+  };
+
+  return (
+    <LicenseGate feature="ai">
+      <div className="mx-auto max-w-5xl space-y-6 p-6">
+        <Breadcrumb
+          items={[
+            { label: 'Admin', href: '/admin' },
+            { label: 'Agents', href: '/admin/agents' },
+            { label: agentId, href: `/admin/agents/${agentId}` },
+            { label: 'Run' },
+          ]}
+        />
+
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-zinc-100">Run agent — live stream</h1>
+          <p className="text-sm text-zinc-400">
+            Submits an instruction to{' '}
+            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">/api/agent-stream</code> and
+            renders chunks in real time. Connected MCP servers can call{' '}
+            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">sampling/create</code> and{' '}
+            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">elicitation/create</code>{' '}
+            mid-run; both surface here.{' '}
+            <Link
+              href={`/admin/agents/${agentId}`}
+              className="text-emerald-400 hover:text-emerald-300"
+            >
+              ← Back to agent detail
+            </Link>
+          </p>
+        </header>
+
+        <form
+          onSubmit={handleStart}
+          className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+        >
+          <label htmlFor="instruction" className="block text-sm font-medium text-zinc-200">
+            Instruction
+          </label>
+          <textarea
+            id="instruction"
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            disabled={stream.isStreaming}
+            rows={4}
+            placeholder="What would you like the agent to do?"
+            className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-60"
+          />
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-xs text-zinc-300">
+              <span>Mode</span>
+              <select
+                value={mode}
+                onChange={(e) => setMode(e.target.value as 'admin' | 'coding')}
+                disabled={stream.isStreaming}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-60"
+              >
+                <option value="admin">admin</option>
+                <option value="coding">coding</option>
+              </select>
+            </label>
+            <div className="flex-1" />
+            {!stream.isStreaming && (
+              <button
+                type="submit"
+                disabled={!instruction.trim()}
+                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Start agent
+              </button>
+            )}
+            {stream.isStreaming && (
+              <button
+                type="button"
+                onClick={stream.abort}
+                className="rounded-md border border-red-800 bg-red-900/30 px-4 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-900/50"
+              >
+                Cancel
+              </button>
+            )}
+            {!stream.isStreaming && stream.chunks.length > 0 && (
+              <button
+                type="button"
+                onClick={stream.reset}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </form>
+
+        <StatusBar
+          isStreaming={stream.isStreaming}
+          sessionId={stream.sessionId}
+          chunkCount={stream.chunks.length}
+          error={stream.error}
+        />
+
+        {stream.pendingElicitations.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-sm font-medium text-blue-300">
+              Pending input ({stream.pendingElicitations.length})
+            </h2>
+            {stream.pendingElicitations.map((pending) => (
+              <ElicitationCard
+                key={pending.elicitationId}
+                namespace={pending.namespace}
+                requestedSchema={pending.requestedSchema}
+                message={pending.message}
+                onSubmit={(action, content) =>
+                  stream.submitElicitation(pending.elicitationId, action, content)
+                }
+              />
+            ))}
+          </section>
+        )}
+
+        {stream.text && (
+          <section className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="mb-2 text-sm font-medium text-zinc-300">Agent output</h2>
+            <pre className="whitespace-pre-wrap text-sm text-zinc-100">{stream.text}</pre>
+          </section>
+        )}
+
+        {stream.chunks.length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-sm font-medium text-zinc-300">Event log</h2>
+            <ol className="space-y-2">
+              {stream.chunks.map((chunk, idx) => (
+                <ChunkRow key={idx} chunk={chunk} index={idx} />
+              ))}
+            </ol>
+          </section>
+        )}
+      </div>
+    </LicenseGate>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status bar — running / idle indicator + sessionId + chunk count
+// ---------------------------------------------------------------------------
+
+interface StatusBarProps {
+  isStreaming: boolean;
+  sessionId: string | null;
+  chunkCount: number;
+  error: string | null;
+}
+
+function StatusBar({ isStreaming, sessionId, chunkCount, error }: StatusBarProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-zinc-800 bg-zinc-900/40 px-3 py-2 text-xs text-zinc-400">
+      <span
+        className={`inline-flex h-2 w-2 rounded-full ${
+          error ? 'bg-red-500' : isStreaming ? 'animate-pulse bg-emerald-500' : 'bg-zinc-600'
+        }`}
+        aria-hidden="true"
+      />
+      <span>{error ? 'Error' : isStreaming ? 'Streaming' : 'Idle'}</span>
+      <span className="text-zinc-600">·</span>
+      <span>chunks: {chunkCount}</span>
+      {sessionId && (
+        <>
+          <span className="text-zinc-600">·</span>
+          <span className="font-mono text-zinc-500">session {sessionId.slice(0, 8)}</span>
+        </>
+      )}
+      {error && (
+        <>
+          <span className="text-zinc-600">·</span>
+          <span className="text-red-400">{error}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Elicitation card — wraps the shared ElicitationForm with namespace label
+// ---------------------------------------------------------------------------
+
+interface ElicitationCardProps {
+  namespace: string;
+  requestedSchema: unknown;
+  message?: string;
+  onSubmit: Parameters<typeof ElicitationForm>[0]['onSubmit'];
+}
+
+function ElicitationCard({ namespace, requestedSchema, message, onSubmit }: ElicitationCardProps) {
+  // Narrow the unknown schema to the form's expected shape. Malformed
+  // schemas degrade to "no fields" — the form still renders the
+  // accept/decline/cancel buttons so the user is never trapped.
+  const schema = (
+    typeof requestedSchema === 'object' && requestedSchema !== null
+      ? (requestedSchema as ElicitationSchema)
+      : { type: 'object', properties: {} }
+  ) satisfies ElicitationSchema;
+
+  return (
+    <div className="rounded-lg border border-blue-800 bg-blue-900/10 p-4">
+      <div className="mb-2 flex items-center gap-2 text-xs text-blue-300">
+        <span className="font-mono">{namespace}</span>
+        <span className="text-blue-700">·</span>
+        <span>requesting input</span>
+      </div>
+      <ElicitationForm message={message} requestedSchema={schema} onSubmit={onSubmit} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chunk row — per-event rendering for the event log
+// ---------------------------------------------------------------------------
+
+function ChunkRow({ chunk, index }: { chunk: AgentStreamChunk; index: number }) {
+  switch (chunk.type) {
+    case 'session_info':
+      return (
+        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-500">
+          <span className="font-mono text-zinc-600">[{index}]</span> session_info{' '}
+          <span className="font-mono">{chunk.sessionId?.slice(0, 8)}…</span>
+        </li>
+      );
+    case 'text':
+      return (
+        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs">
+          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
+          <span className="text-zinc-400">text</span>{' '}
+          <span className="text-zinc-200">{chunk.content?.slice(0, 80)}</span>
+          {chunk.content && chunk.content.length > 80 && <span className="text-zinc-500">…</span>}
+        </li>
+      );
+    case 'tool_call_start':
+      return (
+        <li className="rounded-md border border-emerald-900 bg-emerald-900/10 px-3 py-2 text-xs">
+          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
+          <span className="font-medium text-emerald-300">tool call</span>{' '}
+          <span className="font-mono text-emerald-200">{chunk.toolCall?.name}</span>
+        </li>
+      );
+    case 'tool_call_result':
+      return (
+        <li className="rounded-md border border-emerald-900 bg-emerald-900/10 px-3 py-2 text-xs">
+          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
+          <span className="text-emerald-300">tool result</span>
+        </li>
+      );
+    case 'sampling_request':
+      return (
+        <li className="rounded-md border border-purple-900 bg-purple-900/10 px-3 py-2 text-xs">
+          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
+          <span className="font-medium text-purple-300">sampling</span>{' '}
+          {chunk.namespace && <span className="font-mono text-purple-200">{chunk.namespace}</span>}{' '}
+          <span className="text-zinc-500">
+            model={chunk.sampling?.model}, messages={chunk.sampling?.messageCount}, maxTokens=
+            {chunk.sampling?.maxTokens}
+          </span>
+        </li>
+      );
+    case 'elicitation_request':
+      return (
+        <li className="rounded-md border border-blue-900 bg-blue-900/10 px-3 py-2 text-xs">
+          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
+          <span className="font-medium text-blue-300">elicitation</span>{' '}
+          {chunk.namespace && <span className="font-mono text-blue-200">{chunk.namespace}</span>}{' '}
+          <span className="text-zinc-500">id={chunk.elicitation?.elicitationId.slice(0, 8)}…</span>
+        </li>
+      );
+    case 'error':
+      return (
+        <li className="rounded-md border border-red-800 bg-red-900/20 px-3 py-2 text-xs text-red-300">
+          <span className="font-mono text-zinc-600">[{index}]</span> error{' '}
+          <span className="text-red-200">{chunk.error}</span>
+        </li>
+      );
+    case 'done':
+      return (
+        <li className="rounded-md border border-zinc-700 bg-zinc-800/30 px-3 py-2 text-xs text-zinc-300">
+          <span className="font-mono text-zinc-600">[{index}]</span> done
+        </li>
+      );
+    default:
+      return (
+        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-500">
+          <span className="font-mono text-zinc-600">[{index}]</span> {String(chunk.type)}
+        </li>
+      );
+  }
+}

--- a/apps/admin/src/lib/components/mcp/elicitation-form.tsx
+++ b/apps/admin/src/lib/components/mcp/elicitation-form.tsx
@@ -1,0 +1,201 @@
+/**
+ * Schema-driven elicitation form. Shared between Stage 3.4's
+ * `StreamingToolCard` (where `elicitation/create` arrives during a tool
+ * call to a single MCP server) and A.2b's
+ * `/admin/agents/[agentId]/run` page (where it arrives mid-agent-run from
+ * any of the connected servers).
+ *
+ * The form renders a JSON-Schema `requestedSchema` as a flat list of
+ * inputs, with Accept / Decline / Cancel buttons. Submit returns an
+ * `accept` action with the typed-coerced content; the parent decides
+ * where to POST it (per-server admin route in the inspector flow,
+ * `/api/agent-stream/elicit` in the agent-run flow).
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface JsonSchemaProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+}
+
+export interface ElicitationSchema {
+  type?: string;
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+}
+
+export type ElicitationAction = 'accept' | 'decline' | 'cancel';
+
+// ---------------------------------------------------------------------------
+// Argument field — single-input schema-driven control
+// ---------------------------------------------------------------------------
+
+interface ArgumentFieldProps {
+  name: string;
+  prop: JsonSchemaProperty;
+  required: boolean;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
+  const inputId = `arg-${name}`;
+  const placeholder =
+    prop.default !== undefined
+      ? `default: ${JSON.stringify(prop.default)}`
+      : prop.type === 'object' || prop.type === 'array'
+        ? 'JSON value'
+        : (prop.type ?? 'string');
+
+  return (
+    <div>
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+        {name}
+        {required && <span className="ml-1 text-red-400">*</span>}
+        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
+      </label>
+      {prop.enum && prop.enum.length > 0 ? (
+        <select
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        >
+          <option value="">—</option>
+          {prop.enum.map((opt) => (
+            <option key={String(opt)} value={String(opt)}>
+              {String(opt)}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        />
+      )}
+      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Elicitation form — renders the server's requestedSchema inline
+// ---------------------------------------------------------------------------
+
+export interface ElicitationFormProps {
+  /**
+   * Display message from the server. Optional — schema-only requests
+   * (no prose) render the form without a header label.
+   */
+  message?: string;
+  /**
+   * JSON Schema describing the form fields. The form parses this once
+   * and renders one `ArgumentField` per `properties` entry. Nested
+   * objects/arrays are rendered as JSON-string text inputs (keeping the
+   * surface flat); deep-nested schemas are out of scope today.
+   */
+  requestedSchema: ElicitationSchema;
+  /**
+   * Callback invoked when the user clicks Accept / Decline / Cancel.
+   * Returns a promise so the parent can park the form during the round-trip
+   * (e.g. show a spinner) without the form caring about the transport.
+   */
+  onSubmit: (action: ElicitationAction, content?: Record<string, unknown>) => Promise<void> | void;
+}
+
+export function ElicitationForm({ message, requestedSchema, onSubmit }: ElicitationFormProps) {
+  const properties = requestedSchema.properties ?? {};
+  const required = new Set(requestedSchema.required ?? []);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
+    if (raw === '') return undefined;
+    switch (prop.type) {
+      case 'number':
+      case 'integer': {
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : raw;
+      }
+      case 'boolean':
+        return raw === 'true';
+      default:
+        return raw;
+    }
+  };
+
+  const handleAccept = (e: React.FormEvent) => {
+    e.preventDefault();
+    const content: Record<string, unknown> = {};
+    for (const [key, prop] of Object.entries(properties)) {
+      const raw = values[key] ?? '';
+      const parsed = parseValue(prop, raw);
+      if (parsed !== undefined) content[key] = parsed;
+    }
+    void onSubmit('accept', content);
+  };
+
+  return (
+    <form
+      onSubmit={handleAccept}
+      className="mt-4 rounded-md border border-blue-800 bg-blue-900/10 p-3"
+    >
+      {message && (
+        <div className="mb-3 flex items-center gap-2 text-xs">
+          <span className="rounded-full bg-blue-500/20 px-2 py-0.5 font-medium text-blue-300">
+            Server request
+          </span>
+          <span className="text-blue-200">{message}</span>
+        </div>
+      )}
+      <div className="space-y-3">
+        {Object.entries(properties).map(([key, prop]) => (
+          <ArgumentField
+            key={key}
+            name={key}
+            prop={prop}
+            required={required.has(key)}
+            value={values[key] ?? ''}
+            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
+          />
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="submit"
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => void onSubmit('decline')}
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          onClick={() => void onSubmit('cancel')}
+          className="rounded-md border border-red-800 bg-red-900/20 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-900/40"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
+++ b/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
@@ -20,6 +20,12 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  ArgumentField,
+  ElicitationForm,
+  type ElicitationSchema,
+  type JsonSchemaProperty,
+} from './elicitation-form';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,13 +39,6 @@ interface Tool {
     properties?: Record<string, JsonSchemaProperty>;
     required?: string[];
   };
-}
-
-interface JsonSchemaProperty {
-  type?: string;
-  description?: string;
-  enum?: unknown[];
-  default?: unknown;
 }
 
 interface CallToolResult {
@@ -57,11 +56,7 @@ interface LogEntry {
 interface ElicitationRequest {
   id: string;
   message: string;
-  requestedSchema: {
-    type?: string;
-    properties?: Record<string, JsonSchemaProperty>;
-    required?: string[];
-  };
+  requestedSchema: ElicitationSchema;
 }
 
 type SseEvent =
@@ -317,7 +312,11 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
 
       {progress && <ProgressDisplay progress={progress} />}
       {pendingElicitation && (
-        <ElicitationForm elicitation={pendingElicitation} onSubmit={submitElicitation} />
+        <ElicitationForm
+          message={pendingElicitation.message}
+          requestedSchema={pendingElicitation.requestedSchema}
+          onSubmit={submitElicitation}
+        />
       )}
       {logs.length > 0 && <LogPanel logs={logs} />}
       {result && <ToolResult result={result} />}
@@ -327,64 +326,6 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
         </div>
       )}
     </details>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Argument field (mirrors the Stage 3.2 version)
-// ---------------------------------------------------------------------------
-
-interface ArgumentFieldProps {
-  name: string;
-  prop: JsonSchemaProperty;
-  required: boolean;
-  value: string;
-  onChange: (value: string) => void;
-}
-
-function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
-  const inputId = `arg-${name}`;
-  const placeholder =
-    prop.default !== undefined
-      ? `default: ${JSON.stringify(prop.default)}`
-      : prop.type === 'object' || prop.type === 'array'
-        ? 'JSON value'
-        : (prop.type ?? 'string');
-
-  return (
-    <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
-        {name}
-        {required && <span className="ml-1 text-red-400">*</span>}
-        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
-      </label>
-      {prop.enum && prop.enum.length > 0 ? (
-        <select
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        >
-          <option value="">—</option>
-          {prop.enum.map((opt) => (
-            <option key={String(opt)} value={String(opt)}>
-              {String(opt)}
-            </option>
-          ))}
-        </select>
-      ) : (
-        <input
-          id={inputId}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          required={required}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        />
-      )}
-      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
-    </div>
   );
 }
 
@@ -420,99 +361,6 @@ function ProgressDisplay({
         />
       </div>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Elicitation form — renders the server's requestedSchema inline
-// ---------------------------------------------------------------------------
-
-interface ElicitationFormProps {
-  elicitation: ElicitationRequest;
-  onSubmit: (
-    action: 'accept' | 'decline' | 'cancel',
-    content?: Record<string, unknown>,
-  ) => Promise<void>;
-}
-
-function ElicitationForm({ elicitation, onSubmit }: ElicitationFormProps) {
-  const schema = elicitation.requestedSchema ?? {};
-  const properties = schema.properties ?? {};
-  const required = new Set(schema.required ?? []);
-  const [values, setValues] = useState<Record<string, string>>({});
-
-  const parseValue = (prop: JsonSchemaProperty, raw: string): unknown => {
-    if (raw === '') return undefined;
-    switch (prop.type) {
-      case 'number':
-      case 'integer': {
-        const n = Number(raw);
-        return Number.isFinite(n) ? n : raw;
-      }
-      case 'boolean':
-        return raw === 'true';
-      default:
-        return raw;
-    }
-  };
-
-  const handleAccept = (e: React.FormEvent) => {
-    e.preventDefault();
-    const content: Record<string, unknown> = {};
-    for (const [key, prop] of Object.entries(properties)) {
-      const raw = values[key] ?? '';
-      const parsed = parseValue(prop, raw);
-      if (parsed !== undefined) content[key] = parsed;
-    }
-    void onSubmit('accept', content);
-  };
-
-  return (
-    <form
-      onSubmit={handleAccept}
-      className="mt-4 rounded-md border border-blue-800 bg-blue-900/10 p-3"
-    >
-      <div className="mb-3 flex items-center gap-2 text-xs">
-        <span className="rounded-full bg-blue-500/20 px-2 py-0.5 font-medium text-blue-300">
-          Server request
-        </span>
-        <span className="text-blue-200">{elicitation.message}</span>
-      </div>
-      <div className="space-y-3">
-        {Object.entries(properties).map(([key, prop]) => (
-          <ArgumentField
-            key={key}
-            name={key}
-            prop={prop}
-            required={required.has(key)}
-            value={values[key] ?? ''}
-            onChange={(value) => setValues((v) => ({ ...v, [key]: value }))}
-          />
-        ))}
-      </div>
-      <div className="mt-3 flex items-center gap-2">
-        <button
-          type="submit"
-          className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
-        >
-          Accept
-        </button>
-        <button
-          type="button"
-          onClick={() => void onSubmit('decline')}
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
-        >
-          Decline
-        </button>
-        <button
-          type="button"
-          onClick={() => void onSubmit('cancel')}
-          className="rounded-md border border-red-800 bg-red-900/20 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-900/40"
-        >
-          Cancel
-        </button>
-      </div>
-    </form>
   );
 }
 

--- a/apps/admin/src/lib/hooks/__tests__/useAgentStream.test.ts
+++ b/apps/admin/src/lib/hooks/__tests__/useAgentStream.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the admin-local `useAgentStream` hook (A.2b-frontend).
+ *
+ * @vitest-environment jsdom
+ *
+ * Mirrors `@revealui/ai/client/hooks/useAgentStream.test.ts` — the two
+ * hooks are intentionally identical in shape (boundary discipline puts
+ * the admin copy here so apps don't statically import optional Pro
+ * packages). Cover the new A.2b chunk types + submitElicitation flow.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _applyChunkForTesting,
+  _initialStateForTesting,
+  type AgentStreamChunk,
+  useAgentStream,
+} from '../useAgentStream.js';
+
+const SESSION_ID = '00000000-0000-4000-8000-000000000000';
+
+function makeSseStream(chunks: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function makeOkResponse(body: ReadableStream<Uint8Array>): Response {
+  return new Response(body, { status: 200 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('admin useAgentStream  -  initial state', () => {
+  it('starts empty + idle with null sessionId and no pending elicitations', () => {
+    const { result } = renderHook(() => useAgentStream());
+    expect(result.current.text).toBe('');
+    expect(result.current.chunks).toHaveLength(0);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.pendingElicitations).toEqual([]);
+  });
+});
+
+describe('admin useAgentStream  -  applyChunk reducer', () => {
+  it('captures sessionId from session_info', () => {
+    const next = _applyChunkForTesting(_initialStateForTesting, {
+      type: 'session_info',
+      sessionId: SESSION_ID,
+    });
+    expect(next.sessionId).toBe(SESSION_ID);
+  });
+
+  it('appends elicitation_request to pendingElicitations', () => {
+    const start = { ..._initialStateForTesting, sessionId: SESSION_ID };
+    const next = _applyChunkForTesting(start, {
+      type: 'elicitation_request',
+      sessionId: SESSION_ID,
+      namespace: 'linear',
+      elicitation: {
+        elicitationId: 'elicit-1',
+        requestedSchema: { type: 'object', properties: {} },
+        message: 'Pick one',
+      },
+    });
+    expect(next.pendingElicitations).toHaveLength(1);
+    expect(next.pendingElicitations[0]).toEqual({
+      elicitationId: 'elicit-1',
+      namespace: 'linear',
+      requestedSchema: { type: 'object', properties: {} },
+      message: 'Pick one',
+    });
+  });
+
+  it('clears pending elicitations on done', () => {
+    const start: typeof _initialStateForTesting = {
+      ..._initialStateForTesting,
+      sessionId: SESSION_ID,
+      isStreaming: true,
+      pendingElicitations: [
+        { elicitationId: 'elicit-1', namespace: 'linear', requestedSchema: {} },
+      ],
+    };
+    const next = _applyChunkForTesting(start, { type: 'done' });
+    expect(next.isStreaming).toBe(false);
+    expect(next.pendingElicitations).toEqual([]);
+  });
+
+  it('clears pending elicitations on error', () => {
+    const start: typeof _initialStateForTesting = {
+      ..._initialStateForTesting,
+      sessionId: SESSION_ID,
+      isStreaming: true,
+      pendingElicitations: [
+        { elicitationId: 'elicit-1', namespace: 'linear', requestedSchema: {} },
+      ],
+    };
+    const next = _applyChunkForTesting(start, { type: 'error', error: 'boom' });
+    expect(next.error).toBe('boom');
+    expect(next.pendingElicitations).toEqual([]);
+  });
+
+  it('drops malformed elicitation_request without elicitation payload', () => {
+    const start = { ..._initialStateForTesting, sessionId: SESSION_ID };
+    const malformed: AgentStreamChunk = {
+      type: 'elicitation_request',
+      sessionId: SESSION_ID,
+      namespace: 'linear',
+    };
+    const next = _applyChunkForTesting(start, malformed);
+    expect(next.pendingElicitations).toEqual([]);
+  });
+});
+
+describe('admin useAgentStream  -  submitElicitation', () => {
+  it('POSTs to /api/agent-stream/elicit with action+content and removes the entry', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(
+          makeSseStream([
+            { type: 'session_info', sessionId: SESSION_ID },
+            {
+              type: 'elicitation_request',
+              sessionId: SESSION_ID,
+              namespace: 'linear',
+              elicitation: { elicitationId: 'elicit-1', requestedSchema: {} },
+            },
+          ]),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    await waitFor(() => expect(result.current.pendingElicitations).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.submitElicitation('elicit-1', 'accept', { project: 'web' });
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const elicitCall = fetchSpy.mock.calls[1];
+    expect(elicitCall).toBeDefined();
+    if (!elicitCall) return; // narrow for TS
+    const [url, init] = elicitCall;
+    expect(url).toBe('/api/agent-stream/elicit');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      sessionId: SESSION_ID,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+      content: { project: 'web' },
+    });
+    expect(result.current.pendingElicitations).toHaveLength(0);
+  });
+
+  it('throws when sessionId is missing', async () => {
+    const { result } = renderHook(() => useAgentStream());
+    await expect(result.current.submitElicitation('elicit-1', 'cancel')).rejects.toThrow(
+      /no sessionId/,
+    );
+  });
+
+  it('throws on non-2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(makeSseStream([{ type: 'session_info', sessionId: SESSION_ID }])),
+      )
+      .mockResolvedValueOnce(new Response('Forbidden', { status: 403 }));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+    await waitFor(() => expect(result.current.sessionId).toBe(SESSION_ID));
+
+    await expect(result.current.submitElicitation('elicit-1', 'accept', { x: 1 })).rejects.toThrow(
+      /403/,
+    );
+  });
+});

--- a/apps/admin/src/lib/hooks/useAgentStream.ts
+++ b/apps/admin/src/lib/hooks/useAgentStream.ts
@@ -1,15 +1,23 @@
 /**
- * useAgentStream  -  React hook for streaming agent responses via SSE
+ * useAgentStream  -  React hook for streaming agent responses via SSE.
  *
- * Uses fetch + ReadableStream (NOT EventSource  -  it doesn't support POST).
+ * Admin-local implementation. The Pro `@revealui/ai` package ships an
+ * equivalent hook for non-admin consumers (CLI, harnesses, third-party
+ * agent UIs); admin keeps its own copy so the structural-decoupling
+ * discipline (`scripts/validate/boundary.ts` Check 4) holds — apps must
+ * not statically import from optional Fair Source packages. The hook
+ * shape is intentionally identical to `@revealui/ai/client/hooks/
+ * useAgentStream`; when a chunk type lands in either, mirror it here.
+ *
+ * Uses fetch + ReadableStream (NOT EventSource — it doesn't support POST).
  * Accumulates AgentStreamChunks into state and exposes:
  *   - text: accumulated output text
  *   - chunks: all received chunks in order
  *   - isStreaming: true while the stream is open
  *   - error: last error message, if any
- *   - sessionId: agent-run session id from the leading session_info chunk (A.2b)
- *   - pendingElicitations: outstanding form-mode elicitation requests by id (A.2b)
- *   - submitElicitation: POST a response to /api/agent-stream/elicit (A.2b)
+ *   - sessionId: agent-run session id from the leading session_info chunk
+ *   - pendingElicitations: outstanding form-mode elicitation requests
+ *   - submitElicitation: POST a response to /api/agent-stream/elicit
  *   - abort(): cancels the stream
  */
 
@@ -19,10 +27,11 @@ import { useCallback, useRef, useState } from 'react';
 
 /**
  * Mirror of `AgentStreamChunk` in
- * `@revealui/ai/orchestration/streaming-runtime`. Duplicated here (rather
- * than imported) so client bundles don't pull in server-only orchestration
- * code through the type graph. Keep these in lockstep — when a new chunk
- * type lands in the runtime, mirror it here.
+ * `@revealui/ai/orchestration/streaming-runtime`. Side-channel chunk
+ * types (`session_info`, `sampling_request`, `elicitation_request`)
+ * are emitted by the agent-stream route between turns; the runtime's
+ * core `text | tool_call_start | tool_call_result | error | done`
+ * still come from the generator.
  */
 export interface AgentStreamChunk {
   type:
@@ -71,11 +80,6 @@ export interface AgentStreamRequest {
   mode?: 'admin' | 'coding';
 }
 
-/**
- * Outstanding elicitation request awaiting a UI response. The hook keeps
- * one entry per `elicitationId`; entries are removed when
- * `submitElicitation()` lands successfully or when the stream ends.
- */
 export interface PendingElicitation {
   elicitationId: string;
   namespace: string;
@@ -89,7 +93,7 @@ export type ElicitationAction = 'accept' | 'decline' | 'cancel';
  * Permitted primitive value types per the MCP spec (`ElicitResult.content`).
  * The hook is a thin transport — the server-side zod schema at
  * `apps/api/src/routes/agent-stream-elicit.ts` is the authoritative
- * validator. We accept a wider input shape so callers can pass
+ * validator. We accept a wider input shape here so callers can pass
  * `Record<string, unknown>` from generic form serializers without
  * up-front narrowing; non-primitive values get rejected by the server.
  */
@@ -101,9 +105,7 @@ export interface UseAgentStreamState {
   chunks: AgentStreamChunk[];
   isStreaming: boolean;
   error: string | null;
-  /** Set when the leading `session_info` chunk arrives. Null otherwise. */
   sessionId: string | null;
-  /** Map of pending elicitations keyed by elicitationId. */
   pendingElicitations: PendingElicitation[];
 }
 
@@ -111,11 +113,6 @@ export interface UseAgentStreamReturn extends UseAgentStreamState {
   start: (request: AgentStreamRequest, apiBase?: string) => Promise<void>;
   abort: () => void;
   reset: () => void;
-  /**
-   * POST an elicitation response to `/api/agent-stream/elicit` and remove
-   * the entry from `pendingElicitations` on success. Throws if the network
-   * call fails or the server returns a non-2xx status.
-   */
   submitElicitation: (
     elicitationId: string,
     action: ElicitationAction,
@@ -187,7 +184,6 @@ export function useAgentStream(): UseAgentStreamReturn {
 
         buffer += decoder.decode(value, { stream: true });
 
-        // Parse SSE lines: "data: {...}\n\n"
         const events = buffer.split('\n\n');
         buffer = events.pop() ?? '';
 
@@ -200,7 +196,6 @@ export function useAgentStream(): UseAgentStreamReturn {
           try {
             chunk = JSON.parse(jsonStr) as AgentStreamChunk;
           } catch {
-            // Malformed SSE data  -  skip
             continue;
           }
           setState((s) => applyChunk(s, chunk));
@@ -218,6 +213,9 @@ export function useAgentStream(): UseAgentStreamReturn {
       }));
     }
   }, []);
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   const submitElicitation = useCallback(
     async (
@@ -244,7 +242,6 @@ export function useAgentStream(): UseAgentStreamReturn {
         const errText = await response.text();
         throw new Error(`elicit response failed: HTTP ${response.status}: ${errText}`);
       }
-      // Remove the resolved entry from pendingElicitations
       setState((s) => ({
         ...s,
         pendingElicitations: s.pendingElicitations.filter((p) => p.elicitationId !== elicitationId),
@@ -253,12 +250,6 @@ export function useAgentStream(): UseAgentStreamReturn {
     [],
   );
 
-  // submitElicitation needs the *current* sessionId at call time, so we
-  // mirror state into a ref. Avoids stale-closure bugs without making the
-  // callback's dependencies churn on every chunk.
-  const stateRef = useRef(state);
-  stateRef.current = state;
-
   return { ...state, start, abort, reset, submitElicitation };
 }
 
@@ -266,8 +257,6 @@ export function useAgentStream(): UseAgentStreamReturn {
  * Pure reducer applying one SSE chunk to the hook's state. Extracted for
  * test-friendliness — call sites can simulate `start()` by feeding chunks
  * to `applyChunk()` against `INITIAL_STATE`.
- *
- * @internal
  */
 function applyChunk(s: UseAgentStreamState, chunk: AgentStreamChunk): UseAgentStreamState {
   const next: UseAgentStreamState = {
@@ -285,9 +274,6 @@ function applyChunk(s: UseAgentStreamState, chunk: AgentStreamChunk): UseAgentSt
     case 'error':
       next.error = chunk.error ?? 'Unknown error';
       next.isStreaming = false;
-      // Cancel all pending elicitations on stream error — the server-side
-      // session is being torn down so any open form is no longer
-      // resolvable.
       next.pendingElicitations = [];
       break;
     case 'done':
@@ -307,9 +293,6 @@ function applyChunk(s: UseAgentStreamState, chunk: AgentStreamChunk): UseAgentSt
         ];
       }
       break;
-    // tool_call_start / tool_call_result / sampling_request: no state
-    // mutation beyond appending to `chunks`. Consumers render from the
-    // chunk list directly.
     default:
       break;
   }
@@ -317,16 +300,6 @@ function applyChunk(s: UseAgentStreamState, chunk: AgentStreamChunk): UseAgentSt
   return next;
 }
 
-// ---------------------------------------------------------------------------
-// Test-only export
-// ---------------------------------------------------------------------------
-
-/**
- * Pure reducer used internally to apply a chunk to state. Exported for
- * unit tests so the chunk → state mapping can be verified without
- * mounting a React component or stubbing `fetch`.
- *
- * @internal
- */
+// Test-only exports
 export const _applyChunkForTesting = applyChunk;
 export const _initialStateForTesting: UseAgentStreamState = INITIAL_STATE;

--- a/packages/ai/src/client/hooks/__tests__/useAgentStream.test.ts
+++ b/packages/ai/src/client/hooks/__tests__/useAgentStream.test.ts
@@ -9,7 +9,12 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAgentStream } from '../useAgentStream.js';
+import {
+  _applyChunkForTesting,
+  _initialStateForTesting,
+  type AgentStreamChunk,
+  useAgentStream,
+} from '../useAgentStream.js';
 
 // ─── SSE Stream Builder ───────────────────────────────────────────────────────
 
@@ -59,6 +64,12 @@ describe('useAgentStream  -  initial state', () => {
     expect(result.current.chunks).toHaveLength(0);
     expect(result.current.isStreaming).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it('starts with null sessionId and no pending elicitations (A.2b)', () => {
+    const { result } = renderHook(() => useAgentStream());
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.pendingElicitations).toEqual([]);
   });
 });
 
@@ -298,5 +309,225 @@ describe('useAgentStream  -  reset', () => {
     expect(callCount).toBe(2);
     await waitFor(() => expect(result.current.isStreaming).toBe(false));
     expect(result.current.error).toBeNull();
+  });
+});
+
+// ─── A.2b side-channel chunk handling ────────────────────────────────────────
+
+describe('useAgentStream  -  applyChunk reducer (A.2b)', () => {
+  const SESSION_ID = '00000000-0000-4000-8000-000000000000';
+
+  it('captures sessionId from a session_info chunk', () => {
+    const next = _applyChunkForTesting(_initialStateForTesting, {
+      type: 'session_info',
+      sessionId: SESSION_ID,
+    });
+    expect(next.sessionId).toBe(SESSION_ID);
+    expect(next.chunks).toHaveLength(1);
+  });
+
+  it('appends a sampling_request chunk without other state mutation', () => {
+    const start = { ..._initialStateForTesting, sessionId: SESSION_ID };
+    const next = _applyChunkForTesting(start, {
+      type: 'sampling_request',
+      sessionId: SESSION_ID,
+      namespace: 'linear',
+      sampling: { model: 'gemma3', messageCount: 4, maxTokens: 1024 },
+    });
+    expect(next.chunks).toHaveLength(1);
+    expect(next.pendingElicitations).toEqual([]);
+    expect(next.text).toBe('');
+  });
+
+  it('appends an elicitation_request chunk to pendingElicitations', () => {
+    const start = { ..._initialStateForTesting, sessionId: SESSION_ID };
+    const next = _applyChunkForTesting(start, {
+      type: 'elicitation_request',
+      sessionId: SESSION_ID,
+      namespace: 'linear',
+      elicitation: {
+        elicitationId: 'elicit-1',
+        requestedSchema: { type: 'object', properties: {} },
+        message: 'Pick a project',
+      },
+    });
+    expect(next.pendingElicitations).toEqual([
+      {
+        elicitationId: 'elicit-1',
+        namespace: 'linear',
+        requestedSchema: { type: 'object', properties: {} },
+        message: 'Pick a project',
+      },
+    ]);
+  });
+
+  it('preserves existing pending elicitations when new ones arrive', () => {
+    const start: typeof _initialStateForTesting = {
+      ..._initialStateForTesting,
+      sessionId: SESSION_ID,
+      pendingElicitations: [
+        {
+          elicitationId: 'elicit-1',
+          namespace: 'linear',
+          requestedSchema: {},
+        },
+      ],
+    };
+    const next = _applyChunkForTesting(start, {
+      type: 'elicitation_request',
+      sessionId: SESSION_ID,
+      namespace: 'github',
+      elicitation: { elicitationId: 'elicit-2', requestedSchema: {} },
+    });
+    expect(next.pendingElicitations.map((p) => p.elicitationId)).toEqual(['elicit-1', 'elicit-2']);
+  });
+
+  it('clears pending elicitations on done', () => {
+    const start: typeof _initialStateForTesting = {
+      ..._initialStateForTesting,
+      sessionId: SESSION_ID,
+      isStreaming: true,
+      pendingElicitations: [
+        { elicitationId: 'elicit-1', namespace: 'linear', requestedSchema: {} },
+      ],
+    };
+    const next = _applyChunkForTesting(start, { type: 'done' });
+    expect(next.isStreaming).toBe(false);
+    expect(next.pendingElicitations).toEqual([]);
+  });
+
+  it('clears pending elicitations on error', () => {
+    const start: typeof _initialStateForTesting = {
+      ..._initialStateForTesting,
+      sessionId: SESSION_ID,
+      isStreaming: true,
+      pendingElicitations: [
+        { elicitationId: 'elicit-1', namespace: 'linear', requestedSchema: {} },
+      ],
+    };
+    const next = _applyChunkForTesting(start, {
+      type: 'error',
+      error: 'boom',
+    });
+    expect(next.error).toBe('boom');
+    expect(next.isStreaming).toBe(false);
+    expect(next.pendingElicitations).toEqual([]);
+  });
+
+  it('drops malformed elicitation_request without elicitation payload', () => {
+    const start = { ..._initialStateForTesting, sessionId: SESSION_ID };
+    const malformed: AgentStreamChunk = {
+      type: 'elicitation_request',
+      sessionId: SESSION_ID,
+      namespace: 'linear',
+      // elicitation field intentionally absent
+    };
+    const next = _applyChunkForTesting(start, malformed);
+    expect(next.pendingElicitations).toEqual([]);
+    expect(next.chunks).toHaveLength(1);
+  });
+});
+
+describe('useAgentStream  -  submitElicitation (A.2b)', () => {
+  const SESSION_ID = '00000000-0000-4000-8000-000000000000';
+
+  it('POSTs to /api/agent-stream/elicit with the resolved sessionId + body', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(
+          makeSseStream([
+            { type: 'session_info', sessionId: SESSION_ID },
+            {
+              type: 'elicitation_request',
+              sessionId: SESSION_ID,
+              namespace: 'linear',
+              elicitation: { elicitationId: 'elicit-1', requestedSchema: {} },
+            },
+            // intentionally NOT terminating with `done` so the stream stays
+            // open and we can assert pendingElicitations is populated
+          ]),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    const { result } = renderHook(() => useAgentStream());
+
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    await waitFor(() => expect(result.current.pendingElicitations).toHaveLength(1));
+    expect(result.current.sessionId).toBe(SESSION_ID);
+
+    await act(async () => {
+      await result.current.submitElicitation('elicit-1', 'accept', { project: 'web' });
+    });
+
+    // Second fetch is the POST to /elicit
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchSpy.mock.calls[1];
+    expect(url).toBe('/api/agent-stream/elicit');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      sessionId: SESSION_ID,
+      elicitationId: 'elicit-1',
+      action: 'accept',
+      content: { project: 'web' },
+    });
+    expect(result.current.pendingElicitations).toHaveLength(0);
+  });
+
+  it('omits content when action is decline or cancel', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(makeSseStream([{ type: 'session_info', sessionId: SESSION_ID }])),
+      )
+      .mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    await waitFor(() => expect(result.current.sessionId).toBe(SESSION_ID));
+
+    await act(async () => {
+      await result.current.submitElicitation('elicit-1', 'decline', { ignored: true });
+    });
+
+    const [, init] = fetchSpy.mock.calls[1];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      sessionId: SESSION_ID,
+      elicitationId: 'elicit-1',
+      action: 'decline',
+    });
+  });
+
+  it('throws when called before start() resolves a sessionId', async () => {
+    const { result } = renderHook(() => useAgentStream());
+    await expect(result.current.submitElicitation('elicit-1', 'cancel')).rejects.toThrow(
+      /no sessionId/,
+    );
+  });
+
+  it('throws when the elicit POST returns non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(makeSseStream([{ type: 'session_info', sessionId: SESSION_ID }])),
+      )
+      .mockResolvedValueOnce(new Response('Forbidden', { status: 403 }));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+    await waitFor(() => expect(result.current.sessionId).toBe(SESSION_ID));
+
+    await expect(result.current.submitElicitation('elicit-1', 'accept', { x: 1 })).rejects.toThrow(
+      /403/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

**A.2b-frontend of the post-v1 MCP arc — first user-visible Stage 5 surface.**

The new `/admin/agents/[agentId]/run` page consumes `/api/agent-stream` SSE (A.1 + A.2a + A.2b-backend) and renders chunks live: tool calls, sampling requests, and inline elicitation forms. When a connected MCP server requests user input via `elicitation/create` mid-run, the page renders an inline form derived from the `requestedSchema` and POSTs the response to `/api/agent-stream/elicit` (A.2b-backend's endpoint).

## What ships

- **`packages/ai/src/client/hooks/useAgentStream.ts`** — extend with the three side-channel chunk types (`session_info`, `sampling_request`, `elicitation_request`); track `sessionId` + `pendingElicitations` in state; new `submitElicitation(elicitationId, action, content?)` method; new `mode?: 'admin' | 'coding'` on `AgentStreamRequest`. Pure `applyChunk` reducer extracted as `_applyChunkForTesting` for unit testability.
- **`apps/admin/src/lib/hooks/useAgentStream.ts`** (new) — admin-local copy of the hook so apps/ never statically imports an optional Pro package. Same shape; keep in lockstep when chunk types change.
- **`apps/admin/src/lib/components/mcp/elicitation-form.tsx`** (new) — extract `ElicitationForm` + `ArgumentField` + types from Stage 3.4's `StreamingToolCard` into a reusable component with a flat `(message, requestedSchema, onSubmit)` shape. `StreamingToolCard` updated to import; zero behavior change for the inspector.
- **`apps/admin/src/app/(backend)/admin/agents/[agentId]/run/page.tsx`** (new) — submit-an-instruction form, mode dropdown (admin/coding), cancel/clear/start buttons, status bar (streaming/idle/error + sessionId snippet + chunk count), pending-elicitations stack as inline forms, accumulated text panel, full event log with per-event-type rows. Wrapped in `<LicenseGate feature="ai">`.
- **Agent detail page** — adds a "Watch live ↗" link button to the Task Tester card header. `TaskTester` unchanged; coexists as the polling A2A fallback.

## Design anchors

Closes A.2b in internal docs. The split that landed:

- A.1 ✅ backend wiring (#537)
- A.2a ✅ sampling handler (#546)
- A.2b-backend ✅ elicitation plumbing + chunk types (#549)
- **A.2b-frontend = this PR** — the UI that consumes all of the above

## Discipline held

- **Boundary:** admin imports `useAgentStream` from `@/lib/hooks/useAgentStream`, not `@revealui/ai`. Apps keep zero static imports of optional Fair Source packages — `pnpm validate:boundary` clean.
- **Stream teardown safety:** `pendingElicitations` cleared on `done`/`error` so a stream teardown can't leave a phantom form on screen — matches A.2b-backend's `deleteAgentRunSession` cancel-on-cleanup semantics.
- **Malformed schema degrades gracefully:** `ElicitationCard` narrows `requestedSchema: unknown` to `ElicitationSchema`; non-object schemas fall back to an empty-fields form so the user can still decline/cancel rather than seeing a render error.
- **Cancel button** uses the hook's `abort()` which fires the same `AbortController` the SSE fetch is on — server sees a closed connection and tears down the run-session in the streamSSE `finally`.

## Test plan

- [x] `pnpm --filter @revealui/ai test` — 951 → 963 passing (+12 useAgentStream tests covering applyChunk reducer + submitElicitation round-trip + auth/error paths)
- [x] `pnpm --filter admin test` — 1592 → 1601 passing (+9 admin-hook mirror tests)
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter @revealui/ai typecheck` — clean
- [x] `pnpm validate:boundary` — clean
- [x] Pre-push gate (15 checks) — PASS
- [ ] **Post-merge smoke test** (manual, requires a tenant with an MCP server that emits `elicitation/create`):
  1. Visit `/admin/agents/<id>/run`
  2. Submit an instruction that triggers the server's elicitation flow
  3. Confirm the `session_info` chunk arrives + sessionId surfaces in the status bar
  4. Confirm the `elicitation_request` chunk renders an inline form with the server's fields
  5. Submit the form → POST lands at `/api/agent-stream/elicit` → MCP server's call resolves and the agent turn continues
  6. Confirm cancel button mid-run terminates the SSE + leaves no stale state on screen

## Follow-ups (NOT in this PR)

- **A.3** — `usage_meters` dashboards at `/admin/mcp` (Usage tab). Aggregates the rows A.1 produces. Adds a nullable `duration_ms` migration. ~300 LOC.
- **`StreamingToolCard` further extraction** — `ProgressDisplay`, `LogPanel`, `ToolResult` are still inline in the inspector card. They aren't reused by A.2b-frontend (the run page emits its own per-chunk rows), so leaving them inline is fine; if A.4+ needs them, extract then.
- **Deprecate `TaskTester`** — A.4+ once the `/run` page is proven against real workloads.
- **End-to-end Playwright** for the elicitation round-trip — manual smoke test suffices for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
