### PR TITLE
test -> main: STRIPE_LIVE_MODE toggle + deploy.yml rollback fix (drives fresh api build after #540)

### DIFF
--- a/apps/api/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/api/src/lib/__tests__/validate-startup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type EnvMap, validateStartup } from '../validate-startup.js';
 
 const HEX_64 = 'a'.repeat(64);
@@ -6,9 +6,14 @@ const SECRET_32 = 'x'.repeat(32);
 const CRON_32 = 'c'.repeat(32);
 const HTTPS_URL = 'https://app.revealui.com';
 
-function validProdEnv(overrides: EnvMap = {}): EnvMap {
+/**
+ * Live-mode production fixture. Used by all the long-standing format-check
+ * tests so the strict (`sk_live_` + `pk_live_`) path is exercised.
+ */
+function validLiveProdEnv(overrides: EnvMap = {}): EnvMap {
   return {
     NODE_ENV: 'production',
+    STRIPE_LIVE_MODE: 'true',
     POSTGRES_URL: 'postgresql://user:pw@host/db',
     REVEALUI_SECRET: SECRET_32,
     REVEALUI_KEK: HEX_64,
@@ -23,6 +28,29 @@ function validProdEnv(overrides: EnvMap = {}): EnvMap {
     ...overrides,
   };
 }
+
+/**
+ * Test-mode production fixture (pre-launch / pre-audit posture). Used by the
+ * STRIPE_LIVE_MODE toggle tests + as the realistic shape of today's prod env.
+ */
+function validTestProdEnv(overrides: EnvMap = {}): EnvMap {
+  const live = validLiveProdEnv();
+  return {
+    ...live,
+    STRIPE_LIVE_MODE: undefined,
+    STRIPE_SECRET_KEY: 'sk_test_deadbeef',
+    ...overrides,
+  };
+}
+
+// Backwards-compat: a few legacy tests below reference `validProdEnv` —
+// keep the alias pointed at the live-mode fixture so they exercise the
+// strict path.
+const validProdEnv = validLiveProdEnv;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('validateStartup — always-required presence', () => {
   it('throws when POSTGRES_URL is missing', () => {
@@ -78,21 +106,23 @@ describe('validateStartup — production presence', () => {
   });
 });
 
-describe('validateStartup — production format checks', () => {
+describe('validateStartup — production format checks (live mode)', () => {
   it('rejects STRIPE_SECRET_KEY without sk_live_ prefix', () => {
-    expect(() => validateStartup(validProdEnv({ STRIPE_SECRET_KEY: 'sk_test_abc' }))).toThrow(
+    expect(() => validateStartup(validLiveProdEnv({ STRIPE_SECRET_KEY: 'sk_test_abc' }))).toThrow(
       /sk_live_/,
     );
   });
 
   it('rejects STRIPE_WEBHOOK_SECRET without whsec_ prefix', () => {
-    expect(() => validateStartup(validProdEnv({ STRIPE_WEBHOOK_SECRET: 'abc' }))).toThrow(/whsec_/);
+    expect(() => validateStartup(validLiveProdEnv({ STRIPE_WEBHOOK_SECRET: 'abc' }))).toThrow(
+      /whsec_/,
+    );
   });
 
   it('rejects non-HTTPS REVEALUI_PUBLIC_SERVER_URL', () => {
     expect(() =>
       validateStartup(
-        validProdEnv({
+        validLiveProdEnv({
           REVEALUI_PUBLIC_SERVER_URL: 'http://app.revealui.com',
           NEXT_PUBLIC_SERVER_URL: 'http://app.revealui.com',
         }),
@@ -103,7 +133,7 @@ describe('validateStartup — production format checks', () => {
   it('rejects mismatched REVEALUI_PUBLIC_SERVER_URL and NEXT_PUBLIC_SERVER_URL', () => {
     expect(() =>
       validateStartup(
-        validProdEnv({
+        validLiveProdEnv({
           REVEALUI_PUBLIC_SERVER_URL: 'https://a.example.com',
           NEXT_PUBLIC_SERVER_URL: 'https://b.example.com',
         }),
@@ -112,28 +142,114 @@ describe('validateStartup — production format checks', () => {
   });
 
   it('rejects REVEALUI_KEK shorter than 64 hex chars', () => {
-    expect(() => validateStartup(validProdEnv({ REVEALUI_KEK: 'a'.repeat(63) }))).toThrow();
+    expect(() => validateStartup(validLiveProdEnv({ REVEALUI_KEK: 'a'.repeat(63) }))).toThrow();
   });
 
   it('rejects REVEALUI_ALERT_EMAIL without an @', () => {
-    expect(() => validateStartup(validProdEnv({ REVEALUI_ALERT_EMAIL: 'notanemail' }))).toThrow(
+    expect(() => validateStartup(validLiveProdEnv({ REVEALUI_ALERT_EMAIL: 'notanemail' }))).toThrow(
       /REVEALUI_ALERT_EMAIL/,
     );
   });
 
   it('rejects REVEALUI_CRON_SECRET shorter than 32 chars', () => {
-    expect(() => validateStartup(validProdEnv({ REVEALUI_CRON_SECRET: 'short' }))).toThrow(
+    expect(() => validateStartup(validLiveProdEnv({ REVEALUI_CRON_SECRET: 'short' }))).toThrow(
       /REVEALUI_CRON_SECRET/,
     );
   });
 
   it('rejects CORS_ORIGIN containing an http:// origin', () => {
     expect(() =>
-      validateStartup(validProdEnv({ CORS_ORIGIN: 'https://a.example.com,http://b.example.com' })),
+      validateStartup(
+        validLiveProdEnv({ CORS_ORIGIN: 'https://a.example.com,http://b.example.com' }),
+      ),
     ).toThrow(/CORS_ORIGIN/);
   });
 
-  it('accepts a fully valid production environment', () => {
-    expect(() => validateStartup(validProdEnv())).not.toThrow();
+  it('accepts a fully valid live-mode production environment', () => {
+    expect(() => validateStartup(validLiveProdEnv())).not.toThrow();
+  });
+
+  it('does NOT emit the test-mode warning when STRIPE_LIVE_MODE=true', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    validateStartup(validLiveProdEnv());
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects pk_test_ when STRIPE_LIVE_MODE=true and publishable key is set', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_xxxx' })),
+    ).toThrow(/pk_live_/);
+  });
+
+  it('accepts pk_live_ when STRIPE_LIVE_MODE=true and publishable key is set', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_live_xxxx' })),
+    ).not.toThrow();
+  });
+});
+
+describe('validateStartup — STRIPE_LIVE_MODE toggle (test-mode pre-launch)', () => {
+  it('accepts a fully valid test-mode production environment', () => {
+    // Suppress the warning banner so vitest output stays clean.
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() => validateStartup(validTestProdEnv())).not.toThrow();
+  });
+
+  it('emits a loud warning banner when STRIPE_LIVE_MODE is unset', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    validateStartup(validTestProdEnv());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0] ?? [''];
+    expect(String(message)).toMatch(/STRIPE TEST MODE/i);
+    expect(String(message)).toMatch(/GAP-124/);
+  });
+
+  it('emits the warning banner when STRIPE_LIVE_MODE is the literal string "false"', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    validateStartup(validTestProdEnv({ STRIPE_LIVE_MODE: 'false' }));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects sk_live_ keys when STRIPE_LIVE_MODE is unset', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() =>
+      validateStartup(validTestProdEnv({ STRIPE_SECRET_KEY: 'sk_live_realmoney' })),
+    ).toThrow(/sk_test_/);
+  });
+
+  it('rejects pk_live_ keys when STRIPE_LIVE_MODE is unset and publishable key is set', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() =>
+      validateStartup(
+        validTestProdEnv({ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_live_realmoney' }),
+      ),
+    ).toThrow(/pk_test_/);
+  });
+
+  it('rejects empty STRIPE_SECRET_KEY in test mode (presence still required)', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const env = validTestProdEnv();
+    delete env.STRIPE_SECRET_KEY;
+    expect(() => validateStartup(env)).toThrow(/STRIPE_SECRET_KEY/);
+  });
+
+  it('still requires whsec_ prefix for STRIPE_WEBHOOK_SECRET in test mode', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() =>
+      validateStartup(validTestProdEnv({ STRIPE_WEBHOOK_SECRET: 'not-a-webhook-secret' })),
+    ).toThrow(/whsec_/);
+  });
+
+  it('still enforces non-Stripe production format rules in test mode', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() => validateStartup(validTestProdEnv({ REVEALUI_CRON_SECRET: 'short' }))).toThrow(
+      /REVEALUI_CRON_SECRET/,
+    );
+  });
+
+  it('treats any non-"true" value as test mode (e.g., "1", "yes", " true ")', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    validateStartup(validTestProdEnv({ STRIPE_LIVE_MODE: '1' }));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/lib/validate-startup.ts
+++ b/apps/api/src/lib/validate-startup.ts
@@ -26,9 +26,24 @@ const REQUIRED_IN_PRODUCTION = [
  * Layers:
  *  1. Presence — required vars are set
  *  2. Production presence — extra prod-required vars are set
- *  3. Production format — `sk_live_` prefix, `https://` URLs, `whsec_`
- *     prefix, 64-hex KEK, secret minimum length, URL parity, and HTTPS-only
- *     CORS origins.
+ *  3. Production format — `sk_live_`/`sk_test_` prefix (toggle-dependent),
+ *     `https://` URLs, `whsec_` prefix, 64-hex KEK, secret minimum length,
+ *     URL parity, and HTTPS-only CORS origins.
+ *
+ * `STRIPE_LIVE_MODE` toggle:
+ *   - When `STRIPE_LIVE_MODE=true`: enforces `sk_live_` / `pk_live_` prefixes
+ *     (real customer money flows).
+ *   - When `STRIPE_LIVE_MODE` is unset or any other value: enforces `sk_test_`
+ *     / `pk_test_` prefixes and emits a loud boot-time warning that the API
+ *     is running with TEST Stripe keys in production. This is the
+ *     pre-launch / pre-LLC / pre-billing-audit posture (gated on GAP-124
+ *     in revealui-jv).
+ *
+ * The toggle is intentionally an env var (not a code constant) so flipping
+ * to live mode is a Vercel-side config change rather than a code-deploy
+ * coupled to billing readiness. Enforcing prefix parity in BOTH directions
+ * (test-mode cannot have live keys, live-mode cannot have test keys) catches
+ * half-configured states where someone sets the key but forgets the toggle.
  *
  * Honors `SKIP_ENV_VALIDATION=true` so Docker-build and other build-only
  * contexts can compile without live credentials present.
@@ -62,21 +77,49 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
     );
   }
 
+  const stripeLiveMode = env.STRIPE_LIVE_MODE === 'true';
+  if (!stripeLiveMode) {
+    emitStripeTestModeWarning();
+  }
+
   const errors: string[] = [];
 
-  // Stripe live mode — key prefix
+  // Stripe secret key — prefix depends on STRIPE_LIVE_MODE.
   const stripeSecretKey = env.STRIPE_SECRET_KEY ?? '';
-  if (!stripeSecretKey.startsWith('sk_live_')) {
-    errors.push('STRIPE_SECRET_KEY must be a live key (sk_live_...) in production.');
+  if (stripeLiveMode) {
+    if (!stripeSecretKey.startsWith('sk_live_')) {
+      errors.push('STRIPE_SECRET_KEY must be a live key (sk_live_...) when STRIPE_LIVE_MODE=true.');
+    }
+  } else {
+    if (!stripeSecretKey.startsWith('sk_test_')) {
+      errors.push(
+        'STRIPE_SECRET_KEY must be a test key (sk_test_...) when STRIPE_LIVE_MODE is unset/false. ' +
+          'Set STRIPE_LIVE_MODE=true to use live keys (gated on the billing-readiness audit).',
+      );
+    }
   }
 
+  // Stripe publishable key (optional, but if set it must match the mode).
   const stripePublishable = env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
-  if (stripePublishable && !stripePublishable.startsWith('pk_live_')) {
-    errors.push(
-      'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a live key (pk_live_...) in production.',
-    );
+  if (stripePublishable) {
+    if (stripeLiveMode) {
+      if (!stripePublishable.startsWith('pk_live_')) {
+        errors.push(
+          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a live key (pk_live_...) when STRIPE_LIVE_MODE=true.',
+        );
+      }
+    } else {
+      if (!stripePublishable.startsWith('pk_test_')) {
+        errors.push(
+          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a test key (pk_test_...) when STRIPE_LIVE_MODE is unset/false.',
+        );
+      }
+    }
   }
 
+  // Stripe webhook signing secret — `whsec_` prefix in both modes (Stripe
+  // webhook secrets share the same prefix for test + live; the test/live
+  // distinction is the secret material itself, not the prefix).
   const webhookSecret = env.STRIPE_WEBHOOK_SECRET ?? '';
   if (!webhookSecret.startsWith('whsec_')) {
     errors.push('STRIPE_WEBHOOK_SECRET must start with "whsec_" in production.');
@@ -132,4 +175,35 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
   if (errors.length > 0) {
     throw new Error(`STARTUP VALIDATION FAILED:\n  - ${errors.join('\n  - ')}`);
   }
+}
+
+/**
+ * Emitted once per cold start when running in production with
+ * `STRIPE_LIVE_MODE` unset/false. Made loud + visible so a quick scan of
+ * Vercel runtime logs (or a console pull) makes the test-mode posture
+ * unmistakable. Exported separately so tests can spy on the emission.
+ */
+export function emitStripeTestModeWarning(): void {
+  const banner = [
+    '',
+    '⚠️  ╔══════════════════════════════════════════════════════════════════╗',
+    '⚠️  ║  STRIPE TEST MODE in production                                  ║',
+    '⚠️  ║                                                                  ║',
+    '⚠️  ║  STRIPE_LIVE_MODE is unset/false. apps/api accepts test Stripe   ║',
+    '⚠️  ║  keys (sk_test_*, pk_test_*) and NO real customer money flows   ║',
+    '⚠️  ║  through these endpoints. The Stripe SDK will route requests to ║',
+    '⚠️  ║  the test environment.                                           ║',
+    '⚠️  ║                                                                  ║',
+    '⚠️  ║  Flip STRIPE_LIVE_MODE=true ONLY after the billing-readiness     ║',
+    '⚠️  ║  audit (revealui-jv GAP-124) closes — every money-touching path ║',
+    '⚠️  ║  must be bulletproof first.                                      ║',
+    '⚠️  ╚══════════════════════════════════════════════════════════════════╝',
+    '',
+    '',
+  ].join('\n');
+  // Direct stderr write (rather than the standard console facade) per
+  // the project's noConsole lint rule. Semantically this is a warning,
+  // and stderr is the canonical destination — Vercel captures it as a
+  // runtime log identically to a higher-level warning facade.
+  process.stderr.write(banner);
 }


### PR DESCRIPTION
## Summary

Promotes 2 commits from `test` to `main` to drive the api back up after the [revealui#540](https://github.com/RevealUIStudio/revealui/pull/540) incident:

- [`c2283822d`](https://github.com/RevealUIStudio/revealui/commit/c2283822d) — `fix(deploy): install pnpm in smoke-test job so rollback step actually runs` ([revealui#560](https://github.com/RevealUIStudio/revealui/pull/560), closes GAP-122)
- [`48d588e67`](https://github.com/RevealUIStudio/revealui/commit/48d588e67) — `feat(api): STRIPE_LIVE_MODE toggle in validateStartup (pre-launch test-mode posture)` ([revealui#562](https://github.com/RevealUIStudio/revealui/pull/562), refs GAP-124)

## Goal

Deploy a fresh apps/api artifact that:
1. Uses the STRIPE_LIVE_MODE toggle so test Stripe keys (`sk_test_*`) are valid in production (pre-LLC reality), and
2. If anything goes wrong post-deploy, the smoke-test rollback step actually fires (instead of dying at `pnpm: command not found`).

## Owner action — required BEFORE merging

On the Vercel revealui-api project, **Production** scope:

| Env | Value |
|---|---|
| `STRIPE_LIVE_MODE` | leave **unset** (or set to any non-`true` value like `false`) — pre-launch posture |
| `STRIPE_SECRET_KEY` | a `sk_test_*` key (current value should already be — that's what's been failing the strict check) |
| `STRIPE_WEBHOOK_SECRET` | a valid `whsec_*` test-mode webhook secret (current value didn't start with `whsec_` per the runtime logs) |
| `REVEALUI_CRON_SECRET` | ≥32 chars; recommend `openssl rand -hex 32` (64 hex chars) |
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | if set: must be `pk_test_*` |

After merge, the api rebuilds with these envs baked in. Banner in stderr will confirm test-mode posture.

## Test plan

- [x] CI on test is fully green (Quality / Typecheck / Build / Unit Tests / Drizzle Migrations / CodeQL / Gitleaks / Submodule Audit / Dependency Review / E2E Smoke / Accessibility / Visual Regression / Coverage / Integration Tests / Security Gate)
- [x] `validate-startup.test.ts` 29/29 cases including the new toggle-mode coverage
- [x] Full api suite 2396/2396

## Post-merge verification

`/health/ready` on `api.revealui.com` should return non-500 for the first time today. The smoke-test step will catch any remaining issue, and now the rollback works if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
