### PR TITLE
refactor(contracts): rename page-revision Block to RevisionBlock

### DIFF
--- a/packages/contracts/src/entities/index.ts
+++ b/packages/contracts/src/entities/index.ts
@@ -214,8 +214,8 @@ export {
   UpdatePageInputSchema,
 } from './page.js';
 export {
-  type Block,
-  BlockSchema,
+  type RevisionBlock,
+  RevisionBlockSchema,
   CHANGE_TYPES,
   type ChangeType,
   calculateRevisionNumber,

--- a/packages/contracts/src/entities/index.ts
+++ b/packages/contracts/src/entities/index.ts
@@ -214,8 +214,6 @@ export {
   UpdatePageInputSchema,
 } from './page.js';
 export {
-  type RevisionBlock,
-  RevisionBlockSchema,
   CHANGE_TYPES,
   type ChangeType,
   calculateRevisionNumber,
@@ -254,6 +252,8 @@ export {
   pageRevisionToAgent,
   pageRevisionToHuman,
   REVISION_RETENTION,
+  type RevisionBlock,
+  RevisionBlockSchema,
   type SeoMetadata,
   SeoMetadataSchema,
 } from './page-revision.js';

--- a/packages/contracts/src/entities/page-revision.ts
+++ b/packages/contracts/src/entities/page-revision.ts
@@ -51,15 +51,16 @@ export const REVISION_RETENTION = {
 // =============================================================================
 
 /**
- * Block schema (simplified, matches Page blocks)
+ * Revision block schema (simplified shape for serializing into PageRevision rows;
+ * the canonical discriminated-union Block lives in `../content`).
  */
-export const BlockSchema = z.object({
+export const RevisionBlockSchema = z.object({
   id: z.string(),
   type: z.string(),
   data: z.record(z.string(), z.unknown()).optional(),
 });
 
-export type Block = z.infer<typeof BlockSchema>;
+export type RevisionBlock = z.infer<typeof RevisionBlockSchema>;
 
 /**
  * SEO metadata schema (matches Page seo)
@@ -88,7 +89,7 @@ export const PageRevisionObjectSchema = z.object({
   createdBy: z.string().nullable().optional(),
   revisionNumber: z.number().int().positive('Revision number must be positive'),
   title: z.string().min(1, 'Title is required'),
-  blocks: z.array(BlockSchema).default([]),
+  blocks: z.array(RevisionBlockSchema).default([]),
   seo: SeoMetadataSchema.nullable().optional(),
   changeDescription: z.string().nullable().optional(),
   createdAt: z.date(),
@@ -203,14 +204,14 @@ export function estimateWordCount(revision: PageRevision): number {
 /**
  * Get block by ID
  */
-export function getBlockById(revision: PageRevision, blockId: string): Block | undefined {
+export function getBlockById(revision: PageRevision, blockId: string): RevisionBlock | undefined {
   return revision.blocks.find((block) => block.id === blockId);
 }
 
 /**
  * Get blocks by type
  */
-export function getBlocksByType(revision: PageRevision, type: string): Block[] {
+export function getBlocksByType(revision: PageRevision, type: string): RevisionBlock[] {
   return revision.blocks.filter((block) => block.type === type);
 }
 
@@ -385,7 +386,7 @@ export function createPageRevisionInsert(
   pageId: string,
   revisionNumber: number,
   title: string,
-  blocks: Block[],
+  blocks: RevisionBlock[],
   options?: {
     id?: string;
     seo?: SeoMetadata | null;
@@ -414,7 +415,7 @@ export function createRevisionFromSnapshot(
   revisionNumber: number,
   snapshot: {
     title: string;
-    blocks: Block[];
+    blocks: RevisionBlock[];
     seo?: SeoMetadata | null;
   },
   options?: {


### PR DESCRIPTION
## Summary

Disambiguates the simpler block shape used for serializing PageRevision rows from the canonical discriminated-union `Block` in `@revealui/contracts/content`. Previously both were exported as `Block` from the contracts package; resolution depended on barrel re-export precedence.

After this rename:
- `entities/page-revision.ts` exports `RevisionBlock` and `RevisionBlockSchema` (was `Block`/`BlockSchema`).
- `entities/index.ts` barrel re-exports the new names (alphabetically sorted by Biome).
- `import { Block } from '@revealui/contracts'` now unambiguously resolves to the canonical content shape.

## Audit

- 4 in-repo importers of `BlockSchema` use `@revealui/contracts/content` (the canonical), not `@revealui/contracts/entities`. None affected.
- `grep -n 'export.*\bBlock\b' packages/contracts/src/entities/page-revision.ts` returns zero hits.
- `grep -n 'RevisionBlock' packages/contracts/src/entities/page-revision.ts` returns 8 hits (declaration + 7 references).
- `pnpm typecheck:all` passes (52/52 turbo tasks).

## Test plan

- [ ] CI Quality (Biome + claim-drift) green.
- [ ] CI Typecheck green.
- [ ] CI Unit tests green.
