### PR TITLE
fix(api): route reconcile-customers cron through protectedStripe (GAP-131 follow-up)

### DIFF
--- a/apps/api/src/routes/cron/__tests__/reconcile-customers.test.ts
+++ b/apps/api/src/routes/cron/__tests__/reconcile-customers.test.ts
@@ -43,6 +43,15 @@ vi.mock('stripe', () => {
   return { default: MockStripe };
 });
 
+// GAP-131: route uses protectedStripe from @revealui/services. Mock the wrapper
+// directly so we don't pull in supabase/resilience.ts (which imports
+// `createLogger` and would force this test to mock a wider observability surface).
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    customers: { list: hoisted.customersListMock },
+  },
+}));
+
 import reconcileApp from '../reconcile-customers.js';
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/cron/reconcile-customers.ts
+++ b/apps/api/src/routes/cron/reconcile-customers.ts
@@ -44,9 +44,10 @@ import { timingSafeEqual } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { accountSubscriptions, unreconciledWebhooks, users } from '@revealui/db/schema';
+import { protectedStripe } from '@revealui/services';
 import { eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 
 const app = new Hono();
 
@@ -92,7 +93,12 @@ app.post('/reconcile-customers', async (c) => {
   const lookbackUnix = Math.floor((Date.now() - lookbackDays * 24 * 60 * 60 * 1000) / 1000);
 
   const db = getClient();
-  const stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-03-25.dahlia' });
+  // GAP-131: every Stripe consumer must go through `protectedStripe` (DB-backed
+  // circuit breaker + retry + single API-version pin). The cron originally landed
+  // before #581's consolidation guard merged; this migration fixes the validator
+  // miss without changing behavior — `protectedStripe.customers.list` routes
+  // through the same SDK call wrapped by `callWithResilience`.
+  const stripe = protectedStripe;
 
   // ── pull Stripe customers in window ───────────────────────────────────
   // Bounded: a single page of up to `batchSize`. We DO check `has_more`


### PR DESCRIPTION
## Summary

- Routes apps/api/src/routes/cron/reconcile-customers.ts through  instead of 
- Unblocks the merge train —  (added in #581) was hard-failing all pushes to  because #587 (GAP-143) landed before #581 and used direct SDK construction

## Test plan
- [x] Validator passes locally ([validate:stripe-client] OK — only the canonical protectedStripe wrapper instantiates Stripe.)
- [ ] CI green
- [ ] No behavior change: same SDK calls, just wrapped in the DB-backed circuit breaker + retry from #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)