### PR TITLE
fix(marketing): bump emerald accents to pass WCAG AA contrast

### DIFF
--- a/apps/marketing/src/components/landing/Demo.tsx
+++ b/apps/marketing/src/components/landing/Demo.tsx
@@ -63,7 +63,7 @@ export function Demo() {
         <div className="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3">
           {beats.map((b) => (
             <div key={b.n} className="rounded-2xl bg-white p-8 ring-1 ring-gray-950/5">
-              <div className="font-mono text-xs font-semibold uppercase tracking-widest text-emerald-600">
+              <div className="font-mono text-xs font-semibold uppercase tracking-widest text-emerald-700">
                 {b.n}
               </div>
               <h3 className="mt-3 text-lg font-semibold text-gray-950">{b.title}</h3>

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -130,7 +130,7 @@ export async function PricingTeaser() {
                 }`}
               >
                 {t.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-700 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white">
                     Most popular
                   </div>
                 )}


### PR DESCRIPTION
## Summary

Two SERIOUS color-contrast WCAG AA violations on the home page after the Faq `dl/dt/dd` fix in [revealui#570](https://github.com/RevealUIStudio/revealui/pull/570) unmasked them. Stacked on `test`.

## Violations and fixes

| Where | Before | Ratio | After | Ratio |
|---|---|---:|---|---:|
| `Demo.tsx` beat numbers (01 / 02 / 03) | `text-emerald-600` on white | 3.65:1 | `text-emerald-700` on white | ~5.4:1 |
| `PricingTeaser.tsx` "Most popular" pill | `text-white` on `bg-emerald-500` | 2.47:1 | `text-white` on `bg-emerald-700` | ~5.4:1 |

WCAG 2.1 AA requires 4.5:1 for normal text under 18pt. Both lift comfortably above that line.

## Why this didn't fail earlier

`E2E Smoke` and `Accessibility (E2E)` SKIP on feature-branch PRs in this repo — they only run on PRs targeting `main` or full gate runs. The first violation (Faq `dl/dt/dd`) was the critical one and was the first thing axe reported per page; once that fixed, the next-most-severe (color contrast) became visible. Three rounds of axe is one round per fix; nothing left after this.

## Knock-on effect

Other components already use `emerald-700` for emerald-on-white text — `Hero` eyebrow, `Faq` chevron-open state, `Primitives` accent badges, the bottom-strip `See full pricing` link. This change brings `Demo` and the `PricingTeaser` pill in line with that palette floor.

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] Biome clean
- [ ] Real validation: when this lands on `test`, [revealui#569](https://github.com/RevealUIStudio/revealui/pull/569)'s `E2E Smoke` + `Accessibility (E2E)` reruns must go green
