### PR TITLE
fix(marketing): close pricing-teaser + metadata drift vectors

### DIFF
--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -13,50 +13,55 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
+// SEO/social metadata mirrors the home-page positioning. When the H1 in
+// apps/marketing/src/components/landing/Hero.tsx changes, these strings
+// need to change too — keep them aligned.
+const PAGE_TITLE = 'RevealUI | Build a business your agents can run.';
+const PAGE_DESCRIPTION =
+  'Auth, billing, content, and AI primitives wired into one runtime — so the same APIs your users hit, your agents hit too.';
+const OG_IMAGE_URL = `/api/og?title=${encodeURIComponent('RevealUI')}&description=${encodeURIComponent('Build a business your agents can run.')}`;
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://revealui.com'),
-  title: 'RevealUI | Agentic Business Runtime',
-  description:
-    'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and part of a four-project ecosystem for building, securing, and monetizing agentic software.',
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
   keywords: [
     'open source',
-    'agentic business runtime',
-    'JOSHUA Stack',
-    'software product',
+    'agent-native',
+    'AI agents',
+    'business runtime',
     'auth',
     'billing',
-    'AI agents',
-    'payments',
-    'open source',
+    'CMS',
+    'admin dashboard',
+    'MCP',
+    'Stripe',
+    'Next.js',
+    'self-hostable',
+    'RevealUI',
     'RevVault',
     'RevKit',
     'RevealCoin',
-    'ecosystem',
-    'secret vault',
   ],
   authors: [{ name: 'RevealUI Studio' }],
   openGraph: {
-    title: 'RevealUI | Agentic Business Runtime. Build your business, not your boilerplate.',
-    description:
-      'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and ready to deploy.',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
     type: 'website',
     images: [
       {
-        url: '/api/og?title=RevealUI&description=Agentic business runtime. Build your business, not your boilerplate.',
+        url: OG_IMAGE_URL,
         width: 1200,
         height: 630,
-        alt: 'RevealUI | Agentic Business Runtime',
+        alt: PAGE_TITLE,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'RevealUI | Agentic Business Runtime. Build your business, not your boilerplate.',
-    description:
-      'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and ready to deploy.',
-    images: [
-      '/api/og?title=RevealUI&description=Agentic business runtime. Build your business, not your boilerplate.',
-    ],
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [OG_IMAGE_URL],
   },
 };
 

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -1,10 +1,63 @@
+import type { LicenseTierId, PricingResponse } from '@revealui/contracts/pricing';
 import { Button, ButtonCVA } from '@revealui/presentation';
 
-const tiers = [
+// Cache pricing for 1 hour. Same TTL as /pricing/page.tsx so both pages
+// see consistent prices within a deploy cycle.
+const PRICING_CACHE_REVALIDATE_S = 3600;
+
+// Local fallback used only when /api/pricing is unreachable (network failure,
+// circuit-breaker open). Mirrors HARDCODED_SUBSCRIPTION_PRICES in
+// apps/api/src/routes/pricing.ts. The billing-readiness cron drift-checks the
+// API hardcodes against Stripe; keep these in sync when that cron fires.
+//
+// Stripe Dashboard is the canonical source of truth.
+const TEASER_FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> = {
+  free: { price: '$0' },
+  pro: { price: '$49', period: '/month' },
+  max: { price: '$149', period: '/month' },
+  enterprise: { price: '$299', period: '/month' },
+};
+
+async function fetchTierPrices(): Promise<
+  Record<LicenseTierId, { price: string; period?: string }>
+> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com';
+  const result = { ...TEASER_FALLBACK_PRICE };
+  try {
+    const res = await fetch(`${apiUrl}/api/pricing`, {
+      next: { revalidate: PRICING_CACHE_REVALIDATE_S },
+    });
+    if (!res.ok) return result;
+    const data = (await res.json()) as PricingResponse;
+    for (const tier of data.subscriptions) {
+      if (tier.price) {
+        result[tier.id] = { price: tier.price, period: tier.period };
+      }
+    }
+    return result;
+  } catch {
+    return result;
+  }
+}
+
+// Tier copy lives here (curated for the teaser context); pricing comes from
+// the API. The teaser intentionally shows three tiers — Free, Pro, Forge —
+// instead of the four on /pricing. Max is omitted; the "See full pricing"
+// link surfaces it.
+interface TeaserTier {
+  id: LicenseTierId;
+  name: string;
+  description: string;
+  features: string[];
+  cta: string;
+  href: string;
+  highlight: boolean;
+}
+
+const TEASER_TIERS: TeaserTier[] = [
   {
+    id: 'free',
     name: 'Free',
-    price: '$0',
-    cadence: 'self-host, forever',
     description: 'All open-source packages. MIT-licensed. No telemetry.',
     features: [
       'Full primitive stack',
@@ -17,9 +70,8 @@ const tiers = [
     highlight: false,
   },
   {
+    id: 'pro',
     name: 'Pro',
-    price: '$49',
-    cadence: 'per workspace / month',
     description: 'Managed hosting, AI primitives, and priority support.',
     features: [
       'Everything in Free',
@@ -32,9 +84,8 @@ const tiers = [
     highlight: true,
   },
   {
+    id: 'enterprise',
     name: 'Enterprise',
-    price: '$299',
-    cadence: 'per workspace / month',
     description:
       'SSO, audit logs, on-prem deployment, and a named contact. Custom plans for high volume.',
     features: [
@@ -49,7 +100,9 @@ const tiers = [
   },
 ];
 
-export function PricingTeaser() {
+export async function PricingTeaser() {
+  const prices = await fetchTierPrices();
+
   return (
     <section className="bg-gray-50 py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -65,79 +118,84 @@ export function PricingTeaser() {
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
-          {tiers.map((t) => (
-            <div
-              key={t.name}
-              className={`relative flex flex-col rounded-2xl p-8 ring-1 transition ${
-                t.highlight
-                  ? 'bg-gray-950 text-white ring-gray-950 shadow-xl'
-                  : 'bg-white text-gray-950 ring-gray-950/10 hover:ring-gray-950/20'
-              }`}
-            >
-              {t.highlight && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white">
-                  Most popular
-                </div>
-              )}
-              <h3 className="text-lg font-semibold">{t.name}</h3>
-              <div className="mt-4 flex items-baseline gap-2">
-                <span className="text-4xl font-bold tracking-tight">{t.price}</span>
-                <span className={`text-sm ${t.highlight ? 'text-gray-400' : 'text-gray-500'}`}>
-                  / {t.cadence}
-                </span>
-              </div>
-              <p
-                className={`mt-4 text-sm leading-6 ${
-                  t.highlight ? 'text-gray-300' : 'text-gray-600'
+          {TEASER_TIERS.map((t) => {
+            const { price, period } = prices[t.id];
+            return (
+              <div
+                key={t.id}
+                className={`relative flex flex-col rounded-2xl p-8 ring-1 transition ${
+                  t.highlight
+                    ? 'bg-gray-950 text-white ring-gray-950 shadow-xl'
+                    : 'bg-white text-gray-950 ring-gray-950/10 hover:ring-gray-950/20'
                 }`}
               >
-                {t.description}
-              </p>
-
-              <ul className="mt-6 flex-1 space-y-3">
-                {t.features.map((f) => (
-                  <li
-                    key={f}
-                    className={`flex items-start gap-2 text-sm ${
-                      t.highlight ? 'text-gray-200' : 'text-gray-700'
-                    }`}
-                  >
-                    <svg
-                      className={`mt-0.5 h-4 w-4 flex-shrink-0 ${
-                        t.highlight ? 'text-emerald-400' : 'text-emerald-500'
-                      }`}
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <title>Included</title>
-                      <path
-                        fillRule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                    {f}
-                  </li>
-                ))}
-              </ul>
-
-              <div className="mt-8">
-                {t.highlight ? (
-                  <ButtonCVA
-                    asChild
-                    size="default"
-                    className="w-full bg-white text-gray-950 hover:bg-gray-100"
-                  >
-                    <a href={t.href}>{t.cta}</a>
-                  </ButtonCVA>
-                ) : (
-                  <ButtonCVA asChild size="default" variant="outline" className="w-full">
-                    <a href={t.href}>{t.cta}</a>
-                  </ButtonCVA>
+                {t.highlight && (
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white">
+                    Most popular
+                  </div>
                 )}
+                <h3 className="text-lg font-semibold">{t.name}</h3>
+                <div className="mt-4 flex items-baseline gap-2">
+                  <span className="text-4xl font-bold tracking-tight">{price}</span>
+                  {period && (
+                    <span className={`text-sm ${t.highlight ? 'text-gray-400' : 'text-gray-500'}`}>
+                      {period}
+                    </span>
+                  )}
+                </div>
+                <p
+                  className={`mt-4 text-sm leading-6 ${
+                    t.highlight ? 'text-gray-300' : 'text-gray-600'
+                  }`}
+                >
+                  {t.description}
+                </p>
+
+                <ul className="mt-6 flex-1 space-y-3">
+                  {t.features.map((f) => (
+                    <li
+                      key={f}
+                      className={`flex items-start gap-2 text-sm ${
+                        t.highlight ? 'text-gray-200' : 'text-gray-700'
+                      }`}
+                    >
+                      <svg
+                        className={`mt-0.5 h-4 w-4 flex-shrink-0 ${
+                          t.highlight ? 'text-emerald-400' : 'text-emerald-500'
+                        }`}
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <title>Included</title>
+                        <path
+                          fillRule="evenodd"
+                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-8">
+                  {t.highlight ? (
+                    <ButtonCVA
+                      asChild
+                      size="default"
+                      className="w-full bg-white text-gray-950 hover:bg-gray-100"
+                    >
+                      <a href={t.href}>{t.cta}</a>
+                    </ButtonCVA>
+                  ) : (
+                    <ButtonCVA asChild size="default" variant="outline" className="w-full">
+                      <a href={t.href}>{t.cta}</a>
+                    </ButtonCVA>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         <div className="mt-12 text-center">


### PR DESCRIPTION
## Summary

Two durability fixes for the launch:

1. **`refactor(marketing)`**: `PricingTeaser` fetches from `/api/pricing` instead of hardcoding `$49` and `$299` in the component. Eliminates a real drift vector — see below.
2. **`fix(marketing)`**: home-page metadata (title / description / OG / Twitter / keywords) still surfaced the old "Agentic Business Runtime" / "JOSHUA Stack" / "Build your business, not your boilerplate" positioning to every social-share preview. Now mirrors the new H1.

> **Stacked on [revealui#566](https://github.com/RevealUIStudio/revealui/pull/566)** (which is itself stacked on [revealui#565](https://github.com/RevealUIStudio/revealui/pull/565)). Base is `chore/retire-landing-cruft`. Will be retargeted up the chain to `test` as parents merge — per the suite's stacked-PR merge-train policy: retarget children with `gh pr edit --base` BEFORE merging the parent so GitHub doesn't auto-close them.

## The pricing drift vector that just got closed

Before this change, the price chain looked like:

```
Stripe Dashboard (canonical)
  └─> apps/api/src/routes/pricing.ts HARDCODED_SUBSCRIPTION_PRICES (API fallback)
        └─> billing-readiness cron drift-checks Stripe vs API hardcodes
              └─> /pricing page fetches /api/pricing  ✓ stays current
              └─> /  PricingTeaser HARDCODED IN COMPONENT  ✗ unchecked, drifts silently
```

If a Stripe price had changed: cron catches API drift → API fix lands → `/pricing` updates on next request → home-page teaser keeps showing stale numbers until someone noticed visually.

After:

```
Stripe Dashboard (canonical)
  └─> apps/api/src/routes/pricing.ts HARDCODED_SUBSCRIPTION_PRICES
        └─> billing-readiness cron
              └─> /pricing fetches /api/pricing  ✓
              └─> /  PricingTeaser fetches /api/pricing  ✓ same source
                    └─> TEASER_FALLBACK in component (graceful degrade only,
                        with a comment pointing at the source-of-truth chain)
```

Both pages share the same 1h ISR cadence, so prices stay consistent within a deploy window.

## Metadata drift that just got closed

`apps/marketing/src/app/layout.tsx` previously hardcoded the strings:
- "RevealUI | Agentic Business Runtime"
- "Agentic business runtime. Users, content, products, payments, and AI…"
- Keyword "JOSHUA Stack"
- OG/Twitter title "Build your business, not your boilerplate"

…in five different places (title, description, OG title, OG description, Twitter title, Twitter description, OG image query). Each one was its own drift vector vs. the home-page H1.

After: a single `PAGE_TITLE` / `PAGE_DESCRIPTION` / `OG_IMAGE_URL` constant block at the top of the file feeds title, description, OG, Twitter, and image query — with a comment flagging that these strings must move when the H1 in `apps/marketing/src/components/landing/Hero.tsx` moves. One file to edit on a positioning change instead of seven string updates.

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] `pnpm --filter marketing test` — 97 tests pass
- [x] `pnpm --filter marketing build` succeeds (build correctly server-renders the async `PricingTeaser`)
- [x] Biome clean
- [x] Pre-push gate passed
- [ ] Smoke test: with `/api/pricing` reachable, prices match Stripe / `/pricing`
- [ ] Smoke test: with `/api/pricing` blocked, fallback values render and section doesn't break
- [ ] Crawl `revealui.com` with an OG previewer (e.g. opengraph.xyz) and confirm new title + description
