### PR TITLE
release(test → main): api Dockerfile.forge mcp dep fix

### DIFF
--- a/apps/api/Dockerfile.forge
+++ b/apps/api/Dockerfile.forge
@@ -20,6 +20,7 @@ COPY packages/contracts/package.json  ./packages/contracts/
 COPY packages/core/package.json       ./packages/core/
 COPY packages/db/package.json         ./packages/db/
 COPY packages/dev/package.json        ./packages/dev/
+COPY packages/mcp/package.json        ./packages/mcp/
 COPY packages/openapi/package.json    ./packages/openapi/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json   ./packages/security/


### PR DESCRIPTION
Tiny follow-up to #614. Releases #617 to main so docker.yml on main can build api images successfully.

Includes:
- **#617**  — fixes mcp build failure that blocked api image build (admin already fixed via #613)

After merge: https://github.com/RevealUIStudio/revealui/actions/runs/24994460224 should now succeed end-to-end for both api + admin.