### PR TITLE
feat(db): dual-key KEK boot fallback for zero-downtime rotation

### DIFF
--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -145,6 +145,22 @@ describe('validateStartup — production format checks (live mode)', () => {
     expect(() => validateStartup(validLiveProdEnv({ REVEALUI_KEK: 'a'.repeat(63) }))).toThrow();
   });
 
+  it('accepts a valid REVEALUI_KEK_NEXT during dual-key rotation', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ REVEALUI_KEK_NEXT: 'b'.repeat(64) })),
+    ).not.toThrow();
+  });
+
+  it('rejects REVEALUI_KEK_NEXT with wrong length', () => {
+    expect(() => validateStartup(validLiveProdEnv({ REVEALUI_KEK_NEXT: 'b'.repeat(63) }))).toThrow(
+      /REVEALUI_KEK_NEXT must be exactly 64 hexadecimal characters/,
+    );
+  });
+
+  it('treats empty REVEALUI_KEK_NEXT as unset (steady state, no fallback)', () => {
+    expect(() => validateStartup(validLiveProdEnv({ REVEALUI_KEK_NEXT: '' }))).not.toThrow();
+  });
+
   it('rejects REVEALUI_ALERT_EMAIL without an @', () => {
     expect(() => validateStartup(validLiveProdEnv({ REVEALUI_ALERT_EMAIL: 'notanemail' }))).toThrow(
       /REVEALUI_ALERT_EMAIL/,

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -133,6 +133,18 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
     errors.push('REVEALUI_KEK must be exactly 64 hexadecimal characters (256 bits).');
   }
 
+  // Optional dual-key boot (zero-downtime KEK rotation). Only validated when
+  // present — empty/unset is the steady state. When set, must be 64 hex
+  // chars since the crypto layer uses it as the primary encrypt key + first
+  // decrypt attempt during the rotation window.
+  // See docs/runbooks/rotate-kek.md §Zero-downtime path.
+  const kekNext = (env.REVEALUI_KEK_NEXT ?? '').trim();
+  if (kekNext && !/^[0-9a-f]{64}$/i.test(kekNext)) {
+    errors.push(
+      'REVEALUI_KEK_NEXT must be exactly 64 hexadecimal characters when set (transitional key during dual-key rotation).',
+    );
+  }
+
   // Secret minimum length — required in both modes, so always set here.
   const secret = env.REVEALUI_SECRET ?? '';
   if (secret.length < 32) {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -59,6 +59,16 @@ const optionalSchema = z.object({
     .regex(/^[0-9a-f]{64}$/i, 'Must be exactly 64 hex characters')
     .optional(),
 
+  // Transitional encryption key for zero-downtime KEK rotation.
+  // When set: new encrypts use _NEXT, decrypts try _NEXT first then fall
+  // back to REVEALUI_KEK on GCM auth-tag mismatch. After the rotation tool
+  // re-encrypts every row, the operator promotes _NEXT → REVEALUI_KEK and
+  // removes _NEXT. See docs/runbooks/rotate-kek.md §Zero-downtime path.
+  REVEALUI_KEK_NEXT: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/i, 'Must be exactly 64 hex characters')
+    .optional(),
+
   // Cron endpoint authentication
   REVEALUI_CRON_SECRET: secretSchema.optional(),
 

--- a/packages/db/src/__tests__/crypto.test.ts
+++ b/packages/db/src/__tests__/crypto.test.ts
@@ -405,3 +405,172 @@ describe('crypto  -  API key encryption', () => {
     });
   });
 });
+
+// =============================================================================
+// Dual-key boot (GAP-158) — zero-downtime KEK rotation
+// =============================================================================
+
+describe('crypto  -  dual-key boot for KEK rotation', () => {
+  const KEY_OLD_HEX = randomBytes(32).toString('hex');
+  const KEY_NEW_HEX = randomBytes(32).toString('hex');
+  const KEY_OLD_BUF = Buffer.from(KEY_OLD_HEX, 'hex');
+  const KEY_NEW_BUF = Buffer.from(KEY_NEW_HEX, 'hex');
+
+  const originalKek = process.env.REVEALUI_KEK;
+  const originalKekNext = process.env.REVEALUI_KEK_NEXT;
+
+  function setEnv({ kek, next }: { kek?: string; next?: string }) {
+    if (kek === undefined) {
+      delete process.env.REVEALUI_KEK;
+    } else {
+      process.env.REVEALUI_KEK = kek;
+    }
+    if (next === undefined) {
+      delete process.env.REVEALUI_KEK_NEXT;
+    } else {
+      process.env.REVEALUI_KEK_NEXT = next;
+    }
+  }
+
+  afterEach(() => {
+    if (originalKek !== undefined) process.env.REVEALUI_KEK = originalKek;
+    else delete process.env.REVEALUI_KEK;
+    if (originalKekNext !== undefined) process.env.REVEALUI_KEK_NEXT = originalKekNext;
+    else delete process.env.REVEALUI_KEK_NEXT;
+  });
+
+  describe('env-var resolution', () => {
+    it('throws when neither REVEALUI_KEK nor REVEALUI_KEK_NEXT is set', () => {
+      setEnv({});
+      expect(() => encryptApiKey('x')).toThrow('REVEALUI_KEK environment variable is not set');
+    });
+
+    it('works with REVEALUI_KEK only (steady state)', () => {
+      setEnv({ kek: KEY_OLD_HEX });
+      const enc = encryptApiKey('steady');
+      expect(decryptApiKey(enc)).toBe('steady');
+    });
+
+    it('works with REVEALUI_KEK_NEXT only (post-promotion edge state)', () => {
+      // After the rotation tool completes and the operator promotes
+      // _NEXT → REVEALUI_KEK and removes _NEXT, the steady-state config is
+      // REVEALUI_KEK only. During the redeploy that drops _NEXT, the env
+      // may briefly read as _NEXT-only — this test pins that as a valid
+      // configuration (primary = NEXT, no fallback).
+      setEnv({ next: KEY_NEW_HEX });
+      const enc = encryptApiKey('post-promotion');
+      expect(decryptApiKey(enc)).toBe('post-promotion');
+    });
+
+    it('throws naming REVEALUI_KEK_NEXT when its length is wrong', () => {
+      setEnv({ kek: KEY_OLD_HEX, next: 'abc123' });
+      expect(() => encryptApiKey('x')).toThrow(/REVEALUI_KEK_NEXT must be exactly 64 hex/);
+    });
+
+    it('throws naming REVEALUI_KEK when KEK_NEXT is valid + KEK is wrong length', () => {
+      setEnv({ kek: 'abc123', next: KEY_NEW_HEX });
+      expect(() => encryptApiKey('x')).toThrow(
+        /REVEALUI_KEK must be exactly 64 hex characters .* when set as fallback/,
+      );
+    });
+
+    it('throws naming REVEALUI_KEK when KEK alone has wrong length', () => {
+      setEnv({ kek: 'abc123' });
+      expect(() => encryptApiKey('x')).toThrow(/REVEALUI_KEK must be exactly 64 hex/);
+    });
+  });
+
+  describe('encrypt routing (new encrypts go under primary)', () => {
+    it('encrypts under REVEALUI_KEK when only REVEALUI_KEK is set', () => {
+      setEnv({ kek: KEY_OLD_HEX });
+      const enc = encryptApiKey('routing-old');
+      // Independent verification: the parameterized helper using KEY_OLD_BUF
+      // must decrypt cleanly; KEY_NEW_BUF must not.
+      expect(decryptWithKey(KEY_OLD_BUF, enc)).toBe('routing-old');
+      expect(() => decryptWithKey(KEY_NEW_BUF, enc)).toThrow();
+    });
+
+    it('encrypts under REVEALUI_KEK_NEXT when both keys are set', () => {
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      const enc = encryptApiKey('routing-new');
+      // Primary is _NEXT, so the new-key buffer must decrypt and the old must not.
+      expect(decryptWithKey(KEY_NEW_BUF, enc)).toBe('routing-new');
+      expect(() => decryptWithKey(KEY_OLD_BUF, enc)).toThrow();
+    });
+
+    it('encrypts under REVEALUI_KEK_NEXT when only _NEXT is set', () => {
+      setEnv({ next: KEY_NEW_HEX });
+      const enc = encryptApiKey('routing-next-only');
+      expect(decryptWithKey(KEY_NEW_BUF, enc)).toBe('routing-next-only');
+    });
+
+    it('encryptField follows the same routing rule', () => {
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      const enc = encryptField('field-routing');
+      expect(decryptWithKey(KEY_NEW_BUF, enc)).toBe('field-routing');
+    });
+  });
+
+  describe('decrypt fallback', () => {
+    it('decrypts a primary-encrypted row without ever hitting fallback', () => {
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      const enc = encryptApiKey('primary-row'); // encrypted under _NEXT
+      expect(decryptApiKey(enc)).toBe('primary-row');
+    });
+
+    it('decrypts a fallback-encrypted row via the fallback path', () => {
+      // Simulate a row encrypted before rotation started:
+      // 1. Encrypt under KEK alone.
+      setEnv({ kek: KEY_OLD_HEX });
+      const enc = encryptApiKey('legacy-row');
+      // 2. Operator sets _NEXT — decrypt should still work via fallback to KEK.
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      expect(decryptApiKey(enc)).toBe('legacy-row');
+    });
+
+    it('throws when the row is unreadable under both primary and fallback', () => {
+      const ROGUE = randomBytes(32);
+      const enc = encryptWithKey(ROGUE, 'unreadable');
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      expect(() => decryptApiKey(enc)).toThrow();
+    });
+
+    it('throws when only primary is set and the row is encrypted under a different key (no fallback)', () => {
+      const ROGUE = randomBytes(32);
+      const enc = encryptWithKey(ROGUE, 'unreadable-no-fallback');
+      setEnv({ kek: KEY_OLD_HEX });
+      expect(() => decryptApiKey(enc)).toThrow();
+    });
+
+    it('decryptField also takes the fallback path', () => {
+      setEnv({ kek: KEY_OLD_HEX });
+      const enc = encryptField('field-legacy');
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      expect(decryptField(enc)).toBe('field-legacy');
+    });
+  });
+
+  describe('end-to-end rotation flow', () => {
+    it('encrypts, rotates, promotes — every path remains decryptable until the operator finalizes', () => {
+      // Phase 1 — pre-rotation. KEK = K1. Encrypt val under K1.
+      setEnv({ kek: KEY_OLD_HEX });
+      const encUnderOld = encryptApiKey('phase-1');
+
+      // Phase 2 — rotation start. KEK = K1, _NEXT = K2.
+      // Old rows decrypt via fallback; new rows encrypt under K2.
+      setEnv({ kek: KEY_OLD_HEX, next: KEY_NEW_HEX });
+      expect(decryptApiKey(encUnderOld)).toBe('phase-1'); // fallback hit
+      const encUnderNew = encryptApiKey('phase-2');
+      expect(decryptApiKey(encUnderNew)).toBe('phase-2'); // primary hit
+
+      // Phase 3 — operator promotes _NEXT → REVEALUI_KEK and removes _NEXT.
+      // Steady-state config: KEK = K2 only. Rows still under K1 are now
+      // unreachable — the rotation tool was supposed to re-encrypt them.
+      // This pins the contract that without the fallback they fail loud,
+      // not silently.
+      setEnv({ kek: KEY_NEW_HEX });
+      expect(decryptApiKey(encUnderNew)).toBe('phase-2');
+      expect(() => decryptApiKey(encUnderOld)).toThrow();
+    });
+  });
+});

--- a/packages/db/src/crypto.ts
+++ b/packages/db/src/crypto.ts
@@ -1,29 +1,79 @@
 /**
  * @revealui/db/crypto  -  AES-256-GCM envelope encryption for stored API keys
  *
- * Uses a Key Encryption Key (KEK) sourced from the REVEALUI_KEK environment
- * variable (64 hex chars = 32 bytes). Each key is encrypted with a random
- * 96-bit IV; the output is a dot-separated base64url string:
+ * Uses a Key Encryption Key (KEK) sourced from environment variables (each
+ * 64 hex chars = 32 bytes). Each plaintext is encrypted with a random 96-bit
+ * IV; the output is a dot-separated base64url string:
  *
  *   <iv>.<authTag>.<ciphertext>
  *
  * The auth tag provides tamper detection (GCM authenticated encryption).
+ *
+ * Dual-key boot for zero-downtime KEK rotation:
+ *
+ * - `REVEALUI_KEK` is the steady-state key. When it's the only key set,
+ *   encrypt + decrypt both use it.
+ * - During rotation the operator sets `REVEALUI_KEK_NEXT` to the new key
+ *   while keeping `REVEALUI_KEK` as the old key. New encrypts go under
+ *   `REVEALUI_KEK_NEXT`; decrypts try `REVEALUI_KEK_NEXT` first and fall
+ *   back to `REVEALUI_KEK` on auth-tag mismatch (the GCM signal that the
+ *   row was encrypted under a different key).
+ * - After the rotation tool re-encrypts every row under the new key, the
+ *   operator promotes `REVEALUI_KEK_NEXT` → `REVEALUI_KEK` and removes
+ *   `REVEALUI_KEK_NEXT`. No downtime.
+ *
+ * See `~/suite/.jv/docs/runbooks/rotate-kek.md` §Zero-downtime path for the
+ * operator flow.
  */
 
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
 
+import { logger } from '@revealui/utils/logger';
+
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12; // 96-bit IV  -  recommended for AES-GCM
+const KEK_HEX_LENGTH = 64; // 32 bytes / 256 bits
 
-function getKek(): Buffer {
-  const kekHex = process.env.REVEALUI_KEK;
-  if (!kekHex) {
+/**
+ * Resolve the active KEK pair from process.env.
+ *
+ * Returns `{ primary, fallback? }` where:
+ * - `primary` is the key new encrypts go under and the first key tried on
+ *   decrypt. `REVEALUI_KEK_NEXT` if set, otherwise `REVEALUI_KEK`.
+ * - `fallback` is the second key tried on decrypt when the primary fails the
+ *   GCM auth check. Set only when both `REVEALUI_KEK_NEXT` and `REVEALUI_KEK`
+ *   are configured (the dual-key transition window).
+ *
+ * Throws when no key is set, or when a configured key is not 64 hex chars.
+ */
+function getKekPair(): { primary: Buffer; fallback?: Buffer } {
+  const nextHex = (process.env.REVEALUI_KEK_NEXT ?? '').trim();
+  const kekHex = (process.env.REVEALUI_KEK ?? '').trim();
+
+  if (!nextHex && !kekHex) {
     throw new Error('REVEALUI_KEK environment variable is not set');
   }
-  if (kekHex.length !== 64) {
-    throw new Error('REVEALUI_KEK must be exactly 64 hex characters (32 bytes / 256 bits)');
+
+  const primaryHex = nextHex || kekHex;
+  const primaryName = nextHex ? 'REVEALUI_KEK_NEXT' : 'REVEALUI_KEK';
+  if (primaryHex.length !== KEK_HEX_LENGTH) {
+    throw new Error(`${primaryName} must be exactly 64 hex characters (32 bytes / 256 bits)`);
   }
-  return Buffer.from(kekHex, 'hex');
+
+  let fallbackHex: string | undefined;
+  if (nextHex && kekHex) {
+    if (kekHex.length !== KEK_HEX_LENGTH) {
+      throw new Error(
+        'REVEALUI_KEK must be exactly 64 hex characters (32 bytes / 256 bits) when set as fallback during dual-key rotation',
+      );
+    }
+    fallbackHex = kekHex;
+  }
+
+  return {
+    primary: Buffer.from(primaryHex, 'hex'),
+    fallback: fallbackHex ? Buffer.from(fallbackHex, 'hex') : undefined,
+  };
 }
 
 // =============================================================================
@@ -33,7 +83,7 @@ function getKek(): Buffer {
 /**
  * Encrypt with a caller-supplied 32-byte key.
  * Used by KEK rotation tooling so OLD_KEK and NEW_KEK can coexist in one
- * process without conflicting with the singleton `getKek()` reader. All
+ * process without conflicting with the singleton `getKekPair()` reader. All
  * production encrypt/decrypt fns below delegate here.
  */
 export function encryptWithKey(kek: Buffer, plaintext: string): string {
@@ -54,8 +104,8 @@ export function encryptWithKey(kek: Buffer, plaintext: string): string {
 /**
  * Decrypt with a caller-supplied 32-byte key.
  * Throws if tampered (GCM auth tag mismatch), if the envelope is malformed,
- * or if the supplied key does not match the one used to encrypt. Auth-tag-
- * mismatch is the signal KEK rotation tooling uses to detect "encrypted
+ * or if the supplied key does not match the one used to encrypt. Auth-tag
+ * mismatch is the signal the dual-key boot path uses to detect "encrypted
  * under a different key" — catch the throw, try the other key.
  */
 export function decryptWithKey(kek: Buffer, encrypted: string): string {
@@ -81,40 +131,73 @@ export function decryptWithKey(kek: Buffer, encrypted: string): string {
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
 }
 
+/**
+ * Decrypt with the active primary key; on GCM auth-tag mismatch, retry with
+ * the fallback (when configured). Logs a structured `kek-fallback-decrypt`
+ * event on the fallback path so operators can confirm the rotation tool is
+ * making progress (the event count should drop to 0 once every row is
+ * re-encrypted under the new primary).
+ *
+ * Surfaces the primary error when no fallback is configured or both keys
+ * fail (the primary error is the more accurate signal during rotation —
+ * the fallback failing while primary fails too means the row is genuinely
+ * unreadable, not a key-mismatch).
+ */
+function decryptWithFallback(encrypted: string): string {
+  const { primary, fallback } = getKekPair();
+  try {
+    return decryptWithKey(primary, encrypted);
+  } catch (primaryErr) {
+    if (!fallback) throw primaryErr;
+    try {
+      const result = decryptWithKey(fallback, encrypted);
+      logger.warn('KEK decrypt fell back to old key — rotation in flight', {
+        event: 'kek-fallback-decrypt',
+      });
+      return result;
+    } catch {
+      throw primaryErr;
+    }
+  }
+}
+
 // =============================================================================
-// Production Singletons (read REVEALUI_KEK from process.env)
+// Production Singletons (read REVEALUI_KEK[_NEXT] from process.env)
 // =============================================================================
 
 /**
- * Encrypt a plaintext API key using AES-256-GCM.
+ * Encrypt a plaintext API key using AES-256-GCM under the active primary KEK.
  * Returns a dot-separated base64url string: `<iv>.<authTag>.<ciphertext>`
  */
 export function encryptApiKey(plaintext: string): string {
-  return encryptWithKey(getKek(), plaintext);
+  return encryptWithKey(getKekPair().primary, plaintext);
 }
 
 /**
  * Decrypt an encrypted API key produced by `encryptApiKey`.
- * Throws if tampered (GCM auth tag mismatch) or if KEK is wrong.
+ * Tries the primary KEK first; on auth-tag mismatch, retries with the
+ * fallback when configured. Throws on tamper or wrong KEK with no fallback.
  */
 export function decryptApiKey(encrypted: string): string {
-  return decryptWithKey(getKek(), encrypted);
+  return decryptWithFallback(encrypted);
 }
 
 /**
- * Encrypt an arbitrary string field using AES-256-GCM.
- * Same algorithm as `encryptApiKey`; use for TOTP secrets, tokens, etc.
+ * Encrypt an arbitrary string field using AES-256-GCM under the active
+ * primary KEK. Same algorithm as `encryptApiKey`; use for TOTP secrets,
+ * tokens, etc.
  */
 export function encryptField(plaintext: string): string {
-  return encryptWithKey(getKek(), plaintext);
+  return encryptWithKey(getKekPair().primary, plaintext);
 }
 
 /**
  * Decrypt a field encrypted by `encryptField`.
- * Throws on tamper (GCM auth tag mismatch) or wrong KEK.
+ * Tries the primary KEK first; on auth-tag mismatch, retries with the
+ * fallback when configured.
  */
 export function decryptField(encrypted: string): string {
-  return decryptWithKey(getKek(), encrypted);
+  return decryptWithFallback(encrypted);
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a dual-key boot path to `@revealui/db/crypto` that lets the running app accept both `REVEALUI_KEK` and a transitional `REVEALUI_KEK_NEXT` during a rotation window — supporting zero-downtime KEK rotation.

Closes GAP-158 (internal docs).

## Behavior

- **Steady state** (`REVEALUI_KEK` only) — unchanged. Encrypt + decrypt both use `REVEALUI_KEK`. All existing tests pass without modification.
- **Rotation window** (both env vars set):
  - New encrypts go under `REVEALUI_KEK_NEXT` (primary).
  - Decrypts try `REVEALUI_KEK_NEXT` first; on GCM auth-tag mismatch (the signal the row was encrypted under the old key), retry with `REVEALUI_KEK` as fallback.
  - Each fallback hit emits a structured `kek-fallback-decrypt` log so operators can observe rotation progress (volume drops to 0 once every row is re-encrypted).
- **Post-promotion** — operator promotes `_NEXT` → `REVEALUI_KEK` and removes `_NEXT`. Back to steady state.

## Files

- `packages/db/src/crypto.ts` — internal `getKek()` replaced with `getKekPair()` returning `{primary, fallback?}`; private `decryptWithFallback()` added. Singletons (`encrypt/decryptApiKey`, `encrypt/decryptField`) use the new helpers. Parameterized helpers (`encryptWithKey` / `decryptWithKey`) unchanged so the rotation tool at `scripts/security/rotate-kek.ts` continues to use them as-is.
- `packages/config/src/schema.ts` — `REVEALUI_KEK_NEXT` added to optional env schema (same 64-hex regex as `REVEALUI_KEK`).
- `apps/server/src/lib/validate-startup.ts` — format-check `REVEALUI_KEK_NEXT` when set; empty / unset is the steady state.

## Test coverage

- `packages/db/src/__tests__/crypto.test.ts` — 16 new tests in a new `describe` block "dual-key boot for KEK rotation":
  - **env-var resolution** (6): primary-only / both-set / NEXT-only / neither / wrong-length naming each variable correctly
  - **encrypt routing** (4): KEK-only / both-set / NEXT-only / `encryptField` parity, independently verified via `decryptWithKey(KEY_BUF, ...)`
  - **decrypt fallback** (5): primary-success / fallback-success / both-fail rethrow / no-fallback rethrow / `decryptField` fallback parity
  - **end-to-end rotation flow** (1): K1 → both → K2 with all decrypt paths verified at each phase
- `apps/server/src/lib/__tests__/validate-startup.test.ts` — 3 new tests for `REVEALUI_KEK_NEXT` (accepts valid, rejects wrong length, treats empty as unset).
- All 71 crypto tests pass; all 75 validate-startup tests pass; `pnpm typecheck:all` clean (51/51); pre-push gate clean.

## Backward compatibility

Additive. Production environments without `REVEALUI_KEK_NEXT` continue to encrypt + decrypt under `REVEALUI_KEK` exactly as before. Setting `REVEALUI_KEK_NEXT` is opt-in — until an operator deliberately adds it (e.g., as a Vercel env var), the dual-key path is unreachable.

## Runbook

internal docs §Zero-downtime path will be updated in a follow-up internal docs commit pointing at this PR. The "NOT implemented" caveat at line 109 is removed; line 103 (which previously said decrypt order was "KEK first, `_NEXT` fallback") is corrected to match the implemented `_NEXT` first / `KEK` fallback semantics — both because the gap pseudocode specifies this order and because new writes go under `_NEXT`, so trying `_NEXT` first is the asymptotically dominant access pattern.

## Verification

- `pnpm --filter @revealui/db test crypto -- --run` — 71/71 pass
- `pnpm --filter server test src/lib/__tests__/validate-startup.test.ts -- --run` — 75/75 pass
- `pnpm typecheck:all` — 51/51 successful
- Pre-push gate — PASS (quality + security + typecheck + test + build phases)
