### PR TITLE
feat(billing): refund handler covers credits + subscription cancel (GAP-124 surface 6)

### DIFF
--- a/apps/api/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-pglite.test.ts
@@ -18,9 +18,18 @@ import {
 
 // ─── Mocks (before imports) ─────────────────────────────────────────────────
 
-const { mockConstructEvent, mockSubscriptionsRetrieve } = vi.hoisted(() => ({
+const {
+  mockConstructEvent,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsCancel,
+  mockInvoicesRetrieve,
+  mockPaymentIntentsRetrieve,
+} = vi.hoisted(() => ({
   mockConstructEvent: vi.fn(),
   mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsCancel: vi.fn(),
+  mockInvoicesRetrieve: vi.fn(),
+  mockPaymentIntentsRetrieve: vi.fn(),
 }));
 
 vi.mock('stripe', () => ({
@@ -30,23 +39,34 @@ vi.mock('stripe', () => ({
       subscriptions = {
         update: vi.fn(),
         retrieve: mockSubscriptionsRetrieve,
+        cancel: mockSubscriptionsCancel,
         list: vi.fn().mockResolvedValue({ data: [] }),
+      };
+      invoices = {
+        retrieve: mockInvoicesRetrieve,
+      };
+      paymentIntents = {
+        retrieve: mockPaymentIntentsRetrieve,
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
 }));
 
 // GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+// GAP-124 Surface 6 needs cancel/invoices/paymentIntents on the same mock.
 vi.mock('@revealui/services', () => ({
   protectedStripe: {
     webhooks: { constructEventAsync: mockConstructEvent },
     subscriptions: {
       update: vi.fn(),
       retrieve: mockSubscriptionsRetrieve,
+      cancel: mockSubscriptionsCancel,
       list: vi.fn().mockResolvedValue({ data: [] }),
     },
     customers: { update: vi.fn() },
     charges: { retrieve: vi.fn() },
+    invoices: { retrieve: mockInvoicesRetrieve },
+    paymentIntents: { retrieve: mockPaymentIntentsRetrieve },
   },
 }));
 
@@ -101,7 +121,7 @@ vi.mock('../../middleware/license.js', () => ({
 
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { licenses, processedWebhookEvents, users } from '@revealui/db/schema';
+import { agentCreditBalance, licenses, processedWebhookEvents, users } from '@revealui/db/schema';
 import webhooksRoute from '../webhooks.js';
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
@@ -481,5 +501,261 @@ describe('webhook integration  -  irrelevant events', () => {
       .from(processedWebhookEvents)
       .where(eq(processedWebhookEvents.id, event.id as string));
     expect(rows).toHaveLength(0);
+  });
+});
+
+// GAP-124 Surface 6 fix-train tests — BLOCKING-B (credit-bundle refunds debit
+// agentCreditBalance) and BLOCKING-C (full refund of subscription invoice
+// cancels Stripe subscription).
+describe('webhook integration  -  charge.refunded (Surface 6 fix-train)', () => {
+  it('full credit-bundle refund debits agentCreditBalance', async () => {
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-credit-refund',
+      email: 'creditrefund@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_credit_refund' })
+      .where(eq(users.id, 'user-credit-refund'));
+
+    // Seed a balance that the refund will roll back. Bundle is 1000 tasks;
+    // user has spent 200 (balance=800), so refund debits 1000 down to 0
+    // (clamped) and totalPurchased back to 0.
+    await testDb.drizzle.insert(agentCreditBalance).values({
+      userId: 'user-credit-refund',
+      balance: 800,
+      totalPurchased: 1000,
+    });
+
+    // PaymentIntent metadata identifies this as a credit-bundle purchase.
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_credit_refund',
+      metadata: {
+        credits_bundle: 'starter',
+        credits_tasks: '1000',
+        revealui_user_id: 'user-credit-refund',
+      },
+    });
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_credit_refund',
+      customer: 'cus_credit_refund',
+      payment_intent: 'pi_credit_refund',
+      amount: 5000,
+      amount_refunded: 5000,
+      currency: 'usd',
+      billing_details: { email: 'creditrefund@example.com' },
+      invoice: null,
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const balanceRows = await testDb.drizzle
+      .select()
+      .from(agentCreditBalance)
+      .where(eq(agentCreditBalance.userId, 'user-credit-refund'));
+
+    expect(balanceRows).toHaveLength(1);
+    // 800 - 1000 = -200 → clamped at 0
+    expect(balanceRows[0].balance).toBe(0);
+    // 1000 - 1000 = 0
+    expect(balanceRows[0].totalPurchased).toBe(0);
+
+    expect(mockPaymentIntentsRetrieve).toHaveBeenCalledWith('pi_credit_refund');
+  });
+
+  it('credit-bundle refund with ambiguous user lookup logs warning and skips', async () => {
+    // Two users share the same stripeCustomerId; PaymentIntent metadata
+    // omits revealui_user_id — should skip debit, defer to admin.
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-amb-1',
+      email: 'amb1@example.com',
+    });
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-amb-2',
+      email: 'amb2@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_ambiguous' })
+      .where(eq(users.id, 'user-amb-1'));
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_ambiguous' })
+      .where(eq(users.id, 'user-amb-2'));
+
+    await testDb.drizzle.insert(agentCreditBalance).values({
+      userId: 'user-amb-1',
+      balance: 500,
+      totalPurchased: 500,
+    });
+
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_ambiguous',
+      metadata: {
+        credits_bundle: 'starter',
+        credits_tasks: '500',
+        // No revealui_user_id — forces fallback to customer lookup.
+      },
+    });
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_ambiguous',
+      customer: 'cus_ambiguous',
+      payment_intent: 'pi_ambiguous',
+      amount: 2500,
+      amount_refunded: 2500,
+      currency: 'usd',
+      billing_details: { email: 'amb1@example.com' },
+      invoice: null,
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    // Balance unchanged — debit was skipped due to ambiguity.
+    const balanceRows = await testDb.drizzle
+      .select()
+      .from(agentCreditBalance)
+      .where(eq(agentCreditBalance.userId, 'user-amb-1'));
+    expect(balanceRows).toHaveLength(1);
+    expect(balanceRows[0].balance).toBe(500);
+    expect(balanceRows[0].totalPurchased).toBe(500);
+  });
+
+  it('full subscription invoice refund cancels Stripe subscription', async () => {
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-sub-refund',
+      email: 'subrefund@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_sub_refund' })
+      .where(eq(users.id, 'user-sub-refund'));
+
+    await testDb.drizzle.insert(licenses).values({
+      id: 'lic-sub-refund',
+      userId: 'user-sub-refund',
+      licenseKey: 'sub-refund-key',
+      tier: 'pro',
+      customerId: 'cus_sub_refund',
+      subscriptionId: 'sub_to_cancel',
+      status: 'active',
+      perpetual: false,
+    });
+
+    // No credit-bundle metadata on the PaymentIntent — pure subscription.
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_sub_refund',
+      metadata: {},
+    });
+
+    // Charge → Invoice → Subscription chain. Stripe SDK v20 moved
+    // subscription from invoice.subscription to
+    // invoice.parent.subscription_details.subscription — match the
+    // production code path.
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: 'in_sub_refund',
+      parent: { subscription_details: { subscription: 'sub_to_cancel' } },
+    });
+
+    mockSubscriptionsCancel.mockResolvedValueOnce({
+      id: 'sub_to_cancel',
+      status: 'canceled',
+    });
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_sub_refund',
+      customer: 'cus_sub_refund',
+      payment_intent: 'pi_sub_refund',
+      invoice: 'in_sub_refund',
+      amount: 4900,
+      amount_refunded: 4900,
+      currency: 'usd',
+      billing_details: { email: 'subrefund@example.com' },
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    // Local license revoked.
+    const licenseRows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.id, 'lic-sub-refund'));
+    expect(licenseRows[0].status).toBe('revoked');
+
+    // Stripe subscription canceled with idempotent flags.
+    expect(mockInvoicesRetrieve).toHaveBeenCalledWith('in_sub_refund');
+    expect(mockSubscriptionsCancel).toHaveBeenCalledWith('sub_to_cancel', {
+      invoice_now: false,
+      prorate: false,
+    });
+  });
+
+  it('handles already-canceled Stripe subscription gracefully (idempotent)', async () => {
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-already-cancel',
+      email: 'alreadycancel@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_already_cancel' })
+      .where(eq(users.id, 'user-already-cancel'));
+
+    await testDb.drizzle.insert(licenses).values({
+      id: 'lic-already-cancel',
+      userId: 'user-already-cancel',
+      licenseKey: 'already-cancel-key',
+      tier: 'pro',
+      customerId: 'cus_already_cancel',
+      subscriptionId: 'sub_already_canceled',
+      status: 'active',
+      perpetual: false,
+    });
+
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_already_cancel',
+      metadata: {},
+    });
+
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: 'in_already_cancel',
+      parent: { subscription_details: { subscription: 'sub_already_canceled' } },
+    });
+
+    // Stripe surfaces "already canceled" as resource_missing in modern SDKs.
+    const stripeError = Object.assign(new Error('No such subscription: sub_already_canceled'), {
+      code: 'resource_missing',
+    });
+    mockSubscriptionsCancel.mockRejectedValueOnce(stripeError);
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_already_cancel',
+      customer: 'cus_already_cancel',
+      payment_intent: 'pi_already_cancel',
+      invoice: 'in_already_cancel',
+      amount: 4900,
+      amount_refunded: 4900,
+      currency: 'usd',
+      billing_details: { email: 'alreadycancel@example.com' },
+    });
+
+    const res = await postWebhook(event);
+    // Webhook still returns 200 — the cancel-already-canceled path is a no-op.
+    expect(res.status).toBe(200);
+
+    // License revoke still happened locally.
+    const licenseRows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.id, 'lic-already-cancel'));
+    expect(licenseRows[0].status).toBe('revoked');
+
+    expect(mockSubscriptionsCancel).toHaveBeenCalledWith('sub_already_canceled', {
+      invoice_now: false,
+      prorate: false,
+    });
   });
 });

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -2882,12 +2882,116 @@ app.openapi(stripeWebhookRoute, async (c) => {
         // A charge has been refunded (partial or full). Revoke the customer's
         // NON-PERPETUAL license if the refund fully covers the charge amount.
         // Perpetual licenses are never revoked by a subscription refund —
-        // they are a separate purchase with their own refund path.
+        // they are a separate purchase with their own refund path (BLOCKING-A,
+        // tracked separately; deferred from Surface 6 fix-train).
+        //
+        // GAP-124 Surface 6 BLOCKING-B: credit-bundle refunds debit
+        // agentCreditBalance (when the original charge was a credit-bundle
+        // purchase, detected via PaymentIntent metadata).
+        //
+        // GAP-124 Surface 6 BLOCKING-C: full refunds of subscription invoices
+        // cancel the underlying Stripe subscription so Stripe stops billing.
+        //
+        // usage_meters are NOT rolled back on refund. They are an append-only
+        // ledger of recorded events; the refund itself is the financial
+        // reversal. Reporting that needs a "refund-aware" usage view must
+        // filter out usage from refunded charges separately.
         const charge = event.data.object as Stripe.Charge;
         const customerId = resolveCustomerId(charge.customer);
         if (!customerId) break;
 
         const isFullRefund = charge.amount_refunded >= charge.amount;
+
+        // ── BLOCKING-B: Credit-bundle refund — debit agentCreditBalance ───
+        // The agentCreditBalance schema is keyed by userId (one row per user)
+        // with no charge linkage. To detect a credit-bundle refund we fetch
+        // the original PaymentIntent and inspect its metadata, which is
+        // populated at credit-bundle checkout (see checkout.session.completed
+        // → mode === 'payment' → metadata.credits_bundle).
+        //
+        // Heuristic: if the PaymentIntent carries credits_bundle + credits_tasks
+        // metadata, this charge is a credit-bundle purchase. Debit the
+        // refunded user's balance (and totalPurchased) by `credits_tasks`,
+        // clamped at 0 — the customer may have already spent the credits.
+        //
+        // Ambiguity policy: if revealui_user_id is missing AND the user
+        // cannot be uniquely resolved from stripeCustomerId (multiple matches
+        // or none), we log a warning and skip — defer to admin manual action
+        // rather than guess.
+        const paymentIntentId =
+          typeof charge.payment_intent === 'string'
+            ? charge.payment_intent
+            : (charge.payment_intent?.id ?? null);
+        if (paymentIntentId) {
+          let pi: Stripe.PaymentIntent | null = null;
+          try {
+            pi = await stripe.paymentIntents.retrieve(paymentIntentId);
+          } catch (err) {
+            logger.warn('Failed to retrieve PaymentIntent for refund — skipping credit-debit', {
+              customerId,
+              chargeId: charge.id,
+              paymentIntentId,
+              detail: err instanceof Error ? err.message : 'unknown',
+            });
+          }
+          if (pi?.metadata?.credits_bundle) {
+            const bundleTasks = Number.parseInt(pi.metadata.credits_tasks ?? '0', 10);
+            // Prorate credit debit by the refund ratio so partial $ refunds
+            // debit a proportional number of credits. Full refunds debit the
+            // full bundle.
+            const refundRatio =
+              charge.amount > 0 ? Math.min(charge.amount_refunded / charge.amount, 1) : 1;
+            const refundedTasks = Math.round(bundleTasks * refundRatio);
+            let creditUserId = pi.metadata.revealui_user_id ?? null;
+
+            if (!creditUserId) {
+              const matches = await db
+                .select({ id: users.id })
+                .from(users)
+                .where(eq(users.stripeCustomerId, customerId))
+                .limit(2);
+              if (matches.length === 1) {
+                creditUserId = matches[0].id;
+              } else {
+                logger.warn(
+                  'Credit-bundle refund: ambiguous user lookup — skipping debit (defer to admin)',
+                  {
+                    customerId,
+                    chargeId: charge.id,
+                    paymentIntentId,
+                    matchCount: matches.length,
+                  },
+                );
+              }
+            }
+
+            if (creditUserId && refundedTasks > 0) {
+              await db
+                .update(agentCreditBalance)
+                .set({
+                  balance: sql`GREATEST(${agentCreditBalance.balance} - ${refundedTasks}, 0)`,
+                  totalPurchased: sql`GREATEST(${agentCreditBalance.totalPurchased} - ${refundedTasks}, 0)`,
+                  updatedAt: new Date(),
+                })
+                .where(eq(agentCreditBalance.userId, creditUserId));
+
+              logger.warn('Credit-bundle refund: balance debited', {
+                customerId,
+                chargeId: charge.id,
+                userId: creditUserId,
+                refundedTasks,
+                bundle: pi.metadata.credits_bundle,
+              });
+              auditLicenseEvent(db, 'credits.refunded', 'warn', {
+                customerId,
+                chargeId: charge.id,
+                userId: creditUserId,
+                refundedTasks,
+                bundle: pi.metadata.credits_bundle,
+              });
+            }
+          }
+        }
 
         if (isFullRefund) {
           // Only revoke NON-PERPETUAL licenses. Perpetual licenses represent
@@ -2926,6 +3030,103 @@ app.openapi(stripeWebhookRoute, async (c) => {
             amountRefunded: charge.amount_refunded,
             amount: charge.amount,
           });
+
+          // ── BLOCKING-C: Cancel the underlying Stripe subscription ────────
+          // Without this, Stripe continues invoicing the customer at the next
+          // cycle while our entitlement is 'revoked' — producing immediate
+          // "I got a refund and you charged me again" confusion + likely
+          // chargebacks.
+          //
+          // Detect via Charge → Invoice → Subscription chain. Idempotent:
+          // if the subscription is already canceled, Stripe returns
+          // resource_missing / "No such subscription" or "subscription is
+          // already canceled"; we log info and continue.
+          // charge.invoice exists at runtime (Stripe sends it for invoice-
+          // backed charges) but is not in the SDK type. Same SDK-typing gap
+          // as elsewhere in this file (see line ~2235 comment). Cast through
+          // unknown to read it.
+          const chargeInvoice = (charge as unknown as { invoice?: string | { id: string } | null })
+            .invoice;
+          const invoiceId =
+            typeof chargeInvoice === 'string' ? chargeInvoice : (chargeInvoice?.id ?? null);
+          if (invoiceId) {
+            try {
+              const invoice = await stripe.invoices.retrieve(invoiceId);
+              // Stripe SDK v20 moved subscription from invoice.subscription to
+              // invoice.parent.subscription_details.subscription (matches the
+              // fix at line ~2451 in this file).
+              const invoiceSubscriptionField = invoice.parent?.subscription_details?.subscription;
+              const subscriptionId =
+                typeof invoiceSubscriptionField === 'string'
+                  ? invoiceSubscriptionField
+                  : (invoiceSubscriptionField?.id ?? null);
+              if (subscriptionId) {
+                try {
+                  await stripe.subscriptions.cancel(subscriptionId, {
+                    invoice_now: false,
+                    prorate: false,
+                  });
+                  logger.warn('Stripe subscription canceled after full refund', {
+                    customerId,
+                    chargeId: charge.id,
+                    invoiceId,
+                    subscriptionId,
+                  });
+                  auditLicenseEvent(db, 'subscription.canceled.refund', 'warn', {
+                    customerId,
+                    chargeId: charge.id,
+                    invoiceId,
+                    subscriptionId,
+                  });
+                } catch (cancelErr) {
+                  // Already-canceled is the common idempotent case. Stripe
+                  // surfaces it as a StripeInvalidRequestError with
+                  // code='resource_missing' (deleted) or a message containing
+                  // 'already canceled' / 'already been canceled'. Treat all
+                  // of these as a no-op success.
+                  const msg = cancelErr instanceof Error ? cancelErr.message : 'unknown';
+                  const code = (cancelErr as { code?: string }).code;
+                  const isAlreadyCanceled =
+                    code === 'resource_missing' ||
+                    /already\s+(been\s+)?cance(l|ll)ed/i.test(msg) ||
+                    /no such subscription/i.test(msg);
+                  if (isAlreadyCanceled) {
+                    logger.info(
+                      'Stripe subscription already canceled — refund cancel is no-op (idempotent)',
+                      {
+                        customerId,
+                        chargeId: charge.id,
+                        subscriptionId,
+                        detail: msg,
+                      },
+                    );
+                  } else {
+                    // Unexpected error — log loudly but don't crash the
+                    // webhook (email + audit-log already wrote; subscription
+                    // cancel can be retried by admin).
+                    logger.error(
+                      'Failed to cancel Stripe subscription after full refund',
+                      undefined,
+                      {
+                        customerId,
+                        chargeId: charge.id,
+                        subscriptionId,
+                        detail: msg,
+                        code,
+                      },
+                    );
+                  }
+                }
+              }
+            } catch (invoiceErr) {
+              logger.warn('Failed to retrieve invoice for refund — skipping subscription cancel', {
+                customerId,
+                chargeId: charge.id,
+                invoiceId,
+                detail: invoiceErr instanceof Error ? invoiceErr.message : 'unknown',
+              });
+            }
+          }
         } else {
           logger.info('Partial refund issued  -  license retained', {
             customerId,


### PR DESCRIPTION
Closes Surface 6 BLOCKING-B + BLOCKING-C from `06-refund-flow.md`. GAP-124 surface 6 fix-train.

## BLOCKING-B — Credit-bundle refunds debit `agentCreditBalance`

The `charge.refunded` handler revoked the local subscription license but never debited `agentCreditBalance` for credit-bundle refunds. Customer kept credits + money.

**Fix:** gate on `paymentIntent.metadata` (`credits_bundle` + `credits_tasks` + `revealui_user_id` set at checkout in [billing.ts:1601](apps/api/src/routes/billing.ts#L1601)). When the gate matches, debit `agentCreditBalance` by the prorated amount (`amount_refunded / amount * credits_tasks`), clamped at 0 via `GREATEST(...)`.

If `revealui_user_id` is missing OR customerId resolves to >1 / 0 users, log a warning + skip (defer to admin manual action).

## BLOCKING-C — Full subscription invoice refund cancels Stripe subscription

The handler revoked the local entitlement on a full refund but did NOT call `stripe.subscriptions.cancel(...)`. Stripe re-billed the customer next cycle while our entitlement was 'revoked'.

**Fix:** when `isFullRefund && charge.invoice` is set, fetch the invoice + extract subscription via `invoice.parent?.subscription_details?.subscription` (SDK v20 path; matches the existing pattern at [webhooks.ts:2451](apps/api/src/routes/webhooks.ts#L2451)). Call `stripe.subscriptions.cancel(subId, { invoice_now: false, prorate: false })`.

Idempotent error handling: catches `resource_missing` / `already canceled` / `no such subscription` from Stripe as success.

## Schema linkage caveat (deferred follow-up)

`agentCreditBalance` has no direct charge linkage. The fix uses PaymentIntent metadata as a heuristic. Follow-up work: add a `creditPurchases` ledger so refunds can target the exact purchase without metadata-dependence. Documented in code comment + flagged for post-launch gap.

## Tests

`apps/api/src/routes/__tests__/webhook-pglite.test.ts` adds 4 tests under a new describe block:

1. **full credit-bundle refund debits agentCreditBalance** — full refund with metadata gate matched; balance debited by full amount.
2. **ambiguous user lookup logs warning + skips** — verifies the safety bail-out path.
3. **full subscription invoice refund calls Stripe subscriptions.cancel** — verifies the new cancel call with idempotent flags.
4. **already-canceled Stripe subscription handled gracefully (idempotent)** — Stripe error on `resource_missing` / `already canceled` treated as no-op success.

Mock setup uses the SDK v20 invoice shape (`parent.subscription_details.subscription`).

## Verified

- [x] `pnpm --filter api typecheck` clean
- [x] `pnpm --filter api test webhook-pglite` — 10/10 green (6 prior + 4 new)
- [x] Pre-push gate PASS
- [ ] CI pipeline (will run on this PR)

## Out of scope (deferred)

- BLOCKING-A (perpetual-license refund) — schema-blocked; needs charge → license linkage. Tracked separately as a v0.4.x design task; admin-manual workaround for the rare pre-launch perpetual-refund case.
- Non-blocking gaps from §6 (A: usage_meters policy doc; B: refund email assertions; C: refund-before-checkout race).

## Test plan

- [ ] CI green
- [ ] Squash-merge after CI green per `feedback_no_auto_merge` standing policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
