### PR TITLE
feat(api, db, ai): usage_meters duration/errored + /api/mcp/usage endpoint (A.3a)

### DIFF
--- a/.changeset/mcp-a3a-backend.md
+++ b/.changeset/mcp-a3a-backend.md
@@ -1,0 +1,34 @@
+---
+'@revealui/db': minor
+'@revealui/ai': minor
+---
+
+A.3a of the post-v1 MCP arc — backend for the `/admin/mcp` Usage tab.
+
+The accompanying A.3b PR adds the admin UI on top of this; A.3a lands
+the schema migration + sink-side population + aggregation endpoint
+independently so the UI can ship against a stable backend.
+
+**`@revealui/db`:**
+- Migration `0011_usage_meters_duration_ms.sql` adds two nullable
+  columns to `usage_meters`: `duration_ms` (bigint) + `errored`
+  (boolean). Pre-A.3 rows carry NULL; post-migration rows populate
+  from the Stage 6.1/6.2 sinks.
+- Drizzle schema mirror in `accounts.ts`.
+
+**`@revealui/ai`:**
+- Extend `McpUsageMeterRow` with `durationMs?: number` + `errored?: boolean`.
+- `createUsageMeterSink` populates both from `event.duration_ms` /
+  `!event.success` so existing consumers automatically capture the
+  new fields once the schema accepts them.
+
+**`api`:**
+- New `GET /api/mcp/usage?range=24h|7d|30d` endpoint that aggregates
+  per-`meterName` totals + success/error/unknown counts +
+  p50/p95 duration via PostgreSQL `percentile_disc`. Filters by
+  `entitlementMiddleware`-resolved `accountId` (account-scoped, same
+  precedent as A.1's metering writer). Mounted at canonical +
+  `/api/v1/...` paths.
+- 9 PGlite-backed integration tests cover auth, accountId scoping,
+  per-meter aggregation, percentile correctness, range filtering,
+  and zod validation.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -97,6 +97,7 @@ import licenseRoute from './routes/license.js';
 import logsRoute from './routes/logs.js';
 import maintenanceRoute from './routes/maintenance.js';
 import marketplaceRoute from './routes/marketplace.js';
+import mcpUsageRoute from './routes/mcp-usage.js';
 import pricingRoute from './routes/pricing.js';
 import ragIndexRoute from './routes/rag-index.js';
 import revmarketRoute from './routes/revmarket.js';
@@ -1054,6 +1055,8 @@ app.route('/api/agent-tasks', agentTasksRoute);
 // elicit must be a sibling rather than a sub-route.
 app.route('/api/agent-stream/elicit', agentStreamElicitRoute);
 app.route('/api/agent-stream', agentStreamRoute);
+// A.3: Usage aggregation endpoint for the /admin/mcp Usage tab.
+app.route('/api/mcp/usage', mcpUsageRoute);
 app.route('/api/content', contentRoute);
 app.route('/api/rag', ragIndexRoute);
 app.route('/api/admin', adminObservabilityRoute);
@@ -1109,6 +1112,7 @@ app.route('/api/v1/tickets', ticketsRoute);
 app.route('/api/v1/agent-tasks', agentTasksRoute);
 app.route('/api/v1/agent-stream/elicit', agentStreamElicitRoute);
 app.route('/api/v1/agent-stream', agentStreamRoute);
+app.route('/api/v1/mcp/usage', mcpUsageRoute);
 app.route('/api/v1/content', contentRoute);
 app.route('/api/v1/rag', ragIndexRoute);
 app.route('/api/v1/admin', adminObservabilityRoute);

--- a/apps/api/src/routes/__tests__/mcp-usage.test.ts
+++ b/apps/api/src/routes/__tests__/mcp-usage.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Integration tests for `GET /api/mcp/usage` (A.3). Uses PGlite end-to-end
+ * so the percentile_disc aggregation is exercised against real Postgres
+ * semantics.
+ */
+
+import { accounts, usageMeters } from '@revealui/db/schema';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import mcpUsageRoute from '../mcp-usage.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const ACCOUNT_A = 'acct_test_a';
+const ACCOUNT_B = 'acct_test_b';
+
+interface MountOptions {
+  user?: { id: string; role: string };
+  entitlements?: { accountId: string | null };
+}
+
+function mountApp(opts: MountOptions): Hono {
+  const app = new Hono<{
+    Variables: {
+      user?: { id: string; role: string };
+      entitlements?: { accountId: string | null };
+    };
+  }>();
+  app.use('*', async (c, next) => {
+    if (opts.user) c.set('user', opts.user);
+    if (opts.entitlements) c.set('entitlements', opts.entitlements);
+    await next();
+  });
+  app.route('/api/mcp/usage', mcpUsageRoute);
+  return app;
+}
+
+async function seedAccount(id: string): Promise<void> {
+  await testDb.drizzle.insert(accounts).values({
+    id,
+    name: `Test ${id}`,
+    slug: id,
+    status: 'active',
+  });
+}
+
+async function seedRow(opts: {
+  accountId: string;
+  meterName: string;
+  durationMs?: number | null;
+  errored?: boolean | null;
+  periodStart?: Date;
+  idempotencyKey?: string;
+}): Promise<void> {
+  await testDb.drizzle.insert(usageMeters).values({
+    id: crypto.randomUUID(),
+    accountId: opts.accountId,
+    meterName: opts.meterName,
+    quantity: 1,
+    periodStart: opts.periodStart ?? new Date(),
+    periodEnd: null,
+    source: 'agent',
+    idempotencyKey: opts.idempotencyKey ?? crypto.randomUUID(),
+    durationMs: opts.durationMs ?? null,
+    errored: opts.errored ?? null,
+  });
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+});
+
+afterEach(async () => {
+  await testDb.close();
+});
+
+describe('GET /api/mcp/usage', () => {
+  it('returns 401 when caller is unauthenticated', async () => {
+    const app = mountApp({});
+    const res = await app.request('/api/mcp/usage', {
+      headers: { Accept: 'application/json' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 409 when caller has no resolvable accountId', async () => {
+    const app = mountApp({
+      user: { id: 'user-x', role: 'admin' },
+      entitlements: { accountId: null },
+    });
+    const res = await app.request('/api/mcp/usage');
+    expect(res.status).toBe(409);
+  });
+
+  it('returns empty meters array when no rows in window', async () => {
+    await seedAccount(ACCOUNT_A);
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { meters: unknown[]; range: string; accountId: string };
+    expect(body.meters).toEqual([]);
+    expect(body.range).toBe('24h');
+    expect(body.accountId).toBe(ACCOUNT_A);
+  });
+
+  it('aggregates total / success / error counts per meterName', async () => {
+    await seedAccount(ACCOUNT_A);
+    // 3 successes, 2 errors, 1 unknown (NULL errored) for tool.call
+    for (let i = 0; i < 3; i++) {
+      await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: false });
+    }
+    for (let i = 0; i < 2; i++) {
+      await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: true });
+    }
+    await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: null });
+    // 1 success for sampling
+    await seedRow({
+      accountId: ACCOUNT_A,
+      meterName: 'mcp.sampling.create',
+      errored: false,
+    });
+
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    const body = (await res.json()) as {
+      meters: Array<{
+        meterName: string;
+        total: number;
+        successCount: number;
+        errorCount: number;
+        unknownCount: number;
+      }>;
+    };
+    expect(body.meters).toHaveLength(2);
+    const tool = body.meters.find((m) => m.meterName === 'mcp.tool.call');
+    expect(tool).toMatchObject({
+      total: 6,
+      successCount: 3,
+      errorCount: 2,
+      unknownCount: 1,
+    });
+    const sampling = body.meters.find((m) => m.meterName === 'mcp.sampling.create');
+    expect(sampling).toMatchObject({
+      total: 1,
+      successCount: 1,
+      errorCount: 0,
+      unknownCount: 0,
+    });
+  });
+
+  it('computes p50 / p95 from non-null duration_ms values', async () => {
+    await seedAccount(ACCOUNT_A);
+    // 10 rows with durations 10, 20, 30, ..., 100. Plus 2 NULL rows that
+    // should be excluded.
+    for (let i = 1; i <= 10; i++) {
+      await seedRow({
+        accountId: ACCOUNT_A,
+        meterName: 'mcp.tool.call',
+        errored: false,
+        durationMs: i * 10,
+      });
+    }
+    await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: false });
+    await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: false });
+
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    const body = (await res.json()) as {
+      meters: Array<{
+        meterName: string;
+        total: number;
+        durationCount: number;
+        p50Ms: number | null;
+        p95Ms: number | null;
+      }>;
+    };
+    const tool = body.meters[0];
+    expect(tool?.total).toBe(12);
+    expect(tool?.durationCount).toBe(10);
+    // percentile_disc(0.5) over [10..100] (sorted) discrete-picks the
+    // 5th element = 50. percentile_disc(0.95) picks the value at the
+    // 9.5-rounded position = 100.
+    expect(tool?.p50Ms).toBe(50);
+    expect(tool?.p95Ms).toBe(100);
+  });
+
+  it('returns null p50 / p95 when no rows have duration_ms', async () => {
+    await seedAccount(ACCOUNT_A);
+    await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: false });
+    await seedRow({ accountId: ACCOUNT_A, meterName: 'mcp.tool.call', errored: true });
+
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    const body = (await res.json()) as {
+      meters: Array<{ p50Ms: number | null; p95Ms: number | null; durationCount: number }>;
+    };
+    expect(body.meters[0]?.p50Ms).toBeNull();
+    expect(body.meters[0]?.p95Ms).toBeNull();
+    expect(body.meters[0]?.durationCount).toBe(0);
+  });
+
+  it('isolates rows by accountId — caller never sees another account\u2019s usage', async () => {
+    await seedAccount(ACCOUNT_A);
+    await seedAccount(ACCOUNT_B);
+    await seedRow({
+      accountId: ACCOUNT_A,
+      meterName: 'mcp.tool.call',
+      errored: false,
+      durationMs: 100,
+    });
+    // 5 rows on B that should NOT appear in A's response
+    for (let i = 0; i < 5; i++) {
+      await seedRow({
+        accountId: ACCOUNT_B,
+        meterName: 'mcp.tool.call',
+        errored: false,
+      });
+    }
+
+    const app = mountApp({
+      user: { id: 'user-a', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    const body = (await res.json()) as {
+      meters: Array<{ total: number }>;
+    };
+    expect(body.meters[0]?.total).toBe(1);
+  });
+
+  it('filters by range — older rows are excluded', async () => {
+    await seedAccount(ACCOUNT_A);
+    const now = new Date();
+    const fortyHoursAgo = new Date(now.getTime() - 40 * 60 * 60 * 1000);
+    await seedRow({
+      accountId: ACCOUNT_A,
+      meterName: 'mcp.tool.call',
+      errored: false,
+      periodStart: now,
+    });
+    await seedRow({
+      accountId: ACCOUNT_A,
+      meterName: 'mcp.tool.call',
+      errored: false,
+      periodStart: fortyHoursAgo,
+    });
+
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=24h');
+    const body24 = (await res.json()) as { meters: Array<{ total: number }> };
+    expect(body24.meters[0]?.total).toBe(1);
+
+    const res7d = await app.request('/api/mcp/usage?range=7d');
+    const body7d = (await res7d.json()) as { meters: Array<{ total: number }> };
+    expect(body7d.meters[0]?.total).toBe(2);
+  });
+
+  it('rejects invalid range values via zod validation', async () => {
+    await seedAccount(ACCOUNT_A);
+    const app = mountApp({
+      user: { id: 'user-1', role: 'admin' },
+      entitlements: { accountId: ACCOUNT_A },
+    });
+    const res = await app.request('/api/mcp/usage?range=999d');
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});

--- a/apps/api/src/routes/mcp-usage.ts
+++ b/apps/api/src/routes/mcp-usage.ts
@@ -1,0 +1,205 @@
+/**
+ * MCP usage aggregations.
+ *
+ * `GET /api/mcp/usage?range=24h|7d|30d` — returns per-`meterName`
+ * counts + duration percentiles for the caller's account, filtered by
+ * the requested time window.
+ *
+ * Powers the Usage tab on `/admin/mcp` (A.3 of the post-v1 MCP arc).
+ * Visualizes the rows A.1 / A.2a / A.2b-backend write into
+ * `usage_meters` from the Stage 6.1 / 6.2 sinks.
+ *
+ * Scoping. The endpoint resolves the caller's `accountId` from the
+ * global `entitlementMiddleware` context and filters to that single
+ * account — same precedent as A.1's metering writer. Multi-account /
+ * super-admin views are deferred until a clear product need surfaces;
+ * v1 is "show me my account's usage."
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { sql } from 'drizzle-orm';
+import { getEntitlementsFromContext } from '../middleware/entitlements.js';
+
+type Variables = {
+  user?: { id: string; role: string };
+};
+
+const app = new OpenAPIHono<{ Variables: Variables }>();
+
+const RangeSchema = z.enum(['24h', '7d', '30d']).default('24h');
+
+const MeterAggregateSchema = z.object({
+  meterName: z.string(),
+  total: z.number().int().nonnegative(),
+  successCount: z.number().int().nonnegative(),
+  errorCount: z.number().int().nonnegative(),
+  unknownCount: z.number().int().nonnegative(),
+  durationCount: z.number().int().nonnegative(),
+  p50Ms: z.number().nullable(),
+  p95Ms: z.number().nullable(),
+});
+
+const UsageResponseSchema = z.object({
+  range: RangeSchema,
+  since: z.string(),
+  accountId: z.string().nullable(),
+  meters: z.array(MeterAggregateSchema),
+});
+
+const usageRoute = createRoute({
+  method: 'get',
+  path: '/',
+  tags: ['mcp'],
+  summary: 'Aggregate MCP usage for the caller\u2019s account',
+  description:
+    'Returns per-`meterName` totals, success / error / unknown counts (unknown = pre-A.3 row with NULL `errored`), duration counts, and p50 / p95 duration buckets in milliseconds. Filtered by the caller\u2019s `accountId` (resolved from `entitlementMiddleware`) and the requested time range.',
+  request: {
+    query: z.object({
+      range: RangeSchema.optional(),
+    }),
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: UsageResponseSchema } },
+      description: 'Usage aggregations for the caller\u2019s account',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(false), error: z.string() }),
+        },
+      },
+      description: 'Authentication required',
+    },
+    409: {
+      content: {
+        'application/json': {
+          schema: z.object({ success: z.literal(false), error: z.string() }),
+        },
+      },
+      description: 'Caller has no resolvable account membership',
+    },
+  },
+});
+
+const RANGE_TO_SINCE_MS: Readonly<Record<z.infer<typeof RangeSchema>, number>> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+};
+
+// Drizzle's `db.execute<T>` constrains `T extends Record<string, unknown>`
+// — so the interface needs an index signature alongside the named fields.
+interface UsageRow {
+  meter_name: string;
+  total: string | number;
+  success_count: string | number | null;
+  error_count: string | number | null;
+  duration_count: string | number;
+  p50_ms: string | number | null;
+  p95_ms: string | number | null;
+  [key: string]: unknown;
+}
+
+function toNum(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  return typeof value === 'number' ? value : Number.parseInt(value, 10) || 0;
+}
+
+function toNullableNum(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+app.openapi(usageRoute, async (c) => {
+  const user = c.get('user');
+  if (!user) {
+    return c.json({ success: false as const, error: 'Authentication required' }, 401);
+  }
+
+  const accountId = getEntitlementsFromContext(c).accountId;
+  if (!accountId) {
+    return c.json(
+      {
+        success: false as const,
+        error: 'Caller has no active account membership; usage is account-scoped',
+      },
+      409,
+    );
+  }
+
+  const range = c.req.valid('query').range ?? '24h';
+  const since = new Date(Date.now() - RANGE_TO_SINCE_MS[range]);
+
+  // Raw SQL gives us PostgreSQL's `percentile_disc` directly. Drizzle
+  // doesn't ship a percentile aggregate helper, and writing this
+  // through the query builder would be more code for the same plan.
+  // PGlite (used for tests) supports `percentile_disc` natively.
+  const db = getClient();
+  let rows: UsageRow[] = [];
+  try {
+    const result = await db.execute<UsageRow>(sql`
+      SELECT
+        meter_name,
+        count(*) AS total,
+        sum(CASE WHEN errored = false THEN 1 ELSE 0 END) AS success_count,
+        sum(CASE WHEN errored = true THEN 1 ELSE 0 END) AS error_count,
+        count(duration_ms) AS duration_count,
+        percentile_disc(0.5)
+          WITHIN GROUP (ORDER BY duration_ms)
+          FILTER (WHERE duration_ms IS NOT NULL) AS p50_ms,
+        percentile_disc(0.95)
+          WITHIN GROUP (ORDER BY duration_ms)
+          FILTER (WHERE duration_ms IS NOT NULL) AS p95_ms
+      FROM usage_meters
+      WHERE account_id = ${accountId} AND period_start >= ${since.toISOString()}
+      GROUP BY meter_name
+      ORDER BY meter_name ASC
+    `);
+    // Drizzle's `db.execute` returns either the raw rows array (PGlite,
+    // node-postgres pool) or `{ rows: [...] }` (neon-http). Normalize.
+    rows = Array.isArray(result)
+      ? (result as UsageRow[])
+      : ((result as { rows?: UsageRow[] }).rows ?? []);
+  } catch (error) {
+    logger.error('[/api/mcp/usage] aggregation query failed', {
+      accountId,
+      range,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  const meters = rows.map((row) => {
+    const successCount = toNum(row.success_count);
+    const errorCount = toNum(row.error_count);
+    const total = toNum(row.total);
+    return {
+      meterName: row.meter_name,
+      total,
+      successCount,
+      errorCount,
+      // pre-A.3 rows had NULL `errored`; they fall out of both
+      // success/error sums but still count toward the total.
+      unknownCount: Math.max(0, total - successCount - errorCount),
+      durationCount: toNum(row.duration_count),
+      p50Ms: toNullableNum(row.p50_ms),
+      p95Ms: toNullableNum(row.p95_ms),
+    };
+  });
+
+  return c.json(
+    {
+      range,
+      since: since.toISOString(),
+      accountId,
+      meters,
+    },
+    200,
+  );
+});
+
+export default app;

--- a/packages/ai/src/tools/mcp-events.ts
+++ b/packages/ai/src/tools/mcp-events.ts
@@ -244,6 +244,21 @@ export interface McpUsageMeterRow {
   source: 'system' | 'user' | 'agent' | 'api';
   /** Unique key. Backs `uniqueIndex` on `usage_meters`. */
   idempotencyKey: string;
+  /**
+   * Wall-clock duration of the protocol call in milliseconds, lifted
+   * directly from `event.duration_ms`. Optional in the row shape so
+   * pre-A.3 consumers writing into rows without a `duration_ms`
+   * column don't break — the sink populates it whenever the consumer's
+   * schema accepts it. A.3 of the post-v1 MCP arc.
+   */
+  durationMs?: number;
+  /**
+   * `true` when the protocol call surfaced an error (`!event.success`).
+   * Optional for the same forward-compat reason as `durationMs`.
+   * The Usage tab on `/admin/mcp` aggregates these into success-rate
+   * counts per `meterName`. A.3.
+   */
+  errored?: boolean;
 }
 
 /**
@@ -348,6 +363,8 @@ export function createUsageMeterSink(options: CreateUsageMeterSinkOptions): McpE
       periodEnd: null,
       source,
       idempotencyKey: genKey(event),
+      durationMs: event.duration_ms,
+      errored: !event.success,
     };
 
     const result = options.write(row);

--- a/packages/db/migrations/0011_usage_meters_duration_ms.sql
+++ b/packages/db/migrations/0011_usage_meters_duration_ms.sql
@@ -1,0 +1,24 @@
+-- A.3 of the post-v1 MCP arc: add nullable `duration_ms` + `errored`
+-- columns to `usage_meters` so the new `/admin/mcp` Usage tab can plot
+-- p50/p95 duration buckets per `meterName` and compute success rate.
+--
+-- Backfill semantics:
+--   - Existing rows (written by A.1 / A.2a / A.2b-backend before this
+--     migration) get NULL on both columns and are excluded from
+--     p-bucket / success-rate queries by `WHERE duration_ms IS NOT NULL`
+--     / `WHERE errored IS NOT NULL` filters.
+--   - New rows after this migration carry duration + errored populated
+--     by the Stage 6.1 / 6.2 sinks, which compute `event.duration_ms`
+--     and `!event.success` at adapter exit (see
+--     `@revealui/ai/tools/mcp-events.ts`).
+--
+-- No index is added on `duration_ms` / `errored` directly — A.3 queries
+-- always filter by `(account_id, period_start)` first (existing
+-- composite index `usage_meters_account_period_idx`); the new columns
+-- are only used in aggregation buckets after the row set is narrowed.
+
+ALTER TABLE "usage_meters"
+  ADD COLUMN IF NOT EXISTS "duration_ms" bigint;
+--> statement-breakpoint
+ALTER TABLE "usage_meters"
+  ADD COLUMN IF NOT EXISTS "errored" boolean;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -44,6 +44,12 @@
       "rationale": "Hand-written CREATE TABLE + indexes for the `unreconciled_webhooks` table. The table was defined in packages/db/src/schema/webhook-reconciliation.ts and already appears in the Drizzle snapshots at meta/0006_snapshot.json and meta/0009_snapshot.json, but NO .sql migration ever created it (verified 2026-04-22: grep -n 'unreconciled' migrations/*.sql → zero hits). Production likely has the table from an ad-hoc drizzle-kit push at some point (webhooks.ts writes to it at runtime; if prod didn't have it, webhook processing would be failing). Migration uses CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS so it is safe to apply against both fresh DBs (creates it) and prod (no-op). Partial index `unreconciled_webhooks_unresolved_idx` on (created_at) WHERE resolved_at IS NULL is not expressible in Drizzle's schema DSL beyond the .where() modifier.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Snapshot already captures the table (meta/0006_snapshot.json + meta/0009_snapshot.json reference it). Missing snapshot for this tag specifically because it's a retroactive catch-up for an unmigrated table; the canonical snapshot state is the 0009 snapshot. Full snapshot regen deferred to the general snapshot-debt backfill tracked alongside 0003/0004/0005/0008."
+    },
+    {
+      "tag": "0011_usage_meters_duration_ms",
+      "rationale": "A.3 of the post-v1 MCP arc — adds two nullable columns (`duration_ms` bigint, `errored` boolean) to `usage_meters` so the new `/admin/mcp` Usage tab can plot p50/p95 duration buckets + success/error rate per meterName. Hand-written with `ADD COLUMN IF NOT EXISTS` so it's idempotent against any prod environment that already applied an ad-hoc `drizzle-kit push` for the schema change. drizzle-kit produces functionally equivalent SQL (`ALTER TABLE ... ADD COLUMN ...` without the IF NOT EXISTS guard), but the descriptive tag + idempotency match the 0010 precedent for this kind of small column-addition migration.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as 0003/0004/0005/0008/0010: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. Drizzle schema change at packages/db/src/schema/accounts.ts already adds the columns at the type level; consumers query via Drizzle, not raw SQL, so the type contract is intact."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777171200000,
       "tag": "0010_unreconciled_webhooks",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777257600000,
+      "tag": "0011_usage_meters_duration_ms",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/accounts.ts
+++ b/packages/db/src/schema/accounts.ts
@@ -189,6 +189,22 @@ export const usageMeters = pgTable(
     source: text('source').notNull().default('system'),
     idempotencyKey: text('idempotency_key').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    /**
+     * Wall-clock duration of the call in milliseconds. NULL on rows
+     * written before A.3 (2026-04-24); subsequent rows from the
+     * Stage 6.1 / 6.2 sinks populate this from `event.duration_ms`.
+     * Excluded from p-bucket aggregations via `WHERE duration_ms
+     * IS NOT NULL` so the migration boundary is invisible.
+     */
+    durationMs: bigint('duration_ms', { mode: 'number' }),
+    /**
+     * `true` when the underlying protocol call surfaced an error
+     * (server returned `isError: true`, the call threw, or transport
+     * timed out). NULL on rows written before A.3; new rows populate
+     * from `!event.success`. Used by the `/admin/mcp` Usage tab to
+     * compute success rate per `meterName`.
+     */
+    errored: boolean('errored'),
   },
   (table) => [
     uniqueIndex('usage_meters_idempotency_key_idx').on(table.idempotencyKey),


### PR DESCRIPTION
## Summary

**A.3a of the post-v1 MCP arc — backend for the `/admin/mcp` Usage tab.**

The accompanying A.3b PR (next) adds the admin UI on top of this; A.3a lands the schema migration + sink-side population + aggregation endpoint independently so the UI can ship against a stable backend.

## What ships

- `packages/db/migrations/0011_usage_meters_duration_ms.sql` (new) — adds nullable `duration_ms` + `errored` columns to `usage_meters`.
- `packages/db/src/schema/accounts.ts` — Drizzle mirror.
- `packages/db/migrations/meta/_journal.json` + `_custom.json` — register migration + declare hand-written (matches 0010 precedent).
- `packages/ai/src/tools/mcp-events.ts` — extend `McpUsageMeterRow` with `durationMs?` + `errored?`; `createUsageMeterSink` populates from `event.duration_ms` + `!event.success`.
- `apps/api/src/routes/mcp-usage.ts` (new) — `GET /api/mcp/usage?range=24h|7d|30d` with raw-SQL `percentile_disc` aggregation.
- `apps/api/src/routes/__tests__/mcp-usage.test.ts` (new) — 9 PGlite-backed integration tests.
- `apps/api/src/index.ts` — mount at canonical + `/api/v1` paths.

## Discipline held

- **Account-scoped only.** v1 endpoint resolves accountId via the global `entitlementMiddleware` (same precedent as A.1's `recordUsageMeter` caller). Multi-tenant / super-admin views are deferred until a clear product need surfaces.
- **Forward-compat on the row shape.** New `McpUsageMeterRow` fields are optional so pre-A.3 consumers writing into older schemas still typecheck.
- **Snapshot debt deferred.** Migration 0011 follows the 0010 precedent (descriptive tag + IF NOT EXISTS guards + `_custom.json` entry); full snapshot regen happens in the broader debt-backfill task tracked alongside 0003/0004/0005/0008/0010.

## Test plan

- [x] `pnpm --filter api test src/routes/__tests__/mcp-usage.test.ts` — 9/9
- [x] `pnpm --filter api typecheck` — clean
- [x] `pnpm --filter @revealui/ai typecheck` — clean
- [x] `pnpm --filter "api..." build` — clean
- [x] `pnpm validate:boundary` — clean
- [x] `pnpm validate:migrations` — clean
- [x] Pre-push gate — PASS

## Follow-ups (NOT in this PR)

- **A.3b** — Usage tab on `/admin/mcp` with a hand-rolled SVG bar dashboard (no chart-lib dep). ~300 LOC.
- **A.4** (stretch) — Resources/Prompts/Logs tabs at `/admin/mcp/inspect`. ~200 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
