### PR TITLE
fix(server): handle Vercel-Sensitive env vars in validateStartup (lenient mode)

### DIFF
--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -53,8 +53,22 @@ afterEach(() => {
 });
 
 describe('validateStartup — always-required presence', () => {
-  it('throws when POSTGRES_URL is missing', () => {
-    expect(() => validateStartup({ NODE_ENV: 'development' })).toThrow(/POSTGRES_URL/);
+  it('throws when neither POSTGRES_URL nor DATABASE_URL is set', () => {
+    expect(() => validateStartup({ NODE_ENV: 'development' })).toThrow(
+      /POSTGRES_URL or DATABASE_URL/,
+    );
+  });
+
+  it('passes when only POSTGRES_URL is set (legacy/Vercel-default name)', () => {
+    expect(() =>
+      validateStartup({ NODE_ENV: 'development', POSTGRES_URL: 'postgresql://x' }),
+    ).not.toThrow();
+  });
+
+  it('passes when only DATABASE_URL is set (Neon-driver-aliased name)', () => {
+    expect(() =>
+      validateStartup({ NODE_ENV: 'development', DATABASE_URL: 'postgresql://x' }),
+    ).not.toThrow();
   });
 
   it('throws when NODE_ENV is missing', () => {
@@ -68,7 +82,9 @@ describe('validateStartup — SKIP_ENV_VALIDATION', () => {
   });
 
   it('does not short-circuit for other truthy values', () => {
-    expect(() => validateStartup({ SKIP_ENV_VALIDATION: '1' } as EnvMap)).toThrow(/POSTGRES_URL/);
+    expect(() => validateStartup({ SKIP_ENV_VALIDATION: '1' } as EnvMap)).toThrow(
+      /POSTGRES_URL or DATABASE_URL/,
+    );
   });
 });
 

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -729,3 +729,107 @@ describe('emitRvuiSafeguardsWarning', () => {
     expect(message).toMatch(/devnet/i);
   });
 });
+
+// ─── Lenient mode (pre-deploy validation against vercel-pulled env) ───
+//
+// Mirrors how scripts/validate/prod-env.ts invokes validateStartup against
+// a `.env.production.local` produced by `vercel pull`. Vercel-Sensitive vars
+// pull as empty strings even though they're populated at runtime, so the
+// validator must accept presence-by-name and skip format checks on empties
+// when called in lenient mode. The runtime caller continues to use the
+// strict default — empty-string env vars in process.env still represent
+// real misconfig there.
+describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () => {
+  /**
+   * Production fixture matching what `vercel pull` returns for a project
+   * with every credential-shaped var marked Sensitive: each name appears,
+   * each value is empty. POSTGRES_URL, NEXT_PUBLIC_SERVER_URL, and
+   * REVEALUI_PUBLIC_SERVER_URL are populated as non-Sensitive (Vercel's
+   * actual posture for the revealui-api project at the time this was
+   * written) so URL-parity-style checks have data to operate on.
+   */
+  function sensitivePulledEnv(overrides: EnvMap = {}): EnvMap {
+    return {
+      NODE_ENV: 'production',
+      POSTGRES_URL: 'postgresql://user:pw@host/db',
+      REVEALUI_PUBLIC_SERVER_URL: 'https://api.revealui.com',
+      NEXT_PUBLIC_SERVER_URL: 'https://api.revealui.com',
+      CORS_ORIGIN: 'https://revealui.com',
+      // Hosted-mode signals — non-empty (would be sensitive in real Vercel,
+      // but their PRESENCE is what mode detection cares about; the value is
+      // empty in real pulls).
+      REVEALUI_LICENSE_PRIVATE_KEY: '',
+      REVEALUI_SECRET: '',
+      REVEALUI_KEK: '',
+      REVEALUI_CRON_SECRET: '',
+      REVEALUI_ALERT_EMAIL: '',
+      STRIPE_SECRET_KEY: '',
+      STRIPE_WEBHOOK_SECRET: '',
+      STRIPE_LIVE_MODE: '',
+      ...overrides,
+    };
+  }
+
+  it('detectDeploymentMode treats empty REVEALUI_LICENSE_PRIVATE_KEY as hosted in lenient mode', () => {
+    expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: '' }, { lenient: true })).toBe(
+      'hosted',
+    );
+  });
+
+  it('detectDeploymentMode strict mode (default) treats empty REVEALUI_LICENSE_PRIVATE_KEY as forge', () => {
+    // Original semantic — runtime contract is unchanged.
+    expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: '' })).toBe('forge');
+  });
+
+  it('always-required presence: POSTGRES_URL set as empty string passes in lenient mode', () => {
+    expect(() =>
+      validateStartup({ NODE_ENV: 'development', POSTGRES_URL: '' }, { lenient: true }),
+    ).not.toThrow();
+  });
+
+  it('always-required presence: POSTGRES_URL set as empty string FAILS in strict mode', () => {
+    // Backward-compat — preserves original runtime semantic where empty
+    // string in process.env represents real misconfig.
+    expect(() => validateStartup({ NODE_ENV: 'development', POSTGRES_URL: '' })).toThrow(
+      /POSTGRES_URL or DATABASE_URL/,
+    );
+  });
+
+  it('passes a fully-Sensitive hosted production env (every required var present-but-empty)', () => {
+    expect(() => validateStartup(sensitivePulledEnv(), { lenient: true })).not.toThrow();
+  });
+
+  it('still catches missing-by-name vars in lenient mode (key absent from env entirely)', () => {
+    // If a name is missing entirely (not just empty), that's still a
+    // real config bug — the runtime won't have it either.
+    const env = sensitivePulledEnv();
+    delete env.REVEALUI_LICENSE_PRIVATE_KEY; // mode detection now sees forge
+    delete env.REVEALUI_LICENSE_KEY; // forge-required, absent
+    expect(() => validateStartup(env, { lenient: true })).toThrow(
+      /forge mode.*REVEALUI_LICENSE_KEY/,
+    );
+  });
+
+  it('skips format checks for empty values in lenient mode', () => {
+    // KEK regex would normally fail on empty string; lenient skips it.
+    const env = sensitivePulledEnv({ REVEALUI_KEK: '' });
+    expect(() => validateStartup(env, { lenient: true })).not.toThrow();
+  });
+
+  it('still enforces format checks on non-empty values in lenient mode (defense in depth)', () => {
+    // If Vercel pull DOES include a value for a sensitive var (e.g.
+    // operator unset Sensitive), the format check still runs — lenient
+    // only skips the empty case.
+    const env = sensitivePulledEnv({ REVEALUI_KEK: 'not-64-hex' });
+    expect(() => validateStartup(env, { lenient: true })).toThrow(
+      /REVEALUI_KEK must be exactly 64/,
+    );
+  });
+
+  it('still enforces non-HTTPS rejection on populated CORS_ORIGIN in lenient mode', () => {
+    const env = sensitivePulledEnv({ CORS_ORIGIN: 'http://example.com' });
+    expect(() => validateStartup(env, { lenient: true })).toThrow(
+      /CORS_ORIGIN must contain only HTTPS/,
+    );
+  });
+});

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -23,7 +23,22 @@ export function detectDeploymentMode(env: EnvMap): DeploymentMode {
   return env.REVEALUI_LICENSE_PRIVATE_KEY ? 'hosted' : 'forge';
 }
 
-const REQUIRED_ALWAYS = ['POSTGRES_URL', 'NODE_ENV'] as const;
+// Required-always env vars expressed as alias groups: each group is satisfied
+// when AT LEAST ONE of its names is set. This handles the Postgres connection
+// string having two equally-valid names in the codebase: `POSTGRES_URL` is the
+// historical Vercel-default name (used by validateStartup since the api app
+// was scaffolded), while `DATABASE_URL` is the name read by drizzle-orm's
+// rate-limit middleware path and several @neondatabase/serverless integrations.
+// Either is acceptable as long as ONE of them is set; the runtime resolves the
+// connection string from whichever is present. Treating them as aliases also
+// papers over the Vercel `vercel pull` quirk where Sensitive-marked vars
+// (POSTGRES_URL became sensitive on 2026-05-01) are excluded from the pulled
+// `.env.production.local` even though they're available at runtime — see the
+// 2026-05-01 deploy.yml validate-prod-env failure.
+const REQUIRED_ALWAYS_GROUPS: ReadonlyArray<readonly string[]> = [
+  ['POSTGRES_URL', 'DATABASE_URL'],
+  ['NODE_ENV'],
+] as const;
 
 const REQUIRED_IN_PRODUCTION_HOSTED = [
   'REVEALUI_SECRET',
@@ -100,10 +115,13 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
     return;
   }
 
-  const missing = REQUIRED_ALWAYS.filter((key) => !env[key]);
-  if (missing.length > 0) {
+  const missingGroups = REQUIRED_ALWAYS_GROUPS.filter((group) => !group.some((key) => env[key]));
+  if (missingGroups.length > 0) {
+    const missingNames = missingGroups.map((group) =>
+      group.length > 1 ? `${group.join(' or ')}` : group[0],
+    );
     throw new Error(
-      `STARTUP VALIDATION FAILED: Missing required environment variables: ${missing.join(', ')}. ` +
+      `STARTUP VALIDATION FAILED: Missing required environment variables: ${missingNames.join(', ')}. ` +
         'Check your .env file or deployment configuration.',
     );
   }

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -19,8 +19,45 @@ export type EnvMap = Record<string, string | undefined>;
  */
 export type DeploymentMode = 'forge' | 'hosted';
 
-export function detectDeploymentMode(env: EnvMap): DeploymentMode {
-  return env.REVEALUI_LICENSE_PRIVATE_KEY ? 'hosted' : 'forge';
+/**
+ * Options that change validation behavior across runtime vs pre-deploy contexts.
+ *
+ * - `lenient` (default false): treats empty-string values as "present, sensitive
+ *   — trust runtime" rather than "missing". Use this from the pre-deploy
+ *   `validate-prod-env` script where Vercel-Sensitive vars pull as empty
+ *   strings even though they're populated at runtime. The runtime caller
+ *   (apps/server boot) leaves it false so empty-string env vars are caught
+ *   as real misconfig, matching the semantics this validator was originally
+ *   designed for.
+ *
+ * Background: Vercel's Sensitive flag (default-on for new env vars in 2026)
+ * deliberately excludes values from `vercel pull`'s `.env.production.local`
+ * output. The names appear, the values don't. Strict validation fails on
+ * the empty values even though the runtime function reads them fine. The
+ * lenient flag tells the validator to accept presence-by-name and defer
+ * format checks for sensitive values to runtime (where they're available).
+ */
+export interface ValidateOptions {
+  lenient?: boolean;
+}
+
+/**
+ * Returns true when `key` is set in `env`. Strict semantics treat empty
+ * string as missing (so `KEY=""` in a .env file fails validation, matching
+ * the original runtime contract). Lenient semantics treat empty string as
+ * present (so Sensitive vars that pull empty pre-deploy don't trip the
+ * required-presence check).
+ */
+function isPresent(env: EnvMap, key: string, lenient: boolean): boolean {
+  if (lenient) return env[key] !== undefined;
+  return Boolean(env[key]);
+}
+
+export function detectDeploymentMode(
+  env: EnvMap,
+  { lenient = false }: ValidateOptions = {},
+): DeploymentMode {
+  return isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient) ? 'hosted' : 'forge';
 }
 
 // Required-always env vars expressed as alias groups: each group is satisfied
@@ -110,12 +147,24 @@ const REQUIRED_IN_PRODUCTION_FORGE = [
  * Takes `env` as an argument (defaulted to `process.env`) so tests can pass
  * explicit fixtures without touching real process state.
  */
-export function validateStartup(env: EnvMap = process.env as EnvMap): void {
+export function validateStartup(
+  env: EnvMap = process.env as EnvMap,
+  { lenient = false }: ValidateOptions = {},
+): void {
   if (env.SKIP_ENV_VALIDATION === 'true') {
     return;
   }
 
-  const missingGroups = REQUIRED_ALWAYS_GROUPS.filter((group) => !group.some((key) => env[key]));
+  // Local helper: in lenient (pre-deploy) mode, skip format checks on empty
+  // values — those represent Vercel-Sensitive vars whose values are hidden
+  // from `vercel pull` but populated at runtime. The runtime call (lenient
+  // false) still validates format strictly so a misconfigured `KEY=""` in a
+  // .env file fails loudly.
+  const skipFormat = (value: string): boolean => lenient && value === '';
+
+  const missingGroups = REQUIRED_ALWAYS_GROUPS.filter(
+    (group) => !group.some((key) => isPresent(env, key, lenient)),
+  );
   if (missingGroups.length > 0) {
     const missingNames = missingGroups.map((group) =>
       group.length > 1 ? `${group.join(' or ')}` : group[0],
@@ -130,9 +179,9 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
     return;
   }
 
-  const mode = detectDeploymentMode(env);
+  const mode = detectDeploymentMode(env, { lenient });
   const required = mode === 'forge' ? REQUIRED_IN_PRODUCTION_FORGE : REQUIRED_IN_PRODUCTION_HOSTED;
-  const missingProd = required.filter((key) => !env[key]);
+  const missingProd = required.filter((key) => !isPresent(env, key, lenient));
   if (missingProd.length > 0) {
     throw new Error(
       `STARTUP VALIDATION FAILED (${mode} mode): Missing production-required env vars: ${missingProd.join(', ')}.`,
@@ -147,7 +196,7 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
   // both modes (hosted + forge), so missing-presence is caught by the
   // REQUIRED check above; we always run the format check here.
   const kek = env.REVEALUI_KEK ?? '';
-  if (!/^[0-9a-f]{64}$/i.test(kek)) {
+  if (!skipFormat(kek) && !/^[0-9a-f]{64}$/i.test(kek)) {
     errors.push('REVEALUI_KEK must be exactly 64 hexadecimal characters (256 bits).');
   }
 
@@ -165,7 +214,7 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
 
   // Secret minimum length — required in both modes, so always set here.
   const secret = env.REVEALUI_SECRET ?? '';
-  if (secret.length < 32) {
+  if (!skipFormat(secret) && secret.length < 32) {
     errors.push('REVEALUI_SECRET must be at least 32 characters.');
   }
 
@@ -185,18 +234,20 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
 
     // Stripe secret key — prefix depends on STRIPE_LIVE_MODE.
     const stripeSecretKey = env.STRIPE_SECRET_KEY ?? '';
-    if (stripeLiveMode) {
-      if (!stripeSecretKey.startsWith('sk_live_')) {
-        errors.push(
-          'STRIPE_SECRET_KEY must be a live key (sk_live_...) when STRIPE_LIVE_MODE=true.',
-        );
-      }
-    } else {
-      if (!stripeSecretKey.startsWith('sk_test_')) {
-        errors.push(
-          'STRIPE_SECRET_KEY must be a test key (sk_test_...) when STRIPE_LIVE_MODE is unset/false. ' +
-            'Set STRIPE_LIVE_MODE=true to use live keys (gated on the billing-readiness audit).',
-        );
+    if (!skipFormat(stripeSecretKey)) {
+      if (stripeLiveMode) {
+        if (!stripeSecretKey.startsWith('sk_live_')) {
+          errors.push(
+            'STRIPE_SECRET_KEY must be a live key (sk_live_...) when STRIPE_LIVE_MODE=true.',
+          );
+        }
+      } else {
+        if (!stripeSecretKey.startsWith('sk_test_')) {
+          errors.push(
+            'STRIPE_SECRET_KEY must be a test key (sk_test_...) when STRIPE_LIVE_MODE is unset/false. ' +
+              'Set STRIPE_LIVE_MODE=true to use live keys (gated on the billing-readiness audit).',
+          );
+        }
       }
     }
 
@@ -220,7 +271,7 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
 
     // Stripe webhook signing secret — `whsec_` prefix in both Stripe modes.
     const webhookSecret = env.STRIPE_WEBHOOK_SECRET ?? '';
-    if (!webhookSecret.startsWith('whsec_')) {
+    if (!skipFormat(webhookSecret) && !webhookSecret.startsWith('whsec_')) {
       errors.push('STRIPE_WEBHOOK_SECRET must start with "whsec_" in production.');
     }
 
@@ -235,38 +286,41 @@ export function validateStartup(env: EnvMap = process.env as EnvMap): void {
     }
 
     // HTTPS-only URLs (hosted mode runs on revealui.com).
-    if (!publicUrl.startsWith('https://')) {
+    if (!skipFormat(publicUrl) && !publicUrl.startsWith('https://')) {
       errors.push('REVEALUI_PUBLIC_SERVER_URL must use HTTPS in production.');
     }
-    if (!nextPublicUrl.startsWith('https://')) {
+    if (!skipFormat(nextPublicUrl) && !nextPublicUrl.startsWith('https://')) {
       errors.push('NEXT_PUBLIC_SERVER_URL must use HTTPS in production.');
     }
 
     // Cron secret length (hosted-only — Forge customers don't have crons
     // calling back into revealui.com).
     const cronSecret = env.REVEALUI_CRON_SECRET ?? '';
-    if (cronSecret.length < 32) {
+    if (!skipFormat(cronSecret) && cronSecret.length < 32) {
       errors.push('REVEALUI_CRON_SECRET must be at least 32 characters.');
     }
 
     // Alert email format (hosted-only — primary use is unreconciled Stripe
     // webhooks; Forge customers can configure but aren't required to).
     const alertEmail = env.REVEALUI_ALERT_EMAIL ?? '';
-    if (!alertEmail.includes('@')) {
+    if (!skipFormat(alertEmail) && !alertEmail.includes('@')) {
       errors.push(
         `REVEALUI_ALERT_EMAIL is not a valid email (got: ${JSON.stringify(alertEmail)}).`,
       );
     }
 
     // CORS_ORIGIN is comma-separated; every origin must be HTTPS in hosted prod.
-    const nonHttpsOrigins = (env.CORS_ORIGIN ?? '')
-      .split(',')
-      .map((o) => o.trim())
-      .filter((o) => o.length > 0 && !o.startsWith('https://'));
-    if (nonHttpsOrigins.length > 0) {
-      errors.push(
-        `CORS_ORIGIN must contain only HTTPS origins in production. Got non-HTTPS: ${nonHttpsOrigins.join(', ')}.`,
-      );
+    const corsOriginRaw = env.CORS_ORIGIN ?? '';
+    if (!skipFormat(corsOriginRaw)) {
+      const nonHttpsOrigins = corsOriginRaw
+        .split(',')
+        .map((o) => o.trim())
+        .filter((o) => o.length > 0 && !o.startsWith('https://'));
+      if (nonHttpsOrigins.length > 0) {
+        errors.push(
+          `CORS_ORIGIN must contain only HTTPS origins in production. Got non-HTTPS: ${nonHttpsOrigins.join(', ')}.`,
+        );
+      }
     }
   }
 

--- a/scripts/validate/prod-env.ts
+++ b/scripts/validate/prod-env.ts
@@ -71,7 +71,15 @@ export interface ValidateResult {
 export function validatePulledEnv(pulled: EnvMap): ValidateResult {
   const env: EnvMap = { ...pulled, NODE_ENV: 'production' };
 
-  const mode = detectDeploymentMode(env);
+  // Vercel-Sensitive vars pull as empty strings even though they're
+  // populated at runtime. Run validateStartup in lenient mode here so
+  // presence-by-name passes for sensitive vars and format checks skip
+  // on empty values (the runtime invocation in apps/server still runs
+  // strict and catches misconfig there). See validate-startup.ts
+  // ValidateOptions for the full rationale.
+  const opts = { lenient: true };
+
+  const mode = detectDeploymentMode(env, opts);
   const stripeLiveMode = env.STRIPE_LIVE_MODE === 'true';
 
   if (env.SKIP_ENV_VALIDATION === 'true') {
@@ -85,7 +93,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
   }
 
   try {
-    validateStartup(env);
+    validateStartup(env, opts);
     return {
       ok: true,
       mode,


### PR DESCRIPTION
## Summary

Adds a `lenient` option to `validateStartup()` that handles Vercel-Sensitive env vars correctly, unblocking the production deploy gate that started failing on 2026-05-01. Pre-deploy validators get the lenient semantics (sensitive vars pull as empty strings — accept presence-by-name, skip format checks on empties); the apps/server runtime keeps the strict default (`KEY=""` in process.env still represents real misconfig). Subsumes the earlier `POSTGRES_URL OR DATABASE_URL` alias-group fix in this same PR.

## The bug this closes

After the [#679](https://github.com/RevealUIStudio/revealui/pull/679) merge to main, `deploy.yml`'s `validate-prod-env` step started failing:

```
STARTUP VALIDATION FAILED: Missing required environment variables: POSTGRES_URL.
STARTUP VALIDATION FAILED (forge mode): Missing production-required env vars:
  REVEALUI_SECRET, REVEALUI_KEK, NEXT_PUBLIC_SERVER_URL,
  REVEALUI_LICENSE_KEY, REVEALUI_LICENSE_PUBLIC_KEY.
```

Verified root cause: 9 user-set production env vars on the `revealui-api` Vercel project are flagged **Sensitive** (Vercel's default-on for new entries since 2026). Sensitive vars are deliberately excluded from `vercel pull`'s `.env.production.local` output — the names appear, the values don't. The pre-deploy validator was reading those empty values as "missing" and treating empty `REVEALUI_LICENSE_PRIVATE_KEY` as the forge-mode signal (when it's actually a Sensitive value populated at runtime).

The Vercel API explicitly **prohibits** flipping the Sensitive flag without rotating the value (`PATCH /v10/projects/{id}/env/{envId}` with `{sensitive: false}` returns "You cannot change the type of a Sensitive Environment Variable"). So either the validator handles the case, or every release requires bulk re-adding sensitive vars — not durable.

## What this PR does

### 1. `validateStartup` gets a `lenient` option

```typescript
export interface ValidateOptions {
  lenient?: boolean;
}

export function validateStartup(env: EnvMap = process.env, opts: ValidateOptions = {}): void { … }
export function detectDeploymentMode(env: EnvMap, opts: ValidateOptions = {}): DeploymentMode { … }
```

In **lenient mode** (pre-deploy from `vercel pull`):
- **Presence checks**: `KEY` set with empty string counts as present (Sensitive var, runtime has the value)
- **Mode detection**: empty `REVEALUI_LICENSE_PRIVATE_KEY` correctly resolves to `hosted` (it's Sensitive, not absent)
- **Format checks**: skip on empty values (can't validate what we can't see); still enforce on non-empty values for defense in depth

In **strict mode** (default, runtime call from `apps/server/src/index.ts`):
- **Unchanged**: empty string remains "missing" so a real `KEY=""` in `.env` fails loudly

### 2. `scripts/validate/prod-env.ts` passes `{ lenient: true }`

Single line change at the call site. Mode detection + validateStartup both get the flag. Comment explains the rationale.

### 3. POSTGRES_URL ↔ DATABASE_URL alias group (from earlier commit, preserved)

`REQUIRED_ALWAYS_GROUPS` treats `[POSTGRES_URL, DATABASE_URL]` as a single satisfied-by-either group. Lenient mode is orthogonal — both fixes coexist; either one alone would unblock today's specific failure mode.

## Why this is the right architectural fix (vs. tactical alternatives)

| Approach | Outcome |
|---|---|
| **This PR (lenient mode)** | Validator design matches Vercel's intended Sensitive semantics. Works for any future sensitive var without code changes. |
| Re-add all 9 sensitive vars from revvault | Patches today's specific list. Next sensitive var added (Vercel still defaults to Sensitive in 2026) breaks the same way. Carries irreversible KEK risk if revvault's value drifts from current Vercel value. |
| Bypass `validate-prod-env` step in deploy.yml | Loses the format-check defense that the 2026-04-25 #540 incident proved necessary. |

## Test changes

86 tests pass (was 77; 9 new lenient-mode cases):

- `detectDeploymentMode` lenient mode: empty `REVEALUI_LICENSE_PRIVATE_KEY` → `hosted` (sensitive, runtime present)
- `detectDeploymentMode` strict default: empty → `forge` (backward compat)
- always-required presence: `POSTGRES_URL=""` passes lenient; fails strict
- fully-Sensitive hosted production env passes lenient validation end-to-end
- still catches truly-missing names in lenient mode (key absent vs. present-but-empty)
- skips KEK regex on empty in lenient; still enforces on non-empty values
- still enforces non-HTTPS rejection on populated CORS_ORIGIN

`pnpm --filter server test src/lib/__tests__/validate-startup.test.ts` → 86/86 pass. `pnpm --filter server typecheck` clean.

## Local end-to-end verification

Ran `pnpm validate:prod-env` against the actual Vercel `pull --environment=production` of the `revealui-api` project (the failing scenario from the deploy.yml run):

**Before this PR:**
```
STARTUP VALIDATION FAILED: Missing required environment variables: POSTGRES_URL.
```

**After this PR:**
```
validate:prod-env mode=hosted STRIPE_LIVE_MODE=false
validate:prod-env PASS — all production env presence + format checks satisfied.
```

## Path to production

1. PR-level CI passes
2. Merge to test
3. Open release-PR test→main (small — just this fix + #691 migration snapshot regen)
4. Re-trigger the failed `deploy.yml` run on main (or push another commit) — `validate-prod-env` now passes
5. Vercel deploys to api/admin/docs/marketing/revealcoin

## Follow-up (non-blocking)

A durable next step is finishing GAP-157 Phase 3: making revvault the single source of truth and syncing TO Vercel rather than maintaining two stores. With `revvault rotate` already chaining Vercel sync ([revvault#19](https://github.com/RevealUIStudio/revvault/pull/19), merged), the natural extension is "revvault writes new vars non-sensitively to Vercel automatically." That removes the manual-Sensitive-flag hazard entirely. Tracking as a separate gap; not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
