### PR TITLE
fix(deploy): install pnpm in smoke-test job so rollback step actually runs (closes GAP-122)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -384,6 +384,14 @@ jobs:
     needs: [detect, deploy]
 
     steps:
+      # pnpm is required by the "Rollback on failure" step below. Without
+      # this setup, the rollback fails with `pnpm: command not found`
+      # before it can install vercel CLI, which leaves a broken deploy
+      # live (precedent: 2026-04-25 #540 incident, GAP-122).
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
       - name: Health check — API (readiness probe)
         run: |
           API_URL="${REVEALUI_API_URL:-https://api.revealui.com}"


### PR DESCRIPTION
## Summary

Surfaced during the [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) prod incident at 03:19Z today. The Smoke Test job correctly detected a broken API deploy (12 failed `/health/ready` probes over 2 min) and tried to auto-rollback. The rollback step starts with `pnpm add -g vercel@latest` but the smoke-test job has no setup steps — pnpm isn't in PATH:

```
##[warning]Smoke test failed — rolling back affected apps
/home/runner/work/_temp/...sh: line 2: pnpm: command not found
##[error]Process completed with exit code 127
```

vercel CLI was never installed, `vercel rollback` never ran, the broken deploy stayed live until owner manually patched the env on Vercel and triggered a fresh deploy.

This bit production **twice in 5 days** — the 2026-04-20 deploy run was also failure-conclusion; the rollback bug was the real cause but got attributed to "infra issues" without anyone tracing it.

## Fix

Add the standard pnpm setup at the top of the `smoke-test` job — same pattern as the `apply-migrations` and `deploy` jobs in this same workflow.

```yaml
  smoke-test:
    name: Smoke Test
    runs-on: ubuntu-latest
    timeout-minutes: 5
    needs: [detect, deploy]

    steps:
      # pnpm is required by the "Rollback on failure" step below ...
      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
        with:
          version: ${{ env.PNPM_VERSION }}

      - name: Health check — API (readiness probe)
        ...
```

The action runs unconditionally (~5s on a clean runner) but only matters when the rollback step actually fires. The on-success cost is negligible compared to the on-failure value of having an auto-rollback that actually rolls back.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — yaml syntax OK
- [x] Pre-push gate Phase 1 — PASS
- Validation in production happens when the next deploy fails its smoke test (or, more likely, on the next test→main promotion that follows this merge — that's a clean dry-run of the workflow with the fix in place).

## Closes

GAP-122

## Side note

This PR also serves as the deploy trigger to push the env-var-only fix from earlier today through to production. After this lands on test → test→main PR → that push to main triggers a fresh build of api with `NEXT_PUBLIC_SERVER_URL` baked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
