### PR TITLE
feat(docs): design-system docs polish + governance

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -1,9 +1,24 @@
 import { Link, useLocation } from '@revealui/router';
 import { lazy, Suspense, useEffect, useState } from 'react';
+import { showcaseEntries } from './showcase/registry.js';
 
 const SearchBar = lazy(async () =>
   import('./SearchBar').then((mod) => ({ default: mod.SearchBar })),
 );
+
+/**
+ * Build the Showcase nav items from the registry. Two stable anchors
+ * (Overview + Design Tokens) followed by every entry sorted by display name.
+ * Adding a new showcase to `showcase/registry.ts` automatically surfaces
+ * it here — no hand-maintained list to drift.
+ */
+const showcaseNavItems = [
+  { label: 'Overview', path: '/showcase' },
+  { label: 'Design Tokens', path: '/showcase/tokens' },
+  ...[...showcaseEntries]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => ({ label: entry.name, path: `/showcase/${entry.slug}` })),
+];
 
 interface DocLayoutProps {
   children?: React.ReactNode;
@@ -72,26 +87,7 @@ const sections: NavSection[] = [
   },
   {
     title: 'Showcase',
-    items: [
-      { label: 'Overview', path: '/showcase' },
-      { label: 'Design Tokens', path: '/showcase/tokens' },
-      { label: 'Accordion', path: '/showcase/accordion' },
-      { label: 'Avatar', path: '/showcase/avatar' },
-      { label: 'Badge', path: '/showcase/badge' },
-      { label: 'Button', path: '/showcase/button' },
-      { label: 'Callout', path: '/showcase/callout' },
-      { label: 'Card', path: '/showcase/card' },
-      { label: 'Dialog', path: '/showcase/dialog' },
-      { label: 'Drawer', path: '/showcase/drawer' },
-      { label: 'Input', path: '/showcase/input' },
-      { label: 'Progress', path: '/showcase/progress' },
-      { label: 'Stat', path: '/showcase/stat' },
-      { label: 'Switch', path: '/showcase/switch' },
-      { label: 'Table', path: '/showcase/table' },
-      { label: 'Tabs', path: '/showcase/tabs' },
-      { label: 'Toast', path: '/showcase/toast' },
-      { label: 'Tooltip', path: '/showcase/tooltip' },
-    ],
+    items: showcaseNavItems,
   },
   {
     title: 'Pro & Enterprise',

--- a/apps/docs/app/components/showcase/ShowcaseShell.tsx
+++ b/apps/docs/app/components/showcase/ShowcaseShell.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { renderMarkdown } from '@/utils/markdown';
 import { CodeView } from './CodeView.js';
 import { Preview } from './Preview.js';
 import { PropPanel } from './PropPanel.js';
+import { showcaseEntries } from './registry.js';
 import type { ShowcaseStory } from './types.js';
 import { VariantGrid } from './VariantGrid.js';
 
@@ -10,6 +12,10 @@ type Tab = 'preview' | 'grid' | 'code';
 interface ShowcaseShellProps {
   story: ShowcaseStory;
 }
+
+const REPO_BLOB_BASE = 'https://github.com/RevealUIStudio/revealui/blob/main/packages/presentation';
+
+const DEFAULT_INSTALL = 'npm install @revealui/presentation';
 
 export function ShowcaseShell({ story }: ShowcaseShellProps) {
   const [activeTab, setActiveTab] = useState<Tab>('preview');
@@ -33,18 +39,77 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
     { id: 'code', label: 'Code' },
   ];
 
+  const sourceHref = story.sourceUrl ? `${REPO_BLOB_BASE}/${story.sourceUrl}` : null;
+  const installCmd = story.install ?? DEFAULT_INSTALL;
+  const a11y = story.a11y;
+  const hasA11y =
+    !!a11y &&
+    ((a11y.conformance?.length ?? 0) > 0 ||
+      (a11y.keyboard && Object.keys(a11y.keyboard).length > 0) ||
+      (a11y.aria && Object.keys(a11y.aria).length > 0) ||
+      !!a11y.notes);
+
   return (
     <div className="mx-auto max-w-4xl space-y-6 px-8 py-10">
       {/* Header */}
       <div>
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-ink">{story.name}</h1>
-          <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
-            {story.category}
-          </span>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold tracking-tight text-ink">{story.name}</h1>
+            <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
+              {story.category}
+            </span>
+          </div>
+          {sourceHref && (
+            <a
+              href={sourceHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text-secondary no-underline transition-colors hover:text-ink"
+            >
+              <svg
+                className="h-3.5 w-3.5"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <title>GitHub</title>
+                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+              </svg>
+              View source
+            </a>
+          )}
         </div>
         <p className="mt-1 text-sm text-text-secondary">{story.description}</p>
       </div>
+
+      {/* Install command */}
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-2.5 font-mono text-xs">
+        <span className="select-none text-text-muted">$</span>
+        <span className="flex-1 text-ink">{installCmd}</span>
+      </div>
+
+      {/* Usage guidance */}
+      {(story.usage?.when || story.usage?.avoid) && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {story.usage.when && (
+            <div className="rounded-xl border border-border bg-surface p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+                When to use
+              </h3>
+              <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.when)}</div>
+            </div>
+          )}
+          {story.usage.avoid && (
+            <div className="rounded-xl border border-border bg-surface p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-amber-700">
+                When to avoid
+              </h3>
+              <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.avoid)}</div>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-border">
@@ -100,6 +165,114 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Accessibility */}
+      {hasA11y && a11y && (
+        <details className="group rounded-xl border border-border bg-surface" open>
+          <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-semibold text-ink">
+            <span>Accessibility</span>
+            <svg
+              className="h-4 w-4 text-text-muted transition-transform group-open:rotate-180"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <title>Toggle</title>
+              <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </summary>
+          <div className="space-y-4 border-t border-border px-4 py-4">
+            {a11y.conformance && a11y.conformance.length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Conformance
+                </h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {a11y.conformance.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {a11y.keyboard && Object.keys(a11y.keyboard).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Keyboard
+                </h4>
+                <dl className="divide-y divide-border text-sm">
+                  {Object.entries(a11y.keyboard).map(([key, desc]) => (
+                    <div key={key} className="flex gap-3 py-1.5">
+                      <dt className="flex-shrink-0 font-mono text-xs text-ink">
+                        <kbd className="rounded border border-border bg-bg px-1.5 py-0.5">
+                          {key}
+                        </kbd>
+                      </dt>
+                      <dd className="text-text-secondary">{desc}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+            {a11y.aria && Object.keys(a11y.aria).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  ARIA
+                </h4>
+                <dl className="divide-y divide-border text-sm">
+                  {Object.entries(a11y.aria).map(([attr, desc]) => (
+                    <div key={attr} className="flex gap-3 py-1.5">
+                      <dt className="flex-shrink-0 font-mono text-xs text-ink">{attr}</dt>
+                      <dd className="text-text-secondary">{desc}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+            {a11y.notes && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Notes
+                </h4>
+                <div className="text-sm text-text-secondary">{renderMarkdown(a11y.notes)}</div>
+              </div>
+            )}
+          </div>
+        </details>
+      )}
+
+      {/* Related */}
+      {story.related && story.related.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-text-muted">
+            See also
+          </h2>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {story.related.map((rel) => {
+              const target = showcaseEntries.find((e) => e.slug === rel.slug);
+              const label = target?.name ?? rel.slug;
+              return (
+                <a
+                  key={rel.slug}
+                  href={`/showcase/${rel.slug}`}
+                  className="rounded-xl border border-border bg-surface px-4 py-3 no-underline transition-colors hover:border-accent"
+                >
+                  <div className="text-sm font-semibold text-ink">{label}</div>
+                  {rel.reason && (
+                    <div className="mt-1 text-xs text-text-secondary">{rel.reason}</div>
+                  )}
+                </a>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/apps/docs/app/components/showcase/types.ts
+++ b/apps/docs/app/components/showcase/types.ts
@@ -23,6 +23,29 @@ export interface ShowcaseExample {
   render: () => React.ReactNode;
 }
 
+/**
+ * Accessibility notes for a component. All fields optional; rendered as a
+ * collapsed-by-default section on the showcase page when any field is set.
+ */
+export interface ShowcaseAccessibility {
+  /** WCAG criteria explicitly covered, e.g. ["WCAG 2.1 AA contrast", "WCAG 2.1.1 Keyboard"] */
+  conformance?: string[];
+  /** Keyboard interactions, keyed by key name. e.g. {"Tab": "Move focus to next item"} */
+  keyboard?: Record<string, string>;
+  /** ARIA attributes the component renders or expects. */
+  aria?: Record<string, string>;
+  /** Free-form notes (e.g. "use aria-label when no visible label") */
+  notes?: string;
+}
+
+/**
+ * Cross-link to a related showcase by slug. Rendered as a "See also" strip.
+ */
+export interface ShowcaseRelated {
+  slug: string;
+  reason?: string;
+}
+
 /** Complete showcase definition for a single component */
 export interface ShowcaseStory {
   /** URL slug: /showcase/{slug} */
@@ -43,6 +66,31 @@ export interface ShowcaseStory {
   examples?: ShowcaseExample[];
   /** Custom code generator  -  receives current props, returns JSX string */
   code?: (props: Record<string, unknown>) => string;
+  /**
+   * When-to-use / when-not-to-use guidance. Markdown supported.
+   * Rendered above the interactive preview when present.
+   */
+  usage?: {
+    /** Markdown body explaining when to reach for this component. */
+    when?: string;
+    /** Markdown body explaining when NOT to use it (alternatives, anti-patterns). */
+    avoid?: string;
+  };
+  /**
+   * `npm install` snippet shown at the top of the page. Defaults to
+   * `npm install @revealui/presentation` when omitted; override only if the
+   * component is shipped from a different package or needs extra peerDeps.
+   */
+  install?: string;
+  /**
+   * Path inside the @revealui/presentation package to the component source,
+   * e.g. "src/components/Button.tsx". Renders a "View source" link to GitHub.
+   */
+  sourceUrl?: string;
+  /** Accessibility notes; rendered when any field is set. */
+  a11y?: ShowcaseAccessibility;
+  /** "See also" cross-links to related showcases. */
+  related?: ShowcaseRelated[];
 }
 
 /** Registry entry for lazy-loading stories */

--- a/packages/presentation/CONTRIBUTING.md
+++ b/packages/presentation/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to `@revealui/presentation`
+
+This is the package-level contribution guide for the design system. The repo-wide guide lives at the [root `CONTRIBUTING.md`](../../CONTRIBUTING.md) — read that first for general repo conventions (type system, lint, error codes, commit style).
+
+This file covers what's specific to the design system: adding components, the dual-pattern requirement, accessibility floor, showcases, and the token-versioning contract.
+
+## What ships from this package
+
+`@revealui/presentation` is the **fully featured + artifacted design system** for RevealUI. It exports:
+
+- **Components** under `./components` and the main barrel — over 50 production components
+- **Primitives** under `./primitives` — `Slot`, `Box`, `Flex`, `Grid`, `Heading`, `Text`
+- **Hooks** under `./hooks` — `useTheme`, controllable state, focus trap, escape-key, etc.
+- **Animations** under `./animations` — `useSpring`, `useStagger`, `usePresence`, `useGesture`
+- **Tokens** as `./tokens.css` — OKLCH-based design tokens, dark-first with manual `data-theme` override
+- **Server-safe** subset under `./server` and **client-only** subset under `./client`
+
+Distribution is npm-published, ESM-only, with full TypeScript declarations and source maps.
+
+## Adding a new component
+
+Every new component goes through five steps. Skipping any of these blocks merge.
+
+### 1. File location and dual-pattern
+
+Components live under `src/components/`. Two patterns coexist:
+
+- **Headless** (`button-headless.tsx`) — bare functionality with no styling. Useful when consumers need to bring their own visual treatment.
+- **CVA** (`Button.tsx`) — opinionated styled variant powered by CVA (`class-variance-authority` clone in `utils/cn.ts`). Most consumers use this.
+
+The CVA component should accept the same props as the headless one plus a `variant` and `size` (or component-specific equivalents). Re-export both from `src/components/index.ts` and `src/server.ts` (server-safe subset) or `src/client.ts` (client-only).
+
+### 2. Token usage
+
+**No hardcoded colors, spacing, or radii.** Every visual value comes from `--rvui-*` CSS variables defined in `src/tokens.css`. If you need a value that doesn't exist, add it to the token file in the appropriate group (Spacing, Radius, Surfaces, Status, Motion, Typography, etc.) before referencing it.
+
+The token system is dark-first; light mode overrides via `[data-theme="light"]` and `@media (prefers-color-scheme: light)`. Ensure your component renders correctly in both.
+
+### 3. Accessibility floor
+
+Every shipped component must meet **WCAG 2.1 AA** at minimum:
+
+- **Color contrast** — text on its background ≥ 4.5:1 for normal, ≥ 3:1 for large text. Use `text-emerald-700` floor (not `-500`/`-600`) for emerald accents on white. Run an axe-core check on your showcase before opening the PR.
+- **Keyboard navigation** — every interactive control reachable via Tab, operable via Enter/Space (or component-appropriate keys). No tab traps unless inside a modal/disclosure.
+- **ARIA** — use the right role and aria-* attributes. Prefer native semantics (`<button>`, `<details>`, `<dialog>`) over re-implementing with divs.
+- **Focus visibility** — focus ring must be visible at default contrast. The base `Button` uses `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`; match that pattern.
+- **Reduced motion** — animations respect `prefers-reduced-motion`. Use the `useReducedMotion` hook from `./hooks` or the matching media query.
+
+Document which of these you tested in the showcase's `a11y` field (see step 5).
+
+### 4. Tests
+
+Component tests live in `src/__tests__/components/<Component>.test.tsx`. Use `@testing-library/react` (already a dev-dep). Required coverage:
+
+- Renders without crashing for default props
+- Each `variant` and `size` combination renders without console errors
+- `asChild` (when supported) clones the child element correctly — see `Button.test.tsx` for the canonical pattern
+- Disabled/loading/empty states render the right ARIA
+- Keyboard interactions work (use `userEvent.tab()`, `userEvent.keyboard('{Enter}')`)
+
+`pnpm --filter @revealui/presentation test` must pass.
+
+### 5. Showcase
+
+Every component needs a showcase at `apps/docs/app/showcase/<slug>.showcase.tsx`. The schema is in `apps/docs/app/components/showcase/types.ts`. Required fields:
+
+- `slug`, `name`, `description`, `category`
+- `controls` — interactive prop knobs (boolean, select, text, number, range, color)
+- `render(props)` — JSX using the current control values
+- `code(props)` — a string that mirrors the rendered JSX (so the Code tab works)
+
+Optional but **strongly encouraged** for any production-bound component:
+
+- `variantGrid` — every (variant × size) combination rendered side-by-side
+- `examples[]` — common usage patterns (icon-only button, button group, etc.)
+- `usage.when` / `usage.avoid` — markdown explaining when to reach for it and the alternatives
+- `a11y.conformance` — list of WCAG criteria explicitly covered, e.g. `["WCAG 2.1 AA contrast", "WCAG 2.1.1 Keyboard"]`
+- `a11y.keyboard` — map of key → behavior, e.g. `{"Tab": "Move focus to next item"}`
+- `a11y.aria` — map of aria-* attributes the component sets or expects
+- `sourceUrl` — package-relative path to the source file, e.g. `"src/components/Button.tsx"`. Auto-renders a "View source" link to GitHub.
+- `related[]` — cross-links to related showcases by slug
+
+Then add the entry to `apps/docs/app/components/showcase/registry.ts` so it appears in the sidebar (the sidebar is auto-generated from the registry — no separate hand-maintained list to update).
+
+## Token-versioning policy
+
+Tokens are part of the public contract. Renaming or removing a `--rvui-*` variable is a breaking change.
+
+- **While pre-1.0** (current): breaking token changes bump the **minor** version (e.g. `0.4.x` → `0.5.0`). Document the rename in the changeset.
+- **Post-1.0**: breaking token changes bump **major**. Provide a deprecation period of at least one minor release with both names exposed.
+- **Adding a new token** is always a patch — no consumers break.
+
+When you rename a token, update both `src/tokens.css` and the public reference at `apps/docs/app/components/showcase/TokensPage.tsx`.
+
+## Versioning
+
+Per the [repo-wide versioning rule](../../.claude/rules/versioning.md), the package starts at `0.1.0` and stays pre-1.0 until consumers + governance + token contract are stable. Don't promote to `1.0.0` casually.
+
+Inside `0.x`, any meaningful behavior change or breaking API change bumps **minor**, not major. Use changesets (`pnpm changeset`) to record the intent — the tooling enforces version policy at release time.
+
+**No changeset for CI-only or workflow-file changes.** Changesets are for source code changes that affect what the package emits.
+
+## Where to ask
+
+- Suite-wide questions → root CONTRIBUTING.md, then `#dev` in the project Discussions
+- Design-system-specific decisions (token shape, accessibility tradeoffs, naming) → file an issue with the `package: presentation` label
+
+## Quick checklist before opening a PR
+
+- [ ] Component file lives under `src/components/` (or `src/primitives/` for primitives)
+- [ ] Re-exported from `src/components/index.ts` and the appropriate `server.ts`/`client.ts`
+- [ ] Uses `--rvui-*` tokens, no hardcoded design values
+- [ ] Tests in `src/__tests__/components/<Component>.test.tsx` cover variants, asChild (if supported), keyboard, a11y
+- [ ] Showcase at `apps/docs/app/showcase/<slug>.showcase.tsx` with controls, render, code, and `a11y` field
+- [ ] Showcase registered in `apps/docs/app/components/showcase/registry.ts`
+- [ ] `pnpm --filter @revealui/presentation test` passes
+- [ ] `pnpm --filter @revealui/presentation typecheck` passes
+- [ ] `pnpm --filter @revealui/presentation build` succeeds (artifact + type defs + tokens.css)
+- [ ] Biome clean
+- [ ] Changeset created via `pnpm changeset` (unless this is a docs-only or CI-only change)


### PR DESCRIPTION
## Summary

Phase 1 of "fully featured + artifacted design system" — four backwards-compatible structural improvements to the existing `@revealui/presentation` + `apps/docs` surface. No breaking changes to the 46 existing showcases.

## What changed

### 1. `ShowcaseStory` schema extended ([types.ts](apps/docs/app/components/showcase/types.ts))

New optional fields:

| Field | Purpose |
|---|---|
| `usage.when` / `usage.avoid` | Markdown bodies — when to reach for the component, and when not to |
| `install` | npm install snippet shown at top of page (defaults to `npm install @revealui/presentation`) |
| `sourceUrl` | Package-relative path, e.g. `"src/components/Button.tsx"` — auto-renders a "View source" GitHub link |
| `a11y.conformance` | Array of WCAG criteria explicitly covered, e.g. `["WCAG 2.1 AA contrast"]` |
| `a11y.keyboard` | Map of key → behavior |
| `a11y.aria` | Map of aria-* attributes |
| `a11y.notes` | Free-form markdown notes |
| `related[]` | Cross-links to related showcases by slug |

Every existing showcase keeps working untouched — fields are optional and only render when set.

### 2. `ShowcaseShell` renders the new fields ([ShowcaseShell.tsx](apps/docs/app/components/showcase/ShowcaseShell.tsx))

- "View source" link in the header (when `sourceUrl` is set)
- Install command block right under the header
- Two-column **When to use / When to avoid** panel for usage guidance (markdown via existing `renderMarkdown` utility)
- Collapsible **Accessibility** section listing WCAG conformance pills, keyboard shortcuts in `<kbd>` tags, ARIA attribute table, and notes
- **See also** strip cross-linking related showcases

### 3. DocLayout sidebar auto-generates from the registry ([DocLayout.tsx](apps/docs/app/components/DocLayout.tsx))

Previously: hand-maintained list of **16 entries** linking only the most prominent components.
Registry has **46 showcase entries**.

That's 30 components silently unreachable from the sidebar — visitors had to know the URL slug to find them.

Now: the Showcase nav section is generated from `showcaseEntries` at module load. Two stable anchors (Overview + Design Tokens) followed by every entry sorted by display name. Adding a new showcase to `registry.ts` is the only step — no separate hand-maintained list to drift.

### 4. `CONTRIBUTING.md` for `@revealui/presentation` ([CONTRIBUTING.md](packages/presentation/CONTRIBUTING.md))

Package-level governance covering:

- The **five mandatory steps** for adding a new component:
  1. File location + dual headless/CVA pattern
  2. Token usage (no hardcoded design values)
  3. **Accessibility floor** — WCAG 2.1 AA contrast (`text-emerald-700` floor), keyboard, ARIA, focus visibility, reduced motion
  4. Tests (variants × sizes, asChild, keyboard, a11y)
  5. Showcase + registry entry — with the new schema fields encouraged
- **Token-versioning policy** — pre-1.0: breaking token changes bump minor; post-1.0: bump major with one-minor deprecation period
- **"No changeset for CI-only changes"** rule — preventing the same canary-publish blocker fixed in [revealui#572](https://github.com/RevealUIStudio/revealui/pull/572)
- Pre-PR checklist

## What this enables

This is the foundation for Phase 2 (the honesty audit + visual standout work the user asked for next). With the schema extended, the next pass can sweep every existing showcase and add `a11y` notes + `usage` guidance + `sourceUrl` — turning the surface from "code-first demo" into "fully featured + artifacted design system" in the user's framing.

It also unblocks future contributions: anyone adding a component now follows a documented contract, with a checklist that catches the failure modes that bit us in the marketing-overhaul push (color contrast, dl/dt/dd nesting, missing a11y).

## Test plan

- [x] `pnpm --filter docs typecheck` passes
- [x] `pnpm --filter docs test` — 100 tests pass
- [x] `pnpm --filter docs build` succeeds
- [x] Biome clean
- [x] Pre-push gate passed
- [ ] After merge: visit docs.revealui.com/showcase and confirm the sidebar now lists all 46 components
- [ ] Spot-check one existing showcase page renders unchanged (no `a11y`/`usage`/`sourceUrl` set, so no new sections render)
