### PR TITLE
fix(validate): drop useless String.raw on Forge taxonomy patterns

### DIFF
--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -622,10 +622,10 @@ const SUITE_ATTRIBUTION_QUALIFIER = new RegExp(
     String.raw`\bnot yet shipped\b`,
     // Forge tier / kit phrasings (Forge is both a product and a tier)
     String.raw`Forge \(Enterprise\)`,
-    String.raw`Forge tier`,
-    String.raw`Forge Edition`,
-    String.raw`Forge kit`,
-    String.raw`Forge guide`,
+    'Forge tier',
+    'Forge Edition',
+    'Forge kit',
+    'Forge guide',
   ].join('|'),
   'i',
 );


### PR DESCRIPTION
## Summary

- Drops `String.raw` from 4 lines in `scripts/validate/claim-drift.ts:625-628` that contain no escape sequences (Biome `lint/complexity/noUselessStringRaw`).
- Preserves `String.raw` on entries with `\b` word-boundary or `\(`/`\)` escapes — those are legitimate uses.

## Why

Biome `noUselessStringRaw` failures in the CI Quality job were masked by turbo cache on most PRs (no workspace boundary change). PR #658 (new `apps/agency` workspace) invalidates the cache, forces a full Biome re-check, and exposes them. Introduced by #597 on 2026-04-26.

This unblocks #658 and prevents the same failure on any future PR that adds a new workspace.

## Test plan

- [ ] CI Quality (Biome) green on this PR.
- [ ] No semantic change: plain string literals join identically to `String.raw` templates that contain no escape sequences.
