### PR TITLE
refactor(db,server): collapse cleanup module to single-DB Neon

### DIFF
--- a/apps/server/src/routes/__tests__/maintenance.test.ts
+++ b/apps/server/src/routes/__tests__/maintenance.test.ts
@@ -7,7 +7,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@revealui/db', () => ({
   getRestClient: vi.fn(),
-  getVectorClient: vi.fn(),
 }));
 
 vi.mock('@revealui/db/cleanup', () => ({
@@ -18,13 +17,12 @@ vi.mock('@revealui/core/observability/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn() },
 }));
 
-import { getRestClient, getVectorClient } from '@revealui/db';
+import { getRestClient } from '@revealui/db';
 import { cleanupOrphanedVectorData } from '@revealui/db/cleanup';
 import maintenanceApp from '../maintenance.js';
 
 const mockedCleanup = vi.mocked(cleanupOrphanedVectorData);
 const mockedGetRestClient = vi.mocked(getRestClient);
-const mockedGetVectorClient = vi.mocked(getVectorClient);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -68,7 +66,6 @@ describe('POST /cleanup-orphans  -  auth', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
     mockedCleanup.mockResolvedValue(defaultResult);
   });
 
@@ -112,7 +109,6 @@ describe('POST /cleanup-orphans  -  valid request', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
     mockedCleanup.mockResolvedValue(defaultResult);
   });
 
@@ -128,17 +124,15 @@ describe('POST /cleanup-orphans  -  valid request', () => {
     expect(body.dryRun).toBe(false);
   });
 
-  it('calls cleanupOrphanedVectorData with rest and vector clients', async () => {
-    const fakeRest = { type: 'rest' };
-    const fakeVector = { type: 'vector' };
-    mockedGetRestClient.mockReturnValue(fakeRest as never);
-    mockedGetVectorClient.mockReturnValue(fakeVector as never);
+  it('calls cleanupOrphanedVectorData with the rest client (single-DB)', async () => {
+    const fakeDb = { type: 'rest' };
+    mockedGetRestClient.mockReturnValue(fakeDb as never);
 
     const app = createApp();
     await app.request(makeRequest(VALID_SECRET));
 
     expect(mockedCleanup).toHaveBeenCalledOnce();
-    expect(mockedCleanup).toHaveBeenCalledWith(fakeRest, fakeVector);
+    expect(mockedCleanup).toHaveBeenCalledWith(fakeDb);
   });
 
   it('returns dryRun:true when cleanup reports a dry run', async () => {
@@ -171,7 +165,6 @@ describe('POST /cleanup-orphans  -  error handling', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
   });
 
   it('returns 500 when cleanup throws', async () => {
@@ -186,7 +179,7 @@ describe('POST /cleanup-orphans  -  error handling', () => {
     const app = createApp();
     const res = await app.request(makeRequest(VALID_SECRET));
     const body = await res.json();
-    expect(body.error).toBe('Cross-DB orphan cleanup failed');
+    expect(body.error).toBe('Orphan vector cleanup failed');
   });
 
   it('handles non-Error thrown values gracefully', async () => {
@@ -207,7 +200,6 @@ describe('POST /cleanup-orphans  -  logging', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
     // Override the logger mock with local spies for this suite
     mockLoggerInfo.mockReset();
     mockLoggerError.mockReset();
@@ -222,7 +214,7 @@ describe('POST /cleanup-orphans  -  logging', () => {
     const res = await app.request(makeRequest(VALID_SECRET));
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toBe('Cross-DB orphan cleanup failed');
+    expect(body.error).toBe('Orphan vector cleanup failed');
   });
 
   it('handles large deletedSiteIds array correctly', async () => {
@@ -243,47 +235,6 @@ describe('POST /cleanup-orphans  -  logging', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Vector client failure
-// ---------------------------------------------------------------------------
-
-describe('POST /cleanup-orphans  -  vector client failure', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
-    mockedGetRestClient.mockReturnValue({} as never);
-  });
-
-  it('returns 500 when getVectorClient throws', async () => {
-    mockedGetVectorClient.mockImplementation(() => {
-      throw new Error('Vector client unavailable');
-    });
-    mockedCleanup.mockResolvedValue(defaultResult);
-
-    const app = createApp();
-    const res = await app.request(makeRequest(VALID_SECRET));
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body.error).toBe('Cross-DB orphan cleanup failed');
-  });
-
-  it('returns 500 when both DB clients throw', async () => {
-    mockedGetRestClient.mockImplementation(() => {
-      throw new Error('REST unavailable');
-    });
-    mockedGetVectorClient.mockImplementation(() => {
-      throw new Error('Vector unavailable');
-    });
-
-    const app = createApp();
-    const res = await app.request(makeRequest(VALID_SECRET));
-    expect(res.status).toBe(500);
-    // First error thrown (REST) is the one caught
-    const body = await res.json();
-    expect(body.error).toBe('Cross-DB orphan cleanup failed');
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Logger verification
 // ---------------------------------------------------------------------------
 
@@ -292,7 +243,6 @@ describe('POST /cleanup-orphans  -  logger verification', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
   });
 
   it('logs success info after cleanup completes', async () => {
@@ -303,7 +253,7 @@ describe('POST /cleanup-orphans  -  logger verification', () => {
     await app.request(makeRequest(VALID_SECRET));
 
     expect(logger.info).toHaveBeenCalledWith(
-      'Cross-DB orphan cleanup completed',
+      'Orphan vector cleanup completed',
       expect.objectContaining({
         agentMemoriesDeleted: 3,
         ragDocumentsDeleted: 1,
@@ -322,7 +272,7 @@ describe('POST /cleanup-orphans  -  logger verification', () => {
     const app = createApp();
     await app.request(makeRequest(VALID_SECRET));
 
-    expect(logger.error).toHaveBeenCalledWith('Cross-DB orphan cleanup failed', error);
+    expect(logger.error).toHaveBeenCalledWith('Orphan vector cleanup failed', error);
   });
 
   it('logs deletedSiteIds count (not the full array) on success', async () => {
@@ -334,7 +284,7 @@ describe('POST /cleanup-orphans  -  logger verification', () => {
     await app.request(makeRequest(VALID_SECRET));
 
     expect(logger.info).toHaveBeenCalledWith(
-      'Cross-DB orphan cleanup completed',
+      'Orphan vector cleanup completed',
       expect.objectContaining({ deletedSiteIds: 100 }),
     );
   });
@@ -349,7 +299,6 @@ describe('POST /cleanup-orphans  -  method and path edge cases', () => {
     vi.clearAllMocks();
     process.env.REVEALUI_CRON_SECRET = VALID_SECRET;
     mockedGetRestClient.mockReturnValue({} as never);
-    mockedGetVectorClient.mockReturnValue({} as never);
     mockedCleanup.mockResolvedValue(defaultResult);
   });
 

--- a/apps/server/src/routes/content/sites.ts
+++ b/apps/server/src/routes/content/sites.ts
@@ -281,18 +281,12 @@ app.openapi(
     }
     await siteQueries.deleteSite(db, id);
 
-    // Fire-and-forget: clean up orphaned vector data in Supabase.
-    // Cross-DB FK cascades don't span separate database instances.
-    try {
-      const { getVectorClient } = await import('@revealui/db');
-      const vectorDb = getVectorClient();
-      cleanupVectorDataForSite(vectorDb, id).catch(() => {
-        // Swallowed  -  vector cleanup is best-effort.
-        // The batch cleanup cron handles missed deletions.
-      });
-    } catch {
-      // Vector DB not configured  -  skip cleanup
-    }
+    // Fire-and-forget: cascade delete the site's vector / RAG rows. Sites
+    // soft-delete instead of hard-delete, so FK cascades don't fire — the
+    // batch cleanup cron also handles missed deletions if this throws.
+    cleanupVectorDataForSite(db, id).catch(() => {
+      // Swallowed  -  vector cleanup is best-effort.
+    });
 
     return c.json({ success: true as const, message: 'Site deleted' }, 200);
   },

--- a/apps/server/src/routes/maintenance.ts
+++ b/apps/server/src/routes/maintenance.ts
@@ -1,13 +1,14 @@
 /**
- * Maintenance Routes  -  Cross-DB orphan cleanup cron endpoint
+ * Maintenance Routes  -  Soft-delete fanout cleanup cron endpoint
  *
- * Removes orphaned vector data (Supabase) for sites that have been
- * soft-deleted in NeonDB. Called by a Vercel cron job or external scheduler.
- * Protected by X-Cron-Secret header (REVEALUI_CRON_SECRET env var).
+ * Removes orphaned vector / RAG data on NeonDB for sites that have been
+ * soft-deleted (sites.deletedAt IS NOT NULL). Called by a Vercel cron job
+ * or external scheduler. Protected by X-Cron-Secret header
+ * (REVEALUI_CRON_SECRET env var).
  */
 
 import { logger } from '@revealui/core/observability/logger';
-import { getRestClient, getVectorClient } from '@revealui/db';
+import { getRestClient } from '@revealui/db';
 import { cleanupOrphanedVectorData } from '@revealui/db/cleanup';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
@@ -79,12 +80,10 @@ app.openapi(cleanupOrphansRoute, async (c) => {
   }
 
   try {
-    const restDb = getRestClient();
-    const vectorDb = getVectorClient();
+    const db = getRestClient();
+    const result = await cleanupOrphanedVectorData(db);
 
-    const result = await cleanupOrphanedVectorData(restDb, vectorDb);
-
-    logger.info('Cross-DB orphan cleanup completed', {
+    logger.info('Orphan vector cleanup completed', {
       agentMemoriesDeleted: result.agentMemoriesDeleted,
       ragDocumentsDeleted: result.ragDocumentsDeleted,
       ragChunksDeleted: result.ragChunksDeleted,
@@ -95,8 +94,8 @@ app.openapi(cleanupOrphansRoute, async (c) => {
     return c.json(result, 200);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    logger.error('Cross-DB orphan cleanup failed', error);
-    return c.json({ error: 'Cross-DB orphan cleanup failed' }, 500);
+    logger.error('Orphan vector cleanup failed', error);
+    return c.json({ error: 'Orphan vector cleanup failed' }, 500);
   }
 });
 

--- a/packages/db/src/cleanup/__tests__/cross-db-cleanup.test.ts
+++ b/packages/db/src/cleanup/__tests__/cross-db-cleanup.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentMemories } from '../../schema/agents.js';
+import { ragChunks, ragDocuments } from '../../schema/rag.js';
+import { sites } from '../../schema/sites.js';
 import { cleanupOrphanedVectorData, configureCleanup } from '../cross-db-cleanup.js';
 
 // =============================================================================
@@ -31,18 +34,18 @@ function createDeleteChain() {
 }
 
 /**
- * Creates a mock Drizzle DB client with select and delete methods.
- * Accepts a map of table references -> results for select queries,
- * so different tables return different data.
+ * Creates a mock Drizzle DB client whose `select().from(table)` returns the
+ * rows configured for that table reference (and empty otherwise). One client
+ * handles BOTH the sites query and the per-table orphan queries — the dual-DB
+ * branching that this module historically had collapsed into single-DB
+ * NeonDB during the Supabase phase-out.
  */
 function createMockDb(selectResults: Map<unknown, unknown[]> = new Map()) {
   const selectMock = vi.fn().mockImplementation(() => {
-    // Default empty chain; caller overrides via `fromMock`
     const chain = createSelectChain([]);
     chain.from.mockImplementation((table: unknown) => {
       const result = selectResults.get(table) ?? [];
-      const innerChain = createSelectChain(result);
-      return innerChain;
+      return createSelectChain(result);
     });
     return chain;
   });
@@ -61,32 +64,24 @@ type MockDb = ReturnType<typeof createMockDb>;
 // Tests
 // =============================================================================
 
-describe('cleanupOrphanedVectorData', () => {
-  let restDb: MockDb;
-  let vectorDb: MockDb;
+describe('cleanupOrphanedVectorData (single-DB)', () => {
+  let db: MockDb;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset config to defaults before each test
     configureCleanup({});
   });
 
   afterEach(() => {
-    // Reset config after each test
     configureCleanup({});
   });
 
   // ---- No deleted sites ---------------------------------------------------
 
   it('returns zero counts when no sites are deleted', async () => {
-    // REST DB: sites query returns no rows with deletedAt
-    restDb = createMockDb();
-    vectorDb = createMockDb();
+    db = createMockDb(new Map([[sites, []]]));
 
-    // Override select to return empty for sites
-    restDb.select.mockReturnValue(createSelectChain([]));
-
-    const result = await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    const result = await cleanupOrphanedVectorData(db as never);
 
     expect(result).toEqual({
       agentMemoriesDeleted: 0,
@@ -105,27 +100,16 @@ describe('cleanupOrphanedVectorData', () => {
     const orphanedDocuments = [{ id: 'doc-1' }];
     const orphanedChunks = [{ id: 'chunk-1' }, { id: 'chunk-2' }];
 
-    // REST DB: returns deleted sites
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
+    db = createMockDb(
+      new Map<unknown, unknown[]>([
+        [sites, deletedSites],
+        [agentMemories, orphanedMemories],
+        [ragDocuments, orphanedDocuments],
+        [ragChunks, orphanedChunks],
+      ]),
+    );
 
-    // Vector DB: returns orphaned records per table
-    // We need to track which table is queried by intercepting .from()
-    let vectorSelectCallCount = 0;
-    const vectorResults = [orphanedMemories, orphanedDocuments, orphanedChunks];
-
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        const idx = vectorSelectCallCount++;
-        const result = vectorResults[idx] ?? [];
-        return createSelectChain(result);
-      });
-      return chain;
-    });
-
-    const result = await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    const result = await cleanupOrphanedVectorData(db as never);
 
     expect(result.agentMemoriesDeleted).toBe(3);
     expect(result.ragDocumentsDeleted).toBe(1);
@@ -134,7 +118,7 @@ describe('cleanupOrphanedVectorData', () => {
     expect(result.dryRun).toBe(false);
 
     // Verify delete was called 3 times (one per table with orphans)
-    expect(vectorDb.delete).toHaveBeenCalledTimes(3);
+    expect(db.delete).toHaveBeenCalledTimes(3);
   });
 
   // ---- Dry-run mode -------------------------------------------------------
@@ -142,28 +126,16 @@ describe('cleanupOrphanedVectorData', () => {
   it('reports counts without deleting in dry-run mode', async () => {
     configureCleanup({ dryRun: true });
 
-    const deletedSites = [{ id: 'site-1' }];
-    const orphanedMemories = [{ id: 'mem-1' }];
-    const orphanedDocuments: unknown[] = [];
-    const orphanedChunks = [{ id: 'chunk-1' }];
+    db = createMockDb(
+      new Map<unknown, unknown[]>([
+        [sites, [{ id: 'site-1' }]],
+        [agentMemories, [{ id: 'mem-1' }]],
+        [ragDocuments, []],
+        [ragChunks, [{ id: 'chunk-1' }]],
+      ]),
+    );
 
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
-
-    let vectorSelectCallCount = 0;
-    const vectorResults = [orphanedMemories, orphanedDocuments, orphanedChunks];
-
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        const idx = vectorSelectCallCount++;
-        return createSelectChain(vectorResults[idx] ?? []);
-      });
-      return chain;
-    });
-
-    const result = await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    const result = await cleanupOrphanedVectorData(db as never);
 
     expect(result.agentMemoriesDeleted).toBe(1);
     expect(result.ragDocumentsDeleted).toBe(0);
@@ -171,44 +143,36 @@ describe('cleanupOrphanedVectorData', () => {
     expect(result.dryRun).toBe(true);
 
     // No deletes should have occurred
-    expect(vectorDb.delete).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   // ---- Idempotency --------------------------------------------------------
 
   it('is idempotent when run multiple times', async () => {
     // First run: has orphans
-    const deletedSites = [{ id: 'site-1' }];
+    db = createMockDb(
+      new Map<unknown, unknown[]>([
+        [sites, [{ id: 'site-1' }]],
+        [agentMemories, [{ id: 'mem-1' }]],
+        [ragDocuments, []],
+        [ragChunks, []],
+      ]),
+    );
 
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
-
-    let firstRunCallCount = 0;
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        const idx = firstRunCallCount++;
-        const results = [[{ id: 'mem-1' }], [], []];
-        return createSelectChain(results[idx] ?? []);
-      });
-      return chain;
-    });
-
-    const result1 = await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    const result1 = await cleanupOrphanedVectorData(db as never);
     expect(result1.agentMemoriesDeleted).toBe(1);
 
     // Second run: no more orphans (already cleaned up)
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        return createSelectChain([]);
-      });
-      return chain;
-    });
+    db = createMockDb(
+      new Map<unknown, unknown[]>([
+        [sites, [{ id: 'site-1' }]],
+        [agentMemories, []],
+        [ragDocuments, []],
+        [ragChunks, []],
+      ]),
+    );
 
-    const result2 = await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    const result2 = await cleanupOrphanedVectorData(db as never);
 
     expect(result2.agentMemoriesDeleted).toBe(0);
     expect(result2.ragDocumentsDeleted).toBe(0);
@@ -220,119 +184,104 @@ describe('cleanupOrphanedVectorData', () => {
   it('respects batch size configuration', async () => {
     configureCleanup({ batchSize: 2 });
 
-    // 3 deleted sites should require 2 batches (2 + 1)
+    // 3 deleted sites should require 2 batches (2 + 1) per orphan table
     const deletedSites = [{ id: 'site-1' }, { id: 'site-2' }, { id: 'site-3' }];
 
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
-
-    // Track select calls to verify batching
-    let vectorSelectCallCount = 0;
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
+    let orphanQueryCount = 0;
+    db = createMockDb();
+    db.select.mockImplementation(() => {
       const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        vectorSelectCallCount++;
+      chain.from.mockImplementation((table: unknown) => {
+        if (table === sites) {
+          return createSelectChain(deletedSites);
+        }
+        // Orphan queries (agentMemories / ragDocuments / ragChunks)
+        orphanQueryCount++;
         return createSelectChain([]);
       });
       return chain;
     });
 
-    await cleanupOrphanedVectorData(restDb as never, vectorDb as never);
+    await cleanupOrphanedVectorData(db as never);
 
-    // With batchSize=2 and 3 sites, each table should be queried twice (2 batches)
-    // 3 tables x 2 batches = 6 select->from calls
-    expect(vectorSelectCallCount).toBe(6);
+    // With batchSize=2 and 3 sites, each of 3 orphan tables runs 2 batches
+    // → 3 tables × 2 batches = 6 from() calls for orphan queries
+    expect(orphanQueryCount).toBe(6);
   });
 
   // ---- configureCleanup ---------------------------------------------------
 
-  it('configureCleanup merges with defaults', () => {
+  it('configureCleanup merges with defaults', async () => {
     configureCleanup({ batchSize: 100 });
-    // dryRun should still be false (default)
-    // We verify by running a cleanup and checking the result
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain([]));
-    vectorDb = createMockDb();
+    db = createMockDb(new Map([[sites, []]]));
 
-    return cleanupOrphanedVectorData(restDb as never, vectorDb as never).then((result) => {
-      expect(result.dryRun).toBe(false);
-    });
+    const result = await cleanupOrphanedVectorData(db as never);
+    expect(result.dryRun).toBe(false);
   });
 
-  it('configureCleanup resets to defaults when called with empty object', () => {
+  it('configureCleanup resets to defaults when called with empty object', async () => {
     configureCleanup({ batchSize: 1, dryRun: true });
     configureCleanup({});
 
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain([]));
-    vectorDb = createMockDb();
+    db = createMockDb(new Map([[sites, []]]));
 
-    return cleanupOrphanedVectorData(restDb as never, vectorDb as never).then((result) => {
-      expect(result.dryRun).toBe(false);
-    });
+    const result = await cleanupOrphanedVectorData(db as never);
+    expect(result.dryRun).toBe(false);
   });
 
   // ---- Error propagation --------------------------------------------------
 
-  it('propagates REST DB errors', async () => {
-    restDb = createMockDb();
+  it('propagates DB errors from the sites query', async () => {
+    db = createMockDb();
     const failChain = createSelectChain();
     failChain.from.mockReturnValue(failChain);
     failChain.then = (_resolve: unknown, reject: (e: Error) => void) =>
       reject(new Error('NeonDB connection refused'));
-    restDb.select.mockReturnValue(failChain);
+    db.select.mockReturnValue(failChain);
 
-    vectorDb = createMockDb();
-
-    await expect(cleanupOrphanedVectorData(restDb as never, vectorDb as never)).rejects.toThrow(
+    await expect(cleanupOrphanedVectorData(db as never)).rejects.toThrow(
       'NeonDB connection refused',
     );
   });
 
-  it('propagates vector DB select errors', async () => {
-    const deletedSites = [{ id: 'site-1' }];
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
-
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain();
-      chain.from.mockImplementation(() => {
-        const errorChain = createSelectChain();
-        errorChain.then = (_resolve: unknown, reject: (e: Error) => void) =>
-          reject(new Error('Supabase timeout'));
-        return errorChain;
+  it('propagates DB errors from orphan select queries', async () => {
+    db = createMockDb();
+    let orphanCallCount = 0;
+    db.select.mockImplementation(() => {
+      const chain = createSelectChain([]);
+      chain.from.mockImplementation((table: unknown) => {
+        if (table === sites) {
+          return createSelectChain([{ id: 'site-1' }]);
+        }
+        // First orphan query fails
+        if (orphanCallCount++ === 0) {
+          const errorChain = createSelectChain();
+          errorChain.then = (_resolve: unknown, reject: (e: Error) => void) =>
+            reject(new Error('orphan query failed'));
+          return errorChain;
+        }
+        return createSelectChain([]);
       });
       return chain;
     });
 
-    await expect(cleanupOrphanedVectorData(restDb as never, vectorDb as never)).rejects.toThrow(
-      'Supabase timeout',
-    );
+    await expect(cleanupOrphanedVectorData(db as never)).rejects.toThrow('orphan query failed');
   });
 
-  it('propagates vector DB delete errors', async () => {
-    const deletedSites = [{ id: 'site-1' }];
-    restDb = createMockDb();
-    restDb.select.mockReturnValue(createSelectChain(deletedSites));
-
-    let vectorSelectCallCount = 0;
-    vectorDb = createMockDb();
-    vectorDb.select.mockImplementation(() => {
-      const chain = createSelectChain([]);
-      chain.from.mockImplementation(() => {
-        const idx = vectorSelectCallCount++;
-        const results = [[{ id: 'mem-1' }], [], []];
-        return createSelectChain(results[idx] ?? []);
-      });
-      return chain;
-    });
-    vectorDb.delete.mockImplementation(() => ({
+  it('propagates DB delete errors', async () => {
+    db = createMockDb(
+      new Map<unknown, unknown[]>([
+        [sites, [{ id: 'site-1' }]],
+        [agentMemories, [{ id: 'mem-1' }]],
+        [ragDocuments, []],
+        [ragChunks, []],
+      ]),
+    );
+    db.delete.mockImplementation(() => ({
       where: vi.fn().mockRejectedValue(new Error('delete permission denied')),
     }));
 
-    await expect(cleanupOrphanedVectorData(restDb as never, vectorDb as never)).rejects.toThrow(
+    await expect(cleanupOrphanedVectorData(db as never)).rejects.toThrow(
       'delete permission denied',
     );
   });

--- a/packages/db/src/cleanup/cross-db-cleanup.ts
+++ b/packages/db/src/cleanup/cross-db-cleanup.ts
@@ -1,14 +1,17 @@
 /**
- * Cross-Database Cleanup Utility
+ * Vector / RAG Cleanup Utility
  *
- * Removes orphaned vector data (Supabase) when the owning site has been
- * soft-deleted in NeonDB. PostgreSQL FK cascades cannot span separate
- * database instances, so this utility bridges the gap.
+ * Removes orphaned vector data (agent memories + RAG documents/chunks) for
+ * sites that have been soft-deleted in NeonDB. Runs against a single NeonDB
+ * connection — historical "cross-DB" framing referred to a dual-DB (NeonDB +
+ * Supabase) architecture that is being phased out; these tables now live on
+ * the same database, but the soft-delete fanout is still needed because sites
+ * use soft-delete (`deletedAt`) rather than hard-delete.
  *
- * Affected Supabase tables:
- * - agentMemories.siteId       -> sites.id (NeonDB)
- * - ragDocuments.workspaceId   -> sites.id (NeonDB)
- * - ragChunks.workspaceId      -> sites.id (NeonDB)
+ * Affected tables:
+ * - agentMemories.siteId       -> sites.id
+ * - ragDocuments.workspaceId   -> sites.id
+ * - ragChunks.workspaceId      -> sites.id
  *
  * Safe to run multiple times (idempotent). Supports dry-run mode and
  * configurable batch sizes via `configureCleanup()`.
@@ -77,25 +80,20 @@ export interface CleanupResult {
 // =============================================================================
 
 /**
- * Removes orphaned vector data from Supabase for sites that have been
- * soft-deleted in NeonDB (sites.deletedAt IS NOT NULL).
+ * Removes orphaned vector data (agent memories + RAG documents/chunks) for
+ * sites that have been soft-deleted (sites.deletedAt IS NOT NULL).
  *
  * Steps:
- * 1. Query NeonDB for soft-deleted site IDs.
- * 2. Query Supabase for agentMemories / ragDocuments / ragChunks referencing
- *    those site IDs.
+ * 1. Query for soft-deleted site IDs.
+ * 2. Find agentMemories / ragDocuments / ragChunks referencing those site IDs.
  * 3. Delete the orphaned records in batches.
  *
- * @param restDb  - Drizzle client connected to NeonDB (REST database)
- * @param vectorDb - Drizzle client connected to Supabase (vector database)
+ * @param db - Drizzle client connected to NeonDB
  * @returns Summary of what was cleaned up
  */
-export async function cleanupOrphanedVectorData(
-  restDb: DrizzleClient,
-  vectorDb: DrizzleClient,
-): Promise<CleanupResult> {
-  // 1. Find all soft-deleted site IDs in NeonDB
-  const deletedSiteRows = await restDb
+export async function cleanupOrphanedVectorData(db: DrizzleClient): Promise<CleanupResult> {
+  // 1. Find all soft-deleted site IDs
+  const deletedSiteRows = await db
     .select({ id: sites.id })
     .from(sites)
     .where(isNotNull(sites.deletedAt));
@@ -112,17 +110,17 @@ export async function cleanupOrphanedVectorData(
     };
   }
 
-  // 2. Find orphaned records in Supabase (one query per table)
-  const orphanedMemoryIds = await findOrphanedMemoryIds(vectorDb, deletedSiteIds);
-  const orphanedDocumentIds = await findOrphanedDocumentIds(vectorDb, deletedSiteIds);
-  const orphanedChunkIds = await findOrphanedChunkIds(vectorDb, deletedSiteIds);
+  // 2. Find orphaned records (one query per table)
+  const orphanedMemoryIds = await findOrphanedMemoryIds(db, deletedSiteIds);
+  const orphanedDocumentIds = await findOrphanedDocumentIds(db, deletedSiteIds);
+  const orphanedChunkIds = await findOrphanedChunkIds(db, deletedSiteIds);
 
   // 3. Delete orphaned records (unless dry-run)
   if (!config.dryRun) {
-    await deleteMemoriesById(vectorDb, orphanedMemoryIds);
+    await deleteMemoriesById(db, orphanedMemoryIds);
     // Delete chunks before documents to respect FK ordering (chunks -> documents)
-    await deleteChunksById(vectorDb, orphanedChunkIds);
-    await deleteDocumentsById(vectorDb, orphanedDocumentIds);
+    await deleteChunksById(db, orphanedChunkIds);
+    await deleteDocumentsById(db, orphanedDocumentIds);
   }
 
   return {
@@ -139,13 +137,13 @@ export async function cleanupOrphanedVectorData(
 // =============================================================================
 
 async function findOrphanedMemoryIds(
-  vectorDb: DrizzleClient,
+  db: DrizzleClient,
   deletedSiteIds: string[],
 ): Promise<string[]> {
   const allIds: string[] = [];
   for (let i = 0; i < deletedSiteIds.length; i += config.batchSize) {
     const batch = deletedSiteIds.slice(i, i + config.batchSize);
-    const rows = await vectorDb
+    const rows = await db
       .select({ id: agentMemories.id })
       .from(agentMemories)
       .where(inArray(agentMemories.siteId, batch));
@@ -157,13 +155,13 @@ async function findOrphanedMemoryIds(
 }
 
 async function findOrphanedDocumentIds(
-  vectorDb: DrizzleClient,
+  db: DrizzleClient,
   deletedSiteIds: string[],
 ): Promise<string[]> {
   const allIds: string[] = [];
   for (let i = 0; i < deletedSiteIds.length; i += config.batchSize) {
     const batch = deletedSiteIds.slice(i, i + config.batchSize);
-    const rows = await vectorDb
+    const rows = await db
       .select({ id: ragDocuments.id })
       .from(ragDocuments)
       .where(inArray(ragDocuments.workspaceId, batch));
@@ -175,13 +173,13 @@ async function findOrphanedDocumentIds(
 }
 
 async function findOrphanedChunkIds(
-  vectorDb: DrizzleClient,
+  db: DrizzleClient,
   deletedSiteIds: string[],
 ): Promise<string[]> {
   const allIds: string[] = [];
   for (let i = 0; i < deletedSiteIds.length; i += config.batchSize) {
     const batch = deletedSiteIds.slice(i, i + config.batchSize);
-    const rows = await vectorDb
+    const rows = await db
       .select({ id: ragChunks.id })
       .from(ragChunks)
       .where(inArray(ragChunks.workspaceId, batch));
@@ -196,24 +194,24 @@ async function findOrphanedChunkIds(
 // Per-table delete helpers
 // =============================================================================
 
-async function deleteMemoriesById(vectorDb: DrizzleClient, ids: string[]): Promise<void> {
+async function deleteMemoriesById(db: DrizzleClient, ids: string[]): Promise<void> {
   for (let i = 0; i < ids.length; i += config.batchSize) {
     const batch = ids.slice(i, i + config.batchSize);
-    await vectorDb.delete(agentMemories).where(inArray(agentMemories.id, batch));
+    await db.delete(agentMemories).where(inArray(agentMemories.id, batch));
   }
 }
 
-async function deleteDocumentsById(vectorDb: DrizzleClient, ids: string[]): Promise<void> {
+async function deleteDocumentsById(db: DrizzleClient, ids: string[]): Promise<void> {
   for (let i = 0; i < ids.length; i += config.batchSize) {
     const batch = ids.slice(i, i + config.batchSize);
-    await vectorDb.delete(ragDocuments).where(inArray(ragDocuments.id, batch));
+    await db.delete(ragDocuments).where(inArray(ragDocuments.id, batch));
   }
 }
 
-async function deleteChunksById(vectorDb: DrizzleClient, ids: string[]): Promise<void> {
+async function deleteChunksById(db: DrizzleClient, ids: string[]): Promise<void> {
   for (let i = 0; i < ids.length; i += config.batchSize) {
     const batch = ids.slice(i, i + config.batchSize);
-    await vectorDb.delete(ragChunks).where(inArray(ragChunks.id, batch));
+    await db.delete(ragChunks).where(inArray(ragChunks.id, batch));
   }
 }
 
@@ -222,21 +220,20 @@ async function deleteChunksById(vectorDb: DrizzleClient, ids: string[]): Promise
 // =============================================================================
 
 /**
- * Removes all vector data (agent memories + RAG) for a single site from
- * the Supabase vector database. Designed to be called fire-and-forget
- * after a site is soft-deleted in NeonDB.
+ * Removes all vector data (agent memories + RAG) for a single site. Designed
+ * to be called fire-and-forget after a site is soft-deleted.
  *
  * Deletion order respects FK constraints:
  * 1. ragChunks     (references ragDocuments.id)
  * 2. ragDocuments  (references sites.id via workspaceId)
  * 3. agentMemories (references sites.id via siteId)
  *
- * @param vectorDb - Drizzle client connected to Supabase (vector database)
- * @param siteId   - The site ID whose vector data should be removed
+ * @param db     - Drizzle client connected to NeonDB
+ * @param siteId - The site ID whose vector data should be removed
  * @returns Summary of what was cleaned up
  */
 export async function cleanupVectorDataForSite(
-  vectorDb: DrizzleClient,
+  db: DrizzleClient,
   siteId: string,
 ): Promise<{
   agentMemoriesDeleted: number;
@@ -244,19 +241,19 @@ export async function cleanupVectorDataForSite(
   ragDocumentsDeleted: number;
 }> {
   // 1. RAG chunks (child of ragDocuments)
-  const deletedChunks = await vectorDb
+  const deletedChunks = await db
     .delete(ragChunks)
     .where(eq(ragChunks.workspaceId, siteId))
     .returning();
 
   // 2. RAG documents
-  const deletedDocs = await vectorDb
+  const deletedDocs = await db
     .delete(ragDocuments)
     .where(eq(ragDocuments.workspaceId, siteId))
     .returning();
 
   // 3. Agent memories
-  const deletedMemories = await vectorDb
+  const deletedMemories = await db
     .delete(agentMemories)
     .where(eq(agentMemories.siteId, siteId))
     .returning();

--- a/packages/db/src/cleanup/index.ts
+++ b/packages/db/src/cleanup/index.ts
@@ -1,9 +1,10 @@
 /**
- * Cross-Database Cleanup Utilities
+ * Cleanup Utilities
  *
- * Bridges the gap between NeonDB (REST) and Supabase (vector) databases
- * by cleaning up orphaned records that FK cascades cannot reach across
- * separate database instances.
+ * Soft-delete fanout cleanup for sites and their dependent vector / RAG /
+ * log / token rows on NeonDB. Sites use soft-delete (`deletedAt`) rather
+ * than hard-delete, so FK cascades don't fire automatically — these helpers
+ * remove orphaned rows in batches with idempotent dry-run support.
  */
 
 export {

--- a/packages/db/src/cleanup/rag-site-cleanup.ts
+++ b/packages/db/src/cleanup/rag-site-cleanup.ts
@@ -1,11 +1,11 @@
 /**
  * RAG Site Cleanup  -  Cascade delete for a single site
  *
- * When a site is deleted from NeonDB, the cross-database FK cascades to
- * Supabase are NOT enforced at the DB level. This function immediately
- * removes all RAG data belonging to a specific site from the vector DB.
+ * Sites use soft-delete (`sites.deletedAt`) rather than hard-delete, so FK
+ * cascades don't fire automatically. This function immediately removes all
+ * RAG data belonging to a specific site so dangling rows don't accumulate.
  *
- * Affected Supabase tables (deleted in FK-safe order):
+ * Affected tables (deleted in FK-safe order):
  * 1. rag_chunks      (workspaceId -> sites.id)
  * 2. rag_documents   (workspaceId -> sites.id)
  * 3. rag_workspaces  (id = sites.id)
@@ -56,38 +56,37 @@ export interface CleanupLogger {
 // =============================================================================
 
 /**
- * Deletes all RAG data (chunks, documents, workspace) for a single site
- * from the Supabase vector database.
+ * Deletes all RAG data (chunks, documents, workspace) for a single site.
  *
- * Deletion order respects FK constraints within Supabase:
+ * Deletion order respects FK constraints:
  * 1. rag_chunks  (references rag_documents.id)
  * 2. rag_documents (references sites.id via workspaceId)
  * 3. rag_workspaces (id = site.id)
  *
- * @param vectorDb - Drizzle client connected to Supabase (vector database)
- * @param siteId   - The site ID whose RAG data should be removed
- * @param logger   - Optional logger for observability
+ * @param db     - Drizzle client connected to NeonDB
+ * @param siteId - The site ID whose RAG data should be removed
+ * @param logger - Optional logger for observability
  * @returns Summary of what was cleaned up
  */
 export async function cleanupRagDataForSite(
-  vectorDb: DrizzleClient,
+  db: DrizzleClient,
   siteId: string,
   logger?: CleanupLogger,
 ): Promise<RagSiteCleanupResult> {
   // 1. Delete all chunks belonging to this site
-  const deletedChunks = await vectorDb
+  const deletedChunks = await db
     .delete(ragChunks)
     .where(eq(ragChunks.workspaceId, siteId))
     .returning();
 
   // 2. Delete all documents belonging to this site
-  const deletedDocs = await vectorDb
+  const deletedDocs = await db
     .delete(ragDocuments)
     .where(eq(ragDocuments.workspaceId, siteId))
     .returning();
 
   // 3. Delete the workspace row (id = siteId)
-  const deletedWorkspace = await vectorDb
+  const deletedWorkspace = await db
     .delete(ragWorkspaces)
     .where(eq(ragWorkspaces.id, siteId))
     .returning();


### PR DESCRIPTION
## Summary

Collapses the vector / RAG cleanup module from a dual-client signature to a single-client one. Continues the Supabase phase-out started in #604 and #694.

`cleanupOrphanedVectorData(restDb, vectorDb)` previously bridged a NeonDB ↔ Supabase split. Both tables now live on the same NeonDB instance, so the second client argument is dead weight. This PR removes it and reframes the module's docstrings as "soft-delete fanout cleanup" (the actual remaining purpose) instead of "cross-DB cascade workaround."

## Changes

### Cleanup module (`packages/db/src/cleanup/`)

| File | Change |
|---|---|
| `cross-db-cleanup.ts` | `cleanupOrphanedVectorData(restDb, vectorDb)` → `cleanupOrphanedVectorData(db)`. All internal helpers (`findOrphanedMemoryIds`, `deleteMemoriesById`, etc.) take a single `db`. Header docstring reframed. |
| `rag-site-cleanup.ts` | Already single-arg; renamed `vectorDb` → `db`, dropped Supabase framing from docstring. |
| `index.ts` | Module-level docstring reframed. |
| `__tests__/cross-db-cleanup.test.ts` | Rewrote for single DB. Replaced the two-client mock pattern with one table-keyed mock (`Map<table, rows>`) — cleaner and more honest about the actual wiring. |

### Consumers

| File | Change |
|---|---|
| `apps/server/src/routes/maintenance.ts` | Drop `getVectorClient()` call; use a single `getRestClient()`. Log message updated to "Orphan vector cleanup". |
| `apps/server/src/routes/content/sites.ts` | Drop dynamic import + try/catch for `getVectorClient`. Use the request-context `db` that's already in scope. |
| `apps/server/src/routes/__tests__/maintenance.test.ts` | Drop `getVectorClient` mock + the "vector client failure" describe block (no longer relevant — only one client). Single-arg assertion. Updated log-string expectations. |

Net: **+198 / −310** across 7 files. No production behavior change for the happy path; error paths simplify (one DB-failure mode instead of two).

## Verification

- [x] `pnpm turbo run typecheck --filter @revealui/db --filter server` → 16/16 tasks green
- [x] `pnpm turbo run test --filter @revealui/db --filter server` → 16/16 tasks green; server 2606/2607 pass + 1 pre-existing skip; db 1165/1170 pass + 5 pre-existing skips
- [x] `pnpm exec biome check --write` on all 7 files: clean
- [x] Pre-push gate ran on push (output above showed `Result: PASS`)
- [ ] CI green (full gate runs on PR)

## What's NOT in this PR

- `cleanupRagDataForSite` in `rag-site-cleanup.ts` is currently un-imported — kept in tree as a "WIRE-UP-PENDING" candidate per existing convention; not removed here.
- The dual-DB client (`getVectorClient` / `isSupabaseConnection` / SUPABASE_DATABASE_URL fallback) in `packages/db/src/client/index.ts` stays in this PR — that's PR-C scope (medium risk, gated on Phase 2 RAG data parity).

## Refs

- #687 — `chore(docs): align CLAUDE.md Supabase framing — Neon-primary, legacy phase-out` (the carve-out this PR aligns the cleanup module to)
- #694 — previous internal Supabase-guidance refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
