### PR TITLE
release(test → main): admin Dockerfile.forge mcp dep fix

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -24,6 +24,7 @@ COPY packages/core/package.json          ./packages/core/
 COPY packages/create-revealui/package.json ./packages/create-revealui/
 COPY packages/db/package.json            ./packages/db/
 COPY packages/dev/package.json           ./packages/dev/
+COPY packages/mcp/package.json           ./packages/mcp/
 COPY packages/paywall/package.json       ./packages/paywall/
 COPY packages/presentation/package.json  ./packages/presentation/
 COPY packages/resilience/package.json    ./packages/resilience/


### PR DESCRIPTION
## Summary

Tiny follow-up to #618. Releases #619 to main so docker.yml on main can build admin images successfully (sibling fix to #617's api fix).

Includes:

- **#619** — `fix(docker): add packages/mcp/package.json to admin Dockerfile.forge` — same class of bug as #617 but for the admin Dockerfile. apps/admin directly depends on @revealui/mcp; without mcp's package.json being copied to the deps stage, mcp's node_modules wasn't created at install time, and tsc fails to resolve mcp's own workspace deps when building.

After merge: `gh workflow run docker.yml --ref main` should now succeed end-to-end for both `Build api` and `Build admin`.

## Test plan

- [x] CI green on #619
- [ ] post-merge: docker.yml run on main produces both `revealui-api` and `revealui-admin` GHCR images
- [ ] follow-up: track structural Dockerfile robustness (per-PR notes from #617/#619) so we stop discovering missing-workspace-dep bugs one at a time
