### PR TITLE
refactor(billing): consolidate 8 Stripe-client sites onto protectedStripe wrapper (GAP-131)

### DIFF
--- a/apps/admin/src/app/api/gdpr/delete/route.ts
+++ b/apps/admin/src/app/api/gdpr/delete/route.ts
@@ -6,7 +6,6 @@ import { users } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
 import { eq } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
-import Stripe from 'stripe';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import { writeGDPRAuditEntry } from '@/lib/utilities/gdpr-audit';
 import { getRevealUIInstance } from '@/lib/utilities/revealui-singleton';
@@ -111,24 +110,54 @@ async function gdprDeleteHandler(request: NextRequest) {
     }
 
     // Clean up Stripe customer record (GDPR: remove PII from third-party systems)
+    //
+    // GAP-131: Stripe access goes through the shared `protectedStripe` wrapper
+    // from `@revealui/services` (DB-backed circuit breaker, retry, single API
+    // version pin). The admin app pulls services via dynamic import (Pro peer
+    // dep) so the runtime degrades gracefully if services isn't installed.
+    //
+    // Failure handling: this remains NON-BLOCKING for the user deletion.
+    // GDPR mandates we delete the user record even if a third-party (Stripe)
+    // cleanup fails. The error is logged at ERROR with enough context for an
+    // operator to manually retry the Stripe-side `customers.del` (or a
+    // sweeper cron to pick it up). When the circuit breaker is OPEN the
+    // wrapper throws a recognisable "Stripe circuit breaker is OPEN" error;
+    // the same log path captures it so the retry surface is uniform.
+    let stripeCustomerId: string | null | undefined;
     try {
       const db = getClient();
       const [userRow] = await db
         .select({ stripeCustomerId: users.stripeCustomerId })
         .from(users)
         .where(eq(users.id, userIdToDelete));
+      stripeCustomerId = userRow?.stripeCustomerId;
 
-      if (userRow?.stripeCustomerId && process.env.STRIPE_SECRET_KEY) {
-        const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-          apiVersion: '2026-03-25.dahlia',
-        });
-        await stripe.customers.del(userRow.stripeCustomerId);
+      if (stripeCustomerId && process.env.STRIPE_SECRET_KEY) {
+        const services = await import('@revealui/services').catch(() => null);
+        if (!services) {
+          logger.error(
+            'Stripe customer cleanup skipped during GDPR delete — @revealui/services not installed',
+            {
+              userId: userIdToDelete,
+              stripeCustomerId,
+              action: 'manual-cleanup-required',
+            },
+          );
+        } else {
+          await services.protectedStripe.customers.del(stripeCustomerId);
+        }
       }
     } catch (stripeErr) {
-      // Non-blocking: Stripe cleanup failure should not prevent user deletion
+      // Non-blocking: Stripe cleanup failure should not prevent user deletion.
+      // The log includes stripeCustomerId so a sweeper cron / operator can
+      // replay the deletion when the breaker closes / Stripe recovers.
+      const message = stripeErr instanceof Error ? stripeErr.message : String(stripeErr);
       logger.error('Stripe customer cleanup failed during GDPR delete', {
         userId: userIdToDelete,
-        error: stripeErr instanceof Error ? stripeErr.message : String(stripeErr),
+        stripeCustomerId,
+        breakerOpen: message.includes('circuit breaker is OPEN'),
+        error: message,
+        action: 'manual-cleanup-required',
       });
     }
 

--- a/apps/api/src/lib/webhook-replay.ts
+++ b/apps/api/src/lib/webhook-replay.ts
@@ -18,8 +18,20 @@ export type ReplayOutcome =
   | { kind: 'stripe-error'; detail: string }
   | { kind: 'handler-error'; status: number; body: unknown };
 
+/**
+ * Minimum Stripe surface needed for replay: `events.retrieve`. Both the raw
+ * Stripe SDK client and the `protectedStripe` wrapper from
+ * `@revealui/services` satisfy this — the wrapper is preferred at consumer
+ * sites so replays go through the shared circuit breaker (GAP-131).
+ */
+export interface StripeEventsClient {
+  events: {
+    retrieve(id: string): Promise<Stripe.Event>;
+  };
+}
+
 export interface ReplayDeps {
-  stripe: Stripe;
+  stripe: StripeEventsClient;
   db: DbClient;
   webhookSecret: string;
   /**

--- a/apps/api/src/routes/__tests__/billing-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/billing-lifecycle.test.ts
@@ -14,10 +14,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -30,6 +37,26 @@ vi.mock('stripe', () => ({
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts and billing.ts now use protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    customers: { create: vi.fn(), update: vi.fn() },
+    charges: { retrieve: vi.fn() },
+    checkout: { sessions: { create: vi.fn() } },
+    billingPortal: { sessions: { create: vi.fn() } },
+    refunds: { create: vi.fn() },
+    invoices: { list: vi.fn() },
+    billing: { meterEvents: { create: vi.fn() } },
+  },
+  getStripe: vi.fn(),
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/billing.test.ts
+++ b/apps/api/src/routes/__tests__/billing.test.ts
@@ -46,6 +46,8 @@ vi.mock('@revealui/services', () => ({
     subscriptions: { list: mockSubscriptionsList, update: mockSubscriptionsUpdate },
     refunds: { create: vi.fn() },
     invoices: { list: vi.fn() },
+    // GAP-131: billing.meterEvents.create is now wrapped in protectedStripe
+    billing: { meterEvents: { create: mockMeterEventsCreate } },
   },
   getStripe: vi.fn(() => ({
     billing: { meterEvents: { create: mockMeterEventsCreate } },

--- a/apps/api/src/routes/__tests__/marketplace-endpoints.test.ts
+++ b/apps/api/src/routes/__tests__/marketplace-endpoints.test.ts
@@ -80,6 +80,15 @@ vi.mock('stripe', () => ({
   default: mockStripeConstructor,
 }));
 
+// GAP-131: marketplace now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    accounts: { create: mockStripeAccountsCreate },
+    accountLinks: { create: mockStripeAccountLinksCreate },
+    transfers: { create: mockStripeTransfersCreate },
+  },
+}));
+
 // ─── Drizzle mock with per-query result queue ───────────────────────────────
 
 /** Queue of results  -  each db.select() call shifts the next result from here. */

--- a/apps/api/src/routes/__tests__/marketplace.test.ts
+++ b/apps/api/src/routes/__tests__/marketplace.test.ts
@@ -88,6 +88,15 @@ vi.mock('stripe', () => ({
   default: mockStripeConstructor,
 }));
 
+// GAP-131: marketplace now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    accounts: { create: mockStripeAccountsCreate },
+    accountLinks: { create: mockStripeAccountLinksCreate },
+    transfers: { create: mockStripeTransfersCreate },
+  },
+}));
+
 // ─── Drizzle mock with per-query result queue ───────────────────────────────
 
 let selectResults: unknown[][] = [];

--- a/apps/api/src/routes/__tests__/pricing-edge.test.ts
+++ b/apps/api/src/routes/__tests__/pricing-edge.test.ts
@@ -17,13 +17,23 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 // Mocks  -  must come before imports
 // ---------------------------------------------------------------------------
 
-const mockProductsList = vi.fn();
-const mockLoggerWarn = vi.fn();
-const mockLoggerError = vi.fn();
+// Hoisted because vi.mock factories are hoisted above this line.
+const { mockProductsList, mockLoggerWarn, mockLoggerError } = vi.hoisted(() => ({
+  mockProductsList: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: class MockStripe {
     products = { list: mockProductsList };
+  },
+}));
+
+// GAP-131: pricing.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    products: { list: mockProductsList },
   },
 }));
 
@@ -54,6 +64,12 @@ beforeAll(async () => {
   vi.doMock('stripe', () => ({
     default: class MockStripe {
       products = { list: mockProductsList };
+    },
+  }));
+
+  vi.doMock('@revealui/services', () => ({
+    protectedStripe: {
+      products: { list: mockProductsList },
     },
   }));
 

--- a/apps/api/src/routes/__tests__/pricing.test.ts
+++ b/apps/api/src/routes/__tests__/pricing.test.ts
@@ -2,7 +2,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Module-level spy shared across the MockStripe instances.
 // The source caches the first Stripe instance, so all tests share one spy.
-const mockProductsList = vi.fn();
+// Hoisted because vi.mock factories are hoisted above this line.
+const { mockProductsList } = vi.hoisted(() => ({ mockProductsList: vi.fn() }));
 
 // Mock Stripe before imports
 vi.mock('stripe', () => {
@@ -12,6 +13,13 @@ vi.mock('stripe', () => {
     },
   };
 });
+
+// GAP-131: pricing.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    products: { list: mockProductsList },
+  },
+}));
 
 // Mock circuit breaker to pass through by default.
 // Individual tests can override CircuitBreakerOpenError by throwing it.
@@ -301,6 +309,13 @@ describe('GET /api/pricing  -  Stripe integration', () => {
       },
     }));
 
+    // GAP-131: pricing.ts now uses protectedStripe from @revealui/services
+    vi.doMock('@revealui/services', () => ({
+      protectedStripe: {
+        products: { list: sharedMockList },
+      },
+    }));
+
     vi.doMock('@revealui/core/error-handling', () => ({
       CircuitBreaker: class {
         async execute<T>(fn: () => Promise<T>): Promise<T> {
@@ -561,6 +576,13 @@ describe('GET /api/pricing  -  circuit breaker open', () => {
     vi.doMock('stripe', () => ({
       default: class MockStripe {
         products = { list: vi.fn() };
+      },
+    }));
+
+    // GAP-131: pricing.ts now uses protectedStripe from @revealui/services
+    vi.doMock('@revealui/services', () => ({
+      protectedStripe: {
+        products: { list: vi.fn() },
       },
     }));
 

--- a/apps/api/src/routes/__tests__/webhook-handler.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-handler.test.ts
@@ -21,11 +21,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockChargesRetrieve = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockChargesRetrieve,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -39,6 +47,20 @@ vi.mock('stripe', () => ({
       charges = { retrieve: mockChargesRetrieve };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    charges: { retrieve: mockChargesRetrieve },
+    customers: { update: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/webhook-lifecycle-complete.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-lifecycle-complete.test.ts
@@ -28,11 +28,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports ─────────────────────────────────────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockChargesRetrieve = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockChargesRetrieve,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -46,6 +54,20 @@ vi.mock('stripe', () => ({
       charges = { retrieve: mockChargesRetrieve };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    charges: { retrieve: mockChargesRetrieve },
+    customers: { update: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/webhook-payment-action-required.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-payment-action-required.test.ts
@@ -26,10 +26,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockSubscriptionsUpdate,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -42,6 +49,20 @@ vi.mock('stripe', () => ({
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+      update: mockSubscriptionsUpdate,
+    },
+    customers: { update: vi.fn() },
+    charges: { retrieve: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-pglite.test.ts
@@ -18,8 +18,10 @@ import {
 
 // ─── Mocks (before imports) ─────────────────────────────────────────────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
+const { mockConstructEvent, mockSubscriptionsRetrieve } = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -32,6 +34,20 @@ vi.mock('stripe', () => ({
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: vi.fn(),
+      retrieve: mockSubscriptionsRetrieve,
+      list: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    customers: { update: vi.fn() },
+    charges: { retrieve: vi.fn() },
+  },
 }));
 
 let testDb: TestDb;

--- a/apps/api/src/routes/__tests__/webhook-safety.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-safety.test.ts
@@ -15,12 +15,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockCustomersUpdate = vi.fn();
-const mockChargesRetrieve = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockCustomersUpdate,
+  mockChargesRetrieve,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockCustomersUpdate: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -35,6 +44,20 @@ vi.mock('stripe', () => ({
       charges = { retrieve: mockChargesRetrieve };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    customers: { update: mockCustomersUpdate },
+    charges: { retrieve: mockChargesRetrieve },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/webhook-signature-replay.test.ts
+++ b/apps/api/src/routes/__tests__/webhook-signature-replay.test.ts
@@ -19,10 +19,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
@@ -35,6 +42,20 @@ vi.mock('stripe', () => ({
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    customers: { update: vi.fn() },
+    charges: { retrieve: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({
@@ -825,23 +846,18 @@ describe('POST /stripe webhook  -  signature timing & replay protection', () => 
       expect(res.status).toBe(503);
     });
 
-    it('uses cached Stripe client even when STRIPE_SECRET_KEY is removed (module-level cache)', async () => {
-      // The Stripe client is cached at module level (let cachedStripe) after first use.
-      // Deleting the env var after the client is cached does not cause a 500  -
-      // the cached instance continues to work. This test verifies the caching behavior.
+    it('returns 503 when STRIPE_SECRET_KEY is removed (env preflight on every call)', async () => {
+      // GAP-131: webhooks.ts now uses the shared protectedStripe wrapper from
+      // @revealui/services. The route's `getStripeClient()` re-checks the env
+      // var on every request (preflight) and returns 503 when it is missing.
+      // The previous module-level `cachedStripe` cache that survived env-var
+      // deletion was removed when the per-file factory was deleted.
       delete process.env.STRIPE_SECRET_KEY;
-
-      mockConstructEvent.mockReturnValueOnce({
-        id: 'evt_cached_client',
-        type: 'unknown.event',
-        data: { object: {} },
-      });
 
       const app = createApp();
       const res = await app.request(postStripe(VALID_BODY, 't=123,v1=nokey'));
 
-      // Returns 200 because the cached Stripe client is reused
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(503);
     });
   });
 

--- a/apps/api/src/routes/__tests__/webhooks-expansion.test.ts
+++ b/apps/api/src/routes/__tests__/webhooks-expansion.test.ts
@@ -16,15 +16,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
-const mockChargesRetrieve = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockChargesRetrieve,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
-    // Must use a class  -  webhooks.ts calls `new Stripe(key)`
     class {
       webhooks = { constructEventAsync: mockConstructEvent };
       subscriptions = {
@@ -35,6 +42,20 @@ vi.mock('stripe', () => ({
       charges = { retrieve: mockChargesRetrieve };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    charges: { retrieve: mockChargesRetrieve },
+    customers: { update: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/__tests__/webhooks.test.ts
+++ b/apps/api/src/routes/__tests__/webhooks.test.ts
@@ -10,14 +10,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
-const mockConstructEvent = vi.fn();
-const mockSubscriptionsUpdate = vi.fn();
-const mockSubscriptionsRetrieve = vi.fn();
-const mockSubscriptionsList = vi.fn();
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+}));
 
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
-    // Must use a class  -  webhooks.ts calls `new Stripe(key)`
     class {
       webhooks = { constructEventAsync: mockConstructEvent };
       subscriptions = {
@@ -27,6 +33,20 @@ vi.mock('stripe', () => ({
       };
     } as unknown as (...args: unknown[]) => unknown,
   ),
+}));
+
+// GAP-131: webhooks.ts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    customers: { update: vi.fn() },
+    charges: { retrieve: vi.fn() },
+  },
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -1863,10 +1863,8 @@ app.openapi(reportOverageRoute, async (c) => {
   }
 
   const db = getClient();
-  // billing.meterEvents is not yet wrapped in protectedStripe — use raw client
-  // TODO: add billing.meterEvents to protectedStripe when Track B (credits) launches
-  const { getStripe } = await import('@revealui/services');
-  const stripe = getStripe();
+  // GAP-131: `billing.meterEvents.create` is now wrapped by protectedStripe;
+  // every Stripe call across the suite shares one circuit breaker.
 
   // Previous billing cycle = last calendar month
   const now = new Date();
@@ -1893,7 +1891,7 @@ app.openapi(reportOverageRoute, async (c) => {
     }
 
     try {
-      await stripe.billing.meterEvents.create(
+      await protectedStripe.billing.meterEvents.create(
         {
           event_name: meterEventName,
           payload: {

--- a/apps/api/src/routes/cron/billing-readiness.test.ts
+++ b/apps/api/src/routes/cron/billing-readiness.test.ts
@@ -28,6 +28,14 @@ vi.mock('stripe', () => ({
   },
 }));
 
+// GAP-131: billing-readiness now uses the protectedStripe wrapper from
+// @revealui/services for Stripe price parity checks.
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    prices: { retrieve: mockRetrieve },
+  },
+}));
+
 vi.mock('@revealui/db/client', () => ({
   getClient: vi.fn(() => mockDb),
 }));

--- a/apps/api/src/routes/cron/billing-readiness.ts
+++ b/apps/api/src/routes/cron/billing-readiness.ts
@@ -17,20 +17,11 @@ import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
+import { protectedStripe } from '@revealui/services';
 import { Hono } from 'hono';
-import Stripe from 'stripe';
 import { MRR_TIER_PRICE_FALLBACK_CENTS, type SubscriptionTierId } from '../../lib/tier-pricing.js';
 
 const app = new Hono();
-
-let cachedStripe: Stripe | undefined;
-function getStripeClient(): Stripe {
-  if (cachedStripe) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY?.trim();
-  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
-}
 
 /** Subscription tiers whose Stripe prices must match the MRR fallback. */
 const SUBSCRIPTION_TIERS: Array<{
@@ -159,8 +150,8 @@ app.post('/billing-readiness', async (c) => {
     const priceId = process.env[priceEnvVar]?.trim();
     if (!priceId) continue; // env-var absence already flagged by section 1
     try {
-      const stripe = getStripeClient();
-      const price = await stripe.prices.retrieve(priceId);
+      // GAP-131: shared protectedStripe wrapper.
+      const price = await protectedStripe.prices.retrieve(priceId);
       const expected = MRR_TIER_PRICE_FALLBACK_CENTS[tier];
       if (price.unit_amount === null) {
         results.push({

--- a/apps/api/src/routes/cron/drain-unreconciled.test.ts
+++ b/apps/api/src/routes/cron/drain-unreconciled.test.ts
@@ -55,6 +55,14 @@ vi.mock('stripe', () => {
   return { default: MockStripe };
 });
 
+// GAP-131: drain-unreconciled now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    events: { retrieve: vi.fn() },
+    webhooks: { generateTestHeaderStringAsync: vi.fn() },
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/cron/drain-unreconciled.ts
+++ b/apps/api/src/routes/cron/drain-unreconciled.ts
@@ -34,9 +34,9 @@ import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { unreconciledWebhooks } from '@revealui/db/schema';
+import { protectedStripe } from '@revealui/services';
 import { and, asc, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
-import Stripe from 'stripe';
 import { replayStripeEvent } from '../../lib/webhook-replay.js';
 import webhooksApp from '../webhooks.js';
 
@@ -100,7 +100,10 @@ app.post('/drain-unreconciled', async (c) => {
     Number.parseInt(process.env.DRAIN_DURATION_BUDGET_MS ?? '', 10) || DEFAULT_DURATION_BUDGET_MS;
 
   const db = getClient();
-  const stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-03-25.dahlia' });
+  // GAP-131: shared protectedStripe wrapper. The events.retrieve surface
+  // is structurally compatible with replayStripeEvent's ReplayDeps.stripe
+  // (StripeEventsClient).
+  const stripe = protectedStripe;
 
   // Oldest unresolved first — they are most at risk of escalating past the
   // 24h critical threshold.

--- a/apps/api/src/routes/cron/marketplace-payouts.test.ts
+++ b/apps/api/src/routes/cron/marketplace-payouts.test.ts
@@ -47,6 +47,13 @@ vi.mock('stripe', () => {
   };
 });
 
+// GAP-131: marketplace-payouts now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    transfers: { create: vi.fn() },
+  },
+}));
+
 const mockDb = {
   select: vi.fn(() => mockDb),
   from: vi.fn(() => mockDb),

--- a/apps/api/src/routes/cron/marketplace-payouts.ts
+++ b/apps/api/src/routes/cron/marketplace-payouts.ts
@@ -19,23 +19,14 @@ import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
 import { marketplaceServers, marketplaceTransactions } from '@revealui/db/schema';
+import { protectedStripe } from '@revealui/services';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
-import Stripe from 'stripe';
 
 const app = new Hono();
 
 /** Stripe minimum transfer amount in cents */
 const MIN_TRANSFER_CENTS = 50;
-
-let cachedStripe: Stripe | undefined;
-function getStripeClient(): Stripe {
-  if (cachedStripe) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY?.trim();
-  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
-}
 
 interface PayoutResult {
   stripeAccountId: string;
@@ -99,7 +90,8 @@ app.post('/marketplace-payouts', async (c) => {
       );
     }
 
-    const stripe = getStripeClient();
+    // GAP-131: shared protectedStripe wrapper (DB-backed circuit breaker + retry)
+    const stripe = protectedStripe;
     const results: PayoutResult[] = [];
 
     for (const payout of pendingPayouts) {

--- a/apps/api/src/routes/cron/reconcile-subscriptions.test.ts
+++ b/apps/api/src/routes/cron/reconcile-subscriptions.test.ts
@@ -33,6 +33,13 @@ vi.mock('stripe', () => {
   return { default: MockStripe };
 });
 
+// GAP-131: reconcile-subscriptions now uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    subscriptions: { retrieve: hoisted.retrieveMock },
+  },
+}));
+
 import reconcileApp from './reconcile-subscriptions.js';
 
 interface LocalRow {

--- a/apps/api/src/routes/cron/reconcile-subscriptions.ts
+++ b/apps/api/src/routes/cron/reconcile-subscriptions.ts
@@ -25,9 +25,10 @@ import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { accountSubscriptions } from '@revealui/db/schema';
+import { protectedStripe } from '@revealui/services';
 import { and, inArray, isNotNull } from 'drizzle-orm';
 import { Hono } from 'hono';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 
 const app = new Hono();
 
@@ -120,7 +121,10 @@ app.post('/reconcile-subscriptions', async (c) => {
     DEFAULT_DURATION_BUDGET_MS;
 
   const db = getClient();
-  const stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-03-25.dahlia' });
+  // Stripe access goes through the shared protectedStripe wrapper:
+  // single API-version pin, single DB-backed circuit breaker, single retry
+  // policy across all consumers (GAP-131).
+  const stripe = protectedStripe;
 
   // Only reconcile rows that believe they are live AND have a Stripe sub id
   // to compare against. Perpetual-license rows and credit-bundle-only

--- a/apps/api/src/routes/marketplace.ts
+++ b/apps/api/src/routes/marketplace.ts
@@ -24,9 +24,9 @@ import {
   type NewMarketplaceTransaction,
 } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { protectedStripe } from '@revealui/services';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
-import Stripe from 'stripe';
 import { authMiddleware } from '../middleware/auth.js';
 import { buildPaymentRequired, encodePaymentRequired, verifyPayment } from '../middleware/x402.js';
 
@@ -133,13 +133,15 @@ function computeSplit(priceUsdc: string): {
   };
 }
 
-let cachedStripe: Stripe | undefined;
-function getStripeClient(): Stripe {
-  if (cachedStripe) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY?.trim();
-  if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
+/**
+ * GAP-131: Stripe access goes through the shared protectedStripe wrapper
+ * (DB-backed circuit breaker + retry, single API-version pin).
+ */
+function getStripeClient(): typeof protectedStripe {
+  if (!process.env.STRIPE_SECRET_KEY?.trim()) {
+    throw new Error('STRIPE_SECRET_KEY not configured');
+  }
+  return protectedStripe;
 }
 
 // =============================================================================

--- a/apps/api/src/routes/pricing.ts
+++ b/apps/api/src/routes/pricing.ts
@@ -15,12 +15,18 @@ import {
 import { CircuitBreaker, CircuitBreakerOpenError } from '@revealui/core/error-handling';
 import { logger } from '@revealui/core/observability/logger';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
-import Stripe from 'stripe';
+import { protectedStripe } from '@revealui/services';
+import type Stripe from 'stripe';
 
 const app = new OpenAPIHono();
 
 // ---------------------------------------------------------------------------
-// Stripe client (self-contained  -  does not share with billing.ts)
+// Stripe client (GAP-131): the actual Stripe call goes through the shared
+// protectedStripe wrapper (DB-backed circuit breaker + retry, single API
+// version pin). The local `pricingBreaker` remains as a per-route fast-fail
+// guard that flips the response to fallback prices without waiting for the
+// DB breaker round-trip — pricing is hot-path public data and the fallback
+// is the right answer when Stripe is degraded.
 // ---------------------------------------------------------------------------
 
 const pricingBreaker = new CircuitBreaker({
@@ -29,16 +35,8 @@ const pricingBreaker = new CircuitBreaker({
   successThreshold: 2,
 });
 
-let cachedStripe: Stripe | null | undefined;
-function getStripeClient(): Stripe | null {
-  if (cachedStripe !== undefined) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) {
-    cachedStripe = null;
-    return null;
-  }
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
+function isStripeConfigured(): boolean {
+  return Boolean(process.env.STRIPE_SECRET_KEY);
 }
 
 // ---------------------------------------------------------------------------
@@ -143,12 +141,11 @@ interface StripeProductMap {
 }
 
 async function fetchStripePrices(): Promise<StripeProductMap | null> {
-  const stripe = getStripeClient();
-  if (!stripe) return null;
+  if (!isStripeConfigured()) return null;
 
   try {
     const result = await pricingBreaker.execute(async () => {
-      const products = await stripe.products.list({
+      const products = await protectedStripe.products.list({
         active: true,
         expand: ['data.default_price'],
         limit: 100,

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -28,8 +28,9 @@ import {
   users,
 } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { protectedStripe } from '@revealui/services';
 import { and, desc, eq, isNull, lt, sql } from 'drizzle-orm';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 import { capResourcesOnDowngrade, isDowngrade } from '../lib/downgrade-cap.js';
 import { getHostedLimitsForTier } from '../lib/tier-limits.js';
 import {
@@ -60,15 +61,18 @@ type DbExecutor = Pick<Database, 'select' | 'insert' | 'update' | 'delete'>;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-let cachedStripe: Stripe | undefined;
-function getStripeClient(): Stripe {
-  if (cachedStripe) return cachedStripe;
-  const key = process.env.STRIPE_SECRET_KEY?.trim();
-  if (!key) {
+/**
+ * GAP-131: All Stripe access goes through the shared `protectedStripe`
+ * wrapper from `@revealui/services` (DB-backed circuit breaker, retry,
+ * single API-version pin). The wrapper's `.webhooks` getter exposes the
+ * raw Stripe webhooks object for signature verification — that operation
+ * is offline (HMAC verify) and does not need breaker protection.
+ */
+function getStripeClient(): typeof protectedStripe {
+  if (!process.env.STRIPE_SECRET_KEY?.trim()) {
     throw new Error('STRIPE_SECRET_KEY not configured');
   }
-  cachedStripe = new Stripe(key, { apiVersion: '2026-03-25.dahlia', maxNetworkRetries: 2 });
-  return cachedStripe;
+  return protectedStripe;
 }
 
 function getWebhookSecret(): string {
@@ -698,7 +702,7 @@ const stripeWebhookRoute = createRoute({
 
 app.openapi(stripeWebhookRoute, async (c) => {
   let webhookSecret: string;
-  let stripe: Stripe;
+  let stripe: typeof protectedStripe;
   try {
     webhookSecret = getWebhookSecret();
     stripe = getStripeClient();

--- a/package.json
+++ b/package.json
@@ -201,7 +201,8 @@
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
-    "validate:raw-sql": "tsx scripts/validate/raw-sql.ts"
+    "validate:raw-sql": "tsx scripts/validate/raw-sql.ts",
+    "validate:stripe-client": "tsx scripts/validate/stripe-client.ts"
   },
   "type": "module"
 }

--- a/packages/services/__tests__/stripe-api-methods.test.ts
+++ b/packages/services/__tests__/stripe-api-methods.test.ts
@@ -79,6 +79,26 @@ function buildMockStripe() {
         create: vi.fn(),
       },
     },
+    charges: {
+      retrieve: vi.fn(),
+    },
+    transfers: {
+      create: vi.fn(),
+    },
+    accounts: {
+      create: vi.fn(),
+    },
+    accountLinks: {
+      create: vi.fn(),
+    },
+    events: {
+      retrieve: vi.fn(),
+    },
+    billing: {
+      meterEvents: {
+        create: vi.fn(),
+      },
+    },
     webhooks: { constructEvent: vi.fn() },
     balance: { retrieve: vi.fn() },
   };
@@ -298,5 +318,143 @@ describe('createProtectedStripe  -  error propagation', () => {
   it('propagates non-retryable errors from prices.list', async () => {
     mockStripe.prices.list.mockRejectedValue(new Error('Invalid API key [401]'));
     await expect(client.prices.list()).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GAP-131 — extended surface: charges, transfers, accounts, accountLinks,
+// events, billing.meterEvents (consumed by webhooks, marketplace, crons,
+// drain-unreconciled, billing.ts overage reporter)
+// ---------------------------------------------------------------------------
+
+describe('createProtectedStripe  -  charges', () => {
+  let mockStripe: ReturnType<typeof buildMockStripe>;
+  let client: ReturnType<typeof createProtectedStripe>;
+
+  beforeEach(() => {
+    mockStripe = buildMockStripe();
+    // biome-ignore lint/suspicious/noExplicitAny: test DI
+    client = createProtectedStripe(mockStripe as any);
+  });
+
+  it('charges.retrieve delegates to stripe instance', async () => {
+    const charge = { id: 'ch_1', object: 'charge', amount: 999 };
+    mockStripe.charges.retrieve.mockResolvedValue(charge);
+    const result = await client.charges.retrieve('ch_1');
+    expect(result).toEqual(charge);
+    expect(mockStripe.charges.retrieve).toHaveBeenCalledWith('ch_1');
+  });
+});
+
+describe('createProtectedStripe  -  transfers', () => {
+  let mockStripe: ReturnType<typeof buildMockStripe>;
+  let client: ReturnType<typeof createProtectedStripe>;
+
+  beforeEach(() => {
+    mockStripe = buildMockStripe();
+    // biome-ignore lint/suspicious/noExplicitAny: test DI
+    client = createProtectedStripe(mockStripe as any);
+  });
+
+  it('transfers.create delegates to stripe instance', async () => {
+    const transfer = { id: 'tr_1', object: 'transfer', amount: 5000 };
+    mockStripe.transfers.create.mockResolvedValue(transfer);
+    const result = await client.transfers.create({
+      amount: 5000,
+      currency: 'usd',
+      destination: 'acct_1',
+    });
+    expect(result).toEqual(transfer);
+    expect(mockStripe.transfers.create).toHaveBeenCalledWith(
+      { amount: 5000, currency: 'usd', destination: 'acct_1' },
+      undefined,
+    );
+  });
+
+  it('transfers.create propagates non-retryable errors', async () => {
+    mockStripe.transfers.create.mockRejectedValue(
+      new Error('Insufficient available balance [402]'),
+    );
+    await expect(
+      client.transfers.create({ amount: 5000, currency: 'usd', destination: 'acct_1' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('createProtectedStripe  -  accounts and accountLinks', () => {
+  let mockStripe: ReturnType<typeof buildMockStripe>;
+  let client: ReturnType<typeof createProtectedStripe>;
+
+  beforeEach(() => {
+    mockStripe = buildMockStripe();
+    // biome-ignore lint/suspicious/noExplicitAny: test DI
+    client = createProtectedStripe(mockStripe as any);
+  });
+
+  it('accounts.create delegates to stripe instance', async () => {
+    const account = { id: 'acct_1', object: 'account', type: 'express' };
+    mockStripe.accounts.create.mockResolvedValue(account);
+    const result = await client.accounts.create({ type: 'express' });
+    expect(result).toEqual(account);
+    expect(mockStripe.accounts.create).toHaveBeenCalledWith({ type: 'express' }, undefined);
+  });
+
+  it('accountLinks.create delegates to stripe instance', async () => {
+    const link = { object: 'account_link', url: 'https://connect.stripe.com/setup/...' };
+    mockStripe.accountLinks.create.mockResolvedValue(link);
+    const result = await client.accountLinks.create({
+      account: 'acct_1',
+      refresh_url: 'https://example.com/refresh',
+      return_url: 'https://example.com/return',
+      type: 'account_onboarding',
+    });
+    expect(result).toEqual(link);
+  });
+});
+
+describe('createProtectedStripe  -  events', () => {
+  let mockStripe: ReturnType<typeof buildMockStripe>;
+  let client: ReturnType<typeof createProtectedStripe>;
+
+  beforeEach(() => {
+    mockStripe = buildMockStripe();
+    // biome-ignore lint/suspicious/noExplicitAny: test DI
+    client = createProtectedStripe(mockStripe as any);
+  });
+
+  it('events.retrieve delegates to stripe instance', async () => {
+    const event = { id: 'evt_1', object: 'event', type: 'customer.subscription.updated' };
+    mockStripe.events.retrieve.mockResolvedValue(event);
+    const result = await client.events.retrieve('evt_1');
+    expect(result).toEqual(event);
+    expect(mockStripe.events.retrieve).toHaveBeenCalledWith('evt_1');
+  });
+});
+
+describe('createProtectedStripe  -  billing.meterEvents', () => {
+  let mockStripe: ReturnType<typeof buildMockStripe>;
+  let client: ReturnType<typeof createProtectedStripe>;
+
+  beforeEach(() => {
+    mockStripe = buildMockStripe();
+    // biome-ignore lint/suspicious/noExplicitAny: test DI
+    client = createProtectedStripe(mockStripe as any);
+  });
+
+  it('billing.meterEvents.create delegates to stripe instance with options', async () => {
+    const event = { object: 'billing.meter_event', event_name: 'agent_task_overage' };
+    mockStripe.billing.meterEvents.create.mockResolvedValue(event);
+    const result = await client.billing.meterEvents.create(
+      {
+        event_name: 'agent_task_overage',
+        payload: { stripe_customer_id: 'cus_1', value: '42' },
+      },
+      { idempotencyKey: 'overage-user-1' },
+    );
+    expect(result).toEqual(event);
+    expect(mockStripe.billing.meterEvents.create).toHaveBeenCalledWith(
+      expect.objectContaining({ event_name: 'agent_task_overage' }),
+      { idempotencyKey: 'overage-user-1' },
+    );
   });
 });

--- a/packages/services/src/stripe/stripeClient.ts
+++ b/packages/services/src/stripe/stripeClient.ts
@@ -362,6 +362,56 @@ function createProtectedStripe(stripeInstance?: Stripe) {
           'invoices.retrieve',
         ),
     },
+    charges: {
+      retrieve: (...args: Parameters<Stripe['charges']['retrieve']>): Promise<Stripe.Charge> =>
+        callWithResilience(() => getStripeInstance().charges.retrieve(...args), 'charges.retrieve'),
+    },
+    transfers: {
+      create: (
+        params: Stripe.TransferCreateParams,
+        options?: Stripe.RequestOptions,
+      ): Promise<Stripe.Transfer> =>
+        callWithResilience(
+          () => getStripeInstance().transfers.create(params, options),
+          'transfers.create',
+        ),
+    },
+    accounts: {
+      create: (
+        params?: Stripe.AccountCreateParams,
+        options?: Stripe.RequestOptions,
+      ): Promise<Stripe.Account> =>
+        callWithResilience(
+          () => getStripeInstance().accounts.create(params, options),
+          'accounts.create',
+        ),
+    },
+    accountLinks: {
+      create: (
+        params: Stripe.AccountLinkCreateParams,
+        options?: Stripe.RequestOptions,
+      ): Promise<Stripe.AccountLink> =>
+        callWithResilience(
+          () => getStripeInstance().accountLinks.create(params, options),
+          'accountLinks.create',
+        ),
+    },
+    events: {
+      retrieve: (...args: Parameters<Stripe['events']['retrieve']>): Promise<Stripe.Event> =>
+        callWithResilience(() => getStripeInstance().events.retrieve(...args), 'events.retrieve'),
+    },
+    billing: {
+      meterEvents: {
+        create: (
+          params: Stripe.Billing.MeterEventCreateParams,
+          options?: Stripe.RequestOptions,
+        ): Promise<Stripe.Billing.MeterEvent> =>
+          callWithResilience(
+            () => getStripeInstance().billing.meterEvents.create(params, options),
+            'billing.meterEvents.create',
+          ),
+      },
+    },
     get webhooks(): Stripe['webhooks'] {
       return getStripeInstance().webhooks;
     },

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -310,6 +310,11 @@ async function gate(): Promise<void> {
         args: ['validate:empty-catch'],
       },
       {
+        name: 'Stripe-client consolidation (hard fail)',
+        command: 'pnpm',
+        args: ['validate:stripe-client'],
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],

--- a/scripts/validate/stripe-client.ts
+++ b/scripts/validate/stripe-client.ts
@@ -144,7 +144,7 @@ function main(): void {
     `\n[validate:stripe-client] FAIL — ${violations.length} unauthorised \`new Stripe(\` site(s) detected.\n\n`,
   );
   process.stderr.write(
-    'Every consumer must use \`protectedStripe\` from \`@revealui/services\` (DB-backed\n' +
+    'Every consumer must use `protectedStripe` from `@revealui/services` (DB-backed\n' +
       'circuit breaker + retry + single API-version pin). The only legitimate site\n' +
       'is the canonical wrapper at packages/services/src/stripe/stripeClient.ts.\n\n' +
       'See GAP-131 for context. Migrate the offending site(s) to:\n\n' +

--- a/scripts/validate/stripe-client.ts
+++ b/scripts/validate/stripe-client.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env tsx
+
+/**
+ * Stripe-Client Consolidation Validator (GAP-131)
+ *
+ * Enforces that the only place in the suite that instantiates `new Stripe(...)`
+ * is the canonical `protectedStripe` wrapper at
+ * `packages/services/src/stripe/stripeClient.ts`.
+ *
+ * Rationale: every consumer-side `new Stripe(...)` bypasses the DB-backed
+ * circuit breaker, retry policy, and single API-version pin that
+ * `protectedStripe` provides. Six factories were consolidated in GAP-131; this
+ * gate prevents reintroduction.
+ *
+ * Allowlist:
+ *   - `packages/services/src/stripe/stripeClient.ts` — the canonical wrapper
+ *
+ * Excluded paths:
+ *   - `**\/__tests__/**`, `**\/*.test.ts`, `**\/*.test.tsx` (tests mock Stripe)
+ *   - `**\/dist/**`, `**\/build/**`, `**\/.next/**`, `**\/node_modules/**`
+ *   - `**\/coverage/**`, `**\/.turbo/**`
+ *
+ * Mirrors the pattern used by `validate/empty-catch.ts` /
+ * `validate/raw-sql.ts` — fast file-walk + regex check, hard-fail on
+ * unauthorised match.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const ROOT = join(import.meta.dirname, '..', '..');
+
+const ALLOWED_FILES = new Set<string>([
+  // Canonical wrapper — the only legitimate `new Stripe(...)` site
+  ['packages', 'services', 'src', 'stripe', 'stripeClient.ts'].join(sep),
+  // The validator script itself references the literal string in its rule.
+  ['scripts', 'validate', 'stripe-client.ts'].join(sep),
+]);
+
+const EXCLUDED_DIR_NAMES = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  'coverage',
+  '__tests__',
+]);
+
+function isExcludedDir(name: string): boolean {
+  return EXCLUDED_DIR_NAMES.has(name);
+}
+
+function isExcludedFile(rel: string): boolean {
+  if (rel.endsWith('.test.ts') || rel.endsWith('.test.tsx')) return true;
+  if (rel.endsWith('.d.ts')) return true;
+  return false;
+}
+
+function* walk(dir: string): Generator<string> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (isExcludedDir(entry)) continue;
+    const full = join(dir, entry);
+    let st: ReturnType<typeof statSync>;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      yield* walk(full);
+    } else if (st.isFile() && (entry.endsWith('.ts') || entry.endsWith('.tsx'))) {
+      yield full;
+    }
+  }
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function checkFile(absPath: string): Violation[] {
+  const rel = relative(ROOT, absPath);
+  if (isExcludedFile(rel)) return [];
+  if (ALLOWED_FILES.has(rel)) return [];
+
+  let raw: string;
+  try {
+    raw = readFileSync(absPath, 'utf8');
+  } catch {
+    return [];
+  }
+  if (!raw.includes('new Stripe(')) return [];
+
+  const violations: Violation[] = [];
+  const lines = raw.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    // Comment-only lines that mention "new Stripe(" are ignored.
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+      continue;
+    }
+    if (line.includes('new Stripe(')) {
+      violations.push({ file: rel, line: i + 1, text: line.trim() });
+    }
+  }
+  return violations;
+}
+
+function main(): void {
+  const targetRoots = [join(ROOT, 'apps'), join(ROOT, 'packages'), join(ROOT, 'scripts')];
+
+  const violations: Violation[] = [];
+  for (const root of targetRoots) {
+    let st: ReturnType<typeof statSync> | undefined;
+    try {
+      st = statSync(root);
+    } catch {
+      continue;
+    }
+    if (!st?.isDirectory()) continue;
+    for (const file of walk(root)) {
+      violations.push(...checkFile(file));
+    }
+  }
+
+  if (violations.length === 0) {
+    process.stdout.write(
+      '[validate:stripe-client] OK — only the canonical protectedStripe wrapper instantiates Stripe.\n',
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `\n[validate:stripe-client] FAIL — ${violations.length} unauthorised \`new Stripe(\` site(s) detected.\n\n`,
+  );
+  process.stderr.write(
+    'Every consumer must use \`protectedStripe\` from \`@revealui/services\` (DB-backed\n' +
+      'circuit breaker + retry + single API-version pin). The only legitimate site\n' +
+      'is the canonical wrapper at packages/services/src/stripe/stripeClient.ts.\n\n' +
+      'See GAP-131 for context. Migrate the offending site(s) to:\n\n' +
+      "    import { protectedStripe } from '@revealui/services';\n\n",
+  );
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}:${v.line}\n    ${v.text}\n`);
+  }
+  process.stderr.write('\n');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Closes GAP-131. 8 sites that bypassed the DB-backed circuit breaker now call through protectedStripe; CI guard at scripts/validate/stripe-client.ts rejects future regressions.

## Verified
- pnpm --filter api --filter admin --filter @revealui/services typecheck clean
- pnpm --filter @revealui/services test — 191/191 green
- pnpm --filter api test billing pricing webhook marketplace cron — 798/798 green
- Pre-push gate PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)