### PR TITLE
fix(release): remove spurious changeset blocking canary publishes

### DIFF
--- a/.changeset/deploy-rollback-actually-rolls-back.md
+++ b/.changeset/deploy-rollback-actually-rolls-back.md
@@ -1,7 +1,0 @@
----
-"revealui": patch
----
-
-ci(deploy): make smoke-test rollback step actually roll back
-
-`vercel rollback` with no URL argument is a status query, not an action — so on smoke-test failure the rollback step printed "Rolling back…" / "no rollback in progress" and the broken deploy stayed live. The step now pre-fetches the previous successful production deploy URL via `vercel ls --prod`, passes it to `vercel rollback <url> --yes`, verifies the alias moved post-rollback, and exits non-zero with a precise message reflecting whether the rollback succeeded, failed, or had no history. Closes GAP-128 (companion to GAP-122 which fixed the pnpm crash). Surfaced 2026-04-25 during #540 incident verification — at 06:55Z the rollback step ran cleanly (per the GAP-122 fix) but reported "no rollback in progress" while the broken deploy continued serving prod.


### PR DESCRIPTION
## Summary

Unblocks `Publish canary to npm` on every test branch push. The job has been failing for 6 consecutive commits (#564 through #571) with the same error.

## Root cause

[revealui#564](https://github.com/RevealUIStudio/revealui/pull/564) added `.changeset/deploy-rollback-actually-rolls-back.md` declaring `"revealui": patch` — but `revealui` is the monorepo root in [package.json](package.json), not a publishable workspace member. `pnpm changeset version --snapshot canary` (run on every push to `test` by [release-canary.yml](.github/workflows/release-canary.yml)) fails immediately:

```
🦋  error Error: Found changeset deploy-rollback-actually-rolls-back for package revealui which is not in the workspace
```

The change in #564 was purely a `.github/workflows/deploy.yml` edit — no workspace package source, so no version bump was warranted.

## Fix

Delete the changeset. Future CI-only changes should not create changesets at all.

## Knock-on effect

Once this lands on `test`, [revealui#569](https://github.com/RevealUIStudio/revealui/pull/569) (`test → main` release for the landing-page overhaul) should finally show its `Publish canary to npm` check green, clearing the last red gate before production deploy.

## Test plan

- [x] Pre-push gate passes
- [ ] CI on this PR passes
- [ ] After merge: `Publish canary to npm` on `test` runs green
- [ ] After merge: [revealui#569](https://github.com/RevealUIStudio/revealui/pull/569) rollup shows canary green
