### PR TITLE
chore(contracts): hoist verbatim-duplicate Database<T> generic (GAP-136)

### DIFF
--- a/.changeset/contracts-hoist-database-generic.md
+++ b/.changeset/contracts-hoist-database-generic.md
@@ -1,0 +1,5 @@
+---
+'@revealui/contracts': patch
+---
+
+Hoist the verbatim-duplicate `Database<T>` generic out of `database/bridge.ts` and `database/type-bridge.ts` into a new shared module `database/types.ts`. Both files now `import type` + re-export from the canonical location, eliminating ~50 lines of duplication. Public API is unchanged: `import { Database } from '@revealui/contracts/database/bridge'` (or `/type-bridge`) still works because both modules re-export the type. Closes GAP-136 Phase 1. Phase 2 (renaming the unrelated concrete `interface Database` in `generated/database.ts` to disambiguate) is intentionally deferred — that file is auto-generated and a rename needs generator-tooling investigation; tracked separately if/when prioritized.

--- a/packages/contracts/src/database/bridge.ts
+++ b/packages/contracts/src/database/bridge.ts
@@ -13,39 +13,12 @@
  */
 
 import type { Contract } from '../foundation/contract.js';
+import type { Database } from './types.js';
 
-/**
- * Generic Database type structure
- * Matches the structure of @revealui/db/types Database type
- * Used to avoid circular dependency between @revealui/contracts and @revealui/db
- *
- * @template T - The database tables structure
- */
-export type Database<
-  T extends {
-    public: {
-      Tables: Record<
-        string,
-        {
-          Row: unknown;
-          Insert: unknown;
-          Update: unknown;
-        }
-      >;
-    };
-  } = {
-    public: {
-      Tables: Record<
-        string,
-        {
-          Row: unknown;
-          Insert: unknown;
-          Update: unknown;
-        }
-      >;
-    };
-  },
-> = T;
+// Re-export the canonical `Database<T>` generic so existing consumers of
+// `@revealui/contracts/database/bridge` (or anyone importing `Database`
+// directly from this module) continue to work.
+export type { Database };
 
 /**
  * Convert a database row to a contract-validated entity

--- a/packages/contracts/src/database/type-bridge.ts
+++ b/packages/contracts/src/database/type-bridge.ts
@@ -12,39 +12,12 @@
  */
 
 import type { Contract, ContractValidationResult } from '../foundation/contract.js';
+import type { Database } from './types.js';
 
-/**
- * Generic Database type structure
- * Matches the structure of @revealui/db/types Database type
- * Used to avoid circular dependency between @revealui/contracts and @revealui/db
- *
- * @template T - The database tables structure
- */
-export type Database<
-  T extends {
-    public: {
-      Tables: Record<
-        string,
-        {
-          Row: unknown;
-          Insert: unknown;
-          Update: unknown;
-        }
-      >;
-    };
-  } = {
-    public: {
-      Tables: Record<
-        string,
-        {
-          Row: unknown;
-          Insert: unknown;
-          Update: unknown;
-        }
-      >;
-    };
-  },
-> = T;
+// Re-export the canonical `Database<T>` generic so existing consumers of
+// `@revealui/contracts/database/type-bridge` (or anyone importing `Database`
+// directly from this module) continue to work.
+export type { Database };
 
 /**
  * Convert Contract type to Drizzle insert type

--- a/packages/contracts/src/database/types.ts
+++ b/packages/contracts/src/database/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical `Database<T>` generic structure.
+ *
+ * Bridges Database types (from `@revealui/db`) with `@revealui/contracts`.
+ * Used to avoid circular dependency between the two packages.
+ *
+ * Re-exported from `database/bridge.ts` and `database/type-bridge.ts` for
+ * backward compatibility with consumers of those subpaths. New code should
+ * import from `@revealui/contracts/database` (which re-exports both modules)
+ * or directly from this file.
+ *
+ * @template T - The database tables structure
+ */
+export type Database<
+  T extends {
+    public: {
+      Tables: Record<
+        string,
+        {
+          Row: unknown;
+          Insert: unknown;
+          Update: unknown;
+        }
+      >;
+    };
+  } = {
+    public: {
+      Tables: Record<
+        string,
+        {
+          Row: unknown;
+          Insert: unknown;
+          Update: unknown;
+        }
+      >;
+    };
+  },
+> = T;


### PR DESCRIPTION
## Summary

Hoists the verbatim-duplicate `Database<T>` generic out of `packages/contracts/src/database/bridge.ts` (lines 24-48) and `database/type-bridge.ts` (lines 23-47) into a new shared module `database/types.ts`. Both files now `import type` + re-export from the canonical location. Net diff +53 / −64 across 4 files.

Closes **GAP-136 Phase 1**. Audit at internal docs §2.4.

## What changed

| Path | Change |
|---|---|
| `database/types.ts` | NEW — canonical `Database<T>` declaration with JSDoc |
| `database/bridge.ts` | 33-line block → 2-line `import type` + 1-line `export type { Database }` |
| `database/type-bridge.ts` | Same pattern |
| `.changeset/contracts-hoist-database-generic.md` | `@revealui/contracts: patch` |

Public API is unchanged: `import { Database } from '@revealui/contracts/database/bridge'` (or `/type-bridge`) still works because both modules re-export the type.

## Phase 2 explicitly deferred

The gap's Phase 2 (renaming the unrelated concrete `interface Database` in `packages/contracts/src/generated/database.ts:103` to disambiguate from the generic) is intentionally NOT in this PR. That file is auto-generated (`do not hand-edit` header per the gap notes); a rename would require a generator-template change OR a post-gen rename step. Tracked separately if/when prioritized — the gap closure-notes will name this scope explicitly.

## Test plan

- [x] `pnpm --filter @revealui/contracts typecheck` — clean (after `^... build` for `@revealui/db` deps)
- [x] `pnpm --filter @revealui/contracts test` — 28 test files / 767 tests pass
- [x] Pre-push gate (full local CI Phase 1) — clean
- [ ] CI: full gate green on `test`
- [ ] Manual squash merge after CI green per `feedback_no_auto_merge` (greenlit by owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
