### PR TITLE
feat(security): KEK rotation tool with re-encryption + integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,10 +199,12 @@
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
+    "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",
     "validate:raw-sql": "tsx scripts/validate/raw-sql.ts",
-    "validate:stripe-client": "tsx scripts/validate/stripe-client.ts"
+    "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
+    "kek:rotate": "tsx scripts/security/rotate-kek.ts"
   },
   "type": "module"
 }

--- a/packages/db/src/__tests__/crypto.test.ts
+++ b/packages/db/src/__tests__/crypto.test.ts
@@ -4,8 +4,10 @@ import {
   decryptApiKey,
   decryptField,
   decryptFieldOrPassthrough,
+  decryptWithKey,
   encryptApiKey,
   encryptField,
+  encryptWithKey,
   isEncryptedField,
   redactApiKey,
 } from '../crypto.js';
@@ -95,11 +97,11 @@ describe('crypto  -  API key encryption', () => {
     });
 
     it('throws on invalid format (missing parts)', () => {
-      expect(() => decryptApiKey('just-one-part')).toThrow('Invalid encrypted key format');
+      expect(() => decryptApiKey('just-one-part')).toThrow('Invalid encrypted format');
     });
 
     it('throws on invalid format (too many parts)', () => {
-      expect(() => decryptApiKey('a.b.c.d')).toThrow('Invalid encrypted key format');
+      expect(() => decryptApiKey('a.b.c.d')).toThrow('Invalid encrypted format');
     });
 
     it('throws on tampered ciphertext (GCM auth check)', () => {
@@ -345,6 +347,61 @@ describe('crypto  -  API key encryption', () => {
       process.env.REVEALUI_KEK = '';
       // Empty string is falsy in JS, so getKek() treats it as not set
       expect(() => encryptApiKey('sk-test')).toThrow();
+    });
+  });
+
+  describe('encryptWithKey / decryptWithKey (parameterized for rotation)', () => {
+    const KEY_A = randomBytes(32);
+    const KEY_B = randomBytes(32);
+
+    it('roundtrips with an explicit key (independent of process.env.REVEALUI_KEK)', () => {
+      delete process.env.REVEALUI_KEK;
+      const encrypted = encryptWithKey(KEY_A, 'rotation-payload');
+      expect(decryptWithKey(KEY_A, encrypted)).toBe('rotation-payload');
+    });
+
+    it('throws when decrypting with a key different from the encrypt key', () => {
+      const encrypted = encryptWithKey(KEY_A, 'secret');
+      expect(() => decryptWithKey(KEY_B, encrypted)).toThrow();
+    });
+
+    it('rejects key buffers of the wrong length on encrypt', () => {
+      const tooShort = randomBytes(16);
+      expect(() => encryptWithKey(tooShort, 'x')).toThrow('must be exactly 32 bytes');
+    });
+
+    it('rejects key buffers of the wrong length on decrypt', () => {
+      const encrypted = encryptWithKey(KEY_A, 'x');
+      const tooLong = randomBytes(64);
+      expect(() => decryptWithKey(tooLong, encrypted)).toThrow('must be exactly 32 bytes');
+    });
+
+    it('produces envelopes that the singleton decryptApiKey can read when key matches REVEALUI_KEK', () => {
+      const sharedKeyHex = KEY_A.toString('hex');
+      process.env.REVEALUI_KEK = sharedKeyHex;
+      const encrypted = encryptWithKey(KEY_A, 'shared-payload');
+      expect(decryptApiKey(encrypted)).toBe('shared-payload');
+    });
+
+    it('singleton encryptField produces envelopes that decryptWithKey can read with the same key', () => {
+      const keyHex = KEY_A.toString('hex');
+      process.env.REVEALUI_KEK = keyHex;
+      const encrypted = encryptField('totp-secret');
+      expect(decryptWithKey(KEY_A, encrypted)).toBe('totp-secret');
+    });
+
+    it('GCM auth tag mismatch throws on cross-key decrypt — the rotation idempotency signal', () => {
+      // Rotation idempotency relies on this: try decrypt with NEW first; if
+      // the auth tag verifies, the row is already under NEW. If it throws,
+      // try OLD. This test pins the contract.
+      const encrypted = encryptWithKey(KEY_A, 'value');
+      let threw = false;
+      try {
+        decryptWithKey(KEY_B, encrypted);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
     });
   });
 });

--- a/packages/db/src/crypto.ts
+++ b/packages/db/src/crypto.ts
@@ -26,12 +26,20 @@ function getKek(): Buffer {
   return Buffer.from(kekHex, 'hex');
 }
 
+// =============================================================================
+// Parameterized Helpers (used directly by KEK rotation tooling)
+// =============================================================================
+
 /**
- * Encrypt a plaintext API key using AES-256-GCM.
- * Returns a dot-separated base64url string: `<iv>.<authTag>.<ciphertext>`
+ * Encrypt with a caller-supplied 32-byte key.
+ * Used by KEK rotation tooling so OLD_KEK and NEW_KEK can coexist in one
+ * process without conflicting with the singleton `getKek()` reader. All
+ * production encrypt/decrypt fns below delegate here.
  */
-export function encryptApiKey(plaintext: string): string {
-  const kek = getKek();
+export function encryptWithKey(kek: Buffer, plaintext: string): string {
+  if (kek.length !== 32) {
+    throw new Error(`KEK buffer must be exactly 32 bytes, got ${kek.length}`);
+  }
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, kek, iv);
   const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
@@ -41,6 +49,48 @@ export function encryptApiKey(plaintext: string): string {
     authTag.toString('base64url'),
     ciphertext.toString('base64url'),
   ].join('.');
+}
+
+/**
+ * Decrypt with a caller-supplied 32-byte key.
+ * Throws if tampered (GCM auth tag mismatch), if the envelope is malformed,
+ * or if the supplied key does not match the one used to encrypt. Auth-tag-
+ * mismatch is the signal KEK rotation tooling uses to detect "encrypted
+ * under a different key" — catch the throw, try the other key.
+ */
+export function decryptWithKey(kek: Buffer, encrypted: string): string {
+  if (kek.length !== 32) {
+    throw new Error(`KEK buffer must be exactly 32 bytes, got ${kek.length}`);
+  }
+  const parts = encrypted.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted format — expected <iv>.<authTag>.<ciphertext>');
+  }
+  const [ivB64, authTagB64, ciphertextB64] = parts as [string, string, string];
+  const iv = Buffer.from(ivB64, 'base64url');
+  const authTag = Buffer.from(authTagB64, 'base64url');
+  const ciphertext = Buffer.from(ciphertextB64, 'base64url');
+  if (iv.length !== IV_LENGTH) {
+    throw new Error(`Invalid IV length: expected ${IV_LENGTH} bytes, got ${iv.length}`);
+  }
+  if (authTag.length !== 16) {
+    throw new Error(`Invalid auth tag length: expected 16 bytes, got ${authTag.length}`);
+  }
+  const decipher = createDecipheriv(ALGORITHM, kek, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+// =============================================================================
+// Production Singletons (read REVEALUI_KEK from process.env)
+// =============================================================================
+
+/**
+ * Encrypt a plaintext API key using AES-256-GCM.
+ * Returns a dot-separated base64url string: `<iv>.<authTag>.<ciphertext>`
+ */
+export function encryptApiKey(plaintext: string): string {
+  return encryptWithKey(getKek(), plaintext);
 }
 
 /**
@@ -48,45 +98,15 @@ export function encryptApiKey(plaintext: string): string {
  * Throws if tampered (GCM auth tag mismatch) or if KEK is wrong.
  */
 export function decryptApiKey(encrypted: string): string {
-  const kek = getKek();
-  const parts = encrypted.split('.');
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted key format  -  expected <iv>.<authTag>.<ciphertext>');
-  }
-  const [ivB64, authTagB64, ciphertextB64] = parts as [string, string, string];
-  const iv = Buffer.from(ivB64, 'base64url');
-  const authTag = Buffer.from(authTagB64, 'base64url');
-  const ciphertext = Buffer.from(ciphertextB64, 'base64url');
-  if (iv.length !== IV_LENGTH) {
-    throw new Error(`Invalid IV length: expected ${IV_LENGTH} bytes, got ${iv.length}`);
-  }
-  if (authTag.length !== 16) {
-    throw new Error(`Invalid auth tag length: expected 16 bytes, got ${authTag.length}`);
-  }
-  const decipher = createDecipheriv(ALGORITHM, kek, iv);
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  return decryptWithKey(getKek(), encrypted);
 }
-
-// =============================================================================
-// Generic Field Encryption (reusable for any sensitive column)
-// =============================================================================
 
 /**
  * Encrypt an arbitrary string field using AES-256-GCM.
  * Same algorithm as `encryptApiKey`; use for TOTP secrets, tokens, etc.
  */
 export function encryptField(plaintext: string): string {
-  const kek = getKek();
-  const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, kek, iv);
-  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return [
-    iv.toString('base64url'),
-    authTag.toString('base64url'),
-    ciphertext.toString('base64url'),
-  ].join('.');
+  return encryptWithKey(getKek(), plaintext);
 }
 
 /**
@@ -94,24 +114,7 @@ export function encryptField(plaintext: string): string {
  * Throws on tamper (GCM auth tag mismatch) or wrong KEK.
  */
 export function decryptField(encrypted: string): string {
-  const kek = getKek();
-  const parts = encrypted.split('.');
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted field format — expected <iv>.<authTag>.<ciphertext>');
-  }
-  const [ivB64, authTagB64, ciphertextB64] = parts as [string, string, string];
-  const iv = Buffer.from(ivB64, 'base64url');
-  const authTag = Buffer.from(authTagB64, 'base64url');
-  const ciphertext = Buffer.from(ciphertextB64, 'base64url');
-  if (iv.length !== IV_LENGTH) {
-    throw new Error(`Invalid IV length: expected ${IV_LENGTH} bytes, got ${iv.length}`);
-  }
-  if (authTag.length !== 16) {
-    throw new Error(`Invalid auth tag length: expected 16 bytes, got ${authTag.length}`);
-  }
-  const decipher = createDecipheriv(ALGORITHM, kek, iv);
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  return decryptWithKey(getKek(), encrypted);
 }
 
 /**

--- a/scripts/security/__tests__/rotate-kek.test.ts
+++ b/scripts/security/__tests__/rotate-kek.test.ts
@@ -1,0 +1,337 @@
+import { randomBytes } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { encryptWithKey } from '../../../packages/db/src/crypto';
+import {
+  type DataSource,
+  planRotation,
+  rotateSurface,
+  type Surface,
+  type SurfaceRow,
+} from '../rotate-kek';
+
+const KEY_OLD = randomBytes(32);
+const KEY_NEW = randomBytes(32);
+
+// ============================================================================
+// In-memory DataSource — tests exercise the rotation against this fake
+// rather than a live Postgres. Mirrors the contract PostgresDataSource
+// implements in production.
+// ============================================================================
+
+class InMemorySource implements DataSource {
+  private store: Record<Surface, Map<string, string | null>> = {
+    'api-keys': new Map(),
+    mfa: new Map(),
+  };
+  // Optional crash-injection: throws on the Nth update if set.
+  public crashOnUpdate?: number;
+  private updateCount = 0;
+
+  seed(surface: Surface, rows: Array<{ id: string; value: string | null }>): void {
+    for (const row of rows) this.store[surface].set(row.id, row.value);
+  }
+
+  snapshot(surface: Surface): Array<{ id: string; value: string | null }> {
+    return Array.from(this.store[surface].entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([id, value]) => ({ id, value }));
+  }
+
+  async count(surface: Surface): Promise<number> {
+    return Array.from(this.store[surface].values()).filter((v) => v !== null).length;
+  }
+
+  async *iterate(surface: Surface, fromId: string, _batchSize: number): AsyncIterable<SurfaceRow> {
+    const sorted = Array.from(this.store[surface].entries())
+      .filter(([id, value]) => id > fromId && value !== null)
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [id, value] of sorted) yield { id, value };
+  }
+
+  async update(surface: Surface, id: string, newValue: string): Promise<void> {
+    this.updateCount += 1;
+    if (this.crashOnUpdate !== undefined && this.updateCount === this.crashOnUpdate) {
+      throw new Error(`simulated crash at update #${this.updateCount}`);
+    }
+    this.store[surface].set(id, newValue);
+  }
+}
+
+// ============================================================================
+// planRotation — pure decision logic
+// ============================================================================
+
+describe('planRotation', () => {
+  it('rotates a value encrypted under OLD_KEK', () => {
+    const enc = encryptWithKey(KEY_OLD, 'totp-secret');
+    const decision = planRotation(enc, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+    expect(decision.kind).toBe('rotate');
+  });
+
+  it('skips a value already encrypted under NEW_KEK (idempotency)', () => {
+    const enc = encryptWithKey(KEY_NEW, 'totp-secret');
+    const decision = planRotation(enc, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+    expect(decision.kind).toBe('skip-already-new');
+  });
+
+  it('errors on an envelope decryptable under neither key', () => {
+    const ROGUE = randomBytes(32);
+    const enc = encryptWithKey(ROGUE, 'rogue');
+    const decision = planRotation(enc, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+    expect(decision.kind).toBe('error');
+    if (decision.kind === 'error') {
+      expect(decision.reason).toMatch(/not decryptable/);
+    }
+  });
+
+  it('errors on a non-envelope value when allowPlaintext=false (api-keys)', () => {
+    const decision = planRotation('JBSWY3DPEHPK3PXP', KEY_OLD, KEY_NEW, {
+      allowPlaintext: false,
+    });
+    expect(decision.kind).toBe('error');
+    if (decision.kind === 'error') {
+      expect(decision.reason).toMatch(/not in encrypted-envelope format/);
+    }
+  });
+
+  it('encrypts a non-envelope plaintext value when allowPlaintext=true (mfa rolling migration)', () => {
+    const decision = planRotation('JBSWY3DPEHPK3PXP', KEY_OLD, KEY_NEW, {
+      allowPlaintext: true,
+    });
+    expect(decision.kind).toBe('plaintext-encrypt');
+  });
+
+  it('rotated value, when re-checked, classifies as skip-already-new (no infinite re-rotate)', () => {
+    const original = encryptWithKey(KEY_OLD, 'value');
+    const first = planRotation(original, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+    if (first.kind !== 'rotate') throw new Error('expected rotate');
+    const second = planRotation(first.newValue, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+    expect(second.kind).toBe('skip-already-new');
+  });
+
+  it('plaintext-encrypted value, when re-checked, classifies as skip-already-new', () => {
+    const first = planRotation('legacy-plain', KEY_OLD, KEY_NEW, { allowPlaintext: true });
+    if (first.kind !== 'plaintext-encrypt') throw new Error('expected plaintext-encrypt');
+    const second = planRotation(first.newValue, KEY_OLD, KEY_NEW, { allowPlaintext: true });
+    expect(second.kind).toBe('skip-already-new');
+  });
+
+  it('throws-during-encrypt is reported as error (not propagated)', () => {
+    const tooShort = Buffer.from('aabb', 'hex'); // 2 bytes, not 32
+    const decision = planRotation('plain', KEY_OLD, tooShort, { allowPlaintext: true });
+    expect(decision.kind).toBe('error');
+  });
+});
+
+// ============================================================================
+// rotateSurface — DataSource-driven flow
+// ============================================================================
+
+describe('rotateSurface', () => {
+  it('rotates every row when all rows are under OLD_KEK (api-keys)', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'sk-aaa') },
+      { id: '02', value: encryptWithKey(KEY_OLD, 'sk-bbb') },
+      { id: '03', value: encryptWithKey(KEY_OLD, 'sk-ccc') },
+    ]);
+
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+
+    expect(counts.scanned).toBe(3);
+    expect(counts.rotated).toBe(3);
+    expect(counts.skippedAlreadyNew).toBe(0);
+    expect(counts.errors).toEqual([]);
+    expect(counts.lastId).toBe('03');
+
+    // Every row now decrypts under NEW_KEK
+    const after = src.snapshot('api-keys');
+    for (const row of after) {
+      expect(row.value).toBeTruthy();
+      // a fresh planRotation should now classify all as skip-already-new
+      if (row.value) {
+        const re = planRotation(row.value, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+        expect(re.kind).toBe('skip-already-new');
+      }
+    }
+  });
+
+  it('is idempotent: a second pass over already-rotated rows is a no-op', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'sk-1') },
+      { id: '02', value: encryptWithKey(KEY_OLD, 'sk-2') },
+    ]);
+
+    const first = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+    expect(first.rotated).toBe(2);
+
+    const second = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+    expect(second.rotated).toBe(0);
+    expect(second.skippedAlreadyNew).toBe(2);
+  });
+
+  it('handles mixed state: some rows under OLD, some already under NEW', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'old-1') },
+      { id: '02', value: encryptWithKey(KEY_NEW, 'new-1') },
+      { id: '03', value: encryptWithKey(KEY_OLD, 'old-2') },
+      { id: '04', value: encryptWithKey(KEY_NEW, 'new-2') },
+    ]);
+
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+
+    expect(counts.scanned).toBe(4);
+    expect(counts.rotated).toBe(2);
+    expect(counts.skippedAlreadyNew).toBe(2);
+  });
+
+  it('handles mfa rolling migration: legacy plaintext encrypted in place', async () => {
+    const src = new InMemorySource();
+    src.seed('mfa', [
+      { id: 'u1', value: 'JBSWY3DPEHPK3PXP' }, // legacy plaintext
+      { id: 'u2', value: encryptWithKey(KEY_OLD, 'JBSWY3DPEH2222') }, // already encrypted under OLD
+      { id: 'u3', value: encryptWithKey(KEY_NEW, 'JBSWY3DPEH3333') }, // already under NEW
+      { id: 'u4', value: 'JBSWY3DPEH4444' }, // legacy plaintext
+    ]);
+
+    const counts = await rotateSurface(src, 'mfa', KEY_OLD, KEY_NEW, { dryRun: false });
+
+    expect(counts.scanned).toBe(4);
+    expect(counts.rotated).toBe(1);
+    expect(counts.plaintextEncrypted).toBe(2);
+    expect(counts.skippedAlreadyNew).toBe(1);
+    expect(counts.errors).toEqual([]);
+  });
+
+  it('mfa: null/empty mfa_secret rows do not crash; null filtered upstream, empty counted as skipped', async () => {
+    // PostgresDataSource WHERE mfa_secret IS NOT NULL filters NULL rows in
+    // the SQL — they never reach rotateSurface. Empty strings pass that
+    // filter and reach the row.value === '' branch, counted as
+    // skippedNullOrEmpty. The in-memory source mirrors that contract.
+    const src = new InMemorySource();
+    src.seed('mfa', [
+      { id: 'u1', value: encryptWithKey(KEY_OLD, 'secret') },
+      { id: 'u2', value: null },
+      { id: 'u3', value: '' },
+    ]);
+
+    const counts = await rotateSurface(src, 'mfa', KEY_OLD, KEY_NEW, { dryRun: false });
+
+    expect(counts.scanned).toBe(2); // u1 + u3 (u2 filtered upstream)
+    expect(counts.rotated).toBe(1); // u1
+    expect(counts.skippedNullOrEmpty).toBe(1); // u3 (empty string)
+    expect(counts.errors).toEqual([]);
+  });
+
+  it('dry-run does not write any updates', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'a') },
+      { id: '02', value: encryptWithKey(KEY_OLD, 'b') },
+    ]);
+    const before = src.snapshot('api-keys');
+
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: true });
+
+    expect(counts.rotated).toBe(2);
+    expect(src.snapshot('api-keys')).toEqual(before);
+  });
+
+  it('reports per-row errors but does not halt the run', async () => {
+    const ROGUE = randomBytes(32);
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'good-1') },
+      { id: '02', value: encryptWithKey(ROGUE, 'rogue') }, // un-decryptable
+      { id: '03', value: encryptWithKey(KEY_OLD, 'good-2') },
+    ]);
+
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+
+    expect(counts.scanned).toBe(3);
+    expect(counts.rotated).toBe(2);
+    expect(counts.errors).toHaveLength(1);
+    expect(counts.errors[0]?.id).toBe('02');
+  });
+
+  it('resumes from --from cursor (skips earlier rows entirely)', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'a') },
+      { id: '02', value: encryptWithKey(KEY_OLD, 'b') },
+      { id: '03', value: encryptWithKey(KEY_OLD, 'c') },
+      { id: '04', value: encryptWithKey(KEY_OLD, 'd') },
+    ]);
+
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, {
+      dryRun: false,
+      fromId: '02',
+    });
+
+    expect(counts.scanned).toBe(2); // only 03, 04
+    expect(counts.rotated).toBe(2);
+    expect(counts.lastId).toBe('04');
+
+    // Rows 01, 02 are still under OLD_KEK (not touched)
+    const snap = src.snapshot('api-keys');
+    const row01 = snap.find((r) => r.id === '01');
+    expect(row01?.value).toBeTruthy();
+    if (row01?.value) {
+      const re = planRotation(row01.value, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+      expect(re.kind).toBe('rotate');
+    }
+  });
+
+  it('mid-run crash recovery: restart with same OLD/NEW completes cleanly', async () => {
+    const src = new InMemorySource();
+    src.seed('api-keys', [
+      { id: '01', value: encryptWithKey(KEY_OLD, 'a') },
+      { id: '02', value: encryptWithKey(KEY_OLD, 'b') },
+      { id: '03', value: encryptWithKey(KEY_OLD, 'c') },
+      { id: '04', value: encryptWithKey(KEY_OLD, 'd') },
+    ]);
+
+    src.crashOnUpdate = 3; // crash on the 3rd update
+
+    let lastId = '';
+    try {
+      const r = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+      lastId = r.lastId;
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      // Last successful update was row 02; row 03 is mid-update
+      lastId = '02';
+    }
+
+    // Restart from the last known successful row
+    src.crashOnUpdate = undefined;
+    const resume = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, {
+      dryRun: false,
+      fromId: lastId,
+    });
+
+    // Final state: every row decrypts under NEW_KEK
+    const after = src.snapshot('api-keys');
+    expect(after).toHaveLength(4);
+    for (const row of after) {
+      if (row.value) {
+        const re = planRotation(row.value, KEY_OLD, KEY_NEW, { allowPlaintext: false });
+        expect(re.kind).toBe('skip-already-new');
+      }
+    }
+    expect(resume.errors).toEqual([]);
+  });
+
+  it('empty surface: zero rows, zero counts, no error', async () => {
+    const src = new InMemorySource();
+    const counts = await rotateSurface(src, 'api-keys', KEY_OLD, KEY_NEW, { dryRun: false });
+    expect(counts.scanned).toBe(0);
+    expect(counts.rotated).toBe(0);
+    expect(counts.errors).toEqual([]);
+    expect(counts.lastId).toBe('');
+  });
+});

--- a/scripts/security/rotate-kek.ts
+++ b/scripts/security/rotate-kek.ts
@@ -1,0 +1,409 @@
+#!/usr/bin/env tsx
+
+/**
+ * KEK rotation tool — re-encrypt every KEK-encrypted row with a new key.
+ *
+ * Two surfaces in scope (per the GAP-126 Phase 1 survey at
+ * `revealui-jv/docs/security/kek-encrypted-surfaces.md`):
+ *
+ *   1. user_api_keys.encrypted_key  (NOT NULL, strict envelope)
+ *   2. users.mfa_secret             (NULLABLE, rolling-migration aware)
+ *
+ * Rolling-migration awareness only applies to mfa_secret: legacy plaintext
+ * values are encrypted with NEW_KEK in place. api-keys rejects plaintext —
+ * a non-envelope value there indicates corruption.
+ *
+ * Idempotency: every row is first decrypt-tested with NEW_KEK. If it
+ * verifies, the row is already rotated and the script skips. If it throws
+ * (auth-tag mismatch from the GCM cipher), the row is decrypted with
+ * OLD_KEK and re-encrypted under NEW_KEK.
+ *
+ * The script reads keys from explicit env vars `REVEALUI_KEK_OLD` and
+ * `REVEALUI_KEK_NEW`, NOT `REVEALUI_KEK`. This prevents a misconfigured
+ * environment from accidentally re-encrypting under the same key.
+ *
+ * Local usage:
+ *
+ *   POSTGRES_URL=$(revvault get revealui/dev/postgres-url) \
+ *   REVEALUI_KEK_OLD=$(revvault get revealui/dev/kek) \
+ *   REVEALUI_KEK_NEW=$(openssl rand -hex 32) \
+ *     pnpm validate:kek-rotation:dry-run
+ *
+ *   # Then with --execute to write:
+ *   POSTGRES_URL=... REVEALUI_KEK_OLD=... REVEALUI_KEK_NEW=... \
+ *     tsx scripts/security/rotate-kek.ts --execute
+ */
+
+import { Pool } from 'pg';
+
+import { decryptWithKey, encryptWithKey, isEncryptedField } from '../../packages/db/src/crypto';
+
+// ============================================================================
+// Pure rotation decision (testable without a DB)
+// ============================================================================
+
+export type RotationDecision =
+  | { kind: 'rotate'; newValue: string }
+  | { kind: 'skip-already-new' }
+  | { kind: 'plaintext-encrypt'; newValue: string }
+  | { kind: 'error'; reason: string };
+
+/**
+ * Decide what to do with a single row's encrypted-or-plaintext value.
+ *
+ * @param value           Current stored value (envelope or plaintext)
+ * @param oldKek          32-byte buffer for OLD_KEK
+ * @param newKek          32-byte buffer for NEW_KEK
+ * @param allowPlaintext  True iff this surface tolerates legacy plaintext
+ *                        (mfa_secret yes, encrypted_key no)
+ */
+export function planRotation(
+  value: string,
+  oldKek: Buffer,
+  newKek: Buffer,
+  options: { allowPlaintext: boolean },
+): RotationDecision {
+  if (!isEncryptedField(value)) {
+    if (options.allowPlaintext) {
+      try {
+        return { kind: 'plaintext-encrypt', newValue: encryptWithKey(newKek, value) };
+      } catch (err) {
+        return {
+          kind: 'error',
+          reason: `failed to encrypt legacy plaintext: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+    return {
+      kind: 'error',
+      reason: 'value is not in encrypted-envelope format and surface does not allow plaintext',
+    };
+  }
+
+  // Idempotency probe: try NEW_KEK first. If it verifies, this row is
+  // already rotated. If it throws (auth-tag mismatch), we know the row
+  // is encrypted under a different key — almost certainly OLD_KEK.
+  try {
+    decryptWithKey(newKek, value);
+    return { kind: 'skip-already-new' };
+  } catch {
+    // Fall through to OLD_KEK attempt.
+  }
+
+  let plain: string;
+  try {
+    plain = decryptWithKey(oldKek, value);
+  } catch (err) {
+    return {
+      kind: 'error',
+      reason: `value not decryptable under OLD_KEK or NEW_KEK: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  try {
+    return { kind: 'rotate', newValue: encryptWithKey(newKek, plain) };
+  } catch (err) {
+    return {
+      kind: 'error',
+      reason: `failed to re-encrypt under NEW_KEK: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// ============================================================================
+// Per-surface rotation (uses an injected DataSource for testability)
+// ============================================================================
+
+export type Surface = 'api-keys' | 'mfa';
+
+export const ALL_SURFACES: readonly Surface[] = ['api-keys', 'mfa'] as const;
+
+export interface SurfaceRow {
+  id: string;
+  value: string | null;
+}
+
+export interface DataSource {
+  count(surface: Surface): Promise<number>;
+  iterate(surface: Surface, fromId: string, batchSize: number): AsyncIterable<SurfaceRow>;
+  update(surface: Surface, id: string, newValue: string): Promise<void>;
+}
+
+export interface RotationCounts {
+  scanned: number;
+  rotated: number;
+  skippedAlreadyNew: number;
+  plaintextEncrypted: number;
+  skippedNullOrEmpty: number;
+  errors: Array<{ id: string; reason: string }>;
+  lastId: string;
+}
+
+const SURFACE_OPTIONS: Record<Surface, { allowPlaintext: boolean }> = {
+  'api-keys': { allowPlaintext: false },
+  mfa: { allowPlaintext: true },
+};
+
+export async function rotateSurface(
+  source: DataSource,
+  surface: Surface,
+  oldKek: Buffer,
+  newKek: Buffer,
+  options: { dryRun: boolean; fromId?: string; batchSize?: number },
+): Promise<RotationCounts> {
+  const counts: RotationCounts = {
+    scanned: 0,
+    rotated: 0,
+    skippedAlreadyNew: 0,
+    plaintextEncrypted: 0,
+    skippedNullOrEmpty: 0,
+    errors: [],
+    lastId: options.fromId ?? '',
+  };
+
+  const surfaceOpts = SURFACE_OPTIONS[surface];
+  const batchSize = options.batchSize ?? 200;
+
+  for await (const row of source.iterate(surface, options.fromId ?? '', batchSize)) {
+    counts.scanned += 1;
+    counts.lastId = row.id;
+
+    if (row.value === null || row.value === '') {
+      counts.skippedNullOrEmpty += 1;
+      continue;
+    }
+
+    const decision = planRotation(row.value, oldKek, newKek, surfaceOpts);
+
+    switch (decision.kind) {
+      case 'skip-already-new':
+        counts.skippedAlreadyNew += 1;
+        break;
+      case 'rotate':
+        if (!options.dryRun) await source.update(surface, row.id, decision.newValue);
+        counts.rotated += 1;
+        break;
+      case 'plaintext-encrypt':
+        if (!options.dryRun) await source.update(surface, row.id, decision.newValue);
+        counts.plaintextEncrypted += 1;
+        break;
+      case 'error':
+        counts.errors.push({ id: row.id, reason: decision.reason });
+        break;
+    }
+  }
+
+  return counts;
+}
+
+// ============================================================================
+// Postgres data source (production driver)
+// ============================================================================
+
+interface SurfaceQueries {
+  table: string;
+  valueCol: string;
+  whereClause: string;
+}
+
+const SURFACE_QUERIES: Record<Surface, SurfaceQueries> = {
+  'api-keys': {
+    table: 'user_api_keys',
+    valueCol: 'encrypted_key',
+    // Include soft-deleted rows: production code can still try to decrypt
+    // them (e.g., admin-side audit views), so they need to rotate too.
+    whereClause: '',
+  },
+  mfa: {
+    table: 'users',
+    valueCol: 'mfa_secret',
+    whereClause: 'WHERE mfa_secret IS NOT NULL',
+  },
+};
+
+export class PostgresDataSource implements DataSource {
+  constructor(private readonly pool: Pool) {}
+
+  async count(surface: Surface): Promise<number> {
+    const q = SURFACE_QUERIES[surface];
+    const sql = `SELECT COUNT(*)::int AS n FROM ${q.table} ${q.whereClause}`;
+    const result = await this.pool.query<{ n: number }>(sql);
+    return result.rows[0]?.n ?? 0;
+  }
+
+  async *iterate(surface: Surface, fromId: string, batchSize: number): AsyncIterable<SurfaceRow> {
+    const q = SURFACE_QUERIES[surface];
+    let cursor = fromId;
+    while (true) {
+      const cursorClause = q.whereClause ? `${q.whereClause} AND id > $1` : 'WHERE id > $1';
+      const sql = `SELECT id, ${q.valueCol} AS value FROM ${q.table} ${cursorClause} ORDER BY id ASC LIMIT $2`;
+      const result = await this.pool.query<SurfaceRow>(sql, [cursor, batchSize]);
+      if (result.rows.length === 0) return;
+      for (const row of result.rows) {
+        yield row;
+        cursor = row.id;
+      }
+      if (result.rows.length < batchSize) return;
+    }
+  }
+
+  async update(surface: Surface, id: string, newValue: string): Promise<void> {
+    const q = SURFACE_QUERIES[surface];
+    await this.pool.query(`UPDATE ${q.table} SET ${q.valueCol} = $1 WHERE id = $2`, [newValue, id]);
+  }
+}
+
+// ============================================================================
+// CLI entry
+// ============================================================================
+
+interface Flags {
+  surface: Surface | 'all';
+  dryRun: boolean;
+  fromId?: string;
+  batchSize: number;
+}
+
+function parseFlags(argv: string[]): Flags {
+  let surface: Surface | 'all' = 'all';
+  let dryRun = true; // safe default — must opt in to writes via --execute
+  let fromId: string | undefined;
+  let batchSize = 200;
+
+  for (const arg of argv) {
+    if (arg === '--execute') dryRun = false;
+    else if (arg === '--dry-run') dryRun = true;
+    else if (arg.startsWith('--surface=')) {
+      const value = arg.split('=')[1];
+      if (value === 'api-keys' || value === 'mfa' || value === 'all') {
+        surface = value;
+      } else {
+        throw new Error(`Unknown --surface=${value}; expected api-keys|mfa|all`);
+      }
+    } else if (arg.startsWith('--from=')) {
+      fromId = arg.split('=')[1];
+    } else if (arg.startsWith('--batch-size=')) {
+      const n = Number(arg.split('=')[1]);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(
+          `Invalid --batch-size; expected positive integer, got ${arg.split('=')[1]}`,
+        );
+      }
+      batchSize = n;
+    } else {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+  }
+
+  return { surface, dryRun, fromId, batchSize };
+}
+
+function readKekEnv(name: string): Buffer {
+  const hex = process.env[name];
+  if (!hex) {
+    throw new Error(`${name} environment variable is not set`);
+  }
+  if (hex.length !== 64) {
+    throw new Error(`${name} must be exactly 64 hex characters (got ${hex.length})`);
+  }
+  const buf = Buffer.from(hex, 'hex');
+  if (buf.length !== 32) {
+    throw new Error(
+      `${name} did not decode to 32 bytes (got ${buf.length}); check for non-hex chars`,
+    );
+  }
+  return buf;
+}
+
+function formatCounts(surface: Surface, counts: RotationCounts): string {
+  const errSummary =
+    counts.errors.length === 0
+      ? 'errors=0'
+      : `errors=${counts.errors.length} (first: ${counts.errors[0]?.id} — ${counts.errors[0]?.reason})`;
+  return [
+    `[${surface}]`,
+    `scanned=${counts.scanned}`,
+    `rotated=${counts.rotated}`,
+    `skipped_already_new=${counts.skippedAlreadyNew}`,
+    `plaintext_encrypted=${counts.plaintextEncrypted}`,
+    `skipped_null=${counts.skippedNullOrEmpty}`,
+    errSummary,
+    `last_id=${counts.lastId || '(none)'}`,
+  ].join(' ');
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+
+  const oldKek = readKekEnv('REVEALUI_KEK_OLD');
+  const newKek = readKekEnv('REVEALUI_KEK_NEW');
+
+  if (oldKek.equals(newKek)) {
+    process.stderr.write(
+      'rotate-kek FAIL — REVEALUI_KEK_OLD and REVEALUI_KEK_NEW are identical; nothing to rotate.\n',
+    );
+    process.exit(1);
+  }
+
+  const postgresUrl = process.env.POSTGRES_URL;
+  if (!postgresUrl) {
+    process.stderr.write('rotate-kek FAIL — POSTGRES_URL environment variable is not set.\n');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString: postgresUrl });
+  const source = new PostgresDataSource(pool);
+
+  const surfaces: Surface[] = flags.surface === 'all' ? [...ALL_SURFACES] : [flags.surface];
+
+  process.stdout.write(
+    `rotate-kek mode=${flags.dryRun ? 'dry-run' : 'EXECUTE'} surface=${flags.surface} batch=${flags.batchSize}` +
+      `${flags.fromId ? ` from=${flags.fromId}` : ''}\n`,
+  );
+
+  let totalErrors = 0;
+  try {
+    for (const surface of surfaces) {
+      const total = await source.count(surface);
+      process.stdout.write(`[${surface}] total_rows=${total}\n`);
+
+      const counts = await rotateSurface(source, surface, oldKek, newKek, {
+        dryRun: flags.dryRun,
+        fromId: flags.fromId,
+        batchSize: flags.batchSize,
+      });
+      totalErrors += counts.errors.length;
+      process.stdout.write(`${formatCounts(surface, counts)}\n`);
+      if (counts.errors.length > 0) {
+        for (const err of counts.errors.slice(0, 10)) {
+          process.stderr.write(`[${surface}] error id=${err.id}: ${err.reason}\n`);
+        }
+        if (counts.errors.length > 10) {
+          process.stderr.write(`[${surface}] ... and ${counts.errors.length - 10} more errors\n`);
+        }
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+
+  if (totalErrors > 0) {
+    process.stderr.write(`rotate-kek FAIL — ${totalErrors} row(s) errored.\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `rotate-kek ${flags.dryRun ? 'DRY-RUN COMPLETE' : 'EXECUTE COMPLETE'} — no errors.\n`,
+  );
+  process.exit(0);
+}
+
+const isMainModule = process.argv[1] ? import.meta.url === `file://${process.argv[1]}` : false;
+if (isMainModule) {
+  main().catch((err) => {
+    process.stderr.write(
+      `rotate-kek crashed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -73,6 +73,12 @@
       "rules": ["sql-file-outside-migrations"],
       "reason": "Supabase-side pgvector extension bootstrap (CREATE EXTENSION IF NOT EXISTS vector). Applied by scripts/setup/setup-dual-database.ts against getVectorClient(). drizzle-kit currently only tracks the Neon side of the dual-DB architecture; Supabase-side DDL lives outside drizzle-kit by necessity. Phase 7 (drizzle-consolidation-spec) evaluates standing up a second drizzle-kit pipeline for Supabase; until then, this file + setup-dual-database.ts are the canonical Supabase-side applier. See packages/db/src/supabase/README.md for the architectural rationale.",
       "migrationPhase": 7
+    },
+    {
+      "path": "scripts/security/rotate-kek.ts",
+      "rules": ["direct-import"],
+      "reason": "KEK rotation operational tool (GAP-126 Phase 2). One-off script that performs simple SELECT/UPDATE on the two KEK-encrypted columns (user_api_keys.encrypted_key + users.mfa_secret). Uses raw pg.Pool instead of @revealui/db/client to keep the rotation tool isolated from production DB-client lifecycle (singleton pools, retry policies, observability hooks). Operator-invoked; 2 surfaces, ~3 SQL ops total. Permanent.",
+      "migrationPhase": null
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds tooling to rotate `REVEALUI_KEK` without bricking encrypted data at rest. Two surfaces in scope (per the Phase 1 survey at an internal repo/docs/security/kek-encrypted-surfaces.md`):

- `user_api_keys.encrypted_key` — strict envelope, AES-256-GCM
- `users.mfa_secret` — rolling-migration aware (accepts legacy plaintext)

Naive rotation of the KEK without re-encrypting existing rows decodes them as garbage. Pre-launch the cost is acceptable, but the runbook needs to exist before launch — captured during the 2026-04-25 #540 incident's secret-rotation cleanup when KEK was deliberately held back.

## What changed

- **`packages/db/src/crypto.ts`** — refactored to expose `encryptWithKey(kek, plaintext)` / `decryptWithKey(kek, encrypted)` parameterized over a 32-byte key buffer. Existing `encryptApiKey` / `decryptApiKey` / `encryptField` / `decryptField` now thin-wrap those, calling `getKek()` internally. **Single source of truth** for the AES-256-GCM envelope format; no algorithm duplication into the rotation tool.

- **`scripts/security/rotate-kek.ts`** (new, ~360 LOC):
  - Reads `REVEALUI_KEK_OLD` + `REVEALUI_KEK_NEW` from **explicit env vars** (not `REVEALUI_KEK`) to prevent accidental same-key writes
  - **Idempotent**: probes each row with NEW_KEK first; auth-tag mismatch from the GCM cipher triggers OLD_KEK decrypt + NEW_KEK re-encrypt
  - **Resumable** via `--from=<id>` cursor
  - `--surface=api-keys|mfa|all`, `--dry-run` default, `--execute` opt-in to write
  - **`DataSource` abstraction** — `PostgresDataSource` (raw `pg.Pool`, no Drizzle dep) for production; tests inject an in-memory fake for full coverage without a live DB

- **`scripts/security/__tests__/rotate-kek.test.ts`** (new, 18 tests): clean rotation, idempotency (rotated value classifies as `skip-already-new` on second pass), mixed OLD/NEW state, mfa rolling migration (legacy plaintext encrypted in place), null/empty handling, dry-run no-write contract, per-row error tolerance, cursor resume, **mid-run crash recovery** (kill mid-batch, restart with same OLD/NEW, end state correct)

- **`packages/db/src/__tests__/crypto.test.ts`** — 6 new tests for the parameterized helpers + a pinned contract for the GCM auth-tag-mismatch behavior the rotation idempotency relies on. Two existing tests updated for the unified "Invalid encrypted format" wording (was "Invalid encrypted **key** format" / "**field**" — qualifier dropped now that there's one underlying impl).

- **`package.json`**: registers `pnpm validate:kek-rotation` (CI gate, runs the integration test) + `pnpm kek:rotate` (operator entry).

## Acceptance (mapped to GAP-126)

- [x] `scripts/security/rotate-kek.ts` exists with `--dry-run` (default) + resumable + idempotent modes
- [x] Integration test simulates rotation in-memory + asserts no data loss across all surfaces
- [x] `pnpm validate:kek-rotation` wired
- [x] Tool runs locally via `pnpm kek:rotate` after env vars are sourced

## Out of scope (follow-up)

- **Phase 3 runbook** (an internal repo/docs/runbooks/rotate-kek.md`) — internal docs-scoped doc, lands as a separate internal docs commit alongside the gap closure post-merge
- **Dual-key boot** (`getKek()` falling back to a second env var) — only needed for zero-downtime rotation; pre-launch we can do offline rotation. Track as a separate gap if/when needed
- **Admin-app pre-deploy validation parity** — carry-over from GAP-125 closure notes; distinct concern

## Test plan

- [x] `pnpm validate:kek-rotation` → 18/18 green locally
- [x] `pnpm --filter @revealui/db test crypto` → 55/55 green (49 existing + 6 new)
- [x] `tsc --noEmit` clean on touched files
- [x] Smoke: `REVEALUI_KEK_OLD=... REVEALUI_KEK_NEW=... POSTGRES_URL=... tsx scripts/security/rotate-kek.ts --dry-run --surface=api-keys` runs end-to-end past the import boundary
- [x] Biome auto-formatted on commit; gitleaks clean
- [ ] CI gate green on this PR
