### PR TITLE
chore(harnesses,cli,dev): refresh internal Supabase guidance for Neon-primary posture

### DIFF
--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -1,12 +1,7 @@
 import { commandExists, isTcpReachable } from '../utils/command.js';
 import { detectDbTarget, resolveLocalDbConfig } from '../utils/db.js';
 import { findWorkspaceRoot } from '../utils/workspace.js';
-import {
-  validateNeonUrl,
-  validateNpmToken,
-  validateStripeKey,
-  validateSupabaseUrl,
-} from '../validators/credentials.js';
+import { validateNeonUrl, validateNpmToken, validateStripeKey } from '../validators/credentials.js';
 import { validateNodeVersion } from '../validators/node-version.js';
 
 export interface DoctorCheck {
@@ -95,22 +90,6 @@ const ENV_VAR_SPECS: EnvVarSpec[] = [
     validate: (v) => ({
       valid: v.startsWith('whsec_'),
       message: 'Must start with whsec_',
-    }),
-  },
-  // Supabase
-  {
-    key: 'NEXT_PUBLIC_SUPABASE_URL',
-    label: 'Supabase URL',
-    required: false,
-    validate: validateSupabaseUrl,
-  },
-  {
-    key: 'SUPABASE_SERVICE_ROLE_KEY',
-    label: 'Supabase service role key',
-    required: false,
-    validate: (v) => ({
-      valid: v.startsWith('eyJ'),
-      message: 'Must be a JWT (starts with eyJ)',
     }),
   },
   // npm

--- a/packages/dev/src/editors/__tests__/antigravity.test.ts
+++ b/packages/dev/src/editors/__tests__/antigravity.test.ts
@@ -27,11 +27,12 @@ describe('generateAntigravityRules', () => {
     expect(rules).toContain('typecheck');
   });
 
-  it('specifies the dual-DB boundary rule', () => {
+  it('specifies the Neon-primary database posture', () => {
     const rules = generateAntigravityRules();
     expect(rules).toContain('NeonDB');
-    expect(rules).toContain('Supabase');
-    expect(rules).toContain('@supabase/supabase-js');
+    expect(rules).toContain('pgvector');
+    expect(rules).toContain('Do NOT add new');
+    expect(rules).not.toContain('@supabase/supabase-js');
   });
 
   it('mentions soft-delete convention', () => {

--- a/packages/dev/src/editors/antigravity/agents.ts
+++ b/packages/dev/src/editors/antigravity/agents.ts
@@ -10,7 +10,7 @@ Package manager: pnpm 10 (\`workspace:*\` for internal deps).
 ## Key Packages
 
 - \`@revealui/core\`  -  Runtime engine, collections, access control, hooks
-- \`@revealui/db\`  -  Drizzle schema (NeonDB) + vector schema (Supabase)
+- \`@revealui/db\`  -  Drizzle schema on NeonDB (primary store; vectors via pgvector)
 - \`@revealui/auth\`  -  session auth, bcrypt, rate limiting
 - \`@revealui/contracts\`  -  Zod schemas (canonical source of truth)
 - \`@revealui/presentation\`  -  UI components (Tailwind v4)
@@ -28,8 +28,10 @@ Package manager: pnpm 10 (\`workspace:*\` for internal deps).
 
 ## Database Rules
 
-- NeonDB (Drizzle ORM): all REST content (users, sessions, posts, media, etc.)
-- Supabase: vector embeddings only (\`packages/db/src/vector/\`)
-- Never import \`@supabase/supabase-js\` outside designated vector/auth modules
+- NeonDB (Drizzle ORM): primary database for all internal usage
+- Vector embeddings: NeonDB + pgvector (already installed)
+- Do NOT add new \`@supabase/*\` imports — legacy Supabase phase-out in flight; the
+  customer-facing Supabase MCP adapter at \`packages/mcp/src/servers/supabase.ts\` is
+  intentionally retained, separate from internal usage
 `.trimEnd();
 }

--- a/packages/harnesses/src/content/definitions/rules/database.ts
+++ b/packages/harnesses/src/content/definitions/rules/database.ts
@@ -4,63 +4,52 @@ export const databaseRule: Rule = {
   id: 'database',
   tier: 'oss',
   name: 'Database Conventions',
-  description: 'Dual-database architecture (NeonDB + Supabase) boundaries and query patterns',
+  description: 'Neon-primary database conventions (legacy Supabase phase-out) and query patterns',
   scope: 'project',
   preambleTier: 2,
   tags: ['database', 'architecture', 'drizzle'],
   content: `# Database Conventions
 
-## Dual-Database Architecture
+## Architecture
 
-RevealUI uses **two databases with strictly separated responsibilities**:
+RevealUI uses **NeonDB (PostgreSQL via \`@neondatabase/serverless\`)** as the primary
+database for all internal usage: collections, users, sessions, orders, products, AI
+memory, and vector embeddings (via pgvector).
 
-| Database | Client | Purpose |
-|----------|--------|---------|
-| **NeonDB** (PostgreSQL) | \`@neondatabase/serverless\` | REST content: collections, users, sessions, orders, products |
-| **Supabase** | \`@supabase/supabase-js\` | Vector embeddings, real-time auth, AI memory storage |
+Legacy Supabase code remains in tree during the Supabase phase-out and is being
+progressively removed. **Do not add new \`@supabase/*\` imports to any package** — new
+features must depend on NeonDB only.
 
-## Boundary Rule
+## Customer-extensible MCP adapter (intentionally retained)
 
-**\`@supabase/supabase-js\` must only be imported inside designated vector/auth modules:**
-
-### Allowed paths for Supabase imports
-- \`packages/db/src/vector/\`  -  vector schema and queries
-- \`packages/db/src/auth/\`  -  Supabase auth helpers
-- \`packages/auth/src/\`  -  authentication implementation
-- \`packages/ai/src/\`  -  AI memory and embedding storage
-- \`packages/services/src/supabase/\`  -  Supabase service integrations
-- \`apps/*/src/lib/supabase/\`  -  app-level Supabase utilities
-
-### Forbidden: Supabase imports in
-- \`packages/core/\`  -  admin engine must be DB-agnostic
-- \`packages/contracts/\`  -  contracts are schema-only
-- \`packages/config/\`  -  config must not hardcode DB client
-- \`apps/admin/src/collections/\`  -  collection hooks use Drizzle/Neon only
-- \`apps/admin/src/routes/\`  -  REST routes use Neon only
+The Supabase MCP adapter at \`packages/mcp/src/servers/supabase.ts\` is intentionally
+retained as an OSS adapter for customers who run their own Supabase. It is exported
+from \`@revealui/mcp\` (\`launchSupabaseMcp\`) and documented in the Pro MCP docs
+(\`apps/docs/public/docs-pro/mcp/index.md\`). This is a customer-extensibility surface,
+separate from RevealUI's own database stack — it does not contradict the "no new
+Supabase imports" rule for product code.
 
 ## Schema Organization
 
 \`\`\`
 packages/db/src/schema/
-├── accounts.ts       # NeonDB: user accounts
-├── agents.ts         # NeonDB: AI agent definitions
-├── api-keys.ts       # NeonDB: API key management
-├── admin.ts            # NeonDB: admin collections, media
-├── gdpr.ts           # NeonDB: GDPR consent, deletion
-├── licenses.ts       # NeonDB: license keys, tiers
-├── pages.ts          # NeonDB: pages, navigation
-├── sites.ts          # NeonDB: multi-tenant sites
-├── tickets.ts        # NeonDB: support tickets
-├── users.ts          # NeonDB: user management, sessions
-├── vector.ts         # Supabase: embeddings, AI memory
-├── rest.ts           # NeonDB: REST schema barrel
+├── accounts.ts       # user accounts
+├── agents.ts         # AI agent definitions
+├── api-keys.ts       # API key management
+├── admin.ts          # admin collections, media
+├── gdpr.ts           # GDPR consent, deletion
+├── licenses.ts       # license keys, tiers
+├── pages.ts          # pages, navigation
+├── sites.ts          # multi-tenant sites
+├── tickets.ts        # support tickets
+├── users.ts          # user management, sessions
+├── rest.ts           # REST schema barrel
 ├── index.ts          # Combined schema export
 └── ...               # 30+ schema files total
 \`\`\`
 
-## Query Patterns
+## Query Pattern
 
-### NeonDB (Drizzle ORM)
 \`\`\`ts
 import { db } from '@revealui/db'
 import { posts } from '@revealui/db/schema'
@@ -68,28 +57,13 @@ import { posts } from '@revealui/db/schema'
 const results = await db.select().from(posts).where(eq(posts.status, 'published'))
 \`\`\`
 
-### Supabase (vector/auth only)
-\`\`\`ts
-// Only in designated modules (packages/db/src/vector/, packages/ai/src/)
-import { createSupabaseClient } from '@revealui/db/vector'
-
-const { data } = await supabase.rpc('match_documents', { query_embedding: embedding })
-\`\`\`
-
-## Enforcement
-
-The \`pnpm validate:structure\` script checks for Supabase imports outside permitted paths.
-CI runs this as part of phase 1 (warn-only  -  violations are flagged but don't block builds).
-
-To check locally:
-\`\`\`bash
-pnpm validate:structure
-\`\`\`
-
 ## Migration Guidance
 
 When adding new features:
-1. **Content/REST data** → add to \`packages/db/src/schema/\` + use Drizzle
-2. **AI/vector data** → add to \`packages/db/src/vector/\` + use Supabase client
-3. **Never mix** both DB clients in the same module`,
+1. **Content/REST data** → add to \`packages/db/src/schema/\` + use Drizzle on NeonDB
+2. **Vector data / AI memory** → add to NeonDB with pgvector (already installed; see
+   \`rag_documents\`, \`rag_chunks\`, \`rag_workspaces\`)
+3. **Customer-bring-your-own DB** → expose via a new MCP adapter in \`@revealui/mcp\`
+   following the pattern in \`packages/mcp/src/servers/supabase.ts\`; do not import the
+   target DB's client directly into product packages`,
 };

--- a/packages/harnesses/src/content/definitions/skills/revealui-db.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-db.ts
@@ -5,7 +5,7 @@ export const revealuiDbSkill: Skill = {
   tier: 'pro',
   name: 'RevealUI Database',
   description:
-    'RevealUI database conventions for any task involving database, schema, query, migration,\nDrizzle ORM, Supabase, NeonDB, PostgreSQL, vectors, embeddings, or data modeling.\nEnforces dual-database architecture boundaries and import restrictions.',
+    'RevealUI database conventions for any task involving database, schema, query, migration,\nDrizzle ORM, NeonDB, PostgreSQL, pgvector, embeddings, or data modeling. Reflects the\nNeon-primary architecture (legacy Supabase phase-out in flight).',
   disableModelInvocation: false,
   skipFrontmatter: false,
   filePatterns: [],
@@ -13,49 +13,36 @@ export const revealuiDbSkill: Skill = {
   references: {},
   content: `# Database Conventions
 
-## Dual-Database Architecture
+## Architecture
 
-RevealUI uses **two databases with strictly separated responsibilities**:
+RevealUI uses **NeonDB (PostgreSQL via \`@neondatabase/serverless\`)** as the primary
+database for all internal usage: collections, users, sessions, orders, products, AI
+memory, and vector embeddings (via pgvector).
 
-| Database | Client | Purpose |
-|----------|--------|---------|
-| **NeonDB** (PostgreSQL) | \`@neondatabase/serverless\` | REST content: collections, users, sessions, orders, products |
-| **Supabase** | \`@supabase/supabase-js\` | Vector embeddings, real-time auth, AI memory storage |
+Legacy Supabase code remains in tree during the Supabase phase-out and is being
+progressively removed. **Do not add new \`@supabase/*\` imports to any package** — new
+features must depend on NeonDB only.
 
-## Boundary Rule
+## Customer-extensible MCP adapter (intentionally retained)
 
-**\`@supabase/supabase-js\` must only be imported inside designated vector/auth modules:**
-
-### Allowed paths for Supabase imports
-- \`packages/db/src/vector/\`  -  vector schema and queries
-- \`packages/db/src/auth/\`  -  Supabase auth helpers
-- \`packages/auth/src/\`  -  authentication implementation
-- \`packages/ai/src/\`  -  AI memory and embedding storage
-- \`packages/services/src/supabase/\`  -  Supabase service integrations
-- \`apps/*/src/lib/supabase/\`  -  app-level Supabase utilities
-
-### Forbidden: Supabase imports in
-- \`packages/core/\`  -  admin engine must be DB-agnostic
-- \`packages/contracts/\`  -  contracts are schema-only
-- \`packages/config/\`  -  config must not hardcode DB client
-- \`apps/admin/src/collections/\`  -  collection hooks use Drizzle/Neon only
-- \`apps/admin/src/routes/\`  -  REST routes use Neon only
+The Supabase MCP adapter at \`packages/mcp/src/servers/supabase.ts\` is intentionally
+retained as an OSS adapter for customers who run their own Supabase. It is exported
+from \`@revealui/mcp\` (\`launchSupabaseMcp\`) and documented in the Pro MCP docs. This is
+a customer-extensibility surface, separate from RevealUI's own database stack.
 
 ## Schema Organization
 
 \`\`\`
 packages/db/src/schema/
-├── collections/    # NeonDB: content collections
-├── users/          # NeonDB: user management
-├── commerce/       # NeonDB: products, orders, pricing
-├── sessions/       # NeonDB: auth sessions
-├── vector/         # Supabase: embeddings, similarity search
-└── auth/           # Supabase: auth state
+├── accounts/, users/, sessions/  # auth + identity (NeonDB)
+├── collections/                  # content collections (NeonDB)
+├── commerce/                     # products, orders, pricing (NeonDB)
+├── rag/                          # rag_documents, rag_chunks, rag_workspaces (NeonDB + pgvector)
+└── ...                           # 30+ schema files total
 \`\`\`
 
-## Query Patterns
+## Query Pattern
 
-### NeonDB (Drizzle ORM)
 \`\`\`ts
 import { db } from '@revealui/db'
 import { posts } from '@revealui/db/schema'
@@ -63,28 +50,12 @@ import { posts } from '@revealui/db/schema'
 const results = await db.select().from(posts).where(eq(posts.status, 'published'))
 \`\`\`
 
-### Supabase (vector/auth only)
-\`\`\`ts
-// Only in designated modules (packages/db/src/vector/, packages/ai/src/)
-import { createSupabaseClient } from '@revealui/db/vector'
-
-const { data } = await supabase.rpc('match_documents', { query_embedding: embedding })
-\`\`\`
-
-## Enforcement
-
-The \`pnpm validate:structure\` script checks for Supabase imports outside permitted paths.
-CI runs this as part of phase 1 (warn-only  -  violations are flagged but don't block builds).
-
-To check locally:
-\`\`\`bash
-pnpm validate:structure
-\`\`\`
-
 ## Migration Guidance
 
 When adding new features:
-1. **Content/REST data** → add to \`packages/db/src/schema/\` + use Drizzle
-2. **AI/vector data** → add to \`packages/db/src/vector/\` + use Supabase client
-3. **Never mix** both DB clients in the same module`,
+1. **Content/REST data** → add to \`packages/db/src/schema/\` + use Drizzle on NeonDB
+2. **Vector data / AI memory** → add to NeonDB with pgvector (already installed)
+3. **Customer-bring-your-own DB** → expose via a new MCP adapter in \`@revealui/mcp\`
+   following the pattern in \`packages/mcp/src/servers/supabase.ts\`; do not import the
+   target DB's client directly into product packages`,
 };

--- a/packages/harnesses/src/content/definitions/skills/revealui-safety.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-safety.ts
@@ -28,14 +28,15 @@ Follow these rules for ALL code changes in the RevealUI monorepo.
 
 ## Import Boundaries
 
-\`@supabase/supabase-js\` is ONLY allowed in:
+Do NOT add new \`@supabase/*\` imports to any package. RevealUI uses NeonDB as the
+primary database; legacy Supabase code remains in tree during the Supabase phase-out
+and is being progressively removed. The only intentional Supabase touch-point is the
+customer-extensible MCP adapter at \`packages/mcp/src/servers/supabase.ts\`.
 
-- \`packages/db/src/vector/\`, \`packages/db/src/auth/\`
-- \`packages/auth/src/\`, \`packages/ai/src/\`
-- \`packages/services/src/supabase/\`
-- \`apps/*/src/lib/supabase/\`
-
-FORBIDDEN in: \`packages/core/\`, \`packages/contracts/\`, \`packages/config/\`, \`apps/admin/src/collections/\`, \`apps/admin/src/routes/\`
+If you find yourself wanting to import \`@supabase/*\`, instead:
+- Use Drizzle + NeonDB for content/REST data
+- Use NeonDB + pgvector for vector embeddings (already installed)
+- Expose customer-bring-your-own DB via a new MCP adapter in \`@revealui/mcp\`
 
 ## Code Quality
 


### PR DESCRIPTION
## Summary

Refreshes internal-only Supabase guidance to reflect the Neon-primary architecture set in #687. Touches harness rules + skills, the CLI `doctor` env-var probe, and the Antigravity agent rules.

The customer-extensible Supabase MCP adapter at `packages/mcp/src/servers/supabase.ts` is **intentionally retained** per #687 — internal usage and customer-extensibility are now distinct surfaces. This PR aligns the advisory content (rules / skills / dev rules / doctor env probe) with that distinction; it does not delete the adapter or change any production code path.

## Why this is narrower than the original spec

The internal Phase 5 spec (drafted earlier today) listed `packages/mcp/src/servers/supabase.ts` for deletion. After verifying state, the carve-out you set in #687 — "intentionally retained as an adapter for customers who use Supabase, separate from internal usage" — was the source of truth, and the spec has been amended internally to reflect it. PR scope was narrowed to the advisory/refresh changes that don't conflict with the customer-adapter carve-out.

## Changes

| File | Change |
|---|---|
| `packages/harnesses/src/content/definitions/rules/database.ts` | Replace "Dual-Database Architecture" framing + Supabase import-allowlist with "Neon-primary, customer-extensible MCP adapter" framing |
| `packages/harnesses/src/content/definitions/skills/revealui-db.ts` | Same content reframe; description tag updated |
| `packages/harnesses/src/content/definitions/skills/revealui-safety.ts` | Replace `@supabase/*` import-allowlist with "Do NOT add new `@supabase/*` imports" + customer-adapter pointer |
| `packages/cli/src/runtime/doctor.ts` | Drop `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` env-var probes (no longer relevant for internal dev); drop unused `validateSupabaseUrl` import |
| `packages/dev/src/editors/antigravity/agents.ts` | Refresh DB description + Database Rules section |
| `packages/dev/src/editors/__tests__/antigravity.test.ts` | Update assertion to match new posture (`pgvector`, "Do NOT add new", no `@supabase/supabase-js`) |

Net diff: **+77 / −149** (mostly content rewriting that's also shorter). No production code paths changed.

## Test plan

- [x] `pnpm turbo run typecheck --filter @revealui/cli --filter @revealui/dev --filter @revealui/harnesses` → 14 tasks, 0 failed
- [x] `pnpm turbo run test` (same filter) → 14 tasks, 256 harness tests + cli + dev all green
- [x] `pnpm exec biome check --write` on edited files — clean (only cosmetic flatten of one multi-line import)
- [x] Pre-push gate ran on push (output above shows `Result: PASS`)
- [ ] CI green (full gate runs on PR)

## Verifying the carve-out

The retained adapter's public-API path:

```
packages/mcp/src/servers/supabase.ts  (still present)
packages/mcp/src/index.ts:197         export { launchSupabaseMcp } from './servers/supabase.js';
apps/docs/public/docs-pro/mcp/index.md  (customer-facing docs)
```

None of these are touched in this PR. The advisory content now describes the adapter as "intentionally retained, separate from internal usage."

## Refs

- #687 — `chore(docs): align CLAUDE.md Supabase framing — Neon-primary, legacy phase-out` (set the carve-out this PR aligns to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
