### PR TITLE
test -> main: deploy.yml rollback fix (drives fresh api build for NEXT_PUBLIC_SERVER_URL env)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -384,6 +384,14 @@ jobs:
     needs: [detect, deploy]
 
     steps:
+      # pnpm is required by the "Rollback on failure" step below. Without
+      # this setup, the rollback fails with `pnpm: command not found`
+      # before it can install vercel CLI, which leaves a broken deploy
+      # live (precedent: 2026-04-25 #540 incident, GAP-122).
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
       - name: Health check — API (readiness probe)
         run: |
           API_URL="${REVEALUI_API_URL:-https://api.revealui.com}"


### PR DESCRIPTION
## Summary

Promotes **one commit** from `test` to `main`: [`c2283822d`](https://github.com/RevealUIStudio/revealui/commit/c2283822d) (`fix(deploy): install pnpm in smoke-test job so rollback step actually runs`, [revealui#560](https://github.com/RevealUIStudio/revealui/pull/560)).

This is intentionally a small promotion — the goal is to drive a fresh `apps/api` build through the deploy pipeline so it picks up the `NEXT_PUBLIC_SERVER_URL` environment variable that was just set on Vercel revealui-api Production. The earlier [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) deploy crashed at module init because the env was missing; the fix was an env-var-only change in the Vercel dashboard, but Vercel's prebuilt-deployment guard correctly refuses to redeploy a stale build artifact, so a fresh build is required.

## What ships

- `c2283822d` — adds `pnpm/action-setup` step to the `smoke-test` job in `deploy.yml` so its existing `Rollback on failure` step doesn't die at `pnpm: command not found`. Closes GAP-122.

## Side effect (the actual goal)

Pushing this to `main` triggers `deploy.yml` on the new tip. The api app gets a fresh build that bakes in `NEXT_PUBLIC_SERVER_URL` from the Vercel Production env. Smoke test should pass; if it doesn't, the rollback step now actually rolls back (because of this PR's own fix).

## Test plan

- [x] CI on test branch (which would also run on main): all required checks PASS — Quality / Typecheck / Build / Unit Tests / Drizzle Migrations / CodeQL / Gitleaks / Submodule Audit / Dependency Review / E2E Smoke / Accessibility / Visual Regression / Coverage / Integration Tests / Security Gate.
- [ ] Production smoke test on `https://api.revealui.com/health/ready` (will run as part of the deploy workflow; verified manually post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
