### PR TITLE
fix(billing): customer.deleted preserves perpetual licenses (GAP-140)

### DIFF
--- a/apps/api/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-pglite.test.ts
@@ -350,6 +350,106 @@ describe('webhook integration  -  customer.subscription.deleted', () => {
   });
 });
 
+describe('webhook integration  -  customer.deleted (GAP-140 perpetual protection)', () => {
+  it('revokes ONLY non-perpetual licenses; perpetual licenses are preserved', async () => {
+    // Setup: one user with BOTH a subscription license AND a perpetual license
+    // for the same Stripe customer. The perpetual license represents a
+    // separately-purchased one-time purchase that must NOT be revoked when
+    // the Stripe customer record is deleted.
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-mixed-1',
+      email: 'mixed@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_mixed_1' })
+      .where(eq(users.id, 'user-mixed-1'));
+
+    // Subscription license (must be revoked on customer.deleted)
+    await testDb.drizzle.insert(licenses).values({
+      id: 'lic-sub-1',
+      userId: 'user-mixed-1',
+      licenseKey: 'sub-key',
+      tier: 'pro',
+      customerId: 'cus_mixed_1',
+      subscriptionId: 'sub_mixed_1',
+      status: 'active',
+      perpetual: false,
+    });
+
+    // Perpetual license (must be preserved on customer.deleted)
+    await testDb.drizzle.insert(licenses).values({
+      id: 'lic-perp-1',
+      userId: 'user-mixed-1',
+      licenseKey: 'perp-key',
+      tier: 'pro',
+      customerId: 'cus_mixed_1',
+      subscriptionId: null,
+      status: 'active',
+      perpetual: true,
+    });
+
+    const event = makeStripeEvent('customer.deleted', {
+      id: 'cus_mixed_1',
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    // Subscription license should be revoked
+    const subRow = await testDb.drizzle.select().from(licenses).where(eq(licenses.id, 'lic-sub-1'));
+    expect(subRow).toHaveLength(1);
+    expect(subRow[0].status).toBe('revoked');
+
+    // Perpetual license should be PRESERVED (status still 'active')
+    const perpRow = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.id, 'lic-perp-1'));
+    expect(perpRow).toHaveLength(1);
+    expect(perpRow[0].status).toBe('active');
+    expect(perpRow[0].perpetual).toBe(true);
+  });
+
+  it('revokes only-subscription license set when no perpetual licenses exist', async () => {
+    // Regression check: customer with no perpetual still has all subscription
+    // licenses revoked correctly.
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-sub-only',
+      email: 'subonly@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_sub_only' })
+      .where(eq(users.id, 'user-sub-only'));
+
+    await testDb.drizzle.insert(licenses).values({
+      id: 'lic-sub-only-1',
+      userId: 'user-sub-only',
+      licenseKey: 'sub-only-key',
+      tier: 'pro',
+      customerId: 'cus_sub_only',
+      subscriptionId: 'sub_only_1',
+      status: 'active',
+      perpetual: false,
+    });
+
+    const event = makeStripeEvent('customer.deleted', {
+      id: 'cus_sub_only',
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.id, 'lic-sub-only-1'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('revoked');
+  });
+});
+
 describe('webhook integration  -  irrelevant events', () => {
   it('returns 200 without processing for unknown event types', async () => {
     const event = makeStripeEvent('invoice.created', {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1486,12 +1486,25 @@ app.openapi(stripeWebhookRoute, async (c) => {
         // Uses saga pattern for NeonDB-safe multi-step atomicity with compensating actions.
         const customerDeleteSteps: SagaStep[] = [
           {
-            name: 'revoke-all-licenses',
+            // Revoke only NON-PERPETUAL (subscription) licenses on
+            // Stripe-customer deletion. Perpetual licenses are one-time
+            // purchases the customer rightfully owns and must NOT be
+            // clobbered when their Stripe customer record is deleted (which
+            // can happen via admin action, GDPR flow, or merge). Mirrors
+            // the perpetual-aware filter the dunning + charge.refunded
+            // paths already apply. See GAP-140.
+            name: 'revoke-non-perpetual-licenses',
             execute: async (ctx) => {
               await ctx.db
                 .update(licenses)
                 .set({ status: 'revoked', updatedAt: new Date() })
-                .where(and(eq(licenses.customerId, customerId), isNull(licenses.deletedAt)));
+                .where(
+                  and(
+                    eq(licenses.customerId, customerId),
+                    eq(licenses.perpetual, false),
+                    isNull(licenses.deletedAt),
+                  ),
+                );
               return {};
             },
             compensate: async () => {


### PR DESCRIPTION
Closes GAP-140 (narrowed scope per implementation investigation — see "Scope note" below).

## Summary

The `customer.deleted` webhook handler at [`apps/api/src/routes/webhooks.ts:1487`](apps/api/src/routes/webhooks.ts#L1487) revoked **all** licenses for the deleted customer, including perpetual ones. Perpetual licenses represent one-time purchases the customer rightfully owns; clobbering them when their Stripe customer record is deleted (admin action, GDPR flow, manual merge) is a real bug — customer paid for permanent access, lost it via an unrelated event.

The dunning path (`charge.refunded` handler) and the `customer.subscription.deleted` handler (which scopes by subscriptionId) already correctly leave perpetual licenses intact. This PR brings `customer.deleted` into consistency.

## Changes

- **`apps/api/src/routes/webhooks.ts:1487-1500`**: saga step renamed `revoke-all-licenses` → `revoke-non-perpetual-licenses`. Added `eq(licenses.perpetual, false)` filter to the WHERE clause. Inline comment explains the policy + cross-references the existing perpetual-aware filters.
- **`apps/api/src/routes/__tests__/webhook-pglite.test.ts`**: 2 new tests under `customer.deleted (GAP-140 perpetual protection)`:
  - revokes ONLY non-perpetual licenses; perpetual licenses are preserved (asserts subscription license is revoked AND perpetual license retains `status='active'`)
  - regression check: customer with no perpetual licenses still has subscription licenses revoked correctly

Both tests pass against PGlite (real DB queries via Drizzle).

## Scope note (deferred to follow-up)

GAP-140's original scope also covered the `charge.refunded` handler's missing perpetual-refund path (Surface 6 BLOCKING-A — the OPPOSITE failure mode where a customer can refund a perpetual purchase and keep access forever).

Investigation revealed the schema lacks a clean charge → perpetual-license linkage (`licenses` has no `stripePaymentIntentId` column; `orders` has no `purchase_mode`). Fixing that requires either a schema migration OR an admin-manual workaround for the (currently rare) perpetual-refund case.

**This PR addresses surface-8 Gap B only — the one-direction failure mode (perpetual revoked unfairly via customer.deleted).** A separate gap will track the perpetual-refund work post-launch.

## Verified

- [x] `pnpm --filter api test webhook-pglite` — 8/8 tests green (6 prior + 2 new)
- [x] Pre-push gate PASS
- [ ] CI pipeline (will run on this PR)

## Test plan

- [ ] CI green
- [ ] Squash-merge after CI green per `feedback_no_auto_merge` standing policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
