### PR TITLE
fix(marketing): align primitive + persona + tier claims with shipped state (P1)

### DIFF
--- a/apps/marketing/src/components/landing/Persona.tsx
+++ b/apps/marketing/src/components/landing/Persona.tsx
@@ -1,8 +1,8 @@
 const checklist = [
   'Drop in user accounts and orgs in five lines of config',
   'Wire Stripe billing without writing a single webhook handler',
-  'Edit prompts and content through a real admin UI',
-  'Expose every API to your agents via MCP, automatically',
+  'Configure agents and edit content through a real admin UI',
+  'Every primitive ships with a matching MCP server, so agents work day one',
 ];
 
 export function Persona() {

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -76,8 +76,8 @@ const TEASER_TIERS: TeaserTier[] = [
     features: [
       'Everything in Free',
       '10,000 agent tasks / month included',
-      'Pro AI features (agents, RAG, MCP)',
-      'Priority support, SLA',
+      'Pro AI features (agents, MCP, memory)',
+      'Priority support',
     ],
     cta: 'See Pro pricing',
     href: '/pricing',
@@ -87,12 +87,12 @@ const TEASER_TIERS: TeaserTier[] = [
     id: 'enterprise',
     name: 'Enterprise',
     description:
-      'SSO, audit logs, on-prem deployment, and a named contact. Custom plans for high volume.',
+      'Audit logs, multi-tenant architecture, and a named contact. Custom plans for high volume; SSO and on-prem on the roadmap.',
     features: [
       'Everything in Pro',
-      'SSO + SCIM provisioning',
       'Audit logs + compliance reports',
-      'On-prem and air-gapped deploy',
+      'Multi-tenant architecture',
+      'Roadmap: SSO, SCIM, on-prem deploy',
     ],
     cta: 'Talk to us',
     href: '/contact',

--- a/apps/marketing/src/components/landing/Primitives.tsx
+++ b/apps/marketing/src/components/landing/Primitives.tsx
@@ -24,14 +24,14 @@ const primitives = [
   },
   {
     label: 'Payments',
-    body: 'Stripe billing, invoicing, dunning, webhooks.',
+    body: 'Stripe billing, invoicing, subscriptions, webhooks.',
     color: 'cyan',
     iconPath:
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
     label: 'Intelligence',
-    body: 'Agents, MCP tools, memory, RAG.',
+    body: 'Agents, MCP servers, memory, orchestration.',
     color: 'violet',
     iconPath:
       'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',


### PR DESCRIPTION
Six P1 corrections from the internal honesty audit. PR A handled P0; this clears the P1 layer. PR C/D follow.

## What changed

| Where | Before | After | Why |
|---|---|---|---|
| [Primitives.tsx](apps/marketing/src/components/landing/Primitives.tsx) Payments | *"Stripe billing, invoicing, **dunning**, webhooks"* | *"Stripe billing, invoicing, **subscriptions**, webhooks"* | Dunning is in `packages/harnesses/src/content/definitions/commands/stripe-best-practices.ts` as guidance only — no active logic. Subscriptions DO ship via the prebuilt webhook handler. |
| [Primitives.tsx](apps/marketing/src/components/landing/Primitives.tsx) Intelligence | *"Agents, MCP tools, memory, **RAG**"* | *"Agents, MCP servers, memory, **orchestration**"* | RAG is gated behind Ollama + pgvector setup, not reachable in any default flow. Orchestration (`@revealui/ai` coordinator + `@revealui/harnesses` workboard) ships. |
| [Persona.tsx](apps/marketing/src/components/landing/Persona.tsx) | *"**Edit prompts** and content through a real admin UI"* | *"**Configure agents** and edit content through a real admin UI"* | Re-verified: there IS a prompt-editing surface in admin (`/admin/agents/new` exposes `systemPrompt` + 4 templates), but no CMS-style Prompts collection. "Configure agents" matches the actual surface honestly. |
| [Persona.tsx](apps/marketing/src/components/landing/Persona.tsx) | *"Expose every API to your agents via MCP, **automatically**"* | *"Every primitive ships with a matching MCP server, so agents work day one"* | 14 hand-coded MCP servers under `packages/mcp/src/servers/`, not automatic introspection. |
| [PricingTeaser.tsx](apps/marketing/src/components/landing/PricingTeaser.tsx) Pro | *"Pro AI features (agents, **RAG**, MCP)"* + *"Priority support, **SLA**"* | *"Pro AI features (agents, MCP, memory)"* + *"Priority support"* | RAG drop matches Primitives. SLA: nothing documented in `docs/` yet. |
| [PricingTeaser.tsx](apps/marketing/src/components/landing/PricingTeaser.tsx) Enterprise | *"SSO + SCIM provisioning"* and *"On-prem and air-gapped deploy"* features | Replaced with *"Multi-tenant architecture"* and *"Roadmap: SSO, SCIM, on-prem deploy"* (description rewritten to lead with what ships) | SSO marked planned in `packages/core/src/features.ts`. SCIM not in code. Forge Docker images not published per `forge/START-HERE.md:5-12`. Roadmap framing keeps the pitch visible without overpromising. |

## Net effect

Every claim now matches what's reachable in code today. Buyer-regret risk eliminated for the four most-likely-to-cause-disappointment cases (dunning, SSO/SCIM, on-prem, "edit prompts").

## What's NOT in this PR (deliberately scoped)

- **PR C** (P2/P3 + Fair Source linkage): Hero `"MIT licensed"` → `"OSS (MIT) · Pro is Fair Source [link]"`, wire `/fair-source` link into PricingTeaser Free tier + `/pricing` FAQ, Hero `"Production-ready"` → `"Local dev stack"`, drop `"Background jobs and queues"` from Problem, persona quote re-typeset, FAQ Q5 softened.
- **PR D** (durable): claim-drift CI gate that greps `landing/*.tsx` for blocklist tokens (`managed-hosting`, `dunning`, `SSO`, `SCIM`, `on-prem`, `RAG`) unless paired with a qualifier (`"(coming soon)"`, `"(roadmap)"`, `"(in active development)"`).

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] Biome clean
- [x] Pre-push gate passed
- [ ] Visual sanity check on rendered landing page after merge — confirm new Primitive labels, Persona checklist, and PricingTeaser tiers all read cleanly
