### PR TITLE
chore(claude): sweep top-level Stack drift — qualify Next.js, drop Supabase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Agentic business runtime. Users, content, products, payments, and AI  -  pre-wir
 **Phase 5  -  Agent-First Infrastructure** (post-Phase 4). See `docs/MASTER_PLAN.md` for the active 5.x tracks.
 
 ## Stack
-- React 19, Next.js 16, Node 24, TypeScript 6
+- React 19, Next.js 16 (admin), Vite (docs / marketing / agency / revealcoin), Hono (server), Node 24, TypeScript 6
 - pnpm 10, Turborepo, Biome 2, Vitest 4
-- Drizzle ORM (NeonDB + Supabase), Hono, Tailwind CSS v4
+- Drizzle ORM (NeonDB), Tailwind CSS v4
 - Lexical (rich text), ElectricSQL (sync), Stripe (payments)
 
 ## Git Identity


### PR DESCRIPTION
## Summary

Companion to [revealui#658](https://github.com/RevealUIStudio/revealui/pull/658) which fixed the per-app framework rows in the Apps table. That PR called out the top-level Stack section as also stale; this PR closes that loop.

Two minimal changes to `CLAUDE.md` Stack section:

1. **Stack line 1 was misleading** about which frameworks the monorepo actually uses. `React 19, Next.js 16, Node 24, TypeScript 6` implied Next.js 16 was THE framework. Reality: only `apps/admin` uses Next.js (1 of 6 apps); the other 5 use Vite (4) or Hono (1). Updated to call out Vite + Hono explicitly.

2. **Stack line 3 referenced "(NeonDB + Supabase)"** but Supabase is being removed per GAP-129. Target architecture is Neon + ElectricSQL (the latter already listed on line 4). Dropped Supabase from the parenthetical. Also dropped Hono from line 3 since it's now in line 1.

## Diff

```diff
 ## Stack
-- React 19, Next.js 16, Node 24, TypeScript 6
+- React 19, Next.js 16 (admin), Vite (docs / marketing / agency / revealcoin), Hono (server), Node 24, TypeScript 6
 - pnpm 10, Turborepo, Biome 2, Vitest 4
-- Drizzle ORM (NeonDB + Supabase), Hono, Tailwind CSS v4
+- Drizzle ORM (NeonDB), Tailwind CSS v4
 - Lexical (rich text), ElectricSQL (sync), Stripe (payments)
```

## Audit ground truth (verified via `package.json` per app)

| App | Reality |
|---|---|
| admin | Next.js 16 (`^16.2.4`) — `src/app` + `next.config` |
| docs | Vite (catalog) — `index.html` + `app/` + `vite.config.ts` |
| marketing | Vite (catalog) |
| revealcoin | Vite (catalog) |
| server | Hono (`4.12.14`) |
| agency | Vite (catalog) — added in #658 |

## Not touched

- Description / Phase / Git Identity sections — still accurate
- `docs` port 3002 + `server` port 3004 — not surfaced in their `package.json` scripts; trusting existing CLAUDE.md values
- OSS Packages / Pro Packages tables — not surveyed for drift in this pass
- Supabase code may still exist in the tree (mid-migration) but is no longer the architecture; full removal tracked under GAP-129

## Test plan

- [ ] No code paths affected; doc-only change
- [ ] `git log` shows clean commit
- [ ] CI green on push (only doc files touched, no test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
