### PR TITLE
fix(ci): coverage build step + marketing port post-vite-migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_INSTALL_FLAGS }}
 
+      - name: Build packages (workspace coverage tests resolve some deps from dist/)
+        run: pnpm turbo build --filter='./packages/*'
+        env:
+          SKIP_ENV_VALIDATION: "true"
+
       - name: Generate coverage reports
         run: pnpm test:coverage
         env:
@@ -436,21 +441,19 @@ jobs:
         run: pnpm --filter marketing start &
         env:
           SKIP_ENV_VALIDATION: "true"
-          PORT: "3002"
-          NEXT_PUBLIC_API_URL: "http://localhost:3004"
 
       - name: Wait for servers
         run: |
           for i in $(seq 1 80); do
             curl -sf http://localhost:3004/health/live > /dev/null 2>&1 && \
             curl -sf http://localhost:4000 > /dev/null 2>&1 && \
-            curl -sf http://localhost:3002 > /dev/null 2>&1 && \
+            curl -sf http://localhost:3000 > /dev/null 2>&1 && \
             echo "All three servers ready" && break || \
             echo "Waiting for servers... ($i/80)" && sleep 3
           done
           curl -sf http://localhost:3004/health/live > /dev/null 2>&1 && \
           curl -sf http://localhost:4000 > /dev/null 2>&1 && \
-          curl -sf http://localhost:3002 > /dev/null 2>&1 || \
+          curl -sf http://localhost:3000 > /dev/null 2>&1 || \
           (echo "::error::Servers failed to start within 240s" && exit 1)
 
       - name: Run E2E smoke tests
@@ -460,7 +463,7 @@ jobs:
           SKIP_ENV_VALIDATION: "true"
           API_BASE_URL: "http://localhost:3004"
           PLAYWRIGHT_BASE_URL: "http://localhost:4000"
-          MARKETING_BASE_URL: "http://localhost:3002"
+          MARKETING_BASE_URL: "http://localhost:3000"
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -514,14 +517,12 @@ jobs:
         run: pnpm --filter marketing start &
         env:
           SKIP_ENV_VALIDATION: "true"
-          PORT: "3002"
-          NEXT_PUBLIC_API_URL: "http://localhost:3004"
 
       - name: Wait for servers
         run: |
           for i in $(seq 1 40); do
             curl -sf http://localhost:4000 > /dev/null 2>&1 && \
-            curl -sf http://localhost:3002 > /dev/null 2>&1 && \
+            curl -sf http://localhost:3000 > /dev/null 2>&1 && \
             echo "Both servers ready" && break || \
             echo "Waiting for servers... ($i/40)" && sleep 3
           done
@@ -532,7 +533,7 @@ jobs:
           CI: "true"
           SKIP_ENV_VALIDATION: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:4000"
-          MARKETING_BASE_URL: "http://localhost:3002"
+          MARKETING_BASE_URL: "http://localhost:3000"
 
       - name: Upload accessibility results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary

CI-only fix for two latent issues that surface as required-check failures on every push to `test`. Caught while merging [#679](https://github.com/RevealUIStudio/revealui/pull/679) — these were blocking the test → main release.

## Issues fixed

### 1. Coverage missing a build step

`coverage` job in `ci.yml` runs `pnpm test:coverage` immediately after `pnpm install`, with no preceding `pnpm build`. Workspace tests that import from a dependency's `dist/` (e.g. `packages/db/src/__tests__/imports.test.ts` doing `await import('@revealui/db/core')`) fail with `Cannot find package '@revealui/db/core'` because no `dist/` exists yet.

`test-unit` (line 219) and `test-integration` (line 270) both already do this — Coverage was the odd one out.

**Fix:** copy the same `Build packages` step into `coverage` before `Generate coverage reports`.

### 2. Marketing port mismatch post-Vite migration

`apps/marketing/package.json:start` is `vite preview --port 3000` after [#639](https://github.com/RevealUIStudio/revealui/pull/639) (Next.js → Vite migration). The port is hardcoded; vite preview doesn't honor `PORT` env var. CI's E2E Smoke and Accessibility jobs pass `PORT: "3002"` and curl `http://localhost:3002`, so the wait loop times out waiting for a server that's actually running on `3000`.

**Fix:** drop the dead `PORT: "3002"` (and `NEXT_PUBLIC_API_URL` — Next.js convention, no-op under Vite) from both jobs' marketing-server step, and update curl + `MARKETING_BASE_URL` from `3002` → `3000` to match the actual port. Aligns with CLAUDE.md Apps table (marketing on 3000, docs on 3002).

The Visual Regression job is unaffected by this fix — it only starts admin (port 4000) and is failing on a separate issue (21 stale snapshots from the chip-2 admin URL flatten in [#644](https://github.com/RevealUIStudio/revealui/pull/644)). That needs a snapshot regen, not a CI infra fix; tracked separately.

## Why this matters now

- The chain of test→main releases was getting stuck because Coverage + E2E Smoke + Accessibility all fail-by-default on every push to test. They're listed in `branches/main/protection.required_status_checks`, so [#679](https://github.com/RevealUIStudio/revealui/pull/679) is BLOCKED with `mergeStateStatus: BLOCKED` despite the underlying code being clean.
- Both root causes are pre-existing (test:coverage build sequencing was always missing; marketing port has been wrong since Vite migration in [#639](https://github.com/RevealUIStudio/revealui/pull/639)). Skipping the affected checks via admin override would mask the same drift on the next release.

## Risk

Effectively zero. Both changes are CI-only:
- The Coverage build step is the same recipe `test-unit` and `test-integration` use successfully today.
- The marketing port change brings CI in line with the actual app port — there's no way for the new CI to pass with the old port given the app's start script.

No product code changes. No workflow trigger / required-check name changes (the check names stay identical, so branch protection contexts continue to match).

## Test plan

- [ ] Coverage CI on this PR's HEAD turns green (was failing on `@revealui/services#test:coverage` because of the unresolved `@revealui/db/core` import)
- [ ] E2E Smoke CI on this PR's HEAD turns green (was timing out at 240s on `Wait for servers`)
- [ ] Accessibility (E2E) CI on this PR's HEAD turns green (was timing out at 120s on the same wait)
- [ ] Visual Regression remains failing — that's the snapshot drift issue, not addressed here
- [ ] Once these go green on test, [#679](https://github.com/RevealUIStudio/revealui/pull/679) auto-flips from BLOCKED → mergeable (subject to the Visual Regression snapshot fix landing too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
