### PR TITLE
fix(marketing): correct misleading demo + billing + managed-hosting claims (P0)

### DIFF
--- a/apps/marketing/src/components/landing/Demo.tsx
+++ b/apps/marketing/src/components/landing/Demo.tsx
@@ -4,17 +4,17 @@ const beats = [
   {
     n: '01',
     title: 'Spin up a stack.',
-    body: 'One command. Auth, billing, content, admin UI, and agent layer running locally in 60 seconds.',
+    body: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
   },
   {
     n: '02',
-    title: 'Real customer flow.',
-    body: 'A user signs up, picks a plan, and pays. Stripe handles checkout. The admin UI shows the new account.',
+    title: 'Customer flow, end to end.',
+    body: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
   },
   {
     n: '03',
     title: 'Agent-native, by default.',
-    body: 'A chat agent reads the customer, refunds the subscription, and writes a CMS post explaining why — same APIs.',
+    body: 'Every primitive ships with a matching MCP server. Wire an LLM provider and your agents read customers, refund subscriptions, and write content through the same APIs your app uses.',
   },
 ];
 
@@ -27,10 +27,10 @@ export function Demo() {
             Watch it work
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            From CLI to live business in 90 seconds.
+            From CLI to a working stack in 90 seconds.
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-600">
-            Three beats. No edits. The whole stack, end to end.
+            Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP.
           </p>
         </div>
 

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -72,10 +72,10 @@ const TEASER_TIERS: TeaserTier[] = [
   {
     id: 'pro',
     name: 'Pro',
-    description: 'Managed hosting, AI primitives, and priority support.',
+    description: 'Pro AI primitives, agent task allowance, and priority support.',
     features: [
       'Everything in Free',
-      'Managed hosting + auto-scaling',
+      '10,000 agent tasks / month included',
       'Pro AI features (agents, RAG, MCP)',
       'Priority support, SLA',
     ],


### PR DESCRIPTION
Three P0 corrections from the internal honesty audit (internal docs). PRs B/C/D follow for P1/P2/P3 fixes and the durable CI claim-drift gate.

## What changed

### Demo section ([Demo.tsx](apps/marketing/src/components/landing/Demo.tsx))

- H2 *"From CLI to live business in 90 seconds."* → *"From CLI to a working stack in 90 seconds."*
- Subhead now flags test-mode-by-default and the LLM-key requirement: *"Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP."*
- **Beat 1** drops the false implication that the agent layer auto-runs without an LLM key
- **Beat 2** says *"Stripe test-mode checkout completes"* instead of *"pays"* — production posture is TEST mode by deliberate design (GAP-124 audit gates the LIVE flip)
- **Beat 3** reframed from *"a chat agent reads/refunds/writes"* (presented as recorded demo) to *"every primitive ships with a matching MCP server. Wire an LLM provider and your agents…"* — describes capability not a recording

### Pro pricing tier ([PricingTeaser.tsx](apps/marketing/src/components/landing/PricingTeaser.tsx))

- Description loses *"Managed hosting"* (no such service ships)
- *"Managed hosting + auto-scaling"* feature replaced with *"10,000 agent tasks / month included"* (sourced from `packages/contracts/src/pricing.ts` `SUBSCRIPTION_TIERS` — actually ships)

## Why these were P0

Each one would damage trust if a real prospect read the page and signed up:

1. Demo implied a 90-second path to a live business that takes real money. Production is TEST mode.
2. The recorded demo doesn't exist; copy presented a hypothetical as if recorded.
3. Pro tier sold *"Managed hosting"* that has no implementation behind it.

## What's NOT in this PR (deliberately scoped)

- **P1 fixes** (drop dunning/RAG, persona language, SSO/SCIM/on-prem qualifiers, every-API-via-MCP-automatic) → PR B
- **P2/P3 fixes** (Hero MIT → OSS + Fair-Source, *"Production-ready"* → *"Local dev"*, persona-quote framing) → PR C
- **Durable CI enforcer** (claim-drift gate on `landing/*.tsx`) → PR D

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] Biome clean
- [x] Pre-push gate passed
- [ ] Visual sanity check on the rendered landing page after merge — confirm the Demo section reads naturally and the Pricing teaser still has 4 features per tier
