### PR TITLE
fix(admin): regex allow-list for prompt-arg keys (CodeQL js/remote-property-injection v3, unblocks #540)

### DIFF
--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts
@@ -341,9 +341,13 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
 
   it.each([
     '__proto__',
-    'constructor',
-    'prototype',
-  ])('rejects an argument key named %s with HTTP 400', async (reservedKey) => {
+    '_private',
+    '123_starts_with_digit',
+    'has spaces',
+    'has.dots',
+    'a'.repeat(65),
+    '',
+  ])('rejects an argument key %j that does not match the allow-list', async (badKey) => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
     const { POST } = await import('../get-prompt/route.js');
     const res = await POST(
@@ -352,21 +356,18 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
         body: JSON.stringify({
           tenant: 'acme',
           name: 'greeting',
-          arguments: { [reservedKey]: 'value' },
+          arguments: { [badKey]: 'value' },
         }),
       }) as never,
       { params: Promise.resolve({ server: 'linear' }) },
     );
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain(reservedKey);
-    expect(body.error).toMatch(/reserved/i);
-    // Object.prototype must not be polluted, even though the request
-    // was rejected — the guard runs before any property write.
+    // Object.prototype must not be polluted by a __proto__ key, even
+    // when the JSON parser materialised it before our guard ran.
     expect((Object.prototype as Record<string, unknown>).value).toBeUndefined();
   });
 
-  it('forwards args via a null-prototype object (defense in depth)', async () => {
+  it('forwards regex-allowed args via a null-prototype object', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
     let observedArgs: Record<string, string> | undefined;
     mockBuild.mockImplementationOnce(async () => {
@@ -385,13 +386,19 @@ describe('POST /api/mcp/remote-servers/[server]/get-prompt', () => {
         body: JSON.stringify({
           tenant: 'acme',
           name: 'greeting',
-          arguments: { topic: 'safe' },
+          // All three keys start with a letter and stay within the
+          // allow-list pattern. `constructor` is allowed by the regex
+          // but lands as an ordinary own-property on the null-prototype
+          // destination — no Object.prototype pollution.
+          arguments: { topic: 'safe', user_id: 'u1', constructor: 'literal' },
         }),
       }) as never,
       { params: Promise.resolve({ server: 'linear' }) },
     );
     expect(res.status).toBe(200);
     expect(observedArgs?.topic).toBe('safe');
+    expect(observedArgs?.user_id).toBe('u1');
+    expect(observedArgs?.constructor).toBe('literal');
     expect(Object.getPrototypeOf(observedArgs)).toBeNull();
   });
 });

--- a/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
+++ b/apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts
@@ -27,6 +27,14 @@ import { extractRequestContext } from '@/lib/utils/request-context';
 
 const IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
+// Prompt-argument names must start with a letter — this rejects
+// `__proto__` (and any underscore-prefixed reserved name), and is a
+// pattern that CodeQL's js/remote-property-injection query recognises
+// as a sanitiser for tainted property writes. Underscore + hyphen
+// inside the name are allowed for legitimate identifiers like
+// `user_id` or `account-id`.
+const PROMPT_ARG_KEY_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
 export async function POST(
   request: NextRequest,
   context: { params: Promise<{ server: string }> },
@@ -82,17 +90,21 @@ export async function POST(
     }
     // Two layers of defense for the user-supplied keys we forward to
     // `client.getPrompt`:
-    //   (1) reject the three reserved JS property names that could reach
-    //       Object.prototype's setters, so CodeQL's
-    //       js/remote-property-injection sink sees a guarded write;
-    //   (2) write into a null-prototype object, which makes the previous
-    //       check defense-in-depth (any `__proto__` / `constructor`
-    //       write would just land as an ordinary own-property anyway).
+    //   (1) regex-test each key against `PROMPT_ARG_KEY_RE` (must start
+    //       with a letter — rejects `__proto__` and any other
+    //       underscore-prefixed reserved name); this is the
+    //       allow-list-style sanitiser CodeQL's
+    //       js/remote-property-injection query recognises;
+    //   (2) write into a null-prototype object, so even if a name like
+    //       `constructor` slips past the regex, the resulting property
+    //       is an ordinary own-property with no prototype side effect.
     const out: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(body.arguments as Record<string, unknown>)) {
-      if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+      if (!PROMPT_ARG_KEY_RE.test(k)) {
         return NextResponse.json(
-          { error: `body.arguments.${k} is a reserved JavaScript property name` },
+          {
+            error: `body.arguments key '${k}' must match /^[A-Za-z][A-Za-z0-9_-]{0,63}$/`,
+          },
           { status: 400 },
         );
       }


### PR DESCRIPTION
## Summary

Third pass at the CodeQL `js/remote-property-injection` alert blocking [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540). [#557](https://github.com/RevealUIStudio/revealui/pull/557) added `Object.create(null)` (defense-in-depth, runtime-safe but not CodeQL-recognised). [#558](https://github.com/RevealUIStudio/revealui/pull/558) added explicit `if (k === '__proto__' || ...)` rejection (still not recognised by the query). This PR switches to the **regex allow-list** pattern that CodeQL's docs specifically recommend as a sanitiser for `js/remote-property-injection`.

## Fix

`apps/admin/src/app/api/mcp/remote-servers/[server]/get-prompt/route.ts`:

```ts
const PROMPT_ARG_KEY_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
// ...
if (!PROMPT_ARG_KEY_RE.test(k)) {
  return NextResponse.json({ error: ... }, { status: 400 });
}
```

The regex must start with a letter, then 0-63 of `[A-Za-z0-9_-]`. That:

- Rejects `__proto__` (starts with `_`).
- Rejects `_private`, `123abc`, `has spaces`, `has.dots`, names >64 chars, empty strings.
- Allows legitimate identifiers: `topic`, `user_id`, `account-id`, `prompt-name`, etc.
- Allows `constructor` and `prototype` as own-property writes — but the destination is still `Object.create(null)`, so those land as ordinary own-properties with no Object.prototype side effect.

`Object.create(null)` is kept as defense-in-depth.

## Test

`resources-prompts-routes.test.ts`:

- The previous it.each that asserted the three reserved keys all return 400 is replaced with a broader allow-list it.each covering: `__proto__`, `_private`, `123_starts_with_digit`, `has spaces`, `has.dots`, a 65-char name, and the empty string. All return 400.
- New positive test verifies that `topic`, `user_id`, and (notably) `constructor` all flow through to `client.getPrompt` via a null-prototype object — `constructor` is allowed by the regex but lands safely.

apps/admin: 1611 → 1615 tests (replaced 3 it.each variants, added 7 new ones plus an extra positive case).

## Test plan

- [x] `pnpm --filter admin test src/app/api/mcp/remote-servers/[server]/__tests__/resources-prompts-routes.test.ts --run` — 19/19 PASS
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm validate:boundary` — clean
- [x] `pnpm validate:changesets` — clean

## Cascade

If this finally satisfies CodeQL's barrier recognition, [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) will go green and is ready for `gh pr merge 540 --merge`. If it still flags, fallback is dismissing alert #310 as a `false_positive` with the layered-defense rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
