### PR TITLE
feat(server): GAP-161 Phase B — fork-based sandbox for revmarket task execution

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -54,7 +54,8 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && pnpm run copy-sandbox-runner",
+    "copy-sandbox-runner": "mkdir -p dist && cp src/services/revmarket-sandbox/revmarket-task-runner.mjs dist/",
     "dev": "tsx watch src/index.ts",
     "lint": "biome check .",
     "start": "node dist/index.js",

--- a/apps/server/src/services/revmarket-executor.ts
+++ b/apps/server/src/services/revmarket-executor.ts
@@ -1,22 +1,31 @@
 /**
- * RevMarket Task Executor (Phase 5.16-B)  -  PREVIEW
+ * RevMarket Task Executor (Phase 5.16-B)
  *
- * ⚠️  PREVIEW FEATURE: Task execution runs in-process with timeout enforcement
- * only. There is no process isolation, filesystem sandboxing, or memory limit
- * enforcement. Use only with trusted agents you control or have reviewed.
- * Full sandboxed execution (child process isolation) is planned for Phase B.
+ * Sandboxed execution shipped via GAP-161. Agent task code runs in a
+ * `child_process.fork()` per task with `--max-old-space-size` memory cap +
+ * SIGTERM/SIGKILL timeout escalation (the `forkProvider` in
+ * `./revmarket-sandbox/`). The PREVIEW caveat about "no process isolation"
+ * is closed; remaining caveats — no syscall-level sandbox (kernel shared with
+ * host), best-effort filesystem isolation (cwd is per-task tmpdir but absolute
+ * paths are still reachable), no network egress firewall — are deferred to
+ * Option D (containers / Vercel Sandbox) when polyglot or hostile-publisher
+ * scenarios arrive.
+ *
+ * Trusted-only deployments (forge customer kits running operator-reviewed
+ * agents) can swap in `noSandboxProvider()` via `configureExecutor` to skip
+ * the fork overhead. Hosted SaaS MUST use `forkProvider`.
  *
  * Manages the lifecycle of autonomous agent task execution:
  *   1. Task claiming  -  atomic claim with priority ordering
- *   2. Timeout enforcement  -  AbortController with configurable maxExecutionMs
+ *   2. Timeout enforcement  -  AbortController + sandbox-side SIGTERM/SIGKILL
  *   3. Progress reporting  -  status updates to task_submissions
  *   4. Output validation  -  schema-checked results
  *   5. Audit trail  -  append-only audit_log entries
  *
  * Architecture:
  *   - Uses the existing `jobs` table as a task queue bridge
- *   - Execution is in-process (not child-process) for Phase A
- *   - Resource limits enforced via timeout only (memory monitoring planned)
+ *   - Execution is forked (Option A — `child_process.fork` per task)
+ *   - Memory limit enforced via `--max-old-space-size`; timeout via SIGTERM→SIGKILL
  *   - All state transitions are atomic (single UPDATE with WHERE state = X)
  */
 
@@ -24,6 +33,8 @@ import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { agentSkills, auditLog, marketplaceAgents, taskSubmissions } from '@revealui/db/schema';
 import { and, eq, sql } from 'drizzle-orm';
+
+import { forkProvider, type SandboxProvider } from './revmarket-sandbox/index.js';
 
 // =============================================================================
 // Configuration
@@ -38,6 +49,13 @@ export interface ExecutorConfig {
   pollIntervalMs: number;
   /** Maximum memory per task in MB (default: 512) */
   maxMemoryMb: number;
+  /**
+   * Sandbox provider used to execute agent code per task. Defaults to
+   * `forkProvider()`. Override at boot for trusted-only deployments
+   * (forge customer kits) with `noSandboxProvider()`, or in tests with
+   * a mock provider.
+   */
+  sandboxProvider: SandboxProvider;
 }
 
 const DEFAULT_CONFIG: ExecutorConfig = {
@@ -45,12 +63,21 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   maxConcurrent: 4,
   pollIntervalMs: 5_000,
   maxMemoryMb: 512,
+  sandboxProvider: forkProvider(),
 };
 
 let config: ExecutorConfig = { ...DEFAULT_CONFIG };
 
 export function configureExecutor(overrides: Partial<ExecutorConfig>): void {
   config = { ...DEFAULT_CONFIG, ...overrides };
+}
+
+/**
+ * Replace the active sandbox provider. Convenience over `configureExecutor`
+ * when only the provider needs to change (e.g. in tests).
+ */
+export function setSandboxProvider(provider: SandboxProvider): void {
+  config = { ...config, sandboxProvider: provider };
 }
 
 // =============================================================================
@@ -185,21 +212,34 @@ export async function executeTask(taskId: string): Promise<TaskResult> {
     outputSchema = skill?.outputSchema ?? null;
   }
 
-  // Execute with timeout
+  // Execute with timeout. The AbortController fires at maxExecMs; the sandbox
+  // provider is responsible for translating the abort into a SIGTERM-then-
+  // SIGKILL escalation (forkProvider) or cooperative cancellation (other
+  // providers). We don't wrap in try/catch because the provider contract
+  // requires it to surface failures as { success: false, error } rather than
+  // throwing — internal sandbox bugs are the only path to a thrown error.
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), maxExecMs);
 
   try {
-    // Phase A: Execution placeholder  -  the actual agent invocation
-    // will be wired to the harness spawner or A2A handler in Phase B.
-    // For now, we validate the pipeline and return a structured response.
-    const result = await runAgentTask(task, controller.signal);
+    const sandboxResult = await config.sandboxProvider.run({
+      taskId: task.id,
+      agentId: task.agentId ?? 'unassigned',
+      skillName: task.skillName,
+      input: (task.input as Record<string, unknown>) ?? {},
+      signal: controller.signal,
+      // TODO(GAP-161 Phase 2.5): honor `marketplace_agents.maxMemoryMb` per
+      // task once the per-agent override path is wired (resourceLimits +
+      // maxMemoryMb columns exist on the schema today as metadata-only).
+      maxMemoryMb: config.maxMemoryMb,
+      maxExecMs,
+    });
 
     clearTimeout(timeout);
 
-    // Validate output against skill schema if available
-    if (result.output && outputSchema) {
-      const validation = validateOutput(result.output, outputSchema);
+    // Validate output against skill schema if available.
+    if (sandboxResult.success && sandboxResult.output && outputSchema) {
+      const validation = validateOutput(sandboxResult.output, outputSchema);
       if (!validation.valid) {
         logger.warn('RevMarket task output failed schema validation', {
           taskId,
@@ -209,51 +249,24 @@ export async function executeTask(taskId: string): Promise<TaskResult> {
     }
 
     return {
-      ...result,
+      success: sandboxResult.success,
+      output: sandboxResult.output,
+      artifacts: [...sandboxResult.artifacts],
+      tokensUsed: sandboxResult.tokensUsed,
       durationMs: Date.now() - startTime,
+      ...(sandboxResult.error !== undefined ? { error: sandboxResult.error } : {}),
     };
   } catch (err) {
     clearTimeout(timeout);
-
-    const isTimeout = err instanceof DOMException && err.name === 'AbortError';
     return {
       success: false,
       output: null,
       artifacts: [],
       tokensUsed: 0,
       durationMs: Date.now() - startTime,
-      error: isTimeout
-        ? `Task timed out after ${maxExecMs}ms`
-        : err instanceof Error
-          ? err.message
-          : 'Unknown execution error',
+      error: err instanceof Error ? err.message : 'Sandbox provider crashed',
     };
   }
-}
-
-/**
- * Placeholder agent task runner. In Phase B, this will delegate to:
- * - SpawnerService for local inference
- * - A2A handler for remote agents
- * - Harness adapters for tool-equipped agents
- */
-async function runAgentTask(
-  task: { id: string; skillName: string; input: Record<string, unknown> },
-  _signal: AbortSignal,
-): Promise<Omit<TaskResult, 'durationMs'>> {
-  // Phase A: Return structured acknowledgment
-  // Full execution pipeline will be wired in Phase B
-  return {
-    success: true,
-    output: {
-      taskId: task.id,
-      skillName: task.skillName,
-      status: 'executed',
-      message: 'Task processed by RevMarket executor',
-    },
-    artifacts: [],
-    tokensUsed: 0,
-  };
 }
 
 // =============================================================================

--- a/apps/server/src/services/revmarket-sandbox/__test-runners__/env-echo.mjs
+++ b/apps/server/src/services/revmarket-sandbox/__test-runners__/env-echo.mjs
@@ -1,0 +1,14 @@
+// Test fixture: runner that posts back its env vars. Used to verify
+// forkProvider strips parent env down to the safe minimum and never leaks
+// REVEALUI_* secrets into the sandbox.
+process.on('message', (msg) => {
+  if (msg?.type !== 'task') return;
+  process.send?.({
+    type: 'result',
+    success: true,
+    output: { env: { ...process.env } },
+    artifacts: [],
+    tokensUsed: 0,
+  });
+  process.exit(0);
+});

--- a/apps/server/src/services/revmarket-sandbox/__test-runners__/infinite-loop.mjs
+++ b/apps/server/src/services/revmarket-sandbox/__test-runners__/infinite-loop.mjs
@@ -1,0 +1,13 @@
+// Test fixture: runner that ignores the task and spins forever on a CPU-bound
+// loop. Used by forkProvider tests to verify timeout-driven SIGTERM/SIGKILL
+// escalation kills the fork.
+process.on('message', (msg) => {
+  if (msg?.type !== 'task') return;
+  // Tight loop with periodic noop so V8 doesn't optimize the whole thing
+  // away. Has no exit condition — only the parent's SIGKILL stops it.
+  let counter = 0;
+  while (true) {
+    counter = (counter + 1) | 0;
+    if (counter < 0) counter = 0;
+  }
+});

--- a/apps/server/src/services/revmarket-sandbox/__test-runners__/memory-bomb.mjs
+++ b/apps/server/src/services/revmarket-sandbox/__test-runners__/memory-bomb.mjs
@@ -1,0 +1,43 @@
+// Test fixture: runner that allocates more heap than the memory cap allows on
+// receiving a task. Used by forkProvider tests to verify --max-old-space-size
+// enforcement kills the fork.
+//
+// Allocation pattern: an array of arrays, each inner array filled with unique
+// objects so V8 cannot dedupe / optimize away. ~5MB per inner array, 200
+// inner arrays → ~1GB heap pressure. With --max-old-space-size=64 the V8 old
+// generation can't grow past ~64MB and the fork hits OOM (typically a
+// FATAL ERROR exit, sometimes a SIGABRT).
+process.on('message', (msg) => {
+  if (msg?.type !== 'task') return;
+  const heap = [];
+  try {
+    for (let i = 0; i < 200; i++) {
+      // Each inner array: 500_000 unique objects. V8 stores object headers
+      // + property slots on the heap, so this is ~5MB per iteration.
+      const inner = [];
+      for (let j = 0; j < 500_000; j++) {
+        inner.push({ i, j, payload: `${i}-${j}` });
+      }
+      heap.push(inner);
+    }
+    // If V8 didn't OOM by here, the cap isn't doing its job — send a
+    // misleading success so the test fails loudly rather than passing on
+    // the wrong path.
+    process.send?.({
+      type: 'result',
+      success: true,
+      output: { allocated: heap.length, total: heap.length * 500_000 },
+      artifacts: [],
+      tokensUsed: 0,
+    });
+  } catch (err) {
+    process.send?.({
+      type: 'result',
+      success: false,
+      output: null,
+      artifacts: [],
+      tokensUsed: 0,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});

--- a/apps/server/src/services/revmarket-sandbox/__test-runners__/silent-exit.mjs
+++ b/apps/server/src/services/revmarket-sandbox/__test-runners__/silent-exit.mjs
@@ -1,0 +1,7 @@
+// Test fixture: runner that exits 0 without ever sending a result. Used to
+// verify forkProvider surfaces "exited without producing a result" as a
+// failure rather than hanging or returning success.
+process.on('message', (msg) => {
+  if (msg?.type !== 'task') return;
+  process.exit(0);
+});

--- a/apps/server/src/services/revmarket-sandbox/__tests__/fork-provider.test.ts
+++ b/apps/server/src/services/revmarket-sandbox/__tests__/fork-provider.test.ts
@@ -1,0 +1,143 @@
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { forkProvider } from '../fork-provider.js';
+import type { SandboxRunOptions } from '../types.js';
+
+const TEST_RUNNERS = fileURLToPath(new URL('../__test-runners__/', import.meta.url));
+const PROD_RUNNER = fileURLToPath(new URL('../revmarket-task-runner.mjs', import.meta.url));
+
+function baseOpts(overrides: Partial<SandboxRunOptions> = {}): SandboxRunOptions {
+  const controller = new AbortController();
+  return {
+    taskId: 'test-task-' + Math.random().toString(36).slice(2, 10),
+    agentId: 'test-agent',
+    skillName: 'echo',
+    input: { hello: 'world' },
+    signal: controller.signal,
+    maxMemoryMb: 128,
+    maxExecMs: 30_000,
+    ...overrides,
+  };
+}
+
+describe('forkProvider — happy path with the production runner', () => {
+  it('runs the bundled stub runner and returns the structured result', async () => {
+    const provider = forkProvider({ runnerPath: PROD_RUNNER });
+    const opts = baseOpts({ skillName: 'happy-skill' });
+    const result = await provider.run(opts);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toMatchObject({
+      taskId: opts.taskId,
+      skillName: 'happy-skill',
+      status: 'executed',
+    });
+    expect(result.artifacts).toEqual([]);
+    expect(result.tokensUsed).toBe(0);
+    expect(result.error).toBeUndefined();
+  }, 30_000);
+
+  it('reports the correct provider tag and name', () => {
+    const provider = forkProvider();
+    expect(provider.tag).toBe('fork');
+    expect(provider.name).toBe('fork');
+  });
+});
+
+describe('forkProvider — environment isolation', () => {
+  const SECRETS_TO_LEAK = {
+    REVEALUI_KEK: 'a'.repeat(64),
+    STRIPE_SECRET_KEY: 'sk_test_should_not_leak',
+    REVEALUI_SECRET: 'session-signing-secret-should-not-leak',
+    POSTGRES_URL: 'postgresql://leak/leak',
+  };
+
+  beforeEach(() => {
+    for (const [k, v] of Object.entries(SECRETS_TO_LEAK)) {
+      process.env[k] = v;
+    }
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(SECRETS_TO_LEAK)) {
+      delete process.env[k];
+    }
+  });
+
+  it('strips parent env to a safe minimum — no REVEALUI / STRIPE / POSTGRES leakage', async () => {
+    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'env-echo.mjs' });
+    const opts = baseOpts();
+    const result = await provider.run(opts);
+
+    expect(result.success).toBe(true);
+    const env = (result.output as { env: Record<string, string> }).env;
+
+    // What MUST be set for the runner to function.
+    expect(env.REVMARKET_SANDBOX).toBe('1');
+    expect(env.REVMARKET_TASK_ID).toBe(opts.taskId);
+    expect(env.PATH).toBeDefined();
+
+    // What MUST NOT leak — every secret-shaped parent var.
+    for (const k of Object.keys(SECRETS_TO_LEAK)) {
+      expect(env[k]).toBeUndefined();
+    }
+  }, 30_000);
+});
+
+describe('forkProvider — memory cap enforcement', () => {
+  it('kills the fork when allocations exceed --max-old-space-size', async () => {
+    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'memory-bomb.mjs' });
+    const result = await provider.run(baseOpts({ maxMemoryMb: 64, maxExecMs: 30_000 }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    // The exit may surface as either "Sandbox crashed (exit=N)" (V8 OOM
+    // produces a non-zero exit) or as a successfully-caught error from
+    // inside the bomb. Either way the result must be a failure.
+    expect(result.output).toBeNull();
+  }, 30_000);
+});
+
+describe('forkProvider — timeout escalation', () => {
+  it('SIGTERMs then SIGKILLs an infinite-loop runner via the abort signal', async () => {
+    const provider = forkProvider({
+      runnerPath: TEST_RUNNERS + 'infinite-loop.mjs',
+      killGraceMs: 500,
+    });
+
+    const controller = new AbortController();
+    // Mirror what the executor does: fire abort after maxExecMs.
+    setTimeout(() => controller.abort(), 500);
+
+    const start = Date.now();
+    const result = await provider.run(baseOpts({ signal: controller.signal, maxExecMs: 500 }));
+    const elapsed = Date.now() - start;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/killed|signal/i);
+    // Must finish well within ~5s (500ms abort + 500ms grace + slack).
+    expect(elapsed).toBeLessThan(5_000);
+  }, 30_000);
+});
+
+describe('forkProvider — silent exit handling', () => {
+  it('surfaces a failure when the runner exits 0 without sending a result', async () => {
+    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'silent-exit.mjs' });
+    const result = await provider.run(baseOpts());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/without producing a result|exited/i);
+  }, 30_000);
+});
+
+describe('forkProvider — provider-misconfiguration', () => {
+  it('returns a structured failure when the runner path does not exist', async () => {
+    const provider = forkProvider({ runnerPath: '/nonexistent/path/runner.mjs' });
+    const result = await provider.run(baseOpts());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  }, 30_000);
+});

--- a/apps/server/src/services/revmarket-sandbox/__tests__/fork-provider.test.ts
+++ b/apps/server/src/services/revmarket-sandbox/__tests__/fork-provider.test.ts
@@ -11,7 +11,7 @@ const PROD_RUNNER = fileURLToPath(new URL('../revmarket-task-runner.mjs', import
 function baseOpts(overrides: Partial<SandboxRunOptions> = {}): SandboxRunOptions {
   const controller = new AbortController();
   return {
-    taskId: 'test-task-' + Math.random().toString(36).slice(2, 10),
+    taskId: `test-task-${Math.random().toString(36).slice(2, 10)}`,
     agentId: 'test-agent',
     skillName: 'echo',
     input: { hello: 'world' },
@@ -67,7 +67,7 @@ describe('forkProvider — environment isolation', () => {
   });
 
   it('strips parent env to a safe minimum — no REVEALUI / STRIPE / POSTGRES leakage', async () => {
-    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'env-echo.mjs' });
+    const provider = forkProvider({ runnerPath: `${TEST_RUNNERS}env-echo.mjs` });
     const opts = baseOpts();
     const result = await provider.run(opts);
 
@@ -88,7 +88,7 @@ describe('forkProvider — environment isolation', () => {
 
 describe('forkProvider — memory cap enforcement', () => {
   it('kills the fork when allocations exceed --max-old-space-size', async () => {
-    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'memory-bomb.mjs' });
+    const provider = forkProvider({ runnerPath: `${TEST_RUNNERS}memory-bomb.mjs` });
     const result = await provider.run(baseOpts({ maxMemoryMb: 64, maxExecMs: 30_000 }));
 
     expect(result.success).toBe(false);
@@ -103,7 +103,7 @@ describe('forkProvider — memory cap enforcement', () => {
 describe('forkProvider — timeout escalation', () => {
   it('SIGTERMs then SIGKILLs an infinite-loop runner via the abort signal', async () => {
     const provider = forkProvider({
-      runnerPath: TEST_RUNNERS + 'infinite-loop.mjs',
+      runnerPath: `${TEST_RUNNERS}infinite-loop.mjs`,
       killGraceMs: 500,
     });
 
@@ -124,7 +124,7 @@ describe('forkProvider — timeout escalation', () => {
 
 describe('forkProvider — silent exit handling', () => {
   it('surfaces a failure when the runner exits 0 without sending a result', async () => {
-    const provider = forkProvider({ runnerPath: TEST_RUNNERS + 'silent-exit.mjs' });
+    const provider = forkProvider({ runnerPath: `${TEST_RUNNERS}silent-exit.mjs` });
     const result = await provider.run(baseOpts());
 
     expect(result.success).toBe(false);

--- a/apps/server/src/services/revmarket-sandbox/fork-provider.ts
+++ b/apps/server/src/services/revmarket-sandbox/fork-provider.ts
@@ -1,0 +1,246 @@
+/**
+ * Fork-based sandbox provider (GAP-161 Option A).
+ *
+ * Spawns a fresh Node `child_process.fork` per task with a memory cap via
+ * `--max-old-space-size`. The fork target receives the task payload over IPC
+ * and posts the result back. On timeout the parent escalates SIGTERM → 5s
+ * grace → SIGKILL.
+ *
+ * Threat model — what this provider DOES protect against:
+ *   - Memory exhaustion of the parent process (fork has its own heap cap)
+ *   - Long-running / infinite-loop agents (timeout escalation)
+ *   - Process-state mutation (process.exit, process.env mutation) bleeding
+ *     into the parent — fork has its own process state
+ *   - Top-level throws — fork crashes, parent stays up, task marked failed
+ *
+ * What it DOES NOT protect against (deferred to Option D when polyglot or
+ * container infra arrives):
+ *   - Filesystem reads outside the per-task tmpdir (best-effort: cwd is set
+ *     to tmpdir, but the agent code can still access absolute paths)
+ *   - Network egress — no firewall enforcement at the OS level
+ *   - Syscall isolation — the fork shares the host kernel
+ *   - Side-channel attacks (timing, cache)
+ *
+ * The PREVIEW notice at apps/server/src/services/revmarket-executor.ts:1-7
+ * is updated to reflect this delta — fork isolation is real but not OS-level.
+ */
+
+import { fork, type ChildProcess } from 'node:child_process';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { logger } from '@revealui/core/observability/logger';
+
+import type {
+  RunnerInboundMessage,
+  RunnerOutboundMessage,
+  SandboxProvider,
+  SandboxResult,
+  SandboxRunOptions,
+} from './types.js';
+
+/** Where the compiled / shipped fork target lives. Resolved at provider construction time. */
+export interface ForkProviderOptions {
+  /**
+   * Path to the fork-target script. Defaults to the bundled
+   * `revmarket-task-runner.mjs` next to this file at runtime. Override only
+   * for tests.
+   */
+  readonly runnerPath?: string;
+  /** SIGTERM-to-SIGKILL grace period in ms. Default 5000. */
+  readonly killGraceMs?: number;
+}
+
+const DEFAULT_KILL_GRACE_MS = 5_000;
+
+export function forkProvider(options: ForkProviderOptions = {}): SandboxProvider {
+  const killGraceMs = options.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+  const runnerPath = options.runnerPath ?? defaultRunnerPath();
+
+  return {
+    tag: 'fork',
+    name: 'fork',
+    async run(opts: SandboxRunOptions): Promise<SandboxResult> {
+      return runForked(opts, runnerPath, killGraceMs);
+    },
+  };
+}
+
+async function runForked(
+  opts: SandboxRunOptions,
+  runnerPath: string,
+  killGraceMs: number,
+): Promise<SandboxResult> {
+  const taskTmp = join(tmpdir(), `revmarket-${opts.taskId}`);
+  await mkdir(taskTmp, { recursive: true });
+
+  let child: ChildProcess | null = null;
+  let killTimer: ReturnType<typeof setTimeout> | null = null;
+  let resolved = false;
+
+  const cleanup = async (): Promise<void> => {
+    if (killTimer) {
+      clearTimeout(killTimer);
+      killTimer = null;
+    }
+    try {
+      await rm(taskTmp, { recursive: true, force: true });
+    } catch (err) {
+      // Tmpdir cleanup failure is non-fatal — log and move on.
+      logger.warn('RevMarket sandbox tmpdir cleanup failed', {
+        taskId: opts.taskId,
+        path: taskTmp,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return new Promise<SandboxResult>((resolve) => {
+    const settle = (result: SandboxResult): void => {
+      if (resolved) return;
+      resolved = true;
+      void cleanup().finally(() => resolve(result));
+    };
+
+    try {
+      child = fork(runnerPath, [], {
+        cwd: taskTmp,
+        // Strip parent env to a safe minimum — runner shouldn't see secrets,
+        // tokens, or RevealUI internals. PATH + HOME are kept so Node can
+        // resolve its own deps; everything else is intentionally absent.
+        env: {
+          PATH: process.env.PATH ?? '',
+          HOME: process.env.HOME ?? '',
+          NODE_ENV: process.env.NODE_ENV ?? 'production',
+          REVMARKET_SANDBOX: '1',
+          REVMARKET_TASK_ID: opts.taskId,
+        },
+        execArgv: [`--max-old-space-size=${opts.maxMemoryMb}`],
+        // Don't inherit parent stdio — keep agent stdout/stderr captured for
+        // future telemetry. Pipe so we can drain if needed.
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        serialization: 'json',
+      });
+    } catch (err) {
+      settle({
+        success: false,
+        output: null,
+        artifacts: [],
+        tokensUsed: 0,
+        error: `Failed to fork sandbox: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    const proc = child;
+    if (!proc) {
+      settle({
+        success: false,
+        output: null,
+        artifacts: [],
+        tokensUsed: 0,
+        error: 'Fork returned no child handle',
+      });
+      return;
+    }
+
+    // Drain stdout/stderr so the pipe doesn't fill up and block the runner.
+    proc.stdout?.on('data', () => {});
+    proc.stderr?.on('data', () => {});
+
+    proc.on('message', (msg: RunnerOutboundMessage) => {
+      if (msg && typeof msg === 'object' && msg.type === 'result') {
+        settle({
+          success: msg.success,
+          output: msg.output,
+          artifacts: msg.artifacts,
+          tokensUsed: msg.tokensUsed,
+          ...(msg.error !== undefined ? { error: msg.error } : {}),
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      settle({
+        success: false,
+        output: null,
+        artifacts: [],
+        tokensUsed: 0,
+        error: `Fork errored: ${err.message}`,
+      });
+    });
+
+    proc.on('exit', (code, signal) => {
+      if (resolved) return;
+      // Runner exited without sending a result message. Decide the cause:
+      //   - signal=SIGKILL/SIGTERM after timeout: aborted
+      //   - code != 0: crashed
+      //   - code = 0 but no message: silent exit (process.exit(0) without sending)
+      const isAbort = signal === 'SIGKILL' || signal === 'SIGTERM';
+      settle({
+        success: false,
+        output: null,
+        artifacts: [],
+        tokensUsed: 0,
+        error: isAbort
+          ? `Sandbox killed (signal=${signal})`
+          : code !== 0
+            ? `Sandbox crashed (exit=${code})`
+            : 'Sandbox exited without producing a result',
+      });
+    });
+
+    // Abort handling: SIGTERM, then SIGKILL after grace period.
+    const onAbort = (): void => {
+      if (resolved || !proc.pid) return;
+      try {
+        proc.kill('SIGTERM');
+      } catch {
+        // Process may already be gone; the exit handler will settle.
+      }
+      killTimer = setTimeout(() => {
+        if (resolved || !proc.pid) return;
+        try {
+          proc.kill('SIGKILL');
+        } catch {
+          // Same — exit handler will settle.
+        }
+      }, killGraceMs);
+    };
+
+    if (opts.signal.aborted) {
+      onAbort();
+    } else {
+      opts.signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    // Send the task payload over IPC.
+    const inbound: RunnerInboundMessage = {
+      type: 'task',
+      taskId: opts.taskId,
+      agentId: opts.agentId,
+      skillName: opts.skillName,
+      input: opts.input,
+    };
+    try {
+      proc.send(inbound);
+    } catch (err) {
+      settle({
+        success: false,
+        output: null,
+        artifacts: [],
+        tokensUsed: 0,
+        error: `Failed to send task to sandbox: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  });
+}
+
+function defaultRunnerPath(): string {
+  // The runner ships as a sibling .mjs — both in `src/` (for tsx-driven dev)
+  // and in `dist/` (for compiled prod). At runtime, `import.meta.url` of
+  // this module points at the right neighborhood; the runner sits next to it.
+  const url = new URL('./revmarket-task-runner.mjs', import.meta.url);
+  return url.pathname;
+}

--- a/apps/server/src/services/revmarket-sandbox/fork-provider.ts
+++ b/apps/server/src/services/revmarket-sandbox/fork-provider.ts
@@ -25,7 +25,7 @@
  * is updated to reflect this delta — fork isolation is real but not OS-level.
  */
 
-import { fork, type ChildProcess } from 'node:child_process';
+import { type ChildProcess, fork } from 'node:child_process';
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -117,9 +117,10 @@ async function runForked(
           REVMARKET_TASK_ID: opts.taskId,
         },
         execArgv: [`--max-old-space-size=${opts.maxMemoryMb}`],
-        // Don't inherit parent stdio — keep agent stdout/stderr captured for
-        // future telemetry. Pipe so we can drain if needed.
-        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        // Don't inherit parent stdio. Discard agent stdout/stderr at the OS
+        // level (no Node-side draining required). Future telemetry hook can
+        // switch to 'pipe' and attach a sink at that point.
+        stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
         serialization: 'json',
       });
     } catch (err) {
@@ -144,10 +145,6 @@ async function runForked(
       });
       return;
     }
-
-    // Drain stdout/stderr so the pipe doesn't fill up and block the runner.
-    proc.stdout?.on('data', () => {});
-    proc.stderr?.on('data', () => {});
 
     proc.on('message', (msg: RunnerOutboundMessage) => {
       if (msg && typeof msg === 'object' && msg.type === 'result') {

--- a/apps/server/src/services/revmarket-sandbox/index.ts
+++ b/apps/server/src/services/revmarket-sandbox/index.ts
@@ -1,0 +1,22 @@
+/**
+ * RevMarket sandbox provider — public surface (GAP-161).
+ *
+ * - `forkProvider()` — Option A — `child_process.fork` per task. Default.
+ * - `noSandboxProvider()` — opt-in trusted execution (forge / dev).
+ *
+ * Future Option D (containers / Vercel sandbox / Daytona) and Option E (WASM)
+ * plug in here without touching the executor.
+ *
+ * Provider selection lives in the executor's config (`configureExecutor`) so
+ * deployments can pick at boot time.
+ */
+
+export { forkProvider, type ForkProviderOptions } from './fork-provider.js';
+export { noSandboxProvider, type NoSandboxProviderOptions } from './no-sandbox-provider.js';
+export type {
+  RunnerInboundMessage,
+  RunnerOutboundMessage,
+  SandboxProvider,
+  SandboxResult,
+  SandboxRunOptions,
+} from './types.js';

--- a/apps/server/src/services/revmarket-sandbox/index.ts
+++ b/apps/server/src/services/revmarket-sandbox/index.ts
@@ -11,8 +11,8 @@
  * deployments can pick at boot time.
  */
 
-export { forkProvider, type ForkProviderOptions } from './fork-provider.js';
-export { noSandboxProvider, type NoSandboxProviderOptions } from './no-sandbox-provider.js';
+export { type ForkProviderOptions, forkProvider } from './fork-provider.js';
+export { type NoSandboxProviderOptions, noSandboxProvider } from './no-sandbox-provider.js';
 export type {
   RunnerInboundMessage,
   RunnerOutboundMessage,

--- a/apps/server/src/services/revmarket-sandbox/no-sandbox-provider.ts
+++ b/apps/server/src/services/revmarket-sandbox/no-sandbox-provider.ts
@@ -1,0 +1,67 @@
+/**
+ * No-sandbox provider (GAP-161).
+ *
+ * Runs the agent skill IN-PROCESS in the executor — no isolation. Mirrors the
+ * pre-GAP-161 behavior of `runAgentTask`.
+ *
+ * **Only valid for fully-trusted contexts** — typically:
+ *   - Forge customer deployments where the operator runs only their own
+ *     reviewed agent code (no public marketplace exposure).
+ *   - Dev / test environments where fork-overhead is a measurable nuisance.
+ *
+ * Hosted SaaS deployments (revealui.com) MUST use `forkProvider()` — this
+ * provider trades safety for simplicity.
+ *
+ * Naming follows the sandcastle convention (`noSandbox()`); the explicit
+ * "no-sandbox" tag in logs makes the unsafe choice visible at audit time.
+ */
+
+import type { SandboxProvider, SandboxResult, SandboxRunOptions } from './types.js';
+
+export interface NoSandboxProviderOptions {
+  /**
+   * Caller-supplied promise-of-result generator. Tests substitute a function
+   * that simulates adversarial behavior; production callers leave this
+   * undefined and get the same stub the fork target runs.
+   */
+  readonly run?: (
+    opts: SandboxRunOptions,
+  ) => Promise<Omit<SandboxResult, 'success'> & { success: boolean }>;
+}
+
+export function noSandboxProvider(options: NoSandboxProviderOptions = {}): SandboxProvider {
+  const runner = options.run ?? defaultStub;
+  return {
+    tag: 'no-sandbox',
+    name: 'no-sandbox',
+    async run(opts: SandboxRunOptions): Promise<SandboxResult> {
+      try {
+        return await runner(opts);
+      } catch (err) {
+        return {
+          success: false,
+          output: null,
+          artifacts: [],
+          tokensUsed: 0,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  };
+}
+
+async function defaultStub(opts: SandboxRunOptions): Promise<SandboxResult> {
+  // Mirror revmarket-task-runner.mjs's stub. When real agent dispatch lands,
+  // both providers should call the shared dispatcher.
+  return {
+    success: true,
+    output: {
+      taskId: opts.taskId,
+      skillName: opts.skillName,
+      status: 'executed',
+      message: 'Task processed by RevMarket sandbox runner',
+    },
+    artifacts: [],
+    tokensUsed: 0,
+  };
+}

--- a/apps/server/src/services/revmarket-sandbox/revmarket-task-runner.mjs
+++ b/apps/server/src/services/revmarket-sandbox/revmarket-task-runner.mjs
@@ -1,0 +1,101 @@
+/**
+ * RevMarket fork-target runner (GAP-161).
+ *
+ * Spawned by `forkProvider()` in `fork-provider.ts`. Receives one task message
+ * over IPC, runs the matching agent skill, posts the result back, and exits.
+ *
+ * Written as plain ESM JavaScript (`.mjs`) so it can be `child_process.fork`'d
+ * directly by Node in both dev (tsx-driven parent) and prod (compiled-JS parent)
+ * without depending on a TypeScript build for the fork target itself. Wire-format
+ * messages are stable (see RunnerInboundMessage / RunnerOutboundMessage in
+ * `types.ts`).
+ *
+ * Phase B contract:
+ *   - Today, agent skills don't yet have runtime code. This runner returns a
+ *     structured stub identical to the previous in-process placeholder
+ *     (revmarket-executor.ts pre-GAP-161). When real agent code lands (Phase C+),
+ *     this is the integration point: replace `runStub` with a dispatcher that
+ *     loads the agent module by ID and invokes the skill.
+ *   - Runner errors are caught and surfaced as `{ success: false, error }`.
+ *   - Runner top-level throws crash the fork; parent's exit handler turns
+ *     that into a `failed` task.
+ *
+ * Sandbox-side hygiene:
+ *   - cwd is set by the parent to a per-task tmpdir.
+ *   - env is stripped to PATH/HOME/NODE_ENV/REVMARKET_*.
+ *   - --max-old-space-size enforces the memory cap.
+ */
+
+if (process.env.REVMARKET_SANDBOX !== '1') {
+  // Belt-and-suspenders: refuse to run if not invoked by the sandbox parent.
+  // Stops accidental direct invocation that would skip the env-stripping +
+  // memory cap setup.
+  console.error('revmarket-task-runner must be spawned by forkProvider; refusing direct invoke');
+  process.exit(2);
+}
+
+process.on('message', async (msg) => {
+  if (!msg || typeof msg !== 'object' || msg.type !== 'task') {
+    sendResult({
+      success: false,
+      output: null,
+      artifacts: [],
+      tokensUsed: 0,
+      error: `Unexpected message shape: ${JSON.stringify(msg).slice(0, 200)}`,
+    });
+    process.exit(1);
+    return;
+  }
+
+  try {
+    const result = await runStub(msg);
+    sendResult(result);
+    process.exit(0);
+  } catch (err) {
+    sendResult({
+      success: false,
+      output: null,
+      artifacts: [],
+      tokensUsed: 0,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exit(1);
+  }
+});
+
+// Fail loud if the parent never sends a task within a generous bound. Belt-and-
+// suspenders against the parent dying mid-handshake; the parent's own timeout
+// will normally fire first.
+setTimeout(() => {
+  console.error('revmarket-task-runner: no task received within 60s, exiting');
+  process.exit(3);
+}, 60_000).unref();
+
+/**
+ * Stub agent execution — mirrors the placeholder behavior from the pre-GAP-161
+ * `runAgentTask` in revmarket-executor.ts. Real agent dispatch will replace
+ * this body when agent runtime code lands.
+ */
+async function runStub(task) {
+  return {
+    success: true,
+    output: {
+      taskId: task.taskId,
+      skillName: task.skillName,
+      status: 'executed',
+      message: 'Task processed by RevMarket sandbox runner',
+    },
+    artifacts: [],
+    tokensUsed: 0,
+  };
+}
+
+function sendResult(payload) {
+  if (typeof process.send !== 'function') {
+    // Not running under fork IPC — nothing to send to. Print to stderr so
+    // it's visible if the runner is ever launched manually for debugging.
+    console.error('revmarket-task-runner: no IPC channel; result discarded:', payload);
+    return;
+  }
+  process.send({ type: 'result', ...payload });
+}

--- a/apps/server/src/services/revmarket-sandbox/types.ts
+++ b/apps/server/src/services/revmarket-sandbox/types.ts
@@ -1,0 +1,91 @@
+/**
+ * RevMarket sandbox provider interface (GAP-161 Phase B).
+ *
+ * The sandbox layer is the boundary between the trusted executor and untrusted
+ * agent code. Today the only provider is `forkProvider()` (Node `child_process.fork`
+ * per task — Option A in GAP-161), but the interface accepts future providers
+ * (containerized — Docker / Podman / Firecracker; isolated-vm; WASM) without
+ * touching the executor.
+ *
+ * Inspiration: `mattpocock/sandcastle` provider pattern, slimmed for one-shot
+ * task execution (no worktree / branch / shell-exec semantics — those are
+ * sandcastle's domain, not ours).
+ */
+
+export interface SandboxProvider {
+  /** Stable variant tag — distinguishes provider families for routing logic. */
+  readonly tag: 'fork' | 'no-sandbox' | string;
+  /** Display name for logs / observability. */
+  readonly name: string;
+  /**
+   * Execute a single task in the sandbox.
+   *
+   * Implementations are responsible for:
+   *   1. Honoring the abort signal — SIGTERM grace + SIGKILL escalation, or
+   *      cooperative cancellation depending on provider semantics.
+   *   2. Memory enforcement up to `maxMemoryMb` (best-effort per provider —
+   *      `forkProvider` uses `--max-old-space-size`; container providers will
+   *      use cgroup limits).
+   *   3. Filesystem isolation appropriate to the provider's threat model.
+   *   4. Cleanup of any per-task state (tmpdirs, containers, etc.).
+   *
+   * Must NOT throw on sandbox-internal failures — those should surface as
+   * `{ success: false, error }` so the executor can transition the task to
+   * `failed` cleanly and write the audit trail.
+   *
+   * MAY throw only on provider-misconfiguration errors (e.g. fork target
+   * script missing, container daemon unreachable) since those represent
+   * operator bugs, not agent failures.
+   */
+  run(opts: SandboxRunOptions): Promise<SandboxResult>;
+}
+
+export interface SandboxRunOptions {
+  /** Marketplace task ID (used for tmpdir naming, log correlation). */
+  readonly taskId: string;
+  /** Marketplace agent ID — surfaced to the runner so the agent can self-identify. */
+  readonly agentId: string;
+  /** Skill name within the agent — selects which entrypoint runs. */
+  readonly skillName: string;
+  /** Caller-supplied input payload (already validated against skill input schema). */
+  readonly input: Record<string, unknown>;
+  /** Aborted by the executor on timeout, user cancel, or executor shutdown. */
+  readonly signal: AbortSignal;
+  /** Per-task memory cap in MB. Honored best-effort. */
+  readonly maxMemoryMb: number;
+  /**
+   * Maximum execution time in ms. Sandbox should escalate (SIGTERM → grace →
+   * SIGKILL) at this boundary. Caller's `signal` will fire at the same time
+   * but the sandbox is responsible for actually killing the process.
+   */
+  readonly maxExecMs: number;
+}
+
+export interface SandboxResult {
+  readonly success: boolean;
+  readonly output: Record<string, unknown> | null;
+  readonly artifacts: ReadonlyArray<{ name: string; url: string; mimeType: string }>;
+  readonly tokensUsed: number;
+  readonly error?: string;
+}
+
+/**
+ * Wire-format messages over the provider's IPC / IO channel. Stable so the
+ * fork-target script can be a plain `.mjs` file independent of TS types here.
+ */
+export type RunnerInboundMessage = {
+  readonly type: 'task';
+  readonly taskId: string;
+  readonly agentId: string;
+  readonly skillName: string;
+  readonly input: Record<string, unknown>;
+};
+
+export type RunnerOutboundMessage = {
+  readonly type: 'result';
+  readonly success: boolean;
+  readonly output: Record<string, unknown> | null;
+  readonly artifacts: ReadonlyArray<{ name: string; url: string; mimeType: string }>;
+  readonly tokensUsed: number;
+  readonly error?: string;
+};


### PR DESCRIPTION
## Summary

Replaces the in-process placeholder `runAgentTask` in the revmarket executor with a pluggable `SandboxProvider` interface. Default provider is `forkProvider()` — Option A from GAP-161: `child_process.fork` per task with `--max-old-space-size` memory cap + SIGTERM/SIGKILL timeout escalation.

Closes GAP-161 Phase B (internal docs).

## Architecture

| File | Role |
|---|---|
| `apps/server/src/services/revmarket-sandbox/types.ts` | `SandboxProvider` contract — `tag`, `name`, `run(opts)`. Slimmer than `mattpocock/sandcastle` (no worktree/branch/exec semantics — that's their domain, not the marketplace's). |
| `apps/server/src/services/revmarket-sandbox/fork-provider.ts` | Option A. Per-task tmpdir as cwd, env stripped to `PATH`/`HOME`/`NODE_ENV` + `REVMARKET_*`, `--max-old-space-size` cap, SIGTERM (5s grace) → SIGKILL on abort. |
| `apps/server/src/services/revmarket-sandbox/no-sandbox-provider.ts` | Opt-in trusted alternative (forge customer kits running operator-reviewed agents). Explicit `no-sandbox` tag in logs makes the unsafe choice visible at audit time. |
| `apps/server/src/services/revmarket-sandbox/revmarket-task-runner.mjs` | Fork target. Plain ESM JS so it runs under both tsx-driven dev and tsup-bundled prod without a TS compile step. Refuses direct invocation (`REVMARKET_SANDBOX` env guard). |
| `apps/server/src/services/revmarket-executor.ts` | `runAgentTask` removed. `executeTask` now calls `config.sandboxProvider.run({...})`. Existing AbortController + timeout pattern preserved; signal feeds the provider's escalation. |

## Threat model

**What this provider DOES protect against:**

- Memory exhaustion of the parent process (fork has its own heap cap, enforced by V8)
- Long-running / infinite-loop agents (timeout escalation: SIGTERM → 5s grace → SIGKILL)
- Process-state mutation (`process.exit`, `process.env` mutation, `process.chdir`) bleeding into the parent
- Top-level throws — fork crashes, parent stays up, task marked failed cleanly

**What it does NOT protect against** (deferred to Option D when polyglot or container infra arrives):

- Filesystem reads outside the per-task tmpdir (best-effort: cwd is set to tmpdir, but absolute paths are still reachable)
- Network egress — no firewall enforcement at the OS level
- Syscall isolation — kernel is shared with host
- Side-channel attacks (timing, cache)

The provider abstraction is designed so Option D (containers / Vercel Sandbox / Daytona) and Option E (WASM) drop in without touching the executor.

## Build

The `.mjs` runner is loaded at runtime via `child_process.fork`, not via TS import — so tsup's bundle step doesn't pick it up automatically. Added a `copy-sandbox-runner` postbuild script in `apps/server/package.json` that copies `revmarket-task-runner.mjs` to `dist/` after each build. `defaultRunnerPath()` resolves via `import.meta.url` in both src/ (dev) and dist/ (prod) layouts.

## Test coverage

`apps/server/src/services/revmarket-sandbox/__tests__/fork-provider.test.ts` — 7 tests, all passing:

| Test | Verifies |
|---|---|
| **happy path** | Bundled stub runner returns the structured stub result |
| **provider tag/name** | `provider.tag === 'fork'`, `provider.name === 'fork'` |
| **env isolation** | `REVEALUI_KEK` / `STRIPE_SECRET_KEY` / `REVEALUI_SECRET` / `POSTGRES_URL` set on parent never reach the child. `REVMARKET_SANDBOX=1` and `REVMARKET_TASK_ID` are present. |
| **memory cap** | ~1GB allocator under `maxMemoryMb=64` → fork OOM killed, surfaced as `{ success: false, error }` |
| **timeout** | Infinite-loop runner aborted at `maxExecMs=500` → SIGTERM → SIGKILL after 500ms grace, finishes within 5s |
| **silent exit** | Runner exits 0 without sending result → "exited without producing a result" failure |
| **misconfiguration** | Nonexistent runner path → structured failure (not thrown) |

Test fixtures live in `apps/server/src/services/revmarket-sandbox/__test-runners__/`: `memory-bomb.mjs`, `infinite-loop.mjs`, `silent-exit.mjs`, `env-echo.mjs`. Each is a small `.mjs` that exercises one boundary.

## Verification

- `pnpm --filter server test src/services/revmarket-sandbox/__tests__/fork-provider.test.ts -- --run` — 7/7 pass
- `pnpm exec biome check apps/server/src/services/revmarket-executor.ts apps/server/src/services/revmarket-sandbox/` — clean
- `pnpm turbo build --filter=server` — clean; `dist/revmarket-task-runner.mjs` (3.5KB) lands next to `dist/index.js`
- Pre-push gate — PASS (Phase 1 quality + security + Phase 2 typecheck + Phase 3 test+build)

## Inspiration

Provider abstraction pattern lifted from [mattpocock/sandcastle](https://github.com/mattpocock/sandcastle), slimmed down — sandcastle orchestrates autonomous AI coding agents (worktrees, branches, prompts, iterations), which is far heavier than what one-shot revmarket task execution needs. We took the **pluggable `SandboxProvider` contract** + **explicit "no-sandbox" tag for trusted contexts** and skipped the worktree / shell-exec / Effect runtime layers.

## Deferred (per gap acceptance)

- Per-agent `maxMemoryMb` override from `marketplace_agents.maxMemoryMb` schema column. The column exists today as metadata-only. Wired as a `TODO(GAP-161 Phase 2.5)` in the executor; currently uses `config.maxMemoryMb`.
- Adversarial FS-isolation tests beyond cwd/env stripping (e.g. agent that reads `/etc/passwd`). The cwd + env stripping is in place; explicit reach-out tests follow as a follow-up.
- Vercel deployment story for the `.mjs` runner — only matters when `startExecutor()` gets wired into the prod boot path. Currently the executor is preview-only.

## Backward compatibility

Additive. Existing `executeTask` API unchanged. Existing `configureExecutor(overrides)` accepts the new `sandboxProvider` field as optional — defaults to `forkProvider()`. Existing tests (none for revmarket-executor before this PR) are unaffected; new tests are isolated to the sandbox module.
