### PR TITLE
fix(dev): code validator path exemptions traverse dot-segments

### DIFF
--- a/packages/dev/src/code-validator/__tests__/validator.test.ts
+++ b/packages/dev/src/code-validator/__tests__/validator.test.ts
@@ -111,6 +111,51 @@ describe('CodeValidator', () => {
     expect(result.stats.exemptionsApplied).toBe(1);
   });
 
+  it('respects path exemptions through dot-prefixed segments (worktree paths)', () => {
+    // Regression: git worktrees live under `.wt/<name>/...`, so absolute
+    // paths passed by `scripts/validation/validate-code.ts` from a worktree
+    // contain a `.wt/` segment. minimatch's default behavior refuses to
+    // traverse dot-prefixed segments under `**`, so without `{ dot: true }`
+    // every exemption pattern fails for worktree-resolved paths. This test
+    // pins that fix in place. (Discovered 2026-04-29 during CHIP-3 Phase 3.)
+    const rule0 = testStandards.rules[0];
+    if (!rule0) throw new Error('Rule 0 not found');
+
+    const standardsWithExemptions: CodeStandards = {
+      ...testStandards,
+      rules: [
+        {
+          ...rule0,
+          exemptions: {
+            paths: ['**/vite.config*.ts'],
+          },
+        },
+      ],
+    };
+
+    const validator = new CodeValidator(standardsWithExemptions);
+    const code = `console.log('test')`;
+
+    // Absolute path with .wt/ segment (the worktree case)
+    const wtResult = validator.validate(code, {
+      filePath: '/home/dev/suite/.wt/feature-branch/apps/docs/vite.config.ts',
+    });
+    expect(wtResult.valid).toBe(true);
+    expect(wtResult.violations).toHaveLength(0);
+    expect(wtResult.stats.exemptionsApplied).toBe(1);
+
+    // Also verify .git/, .next/, and .husky/ segments don't defeat matching
+    const gitResult = validator.validate(code, {
+      filePath: '/repo/.git/hooks/vite.config.ts',
+    });
+    expect(gitResult.stats.exemptionsApplied).toBe(1);
+
+    const nextResult = validator.validate(code, {
+      filePath: 'apps/admin/.next/cache/vite.config.ts',
+    });
+    expect(nextResult.stats.exemptionsApplied).toBe(1);
+  });
+
   it('respects comment exemptions', () => {
     const rule0 = testStandards.rules[0];
     if (!rule0) throw new Error('Rule 0 not found');

--- a/packages/dev/src/code-validator/validator.ts
+++ b/packages/dev/src/code-validator/validator.ts
@@ -112,12 +112,19 @@ export class CodeValidator {
   }
 
   /**
-   * Check if file path is exempted from rule
+   * Check if file path is exempted from rule.
+   *
+   * `dot: true` is required so that dot-prefixed path segments
+   * (e.g. `.wt/`, `.git/`, `.husky/`, `.next/`) don't silently
+   * defeat patterns like `**​/vite.config*.ts`. Without it,
+   * minimatch refuses to traverse dot-segments when matching
+   * `**`, which means git worktrees under `.wt/` fail every
+   * exemption regardless of the pattern.
    */
   private isPathExempted(filePath: string, rule: ValidationRule): boolean {
     if (!rule.exemptions?.paths) return false;
 
-    return rule.exemptions.paths.some((pattern) => minimatch(filePath, pattern));
+    return rule.exemptions.paths.some((pattern) => minimatch(filePath, pattern, { dot: true }));
   }
 
   /**


### PR DESCRIPTION
## Summary
- `CodeValidator.isPathExempted` now passes `{ dot: true }` to minimatch so `paths` exemptions in `.revealui/code-standards.json` traverse dot-prefixed segments (`.wt/`, `.git/`, `.husky/`, `.next/`, etc.). Pre-commit hooks running from a git worktree under `.wt/` now correctly honor exemption globs like `**/vite.config*.ts`.
- New regression test pins the worktree case + covers `.git/` and `.next/` segments.

## Why
Surfaced 2026-04-29 during CHIP-3 Phase 3: committing `apps/docs/vite.config.ts` from a worktree at `~/suite/.wt/chip-3-docs-url-flatten/` raised spurious `no-console-log` violations even though the rule explicitly exempts `**/vite.config*.ts`. minimatch's default refuses to traverse dot-prefixed path segments under `**`, so any worktree-resolved absolute path (`/abs/.wt/foo/...`) silently fails every glob exemption.

This affected only worktree-based development; main checkouts (`~/suite/revealui`) and CI didn't hit the bug.

## Test plan
- [x] `pnpm --filter @revealui/dev test` — 53/53 tests pass (1 new regression test for dot-segment paths)
- [x] `pnpm --filter @revealui/dev typecheck` — clean
- [x] Manually: `pnpm tsx scripts/validation/validate-code.ts apps/docs/vite.config.ts` from a `.wt/` worktree — was reporting violations, now reports `✓ Code passes all standards`
- [ ] Pre-commit hook smoke from a worktree (covered by the manual run above)

## Follow-up
A workaround landed on `chore/chip-3-docs-url-flatten` ([apps/docs/vite.config.ts](apps/docs/vite.config.ts) gained a file-level `// console-allowed` header). Once this fix lands on `test`, the workaround can be reverted in a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
