### PR TITLE
fix(admin): customersProxy look-up-first guard before customers.create (GAP-132 B-3)

### DIFF
--- a/apps/admin/src/lib/hooks/__tests__/stripe-sync-hooks.test.ts
+++ b/apps/admin/src/lib/hooks/__tests__/stripe-sync-hooks.test.ts
@@ -312,6 +312,10 @@ describe('customerProxy', () => {
     const newCustomer = { id: 'cus_new_1', email: 'new@test.com' };
 
     mockCustomersRetrieve.mockResolvedValue(existingCustomer);
+    // GAP-132 B-3 look-up-first guard: POST path calls customers.list({email}) before create.
+    // Empty result → fall through to create. (vi.clearAllMocks clears call history but not
+    // mockResolvedValue/mockRejectedValue from prior tests, so set this explicitly.)
+    mockCustomersList.mockResolvedValue({ data: [] });
     mockCustomersCreate.mockResolvedValue(newCustomer);
 
     const req = createMockRequest({

--- a/apps/admin/src/lib/hooks/customersProxy.ts
+++ b/apps/admin/src/lib/hooks/customersProxy.ts
@@ -152,6 +152,64 @@ export const customerProxy: RevealHandler = async (req: RevealRequest) => {
         }
         try {
           const validatedData = CustomerCreateSchema.parse(bodyData);
+
+          // GAP-132 B-3 — look-up-first guard.
+          //
+          // The canonical user-initiated checkout flow at
+          // apps/api/src/routes/billing.ts:233 wraps customers.create in
+          // ensureStripeCustomer, which uses a PostgreSQL advisory lock
+          // (`pg_advisory_xact_lock`) on the customer-by-email key + a Stripe
+          // idempotency-key header to serialize concurrent creations and
+          // prevent duplicate Stripe customer rows for the same email.
+          //
+          // This admin proxy DOES NOT route through that critical section
+          // (admin actions are intentionally god-mode, separate from the
+          // user-initiated flow). The race window: an admin manually
+          // creating a customer for email X while a user is mid-checkout
+          // for email X simultaneously can produce two Stripe customer
+          // records.
+          //
+          // Full atomic resolution (B-1: extract ensureStripeCustomer into
+          // a shared module) is deferred to v0.4.x post-launch. For the
+          // pre-Stripe-live posture, this look-up-first guard catches the
+          // common case where a user-initiated checkout already created
+          // the customer between admin actions: query Stripe for an
+          // existing customer with the requested email; if exactly one
+          // exists, reuse it instead of creating a duplicate.
+          //
+          // Limitations preserved (defer to B-1):
+          // - No advisory lock: a concurrent admin-create + user-checkout
+          //   for a never-seen email can still race. Probability low
+          //   (admin actions are rare); blast radius bounded (one extra
+          //   Stripe customer record, recoverable via manual merge).
+          // - No Stripe idempotency-key: if THIS request retries (admin
+          //   double-click), a non-idempotent create may run twice. The
+          //   look-up-first check catches that on retry.
+          if (validatedData.email) {
+            const existing = await services.protectedStripe.customers.list({
+              email: validatedData.email,
+              limit: 2,
+            });
+            const onlyMatch = existing.data.length === 1 ? existing.data[0] : undefined;
+            if (onlyMatch) {
+              response = onlyMatch;
+              if (logs) {
+                req?.revealui?.logger?.info(
+                  `customersProxy POST: reused existing Stripe customer for email ${validatedData.email} (look-up-first hit, GAP-132 B-3)`,
+                );
+              }
+              break;
+            }
+            // 0 matches → fall through to create (new email)
+            // 2+ matches → fall through to create + log a warning (admin
+            // should reconcile manually); we don't pick one of N
+            if (existing.data.length > 1) {
+              req?.revealui?.logger?.warn(
+                `customersProxy POST: multiple existing Stripe customers (${existing.data.length}) for email ${validatedData.email}; creating a new one. Admin should reconcile.`,
+              );
+            }
+          }
+
           response = await services.protectedStripe.customers.create(
             validatedData as Stripe.CustomerCreateParams,
           );


### PR DESCRIPTION
Closes GAP-132 (B-3 path; full B-1 atomic resolution deferred to v0.4.x).

## Summary
Pre-launch posture mitigating the race where admin customer-creation could produce duplicate Stripe customer records when a user-initiated checkout for the same email is concurrent. Look-up-first guard catches the common case.

## Verified
- pnpm --filter admin typecheck clean
- Pre-push gate PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)