### PR TITLE
feat(revmarket): wire x402 payment gate on POST /tasks (PR 6/N of GAP-149)

### DIFF
--- a/apps/server/src/routes/__tests__/revmarket.test.ts
+++ b/apps/server/src/routes/__tests__/revmarket.test.ts
@@ -22,15 +22,37 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Hoisted mock factories ─────────────────────────────────────────────────
 
-const { mockDbSelect, mockDbInsert, mockDbUpdate, mockGetClient, mockLoggerInfo, mockSql } =
-  vi.hoisted(() => ({
-    mockDbSelect: vi.fn(),
-    mockDbInsert: vi.fn(),
-    mockDbUpdate: vi.fn(),
-    mockGetClient: vi.fn(),
-    mockLoggerInfo: vi.fn(),
-    mockSql: vi.fn().mockReturnValue(0),
-  }));
+const {
+  mockDbSelect,
+  mockDbInsert,
+  mockDbUpdate,
+  mockGetClient,
+  mockLoggerInfo,
+  mockSql,
+  mockGetX402Config,
+  mockBuildPaymentRequired,
+  mockEncodePaymentRequired,
+  mockVerifyPayment,
+} = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockDbInsert: vi.fn(),
+  mockDbUpdate: vi.fn(),
+  mockGetClient: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockSql: vi.fn().mockReturnValue(0),
+  mockGetX402Config: vi.fn(() => ({
+    enabled: false,
+    receivingAddress: '',
+    network: 'evm:base',
+    pricePerTask: '0.001',
+  })),
+  mockBuildPaymentRequired: vi.fn(() => ({
+    x402Version: 1,
+    accepts: [{ scheme: 'exact', network: 'evm:base', maxAmountRequired: '500000' }],
+  })),
+  mockEncodePaymentRequired: vi.fn(() => 'mock-encoded-payment-required'),
+  mockVerifyPayment: vi.fn(async () => ({ valid: true as const })),
+}));
 
 // ─── Module mocks ──────────────────────────────────────────────────────────
 
@@ -42,6 +64,14 @@ vi.mock('../../middleware/auth.js', () => ({
   authMiddleware: vi.fn(
     (_opts?: unknown) => async (_c: unknown, next: () => Promise<void>) => next(),
   ),
+}));
+
+vi.mock('../../middleware/x402.js', () => ({
+  getX402Config: mockGetX402Config,
+  buildPaymentRequired: mockBuildPaymentRequired,
+  encodePaymentRequired: mockEncodePaymentRequired,
+  verifyPayment: mockVerifyPayment,
+  getAdvertisedCurrencyLabel: () => 'usdc-only',
 }));
 
 vi.mock('../../services/revmarket-executor.js', async (importOriginal) => {
@@ -391,6 +421,127 @@ describe('POST /tasks', () => {
     );
 
     expect(res.status).toBe(201);
+  });
+});
+
+describe('POST /tasks  -  x402 payment gate (X402_ENABLED=true)', () => {
+  beforeEach(() => {
+    // Default is X402_ENABLED=false (set in hoisted mock); flip on for these tests.
+    mockGetX402Config.mockReturnValue({
+      enabled: true,
+      receivingAddress: '0xTreasury',
+      network: 'evm:base',
+      pricePerTask: '0.001',
+    });
+    // Default verifier: accept proof. Tests can override.
+    mockVerifyPayment.mockResolvedValue({ valid: true });
+    // Reset call counters captured by the assertions below.
+    mockBuildPaymentRequired.mockClear();
+    mockEncodePaymentRequired.mockClear();
+    mockVerifyPayment.mockClear();
+  });
+
+  it('returns 402 with X-PAYMENT-REQUIRED when paid agent has no payment header', async () => {
+    selectResults = [[{ id: 'agent_paid', status: 'published', basePriceUsdc: '0.50' }]];
+
+    const app = createApp(testUser);
+    const res = await app.request(
+      post('/tasks', {
+        agentId: 'agent_paid',
+        skillName: 'code-review',
+        input: { code: 'function hello() {}' },
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get('X-PAYMENT-REQUIRED')).toBe('mock-encoded-payment-required');
+    // Price is forwarded from the agent's basePriceUsdc
+    expect(mockBuildPaymentRequired).toHaveBeenCalledWith(expect.any(String), '0.50');
+    // No insert happened — the task was rejected before creation
+    expect(mockVerifyPayment).not.toHaveBeenCalled();
+  });
+
+  it('verifies X-PAYMENT-PAYLOAD and creates task when payment is valid', async () => {
+    selectResults = [[{ id: 'agent_paid', status: 'published', basePriceUsdc: '0.50' }]];
+    const created = {
+      id: 'task_paid',
+      status: 'queued',
+      agentId: 'agent_paid',
+      paymentMethod: 'x402-usdc',
+    };
+    insertResults = [[created]];
+    mockVerifyPayment.mockResolvedValueOnce({ valid: true });
+
+    const app = createApp(testUser);
+    const res = await app.request(
+      new Request('http://localhost/tasks', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-PAYMENT-PAYLOAD': 'valid-base64-proof',
+        },
+        body: JSON.stringify({
+          agentId: 'agent_paid',
+          skillName: 'code-review',
+          input: { code: 'function hello() {}' },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockVerifyPayment).toHaveBeenCalledWith(
+      'valid-base64-proof',
+      expect.any(String),
+      expect.objectContaining({ userId: testUser.id, amountUsd: '0.50' }),
+      'revmarket-task',
+    );
+  });
+
+  it('returns 402 when X-PAYMENT-PAYLOAD verification fails', async () => {
+    selectResults = [[{ id: 'agent_paid', status: 'published', basePriceUsdc: '0.50' }]];
+    mockVerifyPayment.mockResolvedValueOnce({
+      valid: false,
+      error: 'Invalid signature',
+    });
+
+    const app = createApp(testUser);
+    const res = await app.request(
+      new Request('http://localhost/tasks', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-PAYMENT-PAYLOAD': 'bad-base64-proof',
+        },
+        body: JSON.stringify({
+          agentId: 'agent_paid',
+          skillName: 'code-review',
+          input: { code: 'function hello() {}' },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Invalid signature');
+  });
+
+  it('passes through without payment when agent has zero basePriceUsdc (free tier)', async () => {
+    selectResults = [[{ id: 'agent_free', status: 'published', basePriceUsdc: '0' }]];
+    const created = { id: 'task_free', status: 'queued', agentId: 'agent_free' };
+    insertResults = [[created]];
+
+    const app = createApp(testUser);
+    const res = await app.request(
+      post('/tasks', {
+        agentId: 'agent_free',
+        skillName: 'code-review',
+        input: { code: 'function hello() {}' },
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockBuildPaymentRequired).not.toHaveBeenCalled();
+    expect(mockVerifyPayment).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/routes/revmarket.ts
+++ b/apps/server/src/routes/revmarket.ts
@@ -2,9 +2,11 @@
  * RevMarket  -  Autonomous Agent Marketplace Routes (Phase 5.16)  -  PREVIEW
  *
  * ⚠️  PREVIEW: Agent task execution runs in-process without sandbox isolation.
- * x402 crypto payments are disabled by default (X402_ENABLED=false).
- * Use only with trusted agents. Full sandboxing and payment settlement
- * are planned for Phase B.
+ * x402 emission on POST /tasks is gated on `X402_ENABLED=true` (default off).
+ * When enabled, paid agents (basePriceUsdc > 0) require a verified payment
+ * proof before the task is queued; free agents are unaffected. Stripe
+ * Connect 80/20 split to the agent publisher is deferred to Phase B.
+ * Use only with trusted agents. Full sandboxing remains planned for Phase B.
  *
  * Extends the MCP Marketplace (Phase 5.5) with autonomous agent task execution.
  * Agents register with skills and pricing, users submit tasks, the system
@@ -25,6 +27,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import { getClient } from '@revealui/db';
 import {
   agentReviews,
@@ -40,6 +43,13 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, desc, eq, ilike, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { authMiddleware } from '../middleware/auth.js';
+import {
+  buildPaymentRequired,
+  encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
+  getX402Config,
+  verifyPayment,
+} from '../middleware/x402.js';
 import { getExecutorStatus, getTaskProgress } from '../services/revmarket-executor.js';
 
 // =============================================================================
@@ -604,6 +614,18 @@ app.openapi(
         },
         description: 'Unauthorized',
       },
+      402: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+              x402Version: z.number().optional(),
+              accepts: z.array(z.unknown()).optional(),
+            }),
+          },
+        },
+        description: 'Payment required (x402)',
+      },
       404: {
         content: {
           'application/json': { schema: z.object({ error: z.string() }) },
@@ -657,6 +679,45 @@ app.openapi(
       }
     }
 
+    // x402 payment gate: when X402_ENABLED=true and the matched agent has a
+    // non-zero basePriceUsdc, require a verified payment proof before the
+    // task is queued. Free agents (costUsdc null/0) and X402_ENABLED=false
+    // both pass through unchanged.
+    const x402 = getX402Config();
+    const requiresPayment = x402.enabled && costUsdc !== null && Number.parseFloat(costUsdc) > 0;
+    let resolvedPaymentMethod: string | null = data.paymentMethod ?? null;
+
+    if (requiresPayment && costUsdc !== null) {
+      const baseUrl = new URL(c.req.url).origin;
+      const resource = `${baseUrl}/api/revmarket/tasks`;
+      const paymentHeader = c.req.header('X-PAYMENT-PAYLOAD');
+
+      if (!paymentHeader) {
+        const paymentRequired = buildPaymentRequired(resource, costUsdc);
+        trackX402PaymentRequired('revmarket-task', getAdvertisedCurrencyLabel());
+        return c.json(
+          {
+            error: 'Payment required',
+            x402Version: 1,
+            accepts: paymentRequired.accepts,
+          },
+          402,
+          { 'X-PAYMENT-REQUIRED': encodePaymentRequired(paymentRequired) },
+        );
+      }
+
+      const verification = await verifyPayment(
+        paymentHeader,
+        resource,
+        { userId: user.id, amountUsd: costUsdc },
+        'revmarket-task',
+      );
+      if (!verification.valid) {
+        return c.json({ error: `Payment verification failed: ${verification.error}` }, 402);
+      }
+      resolvedPaymentMethod = 'x402-usdc';
+    }
+
     const taskId = generateId('task');
     const now = new Date();
 
@@ -668,7 +729,7 @@ app.openapi(
       input: data.input,
       priority: data.priority,
       costUsdc,
-      paymentMethod: data.paymentMethod ?? null,
+      paymentMethod: resolvedPaymentMethod,
       status: assignedAgentId ? 'queued' : 'pending',
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
## Summary

PR 6/N of GAP-149 — closes the agent-marketplace integration deliverable in Phase 6.

When `X402_ENABLED=true` and the matched marketplace agent has a non-zero `basePriceUsdc`, `POST /api/revmarket/tasks` now requires a verified x402 payment proof before queueing the task.

Builds on the full GAP-149 sequence:
- [#645](https://github.com/RevealUIStudio/revealui/pull/645) — schema
- [#646](https://github.com/RevealUIStudio/revealui/pull/646) — A2A handler + 402 wrapper
- [#647](https://github.com/RevealUIStudio/revealui/pull/647) — boot validation + arch doc
- [#648](https://github.com/RevealUIStudio/revealui/pull/648) — GAP-159 RVUI safeguards
- [#650](https://github.com/RevealUIStudio/revealui/pull/650) — devnet runbook
- [#652](https://github.com/RevealUIStudio/revealui/pull/652) — banner relax
- [#653](https://github.com/RevealUIStudio/revealui/pull/653) — observability counters

## Behavior

| Condition | Result |
|---|---|
| `X402_ENABLED=false` (default) | Unchanged free-tier flow; existing tests pass without modification |
| `X402_ENABLED=true` + paid agent (`basePriceUsdc > 0`) + no proof | HTTP 402 with `X-PAYMENT-REQUIRED` (price = agent's `basePriceUsdc`) |
| `X402_ENABLED=true` + paid agent + invalid proof | HTTP 402 with verifier error |
| `X402_ENABLED=true` + paid agent + valid proof | Task created with `paymentMethod='x402-usdc'` |
| `X402_ENABLED=true` + free agent (`basePriceUsdc` null/0) | Unchanged free-tier flow |

Per-listing pricing (price comes from the agent's `basePriceUsdc`, not the global `X402_PRICE_PER_TASK`) mirrors the [marketplace.ts:611](apps/server/src/routes/marketplace.ts:611) pattern.

## Observability

Reuses the metrics from [#653](https://github.com/RevealUIStudio/revealui/pull/653):

- `x402_payment_required_total{route='revmarket-task', currency}` on every 402 emission
- `x402_payment_verify_total{route='revmarket-task', scheme, result}` on every verify attempt
- `x402_payment_verify_duration_seconds{scheme}` histogram (latency)

Auto-surfaces on `/api/metrics` (Prometheus) — no new exposure code.

## File-by-file

| File | Change |
|---|---|
| `apps/server/src/routes/revmarket.ts` | New imports of x402 helpers + metrics. Updated PREVIEW header. New x402 gate inserted between `costUsdc` resolution and task creation. New 402 entry in OpenAPI response schema. |
| `apps/server/src/routes/__tests__/revmarket.test.ts` | New `vi.mock('../../middleware/x402.js')` factory with default `enabled: false` (so existing tests pass unchanged). +4 tests in a dedicated `POST /tasks  -  x402 payment gate (X402_ENABLED=true)` describe block: 402 on no-proof, 201 on valid proof (asserts `route='revmarket-task'` argument to `verifyPayment`), 402 on invalid proof, free-tier pass-through. |

## Out of scope (deferred to Phase B / Phase 6 follow-up)

- **Stripe Connect 80/20 split to the agent publisher** post-task-completion. The marketplace.ts `/invoke` flow handles this synchronously after the proxy call; revmarket needs async post-completion transfer (the in-process executor at `services/revmarket-executor.ts` is the natural emission point but requires Stripe Connect onboarding for agent publishers, which doesn't exist yet).
- **Sandboxing of in-process agent execution** (separate Phase B item per the file's existing PREVIEW header).
- **Daemon-mail off-chain micropayment channel** — depends on GAP-150 / GAP-152.
- **Refunds** — out of scope pre-launch per gap notes.

## Test plan

- [x] `pnpm --filter server typecheck` → clean
- [x] `pnpm --filter server exec vitest run src/routes/__tests__/revmarket.test.ts` → 25/25 pass (21 existing + 4 new)
- [x] `pnpm exec biome check --write` → clean after one auto-format pass
- [ ] CI gate (will run on push)
- [ ] Manual: end-to-end against devnet runbook (deferred to staging activation pass)

## What's left in GAP-149 after this PR

- **PR 7+ (Phase 6 deferrals)** — Stripe Connect onboarding for agent publishers, async treasury batch-payout for revmarket, daemon-mail off-chain channel
- **Refunds + dispute flow** — out of scope pre-launch per gap notes

The x402 emission/verify surface is now wired across all 5 paid endpoints (a2a, marketplace `/invoke`, task-quota, license, revmarket `/tasks`). The observability counters from PR 5 cover all of them. Operator activation against staging is the next outside-the-codebase milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
