### PR TITLE
feat(docs): add Suite map + per-product pages (PR-B honesty audit)

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -98,6 +98,18 @@ const sections: NavSection[] = [
     ],
   },
   {
+    title: 'RevealUI Studio Suite',
+    items: [
+      { label: 'Suite Overview', path: '/docs/SUITE' },
+      { label: 'RevDev — Studio + Console', path: '/docs/suite/revdev' },
+      { label: 'RevVault — Secret Vault', path: '/docs/suite/revvault' },
+      { label: 'RevCon — Editor Sync', path: '/docs/suite/revcon' },
+      { label: 'RevealCoin — RVC Token', path: '/docs/suite/revealcoin' },
+      { label: 'RevSkills — Agent Skills', path: '/docs/suite/revskills' },
+      { label: 'RevKit — WSL Workstation', path: '/docs/suite/revkit' },
+    ],
+  },
+  {
     title: 'Blog',
     items: [
       { label: 'Why We Built RevealUI', path: '/docs/blog/01-why-we-built-revealui' },

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,8 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)**: Justifiable, Orthogonal, Sovereign
 - [Core Stability](./CORE_STABILITY.md): API stability tiers, production verification status, version policy
 - [Component Catalog](./COMPONENT_CATALOG.md): 57 native UI components
 - [AI](./AI.md): AI package overview, prompt/response/semantic caching
-- [Pro](./PRO.md): Studio desktop app, MCP servers, open-model inference, editor integrations, harnesses, services, x402, marketplace, Forge
+- [Pro](./PRO.md): Pro packages (`@revealui/ai`, `@revealui/harnesses`), MCP integration, open-model inference, x402, marketplace
+- [RevealUI Studio Suite](./SUITE.md): Companion products (RevDev, RevVault, RevCon, RevealCoin, Forge, RevSkills, RevKit) — what each does and how they compose
 
 ## Agent Coordination
 
@@ -57,6 +58,18 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)**: Justifiable, Orthogonal, Sovereign
 
 - [MCP Marketplace](./MARKETPLACE.md): Publish MCP servers with agent-commerce pricing and revenue-share options
 - [Forge](./FORGE.md): Self-hosted enterprise deployment (Docker Compose, domain lock, unlimited users)
+
+## RevealUI Studio Suite
+
+RevealUI is one product in a suite of eight that compose into an agent-first SDLC platform. See [Suite Overview](./SUITE.md) for the full table and composition story.
+
+- [RevDev](./suite/revdev.md) — Studio (Tauri 2 desktop) + Console (Go SSH TUI) + harness daemon
+- [RevVault](./suite/revvault.md) — age-encrypted secret vault, source of truth for every suite secret
+- [RevCon](./suite/revcon.md) — editor + agent-rule sync via symlinks (`link.sh`)
+- [RevealCoin](./suite/revealcoin.md) — `RVC` token on Solana Token-2022, mainnet mint deployed
+- [Forge](./FORGE.md) — self-hosted enterprise deployment kit
+- [RevSkills](./suite/revskills.md) — curated Agent Skills for Claude Code / Cursor
+- [RevKit](./suite/revkit.md) — portable WSL workstation toolkit
 
 ## Legal
 

--- a/docs/SUITE.md
+++ b/docs/SUITE.md
@@ -1,0 +1,95 @@
+---
+title: "RevealUI Studio Suite"
+description: "What each product in the RevealUI Studio Suite does, how they relate, and what becomes possible when you compose them."
+category: index
+audience: developer
+---
+
+# The RevealUI Studio Suite
+
+RevealUI is one product in a suite of eight that together form an agent-first SDLC platform. Each ships in its own repo with its own license; the rest of this docs site is the canonical home for **RevealUI** itself.
+
+This page exists for one reason: a customer reading **RevealUI Pro** docs sees mentions of *Studio*, *RevVault*, *RevCon*, and *Forge* and reasonably wonders — *which of those am I buying, which are separate, and how do they fit together?* The table below answers that. The composition story below explains what becomes possible when you use them together.
+
+---
+
+## The eight products
+
+| Product | Repo | What it is | License | Status |
+|---|---|---|---|---|
+| **RevealUI** | [revealui](https://github.com/RevealUIStudio/revealui) | The agent-first business runtime. Five primitives (users, content, products, payments, AI) for humans and agents. **The platform.** | MIT (OSS subset) + FSL-1.1-MIT (Pro packages, MIT after 2 years) | Pre-launch (0 paying customers) |
+| **RevDev** | [revdev](https://github.com/RevealUIStudio/revdev) | Native developer tools. **Studio** (Tauri 2 desktop AI editor + agent dashboard) and **Console** (Go/Bubble Tea SSH TUI). Both UIs talk to a shared harness daemon (Node) that coordinates agents and routes tools to the RevealUI API. | (per-product LICENSE) | Active |
+| **RevVault** | [revvault](https://github.com/RevealUIStudio/revvault) | Age-encrypted secret vault. CLI (`revvault get/set/list/search/export-env`) + Tauri 2 desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible. **Source of truth for every secret in the suite** per the suite-wide secrets rule. | (per-product LICENSE) | Active |
+| **RevCon** | [revcon](https://github.com/RevealUIStudio/revcon) | Centralized editor configs (Zed, VS Code, Cursor) + agent-rule sync (Claude Code, Cursor rules). Symlinked into target projects via `link.sh`/`unlink.sh` — edits propagate instantly, nothing committed downstream. **Not gated by the RevealUI Pro license.** | (per-product LICENSE) | Active |
+| **RevealCoin** | [revealcoin](https://github.com/RevealUIStudio/revealcoin) | Hybrid utility/governance/reward token on Solana Token-2022. **`RVC`** = customer-facing on-chain ticker (6 decimals, 58.906B supply, freeze authority renounced). Live landing page at [revealcoin.revealui.com](https://revealcoin.revealui.com). | (per-product LICENSE) | Pre-launch (mainnet mint deployed; vesting + multi-sig + Raydium pool gate public distribution) |
+| **Forge** | [forge](https://github.com/RevealUIStudio/forge) | Self-hosted enterprise deployment kit. Docker Compose stack + per-customer stamp scripts + domain lock + unlimited users. Same kit produces stamped instances (e.g. AlleviaForge for Allevia Technology). Canonical docs at [`/docs/FORGE`](./FORGE). | (per-product LICENSE) | Pre-launch (Docker images not yet on GHCR — stack runs from source today) |
+| **RevSkills** | [revskills](https://github.com/RevealUIStudio/revskills) | Curated [Agent Skills](https://agentskills.io) (`SKILL.md` format) for modern web development. Compatible with Claude Code, Cursor, and any tool supporting the Agent Skills standard. Install via `npx skills add RevealUIStudio/revskills`. | (per-product LICENSE) | Active |
+| **RevKit** | [revkit](https://github.com/RevealUIStudio/revkit) | Portable WSL development environment toolkit. Profile presets (`solo-dev`, `full-stack`, `ai-studio`, `team`), bootstrap scripts, shell config, boot optimization, RevStation PowerShell module. Plug a USB into a Windows host, boot WSL, get a RevealUI Studio-grade workstation. | (per-product LICENSE) | Active |
+
+---
+
+## What becomes possible together
+
+Each pairing below is something that's hard or impossible without both products.
+
+### RevealUI alone
+
+The agentic business runtime in a single repo. Self-hostable, five primitives, MIT for the OSS subset and Fair Source for the Pro packages (`@revealui/ai`, `@revealui/harnesses`). Everything else in the suite composes against this.
+
+### RevealUI + RevDev
+
+**Managed agent operations.** Studio gives you a desktop UI for the agents running against your RevealUI install — agent task feed, hypervisor view, tool routing, manual approvals. Console gives you the same surface in an SSH TUI for production triage. The harness daemon coordinates PTY sessions and JSON-RPC tool calls so a Claude Code or Cursor agent can take actions through Studio that hit the RevealUI API. Closes the "what is my agent doing right now" gap.
+
+### RevealUI + RevVault
+
+**Secret-managed deployment.** Every credential the suite uses lives in age-encrypted RevVault, never in plaintext `.env` files outside an ephemeral tmpfs. `revvault export-env` materializes secrets at session start; rotation goes through one runbook per credential type. Trust story compresses to one sentence: *"Secrets live in RevVault, encrypted by an age identity that doesn't leave the developer's machine."*
+
+### RevealUI + RevCon
+
+**Team consistency.** Editor settings, Claude Code rules, Cursor rules, agent skill files — all symlinked from one source-of-truth repo. New contributor runs `pnpm dlx revcon sync` (or `./link.sh --target . --profile revealui`) and they have the team's editing posture, agent rules, and convention files. No drift, no per-repo copies.
+
+### RevealUI + Forge
+
+**White-label resale.** Stamp the Forge kit per customer (e.g. AlleviaForge for Allevia Technology), drop in their domain + branding, run on their infrastructure with full domain lock and unlimited users. Enterprise tier without managed-hosting overhead.
+
+### RevealUI + RevealCoin
+
+**Agent-priced commerce (planned).** MCP servers price each call in `RVC` via x402; agents pay other agents in tokens; an 80/20 platform/developer revenue split is the planned launch policy. Live payouts open with the billing-readiness audit. The marketplace endpoints, Stripe Connect onboarding, and x402 facilitator are wired in `apps/api/src/routes/marketplace.ts`; production payouts pending pre-launch gates.
+
+### RevealUI + RevSkills
+
+**Curated agent capability.** Agent skills are versioned, reviewed, and distributed through one repo. Agents inherit behaviour and conventions, not just tools. Plug in to Claude Code / Cursor without writing your own skill files.
+
+### RevealUI + RevKit
+
+**Portable workstation.** Boot a Windows host, plug a USB, run the RevKit bootstrap, and you have the studio's full WSL environment — Nix, direnv, fnm, pnpm, profile-tier defaults, shell aliases, PowerShell module, optional Forge drive mount. Replaces "set up your laptop for four hours" with "run the bootstrap script."
+
+### All eight together
+
+The **RevealUI Studio Suite** — a coherent agent-first SDLC platform. **Build** (RevealUI), **operate** (RevDev), **secure** (RevVault), **align** (RevCon), **monetize** (RevealCoin), **ship** (Forge), **curate** (RevSkills), **portable** (RevKit). Each one is independently useful; the leverage compounds when you compose them.
+
+---
+
+## Boundary statements (worth memorising)
+
+These are the boundaries the rest of the docs site routinely crosses. If a doc inside `/docs/*` says one of these wrong, treat it as drift:
+
+- **Studio lives in RevDev**, not in RevealUI. Mentions of *"the Studio desktop app"* in a RevealUI Pro context are about a product sold separately; your Pro license unlocks Studio's commercial features, but Studio itself ships from the RevDev repo.
+- **Editor sync lives in RevCon**, not in RevealUI. There is no `@revealui/editors` package inside the RevealUI monorepo; `revcon` is the home and is not gated by the Pro license.
+- **`RVC` is the customer-facing ticker** for RevealCoin. `$RVUI` is the *internal* codename used in code constants, env-var prefixes, and route paths (e.g., `/api/billing/rvui-payment`). Public-facing copy uses `RVC`; internal route slugs may stay `rvui-payment`.
+- **Forge is both a tier name AND a separate product.** The "Forge tier" of RevealUI Pro and the **Forge** self-host kit are related but distinct: the kit is what an Enterprise-tier customer deploys; the tier is the licensing posture. The canonical Forge guide is [`/docs/FORGE`](./FORGE).
+- **RevVault is the source of truth for every secret in the suite.** Per the suite-wide secrets rule: there is no escape hatch. CI mirrors are downstream of RevVault, not authoritative.
+
+---
+
+## Per-product pages
+
+Each suite product has a one-page entry under [`/docs/suite/`](./suite/). They cross-link to the canonical README in each product's repo.
+
+- [RevDev](./suite/revdev) — Studio + Console + harness daemon
+- [RevVault](./suite/revvault) — age-encrypted secret store + rotation
+- [RevCon](./suite/revcon) — editor + agent-rule sync
+- [RevealCoin](./suite/revealcoin) — RVC token, Token-2022, Solana mainnet
+- [Forge](./FORGE) — self-host kit (canonical)
+- [RevSkills](./suite/revskills) — Agent Skills curation
+- [RevKit](./suite/revkit) — portable WSL workstation kit

--- a/docs/suite/revcon.md
+++ b/docs/suite/revcon.md
@@ -1,0 +1,62 @@
+---
+title: "RevCon"
+description: "Centralized editor configurations and agent-rule sync for RevealUI projects. Symlinks edit propagate instantly without committing downstream."
+category: suite
+audience: developer
+---
+
+# RevCon
+
+**Centralized editor configurations for RevealUI projects.**
+
+> RevCon is a separate suite product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revcon](https://github.com/RevealUIStudio/revcon) (its package historically shipped under the name `editor-configs`). This page summarises what RevCon is; the canonical product README lives in the RevCon repo.
+
+## What RevCon is
+
+A **non-monorepo, non-published convention bundle** that ships:
+
+- **Editor configs** for Zed, VS Code, and Cursor — symlinked into target projects so edits propagate instantly without commits to the target repo.
+- **Profiles** — per-project rule packs (e.g. `revealui` profile applies the suite's Claude Code rules + Cursor rules + agent skill files).
+- **`link.sh` / `unlink.sh`** — installer + remover. Supports `--target`, `--profile`, `--editor`, and `--dry-run`.
+
+```bash
+# Link into a project with the revealui profile
+./link.sh --target ~/projects/RevealUI --profile revealui
+
+# Link base configs only (no profile)
+./link.sh --target ~/projects/RevealCoin
+
+# Link a single editor
+./link.sh --target ~/projects/RevealUI --profile revealui --editor zed
+
+# Preview without changes
+./link.sh --dry-run --target ~/projects/RevealUI --profile revealui
+
+# Remove symlinks
+./unlink.sh --target ~/projects/RevealUI
+
+# List available profiles
+./link.sh --list
+```
+
+## How it composes with RevealUI
+
+- **New contributor flow**: clone RevealUI, then `pnpm dlx revcon sync` (or run RevCon's `link.sh` against the checkout). They get the team's editing posture, agent rules, and convention files. No drift.
+- **Cross-suite consistency**: the same RevCon profile installs Claude Code rules into RevealUI, RevDev, RevVault, RevealCoin, and Forge. One source of truth for *"how do agents behave in our codebases."*
+- **Symlinks, not copies**: edits to RevCon master files propagate to every linked project on filesystem refresh — no per-repo PRs to keep configs in sync.
+
+## Important: not gated by Pro license
+
+There is no `@revealui/editors` package inside the RevealUI monorepo. RevCon is intentionally decoupled from the RevealUI runtime — editor profiles evolve on a different cadence than the CMS/API packages and are not gated by the Pro license. Anyone can install RevCon against any project, paid tier or not.
+
+If a doc on this site says *"the `@revealui/editors` package"*, that's stale text — the canonical product is RevCon.
+
+## Status
+
+Active.
+
+## See also
+
+- [Suite overview](../SUITE) — how RevCon relates to the rest of the suite
+- [`/pro/editors`](/pro/editors) — Pro-docs page that points back to RevCon
+- [RevCon README](https://github.com/RevealUIStudio/revcon/blob/main/README.md) — canonical product docs

--- a/docs/suite/revdev.md
+++ b/docs/suite/revdev.md
@@ -1,0 +1,56 @@
+---
+title: "RevDev"
+description: "Native developer tools for RevealUI: Studio (Tauri 2 desktop) and Console (Go SSH TUI), backed by a shared harness daemon."
+category: suite
+audience: developer
+---
+
+# RevDev
+
+**Native developer tools for [RevealUI](https://github.com/RevealUIStudio/revealui). One product, two interfaces.**
+
+> RevDev is a separate suite product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev). This page summarises what RevDev is and how it composes with RevealUI; the canonical product README lives in the RevDev repo.
+
+## What RevDev ships
+
+| Interface | Stack | Use case |
+|---|---|---|
+| **Studio** | Tauri 2 + React 19 (desktop) | AI editor + agent coordination dashboard. Visual hypervisor view, agent task feed, manual approvals, tool routing. Daily-driver UI for someone running RevealUI agents. |
+| **Console** | Go + Bubble Tea (SSH TUI) | Ops cockpit. Agent health, deploys, billing, alerts. Designed to run inside an SSH session for production triage. |
+| **Harness Daemon** | Node.js | Shared backend for both UIs. Coordinates AI agents, manages PTY sessions, routes JSON-RPC tool calls. Talks to the RevealUI API (Hono on Vercel) for everything customer-data-shaped. |
+
+```
+┌─────────┐     ┌──────────┐
+│ Studio  │     │ Console  │
+│ (Tauri) │     │   (Go)   │
+└────┬────┘     └────┬─────┘
+     │   JSON-RPC    │
+     └───────┬───────┘
+             │
+     ┌───────┴────────┐
+     │ Harness Daemon  │
+     │   (Node.js)     │
+     └───────┬────────┘
+             │
+     ┌───────┴────────┐
+     │  RevealUI API   │
+     │ (Hono / Vercel) │
+     └────────────────┘
+```
+
+## How it composes with RevealUI
+
+- **Studio talks to your RevealUI deployment.** Point Studio at `https://your-api.example.com`; Studio reads agent tasks, marketplace transactions, license state, and content collections through the RevealUI API.
+- **The harness daemon is where Claude Code / Cursor / other AI agents plug in.** Agents launched from Studio use the daemon's JSON-RPC tool registry to call RevealUI primitives (sign in as a user, create a content row, refund a charge, publish an MCP server, etc.).
+- **A RevealUI Pro license unlocks Studio's commercial features.** The harness daemon and Studio shell are usable against any RevealUI install (including the OSS-only Free tier); Pro-tier interactions (RAG, multi-agent orchestration, billing dashboards) require a Pro license at runtime.
+- **Console is the right tool for production incidents.** When you're on-call and SSH'd into a jump box, you don't want a desktop GUI — Console gives you the same agent / deploy / billing telemetry over a TUI.
+
+## Status
+
+Active. Pre-launch (no published binaries). The harness daemon is documented in the RevDev repo's `apps/harness/` tree; Studio in `apps/studio/`; Console in `apps/console/`.
+
+## See also
+
+- [RevealUI Pro overview](../PRO) — what the Pro tier unlocks (including Studio's Pro features)
+- [Suite overview](../SUITE) — how RevDev relates to the rest of the suite
+- [RevDev README](https://github.com/RevealUIStudio/revdev/blob/main/README.md) — canonical product docs

--- a/docs/suite/revealcoin.md
+++ b/docs/suite/revealcoin.md
@@ -1,0 +1,72 @@
+---
+title: "RevealCoin (RVC)"
+description: "Hybrid utility/governance/reward token on Solana Token-2022. RVC is the customer-facing on-chain ticker."
+category: suite
+audience: developer
+---
+
+# RevealCoin
+
+**Hybrid utility / governance / reward token for the RevealUI ecosystem, built on Solana's Token-2022 program.**
+
+> RevealCoin is a separate suite product. The repo is at [RevealUIStudio/revealcoin](https://github.com/RevealUIStudio/revealcoin). The customer-facing landing page is [revealcoin.revealui.com](https://revealcoin.revealui.com), deployed from `apps/revealcoin` in the RevealUI monorepo.
+
+## Token spec
+
+| Field | Value |
+|---|---|
+| **Name** | RevealCoin |
+| **Symbol (customer-facing)** | `RVC` |
+| **Decimals** | 6 |
+| **Total Supply** | 58,906,000,000 |
+| **Program** | Solana Token-2022 (Token Extensions) |
+| **Extensions** | MetadataPointer, TokenMetadata |
+| **Freeze Authority** | None (permanently renounced) |
+
+> 58,906,000,000 — US currency in circulation on August 14, 1971, the day before Nixon ended dollar–gold convertibility.
+
+## Mainnet deployment
+
+| Parameter | Value |
+|---|---|
+| **Network** | Solana Mainnet-Beta |
+| **Mint Address** | `4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo` |
+
+The mint is deployed and metadata is on-chain. **RevealCoin is pre-launch for public distribution.** The following gates are open:
+
+- **On-chain vesting** schedules for team / contributor / treasury allocations
+- **Multi-sig** controls for treasury operations
+- **Raydium pool** initialization for public liquidity
+
+Until those gates close, the token is not publicly distributed and live trading is not enabled.
+
+## Internal vs external naming
+
+This is the most common drift point in the docs surface — worth memorising:
+
+- **`RVC`** is the **customer-facing on-chain ticker.** Marketing copy, customer-facing API messages, public docs, and Solana Explorer all use `RVC`.
+- **`$RVUI`** is the **internal codename.** It appears in code constants, env-var prefixes (`REVEALUI_RVUI_*`), database column names, and route paths (e.g. `/api/billing/rvui-payment`). Internal Kingdom-taxonomy lore preserved this naming through the rename to RevealCoin.
+
+Both are correct *in their respective contexts* — but a public doc that says *"RVUI payment is not available"* is leaking internal naming. Customer-visible strings should always say `RVC`.
+
+## How it composes with RevealUI
+
+When public distribution opens (post-vesting / multi-sig / Raydium gates), the integration story is:
+
+- **MCP marketplace per-call pricing in `RVC`** via the x402 protocol. Agents pay other agents in tokens.
+- **Tier-gated `RVC` rewards** for ecosystem participation (open question per pricing docs).
+- **`RVC` payment endpoint**: `POST /api/billing/rvui-payment` (route slug retains internal `rvui-` codename) — currently returns `501 RVC payment is not yet available`.
+
+None of this is live yet. Treat any doc that says *"agents can pay in `RVC` today"* as drift.
+
+## Status
+
+Pre-launch (mainnet mint deployed, public distribution gated).
+
+## See also
+
+- [Suite overview](../SUITE) — how RevealCoin relates to the rest of the suite
+- [Marketplace](../MARKETPLACE) — where RVC pricing flows in once public distribution opens
+- [HTTP 402 Payments blog post](../blog/02-http-402-payments) — payment-protocol context
+- [RevealCoin README](https://github.com/RevealUIStudio/revealcoin/blob/main/README.md) — canonical product docs
+- [revealcoin.revealui.com](https://revealcoin.revealui.com) — public landing page + tokenomics

--- a/docs/suite/revkit.md
+++ b/docs/suite/revkit.md
@@ -1,0 +1,64 @@
+---
+title: "RevKit"
+description: "Portable WSL development environment toolkit. Profile-based bootstrap for a RevealUI Studio-grade workstation."
+category: suite
+audience: developer
+---
+
+# RevKit
+
+**Portable WSL development environment toolkit for RevealUI projects.**
+
+> RevKit is a separate suite product. The repo is at [RevealUIStudio/revkit](https://github.com/RevealUIStudio/revkit) (product name: RevealUI DevKit). This page summarises what RevKit is; the canonical product README lives in the RevKit repo.
+
+## What RevKit is
+
+A bootstrap toolkit that takes a Windows host with WSL2 and turns it into a RevealUI Studio-grade workstation. Configurable via TOML profile presets:
+
+| Profile | Tier | RAM | Cores | Docker | Studio Drive | Ollama |
+|---|---|---|---|---|---|---|
+| `solo-dev.toml` | T0 | 8 GB | 4 | No | No | No |
+| `full-stack.toml` | T1 | 12 GB | 8 | Yes | Yes | No |
+| `ai-studio.toml` | T1+ | 16 GB | 8 | Yes | Yes | Yes |
+| `team.toml` | T1 | 16 GB | 8 | Yes | Yes | No |
+
+## Quick start
+
+```bash
+# 1. Copy a profile preset
+cp profiles/solo-dev.toml config.toml
+
+# 2. Edit your identity
+$EDITOR config.toml
+
+# 3. Render templates
+./scripts/render.sh --config config.toml --output ~/.revealui
+
+# 4. Source the environment
+echo 'for f in ~/.revealui/wsl/bashrc.d/*.sh; do source "$f"; done' >> ~/.bashrc
+```
+
+## What it ships
+
+- **Bootstrap scripts** — set up WSL2, install Nix + direnv, fnm, pnpm, Node 24, base shell aliases
+- **Shell config fragments** — sourced from `~/.revealui/wsl/bashrc.d/*.sh`
+- **Boot optimization** — `setup-wsl-boot.sh` masks 23 hardware/desktop services, disables Docker/snap auto-start (sockets preserved); cuts cold-boot time materially
+- **Editor configs** — portable Zed settings (and integrates with RevCon for the rest)
+- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Sync-AllRepos`, `Mount-WSLDev`, etc.)
+- **Forge drive support** — optional ext4 USB mount at `/mnt/forge` for offloading Docker data, models, databases, caches off the C: drive
+
+## How it composes with RevealUI
+
+- **New contributor onboarding**: Joshua's standing pattern — plug a USB into a Windows host, boot WSL, run the RevKit bootstrap, you have the studio's full environment in minutes instead of hours.
+- **Reproducibility**: every dev workstation in the suite builds from the same RevKit profile, so behaviour is consistent (Nix version, Node version, pnpm version, shell aliases, PATH order).
+- **Pairs with RevVault**: RevKit sets up the age-identity mount path RevVault expects (`~/.age-identity/keys.txt`); RevVault provides the secrets RevKit's CI tasks need.
+
+## Status
+
+Active.
+
+## See also
+
+- [Suite overview](../SUITE) — how RevKit relates to the rest of the suite
+- [Local-first setup](../LOCAL_FIRST) — running RevealUI itself locally (separate concern; RevKit is the *workstation*, LOCAL_FIRST is the *runtime*)
+- [RevKit README](https://github.com/RevealUIStudio/revkit/blob/main/README.md) — canonical product docs

--- a/docs/suite/revskills.md
+++ b/docs/suite/revskills.md
@@ -1,0 +1,63 @@
+---
+title: "RevSkills"
+description: "Curated Agent Skills for modern web development. Compatible with Claude Code, Cursor, and any tool supporting the Agent Skills standard."
+category: suite
+audience: developer
+---
+
+# RevSkills
+
+**Curated [Agent Skills](https://agentskills.io) for modern web development. Built by RevealUI Studio.**
+
+> RevSkills is a separate suite product. The repo is at [RevealUIStudio/revskills](https://github.com/RevealUIStudio/revskills). This page summarises what RevSkills is; the canonical product README lives in the RevSkills repo.
+
+## What RevSkills is
+
+A curated collection of **`SKILL.md`-format Agent Skills** packaged for distribution. Compatible with:
+
+- **Claude Code** — load skills via the agent-skills standard
+- **Cursor** — same SKILL.md format
+- **Any tool** supporting the Agent Skills standard at [agentskills.io](https://agentskills.io)
+
+Each skill is independently versioned (per the suite-wide pre-1.0 SemVer rule) and reviewed before publication.
+
+## Install
+
+```bash
+# All skills
+npx skills add RevealUIStudio/revskills
+
+# Single skill
+npx skills add RevealUIStudio/revskills --skill next-best-practices
+```
+
+## What's in the catalog
+
+The RevSkills repo organises skills by surface area. Representative entries (the canonical list lives in the RevSkills repo `skills/` directory):
+
+### Framework + app patterns
+
+- **`next-best-practices`** — Next.js 15+ App Router (RSC, PPR, caching, server actions, metadata)
+- **`tailwind-v4`** — Tailwind CSS v4 (`@theme`, CSS-first config, CVA, migration from v3)
+- **`security-hardening`** — OWASP Top 10 (CSP, CORS, auth, rate limiting, XSS, CSRF)
+
+### Data + sync
+
+(See the RevSkills repo for the full per-skill list — this is a representative sample, not exhaustive.)
+
+## How it composes with RevealUI
+
+- **Agents working inside RevealUI repos** inherit consistent behaviour by loading the relevant RevSkills entries — no per-developer skill duplication.
+- **Cross-suite consistency**: the same skills are loaded into RevealUI, RevDev, RevVault, Forge etc. when an agent works against any suite product.
+- **Pairs with RevCon**: RevCon ships the *symlink mechanism* for editor configs and rule files; RevSkills ships the *content* of agent skills. Together they give a new contributor the full agent posture in one bootstrap.
+
+## Status
+
+Active.
+
+## See also
+
+- [Suite overview](../SUITE) — how RevSkills relates to the rest of the suite
+- [RevCon](./revcon) — symlink machinery for editor configs and agent rules
+- [RevSkills README](https://github.com/RevealUIStudio/revskills/blob/main/README.md) — canonical product docs
+- [agentskills.io](https://agentskills.io) — the upstream Agent Skills standard

--- a/docs/suite/revvault.md
+++ b/docs/suite/revvault.md
@@ -1,0 +1,52 @@
+---
+title: "RevVault"
+description: "Age-encrypted secret vault. CLI plus Tauri 2 desktop app. 100% passage-compatible. Source of truth for every secret in the RevealUI Studio Suite."
+category: suite
+audience: developer
+---
+
+# RevVault
+
+**Age-encrypted secret vault with CLI and Tauri desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.**
+
+> RevVault is a separate suite product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revvault](https://github.com/RevealUIStudio/revvault). This page summarises what RevVault is and how it composes with RevealUI; the canonical product README lives in the RevVault repo.
+
+## What RevVault is
+
+- **Encrypted at rest.** Secrets stored as `.age` files using x25519 key exchange. The age identity (`~/.age-identity/keys.txt` by convention) gates every secret in the vault.
+- **CLI**: `revvault get`, `set`, `list`, `search`, `delete`, `edit`, `export-env`. Implemented in Rust (workspace under `crates/`).
+- **Desktop app**: Tauri 2 + React 19. Search, browse, create, reveal, copy, delete, with secret-shape detection.
+- **Namespaces**: secrets organized by first path segment — `credentials/`, `ssh/`, `revealui/`, `revealcoin/`, etc.
+- **Fuzzy search**: find secrets by partial path match.
+- **Import**: migrate plaintext secret files with automatic categorisation.
+- **Path validation**: directory traversal and injection attacks blocked at the API layer.
+
+## How it composes with RevealUI
+
+RevealUI's [secrets convention](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md) is hard-rule:
+
+> Every secret the RevealUI Suite depends on lives in RevVault. Full stop.
+
+That includes API keys, database URLs, webhook secrets, JWT/session secrets, signing keys, Solana keypairs, license keys, Vercel tokens, Railway tokens, Supabase credentials, Stripe keys, OAuth client secrets, age identities, SSH keys — anything else.
+
+In practice:
+
+- **Local dev**: `revvault export-env` materializes `.env`-shaped output that direnv loads at session start. The `.env` files exist as a convenience; the RevVault entry is authoritative.
+- **CI**: GitHub Actions secrets are mirrored from RevVault by a publish step, never hand-typed.
+- **Rotation**: each credential type has a runbook entry under [`docs/CREDENTIAL-ROTATION-RUNBOOK`](../CREDENTIAL-ROTATION-RUNBOOK). Rotation updates RevVault first; downstream re-reads from the same source.
+
+The trust story compresses to one sentence: *"Secrets live in RevVault, encrypted by an age identity that doesn't leave the developer's machine."*
+
+## Pro-tier integration
+
+Per [`/docs/PRO`](../PRO), a RevealUI Pro license unlocks the **RevVault desktop app** and **rotation engine** as Pro-tier features in the Ecosystem Features table. The CLI and core crate are MIT and free for any tier.
+
+## Status
+
+Active. Production-grade for personal / studio use; commercial offering wraps existing RevealUI Pro tier.
+
+## See also
+
+- [Suite overview](../SUITE) — how RevVault relates to the rest of the suite
+- [Credential rotation runbook](../CREDENTIAL-ROTATION-RUNBOOK) — RevVault paths per credential type
+- [RevVault README](https://github.com/RevealUIStudio/revvault/blob/main/README.md) — canonical product docs


### PR DESCRIPTION
## Summary

Adds the canonical **RevealUI Studio Suite** overview page (`docs/SUITE.md`) plus six per-product pages (`docs/suite/<name>.md`), giving the rest of the docs site a stable link target when it needs to disambiguate between RevealUI and a companion suite product.

This resolves the structural finding from the docs honesty audit at internal docs — multiple line-level drifts (phantom `@revealui/editors`, Studio attribution to RevealUI, RevVault scope unclear, `RVC` vs `$RVUI` ticker confusion) all stem from there being no canonical *"what each product does and how they compose"* page.

Independent of [#592 (PR-A)](https://github.com/RevealUIStudio/revealui/pull/592) — both target `test`, no overlap. PR-A fixes line-level drift; PR-B adds the link target that makes the next round of fixes (PR-C/E) more legible.

## What's in the box

**New files** (9):
- `docs/SUITE.md` — overview, eight-product table, composition story (*"What becomes possible together"*), boundary statements
- `docs/suite/revdev.md` — Studio (Tauri 2 desktop) + Console (Go SSH TUI) + harness daemon
- `docs/suite/revvault.md` — age-encrypted vault, source of truth for every suite secret
- `docs/suite/revcon.md` — editor + agent-rule sync via symlinks; **not gated by Pro license**
- `docs/suite/revealcoin.md` — `RVC` token, Token-2022 spec, mainnet mint address, `RVC` vs `$RVUI` naming
- `docs/suite/revskills.md` — Agent Skills curation
- `docs/suite/revkit.md` — portable WSL workstation toolkit

(Forge already has `docs/FORGE.md` as canonical — `SUITE.md` cross-links to it. RevealUI itself is the rest of the docs site.)

**Cross-linking** (2 files modified):
- `apps/docs/app/components/DocLayout.tsx` — new "RevealUI Studio Suite" sidebar section with seven entries
- `docs/INDEX.md` — replaces the Pro-section bullet that conflated Studio + editors + harnesses with RevealUI itself; adds dedicated "RevealUI Studio Suite" landing-page section linking each product

## Per Joshua's direction in the audit Q&A

- **Q2 "section and page"** — both single overview AND per-product entries ✅
- **Q3 "whichever is sooner"** — bundled together in one PR ✅

## Composition story (the "even more when done together" angle)

The SUITE.md page makes this explicit. Pairings covered:

- **RevealUI + RevDev** = managed agent operations
- **RevealUI + RevVault** = secret-managed deployment
- **RevealUI + RevCon** = team consistency
- **RevealUI + Forge** = white-label resale
- **RevealUI + RevealCoin** = agent-priced commerce (planned)
- **RevealUI + RevSkills** = curated agent capability
- **RevealUI + RevKit** = portable workstation
- **All eight together** = the agent-first SDLC platform: build / operate / secure / align / monetize / ship / curate / portable

## Test plan

- [x] `pnpm validate:claims` green: 48 claims scanned, 0 mismatches, 0 unqualified aspirational features
- [x] Pre-push gate green (all 13 hard-fail validators)
- [ ] CI green on PR
- [ ] Visual smoke after deploy: confirm new sidebar section renders; `/docs/SUITE` returns 200; each `/docs/suite/<name>` returns 200; cross-links from `/docs/PRO`, `/docs/FORGE`, `/docs/MARKETPLACE` to suite pages resolve
- [ ] Verify the seven per-product page entries are reachable in the docs sidebar and not behind the LicenseGate

## Notes

- All claims are grounded against each suite product's actual README (verified by reading `~/suite/<product>/README.md` for revdev / revvault / revcon / revealcoin / revskills / revkit before writing each page).
- The token spec for RevealCoin (mint address, supply, decimals, freeze authority) comes directly from `~/suite/revealcoin/README.md`.
- The `RVC` vs `$RVUI` boundary is called out explicitly in `docs/SUITE.md` and `docs/suite/revealcoin.md` per memory `project_revealcoin_ticker_split`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
