### PR TITLE
chore(ci): bump E2E Smoke wait-for-servers timeout 120s → 240s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,17 +441,17 @@ jobs:
 
       - name: Wait for servers
         run: |
-          for i in $(seq 1 40); do
+          for i in $(seq 1 80); do
             curl -sf http://localhost:3004/health/live > /dev/null 2>&1 && \
             curl -sf http://localhost:4000 > /dev/null 2>&1 && \
             curl -sf http://localhost:3002 > /dev/null 2>&1 && \
             echo "All three servers ready" && break || \
-            echo "Waiting for servers... ($i/40)" && sleep 3
+            echo "Waiting for servers... ($i/80)" && sleep 3
           done
           curl -sf http://localhost:3004/health/live > /dev/null 2>&1 && \
           curl -sf http://localhost:4000 > /dev/null 2>&1 && \
           curl -sf http://localhost:3002 > /dev/null 2>&1 || \
-          (echo "::error::Servers failed to start within 120s" && exit 1)
+          (echo "::error::Servers failed to start within 240s" && exit 1)
 
       - name: Run E2E smoke tests
         run: pnpm test:e2e -- --project=chromium e2e/smoke.e2e.ts


### PR DESCRIPTION
## Summary

Bumps the `Wait for servers` timeout in the E2E Smoke job from 40 iterations × 3s = **120s** to 80 × 3s = **240s**, unblocking [revealui#634](https://github.com/RevealUIStudio/revealui/pull/634).

## Why

E2E Smoke fails reproducibly on `revealui#634` (test → main release of payment_intent.requires_action + 3 paywalls + og endpoint). Two consecutive runs both exceeded the 120s window waiting for the 3 servers (`api:3004` + `admin:4000` + `docs:3002`) to come up. PostgreSQL container logs show pg actually started but the API/admin/docs services hadn't all been healthy by the curl-poll loop's exit. Likely cause: the og endpoint commit (`03bdfe255`) loads `@resvg/resvg-wasm/index_bg.wasm` + Geist TTF binaries at API startup, materially extending startup time; the 3 paywall PRs each registered new Pro-tier routes which adds incremental cost. Sister E2E jobs that wait on fewer servers (Accessibility = 2, Visual Regression = 1) still pass at 40 iters.

## Scope

- Only the E2E Smoke wait-for-servers step changes (lines 442-454 in `.github/workflows/ci.yml`).
- The two other `seq 1 40` waits (Accessibility line 522, Visual Regression line 587) are unchanged — they're not failing.

## Test plan

- [x] Workflow YAML edit only; no code changes
- [ ] CI on this PR runs the test-branch required checks (Quality, Typecheck, Unit Tests, Build, Security Gate, Secret Scanning, Drizzle Migrations, CodeQL, Dependency Review, Submodule Audit) — E2E Smoke is NOT required for test, so this PR's CI doesn't validate the bump itself
- [ ] After merge, [revealui#634](https://github.com/RevealUIStudio/revealui/pull/634) auto-rebuilds against the new test tip; the E2E Smoke run there validates the bump

## Fallback

If 240s isn't enough either, the right next move is to triage which specific server is slow (likely API given the og endpoint WASM/font load), not to bump further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
