### PR TITLE
fix(marketing): Faq drops dl/dt/dd nesting (WCAG 2.1 AA)

### DIFF
--- a/apps/marketing/src/components/landing/Faq.tsx
+++ b/apps/marketing/src/components/landing/Faq.tsx
@@ -36,33 +36,27 @@ export function Faq() {
           </h2>
         </div>
 
-        <div className="mx-auto mt-16 max-w-3xl">
-          <dl className="divide-y divide-gray-200">
-            {faqs.map((item) => (
-              <details key={item.q} className="group py-6">
-                <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                  <dt className="text-lg font-semibold leading-7 text-gray-950">{item.q}</dt>
-                  <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
-                    <svg
-                      className="h-4 w-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={2}
-                      stroke="currentColor"
-                    >
-                      <title>Toggle</title>
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 4.5v15m7.5-7.5h-15"
-                      />
-                    </svg>
-                  </span>
-                </summary>
-                <dd className="mt-4 pr-9 text-base leading-7 text-gray-600">{item.a}</dd>
-              </details>
-            ))}
-          </dl>
+        <div className="mx-auto mt-16 max-w-3xl divide-y divide-gray-200">
+          {faqs.map((item) => (
+            <details key={item.q} className="group py-6">
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+                <h3 className="text-lg font-semibold leading-7 text-gray-950">{item.q}</h3>
+                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <title>Toggle</title>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                </span>
+              </summary>
+              <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{item.a}</div>
+            </details>
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Fixes a critical WCAG 2.1 AA accessibility violation introduced by my Faq component on the new `/` landing page.

## What was wrong

The Faq section wrapped each item with description-list semantics around a `<details>` widget:

```tsx
<dl>
  <details>
    <summary>
      <dt>{question}</dt>
    </summary>
    <dd>{answer}</dd>
  </details>
</dl>
```

axe-core flagged the structure as a critical `wcag2a / wcag131` violation with the message *"Description list item does not have a `<dl>` parent element"* — six instances per page (one per FAQ row), failing across all three E2E viewports (chromium, mobile-chrome, tablet). The rule requires `<dt>` and `<dd>` to be **direct children** of `<dl>`; wrapping them in `<details>/<summary>` breaks the parent relationship.

## Why it wasn't caught earlier

Feature-branch PRs in this repo `SKIP` E2E Smoke and Accessibility (E2E) — the docs note they only run for PRs targeting `main` or on full gate runs. The bug surfaced on the test → main release PR ([revealui#569](https://github.com/RevealUIStudio/revealui/pull/569)), where those checks are required.

## Fix

Drop the description-list semantics. The disclosure widget (`<details>/<summary>`) already provides accessible expand/collapse behaviour out of the box. Replace `<dt>` with `<h3>` (gives screen readers a real heading to navigate by) and `<dd>` with a plain `<div>`.

```tsx
<div>
  <details>
    <summary>
      <h3>{question}</h3>
    </summary>
    <div>{answer}</div>
  </details>
</div>
```

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] Biome clean
- [ ] CI's E2E Smoke + Accessibility (E2E) run on this PR (they skip on feature branches — will only confirm green when [revealui#569](https://github.com/RevealUIStudio/revealui/pull/569) re-runs after this lands on `test`)
