### PR TITLE
test(billing): GAP-124 surfaces 7+9 — pending_change route tests + downgrade-cap e2e webhook test

### DIFF
--- a/apps/api/src/routes/__tests__/billing-pending-change.test.ts
+++ b/apps/api/src/routes/__tests__/billing-pending-change.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Billing pending_change mutex route tests (R5-H10)
+ *
+ * Closes Surface 7 / Gap B (GAP-124): the `pending_change` 409 mutex on
+ * POST /upgrade and POST /downgrade had ZERO route-level test coverage
+ * prior to this file. The in-memory mock in
+ * `apps/api/src/__tests__/concurrency/billing-races.test.ts:304-379` does
+ * NOT exercise the real route's metadata-check path  -  it tests a separate
+ * fake subscription manager.
+ *
+ * Coverage:
+ * - Single plan-change request → 200 success (no pending_change set)
+ * - Concurrent plan-change requests for the SAME customer → second returns
+ *   409 with the "subscription change is already in progress" reason
+ * - Concurrent plan-changes for DIFFERENT customers → both succeed (mutex
+ *   is per-customer / per-subscription, not global)
+ * - All three mirrored across upgrade direction + downgrade direction = 6
+ *
+ * The mock pattern intentionally mirrors `billing.test.ts` and
+ * `billing-comprehensive.test.ts`  -  thenable Drizzle select chain, vi.hoisted
+ * Stripe surface, in-memory metadata state for the subscription so the second
+ * call sees the metadata the first call wrote (analogous to real Stripe-side
+ * pending_change persistence between two separate webhook deliveries).
+ */
+
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
+
+const mockCustomersCreate = vi.hoisted(() => vi.fn());
+const mockCheckoutSessionsCreate = vi.hoisted(() => vi.fn());
+const mockBillingPortalSessionsCreate = vi.hoisted(() => vi.fn());
+const mockSubscriptionsList = vi.hoisted(() => vi.fn());
+const mockSubscriptionsUpdate = vi.hoisted(() => vi.fn());
+const mockMeterEventsCreate = vi.hoisted(() => vi.fn());
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(
+    class {
+      customers = { create: mockCustomersCreate };
+      checkout = { sessions: { create: mockCheckoutSessionsCreate } };
+      billingPortal = { sessions: { create: mockBillingPortalSessionsCreate } };
+      subscriptions = { list: mockSubscriptionsList, update: mockSubscriptionsUpdate };
+      billing = { meterEvents: { create: mockMeterEventsCreate } };
+      refunds = { create: vi.fn() };
+      invoices = { list: vi.fn() };
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+}));
+
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    customers: { create: mockCustomersCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    billingPortal: { sessions: { create: mockBillingPortalSessionsCreate } },
+    subscriptions: { list: mockSubscriptionsList, update: mockSubscriptionsUpdate },
+    refunds: { create: vi.fn() },
+    invoices: { list: vi.fn() },
+  },
+  getStripe: vi.fn(() => ({
+    billing: { meterEvents: { create: mockMeterEventsCreate } },
+  })),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  accountMemberships: {
+    accountId: 'accountMemberships.accountId',
+    userId: 'accountMemberships.userId',
+    status: 'accountMemberships.status',
+  },
+  accountSubscriptions: {
+    accountId: 'accountSubscriptions.accountId',
+    stripeCustomerId: 'accountSubscriptions.stripeCustomerId',
+  },
+  accountEntitlements: {
+    accountId: 'accountEntitlements.accountId',
+    tier: 'accountEntitlements.tier',
+    status: 'accountEntitlements.status',
+  },
+  billingCatalog: {
+    stripePriceId: 'billingCatalog.stripePriceId',
+    planId: 'billingCatalog.planId',
+    tier: 'billingCatalog.tier',
+    billingModel: 'billingCatalog.billingModel',
+    active: 'billingCatalog.active',
+  },
+  users: {
+    id: 'users.id',
+    stripeCustomerId: 'users.stripeCustomerId',
+    updatedAt: 'users.updatedAt',
+  },
+  licenses: {
+    tier: 'licenses.tier',
+    status: 'licenses.status',
+    expiresAt: 'licenses.expiresAt',
+    licenseKey: 'licenses.licenseKey',
+    userId: 'licenses.userId',
+    createdAt: 'licenses.createdAt',
+    deletedAt: 'licenses.deletedAt',
+    perpetual: 'licenses.perpetual',
+    subscriptionId: 'licenses.subscriptionId',
+    supportExpiresAt: 'licenses.supportExpiresAt',
+    id: 'licenses.id',
+  },
+  agentTaskUsage: {
+    userId: 'agentTaskUsage.userId',
+    overage: 'agentTaskUsage.overage',
+    count: 'agentTaskUsage.count',
+    cycleStart: 'agentTaskUsage.cycleStart',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col, _val) => `eq(${String(_col)},${String(_val)})`),
+  desc: vi.fn((_col) => `desc(${String(_col)})`),
+  and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
+  gt: vi.fn((_col, _val) => `gt(${String(_col)},${String(_val)})`),
+  gte: vi.fn((_col, _val) => `gte(${String(_col)},${String(_val)})`),
+  lt: vi.fn((_col, _val) => `lt(${String(_col)},${String(_val)})`),
+  lte: vi.fn((_col, _val) => `lte(${String(_col)},${String(_val)})`),
+  isNull: vi.fn((_col) => `isNull(${String(_col)})`),
+  ne: vi.fn((_col, _val) => `ne(${String(_col)},${String(_val)})`),
+  count: vi.fn(() => 'count()'),
+  countDistinct: vi.fn((_col) => `countDistinct(${String(_col)})`),
+  sql: Object.assign(
+    vi.fn((...args: unknown[]) => `sql(${args.join(',')})`),
+    {
+      join: vi.fn((...args: unknown[]) => `sql.join(${args.join(',')})`),
+    },
+  ),
+}));
+
+// ─── DB Mock  -  thenable fluent chain ─────────────────────────────────────────
+//
+// Mirrors the pattern used by billing.test.ts so the mocked queries route
+// through the same stub object regardless of chain depth.
+
+let _selectResult: unknown[] = [];
+let _selectQueue: unknown[][] = [];
+
+const mockDbSelectChain = {
+  from: vi.fn(),
+  innerJoin: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  limit: vi.fn(),
+  then(
+    onFulfilled?: (value: unknown[]) => unknown,
+    onRejected?: (reason: unknown) => unknown,
+  ): Promise<unknown> {
+    return Promise.resolve(_selectResult).then(onFulfilled, onRejected);
+  },
+  catch(onRejected: (reason: unknown) => unknown) {
+    return Promise.resolve(_selectResult).catch(onRejected);
+  },
+};
+
+const mockDbUpdateChain = { set: vi.fn(), where: vi.fn() };
+
+const mockDb = { select: vi.fn(), update: vi.fn(), transaction: vi.fn() };
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => mockDb),
+  getRestPool: vi.fn(() => null),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: mockLogger,
+  createLogger: () => mockLogger,
+}));
+
+// ─── Import under test (after mocks) ─────────────────────────────────────────
+
+import billingApp from '../billing.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface UserContext {
+  id: string;
+  email: string | null;
+  name: string;
+  role: string;
+}
+
+const MOCK_USER: UserContext = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'admin',
+};
+
+function createApp(user: UserContext = MOCK_USER) {
+  const app = new Hono<{
+    Variables: {
+      user: UserContext | undefined;
+      entitlements?:
+        | {
+            accountId?: string | null;
+            subscriptionStatus?: string | null;
+            tier?: 'free' | 'pro' | 'max' | 'enterprise';
+            limits?: { maxAgentTasks?: number };
+          }
+        | undefined;
+    };
+  }>();
+  app.use('*', async (c, next) => {
+    c.set('user', user);
+    await next();
+  });
+  app.route('/', billingApp);
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) {
+      return c.json({ error: err.message }, err.status);
+    }
+    return c.json({ error: 'Internal server error' }, 500);
+  });
+  return app;
+}
+
+function resetChains() {
+  _selectResult = [];
+  _selectQueue = [];
+  mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.innerJoin.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.where.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.orderBy.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.limit.mockImplementation(() => Promise.resolve(_selectResult));
+  mockDbUpdateChain.set.mockReturnValue(mockDbUpdateChain);
+  mockDbUpdateChain.where.mockResolvedValue({ rowCount: 1 });
+  mockDb.select.mockImplementation(() => {
+    if (_selectQueue.length > 0) {
+      _selectResult = _selectQueue.shift() ?? [];
+    }
+    return mockDbSelectChain;
+  });
+  mockDb.update.mockReturnValue(mockDbUpdateChain);
+  mockDb.transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
+    cb(mockDb),
+  );
+  mockSubscriptionsList.mockResolvedValue({ data: [] });
+  mockSubscriptionsUpdate.mockResolvedValue({});
+}
+
+function queueSelectResults(...results: unknown[][]) {
+  _selectQueue = [...results];
+}
+
+function post(path: string, body: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Build a mock subscription whose `metadata` is a live reference shared
+ * across `subscriptions.list` and `subscriptions.update`. Mutating `metadata`
+ * after a call models Stripe-side persistence: the next list response sees
+ * the metadata that the previous update wrote, exactly as a second concurrent
+ * route handler would observe it on a real Stripe account.
+ */
+function makeStripeSubscription(opts: {
+  id: string;
+  itemId?: string;
+  metadata?: Record<string, string>;
+}) {
+  return {
+    id: opts.id,
+    status: 'active',
+    items: { data: [{ id: opts.itemId ?? `si_${opts.id}` }] },
+    metadata: { ...(opts.metadata ?? {}) },
+    cancel_at: null,
+    cancel_at_period_end: false,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /upgrade  -  pending_change mutex (R5-H10)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChains();
+    process.env.STRIPE_SECRET_KEY = 'stripe_test_placeholder';
+    process.env.STRIPE_PRO_PRICE_ID = 'price_pro_server';
+    process.env.STRIPE_MAX_PRICE_ID = 'price_max_server';
+    process.env.STRIPE_ENTERPRISE_PRICE_ID = 'price_enterprise_server';
+  });
+
+  it('single plan-change request returns 200 success when no pending_change is set', async () => {
+    queueSelectResults(
+      [{ stripePriceId: 'price_enterprise_server' }],
+      [],
+      [{ stripeCustomerId: 'cus_solo' }],
+    );
+    const subscription = makeStripeSubscription({ id: 'sub_solo' });
+    mockSubscriptionsList.mockResolvedValue({ data: [subscription] });
+    mockSubscriptionsUpdate.mockImplementation(
+      async (_id: string, args: { metadata?: Record<string, string> }) => {
+        if (args.metadata) {
+          subscription.metadata = { ...subscription.metadata, ...args.metadata };
+        }
+        return subscription;
+      },
+    );
+
+    const app = createApp();
+    const res = await app.request(
+      post('/upgrade', { priceId: 'price_enterprise_server', targetTier: 'enterprise' }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('concurrent upgrade requests for the SAME customer  -  second returns 409 with pending_change reason', async () => {
+    queueSelectResults(
+      // First request select chain
+      [{ stripePriceId: 'price_enterprise_server' }],
+      [],
+      [{ stripeCustomerId: 'cus_dual' }],
+      // Second request select chain
+      [{ stripePriceId: 'price_enterprise_server' }],
+      [],
+      [{ stripeCustomerId: 'cus_dual' }],
+    );
+
+    // Shared subscription state. After the first .update, the metadata
+    // contains pending_change/pending_change_at; the second .list returns
+    // the same object with that metadata populated  -  same pattern Stripe
+    // exhibits on a real second concurrent webhook delivery.
+    const subscription = makeStripeSubscription({ id: 'sub_dual' });
+    mockSubscriptionsList.mockResolvedValue({ data: [subscription] });
+    mockSubscriptionsUpdate.mockImplementation(
+      async (_id: string, args: { metadata?: Record<string, string> }) => {
+        if (args.metadata) {
+          subscription.metadata = { ...subscription.metadata, ...args.metadata };
+        }
+        return subscription;
+      },
+    );
+
+    const app = createApp();
+
+    // Request 1  -  succeeds, writes pending_change into Stripe metadata
+    const res1 = await app.request(
+      post('/upgrade', { priceId: 'price_enterprise_server', targetTier: 'enterprise' }),
+    );
+    expect(res1.status).toBe(200);
+    expect(subscription.metadata.pending_change).toBe('upgrade:enterprise');
+    expect(subscription.metadata.pending_change_at).toBeDefined();
+
+    // Request 2  -  sees pending_change in metadata, returns 409
+    const res2 = await app.request(
+      post('/upgrade', { priceId: 'price_enterprise_server', targetTier: 'enterprise' }),
+    );
+
+    expect(res2.status).toBe(409);
+    const body2 = (await res2.json()) as Record<string, unknown>;
+    expect(body2.error as string).toContain('subscription change is already in progress');
+    // Only ONE Stripe.subscriptions.update call  -  the second never reached the API
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('concurrent upgrade requests for DIFFERENT customers both succeed (mutex is per-customer)', async () => {
+    // First select chain → customer A; second select chain → customer B
+    queueSelectResults(
+      [{ stripePriceId: 'price_enterprise_server' }],
+      [],
+      [{ stripeCustomerId: 'cus_alice' }],
+      [{ stripePriceId: 'price_enterprise_server' }],
+      [],
+      [{ stripeCustomerId: 'cus_bob' }],
+    );
+
+    const subAlice = makeStripeSubscription({ id: 'sub_alice' });
+    const subBob = makeStripeSubscription({ id: 'sub_bob' });
+
+    // Stripe.subscriptions.list returns the matching customer's subscription.
+    // Each list call sees fresh metadata for that customer; mutex on Alice's
+    // subscription must not affect Bob's.
+    mockSubscriptionsList.mockImplementation(async (args: { customer: string }) => {
+      if (args.customer === 'cus_alice') return { data: [subAlice] };
+      if (args.customer === 'cus_bob') return { data: [subBob] };
+      return { data: [] };
+    });
+
+    mockSubscriptionsUpdate.mockImplementation(
+      async (id: string, args: { metadata?: Record<string, string> }) => {
+        const target = id === 'sub_alice' ? subAlice : subBob;
+        if (args.metadata) {
+          target.metadata = { ...target.metadata, ...args.metadata };
+        }
+        return target;
+      },
+    );
+
+    const aliceUser: UserContext = {
+      id: 'user-alice',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'admin',
+    };
+    const bobUser: UserContext = {
+      id: 'user-bob',
+      email: 'bob@example.com',
+      name: 'Bob',
+      role: 'admin',
+    };
+
+    const aliceApp = createApp(aliceUser);
+    const bobApp = createApp(bobUser);
+
+    // Alice upgrades  -  pending_change written on sub_alice
+    const aliceRes = await aliceApp.request(
+      post('/upgrade', { priceId: 'price_enterprise_server', targetTier: 'enterprise' }),
+    );
+    expect(aliceRes.status).toBe(200);
+    expect(subAlice.metadata.pending_change).toBe('upgrade:enterprise');
+    // Bob's subscription metadata remains untouched (mutex is per-customer)
+    expect(subBob.metadata.pending_change).toBeUndefined();
+
+    // Bob upgrades  -  succeeds because his subscription has no pending_change
+    const bobRes = await bobApp.request(
+      post('/upgrade', { priceId: 'price_enterprise_server', targetTier: 'enterprise' }),
+    );
+    expect(bobRes.status).toBe(200);
+    expect(subBob.metadata.pending_change).toBe('upgrade:enterprise');
+
+    // Both .update calls reached Stripe (the mutex did NOT cross-block customers)
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('POST /downgrade  -  pending_change mutex (R5-H10)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChains();
+    process.env.STRIPE_SECRET_KEY = 'stripe_test_placeholder';
+  });
+
+  it('single plan-change request returns 200 success when no pending_change is set', async () => {
+    _selectResult = [{ stripeCustomerId: 'cus_solo' }];
+    const subscription = makeStripeSubscription({ id: 'sub_solo' });
+    mockSubscriptionsList.mockResolvedValue({ data: [subscription] });
+    mockSubscriptionsUpdate.mockImplementation(
+      async (_id: string, args: { metadata?: Record<string, string> }) => {
+        if (args.metadata) {
+          subscription.metadata = { ...subscription.metadata, ...args.metadata };
+        }
+        return { ...subscription, cancel_at: null };
+      },
+    );
+
+    const app = createApp();
+    const res = await app.request(post('/downgrade', {}));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('concurrent downgrade requests for the SAME customer  -  second returns 409 with pending_change reason', async () => {
+    // Both downgrade calls go through resolveHostedStripeCustomerId → same
+    // queued select results for both requests.
+    let selectCallCount = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCallCount++;
+      _selectResult = [{ stripeCustomerId: 'cus_dual' }];
+      return mockDbSelectChain;
+    });
+
+    const subscription = makeStripeSubscription({ id: 'sub_dual' });
+    mockSubscriptionsList.mockResolvedValue({ data: [subscription] });
+    mockSubscriptionsUpdate.mockImplementation(
+      async (_id: string, args: { metadata?: Record<string, string> }) => {
+        if (args.metadata) {
+          subscription.metadata = { ...subscription.metadata, ...args.metadata };
+        }
+        return { ...subscription, cancel_at: null };
+      },
+    );
+
+    const app = createApp();
+
+    const res1 = await app.request(post('/downgrade', {}));
+    expect(res1.status).toBe(200);
+    expect(subscription.metadata.pending_change).toBe('downgrade:free');
+    expect(subscription.metadata.pending_change_at).toBeDefined();
+
+    const res2 = await app.request(post('/downgrade', {}));
+    expect(res2.status).toBe(409);
+    const body2 = (await res2.json()) as Record<string, unknown>;
+    expect(body2.error as string).toContain('subscription change is already in progress');
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce();
+    expect(selectCallCount).toBeGreaterThan(0);
+  });
+
+  it('concurrent downgrade requests for DIFFERENT customers both succeed (mutex is per-customer)', async () => {
+    // Alice's request reads cus_alice; Bob's request reads cus_bob.
+    // Each downgrade call goes through resolveHostedStripeCustomerId which
+    // performs 2 selects (membership lookup + users.stripeCustomerId fallback).
+    // We toggle Alice → Bob on every 2nd select so each user sees the right
+    // customer end-to-end.
+    let selectCallCount = 0;
+    mockDb.select.mockImplementation(() => {
+      selectCallCount++;
+      _selectResult =
+        selectCallCount <= 2
+          ? [{ stripeCustomerId: 'cus_alice' }]
+          : [{ stripeCustomerId: 'cus_bob' }];
+      return mockDbSelectChain;
+    });
+
+    const subAlice = makeStripeSubscription({ id: 'sub_alice' });
+    const subBob = makeStripeSubscription({ id: 'sub_bob' });
+
+    mockSubscriptionsList.mockImplementation(async (args: { customer: string }) => {
+      if (args.customer === 'cus_alice') return { data: [subAlice] };
+      if (args.customer === 'cus_bob') return { data: [subBob] };
+      return { data: [] };
+    });
+
+    mockSubscriptionsUpdate.mockImplementation(
+      async (id: string, args: { metadata?: Record<string, string> }) => {
+        const target = id === 'sub_alice' ? subAlice : subBob;
+        if (args.metadata) {
+          target.metadata = { ...target.metadata, ...args.metadata };
+        }
+        return { ...target, cancel_at: null };
+      },
+    );
+
+    const aliceUser: UserContext = {
+      id: 'user-alice',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'admin',
+    };
+    const bobUser: UserContext = {
+      id: 'user-bob',
+      email: 'bob@example.com',
+      name: 'Bob',
+      role: 'admin',
+    };
+
+    const aliceRes = await createApp(aliceUser).request(post('/downgrade', {}));
+    expect(aliceRes.status).toBe(200);
+    expect(subAlice.metadata.pending_change).toBe('downgrade:free');
+    expect(subBob.metadata.pending_change).toBeUndefined();
+
+    const bobRes = await createApp(bobUser).request(post('/downgrade', {}));
+    expect(bobRes.status).toBe(200);
+    expect(subBob.metadata.pending_change).toBe('downgrade:free');
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/routes/__tests__/webhook-downgrade-cap.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-downgrade-cap.test.ts
@@ -1,0 +1,585 @@
+/**
+ * Webhook end-to-end downgrade resource cap (PGlite)
+ *
+ * Closes Surface 7 / Gap D + Surface 9 / Gap B (GAP-124): the
+ * `capResourcesOnDowngrade` module is unit-tested for direction logic
+ * (downgrade-cap.test.ts) but no test fires a real
+ * `customer.subscription.updated` webhook with oldTier=max, newTier=<lower>
+ * and verifies sites get archived + non-owner memberships revoked end-to-end.
+ *
+ * This file uses PGlite + the actual webhooks route, so the entire chain
+ * (webhook signature → saga steps → syncHostedSubscriptionState →
+ * capResourcesOnDowngrade → DB UPDATE) is exercised against in-memory
+ * Postgres with real Drizzle queries.
+ *
+ * NEW FILE (not edited webhook-pglite.test.ts) to avoid a merge collision
+ * with the parallel Surface 6 fix-train, which is editing webhook-pglite.test.ts.
+ *
+ * Coverage:
+ * - max → pro downgrade with site count > pro limit → over-quota archived
+ *   (oldest first), under-quota retained
+ * - max → pro downgrade with site count UNDER pro limit → no-op (no archives)
+ * - max → free downgrade → archives sites > free limit AND revokes non-owner
+ *   memberships > free limit (owner is never revoked)
+ * - Multi-account customer downgrade → only the affected account's resources
+ *   are capped (cross-account isolation via per-account memberIds query)
+ */
+
+import {
+  accountEntitlements,
+  accountMemberships,
+  accountSubscriptions,
+  accounts,
+  sites,
+  users,
+} from '@revealui/db/schema';
+import { asc, eq, inArray } from 'drizzle-orm';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  seedTestUser,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+// ─── Mocks (before imports) ─────────────────────────────────────────────────
+
+const mockConstructEvent = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
+const mockSubscriptionsUpdate = vi.fn();
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(
+    class {
+      webhooks = { constructEventAsync: mockConstructEvent };
+      subscriptions = {
+        update: mockSubscriptionsUpdate,
+        retrieve: mockSubscriptionsRetrieve,
+        list: vi.fn().mockResolvedValue({ data: [] }),
+      };
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+}));
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const { DrizzleAuditStore: RealAuditStore, executeSaga: realExecuteSaga } =
+    await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return {
+    getClient: () => testDb.drizzle,
+    DrizzleAuditStore: RealAuditStore,
+    executeSaga: realExecuteSaga,
+  };
+});
+
+vi.mock('@revealui/core/license', () => ({
+  generateLicenseKey: vi.fn().mockResolvedValue('test-jwt-license-key'),
+  resetLicenseState: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn(() => ({ ai: true, payments: true })),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  provisionGitHubAccess: vi.fn().mockResolvedValue(undefined),
+  sendCancellationConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+  sendDisputeLostEmail: vi.fn().mockResolvedValue(undefined),
+  sendDisputeReceivedEmail: vi.fn().mockResolvedValue(undefined),
+  sendGracePeriodStartedEmail: vi.fn().mockResolvedValue(undefined),
+  sendLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentReceiptEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentRecoveredEmail: vi.fn().mockResolvedValue(undefined),
+  sendPerpetualLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendRefundProcessedEmail: vi.fn().mockResolvedValue(undefined),
+  sendSupportRenewalConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+  sendTierFallbackAlert: vi.fn().mockResolvedValue(undefined),
+  sendTrialEndingEmail: vi.fn().mockResolvedValue(undefined),
+  sendTrialExpiredEmail: vi.fn().mockResolvedValue(undefined),
+  sendWebhookFailureAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../middleware/license.js', () => ({
+  resetDbStatusCache: vi.fn(),
+  resetSupportExpiryCache: vi.fn(),
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import webhooksRoute from '../webhooks.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'whsec_test_secret';
+
+function makeStripeEvent(type: string, data: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `evt_${crypto.randomUUID().replace(/-/g, '')}`,
+    type,
+    data: { object: data },
+    created: Math.floor(Date.now() / 1000),
+    livemode: false,
+  };
+}
+
+async function postWebhook(event: Record<string, unknown>): Promise<Response> {
+  const body = JSON.stringify(event);
+  mockConstructEvent.mockResolvedValueOnce(event);
+  return webhooksRoute.request('/stripe', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Stripe-Signature': 't=12345,v1=fake',
+    },
+    body,
+  });
+}
+
+interface SeededAccount {
+  accountId: string;
+  ownerUserId: string;
+  memberUserIds: string[];
+  customerId: string;
+  subscriptionId: string;
+  siteIds: string[];
+  /** Owner membership row id (never revoked). */
+  ownerMembershipId: string;
+  /** Non-owner membership row ids ordered oldest-first by createdAt. */
+  nonOwnerMembershipIds: string[];
+}
+
+/**
+ * Seed an account with a Stripe customer + subscription, an owner, N
+ * non-owner memberships, and N sites distributed across members. Sites are
+ * created sequentially with explicit `createdAt` so the cap's "oldest-first"
+ * archival order is deterministic.
+ *
+ * @param tier  -  starting tier ('max' for the downgrade scenarios)
+ * @param siteCount  -  total sites to create owned by account members
+ * @param nonOwnerMembers  -  number of non-owner memberships beyond the owner
+ */
+async function seedAccount(opts: {
+  prefix: string;
+  tier: 'free' | 'pro' | 'max' | 'enterprise';
+  siteCount: number;
+  nonOwnerMembers: number;
+}): Promise<SeededAccount> {
+  const { prefix, tier, siteCount, nonOwnerMembers } = opts;
+  const accountId = `acct_${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+  const customerId = `cus_${prefix}`;
+  const subscriptionId = `sub_${prefix}`;
+
+  // Owner user
+  const owner = await seedTestUser(testDb.drizzle, {
+    id: `user_${prefix}_owner`,
+    email: `${prefix}-owner@example.com`,
+    stripeCustomerId: customerId,
+  });
+
+  // Non-owner members (one user per membership for ownership distribution)
+  const memberUsers: { id: string }[] = [];
+  for (let i = 0; i < nonOwnerMembers; i++) {
+    const u = await seedTestUser(testDb.drizzle, {
+      id: `user_${prefix}_m${i}`,
+      email: `${prefix}-m${i}@example.com`,
+    });
+    memberUsers.push(u);
+  }
+
+  // Account
+  await testDb.drizzle.insert(accounts).values({
+    id: accountId,
+    name: `${prefix} Account`,
+    slug: `slug-${accountId}`,
+  });
+
+  // Owner membership (oldest, never revoked)
+  const ownerMembershipId = crypto.randomUUID();
+  const baseTs = new Date('2026-01-01T00:00:00Z');
+  await testDb.drizzle.insert(accountMemberships).values({
+    id: ownerMembershipId,
+    accountId,
+    userId: owner.id,
+    role: 'owner',
+    status: 'active',
+    createdAt: baseTs,
+    updatedAt: baseTs,
+  });
+
+  // Non-owner memberships, ordered oldest → newest by createdAt for
+  // deterministic "newest-first" revocation
+  const nonOwnerMembershipIds: string[] = [];
+  for (let i = 0; i < memberUsers.length; i++) {
+    const id = crypto.randomUUID();
+    const ts = new Date(baseTs.getTime() + (i + 1) * 60_000); // +1 min each
+    await testDb.drizzle.insert(accountMemberships).values({
+      id,
+      accountId,
+      userId: memberUsers[i].id,
+      role: 'member',
+      status: 'active',
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    nonOwnerMembershipIds.push(id);
+  }
+
+  // Subscription row so resolveHostedAccountId can find this account from customerId.
+  // Set updatedAt explicitly to the past so the WH-3 eventTimestamp guard
+  // (`updatedAt < eventTimestamp`) lets the upsert proceed during the webhook.
+  const seededTs = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+  await testDb.drizzle.insert(accountSubscriptions).values({
+    id: crypto.randomUUID(),
+    accountId,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: tier,
+    status: 'active',
+    createdAt: seededTs,
+    updatedAt: seededTs,
+  });
+
+  // Entitlement at the seeded tier  -  this is the oldTier the cap reads.
+  // Same WH-3 timing rationale as above.
+  await testDb.drizzle.insert(accountEntitlements).values({
+    accountId,
+    planId: tier,
+    tier,
+    status: 'active',
+    features: {},
+    limits: {},
+    updatedAt: seededTs,
+  });
+
+  // Sites: distribute round-robin across [owner, ...memberUsers]
+  const allMembers = [owner, ...memberUsers];
+  const siteIds: string[] = [];
+  for (let i = 0; i < siteCount; i++) {
+    const id = `site_${prefix}_${i}_${crypto.randomUUID().slice(0, 6)}`;
+    const ownerForSite = allMembers[i % allMembers.length];
+    const siteTs = new Date(baseTs.getTime() + (i + 1) * 1000); // +1s each, deterministic
+    await testDb.drizzle.insert(sites).values({
+      id,
+      ownerId: ownerForSite.id,
+      name: `${prefix} site ${i}`,
+      slug: `${prefix}-site-${i}-${crypto.randomUUID().slice(0, 6)}`,
+      status: 'draft',
+      createdAt: siteTs,
+      updatedAt: siteTs,
+    });
+    siteIds.push(id);
+  }
+
+  return {
+    accountId,
+    ownerUserId: owner.id,
+    memberUserIds: memberUsers.map((m) => m.id),
+    customerId,
+    subscriptionId,
+    siteIds,
+    ownerMembershipId,
+    nonOwnerMembershipIds,
+  };
+}
+
+/** Build the customer.subscription.updated event used by all cases. */
+function makeDowngradeEvent(opts: {
+  customerId: string;
+  subscriptionId: string;
+  newTier: 'free' | 'pro' | 'max' | 'enterprise';
+}): Record<string, unknown> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return makeStripeEvent('customer.subscription.updated', {
+    id: opts.subscriptionId,
+    customer: opts.customerId,
+    status: 'active',
+    cancel_at_period_end: false,
+    metadata: { tier: opts.newTier },
+    items: {
+      data: [
+        {
+          id: 'si_mock',
+          current_period_start: nowSec,
+          current_period_end: nowSec + 30 * 24 * 60 * 60,
+        },
+      ],
+    },
+  });
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+  process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-private-key';
+
+  testDb = await createTestDb();
+}, 30_000);
+
+afterAll(async () => {
+  await testDb.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  // FK-safe delete order (sites depend on users; entitlements + memberships
+  // + subscriptions depend on accounts; accounts depend on nothing).
+  const { sql } = await import('drizzle-orm');
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "sites"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "licenses"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "processed_webhook_events"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "account_subscriptions"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "account_memberships"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "account_entitlements"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "accounts"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "users"'));
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('webhook downgrade cap  -  max → pro (over-quota)', () => {
+  it('archives the oldest excess sites (count > pro limit) and retains the rest', async () => {
+    // Pro limit = 5 sites; seed 8 → expect 3 oldest archived, 5 newest retained.
+    const seeded = await seedAccount({
+      prefix: 'overquota',
+      tier: 'max',
+      siteCount: 8,
+      nonOwnerMembers: 2,
+    });
+
+    const event = makeDowngradeEvent({
+      customerId: seeded.customerId,
+      subscriptionId: seeded.subscriptionId,
+      newTier: 'pro',
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    // Entitlement transitioned to pro
+    const [ent] = await testDb.drizzle
+      .select()
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, seeded.accountId));
+    expect(ent.tier).toBe('pro');
+
+    // Sites: count archived vs active
+    const allSites = await testDb.drizzle
+      .select({ id: sites.id, status: sites.status, createdAt: sites.createdAt })
+      .from(sites)
+      .where(inArray(sites.id, seeded.siteIds))
+      .orderBy(asc(sites.createdAt));
+
+    const archived = allSites.filter((s) => s.status === 'archived');
+    const active = allSites.filter((s) => s.status !== 'archived');
+
+    expect(archived).toHaveLength(3);
+    expect(active).toHaveLength(5);
+
+    // Oldest-first: archived should be the first 3 sites by createdAt
+    expect(archived.map((s) => s.id)).toEqual(seeded.siteIds.slice(0, 3));
+  });
+});
+
+describe('webhook downgrade cap  -  max → pro (under-quota)', () => {
+  it('is a no-op (no archives) when current site count is under the new tier limit', async () => {
+    // Pro limit = 5. Seed only 3 → cap should not archive anything.
+    const seeded = await seedAccount({
+      prefix: 'underquota',
+      tier: 'max',
+      siteCount: 3,
+      nonOwnerMembers: 1,
+    });
+
+    const event = makeDowngradeEvent({
+      customerId: seeded.customerId,
+      subscriptionId: seeded.subscriptionId,
+      newTier: 'pro',
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const [ent] = await testDb.drizzle
+      .select()
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, seeded.accountId));
+    expect(ent.tier).toBe('pro');
+
+    // No sites archived
+    const archived = await testDb.drizzle
+      .select({ id: sites.id })
+      .from(sites)
+      .where(eq(sites.status, 'archived'));
+    expect(archived).toHaveLength(0);
+
+    // All seeded sites still in their original state
+    const intact = await testDb.drizzle
+      .select({ id: sites.id, status: sites.status })
+      .from(sites)
+      .where(inArray(sites.id, seeded.siteIds));
+    expect(intact).toHaveLength(3);
+    for (const s of intact) {
+      expect(s.status).toBe('draft');
+    }
+  });
+});
+
+describe('webhook downgrade cap  -  max → free (sites + memberships)', () => {
+  // SKIPPED 2026-04-25: this test models max → free as a
+  // `customer.subscription.updated` event with `metadata.tier='free'`,
+  // but Stripe's convention is "free = no subscription" — a downgrade
+  // to free arrives as `customer.subscription.deleted`, not as a
+  // metadata-update on the existing subscription. The cap-on-deleted
+  // path requires different webhook fixture setup than the
+  // metadata-update path the other tests use.
+  //
+  // TODO follow-up gap: rewrite this test using
+  // `customer.subscription.deleted` to verify the max → free
+  // transition correctly archives + revokes per the free-tier
+  // limits. Until then, the max → pro tests cover the cap behavior;
+  // the max → free path's correctness is covered by Surface 8's
+  // state-machine tests + the dunning lifecycle tests.
+  it.skip('archives sites > free limit AND revokes non-owner memberships > free limit', async () => {
+    // Free limits: sites = 1, users = 3. Seed 4 sites + 5 non-owner members
+    // (= 6 total memberships including owner). After downgrade:
+    //   - sites: 4 → 1 archived = 3 (oldest first)
+    //   - memberships: 6 → 3 revoked = 3 newest non-owner. Owner survives.
+    const seeded = await seedAccount({
+      prefix: 'freeplunge',
+      tier: 'max',
+      siteCount: 4,
+      nonOwnerMembers: 5,
+    });
+
+    const event = makeDowngradeEvent({
+      customerId: seeded.customerId,
+      subscriptionId: seeded.subscriptionId,
+      newTier: 'free',
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const [ent] = await testDb.drizzle
+      .select()
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, seeded.accountId));
+    expect(ent.tier).toBe('free');
+
+    // Sites: 1 retained (newest), 3 archived (oldest first)
+    const allSites = await testDb.drizzle
+      .select({ id: sites.id, status: sites.status })
+      .from(sites)
+      .where(inArray(sites.id, seeded.siteIds))
+      .orderBy(asc(sites.createdAt));
+
+    const archivedSites = allSites.filter((s) => s.status === 'archived');
+    const activeSites = allSites.filter((s) => s.status !== 'archived');
+    expect(archivedSites).toHaveLength(3);
+    expect(activeSites).toHaveLength(1);
+    // Oldest 3 archived
+    expect(archivedSites.map((s) => s.id)).toEqual(seeded.siteIds.slice(0, 3));
+
+    // Memberships: 6 total → cap to 3. 3 newest non-owner revoked. Owner stays.
+    const allMemberships = await testDb.drizzle
+      .select({
+        id: accountMemberships.id,
+        role: accountMemberships.role,
+        status: accountMemberships.status,
+      })
+      .from(accountMemberships)
+      .where(eq(accountMemberships.accountId, seeded.accountId));
+
+    const revoked = allMemberships.filter((m) => m.status === 'revoked');
+    const active = allMemberships.filter((m) => m.status === 'active');
+
+    expect(revoked).toHaveLength(3);
+    expect(active).toHaveLength(3);
+    // None of the revoked are the owner
+    expect(revoked.every((m) => m.role !== 'owner')).toBe(true);
+    // Owner membership is active and untouched
+    const owner = allMemberships.find((m) => m.id === seeded.ownerMembershipId);
+    expect(owner?.status).toBe('active');
+    expect(owner?.role).toBe('owner');
+
+    // Newest-first revocation: the three newest non-owner memberships should
+    // be the ones revoked. seeded.nonOwnerMembershipIds is oldest-first, so
+    // the last 3 are newest.
+    const newestThreeNonOwner = seeded.nonOwnerMembershipIds.slice(-3);
+    const revokedIds = revoked.map((m) => m.id).sort();
+    expect(revokedIds).toEqual([...newestThreeNonOwner].sort());
+  });
+});
+
+describe('webhook downgrade cap  -  multi-account isolation', () => {
+  it('caps only the affected account; the other account retains its resources untouched', async () => {
+    // Seed two independent accounts. Downgrade ONLY account A; account B's
+    // resources must remain untouched (mutex is per-account, scoped via
+    // memberIds = active memberships of A).
+    const accountA = await seedAccount({
+      prefix: 'accta',
+      tier: 'max',
+      siteCount: 4, // pro limit 5 → no cap on sites
+      nonOwnerMembers: 0,
+    });
+    const accountB = await seedAccount({
+      prefix: 'acctb',
+      tier: 'max',
+      siteCount: 8, // would be over pro limit IF B were affected
+      nonOwnerMembers: 4,
+    });
+
+    // Downgrade only A: max → pro. A's 4 sites < pro limit (5) → no archive on A.
+    const event = makeDowngradeEvent({
+      customerId: accountA.customerId,
+      subscriptionId: accountA.subscriptionId,
+      newTier: 'pro',
+    });
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    // Account A: tier flipped to pro
+    const [entA] = await testDb.drizzle
+      .select()
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, accountA.accountId));
+    expect(entA.tier).toBe('pro');
+
+    // Account B: tier UNCHANGED (still 'max')
+    const [entB] = await testDb.drizzle
+      .select()
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, accountB.accountId));
+    expect(entB.tier).toBe('max');
+
+    // Account B sites all still active (none archived from this event)
+    const bSites = await testDb.drizzle
+      .select({ id: sites.id, status: sites.status })
+      .from(sites)
+      .where(inArray(sites.id, accountB.siteIds));
+    expect(bSites).toHaveLength(8);
+    for (const s of bSites) {
+      expect(s.status).toBe('draft');
+    }
+
+    // Account B memberships untouched
+    const bMemberships = await testDb.drizzle
+      .select({ id: accountMemberships.id, status: accountMemberships.status })
+      .from(accountMemberships)
+      .where(eq(accountMemberships.accountId, accountB.accountId));
+    expect(bMemberships).toHaveLength(5); // owner + 4 non-owners
+    for (const m of bMemberships) {
+      expect(m.status).toBe('active');
+    }
+  });
+});

--- a/apps/api/src/routes/__tests__/webhook-downgrade-cap.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-downgrade-cap.test.ts
@@ -81,9 +81,13 @@ vi.mock('@revealui/core/features', () => ({
   getFeaturesForTier: vi.fn(() => ({ ai: true, payments: true })),
 }));
 
-vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock('@revealui/core/observability/logger', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return {
+    logger,
+    createLogger: vi.fn(() => logger),
+  };
+});
 
 vi.mock('../../lib/webhook-emails.js', () => ({
   provisionGitHubAccess: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Closes Surface 7 Gap B + Gap D (= Surface 9 Gap B; same gap, two audits flagged it). Test-only PR — no production code changes.

**Surface 7 Gap B** (07-proration-on-plan-change.md §6 Gap B): 6 tests for the pending_change 409 mutex (3 upgrade + 3 downgrade) in new file billing-pending-change.test.ts.

**Surface 7 Gap D / Surface 9 Gap B** (09-downgrade-cap.md Gap B): 4 PGlite-backed e2e cap tests in new file webhook-downgrade-cap.test.ts. Note: max→free case skipped with TODO — needs customer.subscription.deleted modeling, not metadata.tier=free.

## Verified
- pnpm --filter api typecheck clean
- pnpm --filter api test billing-pending-change webhook-downgrade-cap — 9/10 passing + 1 skipped
- Pre-push gate PASS

## Production-code finding (documented, NOT fixed)
T7 TOCTOU window between subscriptions.list().find() and subscriptions.update() — already in 07-proration-on-plan-change.md §2 T7, not a new bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)