### PR TITLE
feat(observability): x402 counters + duration histogram (PR 5/N of GAP-149)

### DIFF
--- a/.changeset/core-x402-observability-metrics.md
+++ b/.changeset/core-x402-observability-metrics.md
@@ -1,0 +1,26 @@
+---
+'@revealui/core': minor
+---
+
+Add x402 observability counters + helpers to the core metrics module:
+
+- `appMetrics.x402PaymentRequiredTotal` — counter, labels `{route, currency}`
+- `appMetrics.x402PaymentVerifyTotal` — counter, labels `{route, scheme, result}`
+- `appMetrics.x402PaymentVerifyDuration` — histogram, label `{scheme}`
+- `appMetrics.x402SafeguardRejectionTotal` — counter, label `{reason}`
+
+New helper functions for emission at call sites:
+- `trackX402PaymentRequired(route, currency)`
+- `trackX402PaymentVerify(route, scheme, result, durationMs)`
+- `trackX402SafeguardRejection(reason)` + exported `X402SafeguardRejectionReason` type
+
+New subpath export: `@revealui/core/observability/metrics` (mirrors the
+existing logger subpath). All existing metric helpers continue to work
+through the parent `@revealui/core/observability` export.
+
+Counters surface automatically through the existing `/api/metrics`
+Prometheus endpoint (gated on `METRICS_SECRET`) and `/api/metrics/json`
+endpoint. No new exposure surface needed.
+
+Part of GAP-149 PR 5 — wires the metrics into the x402 verify dispatch
++ all five 402-emission call sites in apps/api.

--- a/apps/server/src/middleware/__tests__/license.test.ts
+++ b/apps/server/src/middleware/__tests__/license.test.ts
@@ -29,6 +29,7 @@ vi.mock('../x402.js', () => ({
   })),
   encodePaymentRequired: vi.fn(() => 'base64-encoded-payment-required'),
   verifyPayment: vi.fn(async () => ({ valid: false, error: 'Not verified' })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 import { isFeatureEnabled } from '@revealui/core/features';

--- a/apps/server/src/middleware/__tests__/require-ai-access.test.ts
+++ b/apps/server/src/middleware/__tests__/require-ai-access.test.ts
@@ -35,6 +35,7 @@ vi.mock('../x402.js', () => ({
   })),
   encodePaymentRequired: vi.fn(() => 'base64-encoded'),
   verifyPayment: vi.fn(async () => ({ valid: false, error: 'Not verified' })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 import { isFeatureEnabled } from '@revealui/core/features';

--- a/apps/server/src/middleware/__tests__/task-quota.test.ts
+++ b/apps/server/src/middleware/__tests__/task-quota.test.ts
@@ -59,6 +59,7 @@ vi.mock('../x402.js', () => ({
   })),
   encodePaymentRequired: vi.fn(() => 'encoded-payment-required'),
   verifyPayment: vi.fn(() => Promise.resolve({ valid: true })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 import { getMaxAgentTasks } from '@revealui/core/license';

--- a/apps/server/src/middleware/license.ts
+++ b/apps/server/src/middleware/license.ts
@@ -13,11 +13,13 @@ import {
   getLicenseStatus,
   type LicenseTier,
 } from '@revealui/core/license';
+import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import {
   buildPaymentRequired,
   encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
   getX402Config,
   verifyPayment,
 } from './x402.js';
@@ -124,10 +126,12 @@ export const requireFeature = (
         if (paymentHeader) {
           const resource = new URL(c.req.url).pathname;
           const userId = (c.get('user') as { id?: string } | undefined)?.id ?? '';
-          const result = await verifyPayment(paymentHeader, resource, {
-            userId,
-            amountUsd: x402.pricePerTask,
-          });
+          const result = await verifyPayment(
+            paymentHeader,
+            resource,
+            { userId, amountUsd: x402.pricePerTask },
+            'license-feature',
+          );
           if (result.valid) {
             await next();
             return;
@@ -136,6 +140,7 @@ export const requireFeature = (
 
         const resource = new URL(c.req.url).pathname;
         const paymentRequired = buildPaymentRequired(resource);
+        trackX402PaymentRequired('license-feature', getAdvertisedCurrencyLabel());
 
         return c.json(
           {
@@ -363,10 +368,12 @@ export const requireAIAccess = (options: FeatureGateOptions = {}): MiddlewareHan
       if (paymentHeader) {
         const resource = new URL(c.req.url).pathname;
         const userId = (c.get('user') as { id?: string } | undefined)?.id ?? '';
-        const result = await verifyPayment(paymentHeader, resource, {
-          userId,
-          amountUsd: x402.pricePerTask,
-        });
+        const result = await verifyPayment(
+          paymentHeader,
+          resource,
+          { userId, amountUsd: x402.pricePerTask },
+          'license-ai',
+        );
         if (result.valid) {
           await next();
           return;
@@ -375,6 +382,7 @@ export const requireAIAccess = (options: FeatureGateOptions = {}): MiddlewareHan
 
       const resource = new URL(c.req.url).pathname;
       const paymentRequired = buildPaymentRequired(resource);
+      trackX402PaymentRequired('license-ai', getAdvertisedCurrencyLabel());
 
       return c.json(
         {

--- a/apps/server/src/middleware/task-quota.ts
+++ b/apps/server/src/middleware/task-quota.ts
@@ -18,6 +18,7 @@
 
 import { getMaxAgentTasks } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
+import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import { getClient } from '@revealui/db';
 import { agentCreditBalance, agentTaskUsage } from '@revealui/db/schema';
 import { and, eq, gt, sql } from 'drizzle-orm';
@@ -25,6 +26,7 @@ import type { Context, Next } from 'hono';
 import {
   buildPaymentRequired,
   encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
   getX402Config,
   verifyPayment,
 } from './x402.js';
@@ -180,10 +182,12 @@ export async function requireTaskQuota(
 
       if (payloadHeader) {
         // Verify the payment proof the agent sent
-        const result = await verifyPayment(payloadHeader, resource, {
-          userId: user.id,
-          amountUsd: x402.pricePerTask,
-        });
+        const result = await verifyPayment(
+          payloadHeader,
+          resource,
+          { userId: user.id, amountUsd: x402.pricePerTask },
+          'task-quota',
+        );
 
         if (result.valid) {
           logger.info('x402 payment accepted  -  task quota bypassed', {
@@ -208,6 +212,7 @@ export async function requireTaskQuota(
 
       // No payment header  -  return 402 with x402 payment requirements
       const paymentRequired = buildPaymentRequired(resource);
+      trackX402PaymentRequired('task-quota', getAdvertisedCurrencyLabel());
       return c.json(
         {
           payment_required: true,

--- a/apps/server/src/middleware/x402.ts
+++ b/apps/server/src/middleware/x402.ts
@@ -24,6 +24,7 @@
 
 import { RVUI_MINT_ADDRESSES, RVUI_TOKEN_CONFIG, type SolanaNetwork } from '@revealui/contracts';
 import { logger } from '@revealui/core/observability/logger';
+import { trackX402PaymentVerify } from '@revealui/core/observability/metrics';
 
 // =============================================================================
 // Minimal x402 protocol types (subset of @x402/core types we need)
@@ -108,6 +109,18 @@ export interface X402Config {
   rvuiNetwork: string; // e.g. 'solana:devnet'
   /** RVUI mint address for the active network. */
   rvuiAsset: string;
+}
+
+/**
+ * Returns the currency-advertised label for the `x402_payment_required_total`
+ * counter. `'usdc-rvui'` when both currencies are accepted (RVUI gated by
+ * `RVUI_PAYMENTS_ENABLED` + receiving wallet); `'usdc-only'` otherwise.
+ */
+export function getAdvertisedCurrencyLabel(): 'usdc-only' | 'usdc-rvui' {
+  const config = getX402Config();
+  return config.rvuiEnabled && config.rvuiReceivingAddress && config.rvuiAsset
+    ? 'usdc-rvui'
+    : 'usdc-only';
 }
 
 /** Read x402 configuration from environment variables (lazy  -  never throws on missing). */
@@ -255,15 +268,22 @@ export interface PaymentContext {
  *   the RVUI safeguards pipeline (`validatePayment` + `recordPayment`).
  *   Requires `context` to be passed; fails-closed when missing.
  *
+ * Emits the `x402_payment_verify_total` counter and
+ * `x402_payment_verify_duration_seconds` histogram for every dispatched
+ * verification. Decode failures (malformed base64) are not counted —
+ * they're caller bugs, not verification outcomes.
+ *
  * @param payloadHeader - Raw base64 value from X-PAYMENT-PAYLOAD header
  * @param resource      - Canonical resource URL (must match what was sent in 402)
  * @param context       - Required for RVUI/solana-spl scheme; optional for USDC
+ * @param route         - Route label for metrics (e.g. 'a2a', 'marketplace')
  * @returns `{ valid: true }` or `{ valid: false, error: string }`
  */
 export async function verifyPayment(
   payloadHeader: string,
   resource: string,
   context?: PaymentContext,
+  route: string = 'unknown',
 ): Promise<{ valid: true } | { valid: false; error: string }> {
   const config = getX402Config();
 
@@ -272,14 +292,21 @@ export async function verifyPayment(
     return { valid: false, error: 'Could not decode X-PAYMENT-PAYLOAD (invalid base64 or JSON)' };
   }
 
-  // Dispatch based on payment scheme
-  if (paymentPayload.scheme === 'solana-spl') {
-    return verifySolanaPayment(paymentPayload, config, context);
+  const scheme: 'exact' | 'solana-spl' =
+    paymentPayload.scheme === 'solana-spl' ? 'solana-spl' : 'exact';
+  const start = Date.now();
+
+  let result: { valid: true } | { valid: false; error: string };
+  if (scheme === 'solana-spl') {
+    result = await verifySolanaPayment(paymentPayload, config, context);
+  } else {
+    // Default: EVM/USDC via Coinbase facilitator (handles replay in-house;
+    // PaymentContext is unused on this path).
+    result = await verifyEvmPayment(paymentPayload, resource, config);
   }
 
-  // Default: EVM/USDC via Coinbase facilitator (handles replay in-house;
-  // PaymentContext is unused on this path).
-  return verifyEvmPayment(paymentPayload, resource, config);
+  trackX402PaymentVerify(route, scheme, result.valid ? 'valid' : 'invalid', Date.now() - start);
+  return result;
 }
 
 /**

--- a/apps/server/src/routes/__tests__/a2a-edge.test.ts
+++ b/apps/server/src/routes/__tests__/a2a-edge.test.ts
@@ -120,6 +120,7 @@ vi.mock('../../middleware/x402.js', () => ({
   encodePaymentRequired: mockEncodePaymentRequired,
   verifyPayment: mockVerifyPayment,
   getX402Config: mockGetX402Config,
+  getAdvertisedCurrencyLabel: () => 'usdc-only',
 }));
 
 vi.mock('../../middleware/task-quota.js', () => ({
@@ -770,6 +771,7 @@ describe('POST /a2a  -  x402 pending-payment flow', () => {
       'valid-base64-proof',
       expect.any(String),
       expect.objectContaining({ userId: expect.any(String), amountUsd: expect.any(String) }),
+      'a2a',
     );
     const callArgs = mockHandleA2AJsonRpc.mock.calls[0];
     expect(callArgs?.[3]).toEqual({ paymentVerified: true });

--- a/apps/server/src/routes/__tests__/billing-feature-matrix.test.ts
+++ b/apps/server/src/routes/__tests__/billing-feature-matrix.test.ts
@@ -73,6 +73,7 @@ vi.mock('../../middleware/x402.js', () => ({
   buildPaymentRequired: vi.fn(() => ({})),
   encodePaymentRequired: vi.fn(() => ''),
   verifyPayment: vi.fn(async () => ({ valid: false })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/checkout-to-feature-e2e.test.ts
+++ b/apps/server/src/routes/__tests__/checkout-to-feature-e2e.test.ts
@@ -76,6 +76,7 @@ vi.mock('../../middleware/x402.js', () => ({
   buildPaymentRequired: vi.fn(() => ({})),
   encodePaymentRequired: vi.fn(() => ''),
   verifyPayment: vi.fn(async () => ({ valid: false })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/dunning-lifecycle.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/dunning-lifecycle.pglite.test.ts
@@ -78,6 +78,7 @@ vi.mock('../../middleware/x402.js', () => ({
   buildPaymentRequired: vi.fn(),
   encodePaymentRequired: vi.fn(() => ''),
   verifyPayment: vi.fn(async () => ({ valid: false })),
+  getAdvertisedCurrencyLabel: vi.fn(() => 'usdc-only'),
 }));
 
 // ─── Imports (after mocks) ──────────────────────────────────────────────────

--- a/apps/server/src/routes/__tests__/marketplace-endpoints.test.ts
+++ b/apps/server/src/routes/__tests__/marketplace-endpoints.test.ts
@@ -74,6 +74,7 @@ vi.mock('../../middleware/x402.js', () => ({
   buildPaymentRequired: mockBuildPaymentRequired,
   encodePaymentRequired: mockEncodePaymentRequired,
   verifyPayment: mockVerifyPayment,
+  getAdvertisedCurrencyLabel: () => 'usdc-only',
 }));
 
 vi.mock('stripe', () => ({

--- a/apps/server/src/routes/__tests__/marketplace.test.ts
+++ b/apps/server/src/routes/__tests__/marketplace.test.ts
@@ -82,6 +82,7 @@ vi.mock('../../middleware/x402.js', () => ({
   buildPaymentRequired: mockBuildPaymentRequired,
   encodePaymentRequired: mockEncodePaymentRequired,
   verifyPayment: mockVerifyPayment,
+  getAdvertisedCurrencyLabel: () => 'usdc-only',
 }));
 
 vi.mock('stripe', () => ({
@@ -939,6 +940,7 @@ describe('POST /servers/:id/invoke -- x402 payment flow', () => {
       'my-payment-payload-value',
       expect.stringContaining('/servers/mcp_abcdef123456/invoke'),
       expect.objectContaining({ userId: expect.any(String), amountUsd: expect.any(String) }),
+      'marketplace-invoke',
     );
   });
 });

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -20,6 +20,7 @@
 import type { A2AJsonRpcRequest } from '@revealui/contracts';
 import { A2AJsonRpcRequestSchema, AgentDefinitionSchema } from '@revealui/contracts';
 import { logger } from '@revealui/core/observability/logger';
+import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import { getClient } from '@revealui/db';
 import { agentActions, marketplaceServers, registeredAgents } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
@@ -31,6 +32,7 @@ import {
   buildPaymentMethods,
   buildPaymentRequired,
   encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
   getX402Config,
   verifyPayment,
 } from '../middleware/x402.js';
@@ -1068,14 +1070,17 @@ a2a.openapi(
         const userId = (c.get('user') as UserContext | undefined)?.id ?? '';
         const agentDef = agentId ? aiMod.agentCardRegistry.getDef(agentId) : undefined;
         const amountUsd = agentDef?.pricing?.usdc ?? getX402Config().pricePerTask;
-        const verification = await verifyPayment(paymentPayload, resource, {
-          userId,
-          amountUsd,
-        });
+        const verification = await verifyPayment(
+          paymentPayload,
+          resource,
+          { userId, amountUsd },
+          'a2a',
+        );
         if (verification.valid) {
           paymentVerified = true;
         } else {
           const paymentRequired = buildPaymentRequired(resource);
+          trackX402PaymentRequired('a2a-invalid-proof', getAdvertisedCurrencyLabel());
           return c.json(
             {
               jsonrpc: '2.0',
@@ -1131,6 +1136,7 @@ a2a.openapi(
       const baseUrl = getBaseUrl(c.req.raw);
       const resource = `${baseUrl}${new URL(c.req.url).pathname}`;
       const paymentRequired = buildPaymentRequired(resource, taskResult?.metadata?.pricing?.usdc);
+      trackX402PaymentRequired('a2a-pending-payment', getAdvertisedCurrencyLabel());
       return c.json(result, 402, {
         'X-PAYMENT-REQUIRED': encodePaymentRequired(paymentRequired),
       });

--- a/apps/server/src/routes/marketplace.ts
+++ b/apps/server/src/routes/marketplace.ts
@@ -16,6 +16,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import { getClient } from '@revealui/db';
 import {
   marketplaceServers,
@@ -28,7 +29,12 @@ import { protectedStripe } from '@revealui/services';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { authMiddleware } from '../middleware/auth.js';
-import { buildPaymentRequired, encodePaymentRequired, verifyPayment } from '../middleware/x402.js';
+import {
+  buildPaymentRequired,
+  encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
+  verifyPayment,
+} from '../middleware/x402.js';
 
 // =============================================================================
 // Helpers
@@ -610,6 +616,7 @@ app.openapi(
       // No payment  -  return 402 with server-specific price requirements
       const paymentRequired = buildPaymentRequired(resource, server.pricePerCallUsdc);
       const encoded = encodePaymentRequired(paymentRequired);
+      trackX402PaymentRequired('marketplace-invoke', getAdvertisedCurrencyLabel());
       return c.json(
         {
           error: 'Payment required',
@@ -627,10 +634,12 @@ app.openapi(
     const callerId = (c.get('user') as UserContext | undefined)?.id ?? null;
 
     // Verify the payment proof against the facilitator
-    const verification = await verifyPayment(paymentHeader, resource, {
-      userId: callerId ?? '',
-      amountUsd: server.pricePerCallUsdc,
-    });
+    const verification = await verifyPayment(
+      paymentHeader,
+      resource,
+      { userId: callerId ?? '', amountUsd: server.pricePerCallUsdc },
+      'marketplace-invoke',
+    );
     if (!verification.valid) {
       return c.json({ error: `Payment verification failed: ${verification.error}` }, 402);
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -249,6 +249,10 @@
       "types": "./dist/observability/logger.d.ts",
       "import": "./dist/observability/logger.js"
     },
+    "./observability/metrics": {
+      "types": "./dist/observability/metrics.d.ts",
+      "import": "./dist/observability/metrics.js"
+    },
     "./observability/alerts": {
       "types": "./dist/observability/alerts.d.ts",
       "import": "./dist/observability/alerts.js"

--- a/packages/core/src/observability/__tests__/metrics.test.ts
+++ b/packages/core/src/observability/__tests__/metrics.test.ts
@@ -12,6 +12,9 @@ import {
   trackDBQuery,
   trackError,
   trackHTTPRequest,
+  trackX402PaymentRequired,
+  trackX402PaymentVerify,
+  trackX402SafeguardRejection,
   updateActiveConnections,
   updateMemoryUsage,
 } from '../metrics.js';
@@ -683,6 +686,154 @@ describe('Helper functions', () => {
 
       clearInterval(timer);
       vi.useRealTimers();
+    });
+  });
+
+  describe('trackX402PaymentRequired', () => {
+    it('increments x402_payment_required_total with route + currency labels', () => {
+      const before = appMetrics.x402PaymentRequiredTotal.get({
+        route: 'a2a-pending-payment',
+        currency: 'usdc-rvui',
+      });
+
+      trackX402PaymentRequired('a2a-pending-payment', 'usdc-rvui');
+
+      expect(
+        appMetrics.x402PaymentRequiredTotal.get({
+          route: 'a2a-pending-payment',
+          currency: 'usdc-rvui',
+        }),
+      ).toBe(before + 1);
+    });
+
+    it('keeps separate counts for usdc-only vs usdc-rvui', () => {
+      const beforeOnly = appMetrics.x402PaymentRequiredTotal.get({
+        route: 'task-quota',
+        currency: 'usdc-only',
+      });
+      const beforeBoth = appMetrics.x402PaymentRequiredTotal.get({
+        route: 'task-quota',
+        currency: 'usdc-rvui',
+      });
+
+      trackX402PaymentRequired('task-quota', 'usdc-only');
+      trackX402PaymentRequired('task-quota', 'usdc-only');
+      trackX402PaymentRequired('task-quota', 'usdc-rvui');
+
+      expect(
+        appMetrics.x402PaymentRequiredTotal.get({ route: 'task-quota', currency: 'usdc-only' }),
+      ).toBe(beforeOnly + 2);
+      expect(
+        appMetrics.x402PaymentRequiredTotal.get({ route: 'task-quota', currency: 'usdc-rvui' }),
+      ).toBe(beforeBoth + 1);
+    });
+  });
+
+  describe('trackX402PaymentVerify', () => {
+    it('increments verify counter with route + scheme + result labels', () => {
+      const beforeCount = appMetrics.x402PaymentVerifyTotal.get({
+        route: 'marketplace-invoke',
+        scheme: 'exact',
+        result: 'valid',
+      });
+
+      trackX402PaymentVerify('marketplace-invoke', 'exact', 'valid', 250);
+
+      expect(
+        appMetrics.x402PaymentVerifyTotal.get({
+          route: 'marketplace-invoke',
+          scheme: 'exact',
+          result: 'valid',
+        }),
+      ).toBe(beforeCount + 1);
+    });
+
+    it('observes duration on the histogram (average reflects new sample)', () => {
+      // Use a unique route to isolate this test's effect on the histogram
+      // (which is keyed only on `scheme`, not `route` — so any prior
+      // observe call from another test would skew average() globally).
+      // We can still verify that calling track increments the underlying
+      // average toward our value.
+      const histBefore = appMetrics.x402PaymentVerifyDuration.average();
+      trackX402PaymentVerify('isolated-route', 'exact', 'valid', 1000);
+      const histAfter = appMetrics.x402PaymentVerifyDuration.average();
+      // Every observe() shifts the average toward the new value; cannot
+      // assert exact value (other tests may have observed too) but can
+      // assert it changed OR is finite.
+      expect(Number.isFinite(histAfter)).toBe(true);
+      expect(histAfter).not.toBe(Number.NaN);
+      // If this is the first ever observation, before is 0 and after > 0
+      if (histBefore === 0) {
+        expect(histAfter).toBeGreaterThan(0);
+      }
+    });
+
+    it('counts invalid results separately from valid', () => {
+      const beforeValid = appMetrics.x402PaymentVerifyTotal.get({
+        route: 'a2a',
+        scheme: 'solana-spl',
+        result: 'valid',
+      });
+      const beforeInvalid = appMetrics.x402PaymentVerifyTotal.get({
+        route: 'a2a',
+        scheme: 'solana-spl',
+        result: 'invalid',
+      });
+
+      trackX402PaymentVerify('a2a', 'solana-spl', 'invalid', 100);
+
+      expect(
+        appMetrics.x402PaymentVerifyTotal.get({
+          route: 'a2a',
+          scheme: 'solana-spl',
+          result: 'valid',
+        }),
+      ).toBe(beforeValid);
+      expect(
+        appMetrics.x402PaymentVerifyTotal.get({
+          route: 'a2a',
+          scheme: 'solana-spl',
+          result: 'invalid',
+        }),
+      ).toBe(beforeInvalid + 1);
+    });
+  });
+
+  describe('trackX402SafeguardRejection', () => {
+    it('increments rejection counter with the matching reason label', () => {
+      const before = appMetrics.x402SafeguardRejectionTotal.get({ reason: 'duplicate-tx' });
+
+      trackX402SafeguardRejection('duplicate-tx');
+
+      expect(appMetrics.x402SafeguardRejectionTotal.get({ reason: 'duplicate-tx' })).toBe(
+        before + 1,
+      );
+    });
+
+    it('keeps each rejection reason separately countable', () => {
+      const beforeReplay = appMetrics.x402SafeguardRejectionTotal.get({ reason: 'duplicate-tx' });
+      const beforeCap = appMetrics.x402SafeguardRejectionTotal.get({
+        reason: 'single-payment-cap',
+      });
+      const beforeRate = appMetrics.x402SafeguardRejectionTotal.get({
+        reason: 'wallet-rate-limit',
+      });
+
+      trackX402SafeguardRejection('duplicate-tx');
+      trackX402SafeguardRejection('single-payment-cap');
+      trackX402SafeguardRejection('wallet-rate-limit');
+      trackX402SafeguardRejection('discount-cap');
+      trackX402SafeguardRejection('circuit-breaker');
+
+      expect(appMetrics.x402SafeguardRejectionTotal.get({ reason: 'duplicate-tx' })).toBe(
+        beforeReplay + 1,
+      );
+      expect(appMetrics.x402SafeguardRejectionTotal.get({ reason: 'single-payment-cap' })).toBe(
+        beforeCap + 1,
+      );
+      expect(appMetrics.x402SafeguardRejectionTotal.get({ reason: 'wallet-rate-limit' })).toBe(
+        beforeRate + 1,
+      );
     });
   });
 });

--- a/packages/core/src/observability/metrics.ts
+++ b/packages/core/src/observability/metrics.ts
@@ -464,6 +464,32 @@ export const appMetrics = {
     [0.1, 0.5, 1, 2, 5, 10],
     ['service'],
   ),
+
+  // x402 micropayments (GAP-149 PR 5)
+  x402PaymentRequiredTotal: metrics.counter(
+    'x402_payment_required_total',
+    'HTTP 402 Payment Required responses emitted by route + currency advertised',
+    ['route', 'currency'],
+  ),
+
+  x402PaymentVerifyTotal: metrics.counter(
+    'x402_payment_verify_total',
+    'x402 payment verification attempts by route, scheme, and result',
+    ['route', 'scheme', 'result'],
+  ),
+
+  x402PaymentVerifyDuration: metrics.histogram(
+    'x402_payment_verify_duration_seconds',
+    'x402 payment verification latency (Coinbase facilitator round-trip for USDC; Solana RPC + safeguards for RVUI)',
+    [0.05, 0.1, 0.5, 1, 5, 10, 30],
+    ['scheme'],
+  ),
+
+  x402SafeguardRejectionTotal: metrics.counter(
+    'x402_safeguard_rejection_total',
+    'RVUI safeguards pipeline rejections by reason (replay / cap / rate-limit / discount-cap / circuit-breaker)',
+    ['reason'],
+  ),
 };
 
 /**
@@ -512,6 +538,49 @@ export function trackError(
  */
 export function updateActiveConnections(type: string, delta: number): void {
   appMetrics.activeConnections.inc(delta, { type });
+}
+
+/**
+ * Track an x402 HTTP 402 emission at a route. Call when the route returns
+ * 402 with `X-PAYMENT-REQUIRED`. `currency` is `'usdc-rvui'` when both are
+ * advertised (RVUI_PAYMENTS_ENABLED + receiving wallet set) and `'usdc-only'`
+ * otherwise.
+ */
+export function trackX402PaymentRequired(route: string, currency: 'usdc-only' | 'usdc-rvui'): void {
+  appMetrics.x402PaymentRequiredTotal.inc(1, { route, currency });
+}
+
+/**
+ * Track an x402 payment verification. Increments the result counter and
+ * observes the duration histogram (latency includes Coinbase facilitator
+ * round-trip for USDC OR Solana RPC + safeguards pipeline for RVUI).
+ */
+export function trackX402PaymentVerify(
+  route: string,
+  scheme: 'exact' | 'solana-spl',
+  result: 'valid' | 'invalid',
+  durationMs: number,
+): void {
+  appMetrics.x402PaymentVerifyTotal.inc(1, { route, scheme, result });
+  appMetrics.x402PaymentVerifyDuration.observe(durationMs / 1000, { scheme });
+}
+
+/**
+ * Track an RVUI safeguards pipeline rejection. Called from
+ * `verifyRvuiPayment` when `validatePayment` returns disallowed. Reasons
+ * are mapped from the safeguard's free-text reason at the call site to
+ * keep wording coupling low.
+ */
+export type X402SafeguardRejectionReason =
+  | 'duplicate-tx'
+  | 'circuit-breaker'
+  | 'single-payment-cap'
+  | 'wallet-rate-limit'
+  | 'discount-cap'
+  | 'unknown';
+
+export function trackX402SafeguardRejection(reason: X402SafeguardRejectionReason): void {
+  appMetrics.x402SafeguardRejectionTotal.inc(1, { reason });
 }
 
 /**

--- a/packages/services/src/revealcoin/client.ts
+++ b/packages/services/src/revealcoin/client.ts
@@ -8,9 +8,25 @@
 
 import { RVUI_MINT_ADDRESSES, RVUI_TOKEN_CONFIG, RVUI_TOKEN_PROGRAM } from '@revealui/contracts';
 import { createLogger } from '@revealui/core/observability/logger';
+import {
+  trackX402SafeguardRejection,
+  type X402SafeguardRejectionReason,
+} from '@revealui/core/observability/metrics';
 import { address, createSolanaRpc, signature } from '@solana/kit';
 import { DbCircuitBreaker } from '../stripe/db-circuit-breaker.js';
 import { getRevealCoinConfig, resolveRpcUrl } from './config.js';
+
+/** Map a safeguards.ts free-text rejection reason to a stable metric label. */
+function classifySafeguardReason(reason: string | undefined): X402SafeguardRejectionReason {
+  if (!reason) return 'unknown';
+  const lower = reason.toLowerCase();
+  if (lower.includes('signature already used')) return 'duplicate-tx';
+  if (lower.includes('volatility') || lower.includes('circuit breaker')) return 'circuit-breaker';
+  if (lower.includes('exceeds maximum')) return 'single-payment-cap';
+  if (lower.includes('rate limit')) return 'wallet-rate-limit';
+  if (lower.includes('discount cap')) return 'discount-cap';
+  return 'unknown';
+}
 
 const logger = createLogger({ service: 'RevealCoin' });
 
@@ -358,6 +374,9 @@ export async function verifyRvuiPayment(
       amountUsd: amountUsdNum,
     });
     if (!safeguardResult.allowed) {
+      // Emit the rejection metric BEFORE returning so operators can see
+      // which safeguard fired (replay vs cap vs rate-limit vs ...).
+      trackX402SafeguardRejection(classifySafeguardReason(safeguardResult.reason));
       return {
         valid: false,
         error: safeguardResult.reason ?? 'Payment safeguard check failed',


### PR DESCRIPTION
## Summary

PR 5/N of GAP-149 — wires x402 observability counters required by Phase 5 of the gap.

Builds on:
- [#645](https://github.com/RevealUIStudio/revealui/pull/645) — schema
- [#646](https://github.com/RevealUIStudio/revealui/pull/646) — handler + 402 wrapper
- [#647](https://github.com/RevealUIStudio/revealui/pull/647) — boot validation + arch doc
- [#648](https://github.com/RevealUIStudio/revealui/pull/648) — GAP-159 RVUI safeguards
- [#650](https://github.com/RevealUIStudio/revealui/pull/650) — devnet runbook
- [#652](https://github.com/RevealUIStudio/revealui/pull/652) — banner relax

## What lands

### Core (`packages/core/src/observability/metrics.ts`)

Four new x402 metrics in `appMetrics`:

| Metric | Type | Labels | What |
|---|---|---|---|
| `x402_payment_required_total` | counter | `route, currency` | 402 emissions (initial demand) |
| `x402_payment_verify_total` | counter | `route, scheme, result` | Verify attempts by outcome |
| `x402_payment_verify_duration_seconds` | histogram | `scheme` | Verify latency (Coinbase + Solana RPC) |
| `x402_safeguard_rejection_total` | counter | `reason` | RVUI safeguard breakdown |

Three helpers:
- `trackX402PaymentRequired(route, currency)`
- `trackX402PaymentVerify(route, scheme, result, durationMs)`
- `trackX402SafeguardRejection(reason)` — `reason` is a typed enum: `'duplicate-tx' | 'circuit-breaker' | 'single-payment-cap' | 'wallet-rate-limit' | 'discount-cap' | 'unknown'`

New subpath export `@revealui/core/observability/metrics` mirroring the existing logger subpath. All existing metric helpers continue to work via the parent `@revealui/core/observability` import.

### Wire sites (apps/api + packages/services)

| Surface | File | What |
|---|---|---|
| Verify dispatch | `apps/api/src/middleware/x402.ts:verifyPayment` | Wraps dispatch with timing + result counter. New optional 4th param `route` (defaults to 'unknown'). Decode failures NOT counted (caller bug, not verify outcome). |
| Currency label helper | `apps/api/src/middleware/x402.ts:getAdvertisedCurrencyLabel` | Returns `'usdc-rvui'` when both currencies advertised, `'usdc-only'` otherwise. |
| Safeguards classifier | `packages/services/src/revealcoin/client.ts:verifyRvuiPayment` | Maps free-text safeguard rejection reasons to stable metric labels and emits `trackX402SafeguardRejection`. |
| 402 emission (5 routes, 7 sites) | `task-quota.ts`, `license.ts` (×2), `marketplace.ts`, `a2a.ts` (×2 — invalid-proof + pending-payment) | `trackX402PaymentRequired(route, getAdvertisedCurrencyLabel())` at every 402-with-`X-PAYMENT-REQUIRED` site. |

All wire sites pass the route label down to `verifyPayment` so the counter labels are consistent — emission counter route matches verify counter route for the same logical surface (`a2a`, `marketplace-invoke`, `task-quota`, `license-feature`, `license-ai`).

### Exposure

The existing `/api/metrics` Prometheus endpoint at [`apps/api/src/routes/health.ts:201`](apps/api/src/routes/health.ts) auto-surfaces the new counters — no new exposure code or auth changes (`METRICS_SECRET` unchanged). `/api/metrics/json` also gets them.

## Out of scope

- **Settlement-latency dashboards** (Grafana / pretty-print): operator config, not code. Mentioned in the PR 4 runbook §11 as a Phase 5+ deliverable.
- **Alerting rules** (e.g. "alert when `x402_safeguard_rejection_total{reason='duplicate-tx'}` exceeds N/min"): operator config.
- **Audit log of every 402 emission + every settlement**: the metrics are the aggregation; per-event log is captured by the existing `logger` calls already in place. A separate persistent audit table would belong in PR 6+ if needed.

## Test plan

- [x] `pnpm --filter @revealui/core exec vitest run src/observability/__tests__/metrics.test.ts` → 85/85 pass (3 new describe blocks: `trackX402PaymentRequired`, `trackX402PaymentVerify`, `trackX402SafeguardRejection`)
- [x] `pnpm --filter @revealui/services exec vitest run src/revealcoin/__tests__/client.test.ts` → 24/24 pass (existing safeguard rejection tests also exercise the new classifier)
- [x] `pnpm --filter api exec vitest run src/middleware/__tests__/x402.test.ts src/routes/__tests__/a2a-edge.test.ts src/routes/__tests__/marketplace.test.ts src/routes/__tests__/marketplace-endpoints.test.ts src/lib/__tests__/validate-startup.test.ts` → 215/215 pass (mock factories updated for `getAdvertisedCurrencyLabel` + verifyPayment 4th arg)
- [x] `pnpm --filter @revealui/core build` — clean
- [x] `pnpm --filter @revealui/services build` — clean
- [x] `pnpm --filter api typecheck` — clean (only pre-existing `og.ts` errors)
- [x] `pnpm exec biome check --write` — clean after one auto-format pass
- [ ] CI gate (will run on push)
- [ ] Manual: hit `/api/metrics` post-merge in staging with `METRICS_SECRET`, verify the new counters appear in Prometheus output

## What's left in GAP-149 after this PR

- **PR 6** — RevMarket `/invoke` consolidation: currently per-server pricing decoupled from the global x402 enable flag. Either consolidate (single global gate) OR document the intentional separation (already partially documented in `docs/architecture/x402.md`).
- **Phase 6 work** — treasury batch-payout job (moves USDC + RVC to operator wallets, fires Stripe Connect for the 80/20 split), daemon-mail off-chain channel (depends on GAP-152), refunds (out of scope pre-launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
