### PR TITLE
docs(automation): retire stale branch-protection recipe (Phase D)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -1168,8 +1168,8 @@ git push
 #### Run Verification Scripts
 
 ```bash
-# Verify branch protection (requires GitHub CLI)
-pnpm verify:branch-protection
+# Branch protection is declared in the private revealui-jv repo.
+# See the 'Branch Protection' section below for posture + audit access.
 
 # Test local validation (if available)
 pnpm validate:all
@@ -1315,8 +1315,8 @@ Solution: Ensure all dependencies are installed and Node.js version matches
 pnpm validate:workspace
 pnpm validate:deps
 
-# Branch protection check
-pnpm verify:branch-protection
+# Branch protection is declared in the private revealui-jv repo.
+# See the 'Branch Protection' section for posture + audit access.
 
 # Changeset testing
 pnpm changeset:status
@@ -1579,336 +1579,31 @@ This section clearly defines the boundaries between automated and manual process
 
 ## Branch Protection
 
-### Overview
+Branch protection for the RevealUI Studio suite is declared as code in the **private** `revealui-jv` coordination repo. The desired state for each repo lives at `branch-protection/<repo>.json`; a small bash + `jq` + `gh api` script (`scripts/apply-branch-protection.sh`) diffs the declarations against live GitHub state and pushes them via `PUT /repos/{owner}/{repo}/branches/{branch}/protection`. The script is idempotent.
 
-Branch protection rules are **critical security controls** that prevent unauthorized code changes from reaching the main branch. Without these rules, all CI/CD security measures are bypassed.
+### Posture
 
-### Critical Security Impact
+Every protected branch enforces:
 
-**Without Branch Protection:**
+- `enforce_admins: true` — repository owners cannot merge red CI
+- `allow_force_pushes: false`, `allow_deletions: false`
+- `required_pull_request_reviews: null` — CI + admin enforcement is the gate. There is no PR-review requirement, by design (solo-founder posture; self-review is theatre).
+- `required_status_checks.strict: false` — branches do not need to be up-to-date with base before merging (compatible with merge-train workflows)
 
-- ❌ PRs can be merged without reviews
-- ❌ Failing CI checks are ignored
-- ❌ Security vulnerabilities bypass validation
-- ❌ Code quality standards unenforced
+Per-repo required-check sets vary and are listed in each `<repo>.json` declaration. As of the latest sweep, protection covers:
 
-**With Branch Protection:**
+- `revealui` (main + test)
+- `revvault` (main)
+- `revdev` (main + test)
+- `revcon` (main)
+- `revskills` (main)
 
-- ✅ All changes require code review
-- ✅ CI/CD pipelines must pass
-- ✅ Security scans block vulnerable code
-- ✅ Quality gates enforced automatically
+Repos with CI but no protection currently: `forge`, `revkit`, `revealcoin` (private repos require GitHub Pro for branch protection — tracked separately), and `status` (deploy-only check-runs need workflow inspection before declaring).
 
-### Required Branch Protection Rules
+### Audit access
 
-#### Target Branch: `main`
+Declaration files are in a private repo. For audit / SOC 2 / compliance access to the source-of-truth files, contact `founder@revealui.com`. The complete security posture is documented in [`SECURITY.md`](../SECURITY.md).
 
-#### Require Pull Request Reviews
-
-```
-Required approving reviews: 1
-Dismiss stale pull request approvals: true
-Require review from Code Owners: false
-Restrict push access: true
-Allow force pushes: false
-Allow deletions: false
-```
-
-#### Require Status Checks
-
-**Required status checks before merging:**
-
-- `validate-config` (CI)
-- `lint` (CI)
-- `typecheck` (CI)
-- `test` (CI)
-- `security-scan` (CI)
-- `docs-verification` (CI)
-- `build-admin` (CI)
-- `build-web` (CI)
-- `validate-crdt` (CI)
-- `integration-tests` (CI)
-- `snyk-security` (Security Scanning)
-- `secret-scanning` (Security Scanning)
-- `dependency-review` (Security Scanning)
-- `codeql-analysis` (Security Scanning)
-
-#### Additional Settings
-
-```
-Require branches to be up to date: true
-Restrict who can dismiss pull request reviews: [Repository administrators only]
-Include administrators: true
-```
-
-### Implementation Steps
-
-#### Option 1: GitHub UI Configuration (Recommended)
-
-1. **Navigate to Repository Settings:**
-   - Go to your repository on GitHub
-   - Click "Settings" tab
-   - Click "Branches" in left sidebar
-
-2. **Add Branch Protection Rule:**
-   - Click "Add rule" button
-   - Enter `main` in "Branch name pattern"
-   - Configure the settings as specified above
-
-3. **Status Check Configuration:**
-   - In the "Require status checks to pass" section
-   - Add each required check from the list above
-   - Ensure "Require branches to be up to date" is checked
-
-#### Option 2: GitHub CLI Configuration
-
-```bash
-# Install GitHub CLI if not already installed
-# https://cli.github.com/
-
-# Set branch protection rules
-gh api repos/{owner}/{repo}/branches/main/protection \
-  -X PUT \
-  -H "Accept: application/vnd.github+json" \
-  --input - << EOF
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": [
-      "validate-config",
-      "lint",
-      "typecheck",
-      "test",
-      "security-scan",
-      "docs-verification",
-      "build-admin",
-      "build-web",
-      "validate-crdt",
-      "integration-tests",
-      "snyk-security",
-      "secret-scanning",
-      "dependency-review",
-      "codeql-analysis"
-    ]
-  },
-  "enforce_admins": true,
-  "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
-    "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": false,
-    "dismissal_restrictions": {
-      "users": [],
-      "teams": []
-    }
-  },
-  "restrictions": null,
-  "allow_force_pushes": false,
-  "allow_deletions": false,
-  "block_creations": false
-}
-EOF
-```
-
-### Verification Steps
-
-#### Manual Verification
-
-1. **Create a test PR** to the main branch
-2. **Verify required checks** are running
-3. **Attempt to merge without approval** - should be blocked
-4. **Attempt to merge with failing checks** - should be blocked
-
-#### Automated Verification Script
-
-```bash
-#!/usr/bin/env node
-// scripts/verify-branch-protection.mjs
-
-import { execSync } from 'child_process';
-
-const REPO = process.env.GITHUB_REPOSITORY || 'RevealUIStudio/revealui';
-const BRANCH = 'main';
-
-console.log(`🔍 Verifying branch protection for ${REPO}:${BRANCH}\n`);
-
-try {
-  // Get branch protection rules
-  const cmd = `gh api repos/${REPO}/branches/${BRANCH}/protection`;
-  const protection = JSON.parse(execSync(cmd, { encoding: 'utf8' }));
-
-  console.log('✅ Branch protection is enabled\n');
-
-  // Check required status checks
-  const requiredChecks = protection.required_status_checks?.contexts || [];
-  console.log(`📋 Required status checks (${requiredChecks.length}):`);
-  requiredChecks.forEach(check => console.log(`   • ${check}`));
-
-  // Verify critical checks are present
-  const criticalChecks = [
-    'validate-config', 'lint', 'typecheck', 'test',
-    'security-scan', 'build-admin', 'build-web'
-  ];
-
-  const missingChecks = criticalChecks.filter(check =>
-    !requiredChecks.includes(check)
-  );
-
-  if (missingChecks.length > 0) {
-    console.error(`❌ Missing critical checks: ${missingChecks.join(', ')}`);
-    process.exit(1);
-  }
-
-  // Check PR review requirements
-  const reviews = protection.required_pull_request_reviews;
-  if (reviews?.required_approving_review_count >= 1) {
-    console.log(`✅ PR reviews required: ${reviews.required_approving_review_count}`);
-  } else {
-    console.error('❌ PR reviews not properly configured');
-    process.exit(1);
-  }
-
-  // Check admin enforcement
-  if (protection.enforce_admins?.enabled) {
-    console.log('✅ Admin enforcement enabled');
-  } else {
-    console.warn('⚠️ Admin enforcement not enabled');
-  }
-
-  console.log('\n🎉 Branch protection verification passed!');
-
-} catch (error) {
-  console.error(`❌ Branch protection verification failed: ${error.message}`);
-  console.error('\nTo fix: Configure branch protection rules in repository settings');
-  process.exit(1);
-}
-```
-
-### Required Status Checks Explained
-
-#### CI Pipeline Checks
-
-- **`validate-config`**: Ensures environment configuration is valid
-- **`lint`**: Code style and quality validation
-- **`typecheck`**: TypeScript compilation verification
-- **`test`**: Unit test execution and coverage
-- **`security-scan`**: Dependency vulnerability scanning
-- **`docs-verification`**: Documentation validation
-- **`build-admin`**: Next.js admin application build
-- **`build-web`**: Vite web application build
-- **`validate-crdt`**: Database schema validation
-- **`integration-tests`**: End-to-end integration testing
-
-#### Security Scanning Checks
-
-- **`snyk-security`**: Snyk vulnerability scanning
-- **`secret-scanning`**: GitLeaks secret detection
-- **`dependency-review`**: GitHub dependency review
-- **`codeql-analysis`**: GitHub CodeQL security analysis
-
-### Troubleshooting
-
-#### Status Checks Not Appearing
-
-**Problem:** Required status checks don't show up in branch protection settings
-
-**Solutions:**
-
-1. **Wait for workflow runs**: Status checks only appear after workflows have run
-2. **Check workflow names**: Ensure job names match exactly in branch protection
-3. **Verify workflow triggers**: Ensure workflows run on pull requests to main
-
-#### PR Reviews Being Dismissed
-
-**Problem:** Reviews are dismissed when new commits are pushed
-
-**Solution:** This is expected behavior with "Dismiss stale reviews" enabled. Re-request review after addressing feedback.
-
-#### Administrators Can't Merge
-
-**Problem:** Repository admins can't merge their own PRs
-
-**Solution:** This is expected with "Include administrators" enabled. Require another admin or team member to review.
-
-### Advanced Configuration
-
-#### Code Owners Integration
-
-```yaml
-# .github/CODEOWNERS
-# Require code owner reviews for specific paths
-packages/core/ @core-team
-packages/security/ @security-team
-```
-
-#### Branch Protection for Other Branches
-
-Consider protecting `test` branch with similar rules:
-
-- Fewer required reviews (1 instead of 2)
-- Same status checks
-- Allow force pushes for maintainers
-
-#### Status Check Customization
-
-For complex repositories, consider:
-
-- **Separate check suites** for different types of validation
-- **Conditional checks** based on changed files
-- **External status checks** from third-party services
-
-### Security Benefits
-
-#### Attack Vector Mitigation
-
-- **Prevents unauthorized merges** without review
-- **Blocks vulnerable code** through security scanning
-- **Enforces quality standards** automatically
-- **Maintains audit trail** of all changes
-
-#### Compliance Benefits
-
-- **SOX/HIPAA**: Change approval requirements
-- **GDPR**: Data protection through security scanning
-- **Industry Standards**: CIS, NIST security controls
-
-### Monitoring & Maintenance
-
-#### Regular Audits
-
-- **Monthly**: Review branch protection effectiveness
-- **Quarterly**: Update required status checks for new workflows
-- **After incidents**: Verify controls prevented similar issues
-
-#### Metrics to Track
-
-- **PR merge success rate**: Should be high with proper reviews
-- **Time to merge**: Should balance speed vs. quality
-- **Security incidents prevented**: Track vulnerabilities caught by scans
-
-### Emergency Procedures
-
-#### Temporary Bypass (Rare)
-
-In extreme circumstances, administrators can temporarily disable branch protection, but this should:
-
-1. Be logged with justification
-2. Be re-enabled immediately after
-3. Trigger additional security review
-
-#### Alternative Merge Strategies
-
-- **Squash merges**: Clean history, easier to revert
-- **Rebase merges**: Linear history, preserves context
-- **Merge commits**: Full history preservation
-
-### Support
-
-For branch protection issues:
-
-1. Check repository settings → Branches
-2. Verify workflow status in Actions tab
-3. Review PR checks and required statuses
-4. Contact repository administrators
 
 ---
 


### PR DESCRIPTION
## Summary
The `## Branch Protection` section in `docs/AUTOMATION.md` documented an aspirational `gh api PUT` recipe with 14 required-check names that never matched the actual CI surface (e.g. `validate-config`, `security-scan`, `docs-verification`, `build-admin`, `build-web`, `validate-crdt`, `snyk-security`) and a `scripts/verify-branch-protection.mjs` Node script that was never written. Anyone copy-pasting it would produce a broken protection rule.

This PR replaces the stale ~334-line section with a 20-line pointer to the actual source of truth (declarations in the private an internal repo + a small bash + `jq` + `gh api` apply script), documents the real posture in plain English, and provides an audit-access path (`founder@revealui.com` + `SECURITY.md`).

Phase D of the branch-protection-sweep handoff (private repo). Phases A–C shipped earlier today and now cover 5 protected branches: `revealui` (main + test, pre-existing), `revvault/main`, `revdev` (main + test), `revcon/main`, `revskills/main`, all with `enforce_admins: true`.

## Changes
- **Replace `## Branch Protection`** (~334 lines → ~20 lines): drops the stale `gh api PUT` recipe, the unwritten `verify-branch-protection.mjs` script, and the 14 stale required-check names. Documents actual posture: `enforce_admins: true`, `required_pull_request_reviews: null`, `strict: false`, per-repo declarations in the private repo.
- **Drop two stale `pnpm verify:branch-protection` references** in unrelated sections (Phase 5: Automated Verification + Quick Test Commands). Replaced with comments pointing at the new section. The script they reference doesn't exist.
- **Net diff:** -305 lines (`2600 → 2295`). TOC anchor `[Branch Protection](#branch-protection)` preserved (heading unchanged).

## Test plan
- [x] `grep "verify:branch-protection\|verify-branch-protection" docs/AUTOMATION.md` — only references now are the new "see X section" pointer comments
- [x] TOC link still resolves (heading is `## Branch Protection` → anchor `#branch-protection`)
- [x] Pre-push gate clean (16/16 checks PASS — see push output)
- [ ] CI (Markdown lint / link check, if any) — checked on PR

## Notes
- The `### Phase 2: Branch Protection Testing` subsection (lines 1063-1099) still describes a "PR review required" workflow that doesn't match current posture. Out of scope here — that subsection lives under "Testing Infrastructure", not "Branch Protection". Can be cleaned up in a follow-up if useful.
- Private repos (forge / revkit / revealcoin) need either a GitHub Pro upgrade OR a rulesets-API extension to the apply script before they can be locked down. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
