### PR TITLE
feat(ci): extend claim-drift gate to docs surface (PR-D honesty audit)

### DIFF
--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1,3 +1,4 @@
+// console-allowed
 /**
  * Claim Drift Detector
  *
@@ -12,6 +13,10 @@
  * Exit codes:
  *   0 = all claims match reality
  *   1 = mismatches found
+ *
+ * This is a CLI script — console output is the program's purpose.
+ * The `console-allowed` marker on line 1 exempts the file from the
+ * no-console-log rule (per .revealui/code-standards.json).
  */
 
 import fs from 'node:fs';
@@ -304,8 +309,23 @@ interface AspirationalMatch {
 
 /** Files scanned for aspirational features without qualifiers. */
 const ASPIRATIONAL_SCAN_FILES = [
+  // Marketing surfaces (existing — marketing-claims-2026-04-25)
   'apps/marketing/src/components/landing',
   'apps/marketing/src/components/GetStarted.tsx',
+  // Docs surfaces (PR-D continuation, docs-claims-2026-04-26)
+  // High-visibility orientation + tutorial pages where the same blocklist applies.
+  // Deeper technical docs (AI.md, DATABASE.md, etc.) are tuned in a follow-up.
+  'docs/INDEX.md',
+  'docs/BUILD_YOUR_BUSINESS.md',
+  'docs/EXAMPLES.md',
+  'docs/QUICK_START.md',
+  'docs/SUITE.md',
+  // Pro tier surface (paying-customer eyes)
+  'apps/docs/public/docs-pro/index.md',
+  'apps/docs/public/docs-pro/ai/index.md',
+  'apps/docs/public/docs-pro/inference/index.md',
+  'apps/docs/public/docs-pro/mcp/index.md',
+  'apps/docs/public/docs-pro/editors/index.md',
 ];
 
 interface BlocklistEntry {
@@ -389,13 +409,27 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
     } catch {
       return;
     }
+    const isMarkdown = filePath.endsWith('.md');
     const lines = content.split('\n');
+    let inFence = false;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      // Skip JSX comments and import lines — they are not user-visible copy
-      if (line.trim().startsWith('//') || line.trim().startsWith('import ')) continue;
-      // Skip lines inside `{/* ... */}` JSX comments (single-line only; multi-line ignored)
-      if (line.trim().startsWith('{/*') && line.trim().endsWith('*/}')) continue;
+
+      // Markdown fenced code blocks: skip — examples, env-var snippets, JSON, etc.
+      if (isMarkdown && line.startsWith('```')) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+
+      // Markdown blockquote prefixes are user-visible — DON'T skip them
+      // (banner notes like "> SSO is on the roadmap" must still qualify)
+
+      // TS/TSX-only skips: JSX comments and import lines are not user-visible copy
+      if (!isMarkdown) {
+        if (line.trim().startsWith('//') || line.trim().startsWith('import ')) continue;
+        if (line.trim().startsWith('{/*') && line.trim().endsWith('*/}')) continue;
+      }
 
       for (const entry of BLOCKLIST) {
         if (!entry.token.test(line)) continue;
@@ -422,7 +456,7 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walk(full);
-      } else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts')) {
+      } else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts') || e.name.endsWith('.md')) {
         scanFile(full);
       }
     }
@@ -441,6 +475,265 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
       // path missing, skip
     }
   }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// Suite-product attribution gate (PR-D, docs-claims-2026-04-26)
+//
+// The RevealUI Studio Suite is eight separate products (RevealUI, RevDev,
+// RevVault, RevCon, RevealCoin, Forge, RevSkills, RevKit). When a docs
+// page that belongs to RevealUI itself names another suite product, it
+// must either:
+//   - link to /docs/SUITE or /docs/suite/<name>
+//   - include explicit "(separate product …)" / "RevealUIStudio/<repo>"
+//     attribution on the same line
+//   - live in an allowlisted file (the suite map itself, the per-product
+//     pages, FORGE.md which is the canonical Forge page).
+//
+// Without this, mentions of "Studio" / "RevVault" / "RevCon" / etc. across
+// docs/PRO.md and similar pages routinely drift into "Pro tier features
+// of RevealUI" framing, when in reality they're shipped from sibling repos.
+// ---------------------------------------------------------------------------
+
+interface SuiteProductMatch {
+  file: string;
+  line: number;
+  product: string;
+  text: string;
+}
+
+/**
+ * Files in scope for the suite-attribution gate. Initial coverage is
+ * deliberately narrow — tutorial pages + the rewritten Pro MCP page
+ * where existing attribution is clean enough that the gate doesn't
+ * trip on legacy text.
+ *
+ * Wider coverage (INDEX.md, PRO.md, MARKETPLACE.md, docs-pro/index,
+ * docs-pro/{ai,inference,editors}/index.md, ROADMAP.md, blog posts,
+ * VAUGHN.md, SECRETS.md, REST API reference) is queued for follow-up
+ * PRs after the remaining attribution in those files is tightened.
+ * The honesty audit at `~/suite/.jv/docs/audits/docs-claims-2026-04-26.md`
+ * tracks the coverage queue.
+ */
+const SUITE_ATTRIBUTION_SCAN_FILES = [
+  'docs/BUILD_YOUR_BUSINESS.md',
+  'docs/EXAMPLES.md',
+  'docs/QUICK_START.md',
+  'apps/docs/public/docs-pro/mcp/index.md',
+];
+
+/**
+ * Files that ARE the canonical home for naming suite products. They can
+ * mention products without per-line attribution because the whole file is
+ * the attribution.
+ */
+const SUITE_ATTRIBUTION_ALLOWLIST = new Set<string>([
+  'docs/SUITE.md',
+  'docs/FORGE.md', // canonical Forge product page
+]);
+
+/** Per-product pages all live under `docs/suite/`. Allowlist by prefix. */
+const SUITE_ATTRIBUTION_ALLOWLIST_PREFIXES = ['docs/suite/'];
+
+/**
+ * Product tokens. The pattern matches each as a standalone word (case-
+ * sensitive — these are proper nouns) so it doesn't fire on "studio"
+ * mid-sentence. `@revealui/editors` is special-cased because the package
+ * doesn't actually exist (lives in revcon).
+ *
+ * `Studio` uses a negative lookbehind to avoid firing on "RevealUI
+ * Studio" — that's the company name, not the desktop app. The Studio
+ * desktop-app references typically appear as "Studio desktop app",
+ * "Studio dashboard", "Studio (Tauri)", etc.
+ */
+const SUITE_PRODUCTS: { token: RegExp; label: string }[] = [
+  { token: /(?<!RevealUI\s)\bStudio\b/, label: 'Studio (lives in RevDev, not the company name)' },
+  { token: /\bRevVault\b/, label: 'RevVault (separate suite product)' },
+  { token: /\bRevCon\b/, label: 'RevCon (separate suite product)' },
+  { token: /\bRevealCoin\b/, label: 'RevealCoin (separate suite product)' },
+  { token: /\bRevDev\b/, label: 'RevDev (separate suite product)' },
+  { token: /\bRevSkills\b/, label: 'RevSkills (separate suite product)' },
+  { token: /\bRevKit\b/, label: 'RevKit (separate suite product)' },
+  { token: /@revealui\/editors\b/, label: '@revealui/editors (does not exist; ships in RevCon)' },
+];
+
+/**
+ * A line is allowed if it cites the suite map, links to a per-product
+ * page, names the source repo, or includes an explicit attribution
+ * phrase. Multiple acceptance patterns — order doesn't matter.
+ */
+const SUITE_ATTRIBUTION_QUALIFIER = new RegExp(
+  [
+    // Direct links to suite map or per-product pages (absolute or relative)
+    String.raw`\/docs\/SUITE`,
+    String.raw`\/docs\/suite\/`,
+    String.raw`\.\/SUITE\.md\b`,
+    String.raw`\.\/suite\/`,
+    String.raw`\.\.\/SUITE\.md\b`,
+    String.raw`\.\.\/suite\/`,
+    // Source-repo mentions (canonical attribution)
+    String.raw`RevealUIStudio\/(revvault|revcon|revealcoin|revdev|revskills|revkit|forge|editor-configs)`,
+    // Explicit attribution phrases (non-greedy spans permit markdown bold etc.)
+    String.raw`\bseparate.{0,30}(?:product|repo|suite|kit|app)\b`,
+    String.raw`\bships in.{0,40}(?:product|repo|suite|kit|app|RevDev|RevVault|RevCon|RevealCoin|RevSkills|RevKit|Forge)\b`,
+    String.raw`\bcompanion product`,
+    String.raw`\bRevealUI Studio Suite`,
+    String.raw`\blives in.{0,30}(?:RevDev|RevVault|RevCon|RevealCoin|RevSkills|RevKit|Forge|monorepo|repo)\b`,
+    String.raw`\bsee (?:\[|\*\*)?(?:RevDev|RevVault|RevCon|RevealCoin|RevSkills|RevKit|Forge|Suite)`,
+    String.raw`\bintentionally decoupled\b`,
+    String.raw`\bnot yet shipped\b`,
+    // Forge tier / kit phrasings (Forge is both a product and a tier)
+    String.raw`Forge \(Enterprise\)`,
+    String.raw`Forge tier`,
+    String.raw`Forge Edition`,
+    String.raw`Forge kit`,
+    String.raw`Forge guide`,
+  ].join('|'),
+  'i',
+);
+
+function scanForSuiteProductLeaks(): SuiteProductMatch[] {
+  const matches: SuiteProductMatch[] = [];
+
+  function isAllowlisted(rel: string): boolean {
+    if (SUITE_ATTRIBUTION_ALLOWLIST.has(rel)) return true;
+    return SUITE_ATTRIBUTION_ALLOWLIST_PREFIXES.some((prefix) => rel.startsWith(prefix));
+  }
+
+  function scanFile(filePath: string): void {
+    const rel = path.relative(ROOT, filePath).replace(/\\/g, '/');
+    if (isAllowlisted(rel)) return;
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    let inFence = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip fenced code (env templates, command blocks, etc.)
+      if (line.startsWith('```')) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+
+      // Skip frontmatter delimiters and YAML-shaped lines (title:, etc.)
+      // — frontmatter is not customer-visible prose
+      if (i < 20 && (line === '---' || /^[a-zA-Z_][a-zA-Z0-9_-]*:\s/.test(line))) continue;
+
+      for (const product of SUITE_PRODUCTS) {
+        if (!product.token.test(line)) continue;
+        if (SUITE_ATTRIBUTION_QUALIFIER.test(line)) continue;
+        matches.push({
+          file: rel,
+          line: i + 1,
+          product: product.label,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+
+  for (const rel of SUITE_ATTRIBUTION_SCAN_FILES) {
+    const full = path.join(ROOT, rel);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.isFile()) scanFile(full);
+    } catch {
+      // path missing, skip
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// $RVUI internal-ticker leak guard (PR-D, docs-claims-2026-04-26)
+//
+// `$RVUI` is the INTERNAL codename for the RevealCoin token. The customer-
+// facing on-chain ticker is `RVC`. Public docs (docs.revealui.com) must
+// use `RVC`; the dollar-sign-prefixed internal form must never leak.
+//
+// Lowercase route slugs like `/api/billing/rvui-payment` are fine — those
+// are code constants on the API, not customer-visible labels. This guard
+// catches the explicit `$RVUI` form only.
+// ---------------------------------------------------------------------------
+
+interface RvuiLeakMatch {
+  file: string;
+  line: number;
+  text: string;
+}
+
+const RVUI_LEAK_PATTERN = /\$RVUI\b/;
+
+/**
+ * Files allowed to mention `$RVUI` because they explicitly explain the
+ * boundary between the internal codename and the customer-facing `RVC`
+ * ticker.
+ */
+const RVUI_LEAK_ALLOWLIST = new Set<string>([
+  'docs/SUITE.md',
+  'docs/suite/revealcoin.md',
+  // The REST API reference cites the internal route slug (`rvui-payment`)
+  // and provides the explicit RVUI-vs-RVC boundary note customers need.
+  'docs/api/rest-api/README.md',
+]);
+
+function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {
+  const matches: RvuiLeakMatch[] = [];
+
+  function isAllowlisted(rel: string): boolean {
+    return RVUI_LEAK_ALLOWLIST.has(rel) || rel.startsWith('docs/suite/revealcoin');
+  }
+
+  function scanFile(filePath: string): void {
+    const rel = path.relative(ROOT, filePath).replace(/\\/g, '/');
+    if (isAllowlisted(rel)) return;
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (RVUI_LEAK_PATTERN.test(line)) {
+        matches.push({
+          file: rel,
+          line: i + 1,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === 'dist' || e.name === '.git') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+      } else if (e.name.endsWith('.md')) {
+        scanFile(full);
+      }
+    }
+  }
+
+  walk(path.join(ROOT, 'docs'));
+  walk(path.join(ROOT, 'apps/docs/public/docs-pro'));
 
   return matches;
 }
@@ -552,8 +845,14 @@ function run(): void {
   // Future-tense claim check (CR9-P2-02)
   const futureClaims = scanForFutureTenseClaims();
 
-  // Aspirational-feature blocklist for high-visibility landing copy
+  // Aspirational-feature blocklist for high-visibility landing + docs copy
   const aspirationalClaims = scanForAspirationalFeatures();
+
+  // Suite-product attribution gate (PR-D)
+  const suiteLeaks = scanForSuiteProductLeaks();
+
+  // $RVUI internal-ticker leak guard (PR-D)
+  const rvuiLeaks = scanForRvuiTickerLeaks();
 
   console.log('====================');
   console.log(`Claims scanned: ${claims.length}`);
@@ -562,6 +861,8 @@ function run(): void {
   console.log(`Unlinked future-tense markers: ${futureClaims.length}`);
   console.log(`Aspirational-feature scan files: ${ASPIRATIONAL_SCAN_FILES.length}`);
   console.log(`Unqualified aspirational features: ${aspirationalClaims.length}`);
+  console.log(`Unattributed suite-product mentions: ${suiteLeaks.length}`);
+  console.log(`Internal $RVUI ticker leaks: ${rvuiLeaks.length}`);
 
   if (futureClaims.length > 0) {
     console.log('\nUnlinked future-tense claims (convention: CONTRIBUTING.md):');
@@ -575,7 +876,7 @@ function run(): void {
   }
 
   if (aspirationalClaims.length > 0) {
-    console.log('\nUnqualified aspirational features in landing copy:');
+    console.log('\nUnqualified aspirational features:');
     for (const c of aspirationalClaims) {
       console.log(`  ${c.file}:${c.line}  "${c.token}" (${c.why})`);
       console.log(`    ${c.text.substring(0, 140)}`);
@@ -585,7 +886,36 @@ function run(): void {
     );
   }
 
-  if (mismatches > 0 || futureClaims.length > 0 || aspirationalClaims.length > 0) {
+  if (suiteLeaks.length > 0) {
+    console.log('\nSuite-product mentions without attribution:');
+    for (const c of suiteLeaks) {
+      console.log(`  ${c.file}:${c.line}  ${c.product}`);
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nEach suite-product mention must either link to /docs/SUITE or /docs/suite/<name>, name the source repo (RevealUIStudio/<repo>), or include a "(separate product)" attribution. The Suite Map and per-product pages under /docs/suite/ are allowlisted.',
+    );
+  }
+
+  if (rvuiLeaks.length > 0) {
+    console.log('\n$RVUI internal-codename leaks (must use customer-facing RVC):');
+    for (const c of rvuiLeaks) {
+      console.log(`  ${c.file}:${c.line}`);
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nThe internal codename `$RVUI` must not appear in public docs. Use `RVC` (the customer-facing on-chain ticker). Lowercase route slugs like `/api/billing/rvui-payment` are fine.',
+    );
+  }
+
+  const anyFailures =
+    mismatches > 0 ||
+    futureClaims.length > 0 ||
+    aspirationalClaims.length > 0 ||
+    suiteLeaks.length > 0 ||
+    rvuiLeaks.length > 0;
+
+  if (anyFailures) {
     if (mismatches > 0) {
       console.log('\nFailed: claims do not match codebase reality.');
       if (!showFix) {
@@ -596,12 +926,18 @@ function run(): void {
       console.log('\nFailed: unlinked future-tense claims.');
     }
     if (aspirationalClaims.length > 0) {
-      console.log('\nFailed: unqualified aspirational features in landing copy.');
+      console.log('\nFailed: unqualified aspirational features.');
+    }
+    if (suiteLeaks.length > 0) {
+      console.log('\nFailed: suite-product mentions without attribution.');
+    }
+    if (rvuiLeaks.length > 0) {
+      console.log('\nFailed: $RVUI internal-codename leaks in public docs.');
     }
     process.exit(1);
   } else {
     console.log(
-      '\nAll claims match codebase reality, future-tense markers are tracked, and aspirational features are qualified.',
+      '\nAll claims match codebase reality, future-tense markers are tracked, aspirational features are qualified, suite products are attributed, and no $RVUI ticker leaks were found.',
     );
   }
 }


### PR DESCRIPTION
## Summary

Extends the claim-drift gate (`scripts/validate/claim-drift.ts`) to the docs surface, mirroring the marketing-claims gate (PR #588). Adds three new validations against docs.revealui.com content + the existing Pro tier surface. Internal audit at internal docs.

Single-file change: `scripts/validate/claim-drift.ts` (+346 / -10).

## What's new

### 1. Aspirational-feature scanner extended to docs (Phase 1)

`ASPIRATIONAL_SCAN_FILES` gains 10 docs paths:

- Orientation pages: `docs/INDEX.md`, `docs/BUILD_YOUR_BUSINESS.md`, `docs/EXAMPLES.md`, `docs/QUICK_START.md`, `docs/SUITE.md`
- Pro tier surface: `apps/docs/public/docs-pro/{index,ai,inference,mcp,editors}/index.md` (5 files)

Existing `BLOCKLIST` (managed hosting, SSO, SCIM, dunning, on-prem, RAG, SLA, etc.) now applied to those docs files. Markdown fenced code blocks are skipped to avoid false positives from env-var snippets and command examples. The walk now picks up `.md` files alongside `.ts`/`.tsx`.

### 2. Suite-product attribution gate (Phase 4) — NEW scanner

`scanForSuiteProductLeaks`: when a docs page in scope mentions a suite product (`Studio`, `RevVault`, `RevCon`, `RevealCoin`, `RevDev`, `RevSkills`, `RevKit`, `@revealui/editors`), the line must include either:

- a link to the suite map (`/docs/SUITE` or `/docs/suite/<name>`, absolute or relative `./suite/`)
- a source-repo URL (`RevealUIStudio/<repo>`)
- an attribution phrase (`separate ... product/repo/suite/kit/app`, `lives in <Product>`, `see <Product>`, `intentionally decoupled`, `not yet shipped`, `RevealUI Studio Suite`, `Forge tier`, `Forge kit`, etc.)
- or live in an allowlisted file (`docs/SUITE.md`, `docs/FORGE.md`, `docs/suite/*`)

The `Studio` pattern uses negative lookbehind to avoid firing on "RevealUI Studio" (the company name, not the desktop app).

**Initial coverage is narrow** — `docs/BUILD_YOUR_BUSINESS.md`, `docs/EXAMPLES.md`, `docs/QUICK_START.md`, `apps/docs/public/docs-pro/mcp/index.md`. Wider coverage (INDEX, PRO, MARKETPLACE, the rest of docs-pro/, ROADMAP, blog posts, VAUGHN, SECRETS, REST API reference) is queued for a follow-up PR after the per-doc P1 attribution touch-ups land.

### 3. `$RVUI` internal-codename leak guard (Phase 5) — NEW scanner

`scanForRvuiTickerLeaks`: any literal `$RVUI` in `docs/` or `apps/docs/public/docs-pro/` is a hard fail. Per memory `project_revealcoin_ticker_split`: `RVC` is the customer-facing on-chain ticker; `$RVUI` is the internal codename. Lowercase route slugs like `/api/billing/rvui-payment` are fine (code constants, not customer labels).

Allowlisted files (they explicitly explain the boundary):
- `docs/SUITE.md`
- `docs/suite/revealcoin.md`
- `docs/api/rest-api/README.md`

## Out of scope (queued for follow-up PRs)

- **Phantom-reference scanner** (mentions of `pnpm` scripts / `apps/<name>/` / `packages/<name>/` / route paths that don't exist) — most complex of the audit's five proposed phases; ships separately with careful tuning to avoid false positives on roadmap mentions
- **Wider suite-attribution coverage**: `INDEX.md`, `PRO.md`, `MARKETPLACE.md`, `docs-pro/{ai,inference,editors}/index.md`, `ROADMAP.md`, blog posts, `VAUGHN.md`, `SECRETS.md`, REST API reference. Each needs the host-doc attribution tightened first; expansion follows.
- **Wider aspirational-feature coverage**: deeper technical docs (`AI.md`, `DATABASE.md`, `AUTH.md`, etc.) need blocklist tuning first.

## Test plan

- [x] `pnpm validate:claims` green on PR-D state: 48 claims, 0 mismatches, 0 unlinked future-tense, 0 unqualified aspirational (across 12 files), 0 unattributed suite mentions (across 4 files), 0 `$RVUI` leaks
- [x] Verified against simulated post-#592 + post-#594 state: gate stays green when the rest of the audit's P0 + Suite Map land. (Cherry-picked PR-A's `docs/PRO.md`, `docs/MARKETPLACE.md`, `docs-pro/*` rewrites + PR-B's `docs/SUITE.md`, `docs/suite/*`, `docs/INDEX.md` updates into a temp branch — gate clean.)
- [x] Pre-push gate green (all 13 hard-fail validators)
- [ ] CI green on PR

## Composes with

- [#592 (PR-A)](https://github.com/RevealUIStudio/revealui/pull/592) — P0 line-level drift fixes (rewrites `docs-pro/mcp/index.md` and other files this gate scans)
- [#594 (PR-B)](https://github.com/RevealUIStudio/revealui/pull/594) — Suite Map + per-product pages (gives the suite-attribution gate its allowlist target)

PR-D is independent from a CI-correctness perspective — its scope is narrow enough that pre-push gate passes without #592 or #594 merged. Once they merge, the gate's coverage can widen in PR-G (or an extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
