### PR TITLE
fix(admin): null-prototype prompt-args object (CodeQL js/remote-property-injection, unblocks #540)

### DIFF
--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
@@ -338,4 +338,39 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
     expect(res.status).toBe(200);
     expect(observedArgs).toBeUndefined();
   });
+
+  it('does not pollute Object.prototype via a __proto__ argument key', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    let observedArgs: Record<string, string> | undefined;
+    mockBuild.mockImplementationOnce(async () => {
+      const client = new FakeMcpClient();
+      client.getPromptImpl = async (_name, args) => {
+        observedArgs = args as Record<string, string>;
+        return { messages: [] };
+      };
+      fakeClients.push(client);
+      return { client: client as never, meta: { serverUrl: 'http://remote.test/mcp' } };
+    });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          name: 'greeting',
+          arguments: { __proto__: 'polluted', constructor: 'evil', topic: 'safe' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(200);
+    // The benign key still flows through.
+    expect(observedArgs?.topic).toBe('safe');
+    // Object.prototype is untouched — no foreign properties leaked.
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    // The forwarded args object has a null prototype (reserved keys land
+    // as ordinary own-properties with no inheritance side effect).
+    expect(Object.getPrototypeOf(observedArgs)).toBeNull();
+  });
 });

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
@@ -80,7 +80,12 @@ export async function POST(
         { status: 400 },
       );
     }
-    const out: Record<string, string> = {};
+    // Null-prototype: prompt-argument keys come from the request body
+    // (untrusted), so writing to a plain object lets a `__proto__` /
+    // `constructor` / `prototype` key reach Object.prototype's setters
+    // (CodeQL js/remote-property-injection). With a null prototype those
+    // become ordinary own-property writes with no prototype side effect.
+    const out: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(body.arguments as Record<string, unknown>)) {
       if (typeof v !== 'string') {
         return NextResponse.json(


### PR DESCRIPTION
## Summary

Unblocks [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) (test → main promotion). CodeQL flagged a single high-severity `js/remote-property-injection` alert (#310) on the merge head at [`apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts:93`](apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts:93) — that's the only check failing on #540, every other required check is green.

## Root cause

The route copies user-supplied prompt-argument keys into a plain object:

```ts
const out: Record<string, string> = {};
for (const [k, v] of Object.entries(body.arguments)) {
  // ... typeof v === 'string' check ...
  out[k] = v;  // k is from request body — could be __proto__/constructor/prototype
}
```

A plain `{}` inherits from `Object.prototype`, so `out['__proto__'] = …` reaches the `Object.prototype.__proto__` setter. In practice our `typeof v === 'string'` check makes the prototype-pollution attack a no-op (the setter ignores non-object values) — but CodeQL doesn't model that, and the alert is a fair flag of an unsafe pattern.

## Fix

Switch the destination to a null-prototype object:

```ts
const out: Record<string, string> = Object.create(null);
```

Reserved keys now land as ordinary own-properties with no inheritance side effect. CodeQL recognizes `Object.create(null)` as the canonical fix for `js/remote-property-injection`. Comment in the code explains the WHY for future readers.

## Test

New test in `resources-prompts-routes.test.ts` asserts:
- The benign `topic` key still flows through to `client.getPrompt`.
- `Object.prototype` is not polluted after the request.
- The forwarded args object has a null prototype (`Object.getPrototypeOf(args) === null`).

apps/admin: 1607 → 1608 tests.

## Discipline held

- Stage 3.3-era pattern; not introduced by the post-v1 A-arc — discovered when CodeQL re-evaluated the test→main diff for #540.
- No package code touched (admin-only); no changeset needed.
- Two medium-severity `js/http-to-file-access` alerts remain in `scripts/electric-latency-probe/probe.ts:509` and `scripts/security/collect-soc2-evidence.ts:53`. Mediums don't fail the CodeQL check, so they don't block #540 — flagged as warn-level follow-ups for a separate PR.

## Test plan

- [x] `pnpm --filter admin test src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts --run` — 12/12 PASS (was 11/11)
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm exec biome check` on the two changed files — clean
- [x] `pnpm validate:boundary` — clean
- [x] `pnpm validate:changesets` — clean
- [x] Pre-push gate Phase 1 — PASS

## Cascade

Once this lands on `test`, [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540)'s head auto-advances and CodeQL re-runs on the new merge-commit. Expected: green; #540 ready for `gh pr merge 540 --merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
