### PR TITLE
feat(ci): claim-drift aspirational-feature scanner for landing copy (PR D)

### DIFF
--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -279,6 +279,173 @@ function scanForFutureTenseClaims(): FutureClaimMatch[] {
 }
 
 // ---------------------------------------------------------------------------
+// Aspirational-feature blocklist (PR D)
+//
+// High-visibility marketing-copy files (the landing page + GetStarted CTA)
+// must NOT name features that don't ship today unless paired with a qualifier
+// on the same line. The list is hand-maintained from the
+// marketing-claims-2026-04-25 internal honesty audit.
+//
+// Each blocklist token is checked case-insensitively. A token is allowed if
+// the line also contains any QUALIFIER pattern (e.g. "(coming soon)",
+// "(roadmap)", "Roadmap:", or a github issue/PR link).
+//
+// Add/remove tokens here when feature reality changes — when "managed
+// hosting" actually ships, for example, drop it from BLOCKLIST.
+// ---------------------------------------------------------------------------
+
+interface AspirationalMatch {
+  file: string;
+  line: number;
+  token: string;
+  why: string;
+  text: string;
+}
+
+/** Files scanned for aspirational features without qualifiers. */
+const ASPIRATIONAL_SCAN_FILES = [
+  'apps/marketing/src/components/landing',
+  'apps/marketing/src/components/GetStarted.tsx',
+];
+
+interface BlocklistEntry {
+  /** Word/phrase that misleads when shipped without a qualifier. */
+  token: RegExp;
+  /** Human-readable label printed when matched. */
+  label: string;
+  /** Why this is blocklisted — printed alongside the failure. */
+  why: string;
+}
+
+const BLOCKLIST: BlocklistEntry[] = [
+  {
+    token: /\bmanaged hosting\b/i,
+    label: 'managed hosting',
+    why: 'no managed-hosting service ships today',
+  },
+  {
+    token: /\bauto-scal(e|ing)\b/i,
+    label: 'auto-scaling',
+    why: 'no managed platform offers auto-scaling',
+  },
+  {
+    token: /\bdunning\b/i,
+    label: 'dunning',
+    why: 'not implemented; only in stripe-best-practices guidance',
+  },
+  {
+    token: /\b(SSO|single sign-on)\b/i,
+    label: 'SSO',
+    why: 'sso marked planned in packages/core/src/features.ts',
+  },
+  {
+    token: /\bSCIM\b/i,
+    label: 'SCIM',
+    why: 'SCIM provisioning not in code',
+  },
+  {
+    token: /\bon-prem\b/i,
+    label: 'on-prem',
+    why: 'forge docker images not yet published to GHCR',
+  },
+  {
+    token: /\bair-gapped\b/i,
+    label: 'air-gapped',
+    why: 'no documented air-gap deploy path',
+  },
+  {
+    token: /\bRAG\b/,
+    label: 'RAG',
+    why: 'gated on Ollama+pgvector setup, not reachable in default flow',
+  },
+  {
+    token: /\bSLA\b/,
+    label: 'SLA',
+    why: 'no SLA documented in docs/',
+  },
+];
+
+/**
+ * A line is allowed if it contains any qualifier signal:
+ *   - parenthetical markers: "(coming soon)", "(planned)", "(roadmap)",
+ *     "(in active development)", "(forthcoming)", "(will ship)",
+ *     "(in progress)", "(TBD)"
+ *   - the bare word "roadmap" anywhere (case-insensitive) — covers both
+ *     "Roadmap: X" prefixes and "X is on the roadmap" framing
+ *   - a tracker citation (#NNN / issues|pull|pulls URL / .yml workflow /
+ *     `milestone`)
+ */
+const QUALIFIER_PATTERN =
+  /\((coming soon|planned|roadmap|in active development|forthcoming|will ship|in progress|TBD)\b[^)]*\)|\broadmap\b|(#\d+|\/(issues|pull|pulls)\/\d+|\bmilestones?\b|\.ya?ml\b)/i;
+
+function scanForAspirationalFeatures(): AspirationalMatch[] {
+  const matches: AspirationalMatch[] = [];
+
+  function scanFile(filePath: string): void {
+    const rel = path.relative(ROOT, filePath);
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip JSX comments and import lines — they are not user-visible copy
+      if (line.trim().startsWith('//') || line.trim().startsWith('import ')) continue;
+      // Skip lines inside `{/* ... */}` JSX comments (single-line only; multi-line ignored)
+      if (line.trim().startsWith('{/*') && line.trim().endsWith('*/}')) continue;
+
+      for (const entry of BLOCKLIST) {
+        if (!entry.token.test(line)) continue;
+        if (QUALIFIER_PATTERN.test(line)) continue;
+        matches.push({
+          file: rel,
+          line: i + 1,
+          token: entry.label,
+          why: entry.why,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+      } else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts')) {
+        scanFile(full);
+      }
+    }
+  }
+
+  for (const rel of ASPIRATIONAL_SCAN_FILES) {
+    const full = path.join(ROOT, rel);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.isFile()) {
+        scanFile(full);
+      } else if (stat.isDirectory()) {
+        walk(full);
+      }
+    } catch {
+      // path missing, skip
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -385,11 +552,16 @@ function run(): void {
   // Future-tense claim check (CR9-P2-02)
   const futureClaims = scanForFutureTenseClaims();
 
+  // Aspirational-feature blocklist for high-visibility landing copy
+  const aspirationalClaims = scanForAspirationalFeatures();
+
   console.log('====================');
   console.log(`Claims scanned: ${claims.length}`);
   console.log(`Mismatches:     ${mismatches}`);
   console.log(`Future-tense files scanned: ${FUTURE_TENSE_SCAN_FILES.length}`);
   console.log(`Unlinked future-tense markers: ${futureClaims.length}`);
+  console.log(`Aspirational-feature scan files: ${ASPIRATIONAL_SCAN_FILES.length}`);
+  console.log(`Unqualified aspirational features: ${aspirationalClaims.length}`);
 
   if (futureClaims.length > 0) {
     console.log('\nUnlinked future-tense claims (convention: CONTRIBUTING.md):');
@@ -402,7 +574,18 @@ function run(): void {
     );
   }
 
-  if (mismatches > 0 || futureClaims.length > 0) {
+  if (aspirationalClaims.length > 0) {
+    console.log('\nUnqualified aspirational features in landing copy:');
+    for (const c of aspirationalClaims) {
+      console.log(`  ${c.file}:${c.line}  "${c.token}" (${c.why})`);
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nEach blocklist token must be paired with a qualifier on the same line: "(coming soon)", "(roadmap)", "(in active development)", "(planned)", or a "Roadmap:" prefix. Or remove the claim.',
+    );
+  }
+
+  if (mismatches > 0 || futureClaims.length > 0 || aspirationalClaims.length > 0) {
     if (mismatches > 0) {
       console.log('\nFailed: claims do not match codebase reality.');
       if (!showFix) {
@@ -412,9 +595,14 @@ function run(): void {
     if (futureClaims.length > 0) {
       console.log('\nFailed: unlinked future-tense claims.');
     }
+    if (aspirationalClaims.length > 0) {
+      console.log('\nFailed: unqualified aspirational features in landing copy.');
+    }
     process.exit(1);
   } else {
-    console.log('\nAll claims match codebase reality and future-tense markers are tracked.');
+    console.log(
+      '\nAll claims match codebase reality, future-tense markers are tracked, and aspirational features are qualified.',
+    );
   }
 }
 


### PR DESCRIPTION
Durable end of the honesty-audit chain. Extends the existing claim-drift validator with a third scanner that prevents aspirational-feature regressions on the marketing landing page.

## What this prevents

After PRs A/B/C/E removed nine misleading claims from the new home page, the risk now is **regression**: a future copy edit reintroduces "managed hosting" or "SSO" or "dunning" without the qualifier, nobody notices, and we're back where we started. This scanner enforces the convention mechanically.

When `pnpm validate:claims` (or the full gate) runs, any new occurrence of the blocklisted tokens fails CI unless the line also contains a qualifier:

- A parenthetical marker — `(coming soon)`, `(roadmap)`, `(in active development)`, `(planned)`, `(forthcoming)`, `(will ship)`, `(in progress)`, `(TBD)`
- The bare word **roadmap** anywhere on the line (case-insensitive) — covers both `Roadmap: X` prefixes and `X is on the roadmap` framing
- A tracker citation: `#NNN`, GitHub issues/pull URL, `milestone`, or a `.yml` workflow reference

## Blocklist

Hand-maintained from the [marketing-claims-2026-04-25 honesty audit](internal docs):

| Token | Why blocklisted |
|---|---|
| `managed hosting` | No managed-hosting service ships today |
| `auto-scaling` | No managed platform offers it |
| `dunning` | Not implemented; only in `stripe-best-practices` guidance |
| `SSO` / `single sign-on` | Marked planned in `packages/core/src/features.ts` |
| `SCIM` | Not in code |
| `on-prem` | Forge Docker images not yet published to GHCR |
| `air-gapped` | No documented air-gap deploy path |
| `RAG` | Gated on Ollama+pgvector setup, not reachable in default flow |
| `SLA` | No SLA documented in `docs/` |

When `managed hosting` actually ships, drop the entry. When a new aspirational pattern slips through future copy, add an entry. One-line edit in `BLOCKLIST`.

## Scope

`apps/marketing/src/components/landing/*.tsx` and `apps/marketing/src/components/GetStarted.tsx`. Narrow by design — these are the high-visibility marketing surfaces. Expanding scope (e.g. `apps/docs/`) is its own audit pass.

## Local verification

```
pnpm tsx scripts/validate/claim-drift.ts
…
Aspirational-feature scan files: 2
Unqualified aspirational features: 0

All claims match codebase reality, future-tense markers are tracked, and aspirational features are qualified.
```

Confirmed against the post-PR-C `test` branch state (with all P0/P1/P2/P3 fixes merged in).

## Order-of-operations note

This PR's pre-push hook caught the still-unmerged `managed hosting` reference on line 115 of PricingTeaser when I first tried to push it. That was the gate doing its job: it correctly refused to push because PR C's line-115 fix wasn't yet on `test`. Resolved by merging PR C first, then `git pull origin test` into this branch (auto-merged cleanly, no conflicts), confirming the gate now passes clean, then pushing.

## Test plan

- [x] `pnpm tsx scripts/validate/claim-drift.ts` exits 0 on the current branch (post-merge from test)
- [x] Pre-push gate passed
- [ ] CI passes once GitHub picks up the push
- [ ] After merge to `test`: confirm CI on the next commit (a future test push) still passes — proving the gate blocks new regressions, not currently-shipping copy
