### PR TITLE
feat(admin): /admin/mcp Usage tab + hand-rolled SVG dashboard (A.3b)

### DIFF
--- a/apps/admin/src/app/(backend)/admin/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/admin/mcp/page.tsx
@@ -1,19 +1,21 @@
 /**
- * MCP — Server Catalog (/admin/mcp)
+ * MCP — Server Catalog + Usage (/admin/mcp)
  *
- * Stage 3.1 of the MCP v1 plan. Lists both built-in MCP servers (driven by
- * `/api/mcp/servers`, the existing endpoint shared with the `/admin/agents`
- * MCP tab) and OAuth-authorized remote servers for the active tenant
- * (driven by the new `/api/mcp/remote-servers?tenant=X`).
+ * Tabbed page:
+ *   - Catalog (Stage 3.1) — built-in servers, content exposure, and
+ *     OAuth-authorized remote servers for the selected tenant.
+ *   - Usage (A.3 of the post-v1 MCP arc) — per-`meterName` call counts
+ *     and p50/p95 durations from `usage_meters`, served by
+ *     `/api/mcp/usage`.
  *
- * Scope is intentionally thin: list, connect (link to `/admin/mcp/connect`),
- * disconnect. Tool/resource/prompt browsing lands in Stage 3.2–3.4.
+ * Tool/resource/prompt browsing lives at `/admin/mcp/inspect`.
  */
 
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
 import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
+import { UsageDashboard } from '@/lib/components/mcp/usage-dashboard';
 import type { CollectionMcpSummary } from '@/lib/mcp/collections';
 
 interface RemoteServerSummary {
@@ -23,8 +25,10 @@ interface RemoteServerSummary {
 }
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+type CatalogTab = 'catalog' | 'usage';
 
 export default function McpCatalogPage() {
+  const [activeTab, setActiveTab] = useState<CatalogTab>('catalog');
   const [tenant, setTenant] = useState<string>('');
   const [activeTenant, setActiveTenant] = useState<string | null>(null);
   const [builtins, setBuiltins] = useState<McpServerInfo[]>([]);
@@ -129,9 +133,9 @@ export default function McpCatalogPage() {
       <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold text-white">MCP Server Catalog</h1>
+            <h1 className="text-xl font-semibold text-white">MCP</h1>
             <p className="mt-0.5 text-sm text-zinc-400">
-              Built-in servers and OAuth-authorized remote servers per tenant
+              Built-in and OAuth-authorized servers, content exposure, and per-meter usage
             </p>
           </div>
           <a
@@ -143,180 +147,210 @@ export default function McpCatalogPage() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-5xl p-6">
-        {message && (
-          <div
-            role="status"
-            className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300"
-          >
-            {message}
-          </div>
-        )}
-
-        {/* Tenant scope selector */}
-        <form
-          onSubmit={handleLoadTenant}
-          className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
-        >
-          <label htmlFor="tenant-input" className="mb-1.5 block text-sm font-medium text-zinc-300">
-            Tenant
-          </label>
-          <div className="flex items-center gap-3">
-            <input
-              id="tenant-input"
-              name="tenant"
-              type="text"
-              value={tenant}
-              onChange={(e) => setTenant(e.target.value)}
-              pattern="[A-Za-z0-9_-]{1,64}"
-              placeholder="acme"
-              className="w-64 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-            />
+      {/* Tabs */}
+      <div className="border-b border-zinc-800 bg-zinc-900/70">
+        <nav className="mx-auto flex max-w-5xl gap-1 px-6" aria-label="MCP page tabs">
+          {(['catalog', 'usage'] as CatalogTab[]).map((t) => (
             <button
-              type="submit"
-              disabled={!tenant.trim() || state === 'loading'}
-              className="rounded-md bg-zinc-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:opacity-50"
+              key={t}
+              type="button"
+              onClick={() => setActiveTab(t)}
+              className={`-mb-px border-b-2 px-3 py-2 text-sm capitalize transition-colors ${
+                activeTab === t
+                  ? 'border-emerald-500 text-emerald-300'
+                  : 'border-transparent text-zinc-400 hover:text-zinc-200'
+              }`}
+              aria-current={activeTab === t ? 'page' : undefined}
             >
-              {state === 'loading' ? 'Loading…' : 'Load'}
+              {t}
             </button>
-            {activeTenant && state === 'ready' && (
-              <span className="text-xs text-zinc-500">
-                Showing remote servers for{' '}
-                <span className="font-mono text-zinc-400">{activeTenant}</span>
-              </span>
+          ))}
+        </nav>
+      </div>
+
+      <div className="mx-auto max-w-5xl p-6">
+        {activeTab === 'usage' && <UsageDashboard />}
+
+        {activeTab === 'catalog' && (
+          <>
+            {message && (
+              <div
+                role="status"
+                className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300"
+              >
+                {message}
+              </div>
             )}
-          </div>
-        </form>
 
-        {/* Remote servers (per tenant) */}
-        <section className="mb-10">
-          <h2 className="mb-3 text-lg font-medium text-white">
-            Remote servers{' '}
-            <span className="text-sm font-normal text-zinc-500">
-              {activeTenant ? `(${activeTenant})` : '(select a tenant)'}
-            </span>
-          </h2>
-          {activeTenant && state === 'ready' && remotes.length === 0 && (
-            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
-              No remote servers connected for{' '}
-              <span className="font-mono text-zinc-400">{activeTenant}</span>. Click{' '}
-              <span className="font-medium text-zinc-300">Connect new server</span> to authorize
-              one.
-            </div>
-          )}
-          {remotes.length > 0 && (
-            <div className="overflow-hidden rounded-lg border border-zinc-800">
-              <table className="w-full text-sm">
-                <thead className="bg-zinc-900/50">
-                  <tr>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Server</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Tenant</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">State</th>
-                    <th className="px-4 py-3 text-right font-medium text-zinc-400">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {remotes.map((r) => (
-                    <tr key={`${r.tenant}/${r.server}`} className="border-t border-zinc-800/50">
-                      <td className="px-4 py-3 font-mono text-zinc-300">{r.server}</td>
-                      <td className="px-4 py-3 font-mono text-xs text-zinc-500">{r.tenant}</td>
-                      <td className="px-4 py-3">
-                        <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
-                          {r.connectionState}
-                        </span>
-                      </td>
-                      <td className="flex items-center justify-end gap-3 px-4 py-3 text-right">
-                        <a
-                          href={`/admin/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
-                          className="text-xs font-medium text-emerald-400 hover:text-emerald-300"
-                        >
-                          Inspect
-                        </a>
-                        <button
-                          type="button"
-                          onClick={() => void handleDisconnect(r.server)}
-                          className="text-xs font-medium text-red-400 hover:text-red-300"
-                        >
-                          Disconnect
-                        </button>
-                      </td>
-                    </tr>
+            {/* Tenant scope selector */}
+            <form
+              onSubmit={handleLoadTenant}
+              className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+            >
+              <label
+                htmlFor="tenant-input"
+                className="mb-1.5 block text-sm font-medium text-zinc-300"
+              >
+                Tenant
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  id="tenant-input"
+                  name="tenant"
+                  type="text"
+                  value={tenant}
+                  onChange={(e) => setTenant(e.target.value)}
+                  pattern="[A-Za-z0-9_-]{1,64}"
+                  placeholder="acme"
+                  className="w-64 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                />
+                <button
+                  type="submit"
+                  disabled={!tenant.trim() || state === 'loading'}
+                  className="rounded-md bg-zinc-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {state === 'loading' ? 'Loading…' : 'Load'}
+                </button>
+                {activeTenant && state === 'ready' && (
+                  <span className="text-xs text-zinc-500">
+                    Showing remote servers for{' '}
+                    <span className="font-mono text-zinc-400">{activeTenant}</span>
+                  </span>
+                )}
+              </div>
+            </form>
+
+            {/* Remote servers (per tenant) */}
+            <section className="mb-10">
+              <h2 className="mb-3 text-lg font-medium text-white">
+                Remote servers{' '}
+                <span className="text-sm font-normal text-zinc-500">
+                  {activeTenant ? `(${activeTenant})` : '(select a tenant)'}
+                </span>
+              </h2>
+              {activeTenant && state === 'ready' && remotes.length === 0 && (
+                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                  No remote servers connected for{' '}
+                  <span className="font-mono text-zinc-400">{activeTenant}</span>. Click{' '}
+                  <span className="font-medium text-zinc-300">Connect new server</span> to authorize
+                  one.
+                </div>
+              )}
+              {remotes.length > 0 && (
+                <div className="overflow-hidden rounded-lg border border-zinc-800">
+                  <table className="w-full text-sm">
+                    <thead className="bg-zinc-900/50">
+                      <tr>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Server</th>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Tenant</th>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">State</th>
+                        <th className="px-4 py-3 text-right font-medium text-zinc-400">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {remotes.map((r) => (
+                        <tr key={`${r.tenant}/${r.server}`} className="border-t border-zinc-800/50">
+                          <td className="px-4 py-3 font-mono text-zinc-300">{r.server}</td>
+                          <td className="px-4 py-3 font-mono text-xs text-zinc-500">{r.tenant}</td>
+                          <td className="px-4 py-3">
+                            <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                              {r.connectionState}
+                            </span>
+                          </td>
+                          <td className="flex items-center justify-end gap-3 px-4 py-3 text-right">
+                            <a
+                              href={`/admin/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
+                              className="text-xs font-medium text-emerald-400 hover:text-emerald-300"
+                            >
+                              Inspect
+                            </a>
+                            <button
+                              type="button"
+                              onClick={() => void handleDisconnect(r.server)}
+                              className="text-xs font-medium text-red-400 hover:text-red-300"
+                            >
+                              Disconnect
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            {/* Content exposure (tenant-agnostic in v1) */}
+            <section className="mb-10">
+              <h2 className="mb-1 text-lg font-medium text-white">
+                Content exposure{' '}
+                <span className="text-sm font-normal text-zinc-500">({collections.length})</span>
+              </h2>
+              <p className="mb-3 text-xs text-zinc-500">
+                Collections exposed to MCP clients as resources via the{' '}
+                <span className="font-mono text-zinc-400">revealui-content</span> server. Opt a
+                collection out by setting{' '}
+                <span className="font-mono text-zinc-400">mcpResource: false</span> in its
+                CollectionConfig.
+              </p>
+              {collections.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                  Loading collection exposure…
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-lg border border-zinc-800">
+                  <table className="w-full text-sm">
+                    <thead className="bg-zinc-900/50">
+                      <tr>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Slug</th>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Label</th>
+                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Exposure</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {collections.map((c) => (
+                        <tr key={c.slug} className="border-t border-zinc-800/50">
+                          <td className="px-4 py-3 font-mono text-zinc-300">{c.slug}</td>
+                          <td className="px-4 py-3 text-zinc-400">{c.labelPlural ?? c.label}</td>
+                          <td className="px-4 py-3">
+                            {c.mcpResource ? (
+                              <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                                exposed
+                              </span>
+                            ) : (
+                              <span className="rounded-full bg-zinc-700/40 px-2 py-0.5 text-xs font-medium text-zinc-400">
+                                hidden
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            {/* Built-in servers (tenant-agnostic) */}
+            <section>
+              <h2 className="mb-3 text-lg font-medium text-white">
+                Built-in servers{' '}
+                <span className="text-sm font-normal text-zinc-500">({builtins.length})</span>
+              </h2>
+              {builtins.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                  Loading built-in servers…
+                </div>
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2">
+                  {builtins.map((server) => (
+                    <McpServerCard key={server.id} server={server} />
                   ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
-
-        {/* Content exposure (tenant-agnostic in v1) */}
-        <section className="mb-10">
-          <h2 className="mb-1 text-lg font-medium text-white">
-            Content exposure{' '}
-            <span className="text-sm font-normal text-zinc-500">({collections.length})</span>
-          </h2>
-          <p className="mb-3 text-xs text-zinc-500">
-            Collections exposed to MCP clients as resources via the{' '}
-            <span className="font-mono text-zinc-400">revealui-content</span> server. Opt a
-            collection out by setting{' '}
-            <span className="font-mono text-zinc-400">mcpResource: false</span> in its
-            CollectionConfig.
-          </p>
-          {collections.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
-              Loading collection exposure…
-            </div>
-          ) : (
-            <div className="overflow-hidden rounded-lg border border-zinc-800">
-              <table className="w-full text-sm">
-                <thead className="bg-zinc-900/50">
-                  <tr>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Slug</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Label</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Exposure</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {collections.map((c) => (
-                    <tr key={c.slug} className="border-t border-zinc-800/50">
-                      <td className="px-4 py-3 font-mono text-zinc-300">{c.slug}</td>
-                      <td className="px-4 py-3 text-zinc-400">{c.labelPlural ?? c.label}</td>
-                      <td className="px-4 py-3">
-                        {c.mcpResource ? (
-                          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
-                            exposed
-                          </span>
-                        ) : (
-                          <span className="rounded-full bg-zinc-700/40 px-2 py-0.5 text-xs font-medium text-zinc-400">
-                            hidden
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
-
-        {/* Built-in servers (tenant-agnostic) */}
-        <section>
-          <h2 className="mb-3 text-lg font-medium text-white">
-            Built-in servers{' '}
-            <span className="text-sm font-normal text-zinc-500">({builtins.length})</span>
-          </h2>
-          {builtins.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
-              Loading built-in servers…
-            </div>
-          ) : (
-            <div className="grid gap-4 md:grid-cols-2">
-              {builtins.map((server) => (
-                <McpServerCard key={server.id} server={server} />
-              ))}
-            </div>
-          )}
-        </section>
+                </div>
+              )}
+            </section>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/admin/src/lib/components/mcp/__tests__/usage-dashboard.test.tsx
+++ b/apps/admin/src/lib/components/mcp/__tests__/usage-dashboard.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UsageDashboard } from '../usage-dashboard';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function jsonResponse<T>(body: T, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('UsageDashboard', () => {
+  it('shows the loading state until fetch resolves', async () => {
+    let resolveFetch!: (r: Response) => void;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    mockFetch.mockReturnValueOnce(fetchPromise);
+
+    render(<UsageDashboard />);
+    expect(screen.getByText(/loading usage/i)).toBeInTheDocument();
+
+    resolveFetch(
+      jsonResponse({
+        range: '24h',
+        since: new Date('2026-04-01T00:00:00Z').toISOString(),
+        accountId: 'acct-1',
+        meters: [],
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByText(/loading usage/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the empty state when no meters exist for the range', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        range: '24h',
+        since: new Date().toISOString(),
+        accountId: 'acct-1',
+        meters: [],
+      }),
+    );
+    render(<UsageDashboard />);
+    expect(await screen.findByText(/No MCP usage in the last 24 hours/i)).toBeInTheDocument();
+  });
+
+  it('renders meter rows with totals, durations, and outcome counts', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        range: '24h',
+        since: new Date().toISOString(),
+        accountId: 'acct-1',
+        meters: [
+          {
+            meterName: 'mcp.tool.call',
+            total: 1234,
+            successCount: 1000,
+            errorCount: 200,
+            unknownCount: 34,
+            durationCount: 1234,
+            p50Ms: 120,
+            p95Ms: 1500,
+          },
+        ],
+      }),
+    );
+    render(<UsageDashboard />);
+    expect(await screen.findByText('mcp.tool.call')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('120 ms')).toBeInTheDocument();
+    expect(screen.getByText('1.50 s')).toBeInTheDocument();
+    expect(screen.getByText(/1000 ok/)).toBeInTheDocument();
+    expect(screen.getByText(/200 err/)).toBeInTheDocument();
+    expect(screen.getByText(/34 unknown/)).toBeInTheDocument();
+    // Stacked bar renders as an inline SVG with a screen-reader label.
+    expect(
+      screen.getByRole('img', { name: /1000 success, 200 error, 34 unknown/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an em-dash for null p50/p95 when no durations were recorded', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        range: '24h',
+        since: new Date().toISOString(),
+        accountId: 'acct-1',
+        meters: [
+          {
+            meterName: 'mcp.tool.call',
+            total: 5,
+            successCount: 5,
+            errorCount: 0,
+            unknownCount: 0,
+            durationCount: 0,
+            p50Ms: null,
+            p95Ms: null,
+          },
+        ],
+      }),
+    );
+    render(<UsageDashboard />);
+    await screen.findByText('mcp.tool.call');
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('surfaces the server error message on a non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { success: false, error: 'Caller has no active account membership' },
+        { status: 409 },
+      ),
+    );
+    render(<UsageDashboard />);
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/no active account membership/i);
+  });
+
+  it('refetches with the new range when a different range button is pressed', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          range: '24h',
+          since: new Date().toISOString(),
+          accountId: 'acct-1',
+          meters: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          range: '7d',
+          since: new Date().toISOString(),
+          accountId: 'acct-1',
+          meters: [],
+        }),
+      );
+    render(<UsageDashboard />);
+    await screen.findByText(/No MCP usage in the last 24 hours/i);
+    fireEvent.click(screen.getByRole('button', { name: '7d' }));
+    await screen.findByText(/No MCP usage in the last 7 days/i);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('/api/mcp/usage?range=24h');
+    expect(mockFetch.mock.calls[1]?.[0]).toBe('/api/mcp/usage?range=7d');
+  });
+});

--- a/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
+++ b/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
@@ -1,0 +1,246 @@
+/**
+ * MCP Usage Dashboard (used by the Usage tab on /admin/mcp).
+ *
+ * Renders per-`meterName` totals + outcome mix + p50/p95 durations
+ * sourced from `GET /api/mcp/usage` (A.3a backend). Bars are
+ * hand-rolled inline SVG; no chart-library dep.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type Range = '24h' | '7d' | '30d';
+
+interface MeterAggregate {
+  meterName: string;
+  total: number;
+  successCount: number;
+  errorCount: number;
+  unknownCount: number;
+  durationCount: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+}
+
+interface UsageResponse {
+  range: Range;
+  since: string;
+  accountId: string | null;
+  meters: MeterAggregate[];
+}
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+const RANGES: readonly Range[] = ['24h', '7d', '30d'] as const;
+const RANGE_LABELS: Readonly<Record<Range, string>> = {
+  '24h': 'Last 24 hours',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+};
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+interface StackedBarProps {
+  successCount: number;
+  errorCount: number;
+  unknownCount: number;
+}
+
+function StackedBar({ successCount, errorCount, unknownCount }: StackedBarProps) {
+  const total = successCount + errorCount + unknownCount;
+  if (total === 0) {
+    return <div aria-hidden="true" className="h-2 w-full rounded-full bg-zinc-800" />;
+  }
+  const successPct = (successCount / total) * 100;
+  const errorPct = (errorCount / total) * 100;
+  const unknownPct = 100 - successPct - errorPct;
+
+  return (
+    <svg
+      role="img"
+      aria-label={`${successCount} success, ${errorCount} error, ${unknownCount} unknown`}
+      viewBox="0 0 100 4"
+      preserveAspectRatio="none"
+      className="h-2 w-full overflow-hidden rounded-full bg-zinc-800"
+    >
+      {successPct > 0 && (
+        <rect x={0} y={0} width={successPct} height={4} className="fill-emerald-500" />
+      )}
+      {errorPct > 0 && (
+        <rect x={successPct} y={0} width={errorPct} height={4} className="fill-red-500" />
+      )}
+      {unknownPct > 0 && (
+        <rect
+          x={successPct + errorPct}
+          y={0}
+          width={unknownPct}
+          height={4}
+          className="fill-zinc-500"
+        />
+      )}
+    </svg>
+  );
+}
+
+export interface UsageDashboardProps {
+  defaultRange?: Range;
+}
+
+export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
+  const [range, setRange] = useState<Range>(defaultRange);
+  const [data, setData] = useState<UsageResponse | null>(null);
+  const [state, setState] = useState<LoadState>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async (r: Range) => {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/mcp/usage?range=${r}`, { credentials: 'include' });
+      // empty-catch-ok: non-JSON error body — res.status is surfaced below.
+      const body = (await res.json().catch(() => ({}))) as Partial<UsageResponse> & {
+        error?: string;
+      };
+      if (!res.ok) {
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData(body as UsageResponse);
+      setState('ready');
+    } catch (err) {
+      setState('error');
+      setMessage((err as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(range);
+  }, [load, range]);
+
+  return (
+    <section aria-label="MCP usage">
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-medium text-white">Usage</h2>
+          <p className="mt-0.5 text-xs text-zinc-500">
+            Per-meter call counts and durations from the events your MCP servers emit.
+          </p>
+        </div>
+        <div
+          className="inline-flex rounded-md border border-zinc-800 bg-zinc-900/50 p-0.5"
+          role="toolbar"
+          aria-label="Time range"
+        >
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setRange(r)}
+              aria-pressed={range === r}
+              className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+                range === r ? 'bg-zinc-800 text-emerald-300' : 'text-zinc-400 hover:text-zinc-200'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {message && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-300"
+        >
+          {message}
+        </div>
+      )}
+
+      {state === 'loading' && (
+        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+          Loading usage…
+        </div>
+      )}
+
+      {state === 'ready' && data && data.meters.length === 0 && (
+        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+          No MCP usage in the {RANGE_LABELS[range].toLowerCase()}. Run an agent that calls an MCP
+          tool, or wait for events to accumulate.
+        </div>
+      )}
+
+      {state === 'ready' && data && data.meters.length > 0 && (
+        <div className="overflow-hidden rounded-lg border border-zinc-800">
+          <table className="w-full text-sm">
+            <thead className="bg-zinc-900/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-zinc-400">Meter</th>
+                <th className="px-4 py-3 text-left font-medium text-zinc-400">Calls</th>
+                <th className="px-4 py-3 text-left font-medium text-zinc-400">Outcome mix</th>
+                <th className="px-4 py-3 text-right font-medium text-zinc-400">p50</th>
+                <th className="px-4 py-3 text-right font-medium text-zinc-400">p95</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.meters.map((m) => (
+                <tr key={m.meterName} className="border-t border-zinc-800/50 align-middle">
+                  <td className="px-4 py-3 font-mono text-xs text-zinc-300">{m.meterName}</td>
+                  <td className="px-4 py-3 text-zinc-300">{m.total.toLocaleString()}</td>
+                  <td className="min-w-48 px-4 py-3">
+                    <StackedBar
+                      successCount={m.successCount}
+                      errorCount={m.errorCount}
+                      unknownCount={m.unknownCount}
+                    />
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-500">
+                      <span>
+                        <span
+                          aria-hidden="true"
+                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-emerald-500 align-middle"
+                        />
+                        {m.successCount} ok
+                      </span>
+                      <span>
+                        <span
+                          aria-hidden="true"
+                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-red-500 align-middle"
+                        />
+                        {m.errorCount} err
+                      </span>
+                      {m.unknownCount > 0 && (
+                        <span>
+                          <span
+                            aria-hidden="true"
+                            className="mr-1 inline-block h-2 w-2 rounded-sm bg-zinc-500 align-middle"
+                          />
+                          {m.unknownCount} unknown
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-xs text-zinc-300">
+                    {formatDuration(m.p50Ms)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-xs text-zinc-300">
+                    {formatDuration(m.p95Ms)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {state === 'ready' && data && (
+        <p className="mt-3 text-xs text-zinc-500">
+          {RANGE_LABELS[range]} · since {new Date(data.since).toLocaleString()} · account{' '}
+          <span className="font-mono text-zinc-400">{data.accountId ?? '—'}</span>
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

**A.3b of the post-v1 MCP arc — admin UI for the Usage tab on `/admin/mcp`.** Closes the A.3 sub-arc; the A.3a backend ([revealui#555](https://github.com/RevealUIStudio/revealui/pull/555), `6ce0d60e5`) is the live data source.

Visit `/admin/mcp` → click the **Usage** tab. Pick a range (`24h | 7d | 30d`). Each `meterName` your account has emitted in the window renders as a row with total calls, an outcome mix (success / error / unknown segments), and p50 / p95 durations in ms or seconds.

## What ships

- `apps/admin/src/app/(backend)/admin/mcp/page.tsx` — refactored to a tabbed structure (`Catalog` | `Usage`) matching the inspector pattern at `apps/admin/src/app/(backend)/admin/mcp/inspect/page.tsx:127-146` (`-mb-px border-b-2`, `emerald-500` active). Catalog tab wraps the existing remote-servers / content-exposure / built-in-servers sections. Usage tab renders the new dashboard.
- `apps/admin/src/lib/components/mcp/usage-dashboard.tsx` (new) — fetches `/api/mcp/usage?range=...` with `credentials: 'include'`, renders:
  - Range selector (`24h | 7d | 30d` toolbar) with `aria-label="Time range"` + per-button `aria-pressed`.
  - Per-meter table row: name (mono), total (`toLocaleString`), outcome mix (hand-rolled inline SVG stacked bar — emerald success / red error / zinc unknown — with text legend underneath), p50 + p95 durations.
  - Loading state, empty state (range-aware copy), error state (surfaces server `error` field).
  - Footer line with absolute `since` timestamp + account id.
- `apps/admin/src/lib/components/mcp/__tests__/usage-dashboard.test.tsx` (new) — 6 tests covering the loading state, empty render, populated row (totals + duration formatting + outcome counts + SVG aria-label), null p50/p95 → em-dash, server-error surfacing, and range-button refetch with the right query string.

## Discipline held

- **No chart-library dep.** The bar is a 4-unit-tall SVG with three `<rect>` children sized as percentages; classes use the Tailwind palette already in the page (`bg-emerald-500` / `bg-red-500` / `bg-zinc-500`). Adding Recharts (~450KB) for a 5-row dashboard with three numbers each was the wrong call.
- **Same accessibility shape as the inspector.** Tab nav is a `<nav aria-label="MCP page tabs">` with `aria-current="page"`; range toolbar is `role="toolbar"` with per-button `aria-pressed`; bars use `role="img"` + `aria-label` for screen readers. No `<title>` redundancy — `aria-label` carries the description.
- **No `@revealui/X` package code touched** — pure admin refactor + new component + new test. No changeset needed (admin is in `.changeset/config.json`'s ignore array, same precedent as Stage 3.1 — `mcp-3-1-server-catalog`'s admin-side work was bundled with `@revealui/mcp` package changes; here there are none).
- **Forward-compat with backend response shape.** The component types `meters[]` from the A.3a `MeterAggregateSchema` exactly: `successCount` / `errorCount` / `unknownCount` / `durationCount` / `p50Ms` / `p95Ms`. Adding fields server-side is a non-breaking change.

## Test plan

- [x] `pnpm --filter admin test src/lib/components/mcp/__tests__/usage-dashboard.test.tsx --run` — 6/6 PASS
- [x] `pnpm --filter admin test --run` — 1607/1617 (10 pre-existing skips), no regressions vs. the 1601 baseline before this PR
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm exec biome check apps/admin/src/{app,lib}/...` — clean
- [x] `pnpm validate:boundary` — clean
- [x] `pnpm validate:changesets` (mixed-changeset validator) — clean (no changesets touched)
- [x] Pre-push gate (Phase 1) — PASS

## Follow-ups (NOT in this PR)

- **A.4** (stretch) — Resources / Prompts / Logs tabs at `/admin/mcp/inspect`. ~200 LOC. The inspector already has stub tabs that no-op; extend them with `client.listResources()` / `client.getPrompt()` / `notifications/message` subscriptions.
- **Multi-account / super-admin views.** v1 endpoint is account-scoped via `entitlementMiddleware`. If the product needs a tenant-aggregate view, that's a deliberate next step.
- **Retention.** `usage_meters` has no retention policy. Define one (30 / 90 / forever-with-archival) as a separate task; A.3b gives us the dashboard the conversation needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
