### PR TITLE
refactor(services): consolidate email sender into @revealui/services/email

### DIFF
--- a/apps/admin/src/lib/email/index.ts
+++ b/apps/admin/src/lib/email/index.ts
@@ -1,256 +1,40 @@
 /**
- * Email Service
+ * Email Service (admin app)
  *
- * Sends emails using Gmail REST API with domain-wide delegation.
- * Edge-compatible (fetch + jose, no Node.js-only dependencies).
+ * The Gmail JWT/REST sender + retry orchestration is now owned by the
+ * shared `@revealui/services/email` package — this file re-exports those
+ * primitives and keeps the admin-specific senders (recovery + password
+ * reset) that bake in admin URL config.
  *
- * Required env vars:
- *   GOOGLE_SERVICE_ACCOUNT_EMAIL  -  GCP service account email
- *   GOOGLE_PRIVATE_KEY            -  RSA private key (PKCS8 PEM)
- *   EMAIL_FROM                    -  sender address (e.g. noreply@revealui.com)
- *   EMAIL_REPLY_TO                -  default reply-to (e.g. support@revealui.com)
+ * GAP-138 closure: this used to be a ~250-line parallel class-based
+ * implementation that mirrored apps/server/src/lib/email.ts (functional).
+ * Both apps now share the implementation; the only divergence is each
+ * app's wrapper-and-app-specific-templates layer.
+ *
+ * Required env vars are documented at packages/services/src/email/index.ts.
  */
 
 import config from '@revealui/config';
-import { logger } from '@revealui/utils/logger';
-import { importPKCS8, SignJWT } from 'jose';
+import { sendEmail } from '@revealui/services/email';
 
-interface EmailOptions {
-  to: string;
-  subject: string;
-  html: string;
-  text?: string;
-  replyTo?: string;
-}
-
-interface EmailProvider {
-  send(options: EmailOptions): Promise<{ success: boolean; error?: string }>;
-}
-
-function sanitizeEmailHeader(value: string): string {
-  return value.replace(/[\r\n]/g, '');
-}
+// Re-export the shared primitives so admin consumers (and verification.ts)
+// continue to import `sendEmail` etc. from `./index` without churning paths.
+export {
+  type EmailLogger,
+  type EmailOptions,
+  type EmailProvider,
+  type EmailSendResult,
+  GmailProvider,
+  getEmailProvider,
+  MockEmailProvider,
+  type SendEmailOptions,
+  sanitizeEmailHeader,
+  sendEmail,
+} from '@revealui/services/email';
 
 // ---------------------------------------------------------------------------
-// Gmail REST API provider (edge-compatible)
+// Admin-specific senders (URL-coupled to admin config)
 // ---------------------------------------------------------------------------
-
-class GmailProvider implements EmailProvider {
-  private serviceAccountEmail: string;
-  private privateKey: string;
-  private delegateEmail: string;
-
-  constructor() {
-    this.serviceAccountEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || '';
-    this.privateKey = process.env.GOOGLE_PRIVATE_KEY || '';
-    this.delegateEmail = process.env.EMAIL_FROM ?? 'noreply@revealui.com';
-  }
-
-  private async getAccessToken(): Promise<string> {
-    const key = await importPKCS8(this.privateKey.replace(/\\n/g, '\n'), 'RS256');
-
-    const now = Math.floor(Date.now() / 1000);
-    const jwt = await new SignJWT({
-      scope: 'https://www.googleapis.com/auth/gmail.send',
-      sub: this.delegateEmail,
-    })
-      .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
-      .setIssuer(this.serviceAccountEmail)
-      .setAudience('https://oauth2.googleapis.com/token')
-      .setIssuedAt(now)
-      .setExpirationTime(now + 3600)
-      .sign(key);
-
-    const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        assertion: jwt,
-      }),
-    });
-
-    if (!tokenRes.ok) {
-      const body = await tokenRes.text();
-      throw new Error(`Google OAuth2 token exchange failed (${tokenRes.status}): ${body}`);
-    }
-
-    const { access_token } = (await tokenRes.json()) as { access_token: string };
-    return access_token;
-  }
-
-  private buildRawMessage(options: EmailOptions): string {
-    const boundary = `boundary_${Date.now().toString(36)}`;
-    const replyTo = options.replyTo ?? process.env.EMAIL_REPLY_TO;
-
-    const lines = [
-      `From: ${this.delegateEmail}`,
-      `To: ${sanitizeEmailHeader(options.to)}`,
-      `Subject: ${sanitizeEmailHeader(options.subject)}`,
-      'MIME-Version: 1.0',
-      `Content-Type: multipart/alternative; boundary="${boundary}"`,
-    ];
-
-    if (replyTo) {
-      lines.push(`Reply-To: ${sanitizeEmailHeader(replyTo)}`);
-    }
-
-    lines.push('');
-
-    if (options.text) {
-      lines.push(
-        `--${boundary}`,
-        'Content-Type: text/plain; charset="UTF-8"',
-        '',
-        options.text,
-        '',
-      );
-    }
-
-    lines.push(`--${boundary}`, 'Content-Type: text/html; charset="UTF-8"', '', options.html, '');
-    lines.push(`--${boundary}--`);
-
-    const raw = lines.join('\r\n');
-    const bytes = new TextEncoder().encode(raw);
-    let b64 = '';
-    for (let i = 0; i < bytes.length; i += 4096) {
-      b64 += String.fromCharCode(...bytes.subarray(i, i + 4096));
-    }
-    return btoa(b64).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  }
-
-  async send(options: EmailOptions): Promise<{ success: boolean; error?: string }> {
-    if (!(this.serviceAccountEmail && this.privateKey)) {
-      return { success: false, error: 'Gmail service account credentials not configured' };
-    }
-
-    try {
-      const accessToken = await this.getAccessToken();
-      const raw = this.buildRawMessage(options);
-
-      const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ raw }),
-      });
-
-      if (!res.ok) {
-        const body = await res.text();
-        const message = `Gmail API error (${res.status}): ${body}`;
-        if (process.env.NODE_ENV === 'production') {
-          logger.error('Gmail email delivery failed', new Error(message), { to: options.to });
-          throw new Error(`Gmail email delivery failed: ${message}`);
-        }
-        return { success: false, error: message };
-      }
-
-      return { success: true };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown Gmail error';
-      if (process.env.NODE_ENV === 'production') {
-        logger.error('Gmail email delivery failed', new Error(message), { to: options.to });
-        throw new Error(`Gmail email delivery failed: ${message}`);
-      }
-      return { success: false, error: message };
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Mock provider (development)
-// ---------------------------------------------------------------------------
-
-class MockEmailProvider implements EmailProvider {
-  async send(options: EmailOptions): Promise<{ success: boolean; error?: string }> {
-    logger.debug('Mock email sent', {
-      to: options.to,
-      subject: options.subject,
-    });
-    return { success: true };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Provider selection
-// ---------------------------------------------------------------------------
-
-function getEmailProvider(): EmailProvider {
-  // Gmail REST API (production  -  edge-compatible, free with Workspace)
-  if (process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL && process.env.GOOGLE_PRIVATE_KEY) {
-    return new GmailProvider();
-  }
-
-  // No provider configured
-  logger.warn('No email provider configured  -  emails will not be sent.');
-  if (process.env.NODE_ENV === 'development') {
-    return new MockEmailProvider();
-  }
-  return {
-    send: async () => ({ success: false, error: 'No email provider configured' }),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-export async function sendEmail(
-  options: EmailOptions,
-  { maxRetries = 2 }: { maxRetries?: number } = {},
-): Promise<{ success: boolean; error?: string }> {
-  const provider = getEmailProvider();
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await provider.send(options);
-
-      if (result.success) return result;
-
-      if (result.error && /not configured/i.test(result.error)) {
-        return result;
-      }
-
-      if (attempt === maxRetries) {
-        if (process.env.NODE_ENV === 'production') {
-          const errorMsg = `Email delivery failed after ${maxRetries + 1} attempts: ${result.error}`;
-          logger.error('Email delivery failed after retries', new Error(errorMsg), {
-            to: options.to,
-            attempts: maxRetries + 1,
-          });
-          throw new Error(errorMsg);
-        }
-        return result;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt));
-    } catch (error) {
-      if (attempt === maxRetries) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        if (process.env.NODE_ENV === 'production') {
-          const errorMsg = `Email delivery failed after ${maxRetries + 1} attempts: ${message}`;
-          logger.error('Email delivery failed after retries', new Error(errorMsg), {
-            to: options.to,
-            attempts: maxRetries + 1,
-          });
-          throw new Error(errorMsg);
-        }
-        return { success: false, error: message };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt));
-    }
-  }
-
-  if (process.env.NODE_ENV === 'production') {
-    logger.error('Email delivery failed: max retries exceeded', new Error('Max retries exceeded'), {
-      to: options.to,
-    });
-    throw new Error('Email delivery failed: max retries exceeded');
-  }
-  return { success: false, error: 'Max retries exceeded' };
-}
 
 export async function sendRecoveryEmail(
   email: string,

--- a/apps/server/src/lib/email.ts
+++ b/apps/server/src/lib/email.ts
@@ -1,173 +1,43 @@
 /**
  * Edge-compatible email sender for the API service.
  *
- * Uses Gmail REST API with domain-wide delegation.
- * No Node.js-only dependencies  -  fully edge-compatible (fetch + jose).
+ * Thin wrapper over `@revealui/services/email` that preserves the
+ * server's historical void-returning + throw-in-prod API. The shared
+ * implementation lives in packages/services/src/email and is also used
+ * by apps/admin (which exposes its own wrapper that returns the richer
+ * { success, error? } shape).
  *
- * Required env vars:
- *   GOOGLE_SERVICE_ACCOUNT_EMAIL  -  GCP service account email
- *   GOOGLE_PRIVATE_KEY            -  RSA private key (PKCS8 PEM)
- *   EMAIL_FROM                    -  sender address (e.g. noreply@revealui.com)
- *   EMAIL_REPLY_TO                -  default reply-to (e.g. support@revealui.com)
+ * Required env vars are documented at packages/services/src/email/index.ts.
+ *
+ * GAP-138 closure: this used to be a ~210-line parallel implementation of
+ * the Gmail JWT flow (see git history). The shared package owns it now.
  */
 
 import { logger } from '@revealui/core/observability/logger';
-import { importPKCS8, SignJWT } from 'jose';
+import {
+  type EmailOptions,
+  sanitizeEmailHeader,
+  sendEmail as sharedSendEmail,
+} from '@revealui/services/email';
 
-interface EmailOptions {
-  to: string;
-  subject: string;
-  html: string;
-  text?: string;
-  replyTo?: string;
-}
+export type { EmailOptions };
+export { sanitizeEmailHeader };
 
-export function sanitizeEmailHeader(value: string): string {
-  return value.replace(/[\r\n]/g, '');
-}
-
-// ---------------------------------------------------------------------------
-// Gmail REST API provider (edge-compatible)
-// ---------------------------------------------------------------------------
-
-interface GmailConfig {
-  serviceAccountEmail: string;
-  privateKey: string;
-  /** The Workspace user to impersonate (must have Gmail enabled). */
-  delegateEmail: string;
-}
-
-function getGmailConfig(): GmailConfig | null {
-  const serviceAccountEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
-  const privateKey = process.env.GOOGLE_PRIVATE_KEY;
-  const delegateEmail = process.env.EMAIL_FROM ?? 'noreply@revealui.com';
-
-  if (!(serviceAccountEmail && privateKey)) return null;
-  return { serviceAccountEmail, privateKey, delegateEmail };
-}
-
-async function getGmailAccessToken(cfg: GmailConfig): Promise<string> {
-  const key = await importPKCS8(cfg.privateKey.replace(/\\n/g, '\n'), 'RS256');
-
-  const now = Math.floor(Date.now() / 1000);
-  const jwt = await new SignJWT({
-    scope: 'https://www.googleapis.com/auth/gmail.send',
-    sub: cfg.delegateEmail,
-  })
-    .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
-    .setIssuer(cfg.serviceAccountEmail)
-    .setAudience('https://oauth2.googleapis.com/token')
-    .setIssuedAt(now)
-    .setExpirationTime(now + 3600)
-    .sign(key);
-
-  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-      assertion: jwt,
-    }),
-  });
-
-  if (!tokenRes.ok) {
-    const body = await tokenRes.text();
-    throw new Error(`Google OAuth2 token exchange failed (${tokenRes.status}): ${body}`);
-  }
-
-  const { access_token } = (await tokenRes.json()) as { access_token: string };
-  return access_token;
-}
-
-function buildRawMessage(
-  from: string,
-  to: string,
-  subject: string,
-  html: string,
-  text?: string,
-  replyTo?: string,
-): string {
-  const boundary = `boundary_${Date.now().toString(36)}`;
-  const effectiveReplyTo = replyTo ?? process.env.EMAIL_REPLY_TO;
-
-  const lines = [
-    `From: ${from}`,
-    `To: ${to}`,
-    `Subject: ${subject}`,
-    'MIME-Version: 1.0',
-    `Content-Type: multipart/alternative; boundary="${boundary}"`,
-  ];
-
-  if (effectiveReplyTo) {
-    lines.push(`Reply-To: ${sanitizeEmailHeader(effectiveReplyTo)}`);
-  }
-
-  lines.push('');
-
-  if (text) {
-    lines.push(`--${boundary}`, 'Content-Type: text/plain; charset="UTF-8"', '', text, '');
-  }
-
-  lines.push(`--${boundary}`, 'Content-Type: text/html; charset="UTF-8"', '', html, '');
-  lines.push(`--${boundary}--`);
-
-  const raw = lines.join('\r\n');
-  const bytes = new TextEncoder().encode(raw);
-  let b64 = '';
-  for (let i = 0; i < bytes.length; i += 4096) {
-    b64 += String.fromCharCode(...bytes.subarray(i, i + 4096));
-  }
-  return btoa(b64).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-async function sendViaGmail(cfg: GmailConfig, options: EmailOptions): Promise<void> {
-  const accessToken = await getGmailAccessToken(cfg);
-
-  const raw = buildRawMessage(
-    cfg.delegateEmail,
-    sanitizeEmailHeader(options.to),
-    sanitizeEmailHeader(options.subject),
-    options.html,
-    options.text,
-    options.replyTo,
-  );
-
-  const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ raw }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Gmail API error (${res.status}): ${body}`);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
+/**
+ * Send an email via the configured provider.
+ *
+ * Behavior preserved from the pre-GAP-138 implementation:
+ *   - In `NODE_ENV=production`, throws on any non-success result so
+ *     callers (OTP flows, webhook emails) surface delivery failures.
+ *   - In dev / test, returns silently when no provider is configured
+ *     (the shared package's own logger.warn already documents the miss).
+ *
+ * Inject the server's observability logger into the shared retry path so
+ * Hono request-correlation IDs land in the right sink.
+ */
 export async function sendEmail(options: EmailOptions): Promise<void> {
-  // Gmail REST API (edge-compatible, free with Workspace)
-  const gmailConfig = getGmailConfig();
-  if (gmailConfig) {
-    await sendViaGmail(gmailConfig, options);
-    return;
+  const result = await sharedSendEmail(options, { logger });
+  if (!result.success && process.env.NODE_ENV === 'production') {
+    throw new Error(result.error || 'Email delivery failed');
   }
-
-  // No provider  -  in production, throw so callers (e.g. OTP flows) can
-  // surface the delivery failure instead of silently succeeding.
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('No email provider configured');
-  }
-
-  // Development: log and continue
-  logger.warn('Email not sent  -  no provider configured', {
-    to: options.to,
-    subject: options.subject,
-  });
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -13,9 +13,11 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/utils": "workspace:*",
     "@solana/kit": "^6.8.0",
     "@vercel/node": "^5.7.12",
     "drizzle-orm": "catalog:",
+    "jose": "^6.2.2",
     "stripe": "^22.1.0"
   },
   "devDependencies": {
@@ -44,6 +46,10 @@
     "./server": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./email": {
+      "types": "./dist/email/index.d.ts",
+      "import": "./dist/email/index.js"
     },
     "./stripe/payment-intent": {
       "types": "./dist/stripe/payment-intent.d.ts",

--- a/packages/services/src/email/index.ts
+++ b/packages/services/src/email/index.ts
@@ -1,0 +1,320 @@
+/**
+ * Shared Email Service
+ *
+ * Sends emails using Gmail REST API with domain-wide delegation.
+ * Edge-compatible (fetch + jose, no Node.js-only dependencies).
+ *
+ * Required env vars:
+ *   GOOGLE_SERVICE_ACCOUNT_EMAIL  -  GCP service account email
+ *   GOOGLE_PRIVATE_KEY            -  RSA private key (PKCS8 PEM)
+ *   EMAIL_FROM                    -  sender address (e.g. noreply@revealui.com)
+ *   EMAIL_REPLY_TO                -  default reply-to (e.g. support@revealui.com)
+ *
+ * History: this is the consolidated home for what used to be two parallel
+ * implementations at apps/server/src/lib/email.ts (functional, void-returning,
+ * throw-on-fail in prod) and apps/admin/src/lib/email/index.ts (class-based,
+ * { success, error } return, retry-with-backoff). The class-based design wins
+ * because it's the more general shape — extensible to additional providers
+ * (SES, Resend, fallback chains) without re-doing the abstraction work in
+ * each app. Server's wrapper preserves the original void+throw API on top.
+ *
+ * Closes GAP-138.
+ */
+
+import { logger as defaultLogger } from '@revealui/utils/logger';
+import { importPKCS8, SignJWT } from 'jose';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  replyTo?: string;
+}
+
+export interface EmailSendResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface EmailProvider {
+  send(options: EmailOptions): Promise<EmailSendResult>;
+}
+
+/**
+ * Minimal logger contract — matches the shapes exposed by both
+ * `@revealui/utils/logger` and `@revealui/core/observability/logger`,
+ * so consumers in either app surface can inject their preferred logger
+ * without coupling this package to one observability stack.
+ */
+export interface EmailLogger {
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, error?: unknown, context?: Record<string, unknown>): void;
+  debug(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface SendEmailOptions {
+  maxRetries?: number;
+  logger?: EmailLogger;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip CR/LF from header values to prevent header-injection attacks.
+ * Used on To/Subject/Reply-To before they hit the multipart boundary.
+ */
+export function sanitizeEmailHeader(value: string): string {
+  return value.replace(/[\r\n]/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Gmail REST API provider (edge-compatible)
+// ---------------------------------------------------------------------------
+
+export class GmailProvider implements EmailProvider {
+  private serviceAccountEmail: string;
+  private privateKey: string;
+  private delegateEmail: string;
+  private logger: EmailLogger;
+
+  constructor(opts: { logger?: EmailLogger } = {}) {
+    this.serviceAccountEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || '';
+    this.privateKey = process.env.GOOGLE_PRIVATE_KEY || '';
+    this.delegateEmail = process.env.EMAIL_FROM ?? 'noreply@revealui.com';
+    this.logger = opts.logger ?? defaultLogger;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    const key = await importPKCS8(this.privateKey.replace(/\\n/g, '\n'), 'RS256');
+
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await new SignJWT({
+      scope: 'https://www.googleapis.com/auth/gmail.send',
+      sub: this.delegateEmail,
+    })
+      .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+      .setIssuer(this.serviceAccountEmail)
+      .setAudience('https://oauth2.googleapis.com/token')
+      .setIssuedAt(now)
+      .setExpirationTime(now + 3600)
+      .sign(key);
+
+    const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: jwt,
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      const body = await tokenRes.text();
+      throw new Error(`Google OAuth2 token exchange failed (${tokenRes.status}): ${body}`);
+    }
+
+    const { access_token } = (await tokenRes.json()) as { access_token: string };
+    return access_token;
+  }
+
+  private buildRawMessage(options: EmailOptions): string {
+    const boundary = `boundary_${Date.now().toString(36)}`;
+    const replyTo = options.replyTo ?? process.env.EMAIL_REPLY_TO;
+
+    const lines = [
+      `From: ${this.delegateEmail}`,
+      `To: ${sanitizeEmailHeader(options.to)}`,
+      `Subject: ${sanitizeEmailHeader(options.subject)}`,
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    ];
+
+    if (replyTo) {
+      lines.push(`Reply-To: ${sanitizeEmailHeader(replyTo)}`);
+    }
+
+    lines.push('');
+
+    if (options.text) {
+      lines.push(
+        `--${boundary}`,
+        'Content-Type: text/plain; charset="UTF-8"',
+        '',
+        options.text,
+        '',
+      );
+    }
+
+    lines.push(`--${boundary}`, 'Content-Type: text/html; charset="UTF-8"', '', options.html, '');
+    lines.push(`--${boundary}--`);
+
+    const raw = lines.join('\r\n');
+    const bytes = new TextEncoder().encode(raw);
+    let b64 = '';
+    for (let i = 0; i < bytes.length; i += 4096) {
+      b64 += String.fromCharCode(...bytes.subarray(i, i + 4096));
+    }
+    return btoa(b64).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+
+  async send(options: EmailOptions): Promise<EmailSendResult> {
+    if (!(this.serviceAccountEmail && this.privateKey)) {
+      return { success: false, error: 'Gmail service account credentials not configured' };
+    }
+
+    try {
+      const accessToken = await this.getAccessToken();
+      const raw = this.buildRawMessage(options);
+
+      const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ raw }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        const message = `Gmail API error (${res.status}): ${body}`;
+        if (process.env.NODE_ENV === 'production') {
+          this.logger.error('Gmail email delivery failed', new Error(message), { to: options.to });
+          throw new Error(`Gmail email delivery failed: ${message}`);
+        }
+        return { success: false, error: message };
+      }
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown Gmail error';
+      if (process.env.NODE_ENV === 'production') {
+        this.logger.error('Gmail email delivery failed', new Error(message), { to: options.to });
+        throw new Error(`Gmail email delivery failed: ${message}`);
+      }
+      return { success: false, error: message };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock provider (development)
+// ---------------------------------------------------------------------------
+
+export class MockEmailProvider implements EmailProvider {
+  private logger: EmailLogger;
+
+  constructor(opts: { logger?: EmailLogger } = {}) {
+    this.logger = opts.logger ?? defaultLogger;
+  }
+
+  async send(options: EmailOptions): Promise<EmailSendResult> {
+    this.logger.debug('Mock email sent', {
+      to: options.to,
+      subject: options.subject,
+    });
+    return { success: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider selection
+// ---------------------------------------------------------------------------
+
+export function getEmailProvider(opts: { logger?: EmailLogger } = {}): EmailProvider {
+  const logger = opts.logger ?? defaultLogger;
+
+  // Gmail REST API (production  -  edge-compatible, free with Workspace)
+  if (process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL && process.env.GOOGLE_PRIVATE_KEY) {
+    return new GmailProvider({ logger });
+  }
+
+  // No provider configured
+  logger.warn('No email provider configured  -  emails will not be sent.');
+  if (process.env.NODE_ENV === 'development') {
+    return new MockEmailProvider({ logger });
+  }
+  return {
+    send: async () => ({ success: false, error: 'No email provider configured' }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API — sendEmail with retry-with-backoff
+// ---------------------------------------------------------------------------
+
+/**
+ * Send an email via the configured provider. Returns `{ success, error? }`.
+ *
+ * Behavior:
+ *   - Retries up to `maxRetries` (default 2) with exponential backoff
+ *   - "Not configured" errors short-circuit retries (no point retrying that)
+ *   - In `NODE_ENV=production`, after all retries fail → throws
+ *   - In dev, after all retries fail → returns the result
+ *
+ * Inject a custom `logger` if you want a non-default observability stack
+ * (e.g. Hono server logger vs Next admin logger). Defaults to
+ * `@revealui/utils/logger`.
+ */
+export async function sendEmail(
+  options: EmailOptions,
+  { maxRetries = 2, logger: customLogger }: SendEmailOptions = {},
+): Promise<EmailSendResult> {
+  const logger = customLogger ?? defaultLogger;
+  const provider = getEmailProvider({ logger });
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await provider.send(options);
+
+      if (result.success) return result;
+
+      if (result.error && /not configured/i.test(result.error)) {
+        return result;
+      }
+
+      if (attempt === maxRetries) {
+        if (process.env.NODE_ENV === 'production') {
+          const errorMsg = `Email delivery failed after ${maxRetries + 1} attempts: ${result.error}`;
+          logger.error('Email delivery failed after retries', new Error(errorMsg), {
+            to: options.to,
+            attempts: maxRetries + 1,
+          });
+          throw new Error(errorMsg);
+        }
+        return result;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt));
+    } catch (error) {
+      if (attempt === maxRetries) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        if (process.env.NODE_ENV === 'production') {
+          const errorMsg = `Email delivery failed after ${maxRetries + 1} attempts: ${message}`;
+          logger.error('Email delivery failed after retries', new Error(errorMsg), {
+            to: options.to,
+            attempts: maxRetries + 1,
+          });
+          throw new Error(errorMsg);
+        }
+        return { success: false, error: message };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt));
+    }
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    logger.error('Email delivery failed: max retries exceeded', new Error('Max retries exceeded'), {
+      to: options.to,
+    });
+    throw new Error('Email delivery failed: max retries exceeded');
+  }
+  return { success: false, error: 'Max retries exceeded' };
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -32,5 +32,6 @@ export function checkServicesLicense(): boolean {
 }
 
 // Re-export client (client-side) exports
+export * from './email/index.js';
 export * from './revealcoin/index.js';
 export * from './stripe/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1544,6 +1544,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../db
+      '@revealui/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@solana/kit':
         specifier: ^6.8.0
         version: 6.8.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -1553,6 +1556,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       stripe:
         specifier: ^22.1.0
         version: 22.1.0(@types/node@25.6.0)


### PR DESCRIPTION
## Summary

Consolidates two parallel Gmail JWT/REST email implementations (apps/server's ~210 LOC functional + apps/admin's ~250 LOC class-based) into a single shared `packages/services/src/email/`. Both apps now go through the same retry-with-backoff logic and the same Gmail OAuth2 token exchange.

## Design

The class-based shape from `apps/admin` wins — more general, extensible to additional providers (SES, Resend, fallback chain) without re-doing the abstraction work in each app:

- `EmailProvider` interface + `GmailProvider` class + `MockEmailProvider`
- `sendEmail(options, { maxRetries, logger })` with exponential-backoff retry
- Throws in `NODE_ENV=production` after all retries fail; returns `{ success, error? }` in dev
- Optional `logger` injection (Hono server logger vs Next admin logger). Defaults to `@revealui/utils/logger`.
- `sanitizeEmailHeader` exported for reuse

## App wrappers

| File | Role |
|---|---|
| `apps/server/src/lib/email.ts` | Thin wrapper preserving the historical void-returning + throw-in-prod API. Passes server's Hono observability logger through to the shared retry path. |
| `apps/admin/src/lib/email/index.ts` | Re-exports the shared primitives + keeps the admin-specific `sendRecoveryEmail` / `sendPasswordResetEmail` (URL-coupled to admin config). |
| `apps/admin/src/lib/email/verification.ts` | Unchanged (still imports `sendEmail` from `./index`, which now resolves to the shared impl). |

## Test plan

- [x] Local: `pnpm --filter server exec vitest run src/lib/email.test.ts` — 2/2 pass (void return + throw-in-prod still work via server's wrapper).
- [x] Local: `pnpm exec turbo typecheck --filter=server --filter=admin --filter=@revealui/services` — 21/21 tasks green.
- [x] Local: `pnpm exec turbo build --filter=@revealui/services` — clean.
- [x] Local: pre-push gate PASS.
- [ ] CI Quality green.
- [ ] CI Typecheck green.
- [ ] CI Unit tests green.

## Net diff

- 6 files changed, 392 insertions, 405 deletions
- Net **-13 LOC** despite adding the shared package (the deduplication wins)
- New deps in `@revealui/services`: `jose ^6.2.2`, `@revealui/utils workspace:*`

## What's preserved vs what's deduplicated

**Preserved per-app (acceptable divergence):**
- Server's `void` return type + immediate throw-in-prod
- Admin's `{ success, error? }` return + retry semantics
- Server's `@revealui/core/observability/logger` (injected; admin uses default `@revealui/utils/logger`)
- Admin's `sendRecoveryEmail` + `sendPasswordResetEmail` (URL-coupled)

**Deduplicated:**
- Gmail OAuth2 JWT signing flow (jose library)
- `buildRawMessage` MIME multipart construction
- Header sanitization
- Provider abstraction

Closes the audit-violations/per-app-utils-overlap.md F1 finding.
