### PR TITLE
fix(docker): add packages/mcp/package.json to admin Dockerfile.forge

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -24,6 +24,7 @@ COPY packages/core/package.json          ./packages/core/
 COPY packages/create-revealui/package.json ./packages/create-revealui/
 COPY packages/db/package.json            ./packages/db/
 COPY packages/dev/package.json           ./packages/dev/
+COPY packages/mcp/package.json           ./packages/mcp/
 COPY packages/paywall/package.json       ./packages/paywall/
 COPY packages/presentation/package.json  ./packages/presentation/
 COPY packages/resilience/package.json    ./packages/resilience/


### PR DESCRIPTION
Sibling fix to #617. The admin Dockerfile.forge has the same missing mcp package.json copy in its deps stage. docker.yml run on main failed admin build with same 24 mcp errors after #613 + #617 + #618 landed. One-line addition to deps stage.