### PR TITLE
fix(api): dbStatusCache TTL 5min → 30s with env override (GAP-139)

### DIFF
--- a/apps/api/src/middleware/__tests__/license-status.test.ts
+++ b/apps/api/src/middleware/__tests__/license-status.test.ts
@@ -210,3 +210,76 @@ describe('checkLicenseStatus', () => {
     expect(queryFn).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-139: dbStatusCache TTL freshness — post-revocation Pro access window
+// ---------------------------------------------------------------------------
+describe('checkLicenseStatus  -  cache TTL freshness (GAP-139)', () => {
+  it('re-queries DB after the cache TTL window expires (revocation propagation)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockedGetLicensePayload.mockReturnValue({
+        tier: 'pro',
+        customerId: 'cus_ttl_1',
+      });
+
+      // First call returns 'active'; subsequent calls return 'revoked' to
+      // simulate Stripe-side revocation that arrived between cache-fill +
+      // next read.
+      const queryFn = vi
+        .fn<(customerId: string) => Promise<string>>()
+        .mockResolvedValueOnce('active')
+        .mockResolvedValue('revoked');
+
+      const app = createApp(queryFn);
+
+      // First request: queries DB, caches 'active' result, returns 200
+      const res1 = await app.request('/resource');
+      expect(res1.status).toBe(200);
+      expect(queryFn).toHaveBeenCalledTimes(1);
+
+      // Within TTL: cached 'active' is reused, DB NOT queried
+      vi.advanceTimersByTime(20_000); // +20s, still within default 30s TTL
+      const res2 = await app.request('/resource');
+      expect(res2.status).toBe(200);
+      expect(queryFn).toHaveBeenCalledTimes(1);
+
+      // After TTL: DB MUST be re-queried; revocation propagates
+      // 35s total = 35s after the first cache write, beyond the 30s default
+      vi.advanceTimersByTime(15_000);
+      const res3 = await app.request('/resource');
+      expect(res3.status).toBe(403);
+      expect(queryFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-queries DB on EVERY request when the cache is invalidated by resetDbStatusCache()', async () => {
+    // Sanity check that the existing reset path still works (used by
+    // webhook handlers post-revocation to invalidate cached state).
+    mockedGetLicensePayload.mockReturnValue({
+      tier: 'pro',
+      customerId: 'cus_reset_1',
+    });
+
+    const queryFn = vi
+      .fn<(customerId: string) => Promise<string>>()
+      .mockResolvedValueOnce('active')
+      .mockResolvedValue('revoked');
+
+    const app = createApp(queryFn);
+
+    // First request: caches 'active'
+    const res1 = await app.request('/resource');
+    expect(res1.status).toBe(200);
+
+    // Manual cache invalidation (what webhook handlers do post-revocation)
+    resetDbStatusCache();
+
+    // Next request: must hit DB again, sees 'revoked'
+    const res2 = await app.request('/resource');
+    expect(res2.status).toBe(403);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/middleware/license.ts
+++ b/apps/api/src/middleware/license.ts
@@ -28,7 +28,51 @@ const SUPPORT_EMAIL = process.env.REVEALUI_SUPPORT_EMAIL ?? 'support@revealui.co
 
 /** Cache for DB-side license status checks, keyed by billing owner/customer */
 const dbStatusCache = new Map<string, { status: string; checkedAt: number }>();
-const DB_STATUS_CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * TTL for the DB status cache. Defaults to 30s (was 5 min until GAP-139).
+ *
+ * Rationale: this cache sits on both the hosted path and the legacy
+ * self-hosted JWT path. On the legacy path, a cancelled / refunded /
+ * revoked customer continues to receive Pro feature access until the TTL
+ * expires. A 5-minute window is too long for STRIPE_LIVE_MODE — for a
+ * paying customer this is a billing-incorrect window; for a fraudulent /
+ * abuse case it's a 5-minute escape hatch.
+ *
+ * 30s balances revocation propagation speed against per-request DB read
+ * pressure on the hosted path. Operators can override via
+ * `DB_STATUS_CHECK_INTERVAL_MS` env (e.g. `=0` to disable the cache for
+ * incident debugging).
+ *
+ * The maximum is capped at 60_000ms (60s) so that a misconfigured value
+ * cannot reintroduce the 5-min regression. Values >60_000 are clamped
+ * with a warning.
+ *
+ * Mirrors the env-override pattern in `@revealui/core/license`'s
+ * LICENSE_CACHE_TTL_MS (which is a separate, JWT-license cache; this one
+ * is the DB-side status cache).
+ *
+ * See GAP-139.
+ */
+const DEFAULT_DB_STATUS_CHECK_INTERVAL_MS = 30 * 1000; // 30 seconds
+const MAX_DB_STATUS_CHECK_INTERVAL_MS = 60 * 1000; // 60 seconds (hard cap)
+
+function parseDbStatusCheckIntervalEnv(raw: string | undefined): number {
+  if (!raw || raw.trim() === '') return DEFAULT_DB_STATUS_CHECK_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DB_STATUS_CHECK_INTERVAL_MS;
+  if (parsed > MAX_DB_STATUS_CHECK_INTERVAL_MS) {
+    process.stderr.write(
+      `DB_STATUS_CHECK_INTERVAL_MS=${parsed} exceeds the ${MAX_DB_STATUS_CHECK_INTERVAL_MS}ms cap; using ${MAX_DB_STATUS_CHECK_INTERVAL_MS}. Longer TTLs extend the post-revocation Pro-access window and are not permitted.\n`,
+    );
+    return MAX_DB_STATUS_CHECK_INTERVAL_MS;
+  }
+  return parsed;
+}
+
+const DB_STATUS_CHECK_INTERVAL = parseDbStatusCheckIntervalEnv(
+  process.env.DB_STATUS_CHECK_INTERVAL_MS,
+);
 
 /** Tracks when the DB became unreachable for infra grace period calculation */
 let dbUnreachableSince: number | null = null;


### PR DESCRIPTION
Closes GAP-139.

## Summary

[`apps/api/src/middleware/license.ts:30-31`](apps/api/src/middleware/license.ts#L30) cached license-status DB reads with a hardcoded 5-minute TTL. The cache sits on both the hosted path and the legacy self-hosted JWT path. On the legacy path, a cancelled / refunded / revoked customer continues to receive Pro feature access until the TTL expires — a 5-minute window is too long for STRIPE_LIVE_MODE.

GAP-124 surface 8's audit (`08-subscription-state-machine.md` Gap A) verdict: the hosted path is fine (saga-based eventual consistency, ~10-50ms convergence). The legacy JWT path's 5-min cache is the load-bearing concern.

## Changes

- **TTL default reduced from 300_000ms (5min) to 30_000ms (30s).** Reduces post-revocation Pro-access window 10x with marginal extra per-request DB read pressure on the hosted path.
- **New env override `DB_STATUS_CHECK_INTERVAL_MS`.** Operators can tune the TTL per environment. Setting `=0` disables the cache for incident debugging.
- **Hard cap at 60_000ms (60s).** Values above the cap are clamped with a stderr warning. Prevents misconfiguration from reintroducing the 5-min regression.
- Inline doc explains the cross-path implications + the relationship to `@revealui/core/license`'s separate `LICENSE_CACHE_TTL_MS` (which is for JWT cache, not DB status cache).

## Tests

`apps/api/src/middleware/__tests__/license-status.test.ts` adds 2 tests under a new describe block `cache TTL freshness (GAP-139)`:

1. **re-queries DB after the cache TTL window expires** — uses fake timers to advance past the 30s default. Asserts the cached `active` value is reused within TTL, and a fresh DB read picks up `revoked` after TTL.
2. **re-queries DB on EVERY request when invalidated by `resetDbStatusCache()`** — sanity check that the existing webhook-side cache invalidation path continues to work.

All 11 license-status tests pass (9 prior + 2 new).

## Verified

- [x] `pnpm --filter api test license-status` — 11/11 green
- [x] Pre-push gate PASS
- [ ] CI pipeline (will run on this PR)

## Test plan

- [ ] CI green
- [ ] Squash-merge after CI green per `feedback_no_auto_merge` standing policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
