### PR TITLE
feat(ci): add reconcile-customers as 4th GHA reconciliation job

### DIFF
--- a/.github/workflows/reconciliation-crons.yml
+++ b/.github/workflows/reconciliation-crons.yml
@@ -114,3 +114,31 @@ jobs:
             echo "::warning::sweep-grace-periods returned $status (non-200)"
             exit 1
           fi
+
+  reconcile-customers:
+    name: reconcile-customers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /api/cron/reconcile-customers
+        env:
+          API_URL: ${{ vars.REVEALUI_API_URL || 'https://api.revealui.com' }}
+          CRON_SECRET: ${{ secrets.REVEALUI_CRON_SECRET }}
+        run: |
+          if [[ -z "$CRON_SECRET" ]]; then
+            echo "::error::REVEALUI_CRON_SECRET secret not set"
+            exit 1
+          fi
+          response=$(curl -sS -X POST \
+            -H "X-Cron-Secret: $CRON_SECRET" \
+            -H "Content-Type: application/json" \
+            -w "\nHTTP_STATUS:%{http_code}" \
+            "$API_URL/api/cron/reconcile-customers" || true)
+          status=$(echo "$response" | grep "HTTP_STATUS:" | cut -d: -f2)
+          body=$(echo "$response" | sed '/HTTP_STATUS:/d')
+          echo "Status: $status"
+          echo "Body: $body"
+          if [[ "$status" != "200" ]]; then
+            echo "::warning::reconcile-customers returned $status (non-200)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds reconcile-customers as the 4th job in .github/workflows/reconciliation-crons.yml
- Mirrors the existing three jobs verbatim — same 5-min timeout, same X-Cron-Secret header, same non-200 -> warning contract
- Closes the wiring gap from HANDOFF-2026-04-25-stripe-live-mode-pr-train.md section 3-B: #587 shipped the route + #583 shipped the workflow but reconcile-customers was deliberately left out until both landed

## Test plan
- [ ] CI green
- [ ] On the next */15 tick after merge: GitHub Actions tab shows 4 jobs running in parallel for the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)