### PR TITLE
fix(server): dual-secret webhook signature verification for rotation

### DIFF
--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -194,6 +194,16 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
       errors.push('STRIPE_WEBHOOK_SECRET must start with "whsec_" in production.');
     }
 
+    // Optional dual-secret rotation transition (GAP-144). Only validated when
+    // present — empty/unset is the steady state. When set, must be a valid
+    // whsec_ secret since the webhook handler will use it as a fallback verifier.
+    const previousWebhookSecret = (env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS ?? '').trim();
+    if (previousWebhookSecret && !previousWebhookSecret.startsWith('whsec_')) {
+      errors.push(
+        'STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS must start with "whsec_" when set (transitional secret used during webhook signing-key rotation).',
+      );
+    }
+
     // HTTPS-only URLs (hosted mode runs on revealui.com).
     if (!publicUrl.startsWith('https://')) {
       errors.push('REVEALUI_PUBLIC_SERVER_URL must use HTTPS in production.');

--- a/apps/server/src/routes/__tests__/webhook-signature-rotation.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-signature-rotation.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Stripe Webhook  -  Dual-Secret Rotation Transition (GAP-144)
+ *
+ * Verifies the `getWebhookSecret()` + `constructEventAsync` try-fallback
+ * path that supports zero-downtime webhook signing-secret rotation.
+ *
+ * Steady state (no rotation in flight):
+ *   STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS unset → only primary tried.
+ *
+ * Rotation overlap window:
+ *   STRIPE_WEBHOOK_SECRET_LIVE      = NEW secret (primary)
+ *   STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS = OLD secret (secondary, transitional)
+ *   Stripe may deliver events signed with EITHER secret during the overlap.
+ *   Verifier tries primary first; on auth-tag mismatch, tries secondary;
+ *   on secondary success, logs a `rotation-transition` warning so operators
+ *   can confirm the overlap is active. Both failing → 400 (current behavior).
+ */
+
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
+
+const { mockConstructEvent } = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+}));
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(
+    class {
+      webhooks = { constructEventAsync: mockConstructEvent };
+      subscriptions = { update: vi.fn(), retrieve: vi.fn(), list: vi.fn() };
+      charges = { retrieve: vi.fn() };
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+}));
+
+// GAP-131: webhooks.ts uses protectedStripe from @revealui/services
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: { update: vi.fn(), retrieve: vi.fn(), list: vi.fn() },
+    charges: { retrieve: vi.fn() },
+    customers: { update: vi.fn() },
+  },
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn(),
+  getFeaturesForTier: vi.fn(() => ({})),
+}));
+
+vi.mock('@revealui/core/license', () => ({
+  generateLicenseKey: vi.fn(),
+  resetLicenseState: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  sendLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentRecoveredEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentReceiptEmail: vi.fn().mockResolvedValue(undefined),
+  sendPerpetualLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendTierFallbackAlert: vi.fn().mockResolvedValue(undefined),
+  sendTrialEndingEmail: vi.fn().mockResolvedValue(undefined),
+  sendWebhookFailureAlert: vi.fn().mockResolvedValue(undefined),
+  sendDisputeLostEmail: vi.fn().mockResolvedValue(undefined),
+  provisionGitHubAccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Minimal DB mock — tests use unknown event types so handler short-circuits
+// before any DB write, but the signature path still needs getClient() to resolve.
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  transaction: vi.fn(),
+};
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => mockDb),
+  DrizzleAuditStore: vi.fn().mockImplementation(
+    class {
+      append = vi.fn();
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+  executeSaga: vi.fn(),
+}));
+
+// ─── Imports under test (after mocks) ─────────────────────────────────────────
+
+import * as loggerModule from '@revealui/core/observability/logger';
+import webhooksApp from '../webhooks.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = new Hono();
+  app.route('/', webhooksApp);
+  return app;
+}
+
+function postStripe(eventJson: unknown, sig = 'valid-sig') {
+  return new Request('http://localhost/stripe', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Stripe-Signature': sig,
+    },
+    body: JSON.stringify(eventJson),
+  });
+}
+
+const UNKNOWN_EVENT = {
+  id: 'evt_rotation_test',
+  type: 'unknown.event.type',
+  data: { object: {} },
+  created: 1700000000,
+  livemode: false,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Webhook signature verification  -  dual-secret rotation transition (GAP-144)', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    savedEnv.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+    savedEnv.STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+    savedEnv.STRIPE_WEBHOOK_SECRET_LIVE = process.env.STRIPE_WEBHOOK_SECRET_LIVE;
+    savedEnv.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS = process.env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS;
+
+    process.env.STRIPE_SECRET_KEY = 'sk_test_placeholder';
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    delete process.env.STRIPE_WEBHOOK_SECRET_LIVE;
+    delete process.env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS;
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  it('verifies with primary alone when no secondary is configured (steady state)', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE = 'whsec_primary_steady';
+
+    mockConstructEvent.mockResolvedValueOnce(UNKNOWN_EVENT);
+
+    const res = await createApp().request(postStripe(UNKNOWN_EVENT, 'sig-steady'));
+
+    expect(res.status).toBe(200);
+    expect(mockConstructEvent).toHaveBeenCalledTimes(1);
+    expect(mockConstructEvent).toHaveBeenCalledWith(
+      expect.any(String),
+      'sig-steady',
+      'whsec_primary_steady',
+    );
+    expect(vi.mocked(loggerModule.logger).warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to secondary when primary fails during rotation overlap', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE = 'whsec_new_primary';
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS = 'whsec_old_secondary';
+
+    // Primary verification rejects (event was signed under the OLD secret),
+    // secondary verification accepts.
+    mockConstructEvent
+      .mockRejectedValueOnce(new Error('No signatures found matching the expected signature'))
+      .mockResolvedValueOnce(UNKNOWN_EVENT);
+
+    const res = await createApp().request(postStripe(UNKNOWN_EVENT, 'sig-old'));
+
+    expect(res.status).toBe(200);
+    expect(mockConstructEvent).toHaveBeenCalledTimes(2);
+    expect(mockConstructEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      'sig-old',
+      'whsec_new_primary',
+    );
+    expect(mockConstructEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      'sig-old',
+      'whsec_old_secondary',
+    );
+    expect(vi.mocked(loggerModule.logger).warn).toHaveBeenCalledWith(
+      expect.stringContaining('rotation in flight'),
+      expect.objectContaining({ eventType: 'rotation-transition' }),
+    );
+    expect(vi.mocked(loggerModule.logger).error).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when both primary and secondary reject the signature', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE = 'whsec_new_primary';
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS = 'whsec_old_secondary';
+
+    mockConstructEvent
+      .mockRejectedValueOnce(new Error('No signatures found matching the expected signature'))
+      .mockRejectedValueOnce(new Error('No signatures found matching the expected signature'));
+
+    const res = await createApp().request(postStripe(UNKNOWN_EVENT, 'sig-bogus'));
+
+    expect(res.status).toBe(400);
+    expect(mockConstructEvent).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(loggerModule.logger).warn).not.toHaveBeenCalled();
+    expect(vi.mocked(loggerModule.logger).error).toHaveBeenCalledWith(
+      expect.stringContaining('both primary and secondary'),
+      undefined,
+      expect.objectContaining({ detail: expect.stringContaining('No signatures') }),
+    );
+  });
+
+  it('returns 400 when primary fails and no secondary is configured', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET_LIVE = 'whsec_only_primary';
+    // no STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS set
+
+    mockConstructEvent.mockRejectedValueOnce(
+      new Error('No signatures found matching the expected signature'),
+    );
+
+    const res = await createApp().request(postStripe(UNKNOWN_EVENT, 'sig-bogus'));
+
+    expect(res.status).toBe(400);
+    expect(mockConstructEvent).toHaveBeenCalledTimes(1); // never tried secondary
+    expect(vi.mocked(loggerModule.logger).warn).not.toHaveBeenCalled();
+    expect(vi.mocked(loggerModule.logger).error).toHaveBeenCalledWith(
+      'Webhook signature verification failed',
+      undefined,
+      expect.objectContaining({ detail: expect.stringContaining('No signatures') }),
+    );
+  });
+});

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -75,14 +75,32 @@ function getStripeClient(): typeof protectedStripe {
   return protectedStripe;
 }
 
-function getWebhookSecret(): string {
-  const secret = (
+/**
+ * Returns the active webhook secret pair for signature verification.
+ *
+ * `primary` is the current secret (must be set or boot fails).
+ * `secondary` is an optional transitional secret that supports zero-downtime
+ * webhook secret rotation: during a rotation window both secrets are valid
+ * verifiers. The signature handler tries `primary` first, falls back to
+ * `secondary` on auth-tag mismatch, and logs a warning when the fallback
+ * succeeds so operators can confirm the rotation transition is in flight.
+ *
+ * Operator flow:
+ *   1. Add new secret in Stripe Dashboard ("Roll secret"). Get the new value.
+ *   2. Set `STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS` to the OLD secret value.
+ *   3. Set `STRIPE_WEBHOOK_SECRET_LIVE` to the NEW secret value.
+ *   4. Wait for the rotation overlap window (24h is Stripe's default).
+ *   5. Unset `STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS`.
+ */
+function getWebhookSecret(): { primary: string; secondary?: string } {
+  const primary = (
     process.env.STRIPE_WEBHOOK_SECRET_LIVE || process.env.STRIPE_WEBHOOK_SECRET
   )?.trim();
-  if (!secret) {
+  if (!primary) {
     throw new Error('STRIPE_WEBHOOK_SECRET must be configured');
   }
-  return secret;
+  const secondary = process.env.STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS?.trim() || undefined;
+  return { primary, secondary };
 }
 
 /**
@@ -724,10 +742,10 @@ const stripeWebhookRoute = createRoute({
 });
 
 app.openapi(stripeWebhookRoute, async (c) => {
-  let webhookSecret: string;
+  let webhookSecrets: { primary: string; secondary?: string };
   let stripe: typeof protectedStripe;
   try {
-    webhookSecret = getWebhookSecret();
+    webhookSecrets = getWebhookSecret();
     stripe = getStripeClient();
   } catch (initErr) {
     const msg = initErr instanceof Error ? initErr.message : 'Unknown init error';
@@ -754,11 +772,33 @@ app.openapi(stripeWebhookRoute, async (c) => {
 
   let event: Stripe.Event;
   try {
-    event = await stripe.webhooks.constructEventAsync(body, sig, webhookSecret);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Unknown error';
-    logger.error('Webhook signature verification failed', undefined, { detail: msg });
-    return c.json({ error: 'Invalid webhook signature' }, 400);
+    event = await stripe.webhooks.constructEventAsync(body, sig, webhookSecrets.primary);
+  } catch (primaryErr) {
+    // GAP-144: dual-secret rotation transition. If a secondary is configured,
+    // try it before rejecting. A successful secondary verification logs a
+    // warning so operators can confirm the rotation overlap is active.
+    if (!webhookSecrets.secondary) {
+      const msg = primaryErr instanceof Error ? primaryErr.message : 'Unknown error';
+      logger.error('Webhook signature verification failed', undefined, { detail: msg });
+      return c.json({ error: 'Invalid webhook signature' }, 400);
+    }
+    try {
+      event = await stripe.webhooks.constructEventAsync(body, sig, webhookSecrets.secondary);
+      logger.warn(
+        'Webhook secret rotation in flight: secondary signature verified  -  remove STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS once rotation overlap window ends',
+        {
+          eventType: 'rotation-transition',
+        },
+      );
+    } catch (_secondaryErr) {
+      const msg = primaryErr instanceof Error ? primaryErr.message : 'Unknown error';
+      logger.error(
+        'Webhook signature verification failed (both primary and secondary secrets rejected)',
+        undefined,
+        { detail: msg },
+      );
+      return c.json({ error: 'Invalid webhook signature' }, 400);
+    }
   }
 
   if (!relevantEvents.has(event.type)) {


### PR DESCRIPTION
## Summary

Adds zero-downtime support for Stripe webhook signing-secret rotation. The webhook handler now reads an optional `STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS` env var; during a rotation overlap window, signatures are verified against the new (primary) secret first, falling back to the old (secondary) secret if the primary rejects. A successful secondary verification logs a `rotation-transition` warning so operators can confirm the overlap is active.

Steady state (no rotation in flight): only primary tried; behavior unchanged from prior code.

## Why

Stripe's "Roll secret" flow keeps the OLD secret valid for a configurable overlap window (24h default). Without dual-secret support, webhook deliveries signed under whichever secret the verifier doesn't know about during the overlap fail signature check → Stripe retries → brief inconsistency. Pre-launch this is theoretical; post-flip every rotation cycle is a small risk.

Companion to `docs/billing-audit/11-webhook-signing-rotation.md` (private repo). Rotation runbook + Surface 11 sign-off doc updated separately.

## Operator flow

```
1. Stripe Dashboard → "Roll secret" → get NEW secret value
2. Vercel: set STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS = OLD secret
3. Vercel: set STRIPE_WEBHOOK_SECRET_LIVE = NEW secret
4. Watch logs for `rotation-transition` warnings (signals secondary verifications)
5. After Stripe overlap window closes: unset STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS
```

`validate-startup.ts` opts the new env var into a `whsec_`-prefix check (only enforced when set; empty/unset is the steady state).

## Tests

New file `apps/server/src/routes/__tests__/webhook-signature-rotation.test.ts` (4 scenarios):

| Scenario | Expectation |
|---|---|
| Primary alone, no secondary set | constructEventAsync called once with primary; no warn log |
| Both secrets set, primary fails, secondary verifies | called twice; warn log fires with `eventType: 'rotation-transition'` |
| Both secrets set, both reject | called twice; 400; error log mentions both |
| Primary fails, no secondary | called once; 400; secondary never tried |

All 4 pass locally.

## Test plan

- [ ] CI Quality (Biome + claim-drift + structure) green.
- [ ] CI Typecheck green.
- [ ] CI Unit tests green (in particular the new `webhook-signature-rotation.test.ts`).
- [ ] CI Integration tests green (no regression in existing webhook tests).
