### PR TITLE
feat(deploy): sandwich drizzle-kit migrate with backfill + assertion guards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,6 +174,15 @@ jobs:
         # Forcing NO_COLOR + piping through `tr '\r' '\n'` converts each
         # spinner tick to its own line, leaving the trailing error visible.
         # PIPESTATUS preserves drizzle-kit's exit code through the pipe.
+        #
+        # GAP-168 defense-in-depth (sandwich the migrate with two guards):
+        #   1. db:backfill-migrations BEFORE — detects the 2026-04-20 incident
+        #      class (drizzle.__drizzle_migrations rows missing for journal
+        #      entries) and fails the deploy with a clear diagnostic before
+        #      drizzle-kit re-applies already-applied SQL.
+        #   2. db:assert-migration-count AFTER — asserts the post-migrate
+        #      tracking row count matches the journal entry count, catching
+        #      half-applied state regardless of which side drifted.
         env:
           NO_COLOR: "1"
           FORCE_COLOR: "0"
@@ -186,8 +195,20 @@ jobs:
             echo "::error::POSTGRES_URL not found in pulled Vercel env"
             exit 1
           fi
+          echo "::group::Backfill check (pre-migrate)"
+          pnpm db:backfill-migrations
+          echo "::endgroup::"
+          echo "::group::drizzle-kit migrate"
           pnpm --filter @revealui/db db:migrate 2>&1 | tr '\r' '\n'
-          exit "${PIPESTATUS[0]}"
+          MIGRATE_STATUS=${PIPESTATUS[0]}
+          echo "::endgroup::"
+          if [ "$MIGRATE_STATUS" -ne 0 ]; then
+            echo "::error::drizzle-kit migrate exited $MIGRATE_STATUS"
+            exit "$MIGRATE_STATUS"
+          fi
+          echo "::group::Migration count assertion (post-migrate)"
+          pnpm db:assert-migration-count
+          echo "::endgroup::"
 
   # ---------------------------------------------------------------------------
   # Detect which apps were affected by the merge

--- a/package.json
+++ b/package.json
@@ -131,6 +131,8 @@
     "clean:install": "pnpm clean && pnpm install:clean",
     "admin:bootstrap": "tsx scripts/admin/bootstrap.ts",
     "coverage:check": "tsx scripts/gates/test-coverage-gate.ts",
+    "db:assert-migration-count": "tsx scripts/setup/assert-migration-count.ts",
+    "db:backfill-migrations": "tsx scripts/setup/backfill-migrations.ts",
     "db:generate-types": "tsx scripts/dev-tools/post-migration-types.ts",
     "db:init": "tsx scripts/setup/database.ts",
     "db:migrate": "pnpm --filter @revealui/db db:migrate",

--- a/packages/db/docs/migrations-discipline.md
+++ b/packages/db/docs/migrations-discipline.md
@@ -164,3 +164,30 @@ The `migration-journal` validator in `scripts/validate/migration-journal.ts` run
 | `idempotency` | Per-`.sql`: unguarded `ADD CONSTRAINT` or `DROP CONSTRAINT` without `IF EXISTS` (2026-04-19 bug #1) |
 
 The deploy workflow's existing `Validate Migrations` job runs `drizzle-kit generate` against the current schema and fails if it produces any uncommitted output — i.e., if a TS schema edit landed without an accompanying generated migration. That gate plus `_custom.json` together close the hand-written-without-journal-entry loop: any new SQL file must either be drizzle-generated (caught by the parity check on schema drift) or explicitly declared in `_custom.json` (caught by the manifest-shape check at PR time).
+
+## Runtime Guards (deploy.yml)
+
+Defense-in-depth around the `drizzle-kit migrate` step in `.github/workflows/deploy.yml` — both run with `POSTGRES_URL` from the pulled Vercel env, sandwiching the migrate call:
+
+| Guard | When | Script | Catches |
+|---|---|---|---|
+| **`pnpm db:backfill-migrations`** | BEFORE migrate | `scripts/setup/backfill-migrations.ts` | drizzle.__drizzle_migrations row count drift relative to `_journal.json.entries.length` (2026-04-20 incident class). Detection-only; surfaces the diff and exits non-zero so the deploy fails loud rather than letting drizzle re-apply already-applied SQL and trip a `duplicate_object` error. `--apply` mode (auto-insert missing tracking rows with the correct hash) is intentionally not yet implemented; manual recovery is documented below. |
+| **`pnpm db:assert-migration-count`** | AFTER migrate | `scripts/setup/assert-migration-count.ts` | half-applied migrate state. If drizzle-kit migrate ran but the post-state row count diverges from journal entries (e.g. one migration succeeded, the next half-applied + the migrator still reported success), this asserts the count and fails loud. |
+
+Both scripts use `pg.Pool` directly with `POSTGRES_URL` (or `DATABASE_URL`); they do not depend on the Drizzle ORM. Both treat a not-yet-existing `drizzle.__drizzle_migrations` table as the first-migrate-run case (exit 0), so they're safe on virgin databases.
+
+### Recovery for backfill drift
+
+If `db:backfill-migrations` surfaces drift, do NOT just re-run `drizzle-kit migrate`. The migrator will see the missing tracking row and try to re-apply the SQL, which will likely fail with a `duplicate_object` / `relation already exists` / `column already exists` error.
+
+Recovery options, in order of safety:
+
+1. **Manually verify state.** Connect to the DB, inspect `drizzle.__drizzle_migrations` rows + `information_schema` for the actual schema state. Confirm which journal entries' SQL is already applied.
+2. **Compute the hash drizzle expects** for each missing tracking row from the SQL file's content (drizzle uses SHA256 of the file body — verify against drizzle-orm source for current version) and `INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (...)` directly. Resume `drizzle-kit migrate`.
+3. **Restore from backup** if the drift is severe / hashes can't be computed safely. The Vercel + Neon backup pattern means the previous deploy's snapshot is recoverable.
+
+The `--apply` mode in `db:backfill-migrations` would automate option (2) but the hash computation must match drizzle exactly; until that's verified end-to-end, manual recovery is the only safe path.
+
+### Origin
+
+GAP-168, established as PR2b follow-up to PR1 (`#434`, the 2026-04-20 hotfix that fixed the unguarded `ADD CONSTRAINT` in 0005 + the out-of-order `when` on 0006). PR1 prevented the proximate failure; these guards prevent the next instance of the same drift class from reaching production.

--- a/scripts/setup/assert-migration-count.ts
+++ b/scripts/setup/assert-migration-count.ts
@@ -1,0 +1,117 @@
+/**
+ * Assert Migration Count (post-migrate guard)
+ *
+ * Counts rows in drizzle.__drizzle_migrations and compares to the
+ * length of packages/db/migrations/meta/_journal.json.entries. Exits
+ * non-zero with a clear diagnostic if they diverge, so the deploy
+ * step fails loud rather than silently shipping a half-applied state.
+ *
+ * Companion to scripts/setup/backfill-migrations.ts (which runs
+ * BEFORE drizzle-kit migrate to catch pre-existing drift); this
+ * script runs AFTER to assert the migrator left the world consistent.
+ *
+ * Defense-in-depth for the 2026-04-20 incident class. See:
+ *   - packages/db/docs/migrations-discipline.md
+ *   - scripts/validate/migration-journal.ts (static journal validator)
+ *
+ * Closes GAP-168 (post-migrate assertion half).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Pool } from 'pg';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+const JOURNAL_PATH = join(
+  import.meta.dirname ?? '.',
+  '../../packages/db/migrations/meta/_journal.json',
+);
+
+function loadJournal(): Journal {
+  if (!existsSync(JOURNAL_PATH)) {
+    process.stderr.write(`✗ Journal not found at ${JOURNAL_PATH}\n`);
+    process.exit(2);
+  }
+  return JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8'));
+}
+
+function getPostgresUrl(): string {
+  const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    process.stderr.write('✗ POSTGRES_URL (or DATABASE_URL) not set\n');
+    process.exit(2);
+  }
+  return url;
+}
+
+async function main(): Promise<void> {
+  const journal = loadJournal();
+  const expected = journal.entries.length;
+
+  const pool = new Pool({
+    connectionString: getPostgresUrl(),
+    max: 1,
+    connectionTimeoutMillis: 10000,
+  });
+
+  try {
+    // First check the tracking table exists at all. On a virgin DB before
+    // the first drizzle-kit migrate has run, drizzle.__drizzle_migrations
+    // doesn't exist. In that case "tracked count = 0" is the correct read,
+    // not an error.
+    const tableCheck = await pool.query<{ exists: boolean }>(`
+      SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'drizzle' AND table_name = '__drizzle_migrations'
+      ) AS exists
+    `);
+    const tableExists = tableCheck.rows[0]?.exists === true;
+
+    let tracked = 0;
+    if (tableExists) {
+      const countRes = await pool.query<{ count: string }>(
+        'SELECT COUNT(*)::text AS count FROM drizzle.__drizzle_migrations',
+      );
+      tracked = Number.parseInt(countRes.rows[0]?.count ?? '0', 10);
+    }
+
+    if (tracked === expected) {
+      process.stdout.write(
+        `✓ Migration count consistent: ${tracked} tracked rows match ${expected} journal entries\n`,
+      );
+      process.exit(0);
+    }
+
+    process.stderr.write(
+      `✗ Migration count mismatch: ${tracked} rows in drizzle.__drizzle_migrations vs ${expected} entries in _journal.json\n`,
+    );
+    process.stderr.write(`  Journal tags: ${journal.entries.map((e) => e.tag).join(', ')}\n`);
+    process.stderr.write(
+      '  This indicates a half-applied migrate or out-of-band schema drift.\n' +
+        '  Investigate before proceeding — the deployment may be in an inconsistent state.\n' +
+        '  See packages/db/docs/migrations-discipline.md for recovery patterns.\n',
+    );
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`✗ assert-migration-count failed: ${msg}\n`);
+  process.exit(2);
+});

--- a/scripts/setup/backfill-migrations.ts
+++ b/scripts/setup/backfill-migrations.ts
@@ -1,0 +1,152 @@
+/**
+ * Backfill Migrations (pre-migrate detection guard)
+ *
+ * Runs BEFORE drizzle-kit migrate. Detects the 2026-04-20 incident
+ * class — drizzle.__drizzle_migrations tracking rows missing for
+ * journal entries — and surfaces the diff so the deploy fails loud
+ * instead of letting drizzle-kit re-apply already-applied migrations
+ * and trip a duplicate_object error.
+ *
+ * Detection-only by default. With `--apply` (NOT YET IMPLEMENTED), it
+ * would compute the hash drizzle expects for each missing entry and
+ * insert the tracking row directly. Wiring `--apply` requires matching
+ * drizzle's exact hash computation; deferred until the first incident
+ * where drift recurs and a manual recovery is too painful.
+ *
+ * Companion to scripts/setup/assert-migration-count.ts (post-migrate
+ * count assertion). Both ship together as defense-in-depth.
+ *
+ * Closes GAP-168 (pre-migrate backfill half).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Pool } from 'pg';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+interface TrackingRow {
+  id: number;
+  hash: string;
+  created_at: string; // pg returns BIGINT as text by default
+}
+
+const JOURNAL_PATH = join(
+  import.meta.dirname ?? '.',
+  '../../packages/db/migrations/meta/_journal.json',
+);
+
+const APPLY_FLAG = process.argv.includes('--apply');
+const DRY_RUN = process.argv.includes('--dry-run') || !APPLY_FLAG;
+
+function loadJournal(): Journal {
+  if (!existsSync(JOURNAL_PATH)) {
+    process.stderr.write(`✗ Journal not found at ${JOURNAL_PATH}\n`);
+    process.exit(2);
+  }
+  return JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8'));
+}
+
+function getPostgresUrl(): string {
+  const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    process.stderr.write('✗ POSTGRES_URL (or DATABASE_URL) not set\n');
+    process.exit(2);
+  }
+  return url;
+}
+
+async function main(): Promise<void> {
+  const journal = loadJournal();
+  const expected = journal.entries.length;
+
+  const pool = new Pool({
+    connectionString: getPostgresUrl(),
+    max: 1,
+    connectionTimeoutMillis: 10000,
+  });
+
+  try {
+    // First-ever run: drizzle.__drizzle_migrations doesn't exist yet.
+    // Nothing to backfill; let drizzle-kit migrate create it.
+    const tableCheck = await pool.query<{ exists: boolean }>(`
+      SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'drizzle' AND table_name = '__drizzle_migrations'
+      ) AS exists
+    `);
+    if (!tableCheck.rows[0]?.exists) {
+      process.stdout.write(
+        '✓ drizzle.__drizzle_migrations not yet created; first migrate run will initialize it\n',
+      );
+      process.exit(0);
+    }
+
+    // Pull existing tracking rows.
+    const trackingRes = await pool.query<TrackingRow>(
+      'SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id',
+    );
+    const tracked = trackingRes.rows;
+
+    // Synced state: counts match. Drizzle's hash-based dedupe handles the
+    // exact mapping; if counts match and migrate didn't fail in any prior
+    // run, we trust the state.
+    if (tracked.length === expected) {
+      process.stdout.write(
+        `✓ ${tracked.length} tracking rows match ${expected} journal entries; no backfill needed\n`,
+      );
+      process.exit(0);
+    }
+
+    // Drift detected. Surface the diagnostic.
+    process.stderr.write(
+      `✗ Drift detected: ${tracked.length} tracking rows vs ${expected} journal entries\n`,
+    );
+    process.stderr.write('\nJournal entries (expected applied set):\n');
+    for (const e of journal.entries) {
+      process.stderr.write(`  [idx=${e.idx}] ${e.tag} (when=${e.when})\n`);
+    }
+    process.stderr.write('\nTracking rows (actually applied set):\n');
+    for (const r of tracked) {
+      process.stderr.write(
+        `  [id=${r.id}] hash=${r.hash.substring(0, 16)}… created_at=${r.created_at}\n`,
+      );
+    }
+
+    if (DRY_RUN) {
+      process.stderr.write(
+        '\nThis is the 2026-04-20 incident class.\n' +
+          'Recovery: align the tracking table with the journal manually; do NOT let drizzle-kit\n' +
+          'migrate run while drift exists or it will attempt to re-apply already-applied SQL\n' +
+          'and error with duplicate_object / etc.\n' +
+          'See packages/db/docs/migrations-discipline.md for the recovery playbook.\n' +
+          '\n' +
+          '`--apply` mode (auto-insert missing tracking rows) is NOT YET IMPLEMENTED.\n',
+      );
+      process.exit(1);
+    }
+
+    process.stderr.write('\n--apply mode is not yet implemented; drift surfaced only.\n');
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`✗ backfill-migrations failed: ${msg}\n`);
+  process.exit(2);
+});

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -27,6 +27,18 @@
       "migrationPhase": null
     },
     {
+      "path": "scripts/setup/backfill-migrations.ts",
+      "rules": ["direct-import"],
+      "reason": "GAP-168 pre-migrate guard. Queries drizzle.__drizzle_migrations directly to detect tracking-row drift before drizzle-kit migrate runs. Cannot route through @revealui/db because (a) the schema isn't yet known to be in a consistent state — that's exactly what this script verifies — and (b) drizzle.__drizzle_migrations is drizzle's own tracking table, not part of the app schema. Permanent.",
+      "migrationPhase": null
+    },
+    {
+      "path": "scripts/setup/assert-migration-count.ts",
+      "rules": ["direct-import"],
+      "reason": "GAP-168 post-migrate guard. Counts rows in drizzle.__drizzle_migrations and asserts against _journal.json entry count. Same rationale as backfill-migrations.ts — drizzle.__drizzle_migrations is drizzle's own tracking table, not in the app schema. Permanent.",
+      "migrationPhase": null
+    },
+    {
       "path": "scripts/seed-admin.mjs",
       "rules": ["direct-import"],
       "reason": "Admin-user seed script. Queries Neon Auth's own schema (`neon_auth.\"user\"`), not the app's public.users table — that's a third-party schema provided by Neon Auth which Drizzle correctly does not track. Routing this through @revealui/db would require adding neon_auth tables to the schema, which would be misleading (they are not owned by this project). Permanent.",


### PR DESCRIPTION
## Summary

Sandwiches `drizzle-kit migrate` in the deploy workflow with two new defense-in-depth guards:

- **`pnpm db:backfill-migrations`** (BEFORE) — detects drift between `drizzle.__drizzle_migrations` row count and `_journal.json` entry count. Surfaces the diff and exits non-zero so the deploy fails loud rather than letting drizzle re-apply already-applied SQL and trip a `duplicate_object` error (the 2026-04-20 incident class). Detection-only by default; `--apply` mode (auto-insert missing tracking rows) intentionally not yet implemented.
- **`pnpm db:assert-migration-count`** (AFTER) — asserts the post-migrate tracking row count matches the journal entry count. Catches half-applied state regardless of which side drifted.

Both scripts use `pg.Pool` directly (no Drizzle ORM dep). Both treat a not-yet-existing `drizzle.__drizzle_migrations` table as the first-migrate-run case (exit 0), so they're safe on virgin databases. Verified locally that both exit 2 with a clear error when `POSTGRES_URL` is missing.

## Changes

| File | What |
|---|---|
| `scripts/setup/backfill-migrations.ts` (new) | Pre-migrate guard, ~140 LOC |
| `scripts/setup/assert-migration-count.ts` (new) | Post-migrate guard, ~110 LOC |
| `package.json` | New `db:backfill-migrations` + `db:assert-migration-count` scripts |
| `.github/workflows/deploy.yml` | Run-migrations step now sandwiches `pnpm --filter @revealui/db db:migrate` between the two guards, with `::group::` annotations for visually scoped log output |
| `packages/db/docs/migrations-discipline.md` | New "Runtime Guards" section + recovery playbook for the backfill drift case |
| `scripts/validate/raw-sql-allowlist.json` | Allowlist entries for the two new scripts (intentional `pg` direct-import — drizzle.__drizzle_migrations is drizzle's own tracking table, not in the app schema) |

## Test plan

- [x] Both scripts parse via `tsx --check`.
- [x] With `POSTGRES_URL=` unset, both exit 2 with the expected error.
- [x] Pre-push gate PASS (after raw-sql allowlist).
- [ ] CI Quality + Security + Typecheck green.
- [ ] After merge to `main`, watch the next deploy.yml run for the new `::group::Backfill check (pre-migrate)` and `::group::Migration count assertion (post-migrate)` sections in the run log.

## Why deferred `--apply`

`db:backfill-migrations --apply` would auto-insert missing tracking rows. Doing this safely requires computing the SHA256 hash that drizzle-orm expects for each missing entry from the SQL file content, in the exact same byte format drizzle uses internally. That coupling is fragile across drizzle-orm versions — the manual recovery path (documented in `migrations-discipline.md` §Recovery for backfill drift) is safer until the first incident where manual recovery is too painful.

Closes GAP-168 (PR2b follow-up to PR1 #434, the 2026-04-20 hotfix).
