### PR TITLE
fix(security): trusted-proxy-aware client IP for session binding (GAP-130)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,6 +14,7 @@
     "@revealui/mcp": "workspace:*",
     "@revealui/paywall": "workspace:*",
     "@revealui/presentation": "workspace:*",
+    "@revealui/security": "workspace:*",
     "@revealui/setup": "workspace:*",
     "@revealui/sync": "workspace:*",
     "@revealui/utils": "workspace:*",

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -14,10 +14,17 @@ export async function register() {
   }
 
   try {
-    const [{ logger }, { validateRequiredEnvVars }] = await Promise.all([
+    const [{ logger }, { validateRequiredEnvVars }, { configureClientIp }] = await Promise.all([
       import('@revealui/core/observability/logger'),
       import('@/lib/utils/env-validation'),
+      import('@revealui/security'),
     ]);
+
+    // Configure trusted-proxy-aware client IP extraction for session-binding
+    // validation. See GAP-130 + packages/security/src/request-ip.ts.
+    // trustedProxyCount: 1 reflects the current Vercel-only proxy chain. Bump
+    // to 2 in the SAME PR as Cloudflare orange-cloud cutover (GAP-133 phases 5-6).
+    configureClientIp({ trustedProxyCount: 1 });
 
     const environment = process.env.NODE_ENV || 'development';
 

--- a/apps/admin/src/lib/utils/__tests__/request-context.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/request-context.test.ts
@@ -1,0 +1,77 @@
+import { resetClientIpConfig } from '@revealui/security';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { extractRequestContext } from '../request-context.js';
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request('https://admin.example/test', { headers });
+}
+
+describe('extractRequestContext (admin / WHATWG Request)', () => {
+  // Keep the trusted-proxy-aware extractor's default config consistent across
+  // tests. The admin app calls `configureClientIp({ trustedProxyCount: 1 })`
+  // at startup; tests reset between cases for isolation.
+  beforeEach(() => {
+    resetClientIpConfig();
+  });
+  afterEach(() => {
+    resetClientIpConfig();
+  });
+
+  it('reads user-agent header', () => {
+    const ctx = extractRequestContext(makeRequest({ 'user-agent': 'Mozilla/5.0 (test)' }));
+    expect(ctx.userAgent).toBe('Mozilla/5.0 (test)');
+  });
+
+  it('returns undefined userAgent when header missing', () => {
+    const ctx = extractRequestContext(makeRequest({}));
+    expect(ctx.userAgent).toBeUndefined();
+  });
+
+  describe('IP extraction (trusted-proxy-aware, GAP-130)', () => {
+    it('returns the single XFF entry when only one proxy hop is present', () => {
+      const ctx = extractRequestContext(makeRequest({ 'x-forwarded-for': '203.0.113.1' }));
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
+
+    it('REJECTS leftmost spoofed XFF entries (the GAP-130 defense)', () => {
+      // Attacker sets their own X-Forwarded-For before reaching the proxy;
+      // proxy appends the attacker's real IP. Trusted-proxy-aware extractor
+      // returns the proxy-written value (real attacker IP), NOT the spoof.
+      const ctx = extractRequestContext(
+        makeRequest({ 'x-forwarded-for': '99.99.99.99, 203.0.113.1' }),
+      );
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+      expect(ctx.ipAddress).not.toBe('99.99.99.99');
+    });
+
+    it('handles multi-entry XFF correctly', () => {
+      const ctx = extractRequestContext(
+        makeRequest({ 'x-forwarded-for': '99.1.1.1, 99.2.2.2, 203.0.113.1' }),
+      );
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
+
+    it('falls back to x-real-ip when x-forwarded-for is absent', () => {
+      const ctx = extractRequestContext(makeRequest({ 'x-real-ip': '203.0.113.9' }));
+      expect(ctx.ipAddress).toBe('203.0.113.9');
+    });
+
+    it('prefers x-forwarded-for over x-real-ip when both are present', () => {
+      const ctx = extractRequestContext(
+        makeRequest({
+          'x-forwarded-for': '203.0.113.1',
+          'x-real-ip': '198.51.100.5',
+        }),
+      );
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
+
+    it('returns undefined ipAddress when neither header is set (contract preserved)', () => {
+      // getClientIp returns 'unknown' when no proxy headers present; our
+      // wrapper converts to undefined so validateSessionBinding's
+      // `if (ctx.ipAddress && session.ipAddress && …)` short-circuits.
+      const ctx = extractRequestContext(makeRequest({}));
+      expect(ctx.ipAddress).toBeUndefined();
+    });
+  });
+});

--- a/apps/admin/src/lib/utils/request-context.ts
+++ b/apps/admin/src/lib/utils/request-context.ts
@@ -1,19 +1,28 @@
+import { getClientIp } from '@revealui/security';
+
 /**
  * Extract request context (IP + user-agent) for session binding validation.
  *
  * Pass the result as the second argument to `getSession()` so the auth layer
  * can validate that the session matches the current request's origin.
+ *
+ * Uses `getClientIp` from `@revealui/security/request-ip` (trusted-proxy-aware
+ * "rightmost untrusted" strategy) instead of taking the leftmost
+ * X-Forwarded-For entry — that older approach was spoofable by any direct
+ * client setting their own X-Forwarded-For header. See GAP-130.
+ *
+ * Contract preserved: `ipAddress` is `undefined` when the client IP cannot be
+ * determined. `getClientIp` returns the string `'unknown'` in that case; we
+ * convert to `undefined` so `validateSessionBinding` short-circuits the way
+ * it always has when no IP was available.
  */
 export function extractRequestContext(request: Request): {
   userAgent: string | undefined;
   ipAddress: string | undefined;
 } {
-  const headers = request.headers;
+  const ip = getClientIp(request);
   return {
-    userAgent: headers.get('user-agent') ?? undefined,
-    ipAddress:
-      headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-      headers.get('x-real-ip') ??
-      undefined,
+    userAgent: request.headers.get('user-agent') ?? undefined,
+    ipAddress: ip === 'unknown' ? undefined : ip,
   };
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@revealui/db": "workspace:*",
     "@revealui/mcp": "workspace:*",
     "@revealui/openapi": "workspace:*",
+    "@revealui/security": "workspace:*",
     "@sentry/node": "^10.49.0",
     "@vercel/blob": "^2.3.3",
     "drizzle-orm": "catalog:",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,11 +30,11 @@ import {
 } from '@revealui/core/observability/alerts';
 import { logger } from '@revealui/core/observability/logger';
 import { audit, SecurityHeaders, SecurityPresets } from '@revealui/core/security';
-import { configureClientIp } from '@revealui/security';
 import { closeAllPools, getClient } from '@revealui/db';
 import { createDbLogHandler } from '@revealui/db/log-transport';
 import { sites, users } from '@revealui/db/schema';
 import { OpenAPIHono } from '@revealui/openapi';
+import { configureClientIp } from '@revealui/security';
 import { sql } from 'drizzle-orm';
 import { bodyLimit } from 'hono/body-limit';
 import { createMiddleware } from 'hono/factory';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from '@revealui/core/observability/alerts';
 import { logger } from '@revealui/core/observability/logger';
 import { audit, SecurityHeaders, SecurityPresets } from '@revealui/core/security';
+import { configureClientIp } from '@revealui/security';
 import { closeAllPools, getClient } from '@revealui/db';
 import { createDbLogHandler } from '@revealui/db/log-transport';
 import { sites, users } from '@revealui/db/schema';
@@ -1211,6 +1212,15 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   logger.info(`📚 API documentation available at http://localhost:${port}/docs`);
   logger.info(`📄 OpenAPI spec available at http://localhost:${port}/openapi.json`);
 }
+
+// Configure trusted-proxy-aware client IP extraction for session-binding
+// validation. See GAP-130 + packages/security/src/request-ip.ts.
+// trustedProxyCount: 1 reflects the current Vercel-only proxy chain. When
+// Cloudflare is added in front of api.revealui.com (GAP-133 phases 5-6), bump
+// to 2 in the SAME PR as the orange-cloud cutover — leaving N=1 after Cloudflare
+// goes orange = spoofable IPs again; setting N=2 before Cloudflare = garbage
+// IPs / 'unknown' for everyone.
+configureClientIp({ trustedProxyCount: 1 });
 
 // Also validate in production before accepting traffic
 if (process.env.NODE_ENV === 'production') {

--- a/apps/api/src/lib/__tests__/request-context.test.ts
+++ b/apps/api/src/lib/__tests__/request-context.test.ts
@@ -1,5 +1,6 @@
+import { resetClientIpConfig } from '@revealui/security';
 import { Hono } from 'hono';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { extractRequestContext } from '../request-context.js';
 
 function extractFromRequest(headers: Record<string, string>) {
@@ -15,7 +16,17 @@ function extractFromRequest(headers: Record<string, string>) {
   );
 }
 
-describe('extractRequestContext', () => {
+describe('extractRequestContext (Hono)', () => {
+  // Keep the trusted-proxy-aware extractor's default config consistent across
+  // tests. The api app calls `configureClientIp({ trustedProxyCount: 1 })`
+  // at startup; tests reset between cases for isolation.
+  beforeEach(() => {
+    resetClientIpConfig();
+  });
+  afterEach(() => {
+    resetClientIpConfig();
+  });
+
   it('reads user-agent header', async () => {
     const ctx = await extractFromRequest({ 'user-agent': 'Mozilla/5.0 (test)' });
     expect(ctx.userAgent).toBe('Mozilla/5.0 (test)');
@@ -26,33 +37,68 @@ describe('extractRequestContext', () => {
     expect(ctx.userAgent).toBeUndefined();
   });
 
-  it('reads the first IP from x-forwarded-for', async () => {
-    const ctx = await extractFromRequest({
-      'x-forwarded-for': '203.0.113.1, 198.51.100.5, 192.0.2.10',
+  describe('IP extraction (trusted-proxy-aware, GAP-130)', () => {
+    it('returns the single XFF entry when only one proxy hop is present', async () => {
+      // With trustedProxyCount=1 and a single entry, that entry was written
+      // by the trusted proxy and represents the client peer.
+      const ctx = await extractFromRequest({ 'x-forwarded-for': '203.0.113.1' });
+      expect(ctx.ipAddress).toBe('203.0.113.1');
     });
-    expect(ctx.ipAddress).toBe('203.0.113.1');
-  });
 
-  it('trims whitespace from x-forwarded-for entries', async () => {
-    const ctx = await extractFromRequest({ 'x-forwarded-for': '   203.0.113.1  , 198.51.100.5' });
-    expect(ctx.ipAddress).toBe('203.0.113.1');
-  });
-
-  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
-    const ctx = await extractFromRequest({ 'x-real-ip': '203.0.113.9' });
-    expect(ctx.ipAddress).toBe('203.0.113.9');
-  });
-
-  it('prefers x-forwarded-for over x-real-ip when both are present', async () => {
-    const ctx = await extractFromRequest({
-      'x-forwarded-for': '203.0.113.1',
-      'x-real-ip': '198.51.100.5',
+    it('REJECTS leftmost spoofed XFF entries (the GAP-130 defense)', async () => {
+      // Attacker sets their own X-Forwarded-For header before reaching the
+      // proxy; the proxy then APPENDS the attacker's real IP. With
+      // trustedProxyCount=1, the rightmost 1 entry was added by the trusted
+      // proxy and that's the only entry we trust as client-IP origin. A
+      // naive leftmost extractor would return '99.99.99.99' (the spoof);
+      // the correct extractor returns '203.0.113.1' (real attacker IP as
+      // seen by the proxy).
+      const ctx = await extractFromRequest({
+        'x-forwarded-for': '99.99.99.99, 203.0.113.1',
+      });
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+      expect(ctx.ipAddress).not.toBe('99.99.99.99');
     });
-    expect(ctx.ipAddress).toBe('203.0.113.1');
-  });
 
-  it('returns undefined ipAddress when neither header is set', async () => {
-    const ctx = await extractFromRequest({});
-    expect(ctx.ipAddress).toBeUndefined();
+    it('handles multi-entry XFF correctly', async () => {
+      // 3 entries with trustedProxyCount=1: the rightmost 1 is trusted; the
+      // entry IMMEDIATELY before it (parts[length - trustedProxyCount] in
+      // the implementation) is the trusted proxy's view of the client.
+      const ctx = await extractFromRequest({
+        'x-forwarded-for': '99.1.1.1, 99.2.2.2, 203.0.113.1',
+      });
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
+
+    it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+      const ctx = await extractFromRequest({ 'x-real-ip': '203.0.113.9' });
+      expect(ctx.ipAddress).toBe('203.0.113.9');
+    });
+
+    it('prefers x-forwarded-for over x-real-ip when both are present', async () => {
+      const ctx = await extractFromRequest({
+        'x-forwarded-for': '203.0.113.1',
+        'x-real-ip': '198.51.100.5',
+      });
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
+
+    it('returns undefined ipAddress when neither header is set', async () => {
+      // Contract preserved: getClientIp returns the literal string 'unknown'
+      // when no proxy headers are present; our wrapper converts that to
+      // undefined so validateSessionBinding's `if (ctx.ipAddress && ...)`
+      // short-circuits the way it always has when no IP was available.
+      const ctx = await extractFromRequest({});
+      expect(ctx.ipAddress).toBeUndefined();
+    });
+
+    it('trims whitespace inside XFF entries', async () => {
+      // Spec format allows whitespace after commas; the rightmost-untrusted
+      // strategy still picks the correct entry after trimming.
+      const ctx = await extractFromRequest({
+        'x-forwarded-for': '   99.1.1.1   ,   203.0.113.1   ',
+      });
+      expect(ctx.ipAddress).toBe('203.0.113.1');
+    });
   });
 });

--- a/apps/api/src/lib/request-context.ts
+++ b/apps/api/src/lib/request-context.ts
@@ -1,4 +1,5 @@
 import type { RequestContext } from '@revealui/auth/server';
+import { getClientIp } from '@revealui/security';
 import type { Context } from 'hono';
 
 /**
@@ -9,13 +10,22 @@ import type { Context } from 'hono';
  * the Next.js admin surface apply the same binding check against a stolen
  * session cookie. Without passing this to `getSession(...)`, a cookie lifted
  * from one device would stay valid against the API from any UA / IP.
+ *
+ * Uses `getClientIp` from `@revealui/security/request-ip` (trusted-proxy-aware
+ * "rightmost untrusted" strategy) instead of taking the leftmost
+ * X-Forwarded-For entry — that older approach was spoofable by any direct
+ * client setting their own X-Forwarded-For header. See GAP-130.
+ *
+ * Contract preserved: `ipAddress` is `undefined` when the client IP cannot be
+ * determined (no trusted proxy headers). `getClientIp` returns the literal
+ * string `'unknown'` in that case; we convert to `undefined` so that
+ * `validateSessionBinding`'s `if (ctx.ipAddress && session.ipAddress && …)`
+ * short-circuits the way it always has when no IP was available.
  */
 export function extractRequestContext(c: Context): RequestContext {
+  const ip = getClientIp(c.req.raw);
   return {
     userAgent: c.req.header('user-agent') ?? undefined,
-    ipAddress:
-      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ??
-      c.req.header('x-real-ip') ??
-      undefined,
+    ipAddress: ip === 'unknown' ? undefined : ip,
   };
 }

--- a/apps/api/src/middleware/__tests__/auth.test.ts
+++ b/apps/api/src/middleware/__tests__/auth.test.ts
@@ -123,7 +123,7 @@ describe('authMiddleware', () => {
         headers: {
           cookie: 'revealui-session=abc123',
           'user-agent': 'Mozilla/5.0 (test)',
-          'x-forwarded-for': '203.0.113.1, 198.51.100.5',
+          'x-forwarded-for': '203.0.113.1',
         },
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@revealui/presentation':
         specifier: workspace:*
         version: link:../../packages/presentation
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../../packages/security
       '@revealui/services':
         specifier: workspace:^
         version: link:../../packages/services
@@ -427,6 +430,9 @@ importers:
       '@revealui/openapi':
         specifier: workspace:*
         version: link:../../packages/openapi
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../../packages/security
       '@revealui/services':
         specifier: workspace:^
         version: link:../../packages/services


### PR DESCRIPTION
Closes GAP-130.

## Summary

Both `apps/api/src/lib/request-context.ts` and `apps/admin/src/lib/utils/request-context.ts` previously took the **leftmost** X-Forwarded-For entry as the client IP for session-binding validation. That value is set by the direct client and is trivially spoofable: an attacker who lifts a session cookie can pass `X-Forwarded-For: <original-IP>` and defeat the binding check at [`packages/auth/src/server/session.ts:75`](packages/auth/src/server/session.ts:75) (the IP-mismatch line in `validateSessionBinding`).

The canonical "rightmost untrusted" extractor at [`packages/security/src/request-ip.ts`](packages/security/src/request-ip.ts) (`getClientIp` + `configureClientIp`) was already implemented and documented but unused by either app. Surfaced as Finding F2b in §5.19 sweep target 3.

## Changes

- **`apps/api/src/index.ts`**: imports `configureClientIp` and calls it at module scope before route registration with `trustedProxyCount: 1` (Vercel-only chain).
- **`apps/admin/src/instrumentation.ts`**: imports `configureClientIp` in the existing `register()` Node-runtime path with the same config.
- **`apps/api/src/lib/request-context.ts`**: replaces inline X-Forwarded-For parsing with `getClientIp(c.req.raw)`. **Converts the security package's `'unknown'` fallback to `undefined`** to preserve the existing `validateSessionBinding` short-circuit when no IP is available — without this conversion, dev/local sessions would spuriously fail the binding check.
- **`apps/admin/src/lib/utils/request-context.ts`**: same migration on the WHATWG `Request` shape.
- **`apps/{api,admin}/package.json`**: adds `@revealui/security` as a direct workspace dep.

## Critical: Cloudflare re-tune note

This PR ships with `trustedProxyCount: 1` for the Vercel-only chain. When Cloudflare is added in front of `api.revealui.com` / `admin.revealui.com` (per GAP-133 phases 5-6), bump to `2` in the **same PR** as the orange-cloud cutover. Failure modes if mismatched:
- N=1 after Cloudflare goes orange = spoofable IPs again
- N=2 before Cloudflare = garbage IPs / `'unknown'` for everyone

## Tests

- **`apps/api/src/lib/__tests__/request-context.test.ts` rewritten** to assert spoof-defense behavior. **9 new tests** including an explicit `expect(ipAddress).not.toBe('99.99.99.99')` assertion in the spoof-rejection case.
- **`apps/admin/src/lib/utils/__tests__/request-context.test.ts` added** (was missing entirely): **8 tests** mirroring the api set on the WHATWG Request shape.
- `beforeEach` / `afterEach` call `resetClientIpConfig()` to keep the trusted-proxy-aware extractor's default config consistent across tests.

## Verified

- [x] `pnpm --filter api typecheck` clean
- [x] `pnpm --filter admin typecheck` clean
- [x] `pnpm --filter api test request-context` — 9/9 green
- [x] `pnpm --filter admin test request-context` — 8/8 green
- [x] Pre-push gate (Phase 1: lint + audits + boundary + structure + claims + security) PASS
- [ ] CI pipeline (will run on this PR)
- [ ] Manual review of the Cloudflare re-tune note

## Test plan

- [ ] CI green
- [ ] Owner verifies the Vercel proxy chain assumption (`trustedProxyCount: 1` is correct for Vercel-only) before merge
- [ ] Squash-merge after CI green per `feedback_no_auto_merge` standing policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
