### PR TITLE
release(test → main): honesty audit + design-system Phase 1 + Fair Source + CI gate

### DIFF
--- a/apps/api/src/middleware/__tests__/license-status.test.ts
+++ b/apps/api/src/middleware/__tests__/license-status.test.ts
@@ -210,3 +210,76 @@ describe('checkLicenseStatus', () => {
     expect(queryFn).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-139: dbStatusCache TTL freshness — post-revocation Pro access window
+// ---------------------------------------------------------------------------
+describe('checkLicenseStatus  -  cache TTL freshness (GAP-139)', () => {
+  it('re-queries DB after the cache TTL window expires (revocation propagation)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockedGetLicensePayload.mockReturnValue({
+        tier: 'pro',
+        customerId: 'cus_ttl_1',
+      });
+
+      // First call returns 'active'; subsequent calls return 'revoked' to
+      // simulate Stripe-side revocation that arrived between cache-fill +
+      // next read.
+      const queryFn = vi
+        .fn<(customerId: string) => Promise<string>>()
+        .mockResolvedValueOnce('active')
+        .mockResolvedValue('revoked');
+
+      const app = createApp(queryFn);
+
+      // First request: queries DB, caches 'active' result, returns 200
+      const res1 = await app.request('/resource');
+      expect(res1.status).toBe(200);
+      expect(queryFn).toHaveBeenCalledTimes(1);
+
+      // Within TTL: cached 'active' is reused, DB NOT queried
+      vi.advanceTimersByTime(20_000); // +20s, still within default 30s TTL
+      const res2 = await app.request('/resource');
+      expect(res2.status).toBe(200);
+      expect(queryFn).toHaveBeenCalledTimes(1);
+
+      // After TTL: DB MUST be re-queried; revocation propagates
+      // 35s total = 35s after the first cache write, beyond the 30s default
+      vi.advanceTimersByTime(15_000);
+      const res3 = await app.request('/resource');
+      expect(res3.status).toBe(403);
+      expect(queryFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-queries DB on EVERY request when the cache is invalidated by resetDbStatusCache()', async () => {
+    // Sanity check that the existing reset path still works (used by
+    // webhook handlers post-revocation to invalidate cached state).
+    mockedGetLicensePayload.mockReturnValue({
+      tier: 'pro',
+      customerId: 'cus_reset_1',
+    });
+
+    const queryFn = vi
+      .fn<(customerId: string) => Promise<string>>()
+      .mockResolvedValueOnce('active')
+      .mockResolvedValue('revoked');
+
+    const app = createApp(queryFn);
+
+    // First request: caches 'active'
+    const res1 = await app.request('/resource');
+    expect(res1.status).toBe(200);
+
+    // Manual cache invalidation (what webhook handlers do post-revocation)
+    resetDbStatusCache();
+
+    // Next request: must hit DB again, sees 'revoked'
+    const res2 = await app.request('/resource');
+    expect(res2.status).toBe(403);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/middleware/license.ts
+++ b/apps/api/src/middleware/license.ts
@@ -28,7 +28,51 @@ const SUPPORT_EMAIL = process.env.REVEALUI_SUPPORT_EMAIL ?? 'support@revealui.co
 
 /** Cache for DB-side license status checks, keyed by billing owner/customer */
 const dbStatusCache = new Map<string, { status: string; checkedAt: number }>();
-const DB_STATUS_CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * TTL for the DB status cache. Defaults to 30s (was 5 min until GAP-139).
+ *
+ * Rationale: this cache sits on both the hosted path and the legacy
+ * self-hosted JWT path. On the legacy path, a cancelled / refunded /
+ * revoked customer continues to receive Pro feature access until the TTL
+ * expires. A 5-minute window is too long for STRIPE_LIVE_MODE — for a
+ * paying customer this is a billing-incorrect window; for a fraudulent /
+ * abuse case it's a 5-minute escape hatch.
+ *
+ * 30s balances revocation propagation speed against per-request DB read
+ * pressure on the hosted path. Operators can override via
+ * `DB_STATUS_CHECK_INTERVAL_MS` env (e.g. `=0` to disable the cache for
+ * incident debugging).
+ *
+ * The maximum is capped at 60_000ms (60s) so that a misconfigured value
+ * cannot reintroduce the 5-min regression. Values >60_000 are clamped
+ * with a warning.
+ *
+ * Mirrors the env-override pattern in `@revealui/core/license`'s
+ * LICENSE_CACHE_TTL_MS (which is a separate, JWT-license cache; this one
+ * is the DB-side status cache).
+ *
+ * See GAP-139.
+ */
+const DEFAULT_DB_STATUS_CHECK_INTERVAL_MS = 30 * 1000; // 30 seconds
+const MAX_DB_STATUS_CHECK_INTERVAL_MS = 60 * 1000; // 60 seconds (hard cap)
+
+function parseDbStatusCheckIntervalEnv(raw: string | undefined): number {
+  if (!raw || raw.trim() === '') return DEFAULT_DB_STATUS_CHECK_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DB_STATUS_CHECK_INTERVAL_MS;
+  if (parsed > MAX_DB_STATUS_CHECK_INTERVAL_MS) {
+    process.stderr.write(
+      `DB_STATUS_CHECK_INTERVAL_MS=${parsed} exceeds the ${MAX_DB_STATUS_CHECK_INTERVAL_MS}ms cap; using ${MAX_DB_STATUS_CHECK_INTERVAL_MS}. Longer TTLs extend the post-revocation Pro-access window and are not permitted.\n`,
+    );
+    return MAX_DB_STATUS_CHECK_INTERVAL_MS;
+  }
+  return parsed;
+}
+
+const DB_STATUS_CHECK_INTERVAL = parseDbStatusCheckIntervalEnv(
+  process.env.DB_STATUS_CHECK_INTERVAL_MS,
+);
 
 /** Tracks when the DB became unreachable for infra grace period calculation */
 let dbUnreachableSince: number | null = null;

--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -1,9 +1,24 @@
 import { Link, useLocation } from '@revealui/router';
 import { lazy, Suspense, useEffect, useState } from 'react';
+import { showcaseEntries } from './showcase/registry.js';
 
 const SearchBar = lazy(async () =>
   import('./SearchBar').then((mod) => ({ default: mod.SearchBar })),
 );
+
+/**
+ * Build the Showcase nav items from the registry. Two stable anchors
+ * (Overview + Design Tokens) followed by every entry sorted by display name.
+ * Adding a new showcase to `showcase/registry.ts` automatically surfaces
+ * it here — no hand-maintained list to drift.
+ */
+const showcaseNavItems = [
+  { label: 'Overview', path: '/showcase' },
+  { label: 'Design Tokens', path: '/showcase/tokens' },
+  ...[...showcaseEntries]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => ({ label: entry.name, path: `/showcase/${entry.slug}` })),
+];
 
 interface DocLayoutProps {
   children?: React.ReactNode;
@@ -72,26 +87,7 @@ const sections: NavSection[] = [
   },
   {
     title: 'Showcase',
-    items: [
-      { label: 'Overview', path: '/showcase' },
-      { label: 'Design Tokens', path: '/showcase/tokens' },
-      { label: 'Accordion', path: '/showcase/accordion' },
-      { label: 'Avatar', path: '/showcase/avatar' },
-      { label: 'Badge', path: '/showcase/badge' },
-      { label: 'Button', path: '/showcase/button' },
-      { label: 'Callout', path: '/showcase/callout' },
-      { label: 'Card', path: '/showcase/card' },
-      { label: 'Dialog', path: '/showcase/dialog' },
-      { label: 'Drawer', path: '/showcase/drawer' },
-      { label: 'Input', path: '/showcase/input' },
-      { label: 'Progress', path: '/showcase/progress' },
-      { label: 'Stat', path: '/showcase/stat' },
-      { label: 'Switch', path: '/showcase/switch' },
-      { label: 'Table', path: '/showcase/table' },
-      { label: 'Tabs', path: '/showcase/tabs' },
-      { label: 'Toast', path: '/showcase/toast' },
-      { label: 'Tooltip', path: '/showcase/tooltip' },
-    ],
+    items: showcaseNavItems,
   },
   {
     title: 'Pro & Enterprise',

--- a/apps/docs/app/components/showcase/ShowcaseShell.tsx
+++ b/apps/docs/app/components/showcase/ShowcaseShell.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { renderMarkdown } from '@/utils/markdown';
 import { CodeView } from './CodeView.js';
 import { Preview } from './Preview.js';
 import { PropPanel } from './PropPanel.js';
+import { showcaseEntries } from './registry.js';
 import type { ShowcaseStory } from './types.js';
 import { VariantGrid } from './VariantGrid.js';
 
@@ -10,6 +12,10 @@ type Tab = 'preview' | 'grid' | 'code';
 interface ShowcaseShellProps {
   story: ShowcaseStory;
 }
+
+const REPO_BLOB_BASE = 'https://github.com/RevealUIStudio/revealui/blob/main/packages/presentation';
+
+const DEFAULT_INSTALL = 'npm install @revealui/presentation';
 
 export function ShowcaseShell({ story }: ShowcaseShellProps) {
   const [activeTab, setActiveTab] = useState<Tab>('preview');
@@ -33,18 +39,77 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
     { id: 'code', label: 'Code' },
   ];
 
+  const sourceHref = story.sourceUrl ? `${REPO_BLOB_BASE}/${story.sourceUrl}` : null;
+  const installCmd = story.install ?? DEFAULT_INSTALL;
+  const a11y = story.a11y;
+  const hasA11y =
+    !!a11y &&
+    ((a11y.conformance?.length ?? 0) > 0 ||
+      (a11y.keyboard && Object.keys(a11y.keyboard).length > 0) ||
+      (a11y.aria && Object.keys(a11y.aria).length > 0) ||
+      !!a11y.notes);
+
   return (
     <div className="mx-auto max-w-4xl space-y-6 px-8 py-10">
       {/* Header */}
       <div>
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-ink">{story.name}</h1>
-          <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
-            {story.category}
-          </span>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold tracking-tight text-ink">{story.name}</h1>
+            <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">
+              {story.category}
+            </span>
+          </div>
+          {sourceHref && (
+            <a
+              href={sourceHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text-secondary no-underline transition-colors hover:text-ink"
+            >
+              <svg
+                className="h-3.5 w-3.5"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <title>GitHub</title>
+                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+              </svg>
+              View source
+            </a>
+          )}
         </div>
         <p className="mt-1 text-sm text-text-secondary">{story.description}</p>
       </div>
+
+      {/* Install command */}
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-2.5 font-mono text-xs">
+        <span className="select-none text-text-muted">$</span>
+        <span className="flex-1 text-ink">{installCmd}</span>
+      </div>
+
+      {/* Usage guidance */}
+      {(story.usage?.when || story.usage?.avoid) && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {story.usage.when && (
+            <div className="rounded-xl border border-border bg-surface p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+                When to use
+              </h3>
+              <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.when)}</div>
+            </div>
+          )}
+          {story.usage.avoid && (
+            <div className="rounded-xl border border-border bg-surface p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-amber-700">
+                When to avoid
+              </h3>
+              <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.avoid)}</div>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-border">
@@ -100,6 +165,114 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Accessibility */}
+      {hasA11y && a11y && (
+        <details className="group rounded-xl border border-border bg-surface" open>
+          <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-semibold text-ink">
+            <span>Accessibility</span>
+            <svg
+              className="h-4 w-4 text-text-muted transition-transform group-open:rotate-180"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <title>Toggle</title>
+              <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </summary>
+          <div className="space-y-4 border-t border-border px-4 py-4">
+            {a11y.conformance && a11y.conformance.length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Conformance
+                </h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {a11y.conformance.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {a11y.keyboard && Object.keys(a11y.keyboard).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Keyboard
+                </h4>
+                <dl className="divide-y divide-border text-sm">
+                  {Object.entries(a11y.keyboard).map(([key, desc]) => (
+                    <div key={key} className="flex gap-3 py-1.5">
+                      <dt className="flex-shrink-0 font-mono text-xs text-ink">
+                        <kbd className="rounded border border-border bg-bg px-1.5 py-0.5">
+                          {key}
+                        </kbd>
+                      </dt>
+                      <dd className="text-text-secondary">{desc}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+            {a11y.aria && Object.keys(a11y.aria).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  ARIA
+                </h4>
+                <dl className="divide-y divide-border text-sm">
+                  {Object.entries(a11y.aria).map(([attr, desc]) => (
+                    <div key={attr} className="flex gap-3 py-1.5">
+                      <dt className="flex-shrink-0 font-mono text-xs text-ink">{attr}</dt>
+                      <dd className="text-text-secondary">{desc}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+            {a11y.notes && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Notes
+                </h4>
+                <div className="text-sm text-text-secondary">{renderMarkdown(a11y.notes)}</div>
+              </div>
+            )}
+          </div>
+        </details>
+      )}
+
+      {/* Related */}
+      {story.related && story.related.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-text-muted">
+            See also
+          </h2>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {story.related.map((rel) => {
+              const target = showcaseEntries.find((e) => e.slug === rel.slug);
+              const label = target?.name ?? rel.slug;
+              return (
+                <a
+                  key={rel.slug}
+                  href={`/showcase/${rel.slug}`}
+                  className="rounded-xl border border-border bg-surface px-4 py-3 no-underline transition-colors hover:border-accent"
+                >
+                  <div className="text-sm font-semibold text-ink">{label}</div>
+                  {rel.reason && (
+                    <div className="mt-1 text-xs text-text-secondary">{rel.reason}</div>
+                  )}
+                </a>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/apps/docs/app/components/showcase/types.ts
+++ b/apps/docs/app/components/showcase/types.ts
@@ -23,6 +23,29 @@ export interface ShowcaseExample {
   render: () => React.ReactNode;
 }
 
+/**
+ * Accessibility notes for a component. All fields optional; rendered as a
+ * collapsed-by-default section on the showcase page when any field is set.
+ */
+export interface ShowcaseAccessibility {
+  /** WCAG criteria explicitly covered, e.g. ["WCAG 2.1 AA contrast", "WCAG 2.1.1 Keyboard"] */
+  conformance?: string[];
+  /** Keyboard interactions, keyed by key name. e.g. {"Tab": "Move focus to next item"} */
+  keyboard?: Record<string, string>;
+  /** ARIA attributes the component renders or expects. */
+  aria?: Record<string, string>;
+  /** Free-form notes (e.g. "use aria-label when no visible label") */
+  notes?: string;
+}
+
+/**
+ * Cross-link to a related showcase by slug. Rendered as a "See also" strip.
+ */
+export interface ShowcaseRelated {
+  slug: string;
+  reason?: string;
+}
+
 /** Complete showcase definition for a single component */
 export interface ShowcaseStory {
   /** URL slug: /showcase/{slug} */
@@ -43,6 +66,31 @@ export interface ShowcaseStory {
   examples?: ShowcaseExample[];
   /** Custom code generator  -  receives current props, returns JSX string */
   code?: (props: Record<string, unknown>) => string;
+  /**
+   * When-to-use / when-not-to-use guidance. Markdown supported.
+   * Rendered above the interactive preview when present.
+   */
+  usage?: {
+    /** Markdown body explaining when to reach for this component. */
+    when?: string;
+    /** Markdown body explaining when NOT to use it (alternatives, anti-patterns). */
+    avoid?: string;
+  };
+  /**
+   * `npm install` snippet shown at the top of the page. Defaults to
+   * `npm install @revealui/presentation` when omitted; override only if the
+   * component is shipped from a different package or needs extra peerDeps.
+   */
+  install?: string;
+  /**
+   * Path inside the @revealui/presentation package to the component source,
+   * e.g. "src/components/Button.tsx". Renders a "View source" link to GitHub.
+   */
+  sourceUrl?: string;
+  /** Accessibility notes; rendered when any field is set. */
+  a11y?: ShowcaseAccessibility;
+  /** "See also" cross-links to related showcases. */
+  related?: ShowcaseRelated[];
 }
 
 /** Registry entry for lazy-loading stories */

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -19,6 +19,24 @@ export default defineConfig({
     minWorkers: 1,
     coverage: {
       provider: 'v8',
+      // Showcase entries and the registry that loads them are pure configuration
+      // (lazy-import loaders + JSX render functions consumed by the docs site at
+      // runtime). They have no testable behaviour as units — they are exercised
+      // by clicking through the showcase routes, which the docs E2E suite covers
+      // separately. Excluding them keeps the unit coverage gate honest about
+      // logic-bearing code (DocLayout, hooks, utils, components/showcase/Shell).
+      exclude: [
+        'app/components/showcase/registry.ts',
+        'app/showcase/**/*.showcase.tsx',
+        // Default vitest excludes (preserved when we override exclude)
+        'coverage/**',
+        'dist/**',
+        'node_modules/**',
+        '**/__tests__/**',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        'vitest.config.ts',
+      ],
       thresholds: {
         lines: 60,
         functions: 60,

--- a/apps/marketing/src/app/fair-source/page.tsx
+++ b/apps/marketing/src/app/fair-source/page.tsx
@@ -1,0 +1,449 @@
+import { ButtonCVA } from '@revealui/presentation';
+import type { Metadata } from 'next';
+import { Footer } from '@/components/Footer';
+
+const PAGE_TITLE = 'Fair Source — RevealUI';
+const PAGE_DESCRIPTION =
+  'How RevealUI Pro packages are licensed: source-visible on GitHub, commercially usable, with a single non-compete clause, and MIT-licensed two years after each release.';
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    type: 'website',
+    images: [
+      {
+        url: `/api/og?title=${encodeURIComponent('Fair Source')}&description=${encodeURIComponent('Source-visible. Commercially usable. MIT in two years.')}`,
+        width: 1200,
+        height: 630,
+        alt: PAGE_TITLE,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+};
+
+const contractCards = [
+  {
+    kind: 'yes' as const,
+    title: 'Use it commercially',
+    body: 'Ship Fair Source code in your product, charge customers, run it in production. No royalties, no per-seat fees, no usage caps.',
+  },
+  {
+    kind: 'yes' as const,
+    title: 'Read and modify the source',
+    body: 'Every line is on GitHub. Fork it, patch it, audit it for security. The source is the source of truth — there is no closed binary hiding behind it.',
+  },
+  {
+    kind: 'yes' as const,
+    title: 'Self-host on your own infra',
+    body: 'Run it in your VPC, on bare metal, or air-gapped. RevealUI does not phone home and does not depend on a vendor service to function.',
+  },
+  {
+    kind: 'no' as const,
+    title: 'Build a competing developer platform',
+    body: 'You cannot ship a substantially similar developer platform that competes with RevealUI on top of these packages. This is the only restriction. After two years, even this restriction lifts and the release becomes plain MIT.',
+  },
+];
+
+const packages = [
+  {
+    name: '@revealui/ai',
+    purpose: 'AI agents, CRDT memory, LLM provider abstractions, orchestration',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/ai',
+    npm: 'https://www.npmjs.com/package/@revealui/ai',
+  },
+  {
+    name: '@revealui/harnesses',
+    purpose: 'AI harness adapters, workboard coordination, JSON-RPC primitives',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses',
+    npm: 'https://www.npmjs.com/package/@revealui/harnesses',
+  },
+];
+
+const peers = [
+  {
+    name: 'Sentry',
+    note: 'Application monitoring; flagship FSL adopter (license they originally co-authored with FOSSA).',
+    url: 'https://blog.sentry.io/introducing-the-functional-source-license-freedom-without-free-riding/',
+  },
+  {
+    name: 'GitButler',
+    note: 'Git client for branch management. FSL across the stack.',
+    url: 'https://gitbutler.com/blog/fair-source',
+  },
+  {
+    name: 'Keygen',
+    note: 'License management infrastructure; FSL on their core engine.',
+    url: 'https://keygen.sh/blog/fair-source/',
+  },
+];
+
+const faqs = [
+  {
+    q: 'Is Fair Source open source?',
+    a: 'Not in the OSI-approved sense — the non-compete clause means it is "source-available" rather than "open source." But for almost every practical purpose (read, modify, deploy, charge for products built on top), the freedoms match what most builders need from open source. After two years per release, the clause lifts and the code becomes plain MIT, which IS OSI open source.',
+  },
+  {
+    q: 'What counts as a "competing developer platform"?',
+    a: 'The license uses the standard FSL definition: a software product with substantially the same functionality as RevealUI that is offered to the same audience as a developer platform. Building a SaaS app for end users that happens to use @revealui/ai under the hood is fine. Building a marketplace for AI-agent tooling on top of @revealui/harnesses and selling it to developers is the case the clause addresses. If you are unsure, email founder@revealui.com — we would rather you ship than worry.',
+  },
+  {
+    q: 'When exactly does each release convert to MIT?',
+    a: "Two years after the publish date of that specific release. So today's 0.4.0 release of @revealui/ai becomes MIT on its 2-year anniversary; a future 0.5.0 starts its own clock from its own publish date. Older releases reach MIT first; this is intentional.",
+  },
+  {
+    q: 'Why not just use plain MIT for everything?',
+    a: 'The Pro packages represent meaningful R&D investment in agent runtimes and harness coordination. Plain MIT lets a competitor fork the entire stack on day one and undercut the project on price, leaving the studio with no path to sustain the work. Fair Source closes that specific risk while keeping every other freedom you need. It is a deliberate middle path between "everything free, no business model" and "closed proprietary."',
+  },
+  {
+    q: 'How is the Pro tier enforced if the source is visible?',
+    a: 'License enforcement is at runtime, not at the source level. Pro packages check RS256-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
+  },
+  {
+    q: 'What about the rest of the RevealUI packages?',
+    a: 'Every other RevealUI package is plain MIT — no non-compete clause, no time limit, fully open source. That is the OSS substrate (auth, content, billing primitives, admin UI, MCP framework, presentation system, etc.). Fair Source applies only to @revealui/ai and @revealui/harnesses today.',
+  },
+];
+
+export default function FairSourcePage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Hero */}
+      <section className="relative isolate overflow-hidden bg-white px-6 pt-20 pb-16 sm:pt-28 sm:pb-20 lg:px-8">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-emerald-50/40 via-white to-white"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,rgba(16,185,129,0.18),rgba(16,185,129,0.04)_60%,transparent_80%)] blur-2xl"
+        />
+
+        <div className="relative mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 mb-6">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle mr-2" />
+            License contract for the Pro packages
+          </p>
+          <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
+            Fair Source.
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-xl leading-8 text-gray-600 sm:text-2xl">
+            Source-visible. Commercially usable. MIT in two years.
+          </p>
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-gray-600">
+            Two RevealUI packages ship under{' '}
+            <a
+              href="https://fsl.software/"
+              className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+            >
+              FSL-1.1-MIT
+            </a>{' '}
+            instead of plain MIT. The source is on GitHub, commercial use is permitted, and every
+            release auto-converts to plain MIT two years after publish. Here is what that means in
+            practice.
+          </p>
+        </div>
+      </section>
+
+      {/* The contract */}
+      <section className="bg-white py-16 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              The contract, in plain English
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+              Three yeses and one no.
+            </h2>
+          </div>
+
+          <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
+            {contractCards.map((c) => (
+              <div
+                key={c.title}
+                className={`rounded-2xl p-6 ring-1 transition ${
+                  c.kind === 'yes'
+                    ? 'bg-emerald-50/40 ring-emerald-200'
+                    : 'bg-amber-50/40 ring-amber-200'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  {c.kind === 'yes' ? (
+                    <svg
+                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-emerald-600"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      aria-hidden="true"
+                    >
+                      <title>Yes</title>
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-amber-700"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      aria-hidden="true"
+                    >
+                      <title>One restriction</title>
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-950">{c.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-gray-700">{c.body}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Which packages */}
+      <section className="bg-gray-50 py-16 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">Scope</p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+              Which RevealUI packages are Fair Source.
+            </h2>
+            <p className="mt-6 text-base leading-7 text-gray-600">
+              Two packages today. Every other package in the suite is plain MIT — no non-compete, no
+              time limit, fully open source.
+            </p>
+          </div>
+
+          <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-white ring-1 ring-gray-950/5">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-gray-100 text-xs font-semibold uppercase tracking-widest text-gray-500">
+                <tr>
+                  <th className="px-6 py-3">Package</th>
+                  <th className="px-6 py-3">Purpose</th>
+                  <th className="px-6 py-3">License</th>
+                  <th className="px-6 py-3">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {packages.map((p) => (
+                  <tr key={p.name}>
+                    <td className="px-6 py-4 font-mono text-sm font-semibold text-gray-950">
+                      {p.name}
+                    </td>
+                    <td className="px-6 py-4 text-gray-700">{p.purpose}</td>
+                    <td className="px-6 py-4">
+                      <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                        {p.license}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-sm">
+                      <a
+                        href={p.repo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-emerald-700 hover:text-emerald-800"
+                      >
+                        GitHub
+                      </a>
+                      <span className="px-2 text-gray-300">·</span>
+                      <a
+                        href={p.npm}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-emerald-700 hover:text-emerald-800"
+                      >
+                        npm
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-gray-500">
+            Looking for a specific package&rsquo;s license? Run{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
+              npm view @revealui/&lt;name&gt; license
+            </code>{' '}
+            — npm always tells the truth.
+          </p>
+        </div>
+      </section>
+
+      {/* The two-year clock */}
+      <section className="bg-white py-16 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              The two-year clock
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+              Every release auto-converts to MIT.
+            </h2>
+            <p className="mt-6 text-base leading-7 text-gray-600">
+              The 2-year timer starts on each release&rsquo;s publish date. Older releases reach MIT
+              first; newer releases start their own clock from their own publish date. The clause
+              does not require any action from RevealUI Studio — it is in the license text and
+              self-executing.
+            </p>
+          </div>
+
+          <div className="mx-auto mt-12 max-w-3xl">
+            <ol className="relative border-l-2 border-emerald-200 pl-8">
+              <li className="mb-8 last:mb-0">
+                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-600 ring-4 ring-white">
+                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                </span>
+                <h3 className="font-semibold text-gray-950">Release publishes under FSL-1.1-MIT</h3>
+                <p className="mt-1 text-sm text-gray-600">
+                  Source on GitHub. Installable from npm. The 2-year clock starts ticking the moment
+                  the version tag lands.
+                </p>
+              </li>
+              <li className="mb-8 last:mb-0">
+                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-amber-600 ring-4 ring-white">
+                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                </span>
+                <h3 className="font-semibold text-gray-950">Year one and year two</h3>
+                <p className="mt-1 text-sm text-gray-600">
+                  All freedoms apply (use commercially, modify, self-host) except the non-compete
+                  clause. You build on it, you ship products with it, you charge customers for those
+                  products.
+                </p>
+              </li>
+              <li>
+                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-600 ring-4 ring-white">
+                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                </span>
+                <h3 className="font-semibold text-gray-950">Two years later: plain MIT</h3>
+                <p className="mt-1 text-sm text-gray-600">
+                  That specific release auto-converts to plain MIT. The non-compete clause lifts;
+                  the license becomes OSI-approved open source.
+                </p>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      {/* In good company */}
+      <section className="bg-gray-50 py-16 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              In good company
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+              The same license model used by serious infrastructure projects.
+            </h2>
+          </div>
+
+          <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
+            {peers.map((p) => (
+              <a
+                key={p.name}
+                href={p.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-2xl bg-white p-6 ring-1 ring-gray-950/5 no-underline transition hover:ring-gray-950/10"
+              >
+                <h3 className="text-lg font-semibold text-gray-950">{p.name}</h3>
+                <p className="mt-2 text-sm leading-6 text-gray-600">{p.note}</p>
+                <p className="mt-3 text-xs font-medium text-emerald-700">Read their post &rarr;</p>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="bg-white py-16 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              Common questions
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+              Detailed answers, not lawyer-speak.
+            </h2>
+          </div>
+
+          <div className="mx-auto mt-12 max-w-3xl divide-y divide-gray-200">
+            {faqs.map((f) => (
+              <details key={f.q} className="group py-6">
+                <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+                  <h3 className="text-lg font-semibold leading-7 text-gray-950">{f.q}</h3>
+                  <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={2}
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <title>Toggle</title>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 4.5v15m7.5-7.5h-15"
+                      />
+                    </svg>
+                  </span>
+                </summary>
+                <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{f.a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-gray-950 py-16 sm:py-24">
+        <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Read the spec yourself.
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-gray-400">
+            FSL-1.1-MIT is short, plain English, and authored by the FOSSA legal team. Two pages.
+            Read it before you ship.
+          </p>
+          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+            <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">
+              <a href="https://fsl.software/FSL-1.1-MIT.template.md">FSL-1.1-MIT spec text</a>
+            </ButtonCVA>
+            <ButtonCVA
+              asChild
+              variant="outline"
+              size="lg"
+              className="border-gray-700 text-gray-300 hover:text-white hover:border-gray-500"
+            >
+              <a href="mailto:founder@revealui.com?subject=Fair%20Source%20question">
+                Email a license question
+              </a>
+            </ButtonCVA>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -86,7 +86,7 @@ const faqs = [
   {
     question: 'What is Fair Source (FSL-1.1-MIT)?',
     answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection.",
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/apps/marketing/src/components/GetStarted.tsx
+++ b/apps/marketing/src/components/GetStarted.tsx
@@ -10,8 +10,8 @@ export function GetStarted() {
             Ready to build?
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-400">
-            Users, content, products, payments, and AI, pre-wired and ready to deploy. Start
-            building your business in minutes.
+            Users, content, products, payments, and AI, pre-wired. Start building locally in
+            minutes; flip to live mode when you are ready.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">

--- a/apps/marketing/src/components/landing/Demo.tsx
+++ b/apps/marketing/src/components/landing/Demo.tsx
@@ -4,17 +4,17 @@ const beats = [
   {
     n: '01',
     title: 'Spin up a stack.',
-    body: 'One command. Auth, billing, content, admin UI, and agent layer running locally in 60 seconds.',
+    body: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
   },
   {
     n: '02',
-    title: 'Real customer flow.',
-    body: 'A user signs up, picks a plan, and pays. Stripe handles checkout. The admin UI shows the new account.',
+    title: 'Customer flow, end to end.',
+    body: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
   },
   {
     n: '03',
     title: 'Agent-native, by default.',
-    body: 'A chat agent reads the customer, refunds the subscription, and writes a CMS post explaining why — same APIs.',
+    body: 'Every primitive ships with a matching MCP server. Wire an LLM provider and your agents read customers, refund subscriptions, and write content through the same APIs your app uses.',
   },
 ];
 
@@ -27,10 +27,10 @@ export function Demo() {
             Watch it work
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            From CLI to live business in 90 seconds.
+            From CLI to a working stack in 90 seconds.
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-600">
-            Three beats. No edits. The whole stack, end to end.
+            Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP.
           </p>
         </div>
 

--- a/apps/marketing/src/components/landing/Faq.tsx
+++ b/apps/marketing/src/components/landing/Faq.tsx
@@ -17,7 +17,7 @@ const faqs = [
   },
   {
     q: 'Production-ready?',
-    a: 'Built behind a full CI gate: Biome lint, Vitest unit and integration, Playwright E2E, CodeQL, Gitleaks, dependency auditing. The full feature set is covered by the test suite, and every PR runs the gate before it can land. Used in production by RevealUI Studio.',
+    a: "Built behind a full CI gate: Biome lint, Vitest unit and integration, Playwright E2E, CodeQL, Gitleaks, dependency auditing. The full feature set is covered by the test suite, and every PR runs the gate before it can land. Used to run RevealUI Studio's own site and admin.",
   },
   {
     q: "What's the rest of the suite?",

--- a/apps/marketing/src/components/landing/Hero.tsx
+++ b/apps/marketing/src/components/landing/Hero.tsx
@@ -82,8 +82,8 @@ export function Hero() {
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Auth, billing, content, and AI primitives wired into one runtime &mdash; so the same
-            APIs your users hit, your agents hit too.
+            Auth, billing, content, and AI primitives wired into one runtime, with every primitive
+            exposed to your agents via MCP.
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -126,28 +126,48 @@ export function Hero() {
           </div>
 
           <p className="mt-4 text-sm text-gray-500">
-            Production-ready in 60 seconds. No credit card.
+            Local dev stack in 60 seconds. No credit card.
           </p>
 
           <div className="mt-10 flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-sm text-gray-500">
-            {['MIT licensed', 'Self-hostable', 'No vendor lock-in'].map((item) => (
-              <div key={item} className="flex items-center gap-2">
-                <svg
-                  className="h-4 w-4 text-emerald-500"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  aria-hidden="true"
+            {[
+              { label: 'OSS (MIT)', href: undefined },
+              { label: 'Pro is Fair Source', href: '/fair-source' },
+              { label: 'Self-hostable', href: undefined },
+              { label: 'No vendor lock-in', href: undefined },
+            ].map((item) => {
+              const inner = (
+                <>
+                  <svg
+                    className="h-4 w-4 text-emerald-500"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    aria-hidden="true"
+                  >
+                    <title>Check</title>
+                    <path
+                      fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {item.label}
+                </>
+              );
+              return item.href ? (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  className="flex items-center gap-2 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-700"
                 >
-                  <title>Check</title>
-                  <path
-                    fillRule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-                {item}
-              </div>
-            ))}
+                  {inner}
+                </a>
+              ) : (
+                <div key={item.label} className="flex items-center gap-2">
+                  {inner}
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/apps/marketing/src/components/landing/Persona.tsx
+++ b/apps/marketing/src/components/landing/Persona.tsx
@@ -1,8 +1,8 @@
 const checklist = [
   'Drop in user accounts and orgs in five lines of config',
   'Wire Stripe billing without writing a single webhook handler',
-  'Edit prompts and content through a real admin UI',
-  'Expose every API to your agents via MCP, automatically',
+  'Configure agents and edit content through a real admin UI',
+  'Every primitive ships with a matching MCP server, so agents work day one',
 ];
 
 export function Persona() {

--- a/apps/marketing/src/components/landing/Persona.tsx
+++ b/apps/marketing/src/components/landing/Persona.tsx
@@ -19,20 +19,14 @@ export function Persona() {
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl">
-          <figure className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
-            <svg
-              className="h-8 w-8 text-emerald-500"
-              fill="currentColor"
-              viewBox="0 0 32 32"
-              aria-hidden="true"
-            >
-              <title>Quote</title>
-              <path d="M9.352 4C4.456 7.456 1 13.12 1 19.36c0 5.088 3.072 8.064 6.624 8.064 3.36 0 5.856-2.688 5.856-5.856 0-3.168-2.208-5.472-5.088-5.472-.576 0-1.344.096-1.536.192.48-3.264 3.552-7.104 6.624-9.024L9.352 4Zm16.512 0c-4.8 3.456-8.256 9.12-8.256 15.36 0 5.088 3.072 8.064 6.624 8.064 3.264 0 5.856-2.688 5.856-5.856 0-3.168-2.304-5.472-5.184-5.472-.576 0-1.248.096-1.44.192.48-3.264 3.456-7.104 6.528-9.024L25.864 4Z" />
-            </svg>
-            <blockquote className="mt-6 text-xl leading-8 font-medium text-gray-900">
-              &ldquo;You have a working agent demo. Now you need accounts, billing, a CMS for
-              prompts, and an admin UI &mdash; without spending Q2 on plumbing.&rdquo;
-            </blockquote>
+          <div className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+              What this team is dealing with
+            </p>
+            <p className="mt-4 text-xl leading-8 italic text-gray-700">
+              You have a working agent demo. Now you need accounts, billing, configurable agents,
+              and an admin UI &mdash; without spending Q2 on plumbing.
+            </p>
 
             <ul className="mt-10 space-y-4">
               {checklist.map((item) => (
@@ -53,7 +47,7 @@ export function Persona() {
                 </li>
               ))}
             </ul>
-          </figure>
+          </div>
 
           <p className="mt-8 text-center text-sm text-gray-500">
             Also a fit for <span className="font-medium text-gray-700">indie founders</span>{' '}

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -76,8 +76,8 @@ const TEASER_TIERS: TeaserTier[] = [
     features: [
       'Everything in Free',
       '10,000 agent tasks / month included',
-      'Pro AI features (agents, RAG, MCP)',
-      'Priority support, SLA',
+      'Pro AI features (agents, MCP, memory)',
+      'Priority support',
     ],
     cta: 'See Pro pricing',
     href: '/pricing',
@@ -87,12 +87,12 @@ const TEASER_TIERS: TeaserTier[] = [
     id: 'enterprise',
     name: 'Enterprise',
     description:
-      'SSO, audit logs, on-prem deployment, and a named contact. Custom plans for high volume.',
+      'Audit logs, multi-tenant architecture, and a named contact. Custom plans for high volume; SSO and on-prem on the roadmap.',
     features: [
       'Everything in Pro',
-      'SSO + SCIM provisioning',
       'Audit logs + compliance reports',
-      'On-prem and air-gapped deploy',
+      'Multi-tenant architecture',
+      'Roadmap: SSO, SCIM, on-prem deploy',
     ],
     cta: 'Talk to us',
     href: '/contact',

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -58,7 +58,8 @@ const TEASER_TIERS: TeaserTier[] = [
   {
     id: 'free',
     name: 'Free',
-    description: 'All open-source packages. MIT-licensed. No telemetry.',
+    description:
+      'OSS packages, MIT-licensed. No telemetry. Pro packages are Fair Source (FSL), source-visible and convert to MIT after two years.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',
@@ -112,8 +113,8 @@ export async function PricingTeaser() {
             Start free. Pay when you scale.
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-600">
-            Self-host the open-source stack at no cost. Move to Pro for managed hosting and AI
-            primitives.
+            Self-host the open-source stack at no cost. Pay for the AI primitives and priority
+            support when your business needs them.
           </p>
         </div>
 

--- a/apps/marketing/src/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/src/components/landing/PricingTeaser.tsx
@@ -72,10 +72,10 @@ const TEASER_TIERS: TeaserTier[] = [
   {
     id: 'pro',
     name: 'Pro',
-    description: 'Managed hosting, AI primitives, and priority support.',
+    description: 'Pro AI primitives, agent task allowance, and priority support.',
     features: [
       'Everything in Free',
-      'Managed hosting + auto-scaling',
+      '10,000 agent tasks / month included',
       'Pro AI features (agents, RAG, MCP)',
       'Priority support, SLA',
     ],

--- a/apps/marketing/src/components/landing/Primitives.tsx
+++ b/apps/marketing/src/components/landing/Primitives.tsx
@@ -24,14 +24,14 @@ const primitives = [
   },
   {
     label: 'Payments',
-    body: 'Stripe billing, invoicing, dunning, webhooks.',
+    body: 'Stripe billing, invoicing, subscriptions, webhooks.',
     color: 'cyan',
     iconPath:
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
     label: 'Intelligence',
-    body: 'Agents, MCP tools, memory, RAG.',
+    body: 'Agents, MCP servers, memory, orchestration.',
     color: 'violet',
     iconPath:
       'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',

--- a/apps/marketing/src/components/landing/Problem.tsx
+++ b/apps/marketing/src/components/landing/Problem.tsx
@@ -4,7 +4,7 @@ export function Problem() {
     'Stripe billing + webhooks',
     'A CMS for your team',
     'An admin dashboard',
-    'Background jobs and queues',
+    'Reliable webhook delivery',
     'Agent glue for every endpoint',
   ];
 

--- a/docs/FAIR_SOURCE.md
+++ b/docs/FAIR_SOURCE.md
@@ -1,0 +1,109 @@
+---
+title: "Fair Source"
+description: "How RevealUI Pro packages are licensed under FSL-1.1-MIT, what you can and cannot do with them, and how each release auto-converts to plain MIT after two years."
+category: reference
+audience: developer
+---
+
+# Fair Source
+
+The narrative version of this page lives at [revealui.com/fair-source](https://revealui.com/fair-source). This document is the engineer-targeted reference: license text, package status, runtime enforcement, and how to verify everything yourself.
+
+## What's licensed how
+
+Two RevealUI packages ship under **FSL-1.1-MIT** (Fair Source). Every other package in the suite is plain MIT.
+
+| Package | License | Source | npm |
+|---------|---------|--------|-----|
+| `@revealui/ai` | FSL-1.1-MIT | [packages/ai](https://github.com/RevealUIStudio/revealui/tree/main/packages/ai) | [npm](https://www.npmjs.com/package/@revealui/ai) |
+| `@revealui/harnesses` | FSL-1.1-MIT | [packages/harnesses](https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses) | [npm](https://www.npmjs.com/package/@revealui/harnesses) |
+| Everything else (`@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/presentation`, `@revealui/router`, `@revealui/security`, `@revealui/utils`, `@revealui/cache`, `@revealui/resilience`, `@revealui/sync`, `@revealui/cli`, `@revealui/setup`, `@revealui/dev`, `@revealui/test`, `@revealui/editors`, `@revealui/mcp`, `@revealui/services`, `@revealui/openapi`, `@revealui/config`, `create-revealui`) | MIT | [packages/](https://github.com/RevealUIStudio/revealui/tree/main/packages) | [npm registry](https://www.npmjs.com/org/revealui) |
+
+To verify any package's license:
+
+```bash
+npm view @revealui/ai license
+# → "FSL-1.1-MIT"
+
+npm view @revealui/core license
+# → "MIT"
+```
+
+The `license` field in each package's `package.json` is the canonical record. Do not rely on this document if the npm registry says otherwise.
+
+## What FSL-1.1-MIT lets you do
+
+In plain English:
+
+- ✅ **Use it commercially.** Ship it in your product, charge customers, no royalties or per-seat fees.
+- ✅ **Read and modify the source.** Every line is on GitHub. Audit it for security, fork it, patch it.
+- ✅ **Self-host on your own infra.** No phone-home, no vendor service required to function.
+- ❌ **Build a competing developer platform.** You cannot ship a substantially similar developer platform that competes with RevealUI on top of these specific packages.
+
+The non-compete clause is the only restriction. After **two years** (per release), even that lifts and the release becomes plain MIT.
+
+The FSL spec is short and plain — read it: [fsl.software/FSL-1.1-MIT.template.md](https://fsl.software/FSL-1.1-MIT.template.md).
+
+## How the 2-year MIT clock works
+
+Each release starts its own clock at publish time. Older releases reach MIT first; newer releases extend the clock from their own publish dates.
+
+```
+@revealui/ai 0.4.0 published 2026-04-25
+  → becomes MIT 2028-04-25
+
+@revealui/ai 0.5.0 published 2026-08-01 (hypothetical)
+  → becomes MIT 2028-08-01
+
+@revealui/ai 0.6.0 published 2027-01-15 (hypothetical)
+  → becomes MIT 2029-01-15
+```
+
+The conversion is in the license text and self-executing — RevealUI Studio does not need to take any action. Two years after publish, that release IS plain MIT, full stop.
+
+## Pro tier enforcement (runtime, not source)
+
+Source visibility ≠ free runtime access. The Pro tier is enforced at runtime via:
+
+- **License JWTs** — RS256-signed by the license server (`apps/api/src/routes/license/`). Validated on every Pro entry point.
+- **Per-package feature gates** — each Pro feature checks `isFeatureEnabled('ai' | 'mcp' | 'aiMemory' | ...)` from `@revealui/core/features` before executing.
+- **Status checks every 5 minutes** — `checkLicenseStatus()` re-validates against the license server. Stale licenses are revoked at runtime.
+
+This is documented at [apps/api/src/routes/license/](https://github.com/RevealUIStudio/revealui/tree/main/apps/api/src/routes/license).
+
+The legal protection (FSL non-compete) and the runtime enforcement (license JWTs) are independent layers. Even with the source, building a competing platform on top is the case the license addresses, with civil remedies. Cracking the runtime check is technically possible (the source is there) but commercializing the result lands you in scope of the non-compete.
+
+## Why not plain MIT for the Pro packages
+
+Plain MIT lets a competitor fork on day one and undercut the project on price, leaving the studio with no path to sustain the work. FSL closes that specific risk while keeping every other freedom you actually need (commercial use, modification, self-host).
+
+It's a deliberate middle path between "everything free, no business model" and "closed proprietary." The same approach used by Sentry, GitButler, and Keygen on their core platforms.
+
+## Common engineer questions
+
+### Can I deploy `@revealui/ai` to my own production for my own customers?
+
+Yes. Charge them. No royalties. No usage caps from the license itself (the license server has its own usage limits per Pro tier, which are separate from the legal license).
+
+### Can I fork `@revealui/ai` to fix a bug or add a feature?
+
+Yes. Fork it, patch it, deploy your fork in your own production. The source is yours to modify.
+
+### Can I publish my fork to npm as `@my-org/revealui-ai-improved`?
+
+Generally yes — you're modifying source under a license that permits modification. The non-compete clause kicks in if your fork is positioned as a developer platform competing with RevealUI Studio's offering. If your fork is for your own internal use or for a non-competing product, you're fine.
+
+### What if I'm building a competing developer platform without using these packages?
+
+You can build whatever you want without using FSL packages. The license only restricts how you use the FSL-licensed code, not what you can build in general.
+
+### Where do I send a license question?
+
+[founder@revealui.com](mailto:founder@revealui.com?subject=Fair%20Source%20question). We'd rather answer ten "is this OK?" emails than have one company avoid shipping because they couldn't get a quick yes.
+
+## See also
+
+- Public-facing explainer with examples: [revealui.com/fair-source](https://revealui.com/fair-source)
+- FSL-1.1-MIT canonical text: [fsl.software/FSL-1.1-MIT.template.md](https://fsl.software/FSL-1.1-MIT.template.md)
+- FOSSA's announcement of the Functional Source License: [Sentry's blog post](https://blog.sentry.io/introducing-the-functional-source-license-freedom-without-free-riding/)
+- Pro tier features and pricing: [revealui.com/pricing](https://revealui.com/pricing)

--- a/packages/presentation/CONTRIBUTING.md
+++ b/packages/presentation/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to `@revealui/presentation`
+
+This is the package-level contribution guide for the design system. The repo-wide guide lives at the [root `CONTRIBUTING.md`](../../CONTRIBUTING.md) — read that first for general repo conventions (type system, lint, error codes, commit style).
+
+This file covers what's specific to the design system: adding components, the dual-pattern requirement, accessibility floor, showcases, and the token-versioning contract.
+
+## What ships from this package
+
+`@revealui/presentation` is the **fully featured + artifacted design system** for RevealUI. It exports:
+
+- **Components** under `./components` and the main barrel — over 50 production components
+- **Primitives** under `./primitives` — `Slot`, `Box`, `Flex`, `Grid`, `Heading`, `Text`
+- **Hooks** under `./hooks` — `useTheme`, controllable state, focus trap, escape-key, etc.
+- **Animations** under `./animations` — `useSpring`, `useStagger`, `usePresence`, `useGesture`
+- **Tokens** as `./tokens.css` — OKLCH-based design tokens, dark-first with manual `data-theme` override
+- **Server-safe** subset under `./server` and **client-only** subset under `./client`
+
+Distribution is npm-published, ESM-only, with full TypeScript declarations and source maps.
+
+## Adding a new component
+
+Every new component goes through five steps. Skipping any of these blocks merge.
+
+### 1. File location and dual-pattern
+
+Components live under `src/components/`. Two patterns coexist:
+
+- **Headless** (`button-headless.tsx`) — bare functionality with no styling. Useful when consumers need to bring their own visual treatment.
+- **CVA** (`Button.tsx`) — opinionated styled variant powered by CVA (`class-variance-authority` clone in `utils/cn.ts`). Most consumers use this.
+
+The CVA component should accept the same props as the headless one plus a `variant` and `size` (or component-specific equivalents). Re-export both from `src/components/index.ts` and `src/server.ts` (server-safe subset) or `src/client.ts` (client-only).
+
+### 2. Token usage
+
+**No hardcoded colors, spacing, or radii.** Every visual value comes from `--rvui-*` CSS variables defined in `src/tokens.css`. If you need a value that doesn't exist, add it to the token file in the appropriate group (Spacing, Radius, Surfaces, Status, Motion, Typography, etc.) before referencing it.
+
+The token system is dark-first; light mode overrides via `[data-theme="light"]` and `@media (prefers-color-scheme: light)`. Ensure your component renders correctly in both.
+
+### 3. Accessibility floor
+
+Every shipped component must meet **WCAG 2.1 AA** at minimum:
+
+- **Color contrast** — text on its background ≥ 4.5:1 for normal, ≥ 3:1 for large text. Use `text-emerald-700` floor (not `-500`/`-600`) for emerald accents on white. Run an axe-core check on your showcase before opening the PR.
+- **Keyboard navigation** — every interactive control reachable via Tab, operable via Enter/Space (or component-appropriate keys). No tab traps unless inside a modal/disclosure.
+- **ARIA** — use the right role and aria-* attributes. Prefer native semantics (`<button>`, `<details>`, `<dialog>`) over re-implementing with divs.
+- **Focus visibility** — focus ring must be visible at default contrast. The base `Button` uses `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`; match that pattern.
+- **Reduced motion** — animations respect `prefers-reduced-motion`. Use the `useReducedMotion` hook from `./hooks` or the matching media query.
+
+Document which of these you tested in the showcase's `a11y` field (see step 5).
+
+### 4. Tests
+
+Component tests live in `src/__tests__/components/<Component>.test.tsx`. Use `@testing-library/react` (already a dev-dep). Required coverage:
+
+- Renders without crashing for default props
+- Each `variant` and `size` combination renders without console errors
+- `asChild` (when supported) clones the child element correctly — see `Button.test.tsx` for the canonical pattern
+- Disabled/loading/empty states render the right ARIA
+- Keyboard interactions work (use `userEvent.tab()`, `userEvent.keyboard('{Enter}')`)
+
+`pnpm --filter @revealui/presentation test` must pass.
+
+### 5. Showcase
+
+Every component needs a showcase at `apps/docs/app/showcase/<slug>.showcase.tsx`. The schema is in `apps/docs/app/components/showcase/types.ts`. Required fields:
+
+- `slug`, `name`, `description`, `category`
+- `controls` — interactive prop knobs (boolean, select, text, number, range, color)
+- `render(props)` — JSX using the current control values
+- `code(props)` — a string that mirrors the rendered JSX (so the Code tab works)
+
+Optional but **strongly encouraged** for any production-bound component:
+
+- `variantGrid` — every (variant × size) combination rendered side-by-side
+- `examples[]` — common usage patterns (icon-only button, button group, etc.)
+- `usage.when` / `usage.avoid` — markdown explaining when to reach for it and the alternatives
+- `a11y.conformance` — list of WCAG criteria explicitly covered, e.g. `["WCAG 2.1 AA contrast", "WCAG 2.1.1 Keyboard"]`
+- `a11y.keyboard` — map of key → behavior, e.g. `{"Tab": "Move focus to next item"}`
+- `a11y.aria` — map of aria-* attributes the component sets or expects
+- `sourceUrl` — package-relative path to the source file, e.g. `"src/components/Button.tsx"`. Auto-renders a "View source" link to GitHub.
+- `related[]` — cross-links to related showcases by slug
+
+Then add the entry to `apps/docs/app/components/showcase/registry.ts` so it appears in the sidebar (the sidebar is auto-generated from the registry — no separate hand-maintained list to update).
+
+## Token-versioning policy
+
+Tokens are part of the public contract. Renaming or removing a `--rvui-*` variable is a breaking change.
+
+- **While pre-1.0** (current): breaking token changes bump the **minor** version (e.g. `0.4.x` → `0.5.0`). Document the rename in the changeset.
+- **Post-1.0**: breaking token changes bump **major**. Provide a deprecation period of at least one minor release with both names exposed.
+- **Adding a new token** is always a patch — no consumers break.
+
+When you rename a token, update both `src/tokens.css` and the public reference at `apps/docs/app/components/showcase/TokensPage.tsx`.
+
+## Versioning
+
+Per the [repo-wide versioning rule](../../.claude/rules/versioning.md), the package starts at `0.1.0` and stays pre-1.0 until consumers + governance + token contract are stable. Don't promote to `1.0.0` casually.
+
+Inside `0.x`, any meaningful behavior change or breaking API change bumps **minor**, not major. Use changesets (`pnpm changeset`) to record the intent — the tooling enforces version policy at release time.
+
+**No changeset for CI-only or workflow-file changes.** Changesets are for source code changes that affect what the package emits.
+
+## Where to ask
+
+- Suite-wide questions → root CONTRIBUTING.md, then `#dev` in the project Discussions
+- Design-system-specific decisions (token shape, accessibility tradeoffs, naming) → file an issue with the `package: presentation` label
+
+## Quick checklist before opening a PR
+
+- [ ] Component file lives under `src/components/` (or `src/primitives/` for primitives)
+- [ ] Re-exported from `src/components/index.ts` and the appropriate `server.ts`/`client.ts`
+- [ ] Uses `--rvui-*` tokens, no hardcoded design values
+- [ ] Tests in `src/__tests__/components/<Component>.test.tsx` cover variants, asChild (if supported), keyboard, a11y
+- [ ] Showcase at `apps/docs/app/showcase/<slug>.showcase.tsx` with controls, render, code, and `a11y` field
+- [ ] Showcase registered in `apps/docs/app/components/showcase/registry.ts`
+- [ ] `pnpm --filter @revealui/presentation test` passes
+- [ ] `pnpm --filter @revealui/presentation typecheck` passes
+- [ ] `pnpm --filter @revealui/presentation build` succeeds (artifact + type defs + tokens.css)
+- [ ] Biome clean
+- [ ] Changeset created via `pnpm changeset` (unless this is a docs-only or CI-only change)

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -279,6 +279,173 @@ function scanForFutureTenseClaims(): FutureClaimMatch[] {
 }
 
 // ---------------------------------------------------------------------------
+// Aspirational-feature blocklist (PR D)
+//
+// High-visibility marketing-copy files (the landing page + GetStarted CTA)
+// must NOT name features that don't ship today unless paired with a qualifier
+// on the same line. The list is hand-maintained from the
+// marketing-claims-2026-04-25 internal honesty audit.
+//
+// Each blocklist token is checked case-insensitively. A token is allowed if
+// the line also contains any QUALIFIER pattern (e.g. "(coming soon)",
+// "(roadmap)", "Roadmap:", or a github issue/PR link).
+//
+// Add/remove tokens here when feature reality changes — when "managed
+// hosting" actually ships, for example, drop it from BLOCKLIST.
+// ---------------------------------------------------------------------------
+
+interface AspirationalMatch {
+  file: string;
+  line: number;
+  token: string;
+  why: string;
+  text: string;
+}
+
+/** Files scanned for aspirational features without qualifiers. */
+const ASPIRATIONAL_SCAN_FILES = [
+  'apps/marketing/src/components/landing',
+  'apps/marketing/src/components/GetStarted.tsx',
+];
+
+interface BlocklistEntry {
+  /** Word/phrase that misleads when shipped without a qualifier. */
+  token: RegExp;
+  /** Human-readable label printed when matched. */
+  label: string;
+  /** Why this is blocklisted — printed alongside the failure. */
+  why: string;
+}
+
+const BLOCKLIST: BlocklistEntry[] = [
+  {
+    token: /\bmanaged hosting\b/i,
+    label: 'managed hosting',
+    why: 'no managed-hosting service ships today',
+  },
+  {
+    token: /\bauto-scal(e|ing)\b/i,
+    label: 'auto-scaling',
+    why: 'no managed platform offers auto-scaling',
+  },
+  {
+    token: /\bdunning\b/i,
+    label: 'dunning',
+    why: 'not implemented; only in stripe-best-practices guidance',
+  },
+  {
+    token: /\b(SSO|single sign-on)\b/i,
+    label: 'SSO',
+    why: 'sso marked planned in packages/core/src/features.ts',
+  },
+  {
+    token: /\bSCIM\b/i,
+    label: 'SCIM',
+    why: 'SCIM provisioning not in code',
+  },
+  {
+    token: /\bon-prem\b/i,
+    label: 'on-prem',
+    why: 'forge docker images not yet published to GHCR',
+  },
+  {
+    token: /\bair-gapped\b/i,
+    label: 'air-gapped',
+    why: 'no documented air-gap deploy path',
+  },
+  {
+    token: /\bRAG\b/,
+    label: 'RAG',
+    why: 'gated on Ollama+pgvector setup, not reachable in default flow',
+  },
+  {
+    token: /\bSLA\b/,
+    label: 'SLA',
+    why: 'no SLA documented in docs/',
+  },
+];
+
+/**
+ * A line is allowed if it contains any qualifier signal:
+ *   - parenthetical markers: "(coming soon)", "(planned)", "(roadmap)",
+ *     "(in active development)", "(forthcoming)", "(will ship)",
+ *     "(in progress)", "(TBD)"
+ *   - the bare word "roadmap" anywhere (case-insensitive) — covers both
+ *     "Roadmap: X" prefixes and "X is on the roadmap" framing
+ *   - a tracker citation (#NNN / issues|pull|pulls URL / .yml workflow /
+ *     `milestone`)
+ */
+const QUALIFIER_PATTERN =
+  /\((coming soon|planned|roadmap|in active development|forthcoming|will ship|in progress|TBD)\b[^)]*\)|\broadmap\b|(#\d+|\/(issues|pull|pulls)\/\d+|\bmilestones?\b|\.ya?ml\b)/i;
+
+function scanForAspirationalFeatures(): AspirationalMatch[] {
+  const matches: AspirationalMatch[] = [];
+
+  function scanFile(filePath: string): void {
+    const rel = path.relative(ROOT, filePath);
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip JSX comments and import lines — they are not user-visible copy
+      if (line.trim().startsWith('//') || line.trim().startsWith('import ')) continue;
+      // Skip lines inside `{/* ... */}` JSX comments (single-line only; multi-line ignored)
+      if (line.trim().startsWith('{/*') && line.trim().endsWith('*/}')) continue;
+
+      for (const entry of BLOCKLIST) {
+        if (!entry.token.test(line)) continue;
+        if (QUALIFIER_PATTERN.test(line)) continue;
+        matches.push({
+          file: rel,
+          line: i + 1,
+          token: entry.label,
+          why: entry.why,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+      } else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts')) {
+        scanFile(full);
+      }
+    }
+  }
+
+  for (const rel of ASPIRATIONAL_SCAN_FILES) {
+    const full = path.join(ROOT, rel);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.isFile()) {
+        scanFile(full);
+      } else if (stat.isDirectory()) {
+        walk(full);
+      }
+    } catch {
+      // path missing, skip
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -385,11 +552,16 @@ function run(): void {
   // Future-tense claim check (CR9-P2-02)
   const futureClaims = scanForFutureTenseClaims();
 
+  // Aspirational-feature blocklist for high-visibility landing copy
+  const aspirationalClaims = scanForAspirationalFeatures();
+
   console.log('====================');
   console.log(`Claims scanned: ${claims.length}`);
   console.log(`Mismatches:     ${mismatches}`);
   console.log(`Future-tense files scanned: ${FUTURE_TENSE_SCAN_FILES.length}`);
   console.log(`Unlinked future-tense markers: ${futureClaims.length}`);
+  console.log(`Aspirational-feature scan files: ${ASPIRATIONAL_SCAN_FILES.length}`);
+  console.log(`Unqualified aspirational features: ${aspirationalClaims.length}`);
 
   if (futureClaims.length > 0) {
     console.log('\nUnlinked future-tense claims (convention: CONTRIBUTING.md):');
@@ -402,7 +574,18 @@ function run(): void {
     );
   }
 
-  if (mismatches > 0 || futureClaims.length > 0) {
+  if (aspirationalClaims.length > 0) {
+    console.log('\nUnqualified aspirational features in landing copy:');
+    for (const c of aspirationalClaims) {
+      console.log(`  ${c.file}:${c.line}  "${c.token}" (${c.why})`);
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nEach blocklist token must be paired with a qualifier on the same line: "(coming soon)", "(roadmap)", "(in active development)", "(planned)", or a "Roadmap:" prefix. Or remove the claim.',
+    );
+  }
+
+  if (mismatches > 0 || futureClaims.length > 0 || aspirationalClaims.length > 0) {
     if (mismatches > 0) {
       console.log('\nFailed: claims do not match codebase reality.');
       if (!showFix) {
@@ -412,9 +595,14 @@ function run(): void {
     if (futureClaims.length > 0) {
       console.log('\nFailed: unlinked future-tense claims.');
     }
+    if (aspirationalClaims.length > 0) {
+      console.log('\nFailed: unqualified aspirational features in landing copy.');
+    }
     process.exit(1);
   } else {
-    console.log('\nAll claims match codebase reality and future-tense markers are tracked.');
+    console.log(
+      '\nAll claims match codebase reality, future-tense markers are tracked, and aspirational features are qualified.',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Promotes 6 commits from `test` to `main` for production release. **Merging this auto-triggers `deploy.yml` and pushes to revealui.com.**

This batch ships the entire honesty audit and design-system Phase 1 work from this session — every misleading claim corrected, the Fair Source explainer live, and a durable CI gate to prevent regression.

## What ships

### Design system Phase 1
- [revealui#573](https://github.com/RevealUIStudio/revealui/pull/573) — `feat(docs)`: design-system docs polish + governance. ShowcaseStory schema extended with `usage`/`a11y`/`sourceUrl`/`install`/`related`. DocLayout sidebar auto-generates from registry (16 → 46 entries). New `packages/presentation/CONTRIBUTING.md`.

### Honesty audit corrections
- [revealui#575](https://github.com/RevealUIStudio/revealui/pull/575) — `fix(marketing)`: P0 corrections. Demo H2 + 3 beats rewritten honest about test-mode-by-default Stripe; PricingTeaser Pro tier dropped misleading "Managed hosting + auto-scaling".
- [revealui#584](https://github.com/RevealUIStudio/revealui/pull/584) — `fix(marketing)`: P1 corrections. Primitives drop dunning + qualify RAG; Persona "Edit prompts" → "Configure agents", "Expose every API automatically" → matching-MCP-server framing; Pro tier drops SLA + RAG; Enterprise tier qualifies SSO/SCIM/on-prem as roadmap.
- [revealui#585](https://github.com/RevealUIStudio/revealui/pull/585) — `fix(marketing)`: P2/P3 corrections + Fair Source linkage. Hero subhead MCP framing, "Production-ready" → "Local dev stack", trust strip "MIT licensed" → "OSS (MIT) · Pro is Fair Source [→]", Problem drops "Background jobs and queues", Persona quote re-typeset as hypothetical, FAQ Q5 softened, Free tier surfaces FSL split, GetStarted drops "ready to deploy", `/pricing` FAQ links to `/fair-source`. Plus a follow-up commit removing the section-description "managed hosting" reference caught by the new gate.

### Fair Source explainer
- [revealui#577](https://github.com/RevealUIStudio/revealui/pull/577) — `feat(marketing)`: Public-facing `/fair-source` page (hero + contract grid + package table + 2-year clock + peer projects + FAQ + CTA) and engineer-targeted `docs/FAIR_SOURCE.md`.

### Durable enforcement
- [revealui#588](https://github.com/RevealUIStudio/revealui/pull/588) — `feat(ci)`: claim-drift aspirational-feature scanner. Hand-maintained blocklist of words (`managed hosting`, `dunning`, `SSO`, `SCIM`, `on-prem`, `RAG`, `SLA`, etc.) that fail the gate when used in `apps/marketing/src/components/landing/*.tsx` without a qualifier. Self-validated: caught its own first attempt to push when one violation remained.

## What this changes externally

- **revealui.com home**: every claim now matches what's reachable in code today; new `/fair-source` page linked from the Hero trust strip
- **docs.revealui.com**: design-system showcases now cover all 46 components in the sidebar (not just 16); `/docs/FAIR_SOURCE` engineer reference live; `packages/presentation/CONTRIBUTING.md` documents the per-component bar
- **CI**: future copy regressions blocked at the gate; `pnpm validate:claims` is the canonical command

## What's still queued (post-prod)

- **UI/DX-first initiative** — full visual + dx pass on marketing/docs/admin/studio/CLI; needs a dedicated planning session
- **Cron orchestration** — daily-funnel pattern for the recurring agent tasks
- **Real demo recording** — replace the static play-button placeholder with an asciinema/tmux cast

## Test plan

- [x] Every PR in this batch CI-green at squash-merge time on `test`
- [x] Claim-drift gate locally clean on the post-PR-C `test` state
- [x] Pre-push gate clean
- [ ] After merge: deploy.yml run all 10 jobs green
- [ ] After merge: visit `revealui.com` — confirm new positioning, Hero brand background, `/fair-source` link works, `/pricing` FAQ links to `/fair-source`
- [ ] Smoke-test the `/v2 → /` consolidation: hit `/v2` should be a 404 now (was retired in #566)
