### PR TITLE
chore(contracts): drop dead Session vestige in user.ts (GAP-134)

### DIFF
--- a/.changeset/contracts-drop-session-vestige.md
+++ b/.changeset/contracts-drop-session-vestige.md
@@ -1,0 +1,5 @@
+---
+'@revealui/contracts': patch
+---
+
+Drop the vestigial `SessionSchema` / `Session` type / `createSession` helper from `packages/contracts/src/entities/user.ts`. They were the older ISO-string shape (predating `entities/session.ts`), still re-exported at top level even though every `import { Session } from '@revealui/contracts'` consumer was zero (verified). Top-level `@revealui/contracts` now redirects `Session` and `SessionSchema` to the comprehensive Date-typed shape from `entities/session.ts` (which the entities barrel already pointed at). Also removes the orphan `SESSION_SCHEMA_VERSION` constant from `user.ts` and its `USER_SESSION_SCHEMA_VERSION` alias re-export from `entities/index.ts` (the canonical `SESSION_SCHEMA_VERSION` lives in `entities/session.ts`). Closes GAP-134.

--- a/packages/contracts/src/entities/index.ts
+++ b/packages/contracts/src/entities/index.ts
@@ -487,7 +487,6 @@ export {
   type CreateUserInput,
   CreateUserInputSchema,
   createUser,
-  SESSION_SCHEMA_VERSION as USER_SESSION_SCHEMA_VERSION,
   type UpdateUserInput,
   UpdateUserInputSchema,
   USER_SCHEMA_VERSION,

--- a/packages/contracts/src/entities/user.ts
+++ b/packages/contracts/src/entities/user.ts
@@ -26,7 +26,6 @@ import {
 // =============================================================================
 
 export const USER_SCHEMA_VERSION = 1;
-export const SESSION_SCHEMA_VERSION = 1;
 
 // =============================================================================
 // User Types
@@ -263,70 +262,3 @@ export const UpdateUserInputSchema = z.object({
 });
 
 export type UpdateUserInput = z.infer<typeof UpdateUserInputSchema>;
-
-// =============================================================================
-// Session Schema
-// =============================================================================
-
-export const SessionSchema = z.object({
-  /** Session ID */
-  id: z.string(),
-
-  /** Schema version */
-  version: z.number().int().default(SESSION_SCHEMA_VERSION),
-
-  /** User who owns this session */
-  userId: z.string(),
-
-  /** Session token (hashed) */
-  tokenHash: z.string(),
-
-  /** When the session expires */
-  expiresAt: z.string().datetime(),
-
-  /** Device/client info */
-  userAgent: z.string().optional(),
-
-  /** IP address (for security) */
-  ipAddress: z.string().optional(),
-
-  /** Whether this is a long-lived session (remember me) */
-  persistent: z.boolean().default(false),
-
-  /** Creation timestamp */
-  createdAt: z.string().datetime(),
-
-  /** Last activity timestamp */
-  lastActivityAt: z.string().datetime(),
-});
-
-export type Session = z.infer<typeof SessionSchema>;
-
-/**
- * Creates a new session
- */
-export function createSession(
-  id: string,
-  userId: string,
-  tokenHash: string,
-  expiresAt: Date,
-  options?: {
-    userAgent?: string;
-    ipAddress?: string;
-    persistent?: boolean;
-  },
-): Session {
-  const now = new Date().toISOString();
-  return {
-    id,
-    version: SESSION_SCHEMA_VERSION,
-    userId,
-    tokenHash,
-    expiresAt: expiresAt.toISOString(),
-    userAgent: options?.userAgent,
-    ipAddress: options?.ipAddress,
-    persistent: options?.persistent ?? false,
-    createdAt: now,
-    lastActivityAt: now,
-  };
-}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -106,7 +106,7 @@ export {
   type UpdatePageInput,
   UpdatePageInputSchema,
 } from './entities/page.js';
-
+export { type Session, SessionSchema } from './entities/session.js';
 export {
   type CreateSiteInput,
   CreateSiteInputSchema,
@@ -129,14 +129,10 @@ export {
   type UpdateSiteInput,
   UpdateSiteInputSchema,
 } from './entities/site.js';
-
 export {
   type CreateUserInput,
   CreateUserInputSchema,
-  createSession,
   createUser,
-  type Session,
-  SessionSchema,
   type UpdateUserInput,
   UpdateUserInputSchema,
   USER_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

Drops the vestigial `SessionSchema` / `Session` / `createSession` from `packages/contracts/src/entities/user.ts` (the older ISO-string shape predating `entities/session.ts`), the orphan `SESSION_SCHEMA_VERSION` constant in user.ts, and the `USER_SESSION_SCHEMA_VERSION` alias in `entities/index.ts`. Top-level `@revealui/contracts` now redirects `Session` / `SessionSchema` to the comprehensive Date-typed shape from `entities/session.ts` (the entities barrel already pointed there).

Net +1 / −72 lines across 3 files (plus a changeset).

Closes GAP-134. Audit at internal docs §2.2.

## Audit (re-verified post-chip-4 + post-GAP-135)

- Zero production imports of `Session*` from top-level `@revealui/contracts` (40+ top-level imports verified, none touch Session symbols).
- Zero callers of the `USER_SESSION_SCHEMA_VERSION` alias.
- The canonical `SESSION_SCHEMA_VERSION` lives at `entities/session.ts:22`; user.ts:29 was a duplicate.
- `entities/index.ts:454-468` already re-exports the comprehensive Session shape from `./session.js`, so subpath imports `import { Session } from '@revealui/contracts/entities'` were never affected by the user.ts vestige.

## Test plan

- [x] `pnpm --filter @revealui/contracts typecheck` — clean
- [x] `pnpm --filter @revealui/contracts test` — 28 test files / 767 tests pass
- [x] Pre-commit hooks pass clean (secrets scan, lint-staged, validators)
- [ ] CI: full gate green on `test`
- [ ] Manual squash merge after CI green per `feedback_no_auto_merge` (greenlit by owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
