### PR TITLE
fix(docker): copy root manifests into admin Dockerfile.forge builder stage

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -42,6 +42,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Builder stage
 FROM base AS builder
 
+COPY --from=deps /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/.npmrc ./
 COPY --from=deps /app/node_modules         ./node_modules
 COPY --from=deps /app/packages             ./packages
 COPY --from=deps /app/apps/admin/node_modules ./apps/admin/node_modules


### PR DESCRIPTION
## Summary

`apps/admin/Dockerfile.forge` two-stage build (`deps` → `builder`) is missing a `COPY --from=deps` for the root manifests. The `deps` stage installs them at line 16:

```docker
COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
```

…but the `builder` stage starts `FROM base` (clean `/app`) and only copies forward `node_modules`, `packages`, and `apps/admin/node_modules`. Then it runs:

```docker
RUN pnpm turbo run build --filter=admin...
```

…which fails immediately:

```
ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND
No package.json (or package.yaml, or package.json5) was found in "/app".
```

## Why this matters now

The forge enforcement chain just landed on `main` via #612 (covers #606, #609, #603, #607 + the previously merged #608 release). The handoff goal is:

> After all 10 open merge: `gh workflow run docker.yml -R RevealUIStudio/revealui` — publishes the GHCR images including the full forge enforcement chain.

…but `docker.yml` has been broken since at least 2026-04-10 (PR #259 added missing workspace package.json copies to `deps` but didn't touch `builder`). Last 5 runs all failed at the admin `pnpm turbo run build --filter=admin...` step.

Without this fix, the GHCR `revealui-admin` image never updates, so customer kits don't get the new forge boot enforcement (`process.exit(1)` on bad/missing license JWT — #600/#601/#603) or the KEK requirement (#607).

## Fix

One line: copy the root manifests from `deps` into `builder` before turbo runs.

```diff
 FROM base AS builder

+COPY --from=deps /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/.npmrc ./
 COPY --from=deps /app/node_modules         ./node_modules
 COPY --from=deps /app/packages             ./packages
 COPY --from=deps /app/apps/admin/node_modules ./apps/admin/node_modules
```

The `deps` stage already has them (cache-friendly — no fresh fetch).

## Scope notes

- `apps/api/Dockerfile.forge` is a single-stage build and does NOT have this bug. Its `Build api` job was cancelled in the 2026-04-27 run because the matrix's `Build admin` failed first, not because the api Dockerfile itself broke.
- This PR is targeted at `test`. After merge, a follow-up `test → main` release PR is needed to ship the fix to `main` (which is what `docker.yml` builds from when given no explicit ref — though the workflow defaults to repo default branch = `test`, so technically the test build will also produce working images).

## Test plan

- [x] CI green (no source code changes — Dockerfile-only)
- [ ] post-merge: `gh workflow run docker.yml` succeeds end-to-end (both `Build api` and `Build admin` push to GHCR)
- [ ] post-merge: GHCR `revealui-admin:latest` image runs the full Next.js standalone server with paywall + license enforcement on boot
