### PR TITLE
feat(marketing): cross-link to RevealUI Studio agency site

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -142,6 +142,16 @@ export function Footer() {
                 </a>
               </li>
               <li>
+                <a
+                  href="https://revealuistudio.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-white transition-colors"
+                >
+                  Studio
+                </a>
+              </li>
+              <li>
                 <a href="/contact" className="hover:text-white transition-colors">
                   Contact
                 </a>
@@ -151,7 +161,18 @@ export function Footer() {
         </div>
         <div className="mt-12 pt-8 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-4 text-gray-400 text-sm">
           <div className="flex items-center gap-4">
-            <p>&copy; {currentYear} RevealUI Studio. All rights reserved.</p>
+            <p>
+              &copy; {currentYear}{' '}
+              <a
+                href="https://revealuistudio.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-white transition-colors underline-offset-4 hover:underline"
+              >
+                RevealUI Studio
+              </a>
+              . All rights reserved.
+            </p>
             <BuiltWithRevealUI size="sm" colorScheme="dark" />
           </div>
           <div className="flex gap-6">


### PR DESCRIPTION
## Summary

Adds two minimal Footer cross-links from revealui.com → revealuistudio.com so the discovery path between the two brand surfaces is wired both ways. Pairs with the agency site scaffold in [revealui#658](https://github.com/RevealUIStudio/revealui/pull/658) (`apps/agency`).

## Changes

`apps/marketing/app/components/Footer.tsx`:

1. **Copyright link** — `RevealUI Studio` in `© {year} RevealUI Studio. All rights reserved` is now clickable, externally to revealuistudio.com. Discreet, semantically correct cross-link.

2. **Community column entry** — added `Studio` between `Sponsor` and `Contact`. Single-word label, externally targeted, opens in new tab.

## Why Footer-only (no NavBar change)

The marketing site already has `/services` as a top-level nav route — that's RevealUI's product-services page. Adding a NavBar external link to revealuistudio.com risks user confusion about which "services" they're navigating to. **Defer NavBar cross-link until the content split between revealui.com/services (product) and revealuistudio.com/services (agency) is intentional.**

## Activation

The links go live as soon as this merges. They become useful once Joshua completes the owner-action items in [revealui#658](https://github.com/RevealUIStudio/revealui/pull/658) (Vercel project + Namecheap DNS for revealuistudio.com). Until then the links resolve to a Namecheap parking page; harmless but no value yet.

## Test plan

- [ ] `pnpm --filter marketing dev` runs cleanly
- [ ] Footer renders with the two new links
- [ ] Hover state on copyright link shows underline
- [ ] Both links have `target="_blank"` + `rel="noopener noreferrer"`
- [ ] No lint / typecheck regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
