### PR TITLE
fix(admin): reject reserved JS property names in prompt args (unblocks #540)

### DIFF
--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
@@ -339,7 +339,34 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
     expect(observedArgs).toBeUndefined();
   });
 
-  it('does not pollute Object.prototype via a __proto__ argument key', async () => {
+  it.each([
+    '__proto__',
+    'constructor',
+    'prototype',
+  ])('rejects an argument key named %s with HTTP 400', async (reservedKey) => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+    const { POST } = await import('../get-prompt/route.js');
+    const res = await POST(
+      makeRequest('http://admin.test/api/mcp/remote-servers/linear/get-prompt', {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant: 'acme',
+          name: 'greeting',
+          arguments: { [reservedKey]: 'value' },
+        }),
+      }) as never,
+      { params: Promise.resolve({ server: 'linear' }) },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain(reservedKey);
+    expect(body.error).toMatch(/reserved/i);
+    // Object.prototype must not be polluted, even though the request
+    // was rejected — the guard runs before any property write.
+    expect((Object.prototype as Record<string, unknown>).value).toBeUndefined();
+  });
+
+  it('forwards args via a null-prototype object (defense in depth)', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
     let observedArgs: Record<string, string> | undefined;
     mockBuild.mockImplementationOnce(async () => {
@@ -358,19 +385,13 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
         body: JSON.stringify({
           tenant: 'acme',
           name: 'greeting',
-          arguments: { __proto__: 'polluted', constructor: 'evil', topic: 'safe' },
+          arguments: { topic: 'safe' },
         }),
       }) as never,
       { params: Promise.resolve({ server: 'linear' }) },
     );
     expect(res.status).toBe(200);
-    // The benign key still flows through.
     expect(observedArgs?.topic).toBe('safe');
-    // Object.prototype is untouched — no foreign properties leaked.
-    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
-    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
-    // The forwarded args object has a null prototype (reserved keys land
-    // as ordinary own-properties with no inheritance side effect).
     expect(Object.getPrototypeOf(observedArgs)).toBeNull();
   });
 });

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
@@ -80,13 +80,22 @@ export async function POST(
         { status: 400 },
       );
     }
-    // Null-prototype: prompt-argument keys come from the request body
-    // (untrusted), so writing to a plain object lets a `__proto__` /
-    // `constructor` / `prototype` key reach Object.prototype's setters
-    // (CodeQL js/remote-property-injection). With a null prototype those
-    // become ordinary own-property writes with no prototype side effect.
+    // Two layers of defense for the user-supplied keys we forward to
+    // `client.getPrompt`:
+    //   (1) reject the three reserved JS property names that could reach
+    //       Object.prototype's setters, so CodeQL's
+    //       js/remote-property-injection sink sees a guarded write;
+    //   (2) write into a null-prototype object, which makes the previous
+    //       check defense-in-depth (any `__proto__` / `constructor`
+    //       write would just land as an ordinary own-property anyway).
     const out: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(body.arguments as Record<string, unknown>)) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+        return NextResponse.json(
+          { error: `body.arguments.${k} is a reserved JavaScript property name` },
+          { status: 400 },
+        );
+      }
       if (typeof v !== 'string') {
         return NextResponse.json(
           {


### PR DESCRIPTION
## Summary

Follow-up to [revealui#557](https://github.com/RevealUIStudio/revealui/pull/557). The `Object.create(null)` destination removed the actual runtime risk of prototype pollution, but CodeQL's `js/remote-property-injection` query doesn't model prototype-chain shape and kept flagging the write as a high-severity sink — alert #310 stayed open on [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) after the v1 fix landed.

The CodeQL-recognized barrier is an **explicit reserved-key reject** before the property write. That's what this PR adds, and it's also semantically correct: MCP prompt argument names are identifiers, not JS reserved property names.

## Fix

`apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts`:

- Reject `__proto__`, `constructor`, `prototype` as argument keys with HTTP 400 before any property write.
- Keep the `Object.create(null)` destination as defense-in-depth.
- Comment block updated to explain both layers.

## Test

`resources-prompts-routes.test.ts`:

- The previous "does not pollute Object.prototype via __proto__" test (which asserted silent forwarding) is replaced with an `it.each` that asserts each of the three reserved keys returns 400 with a `reserved` error.
- New positive test verifies that a benign `topic` key still flows through to `client.getPrompt` and the forwarded args object has a null prototype.

apps/admin: 1608 → 1611 tests (replaced 1, added 3 via `it.each`).

## Test plan

- [x] `pnpm --filter admin test src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts --run` — 15/15 PASS
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm validate:boundary` — clean
- [x] `pnpm validate:changesets` — clean
- [x] Pre-push gate Phase 1 — PASS

## Cascade

Once this lands on `test`, [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540)'s head auto-advances and CodeQL re-runs on the new merge-commit. With the explicit barrier, the query should be satisfied and the alert should resolve. If green, #540 is ready for `gh pr merge 540 --merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
