### PR TITLE
feat(a2a): wire x402 pending-payment + HTTP 402 (PR 2/N of GAP-149)

### DIFF
--- a/.changeset/ai-x402-a2a-pending-payment.md
+++ b/.changeset/ai-x402-a2a-pending-payment.md
@@ -1,0 +1,25 @@
+---
+'@revealui/ai': minor
+---
+
+A2A handler now emits `pending-payment` task state when the resolved
+agent definition has a `pricing` field AND no payment proof was verified
+upstream by the route. The HTTP layer (`apps/api/src/routes/a2a.ts`)
+verifies `X-PAYMENT-PAYLOAD` headers before calling the handler, sets
+`{ paymentVerified: true }` on success, and converts `pending-payment`
+states into HTTP 402 responses with `X-PAYMENT-REQUIRED` headers (using
+the existing `buildPaymentRequired` + `encodePaymentRequired` middleware
+primitives).
+
+Pricing rides on `task.metadata.pricing` so the route can build the 402
+body without re-querying the agent registry. Tasks in the
+`pending-payment` state are cancelable so a requester who decides not to
+pay can release the task slot.
+
+`handleA2AJsonRpc` and `handleTasksSend` gain an optional
+`options?: { paymentVerified?: boolean }` 4th parameter (backward
+compatible — falsy by default). USDC remains the primary settlement
+currency; RVUI is gated behind `RVUI_PAYMENTS_ENABLED=false` in prod
+pending the safeguards-pipeline fix tracked separately.
+
+Part of the GAP-149 (x402 / A2A wiring) sequence — PR 2 of N.

--- a/apps/api/src/routes/__tests__/a2a-edge.test.ts
+++ b/apps/api/src/routes/__tests__/a2a-edge.test.ts
@@ -29,6 +29,9 @@ const {
   mockA2AJsonRpcSafeParse,
   mockGetClient,
   mockBuildPaymentMethods,
+  mockBuildPaymentRequired,
+  mockEncodePaymentRequired,
+  mockVerifyPayment,
   mockRequireTaskQuota,
 } = vi.hoisted(() => ({
   mockGetCard: vi.fn(),
@@ -45,6 +48,9 @@ const {
   mockA2AJsonRpcSafeParse: vi.fn((data: unknown) => ({ success: true, data })),
   mockGetClient: vi.fn(),
   mockBuildPaymentMethods: vi.fn(),
+  mockBuildPaymentRequired: vi.fn(),
+  mockEncodePaymentRequired: vi.fn(),
+  mockVerifyPayment: vi.fn(),
   mockRequireTaskQuota: vi.fn(),
 }));
 
@@ -96,6 +102,9 @@ vi.mock('../../middleware/license.js', () => ({
 
 vi.mock('../../middleware/x402.js', () => ({
   buildPaymentMethods: mockBuildPaymentMethods,
+  buildPaymentRequired: mockBuildPaymentRequired,
+  encodePaymentRequired: mockEncodePaymentRequired,
+  verifyPayment: mockVerifyPayment,
 }));
 
 vi.mock('../../middleware/task-quota.js', () => ({
@@ -222,6 +231,9 @@ function resetMocks() {
   mockIsFeatureEnabled.mockReturnValue(true);
   mockHandleA2AJsonRpc.mockResolvedValue({ jsonrpc: '2.0', id: 1, result: { status: 'ok' } });
   mockBuildPaymentMethods.mockReturnValue(null);
+  mockBuildPaymentRequired.mockReturnValue({ x402Version: 1, accepts: [] });
+  mockEncodePaymentRequired.mockReturnValue('mock-encoded-payment-required');
+  mockVerifyPayment.mockResolvedValue({ valid: true });
   mockRequireTaskQuota.mockResolvedValue(undefined);
 
   // Default DB: hydration query (registeredAgents) returns []
@@ -667,5 +679,157 @@ describe('DELETE /a2a/agents/:id  -  edge cases', () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain('not found');
+  });
+});
+
+// ─── PR 2 of GAP-149  -  x402 pending-payment flow ──────────────────────────
+
+describe('POST /a2a  -  x402 pending-payment flow', () => {
+  beforeEach(() => {
+    resetMocks();
+    mockA2AJsonRpcSafeParse.mockImplementation((data: unknown) => ({ success: true, data }));
+    mockAgentDefinitionSafeParse.mockImplementation((data: unknown) => ({ success: true, data }));
+  });
+
+  it('returns 402 with X-PAYMENT-REQUIRED when handler emits pending-payment state', async () => {
+    mockHandleA2AJsonRpc.mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        id: 'task-pending-1',
+        status: { state: 'pending-payment', timestamp: '2026-04-28T00:00:00.000Z' },
+        metadata: { pricing: { usdc: '0.05' } },
+        history: [],
+      },
+    });
+    mockBuildPaymentRequired.mockReturnValue({
+      x402Version: 1,
+      accepts: [{ scheme: 'exact', network: 'evm:base', maxAmountRequired: '50000' }],
+    });
+    mockEncodePaymentRequired.mockReturnValue('encoded-payment-required-base64');
+
+    const app = makeA2AApp({ id: 'user-1' }, { features: { ai: true } });
+    const res = await app.request(
+      post('/', {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/send',
+        params: { id: 'paid-agent', message: { role: 'user', parts: [{ text: 'do work' }] } },
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get('X-PAYMENT-REQUIRED')).toBe('encoded-payment-required-base64');
+    expect(mockBuildPaymentRequired).toHaveBeenCalledWith(expect.any(String), '0.05');
+    expect(mockVerifyPayment).not.toHaveBeenCalled();
+  });
+
+  it('passes paymentVerified=true to handler when X-PAYMENT-PAYLOAD verifies', async () => {
+    mockVerifyPayment.mockResolvedValue({ valid: true });
+    mockHandleA2AJsonRpc.mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        id: 'task-completed-1',
+        status: { state: 'completed' },
+        history: [],
+      },
+    });
+
+    const app = makeA2AApp({ id: 'user-1' }, { features: { ai: true } });
+    const res = await app.request(
+      post(
+        '/',
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tasks/send',
+          params: { id: 'paid-agent', message: { role: 'user', parts: [{ text: 'work' }] } },
+        },
+        { 'X-PAYMENT-PAYLOAD': 'valid-base64-proof' },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyPayment).toHaveBeenCalledWith('valid-base64-proof', expect.any(String));
+    const callArgs = mockHandleA2AJsonRpc.mock.calls[0];
+    expect(callArgs?.[3]).toEqual({ paymentVerified: true });
+  });
+
+  it('returns 402 immediately when X-PAYMENT-PAYLOAD fails verification', async () => {
+    mockVerifyPayment.mockResolvedValue({ valid: false, error: 'Invalid signature' });
+    mockBuildPaymentRequired.mockReturnValue({
+      x402Version: 1,
+      accepts: [{ scheme: 'exact', network: 'evm:base', maxAmountRequired: '1000' }],
+    });
+    mockEncodePaymentRequired.mockReturnValue('encoded-fresh-requirements');
+
+    const app = makeA2AApp({ id: 'user-1' }, { features: { ai: true } });
+    const res = await app.request(
+      post(
+        '/',
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tasks/send',
+          params: { id: 'paid-agent', message: { role: 'user', parts: [{ text: 'work' }] } },
+        },
+        { 'X-PAYMENT-PAYLOAD': 'bad-base64-proof' },
+      ),
+    );
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get('X-PAYMENT-REQUIRED')).toBe('encoded-fresh-requirements');
+    const body = (await res.json()) as {
+      jsonrpc: string;
+      id: number;
+      error: { code: number; message: string };
+    };
+    expect(body.error.code).toBe(-32004);
+    expect(body.error.message).toContain('Invalid signature');
+    expect(mockHandleA2AJsonRpc).not.toHaveBeenCalled();
+  });
+
+  it('does NOT verify payment for read-only methods (tasks/get)', async () => {
+    mockHandleA2AJsonRpc.mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 4,
+      result: { id: 'task-1' },
+    });
+
+    const app = makeA2AApp({ id: 'user-1' });
+    const res = await app.request(
+      post(
+        '/',
+        { jsonrpc: '2.0', id: 4, method: 'tasks/get', params: { id: 'task-1' } },
+        { 'X-PAYMENT-PAYLOAD': 'irrelevant-for-read-only' },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyPayment).not.toHaveBeenCalled();
+  });
+
+  it('passes paymentVerified=false to handler when no X-PAYMENT-PAYLOAD attached', async () => {
+    mockHandleA2AJsonRpc.mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 5,
+      result: { id: 'task-x', status: { state: 'completed' }, history: [] },
+    });
+
+    const app = makeA2AApp({ id: 'user-1' }, { features: { ai: true } });
+    const res = await app.request(
+      post('/', {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tasks/send',
+        params: { id: 'free-agent', message: { role: 'user', parts: [{ text: 'work' }] } },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyPayment).not.toHaveBeenCalled();
+    const callArgs = mockHandleA2AJsonRpc.mock.calls[0];
+    expect(callArgs?.[3]).toEqual({ paymentVerified: false });
   });
 });

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -27,7 +27,12 @@ import { desc, eq } from 'drizzle-orm';
 import { authMiddleware } from '../middleware/auth.js';
 import { requireFeature } from '../middleware/license.js';
 import { requireTaskQuota } from '../middleware/task-quota.js';
-import { buildPaymentMethods } from '../middleware/x402.js';
+import {
+  buildPaymentMethods,
+  buildPaymentRequired,
+  encodePaymentRequired,
+  verifyPayment,
+} from '../middleware/x402.js';
 
 // JSON-RPC error codes (inlined  -  avoids static import of @revealui/ai)
 const RPC_INVALID_REQUEST = -32600;
@@ -1044,6 +1049,37 @@ a2a.openapi(
     // Extract optional agent ID from X-Agent-ID header
     const agentId = c.req.header('X-Agent-ID');
 
+    // x402 payment proof verification: when an X-PAYMENT-PAYLOAD header is
+    // present on an executable JSON-RPC method, verify it before calling
+    // the handler. Valid → set paymentVerified so the handler skips its
+    // pending-payment branch. Invalid → 402 with fresh requirements.
+    let paymentVerified = false;
+    if (executionMethods.has(req.method)) {
+      const paymentPayload = c.req.header('X-PAYMENT-PAYLOAD');
+      if (paymentPayload) {
+        const baseUrl = getBaseUrl(c.req.raw);
+        const resource = `${baseUrl}${new URL(c.req.url).pathname}`;
+        const verification = await verifyPayment(paymentPayload, resource);
+        if (verification.valid) {
+          paymentVerified = true;
+        } else {
+          const paymentRequired = buildPaymentRequired(resource);
+          return c.json(
+            {
+              jsonrpc: '2.0',
+              id: req.id,
+              error: {
+                code: -32004,
+                message: `Payment verification failed: ${verification.error}`,
+              },
+            },
+            402,
+            { 'X-PAYMENT-REQUIRED': encodePaymentRequired(paymentRequired) },
+          );
+        }
+      }
+    }
+
     // Resolve LLM client from environment-configured open models
     let llmClient: unknown;
     try {
@@ -1063,13 +1099,34 @@ a2a.openapi(
       req,
       agentId ?? undefined,
       llmClient as HandleParams[2],
+      { paymentVerified },
     );
     const completedAt = Date.now();
 
+    // Inspect handler outcome up front — used by both the 402 branch and
+    // the agentActions audit log below.
+    const taskResult = result.result as {
+      id?: string;
+      status?: { state?: string };
+      metadata?: { pricing?: { usdc?: string } };
+    } | null;
+    const taskState = taskResult?.status?.state;
+
+    // Pending-payment tasks: convert to HTTP 402 with X-PAYMENT-REQUIRED.
+    // The route owns this protocol-layer wrapper because verifyPayment lives
+    // in apps/api middleware and must not leak into the @revealui/ai package.
+    if (taskState === 'pending-payment') {
+      const baseUrl = getBaseUrl(c.req.raw);
+      const resource = `${baseUrl}${new URL(c.req.url).pathname}`;
+      const paymentRequired = buildPaymentRequired(resource, taskResult?.metadata?.pricing?.usdc);
+      return c.json(result, 402, {
+        'X-PAYMENT-REQUIRED': encodePaymentRequired(paymentRequired),
+      });
+    }
+
     // Fire-and-forget: persist task execution record to agentActions
     if (executionMethods.has(req.method)) {
-      const taskResult = result.result as { status?: { state?: string } } | null;
-      const status = taskResult?.status?.state === 'failed' ? 'failed' : 'completed';
+      const status = taskState === 'failed' ? 'failed' : 'completed';
       void (async () => {
         try {
           const db = getClient();

--- a/packages/ai/src/a2a/__tests__/a2a.test.ts
+++ b/packages/ai/src/a2a/__tests__/a2a.test.ts
@@ -155,6 +155,18 @@ describe('a2a task store', () => {
     expect(cancelTask(task.id)).toBe(false);
     expect(getTask(task.id)?.status.state).toBe('completed');
   });
+
+  it('allows cancel from the pending-payment state (requester releases the slot)', () => {
+    const task = createTask({
+      id: trackTaskId('task-store-pending-payment-cancel'),
+      message: userMessage('Pay or cancel'),
+    });
+    updateTaskState(task.id, 'pending-payment');
+
+    expect(getTask(task.id)?.status.state).toBe('pending-payment');
+    expect(cancelTask(task.id)).toBe(true);
+    expect(getTask(task.id)?.status.state).toBe('canceled');
+  });
 });
 
 describe('a2a json-rpc handler', () => {
@@ -328,6 +340,86 @@ describe('a2a json-rpc handler', () => {
         code: -32001,
         message: "Task 'does-not-exist' not found",
       },
+    });
+  });
+
+  it('emits pending-payment when agent has pricing and payment is not verified', async () => {
+    const agentId = 'paid-test-agent-pending';
+    registeredAgentIds.push(agentId);
+    agentCardRegistry.register({
+      id: agentId,
+      version: 1,
+      name: 'Paid Agent',
+      description: 'Charges for tasks',
+      model: 'gpt-test',
+      systemPrompt: 'Charges per call',
+      tools: [],
+      capabilities: ['paid'],
+      temperature: 0.2,
+      maxTokens: 512,
+      pricing: { usdc: '0.05' },
+    });
+    trackTaskId('rpc-paid-pending');
+
+    const response = await handleA2AJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 'rpc-paid-pending',
+        method: 'tasks/send',
+        params: {
+          id: 'rpc-paid-pending',
+          message: userMessage('Do paid work'),
+        },
+      },
+      agentId,
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toMatchObject({
+      id: 'rpc-paid-pending',
+      status: { state: 'pending-payment' },
+      metadata: { pricing: { usdc: '0.05' } },
+    });
+    expect(getTask('rpc-paid-pending')?.status.state).toBe('pending-payment');
+  });
+
+  it('falls through to execution when paymentVerified=true is passed via options', async () => {
+    const agentId = 'paid-test-agent-verified';
+    registeredAgentIds.push(agentId);
+    agentCardRegistry.register({
+      id: agentId,
+      version: 1,
+      name: 'Paid Agent Verified',
+      description: 'Charges for tasks',
+      model: 'gpt-test',
+      systemPrompt: 'Charges per call',
+      tools: [],
+      capabilities: ['paid'],
+      temperature: 0.2,
+      maxTokens: 512,
+      pricing: { usdc: '0.05' },
+    });
+    trackTaskId('rpc-paid-verified');
+
+    const response = await handleA2AJsonRpc(
+      {
+        jsonrpc: '2.0',
+        id: 'rpc-paid-verified',
+        method: 'tasks/send',
+        params: {
+          id: 'rpc-paid-verified',
+          message: userMessage('Paid work'),
+        },
+      },
+      agentId,
+      undefined,
+      { paymentVerified: true },
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toMatchObject({
+      id: 'rpc-paid-verified',
+      status: { state: 'completed' },
     });
   });
 });

--- a/packages/ai/src/a2a/handler.ts
+++ b/packages/ai/src/a2a/handler.ts
@@ -69,6 +69,7 @@ async function handleTasksSend(
   params: unknown,
   agentId?: string,
   llmClient?: LLMClient,
+  options?: { paymentVerified?: boolean },
 ): Promise<A2AJsonRpcResponse> {
   const parsed = A2ASendTaskParamsSchema.safeParse(params);
   if (!parsed.success) {
@@ -80,6 +81,28 @@ async function handleTasksSend(
   // Validate agent exists if agentId provided
   if (agentId && !agentCardRegistry.has(agentId)) {
     return err(id, RPC_AGENT_NOT_FOUND, `Agent '${agentId}' not found`);
+  }
+
+  // Resolve agent definition early — needed for the pricing gate below AND
+  // for execution context (system prompt, capabilities) further down.
+  const agentDef = agentId
+    ? agentCardRegistry.getDef(agentId)
+    : agentCardRegistry.getDef('revealui-creator');
+
+  // x402 payment gate: when an agent has pricing AND payment was not
+  // verified upstream by the route, emit a 'pending-payment' task. The
+  // route layer translates this state into HTTP 402 with a fresh
+  // X-PAYMENT-REQUIRED header. Pricing rides in task.metadata so the
+  // route can build the requirements without re-querying the registry.
+  if (agentDef?.pricing && !options?.paymentVerified) {
+    const task = createTask({
+      id: p.id,
+      sessionId: p.sessionId,
+      message: p.message,
+      metadata: { ...p.metadata, pricing: agentDef.pricing },
+    });
+    const pending = updateTaskState(task.id, 'pending-payment');
+    return ok(id, pending);
   }
 
   // Create task in submitted state
@@ -98,10 +121,6 @@ async function handleTasksSend(
 
     // Execute via orchestration  -  for now, produce a direct text response.
     // Full AgentRuntime integration wires in when an LLM provider is configured.
-    const agentDef = agentId
-      ? agentCardRegistry.getDef(agentId)
-      : agentCardRegistry.getDef('revealui-creator');
-
     if (signal?.aborted) {
       return ok(id, getTask(task.id));
     }
@@ -201,12 +220,13 @@ export async function handleA2AJsonRpc(
   req: A2AJsonRpcRequest,
   agentId?: string,
   llmClient?: LLMClient,
+  options?: { paymentVerified?: boolean },
 ): Promise<A2AJsonRpcResponse> {
   const { id, method, params } = req;
 
   switch (method) {
     case 'tasks/send':
-      return handleTasksSend(id, params, agentId, llmClient);
+      return handleTasksSend(id, params, agentId, llmClient, options);
 
     case 'tasks/get':
       return handleTasksGet(id, params);
@@ -216,7 +236,7 @@ export async function handleA2AJsonRpc(
 
     case 'tasks/sendSubscribe':
       // SSE streaming is handled at the Hono route level; return a reference task here
-      return handleTasksSend(id, params, agentId, llmClient);
+      return handleTasksSend(id, params, agentId, llmClient, options);
 
     default:
       return err(id, RPC_METHOD_NOT_FOUND, `Method '${method}' not found`);

--- a/packages/ai/src/a2a/task-store.ts
+++ b/packages/ai/src/a2a/task-store.ts
@@ -94,7 +94,12 @@ export function cancelTask(id: string): boolean {
   const task = _tasks.get(id);
   if (!task) return false;
 
-  const cancelable = task.status.state === 'submitted' || task.status.state === 'working';
+  // 'pending-payment' is cancelable so a requester who decides not to pay
+  // can release the task slot rather than leaving it dangling.
+  const cancelable =
+    task.status.state === 'submitted' ||
+    task.status.state === 'working' ||
+    task.status.state === 'pending-payment';
   if (!cancelable) return false;
 
   // Signal abort to any running execution


### PR DESCRIPTION
## Summary

PR 2/N of GAP-149 — the x402 / A2A wiring track. Builds on the schema-only foundation that landed in [#645](https://github.com/RevealUIStudio/revealui/pull/645).

This PR turns on the runtime behavior:

- A2A handler now emits `pending-payment` task state when the resolved agent definition has `pricing` AND no payment proof was verified upstream.
- The `/a2a` route verifies `X-PAYMENT-PAYLOAD` headers before calling the handler. Valid → handler proceeds with `paymentVerified=true`. Invalid → returns HTTP 402 with fresh `X-PAYMENT-REQUIRED` payload.
- Pending-payment task states emitted by the handler are converted to HTTP 402 responses (reusing the existing `buildPaymentRequired` + `encodePaymentRequired` middleware primitives — no new x402 surface).
- `pending-payment` tasks are cancelable so a requester who decides not to pay can release the slot.

USDC is the primary settlement currency for this PR (Coinbase facilitator handles its own replay protection). RVUI is gated behind `RVUI_PAYMENTS_ENABLED=false` in prod, with a hard-blocker safeguards-pipeline fix tracked as **GAP-159** (filed during this PR's preflight — see "Audit findings" below).

## File-by-file

| Surface | File | Change |
|---|---|---|
| Handler | `packages/ai/src/a2a/handler.ts` | `handleTasksSend` + `handleA2AJsonRpc` gain optional 4th param `options?: { paymentVerified?: boolean }` (backward compatible). agentDef hoisted ahead of `createTask` so the pricing gate can run first. New early-return branch: when `agentDef.pricing` set and not verified, create task with `pricing` on metadata and emit `pending-payment` state. |
| Task store | `packages/ai/src/a2a/task-store.ts` | Cancelable predicate accepts `pending-payment` (one-line + comment explaining the WHY). |
| Route | `apps/api/src/routes/a2a.ts` | New imports of `buildPaymentRequired`, `encodePaymentRequired`, `verifyPayment`. Pre-handler verify step gated on `executionMethods` + presence of `X-PAYMENT-PAYLOAD`. Post-handler intercept of `taskState === 'pending-payment'` returns HTTP 402 with `X-PAYMENT-REQUIRED`. Skips `agentActions` audit log for pending-payment (no execution happened). |
| Handler tests | `packages/ai/src/a2a/__tests__/a2a.test.ts` | +3 tests: cancel-from-pending-payment in task-store, pending-payment emission with pricing, paymentVerified=true falls through to existing flow. |
| Route tests | `apps/api/src/routes/__tests__/a2a-edge.test.ts` | +5 tests covering 402 emission with `X-PAYMENT-REQUIRED`, paymentVerified=true threading, invalid proof returns 402 directly, read-only methods skip verification, paymentVerified=false default. New mocks for `buildPaymentRequired`, `encodePaymentRequired`, `verifyPayment`. |
| Changeset | `.changeset/ai-x402-a2a-pending-payment.md` | `@revealui/ai`: minor (new behavior in 0.x). |

## Phase 1 decisions honored (locked yesterday)

| # | Decision | How this PR honors it |
|---|---|---|
| 1 | USDC always available; RVUI optional discount | Existing `buildPaymentRequired` already handles both; this PR doesn't change currency negotiation |
| 2 | A2A 402 emission via `pending-payment` task state | This PR's core behavior |
| 3 | On-chain only Phase 2; defer off-chain (daemon-mail) | No daemon involvement here |
| 4 | Treasury escrow + batch payouts | No publisher-wallet code in this PR |
| 5 | Pricing source: `agentDef.pricing` field | Handler reads `agentDef.pricing`; pricing rides on `task.metadata` |
| 6 | Pre-launch RVC: `RVUI_PAYMENTS_ENABLED=false` | No code change to that env-flag; existing gating preserved |

## Open decisions resolved in this PR

- **Cancelability of `pending-payment`**: ALLOWED. A requester who decides not to pay should be able to release the slot rather than have it dangle until the in-memory store evicts. Documented in a one-line comment at `task-store.ts:97`.
- **`paymentVerified` plumbing shape**: kept as a single boolean for now. If we ever surface verified amount/scheme to the agent runtime, expand to `{ verified, scheme?, amount? }` later.

## Audit findings

The GAP-149 audit surfaced two findings worth re-verifying. Resolved during this PR's preflight:

1. **`marketplace.ts:609-628` does not check `X402_ENABLED`** → confirmed **intentional decoupling**, not a missed gate. Marketplace is its own surface (per-server price gating, always-on if the server is `active`). Docs PR (PR 4 of GAP-149) will document this.
2. **`safeguards.isDuplicateTransaction` not wired upstream of `verifyRvuiPayment`** → confirmed **REAL replay-attack hole**. Worse than framed: the entire RVUI safeguards pipeline (`validatePayment`, `recordPayment`, `isDuplicateTransaction`) is dead code — never called from production paths. **Filed as GAP-159** (priority: blocker; gates `RVUI_PAYMENTS_ENABLED=true` in any environment carrying real RVC value). USDC path unaffected by this hole, so this PR ships unblocked.

## Test plan

- [x] `pnpm --filter @revealui/ai test` → 942/942 pass (3 new tests)
- [x] `pnpm --filter api exec vitest run src/middleware/__tests__/x402.test.ts src/routes/__tests__/a2a.test.ts src/routes/__tests__/a2a-edge.test.ts` → 99/99 pass (5 new tests in a2a-edge)
- [x] `pnpm --filter @revealui/ai typecheck` → clean
- [x] `pnpm --filter api typecheck` → clean (pre-existing `og.ts` errors unrelated to this PR; modules `@resvg/resvg-wasm` + `satori` declared in package.json but missing locally; CI installs them)
- [x] `pnpm exec biome check --write` on touched files → clean after one auto-format on the type assertion in `a2a.ts`
- [ ] CI gate (will run on push)
- [ ] E2E manual: with `X402_ENABLED=true` and a paid agent definition, POST `tasks/send` → expect 402 → POST again with `X-PAYMENT-PAYLOAD` → expect 200 (deferred to PR 4 runbook)

## Refs

- Parent gap: GAP-149 (still open — PR 3-5 carry the rest)
- Audit doc: docs/audits/gap-149-x402-audit-2026-04-28.md (file:line citations)
- Schema PR: [#645](https://github.com/RevealUIStudio/revealui/pull/645) (merged as `f8199c87d`)
- Spawned during preflight: GAP-159 (RVUI safeguards pipeline unwired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
