### PR TITLE
docs(x402): devnet runbook + SECRETS entries (PR 4/N of GAP-149)

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -66,6 +66,8 @@ revealui/dev/admin/bootstrap/email       # CLI admin bootstrap
 revealui/dev/admin/bootstrap/password    # CLI admin bootstrap (≥12 chars)
 revealui/dev/admin/bootstrap/name        # optional, defaults to "Super Admin"
 revealui/dev/admin/bootstrap/force-rotate # optional, default true
+revealui/dev/x402/receiving-address      # Sepolia EVM USDC receiving wallet (testnet) — X402_RECEIVING_ADDRESS
+revealui/dev/rvui/receiving-wallet       # Solana devnet RVC receiving wallet — RVUI_RECEIVING_WALLET
 ```
 
 Production (what CI + Vercel pull from when deploying):
@@ -93,6 +95,8 @@ revealui/prod/google/private-key         # Gmail API service-account PKCS8 PEM
 revealui/prod/github/client-id
 revealui/prod/github/client-secret
 revealui/prod/sentry/auth-token          # CI/CD error tracking
+revealui/prod/x402/receiving-address     # Base mainnet EVM USDC receiving wallet — X402_RECEIVING_ADDRESS
+revealui/prod/rvui/receiving-wallet      # Solana mainnet RVC receiving wallet (post-launch) — RVUI_RECEIVING_WALLET
 ```
 
 ### Revealcoin

--- a/docs/architecture/x402.md
+++ b/docs/architecture/x402.md
@@ -149,27 +149,330 @@ The fix wires `validatePayment` + `recordPayment` upstream of the verify path in
 
 Until GAP-159 closes, the only safe environment for `RVUI_PAYMENTS_ENABLED=true` is **devnet** (testnet RVUI has no economic value).
 
-## Devnet test runbook (high level)
+## Devnet activation runbook
 
-For staging activation against devnet RVC:
+End-to-end staging activation against testnet USDC (Base Sepolia) and devnet RVC. **GAP-159 (replay-attack hole) is closed**, so this runbook is safe to execute on any devnet/staging environment. Mainnet activation requires the additional pre-launch gates (multi-sig + on-chain vesting per `project_revealcoin_pre_launch_gates`); those are out of scope for this runbook.
 
-1. Provision a devnet Solana wallet for receiving (devnet faucet → revvault).
-2. Set in staging environment:
-   ```
-   X402_ENABLED=true
-   X402_RECEIVING_ADDRESS=0x...           # Sepolia USDC wallet
-   X402_NETWORK=evm:base-sepolia
-   RVUI_PAYMENTS_ENABLED=true             # devnet only — see GAP-159 above
-   RVUI_RECEIVING_WALLET=<devnet_wallet>
-   SOLANA_NETWORK=devnet
-   ```
-3. Boot apps/api → expect Stripe test-mode banner + RVUI GAP-159 banner.
-4. Register an agent with `pricing: { usdc: '0.01' }` via `POST /a2a/agents`.
-5. Hit `POST /a2a` with `tasks/send` → expect 402 + `X-PAYMENT-REQUIRED`.
-6. Pay the advertised amount on-chain (Sepolia faucet USDC, devnet faucet RVC).
-7. Retry with `X-PAYMENT-PAYLOAD` carrying the proof → expect 200 + completed task.
+### 0 — Prerequisites
 
-Detailed step-by-step (with shell commands, faucet links, and verification queries) lands in PR 4 of the GAP-149 sequence.
+- `revvault` CLI installed and unlocked (`revvault unlock` with the age identity passphrase)
+- `solana` CLI for devnet faucet + tx inspection
+- A devnet Solana keypair you control (file path or in revvault under `revealcoin/devnet-receive.json`)
+- A Base Sepolia EVM wallet you control (we'll just use the address; signing happens client-side via the agent)
+- Staging Vercel deployment access (or local `pnpm dev:api`)
+
+### 1 — Provision the receiving wallets
+
+**EVM (Base Sepolia for USDC):**
+
+```bash
+# Generate or pick an EVM address you control. The seed/private key
+# stays in your wallet provider (Metamask, etc.); we only need the
+# public address.
+echo '0xYourBaseSepoliaAddress' | revvault set revealui/dev/x402/receiving-address
+```
+
+**Solana (devnet for RVC):**
+
+```bash
+# Generate a devnet keypair if you don't have one
+solana-keygen new --outfile /tmp/devnet-rvc-receive.json --no-bip39-passphrase
+PUBKEY=$(solana-keygen pubkey /tmp/devnet-rvc-receive.json)
+
+# Fund it from the devnet faucet (3 SOL for tx fees; RVC arrives via test mints later)
+solana airdrop 3 "$PUBKEY" --url devnet
+
+# Store the public address in revvault for the API server
+echo "$PUBKEY" | revvault set revealui/dev/rvui/receiving-wallet
+
+# Store the keypair separately if you want to drain the wallet later;
+# the API server only needs the public address.
+revvault set revealcoin/devnet-receive < /tmp/devnet-rvc-receive.json
+shred -u /tmp/devnet-rvc-receive.json
+```
+
+### 2 — Configure the staging deployment
+
+For Vercel staging (the canonical apps/api deployment for `test`):
+
+```bash
+cd ~/suite/revealui
+
+# Pull the just-set values from revvault and push to Vercel env
+X402_ADDR=$(revvault get --full revealui/dev/x402/receiving-address)
+RVUI_WALLET=$(revvault get --full revealui/dev/rvui/receiving-wallet)
+
+vercel env add X402_ENABLED preview <<<'true'
+vercel env add X402_RECEIVING_ADDRESS preview <<<"$X402_ADDR"
+vercel env add X402_NETWORK preview <<<'evm:base-sepolia'
+vercel env add X402_PRICE_PER_TASK preview <<<'0.01'
+vercel env add RVUI_PAYMENTS_ENABLED preview <<<'true'
+vercel env add RVUI_RECEIVING_WALLET preview <<<"$RVUI_WALLET"
+vercel env add SOLANA_NETWORK preview <<<'devnet'
+```
+
+For local development (using `pnpm dev:api`), populate `.env.local` from revvault:
+
+```bash
+cat <<EOF >> apps/api/.env.local
+X402_ENABLED=true
+X402_RECEIVING_ADDRESS=$(revvault get --full revealui/dev/x402/receiving-address)
+X402_NETWORK=evm:base-sepolia
+X402_PRICE_PER_TASK=0.01
+RVUI_PAYMENTS_ENABLED=true
+RVUI_RECEIVING_WALLET=$(revvault get --full revealui/dev/rvui/receiving-wallet)
+SOLANA_NETWORK=devnet
+EOF
+```
+
+### 3 — Boot apps/api and verify the activation banners
+
+```bash
+pnpm --filter api start  # or: vercel --prod redeploy
+```
+
+Expected stderr output (both banners are by-design with the current pre-launch posture):
+
+```
+⚠️  ╔══════════════════════════════════════════════════════════════════╗
+⚠️  ║  STRIPE TEST MODE in production                                  ║
+...
+⚠️  ╚══════════════════════════════════════════════════════════════════╝
+
+⚠️  ╔══════════════════════════════════════════════════════════════════╗
+⚠️  ║  RVUI PAYMENTS — replay-attack hole (GAP-159)                    ║
+...
+⚠️  ╚══════════════════════════════════════════════════════════════════╝
+```
+
+The GAP-159 banner wording is now stale (the hole closed via revealui#648). It still fires whenever `RVUI_PAYMENTS_ENABLED=true` as a soft "experimental currency" notice; can be relaxed in a follow-up.
+
+If `validateStartup` rejects the boot, the error message names the missing/malformed env var. Common failures:
+
+- `X402_RECEIVING_ADDRESS must be a 0x-prefixed 40-hex EVM address` → check revvault value matches `^0x[0-9a-f]{40}$`
+- `RVUI_PAYMENTS_ENABLED=true requires RVUI_RECEIVING_WALLET` → revvault path empty; re-run step 1
+
+### 4 — Confirm the public discovery endpoints
+
+```bash
+BASE=https://api-staging.revealui.com
+
+curl -s "$BASE/.well-known/payment-methods.json" | jq '.'
+# → { "version": "1.0", "accepts": [ { scheme: "exact", network: "evm:base-sepolia", ... } ] }
+
+curl -s "$BASE/.well-known/marketplace.json" | jq '.revenueShare, .paymentMethods'
+# → { "platform": 0.2, "developer": 0.8 }
+# → ["x402-usdc"]
+```
+
+If `payment-methods.json` returns 404, `X402_ENABLED` is not `true` (or the receiving address is empty).
+
+### 5 — Register a paid agent
+
+```bash
+curl -s -X POST "$BASE/a2a/agents" \
+  -H 'Content-Type: application/json' \
+  -H "Cookie: revealui-session=<your-session-cookie>" \
+  -d '{
+    "id": "test-paid-agent",
+    "version": 1,
+    "name": "Paid Test Agent",
+    "description": "Charges per call for x402 staging activation",
+    "model": "claude-sonnet-4-6",
+    "systemPrompt": "You are a test agent.",
+    "tools": [],
+    "capabilities": ["test"],
+    "temperature": 0.2,
+    "maxTokens": 512,
+    "pricing": { "usdc": "0.01", "rvui": "0.008" }
+  }' | jq '.'
+```
+
+The pricing fields land in `AgentDefinitionSchema.pricing` (added in revealui#645). RVUI `0.008` reflects the 20% discount baked into `buildPaymentRequired`.
+
+### 6 — Trigger 402 emission
+
+```bash
+curl -i -X POST "$BASE/a2a" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Agent-ID: test-paid-agent' \
+  -H "Cookie: revealui-session=<your-session-cookie>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-001",
+      "message": { "role": "user", "parts": [{ "type": "text", "text": "Test paid call" }] }
+    }
+  }'
+```
+
+Expected response:
+
+- HTTP `402 Payment Required`
+- `X-PAYMENT-REQUIRED` header (base64-encoded `PaymentRequired`)
+- Response body: JSON-RPC envelope with `result.status.state === 'pending-payment'` and `result.metadata.pricing === { usdc: '0.01', rvui: '0.008' }`
+
+Decode the `X-PAYMENT-REQUIRED` header to inspect the accepted currencies:
+
+```bash
+RESP=$(curl -is -X POST "$BASE/a2a" -H 'X-Agent-ID: test-paid-agent' \
+  -H "Cookie: revealui-session=$SESSION" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"task-002","message":{"role":"user","parts":[{"type":"text","text":"x"}]}}}')
+echo "$RESP" | grep -i 'x-payment-required:' | sed 's/.*: //' | tr -d '\r' | base64 -d | jq '.accepts'
+```
+
+You should see TWO entries: USDC (`scheme: 'exact'`, network `evm:base-sepolia`) and RVC (`scheme: 'solana-spl'`, network `solana:devnet`).
+
+### 7 — Pay with USDC (test path)
+
+Get test USDC on Base Sepolia from the [Circle faucet](https://faucet.circle.com/) or [Coinbase faucet](https://portal.cdp.coinbase.com/products/faucet) and send `0.01` USDC to the receiving wallet. Capture the tx hash.
+
+The agent-side payment payload is a signed EIP-712 message — agents typically use the `@x402/client` library or the [Coinbase x402 SDK](https://github.com/coinbase/x402). For manual testing, the simplest path is to use the Coinbase facilitator's example client:
+
+```bash
+# Pseudocode — actual implementation depends on your wallet client
+PAYLOAD=$(node scripts/x402-sign-payment.mjs \
+  --recipient "$X402_ADDR" \
+  --amount 10000 \
+  --resource "$BASE/a2a")
+
+curl -i -X POST "$BASE/a2a" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Agent-ID: test-paid-agent' \
+  -H "X-PAYMENT-PAYLOAD: $PAYLOAD" \
+  -H "Cookie: revealui-session=$SESSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-003",
+      "message": { "role": "user", "parts": [{ "type": "text", "text": "Paid call" }] }
+    }
+  }'
+```
+
+Expected: `200 OK` with `result.status.state === 'completed'`.
+
+### 8 — Pay with RVC (devnet path)
+
+Mint test RVC on devnet:
+
+```bash
+# RVUI mint is at devnet:4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo
+spl-token create-account 4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo \
+  --owner $(solana-keygen pubkey) \
+  --url devnet --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+
+# Mint 100 RVC to your account (mint authority required — devnet only)
+spl-token mint 4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo 100 \
+  --url devnet --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+```
+
+Send `0.008` RVC to the receiving wallet:
+
+```bash
+RVUI_WALLET=$(revvault get --full revealui/dev/rvui/receiving-wallet)
+TX_SIG=$(spl-token transfer 4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo \
+  0.008 "$RVUI_WALLET" \
+  --url devnet --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb \
+  --output json | jq -r '.signature')
+echo "Tx signature: $TX_SIG"
+
+# Build the X-PAYMENT-PAYLOAD (base64 of { x402Version, scheme, network, payload })
+PAYLOAD=$(jq -nc --arg sig "$TX_SIG" '{
+  x402Version: 1,
+  scheme: "solana-spl",
+  network: "solana:devnet",
+  payload: { txSignature: $sig, amount: "8000" }
+}' | base64 -w0)
+
+# Wait for finalization (paymentCommitment is "finalized" — ~30s)
+sleep 30
+
+curl -i -X POST "$BASE/a2a" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Agent-ID: test-paid-agent' \
+  -H "X-PAYMENT-PAYLOAD: $PAYLOAD" \
+  -H "Cookie: revealui-session=$SESSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-004",
+      "message": { "role": "user", "parts": [{ "type": "text", "text": "RVC paid call" }] }
+    }
+  }'
+```
+
+Expected: `200 OK` with `result.status.state === 'completed'`.
+
+### 9 — Verify the safeguards (replay-attack test)
+
+This is the GAP-159 acceptance check. Reuse the **same** `X-PAYMENT-PAYLOAD` from step 8:
+
+```bash
+curl -i -X POST "$BASE/a2a" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Agent-ID: test-paid-agent' \
+  -H "X-PAYMENT-PAYLOAD: $PAYLOAD" \
+  -H "Cookie: revealui-session=$SESSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tasks/send",
+    "params": {
+      "id": "task-005",
+      "message": { "role": "user", "parts": [{ "type": "text", "text": "Replay attempt" }] }
+    }
+  }'
+```
+
+Expected: `402 Payment Required` with error containing **"Transaction signature already used"**. This proves `validatePayment` → `isDuplicateTransaction` is wired and the row from step 8 was inserted into `revealcoinPayments`.
+
+Confirm the DB write:
+
+```bash
+cd ~/suite/revealui
+PGURL=$(revvault get --full revealui/dev/neon/postgres-url)
+psql "$PGURL" -c "SELECT tx_signature, wallet_address, user_id, amount_usd, discount_usd, created_at FROM revealcoin_payments ORDER BY created_at DESC LIMIT 5;"
+```
+
+You should see the tx from step 8 with `amount_usd ≈ 0.008` and `discount_usd ≈ 0.002`.
+
+### 10 — Rollback
+
+If staging activation surfaces issues, the kill-switch is a single env var:
+
+```bash
+vercel env rm X402_ENABLED preview --yes
+vercel env add X402_ENABLED preview <<<'false'
+vercel --target preview redeploy
+```
+
+This reverts to the pre-PR-3 posture: no 402 emission, no payment verification, all paid surfaces fall through to their pre-x402 behavior (quota-exhaust returns 429, marketplace `/invoke` still emits 402 because that path is per-server independent of the global flag — see "Marketplace decoupling" above).
+
+For a partial rollback (RVC off, USDC on):
+
+```bash
+vercel env rm RVUI_PAYMENTS_ENABLED preview --yes
+vercel env add RVUI_PAYMENTS_ENABLED preview <<<'false'
+```
+
+USDC continues to work; RVC payments now fail-closed with "RVUI payments are not enabled".
+
+### 11 — What's not covered yet
+
+The following capabilities land in subsequent GAP-149 PRs:
+
+- **Per-route x402 hit/payment/fail counters** — observability dashboards (PR 5)
+- **Settlement latency dashboards** — Phase 5 of gap
+- **Treasury batch-payout job** — moves USDC + RVC from receiving wallets to operator wallets / 80/20 marketplace splits (Phase 6)
+- **Refund / dispute flow** — out of scope pre-launch per gap notes
+- **Mainnet activation** — additional gates (multi-sig + on-chain vesting per `project_revealcoin_pre_launch_gates`); this runbook covers devnet/staging only
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

PR 4/N of GAP-149 — pure docs PR. Closes the docs side of the x402 / A2A wiring track.

Builds on:
- [#645](https://github.com/RevealUIStudio/revealui/pull/645) — schema (`pending-payment` + `agentDef.pricing`)
- [#646](https://github.com/RevealUIStudio/revealui/pull/646) — handler emits `pending-payment` + HTTP 402 wrapper
- [#647](https://github.com/RevealUIStudio/revealui/pull/647) — boot validation gates + `docs/architecture/x402.md`
- [#648](https://github.com/RevealUIStudio/revealui/pull/648) — GAP-159 RVUI safeguards pipeline wired (replay-attack hole closed)

This PR ships the **operator-facing devnet activation runbook** and the **revvault SECRETS index entries** so the activation flow is repeatable and documented end-to-end.

## What lands

| File | Change |
|---|---|
| `docs/architecture/x402.md` | Replaces the high-level "Devnet test runbook" stub from PR 3 with an 11-section step-by-step runbook: prerequisites, wallet provisioning via revvault, Vercel env config, boot validation, well-known discovery, paid-agent registration, 402 emission test, USDC payment proof, RVC payment proof, **GAP-159 replay-attack verification**, rollback, and what's deferred to PR 5+. Includes shell commands, faucet links, expected `psql` output for the `revealcoin_payments` row, and decode-`X-PAYMENT-REQUIRED` snippets. |
| `docs/SECRETS.md` | Adds canonical revvault paths to both the dev and prod indexes: `revealui/{dev,prod}/x402/receiving-address` (EVM USDC) and `revealui/{dev,prod}/rvui/receiving-wallet` (Solana RVC). Dev paths are usable today; prod paths are reserved for post-launch activation. |

No code changes — pure docs PR.

## Why now

The runbook is **safe to execute** today because GAP-159 (#648) closed the RVUI replay-attack hole. The "wait for GAP-159" caveat from PR 3's stub runbook is removed. The GAP-159 advisory banner from PR 3 still fires on `RVUI_PAYMENTS_ENABLED=true` — the wording about "until GAP-159 closes" is now stale; can be relaxed in a small follow-up to a softer "RVUI experimental — devnet recommended" notice. Functional gate is gone.

Mainnet activation still requires the additional pre-launch gates (multi-sig + on-chain vesting per `project_revealcoin_pre_launch_gates`); explicitly out of scope for this runbook.

## Test plan

- [x] Markdown links verified manually (relative `../../` paths to source files)
- [x] Shell snippets reviewed for shell-safety (single-quoted heredocs where needed; no $-injection from revvault output)
- [ ] CI gate (will run on push)
- [ ] First operator run-through against staging will surface any gaps; this PR is the canonical baseline to iterate on

## Refs

- Parent gap: GAP-149 — still open (PR 5+ adds observability + RevMarket wiring)
- Audit: `docs/audits/gap-149-x402-audit-2026-04-28.md`
- Closed gap referenced in §9 (replay-attack verification): GAP-159

## What's left in GAP-149 after this PR

- **PR 5** — observability counters (per-route x402 hit/payment/fail), settlement-latency dashboards
- **PR 6** — RevMarket `/invoke` integration cleanup (currently per-server; consolidate with the global x402 surface)
- **Phase 6 work** — treasury batch-payout job, daemon-mail off-chain channel (depends on GAP-152), refunds (out of scope pre-launch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
