### PR TITLE
chore(contracts): flatten redundant __tests__/contracts/ folder

### DIFF
--- a/packages/contracts/src/__tests__/collection.test.ts
+++ b/packages/contracts/src/__tests__/collection.test.ts
@@ -10,8 +10,8 @@ import {
   isCollectionConfig,
   parseCollection,
   validateCollection,
-} from '../../admin/collection.js';
-import { MockPostsCollection } from '../mocks/revealui.js';
+} from '../admin/collection.js';
+import { MockPostsCollection } from './mocks/revealui.js';
 
 describe('Collection Contract', () => {
   describe('Validation', () => {

--- a/packages/contracts/src/__tests__/config.test.ts
+++ b/packages/contracts/src/__tests__/config.test.ts
@@ -9,7 +9,7 @@ import {
   isConfigStructure,
   parseConfigStructure,
   validateConfigStructure,
-} from '../../admin/config-contract.js';
+} from '../admin/config-contract.js';
 
 describe('Config Contract', () => {
   describe('Validation', () => {

--- a/packages/contracts/src/__tests__/contract.test.ts
+++ b/packages/contracts/src/__tests__/contract.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { type ContractType, contractRegistry, createContract } from '../../foundation/contract.js';
+import { type ContractType, contractRegistry, createContract } from '../foundation/contract.js';
 
 describe('Unified Contract System', () => {
   describe('createContract', () => {

--- a/packages/contracts/src/__tests__/field.test.ts
+++ b/packages/contracts/src/__tests__/field.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { isFieldConfig, parseField, validateField } from '../../admin/field.js';
+import { isFieldConfig, parseField, validateField } from '../admin/field.js';
 
 describe('Field Contract', () => {
   describe('Validation', () => {

--- a/packages/contracts/src/__tests__/global.test.ts
+++ b/packages/contracts/src/__tests__/global.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { isGlobalConfig, parseGlobal, validateGlobal } from '../../admin/global.js';
-import { MockSettingsGlobal } from '../mocks/revealui.js';
+import { isGlobalConfig, parseGlobal, validateGlobal } from '../admin/global.js';
+import { MockSettingsGlobal } from './mocks/revealui.js';
 
 describe('Global Contract', () => {
   describe('Validation', () => {

--- a/packages/contracts/src/__tests__/type-safety.test.ts
+++ b/packages/contracts/src/__tests__/type-safety.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { type ContractType, createContract } from '../../foundation/contract.js';
+import { type ContractType, createContract } from '../foundation/contract.js';
 
 describe('Contract Type Safety', () => {
   describe('Type Inference', () => {

--- a/packages/contracts/src/__tests__/validation.test.ts
+++ b/packages/contracts/src/__tests__/validation.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { createContract } from '../../foundation/contract.js';
+import { createContract } from '../foundation/contract.js';
 
 describe('Contract Runtime Validation', () => {
   describe('Basic Validation', () => {


### PR DESCRIPTION
## Summary

Flattens `packages/contracts/src/__tests__/contracts/` — the doubled-up `contracts/contracts/` segment is the smallest item on the queued zero-repeated-path-segments cleanup list (`feedback_zero_repeated_path_segments.md` memory). All 7 contract test files move up one directory level to sit alongside the rest of the package's test files.

## Renames (git rename-tracked, ≥95% similarity each)

```
contracts/collection.test.ts   → collection.test.ts
contracts/config.test.ts       → config.test.ts
contracts/contract.test.ts     → contract.test.ts
contracts/field.test.ts        → field.test.ts
contracts/global.test.ts       → global.test.ts
contracts/type-safety.test.ts  → type-safety.test.ts
contracts/validation.test.ts   → validation.test.ts
```

## Import paths adjusted (one level shallower)

- `../../foundation/contract.js` → `../foundation/contract.js`
- `../../admin/{collection,config-contract,field,global}.js` → `../admin/{...}.js`
- `../mocks/revealui.js` → `./mocks/revealui.js` _(in `collection.test.ts` + `global.test.ts`)_

## Audit

- **No external references**: `grep -r "__tests__/contracts/"` across `packages/`, `apps/`, `tools/`, `scripts/`, `docs/`, `tests/` — zero matches. No tooling, build pipeline, or doc references the old path.
- **Vitest discovery unaffected**: config uses `src/**/*.test.ts` (recursive). Both old and new locations match.
- **No name conflicts at parent level**: `contract.test.ts` (singular, moving in) vs existing `contracts.test.ts` (plural, already at parent) — different filenames, no collision. All 7 incoming names are unique against the 14 existing parent-level test files.
- **Empty `contracts/` folder removed** after rename.

## Test plan

- [x] `pnpm --filter @revealui/contracts typecheck` — clean
- [x] `pnpm --filter @revealui/contracts test` — **758/758 passing across 27 test files**
- [x] `pnpm exec biome check packages/contracts/src/__tests__` — clean
- [ ] CI: full gate

## Why now

Previous session shipped marketing migration ([revealui#639](https://github.com/RevealUIStudio/revealui/pull/639)) + OG endpoint reland ([revealui#641](https://github.com/RevealUIStudio/revealui/pull/641)). The post-merge follow-up queue (per `feedback_zero_repeated_path_segments.md`) lists 4 items in increasing blast-radius order:

1. **`packages/contracts/src/__tests__/contracts/` rename (this PR — ~30 min, zero blast)**
2. `apps/admin/src/app/(backend)/admin/` URL flatten (1–2 days)
3. `apps/docs/public/docs/` URL flatten (1–2 days)
4. `apps/api/` → `apps/server/` rename (1 day, eliminates `apps/api/api/`)

Picking off the smallest first to keep momentum and validate the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
