### PR TITLE
chore(docs): P2 polish — SemVer demotions, stutter cleanup, timing softening (PR-F)

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -119,7 +119,7 @@ const sections: NavSection[] = [
       { label: 'The Five Primitives', path: '/docs/blog/05-five-primitives' },
       { label: 'Open Source & Pro', path: '/docs/blog/06-open-source-and-pro' },
       { label: 'Agent-First Future', path: '/docs/blog/07-agent-first-future' },
-      { label: 'Getting Started in 10 Minutes', path: '/docs/blog/08-getting-started' },
+      { label: 'Getting Started in About 30 Minutes', path: '/docs/blog/08-getting-started' },
     ],
   },
   {

--- a/apps/docs/app/routes/HomePage.tsx
+++ b/apps/docs/app/routes/HomePage.tsx
@@ -24,7 +24,7 @@ See the [Quick Start guide](/docs/QUICK_START) for the full walkthrough, or brow
 ## Documentation Sections
 
 ### Getting Started
-- [Quick Start](/docs/QUICK_START)  -  Get running in 5 minutes
+- [Quick Start](/docs/QUICK_START)  -  Get a local dev stack running
 - [Build Your Business](/docs/BUILD_YOUR_BUSINESS)  -  End-to-end tutorial: scaffold to deploy
 - [Examples](/docs/EXAMPLES)  -  Blog, subscription starter, e-commerce storefront
 
@@ -61,7 +61,7 @@ See the [Quick Start guide](/docs/QUICK_START) for the full walkthrough, or brow
 - [The Five Primitives](/docs/blog/05-five-primitives)  -  Users, content, products, payments, AI
 - [Open Source & Pro](/docs/blog/06-open-source-and-pro)  -  Our monetization philosophy
 - [Agent-First Future](/docs/blog/07-agent-first-future)  -  Building for the agent economy
-- [Getting Started in 10 Minutes](/docs/blog/08-getting-started)  -  From zero to deployed
+- [Getting Started in About 30 Minutes](/docs/blog/08-getting-started)  -  From zero to deployed
 
 ---
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -831,7 +831,7 @@ Before creating posts, you may want to set up categories:
 
 ### Content Examples
 
-Ready-to-use content examples for each collection. Copy and paste these into your admin admin panel and replace the placeholder text with your own content.
+Ready-to-use content examples for each collection. Copy and paste these into your admin panel and replace the placeholder text with your own content.
 
 **Contents Collection Examples**
 
@@ -1052,7 +1052,7 @@ Image: [Link uploaded media]
 **Problem**: API returns empty `docs` array
 **Solutions**:
 
-- Check if data exists in admin admin
+- Check if data exists in admin
 - Verify collection access permissions
 - Check `where` filters are correct
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1319,5 +1319,5 @@ setInterval(() => {
 
 ---
 
-**Last Updated**: February 2026
-**Version**: 1.0.0
+**Last Updated**: 2026-04-26
+**Version**: 0.2 (working draft — pre-1.0 per the suite-wide [versioning convention](../CONTRIBUTING.md#versioning))

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,7 +13,7 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)**: Justifiable, Orthogonal, Sovereign
 
 ## Getting Started
 
-- [Quick Start](./QUICK_START.md): 5-minute setup guide
+- [Quick Start](./QUICK_START.md): get a local dev stack running
 - [Build Your Business](./BUILD_YOUR_BUSINESS.md): End-to-end tutorial: scaffold to deploy
 - [Examples](./EXAMPLES.md): Blog, subscription starter, storefront
 

--- a/docs/VAUGHN.md
+++ b/docs/VAUGHN.md
@@ -657,7 +657,7 @@ Failed verifications downgrade the declared capability to `false` and log a warn
 - [x] Session identity detection (6-tier)
 - [x] Claude Code adapter (hooks + workboard)
 - [x] Content layer (canonical definitions → tool-specific generation)
-- [x] RPC server (JSON-RPC over Unix socket)
+- [x] RPC server (JSON-RPC over Unix socket) — code shipped; the daemon process itself is not auto-started in default sessions today, so RPC features no-op gracefully when the socket is absent. See `~/.claude/hooks/` for the `isDaemonAlive()` gate.
 
 ### Phase 2: VAUGHN Core
 - [x] Define `VaughnAdapter` interface in `@revealui/harnesses`

--- a/docs/architecture/ADR-005-two-repo-model.md
+++ b/docs/architecture/ADR-005-two-repo-model.md
@@ -28,7 +28,7 @@ After adopting Fair Source licensing (ADR-003), all source code moved to the pub
 
 ### No submodules
 
-The repos are fully independent. No submodules, no git-level coupling. Coordination happens through convention (both repos share the same `.claude/rules/` via RevCon symlinks) and the workboard protocol.
+The repos are fully independent. No submodules, no git-level coupling. Coordination happens through convention (both repos share the same agent / editor convention rules) and a shared workboard protocol.
 
 ## Alternatives Considered
 
@@ -41,4 +41,4 @@ The repos are fully independent. No submodules, no git-level coupling. Coordinat
 - Contributors only need the public repo. The private repo is founder-only.
 - MASTER_PLAN updates require a separate commit to the private repo (agents handle this automatically via the coordination protocol)
 - No sync scripts, no code duplication between repos
-- The private repo is lightweight (~114 files, mostly markdown)
+- The private repo is lightweight — markdown plans, gap trackers, and business documents

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -16,7 +16,7 @@ When you build a SaaS product today, the acquisition funnel looks something like
 
 Now consider what happens when a developer asks Claude, "What platform has billing built in and supports MCP?" The agent does not open a browser. It does not read your hero banner. It does not care about your gradient backgrounds or testimonial carousel. It searches structured data sources -- package registries, OpenAPI specs, Agent Cards, tool definitions -- and evaluates them programmatically.
 
-This is not a hypothetical future. IEEE Spectrum has reported that autonomous AI agents are becoming primary users of the web. Gartner projects that 40% of enterprise applications will embed AI agents by the end of 2026. The agent economy is projected to reach $10.91 billion in 2026, growing at 43% year-over-year.
+This is not a hypothetical future. Industry coverage and analyst forecasts in 2025–2026 have consistently put autonomous AI agents on the path to becoming primary consumers of web APIs and structured data, with adoption projections in the tens of percent of enterprise applications and the agent-economy total addressable market growing at high double-digit rates year-over-year. (Specific figures cycle quickly; treat the directional signal as the durable claim, not the exact percentages.)
 
 The traditional marketing funnel is not going away. But it is being supplemented by a parallel funnel:
 

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -1,4 +1,4 @@
-# From Zero to Production in 10 Minutes
+# From Zero to Production in About 30 Minutes
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 
@@ -572,7 +572,7 @@ Your application is live. Visit `https://my-business.vercel.app/admin` to access
 
 ## What you have built
 
-Stop the clock. In roughly 10 minutes, you have a ready-to-deploy business application with:
+Stop the clock. With accounts pre-provisioned (NeonDB, Stripe, Vercel) and copy-paste commands, the walkthrough fits in about 30 minutes start to deployed. From here you have a business application with:
 
 - **A admin with typed collections and access control**  -  define your data model in TypeScript, get a full admin UI and REST API automatically
 - **User authentication with session-based auth**  -  secure by default with httpOnly cookies, brute force protection, and rate limiting

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -183,15 +183,19 @@ docker compose down
 
 ### Health Checks
 
-The API exposes a health endpoint at `GET /api/health` that returns:
+The API exposes a health endpoint at `GET /health/ready` (Vercel-friendly path; legacy alias at `GET /api/health`) that returns:
 
 ```json
 {
   "status": "ok",
-  "version": "1.0.0",
-  "uptime": 3600
+  "version": "0.5.5",
+  "uptime": 3600,
+  "db": "healthy",
+  "memory": "47.52%"
 }
 ```
+
+Pre-1.0; the `version` field reports the runtime package version from `package.json`. Don't depend on it being stable until the project promotes to 1.0.
 
 Use this in your Docker health check or load balancer configuration.
 


### PR DESCRIPTION
## Summary

Final P2 polish batch from the docs honesty audit. 10 files (+21 / -17). Internal audit at internal docs.

This is the last of the audit-driven PR series (PR-A through PR-F). After this lands, the audit's P0 / P1 / P2 / P3 findings are addressed in shipped or in-flight PRs.

## What landed

### 1. SemVer hardline rule violations

Per `~/.claude/rules/versioning.md` "start pre-1.0":

- `docs/DATABASE.md` trailing `Version: 1.0.0` → `0.2 (working draft)` with cross-link to versioning convention
- `docs/guides/deployment.md` health-endpoint example `"version": "1.0.0"` → `"0.5.5"` (matches actual runtime), with note that the field reports `package.json` version and is unstable until 1.0 promotion

### 2. `admin admin` stutter cleanup

Search/replace artifact from a past `payload` → `admin` rewrite. Two occurrences in `docs/ADMIN_GUIDE.md` collapsed to single `admin`.

### 3. Timing claims softened

- `blog/08-getting-started.md` — "From Zero to Production in 10 Minutes" → "in About 30 Minutes"; "In roughly 10 minutes you have..." → "fits in about 30 minutes start to deployed" with the prerequisite-account caveat
- `docs/INDEX.md` "5-minute setup guide" → "get a local dev stack running"
- `apps/docs/app/routes/HomePage.tsx` matching softening on "Get running in 5 minutes" + the blog 08 link label
- `apps/docs/app/components/DocLayout.tsx` sidebar entry matches

### 4. ADR-005 internal-coordination leakage cleanup

Per audit Cluster D:
- "both repos share the same `.claude/rules/` via RevCon symlinks" → "agent / editor convention rules" (drops RevCon implementation detail from public ADR)
- "lightweight (~114 files, mostly markdown)" → "lightweight — markdown plans, gap trackers, and business documents" (drops stale file count)

### 5. VAUGHN.md Phase 1 daemon caveat

The "RPC server (JSON-RPC over Unix socket)" checkbox now has an inline note: *the daemon process itself is not auto-started in default sessions today; RPC calls no-op gracefully via the `isDaemonAlive()` gate.* Per internal docs.

### 6. Blog 07 IEEE Spectrum / Gartner stats footnoting

Specific "$10.91 billion in 2026, growing at 43%" + "40% of enterprise applications" + "IEEE Spectrum has reported" replaced with directional framing ("tens of percent...", "high double-digit rates year-over-year") plus an explicit parenthetical that figures cycle quickly. The directional signal is the durable claim; specific cited percentages were not properly footnoted.

## Test plan

- [x] `pnpm validate:claims` green: 48 claims, 0 mismatches, 0 unlinked future-tense, 0 unqualified aspirational, 0 unattributed suite mentions, 0 `$RVUI` leaks
- [x] Pre-push gate green (all 13 hard-fail validators)
- [ ] CI green on PR

(48-claim count is pre-PR-C-merge; PR-C's tables metric brings it to 72.)

## Stack now (full audit cycle)

| PR | Title | State |
|---|---|---|
| [#592](https://github.com/RevealUIStudio/revealui/pull/592) | PR-A: P0 line-level drift fixes | **Open** |
| [#594](https://github.com/RevealUIStudio/revealui/pull/594) | PR-B: Suite map + per-product pages | ✅ Merged |
| [#597](https://github.com/RevealUIStudio/revealui/pull/597) | PR-D: Extend claim-drift gate to docs | ✅ Merged |
| [#598](https://github.com/RevealUIStudio/revealui/pull/598) | PR-C: Number-drift sweep + tables metric | **Open** |
| [#599](https://github.com/RevealUIStudio/revealui/pull/599) | PR-E: Framing fixes (cloud APIs, JWT/session, TEST mode) | **Open** |
| [#600](https://github.com/RevealUIStudio/revealui/pull/600) | PR-F: P2 polish (this PR) | **Open** |

PR-A, PR-C, PR-E, PR-F all target `test`; checked for file overlaps. Each merges independently of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
