### PR TITLE
refactor(boot): relax stale GAP-159 wording in RVUI advisory banner

### DIFF
--- a/apps/api/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/api/src/lib/__tests__/validate-startup.test.ts
@@ -619,7 +619,7 @@ describe('validateStartup — RVUI activation gate + GAP-159 warning', () => {
     );
   });
 
-  it('emits the GAP-159 banner when RVUI_PAYMENTS_ENABLED=true and wallet is set', () => {
+  it('emits the RVUI experimental banner when RVUI_PAYMENTS_ENABLED=true and wallet is set', () => {
     const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     validateStartup(
       validTestProdEnv({
@@ -629,20 +629,24 @@ describe('validateStartup — RVUI activation gate + GAP-159 warning', () => {
     );
 
     const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ''));
-    const rvuiBanner = messages.find((m) => m.includes('GAP-159'));
+    const rvuiBanner = messages.find((m) => m.includes('RVUI PAYMENTS'));
     expect(rvuiBanner).toBeDefined();
-    expect(rvuiBanner).toMatch(/replay-attack hole/);
+    expect(rvuiBanner).toMatch(/experimental/i);
+    // GAP-159 is referenced as historical closure context, not as an
+    // active gate (closed via revealui#648).
+    expect(rvuiBanner).toMatch(/GAP-159/);
+    expect(rvuiBanner).toMatch(/devnet/i);
   });
 
-  it('does NOT emit the GAP-159 banner when RVUI_PAYMENTS_ENABLED is unset', () => {
+  it('does NOT emit the RVUI experimental banner when RVUI_PAYMENTS_ENABLED is unset', () => {
     const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     validateStartup(validTestProdEnv());
 
     const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ''));
-    expect(messages.some((m) => m.includes('GAP-159'))).toBe(false);
+    expect(messages.some((m) => m.includes('RVUI PAYMENTS'))).toBe(false);
   });
 
-  it('emits both Stripe test-mode AND GAP-159 banners when both apply', () => {
+  it('emits both Stripe test-mode AND RVUI experimental banners when both apply', () => {
     const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     validateStartup(
       validTestProdEnv({
@@ -653,7 +657,7 @@ describe('validateStartup — RVUI activation gate + GAP-159 warning', () => {
 
     const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ''));
     expect(messages.some((m) => m.includes('STRIPE TEST MODE'))).toBe(true);
-    expect(messages.some((m) => m.includes('GAP-159'))).toBe(true);
+    expect(messages.some((m) => m.includes('RVUI PAYMENTS'))).toBe(true);
   });
 
   it('also enforces the RVUI gate in forge mode', () => {
@@ -678,15 +682,18 @@ describe('validateStartup — RVUI activation gate + GAP-159 warning', () => {
 });
 
 describe('emitRvuiSafeguardsWarning', () => {
-  it('writes a single banner naming GAP-159 + the replay-attack hole', () => {
+  it('writes a single banner naming RVUI as experimental with safeguards wired', () => {
     const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     emitRvuiSafeguardsWarning();
 
     expect(writeSpy).toHaveBeenCalledTimes(1);
     const message = String(writeSpy.mock.calls[0]?.[0] ?? '');
-    expect(message).toMatch(/GAP-159/);
-    expect(message).toMatch(/replay-attack hole/);
-    expect(message).toMatch(/safeguards pipeline/i);
+    expect(message).toMatch(/RVUI PAYMENTS/);
+    expect(message).toMatch(/experimental/i);
     expect(message).toMatch(/RVUI_PAYMENTS_ENABLED/);
+    // Historical closure context — banner names GAP-159 + the PR that closed it
+    // so an operator reading runtime logs can trace the safety story.
+    expect(message).toMatch(/GAP-159/);
+    expect(message).toMatch(/devnet/i);
   });
 });

--- a/apps/api/src/lib/validate-startup.ts
+++ b/apps/api/src/lib/validate-startup.ts
@@ -370,25 +370,29 @@ export function emitStripeTestModeWarning(): void {
 
 /**
  * Emitted once per cold start when running with `RVUI_PAYMENTS_ENABLED=true`.
- * The RVUI verification path skips the safeguards pipeline today (replay
- * attack hole tracked as GAP-159 in revealui-jv); the warning makes the
- * posture unmistakable in runtime logs so an operator can't accidentally
- * leave it on in an environment carrying real RVC value.
+ * RVUI is treated as an experimental discount currency — the safeguards
+ * pipeline is wired (replay protection + caps + circuit breaker) but
+ * mainnet activation still requires the on-chain unlock per
+ * `project_revealcoin_pre_launch_gates`. The warning keeps the experimental
+ * posture visible in runtime logs.
+ *
+ * History: pre-#648 this banner warned about a replay-attack hole in the
+ * verify path (GAP-159). #648 closed the hole; the wording was relaxed in
+ * #651 once safeguards were wired.
  */
 export function emitRvuiSafeguardsWarning(): void {
   const banner = [
     '',
     '⚠️  ╔══════════════════════════════════════════════════════════════════╗',
-    '⚠️  ║  RVUI PAYMENTS — replay-attack hole (GAP-159)                    ║',
+    '⚠️  ║  RVUI PAYMENTS — experimental discount currency                  ║',
     '⚠️  ║                                                                  ║',
-    '⚠️  ║  RVUI_PAYMENTS_ENABLED=true and the RVUI safeguards pipeline    ║',
-    '⚠️  ║  (validatePayment + recordPayment + isDuplicateTransaction) is  ║',
-    '⚠️  ║  unwired upstream of verifyRvuiPayment. A single txSignature    ║',
-    '⚠️  ║  can be replayed N times across paid endpoints — all N pass.    ║',
+    '⚠️  ║  RVUI_PAYMENTS_ENABLED=true. Replay protection + caps + circuit ║',
+    '⚠️  ║  breaker are wired into the verify path (GAP-159 closed via     ║',
+    '⚠️  ║  revealui#648).                                                  ║',
     '⚠️  ║                                                                  ║',
-    '⚠️  ║  Safe ONLY in devnet test environments. Do NOT enable in any    ║',
-    '⚠️  ║  environment carrying real RVC value until GAP-159 closes —     ║',
-    '⚠️  ║  wires safeguards into x402.verifySolanaPayment.                ║',
+    '⚠️  ║  Mainnet activation still gated on the pre-launch unlock        ║',
+    '⚠️  ║  (multi-sig + on-chain vesting); devnet/staging is the          ║',
+    '⚠️  ║  recommended environment until that lands.                       ║',
     '⚠️  ╚══════════════════════════════════════════════════════════════════╝',
     '',
     '',


### PR DESCRIPTION
Small follow-up to [#648](https://github.com/RevealUIStudio/revealui/pull/648). The RVUI advisory banner from [#647](https://github.com/RevealUIStudio/revealui/pull/647) (PR 3 of GAP-149) warned about a replay-attack hole; #648 closed that hole by wiring the safeguards pipeline. The banners 'until GAP-159 closes' wording is now stale.

Relaxed to 'RVUI PAYMENTS — experimental discount currency' with three substantive lines:
- Confirms safeguards are wired (points at #648 for audit context)
- Names mainnet activation gates (multi-sig + on-chain vesting per pre-launch posture)
- Recommends devnet/staging until those land

GAP-159 still appears in the banner as historical closure context (not an active gate), so the safety story is traceable from runtime logs.

Test plan:
- pnpm --filter api exec vitest run src/lib/__tests__/validate-startup.test.ts → 72/72 pass
- biome check clean

Closes the small follow-up flagged in GAP-159 closure notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)