### PR TITLE
fix(docker): add packages/mcp/package.json to api Dockerfile.forge

### DIFF
--- a/apps/api/Dockerfile.forge
+++ b/apps/api/Dockerfile.forge
@@ -20,6 +20,7 @@ COPY packages/contracts/package.json  ./packages/contracts/
 COPY packages/core/package.json       ./packages/core/
 COPY packages/db/package.json         ./packages/db/
 COPY packages/dev/package.json        ./packages/dev/
+COPY packages/mcp/package.json        ./packages/mcp/
 COPY packages/openapi/package.json    ./packages/openapi/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json   ./packages/security/


### PR DESCRIPTION
## Summary

Same class of bug as #613, different file. `apps/api/Dockerfile.forge`'s install setup was missing `packages/mcp/package.json` despite api directly depending on `@revealui/mcp` (workspace:*).

## Symptom

`docker.yml` run [24993872407](https://github.com/RevealUIStudio/revealui/actions/runs/24993872407) (the first run after #613/#614 fixed admin) succeeded on `Build admin` but failed on `Build api` with 24 TypeScript errors:

```
@revealui/mcp:build: src/adapters/db.ts(14,26): error TS2307: Cannot find module '@revealui/config/mcp'
@revealui/mcp:build: src/adapters/db.ts(15,76): error TS2307: Cannot find module '@revealui/contracts'
@revealui/mcp:build: src/adapters/db.ts(16,30): error TS2307: Cannot find module '@revealui/core/database/ssl-config'
... (21 more)
@revealui/mcp:build: WARN  Local package.json exists, but node_modules missing, did you mean to install?
```

…then cascading `@revealui/auth`, `@revealui/ai`, `@revealui/services` build failures because they sit downstream of mcp in the build graph.

## Root cause

`pnpm install --frozen-lockfile --filter api...` runs at install time and resolves the api filter against pnpm-lock.yaml. mcp is in api's direct deps so pnpm marks it for installation — but install only creates `node_modules` for packages whose `package.json` is *present at install time*. Since `packages/mcp/package.json` wasn't copied before install, no `packages/mcp/node_modules/` was created.

Then `COPY packages ./packages` brought all source in (including `packages/mcp/package.json` for the first time) and `pnpm turbo run build --filter=api...` started compiling mcp's source — but mcp had no node_modules, so its imports of other workspace packages couldn't resolve.

## Diff

```diff
 COPY packages/dev/package.json        ./packages/dev/
+COPY packages/mcp/package.json        ./packages/mcp/
 COPY packages/openapi/package.json    ./packages/openapi/
```

mcp's transitive deps (`@revealui/config`, `@revealui/contracts`, `@revealui/core`, `@revealui/security`) are all already in the api Dockerfile copy list — no further additions needed.

## Test plan

- [x] CI green (no source changes — Dockerfile-only)
- [ ] post-merge + new test→main release: `gh workflow run docker.yml --ref main` succeeds end-to-end (both `Build api` and `Build admin` push to GHCR)
- [ ] post-merge: pulled GHCR `revealui-api:latest` boots and enforces `REVEALUI_KEK` requirement (the forge enforcement chain on main)

## Note on Dockerfile robustness

This is the second "missing workspace package.json" Dockerfile bug discovered in this session (#613 was the first, for admin). A more robust pattern — e.g. `COPY packages/*/package.json ./packages/` via BuildKit's `--parents`, or copying all packages' manifests via a tarball helper — would prevent this class of bug from recurring as new workspace packages are added. Tracking as a follow-up rather than expanding this PR's scope.
