### PR TITLE
fix(ci): make deploy.yml smoke-test rollback actually roll back (GAP-128)

### DIFF
--- a/.changeset/deploy-rollback-actually-rolls-back.md
+++ b/.changeset/deploy-rollback-actually-rolls-back.md
@@ -1,0 +1,7 @@
+---
+"revealui": patch
+---
+
+ci(deploy): make smoke-test rollback step actually roll back
+
+`vercel rollback` with no URL argument is a status query, not an action — so on smoke-test failure the rollback step printed "Rolling back…" / "no rollback in progress" and the broken deploy stayed live. The step now pre-fetches the previous successful production deploy URL via `vercel ls --prod`, passes it to `vercel rollback <url> --yes`, verifies the alias moved post-rollback, and exits non-zero with a precise message reflecting whether the rollback succeeded, failed, or had no history. Closes GAP-128 (companion to GAP-122 which fixed the pnpm crash). Surfaced 2026-04-25 during #540 incident verification — at 06:55Z the rollback step ran cleanly (per the GAP-122 fix) but reported "no rollback in progress" while the broken deploy continued serving prod.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -425,10 +425,18 @@ jobs:
 
       - name: Rollback on failure
         if: failure()
+        # Per GAP-128: `vercel rollback` with no URL argument is a STATUS
+        # QUERY ("checking rollback status..."), not an action. To actually
+        # roll back, we must pass the previous-good deployment URL. This
+        # step pre-fetches it via `vercel ls --prod` and rolls the alias
+        # explicitly, then verifies the alias moved.
         run: |
+          set -uo pipefail
           echo "::warning::Smoke test failed — rolling back affected apps"
           pnpm add -g vercel@latest
           APP_LIST="${{ needs.detect.outputs.app-list }}"
+          ROLLBACK_FAILED=0
+          ROLLBACK_NO_HISTORY=0
           for app in $APP_LIST; do
             case "$app" in
               api)        PID="prj_zk6EQijYXwd9L7BccuBssi436ktM" ;;
@@ -438,10 +446,63 @@ jobs:
               revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;
               *) continue ;;
             esac
-            echo "Rolling back $app..."
-            VERCEL_PROJECT_ID="$PID" vercel rollback --token="$VERCEL_TOKEN" || echo "::warning::Rollback failed for $app"
+
+            echo ""
+            echo "=== Rolling back $app ($PID) ==="
+
+            # 1. List recent production deployments. Take the second-most-
+            #    recent READY one — the most recent IS the broken deploy.
+            DEPLOY_LIST=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod --token="$VERCEL_TOKEN" 2>&1 || true)
+            PREV_URL=$(printf '%s\n' "$DEPLOY_LIST" \
+              | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
+              | sed -n '2p')
+
+            if [ -z "$PREV_URL" ]; then
+              echo "::warning::No previous deployment found for $app — broken deploy is live, manual intervention required"
+              ROLLBACK_NO_HISTORY=$((ROLLBACK_NO_HISTORY+1))
+              continue
+            fi
+
+            echo "Previous good deploy: $PREV_URL"
+
+            # 2. Roll the alias explicitly to that URL.
+            if ! VERCEL_PROJECT_ID="$PID" vercel rollback "$PREV_URL" --token="$VERCEL_TOKEN" --yes 2>&1; then
+              echo "::warning::vercel rollback command failed for $app"
+              ROLLBACK_FAILED=$((ROLLBACK_FAILED+1))
+              continue
+            fi
+
+            # 3. Verify the alias actually moved by inspecting the
+            #    project's current production deploy. Wait briefly for
+            #    propagation.
+            sleep 5
+            CURRENT_URL=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod --token="$VERCEL_TOKEN" 2>&1 \
+              | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
+              | head -n 1)
+
+            if [ "$CURRENT_URL" = "$PREV_URL" ]; then
+              echo "✅ Rollback verified: $app production now serving $CURRENT_URL"
+            else
+              echo "::warning::Rollback issued but verification failed — current=$CURRENT_URL, expected=$PREV_URL"
+              ROLLBACK_FAILED=$((ROLLBACK_FAILED+1))
+            fi
           done
-          echo "::error::Rollback complete — investigate before re-deploying"
+
+          echo ""
+          echo "=== Rollback summary ==="
+          echo "Failed:     $ROLLBACK_FAILED"
+          echo "No history: $ROLLBACK_NO_HISTORY"
+
+          # Exit non-zero so the workflow status reflects the failed
+          # smoke test AND the rollback outcome. If any rollback failed
+          # or had no history, that's a clear "broken deploy still live"
+          # signal that needs human attention.
+          if [ "$ROLLBACK_FAILED" -gt 0 ] || [ "$ROLLBACK_NO_HISTORY" -gt 0 ]; then
+            echo "::error::One or more apps could not be auto-rolled-back — broken deploy may still be live; investigate immediately"
+            exit 1
+          fi
+          echo "::error::Smoke test failed — affected apps were auto-rolled-back successfully; investigate cause before re-deploying"
+          exit 1
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary

`vercel rollback` with no URL argument is a **status query**, not an action. So on smoke-test failure the rollback step printed "Rolling back…" / "no rollback in progress" and the broken deploy stayed live.

Surfaced 2026-04-25 during the #540 incident verification: at 06:55Z the rollback step ran cleanly (per the GAP-122 pnpm fix shipped in #560) but reported "no rollback in progress" while the broken deploy continued serving prod.

## What changed

The "Rollback on failure" step in `.github/workflows/deploy.yml` (smoke-test job) now:

1. Pre-fetches the previous successful production deploy URL via `vercel ls --prod` (second-most-recent in the list, since the most recent IS the broken deploy).
2. Passes the URL: `vercel rollback <url> --yes`.
3. Verifies the alias moved post-rollback by re-querying the production deploy list and comparing.
4. Handles the empty-history case with a distinct warning ("No previous deployment found — broken deploy is live, manual intervention required").
5. Exits non-zero with a precise message reflecting whether rollback succeeded, failed, or had no history.

## Why this matters

The [GAP-122 fix](https://github.com/RevealUIStudio/revealui/pull/560) only ensured the rollback step **runs without crashing**. This PR ensures it actually **achieves a state change**. Together (GAP-122 + GAP-128) the deploy-pipeline durability track is on the right footing: future incidents where the regression is in **code** (not env) will auto-rollback without owner watching.

The 2026-04-25 incident itself wouldn't have benefited (rollback target also had bad env config) — but for FUTURE incidents this will make the difference.

## Test plan

- [x] YAML parse-check on edited workflow (`python3 -c "import yaml; yaml.safe_load(...)"` clean)
- [ ] CI runs on this PR confirm the unmodified jobs (Quality / Typecheck / Tests / Build) stay green
- [ ] Stage-validate the rollback path post-merge per GAP-128 verify field — deploy a non-prod branch where `/health/ready` intentionally returns 500; workflow should: (a) deploy successfully, (b) smoke test fails after 2 min, (c) rollback step fetches the previous good deploy URL, (d) rolls back the alias, (e) verifies the alias moved, (f) exits non-zero so the workflow shows failure state.

## Closes

Closes GAP-128 (internal docs).
Companion to GAP-122 (closed via #560).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
