### PR TITLE
fix(marketing): tighten landing copy + wire Fair Source link (P2/P3)

### DIFF
--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -86,7 +86,7 @@ const faqs = [
   {
     question: 'What is Fair Source (FSL-1.1-MIT)?',
     answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection.",
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/apps/marketing/src/components/GetStarted.tsx
+++ b/apps/marketing/src/components/GetStarted.tsx
@@ -10,8 +10,8 @@ export function GetStarted() {
             Ready to build?
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-400">
-            Users, content, products, payments, and AI, pre-wired and ready to deploy. Start
-            building your business in minutes.
+            Users, content, products, payments, and AI, pre-wired. Start building locally in
+            minutes; flip to live mode when you are ready.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">

--- a/apps/marketing/src/components/landing/Faq.tsx
+++ b/apps/marketing/src/components/landing/Faq.tsx
@@ -17,7 +17,7 @@ const faqs = [
   },
   {
     q: 'Production-ready?',
-    a: 'Built behind a full CI gate: Biome lint, Vitest unit and integration, Playwright E2E, CodeQL, Gitleaks, dependency auditing. The full feature set is covered by the test suite, and every PR runs the gate before it can land. Used in production by RevealUI Studio.',
+    a: "Built behind a full CI gate: Biome lint, Vitest unit and integration, Playwright E2E, CodeQL, Gitleaks, dependency auditing. The full feature set is covered by the test suite, and every PR runs the gate before it can land. Used to run RevealUI Studio's own site and admin.",
   },
   {
     q: "What's the rest of the suite?",

--- a/apps/marketing/src/components/landing/Hero.tsx
+++ b/apps/marketing/src/components/landing/Hero.tsx
@@ -82,8 +82,8 @@ export function Hero() {
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Auth, billing, content, and AI primitives wired into one runtime &mdash; so the same
-            APIs your users hit, your agents hit too.
+            Auth, billing, content, and AI primitives wired into one runtime, with every primitive
+            exposed to your agents via MCP.
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -126,28 +126,48 @@ export function Hero() {
           </div>
 
           <p className="mt-4 text-sm text-gray-500">
-            Production-ready in 60 seconds. No credit card.
+            Local dev stack in 60 seconds. No credit card.
           </p>
 
           <div className="mt-10 flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-sm text-gray-500">
-            {['MIT licensed', 'Self-hostable', 'No vendor lock-in'].map((item) => (
-              <div key={item} className="flex items-center gap-2">
-                <svg
-                  className="h-4 w-4 text-emerald-500"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  aria-hidden="true"
+            {[
+              { label: 'OSS (MIT)', href: undefined },
+              { label: 'Pro is Fair Source', href: '/fair-source' },
+              { label: 'Self-hostable', href: undefined },
+              { label: 'No vendor lock-in', href: undefined },
+            ].map((item) => {
+              const inner = (
+                <>
+                  <svg
+                    className="h-4 w-4 text-emerald-500"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    aria-hidden="true"
+                  >
+                    <title>Check</title>
+                    <path
+                      fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {item.label}
+                </>
+              );
+              return item.href ? (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  className="flex items-center gap-2 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-700"
                 >
-                  <title>Check</title>
-                  <path
-                    fillRule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-                {item}
-              </div>
-            ))}
+                  {inner}
+                </a>
+              ) : (
+                <div key={item.label} className="flex items-center gap-2">
+                  {inner}
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/apps/marketing/src/components/landing/Persona.tsx
+++ b/apps/marketing/src/components/landing/Persona.tsx
@@ -19,20 +19,14 @@ export function Persona() {
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl">
-          <figure className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
-            <svg
-              className="h-8 w-8 text-emerald-500"
-              fill="currentColor"
-              viewBox="0 0 32 32"
-              aria-hidden="true"
-            >
-              <title>Quote</title>
-              <path d="M9.352 4C4.456 7.456 1 13.12 1 19.36c0 5.088 3.072 8.064 6.624 8.064 3.36 0 5.856-2.688 5.856-5.856 0-3.168-2.208-5.472-5.088-5.472-.576 0-1.344.096-1.536.192.48-3.264 3.552-7.104 6.624-9.024L9.352 4Zm16.512 0c-4.8 3.456-8.256 9.12-8.256 15.36 0 5.088 3.072 8.064 6.624 8.064 3.264 0 5.856-2.688 5.856-5.856 0-3.168-2.304-5.472-5.184-5.472-.576 0-1.248.096-1.44.192.48-3.264 3.456-7.104 6.528-9.024L25.864 4Z" />
-            </svg>
-            <blockquote className="mt-6 text-xl leading-8 font-medium text-gray-900">
-              &ldquo;You have a working agent demo. Now you need accounts, billing, a CMS for
-              prompts, and an admin UI &mdash; without spending Q2 on plumbing.&rdquo;
-            </blockquote>
+          <div className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+              What this team is dealing with
+            </p>
+            <p className="mt-4 text-xl leading-8 italic text-gray-700">
+              You have a working agent demo. Now you need accounts, billing, configurable agents,
+              and an admin UI &mdash; without spending Q2 on plumbing.
+            </p>
 
             <ul className="mt-10 space-y-4">
               {checklist.map((item) => (
@@ -53,7 +47,7 @@ export function Persona() {
                 </li>
               ))}
             </ul>
-          </figure>
+          </div>
 
           <p className="mt-8 text-center text-sm text-gray-500">
             Also a fit for <span className="font-medium text-gray-700">indie founders</span>{' '}

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -58,7 +58,8 @@ const TEASER_TIERS: TeaserTier[] = [
   {
     id: 'free',
     name: 'Free',
-    description: 'All open-source packages. MIT-licensed. No telemetry.',
+    description:
+      'OSS packages, MIT-licensed. No telemetry. Pro packages are Fair Source (FSL), source-visible and convert to MIT after two years.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -113,8 +113,8 @@ export async function PricingTeaser() {
             Start free. Pay when you scale.
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-600">
-            Self-host the open-source stack at no cost. Move to Pro for managed hosting and AI
-            primitives.
+            Self-host the open-source stack at no cost. Pay for the AI primitives and priority
+            support when your business needs them.
           </p>
         </div>
 

--- a/apps/marketing/src/components/landing/Problem.tsx
+++ b/apps/marketing/src/components/landing/Problem.tsx
@@ -4,7 +4,7 @@ export function Problem() {
     'Stripe billing + webhooks',
     'A CMS for your team',
     'An admin dashboard',
-    'Background jobs and queues',
+    'Reliable webhook delivery',
     'Agent glue for every endpoint',
   ];
 


### PR DESCRIPTION
Final layer of the honesty audit — P2/P3 polish + wires the new `/fair-source` page (shipped in [#577](https://github.com/RevealUIStudio/revealui/pull/577)) into the surfaces that needed it. Closes the per-claim audit backlog. Only PR D (durable claim-drift CI gate) remains before the `test → main` release.

## What changed

| File | Change |
|---|---|
| [Hero.tsx](apps/marketing/src/components/landing/Hero.tsx) | Subhead now says *"with every primitive exposed to your agents via MCP"* instead of conflating user APIs with agent APIs. *"Production-ready in 60 seconds"* → *"Local dev stack in 60 seconds"*. Trust strip restructured: *"MIT licensed"* → *"OSS (MIT)"* + new linked item *"Pro is Fair Source"* → `/fair-source`. |
| [Problem.tsx](apps/marketing/src/components/landing/Problem.tsx) | Dropped *"Background jobs and queues"* (no job runner ships). Replaced with *"Reliable webhook delivery"* (which the prebuilt Stripe webhook handler does cover). |
| [Persona.tsx](apps/marketing/src/components/landing/Persona.tsx) | Re-typeset the blockquote as italic descriptive prose with a *"What this team is dealing with"* prefix. The old quote-icon + quote-marks shape read as a customer testimonial; we don't have those yet. Updated wishlist *"a CMS for prompts"* → *"configurable agents"* to match truthful checklist (PR B). |
| [Faq.tsx](apps/marketing/src/components/landing/Faq.tsx) | Q5 *"Used in production by RevealUI Studio."* → *"Used to run RevealUI Studio's own site and admin."* No paying customers yet; conflating "we host our site on RevealUI" with "in production with paying users" was misleading. |
| [PricingTeaser.tsx](apps/marketing/src/components/landing/PricingTeaser.tsx) | Free tier description now surfaces the FSL split: *"OSS packages, MIT-licensed. No telemetry. Pro packages are Fair Source (FSL), source-visible and convert to MIT after two years."* |
| [GetStarted.tsx](apps/marketing/src/components/GetStarted.tsx) | *"…pre-wired and ready to deploy. Start building your business in minutes."* → *"…pre-wired. Start building locally in minutes; flip to live mode when you are ready."* Same test-mode honesty as the Demo P0 fix. |
| [pricing/page.tsx](apps/marketing/src/app/pricing/page.tsx) | Existing FSL FAQ answer now ends with *"Full explainer at /fair-source."* Cross-links the page shipped in #577. |

## Net effect

Every claim across Hero, Problem, Persona, FAQ, PricingTeaser, GetStarted, and the `/pricing` FAQ now matches what's reachable in code today. The Fair Source story is wired into three places (Hero trust strip, Free tier description, /pricing FAQ) so a buyer comparing tiers learns the FSL distinction at the right moment, not after they've signed up.

## What's left

- **PR D (durable)**: extend the existing CI claim-drift gate to grep `landing/*.tsx` for blocklist tokens (`managed-hosting`, `dunning`, `RAG`, `SSO`, `SCIM`, `on-prem`, etc.) unless paired with a qualifier (`(coming soon)`, `(roadmap)`, `(in active development)`). Prevents the same drift from re-accumulating.
- **`test → main` release**: ships everything currently on `test` to revealui.com.

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] Biome clean across all 7 changed files
- [x] Pre-push gate passed
- [ ] Visual sanity check on rendered landing page after merge
- [ ] Click-through `/fair-source` link from Hero trust strip works
- [ ] PricingTeaser Free tier description reads cleanly with the FSL qualifier inline
