### PR TITLE
refactor(config,scripts,server): drop SUPABASE_* env-var schema + scripts dual-DB factory

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -60,19 +60,6 @@ POSTGRES_URL=postgresql://user:password@host/dbname?sslmode=require
 # REVEALUI_DROP_DATABASE=false
 
 # -----------------------------------------------------------------------------
-# Supabase (vectors + auth DB — optional, required for AI/vector features)
-# -----------------------------------------------------------------------------
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
-SUPABASE_DATABASE_URI=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
-# Next.js private aliases (not exposed to browser):
-NEXT_PRIVATE_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PRIVATE_SUPABASE_ANON_KEY=your-supabase-anon-key
-
-# -----------------------------------------------------------------------------
 # ElectricSQL (real-time sync — optional)
 # -----------------------------------------------------------------------------
 ELECTRIC_SERVICE_URL=http://localhost:3000

--- a/apps/admin/.env.production.template
+++ b/apps/admin/.env.production.template
@@ -109,10 +109,3 @@ ELECTRIC_SECRET=<your-electric-secret>
 # SENTRY_ORG=revealui-studio
 # SENTRY_PROJECT=revealui-admin
 
-# -----------------------------------------------------------------------------
-# Supabase — Vectors + Auth (optional — required for AI/vector features)
-# Supabase Dashboard: Project Settings → API
-# -----------------------------------------------------------------------------
-# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-# NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
-# SUPABASE_SERVICE_ROLE_KEY=eyJ...

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -22,14 +22,6 @@ POSTGRES_URL=postgresql://user:password@host/dbname?sslmode=require
 # DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
 
 # -----------------------------------------------------------------------------
-# Supabase (vectors + auth DB)
-# -----------------------------------------------------------------------------
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
-SUPABASE_DATABASE_URI=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
-
-# -----------------------------------------------------------------------------
 # RevealUI License (license validation route)
 # -----------------------------------------------------------------------------
 REVEALUI_LICENSE_PUBLIC_KEY=your-rsa-public-key-pem

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -317,7 +317,6 @@ describe('@revealui/config', () => {
       const config = getConfig();
 
       expect(config.optional).toBeDefined();
-      expect(config.optional.supabase).toBeDefined();
       expect(config.optional.sentry).toBeDefined();
       expect(config.optional.devTools).toBeDefined();
     });
@@ -334,17 +333,6 @@ describe('@revealui/config', () => {
     beforeEach(() => {
       Object.assign(process.env, validEnv);
       resetConfig(); // Reset after setting env vars to force fresh load
-    });
-
-    it('should handle optional Supabase config', () => {
-      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'test-publishable-key';
-
-      resetConfig(); // Reset again after adding optional vars
-      const config = getConfig();
-
-      expect(config.optional.supabase.url).toBe('https://test.supabase.co');
-      expect(config.optional.supabase.publishableKey).toBe('test-publishable-key');
     });
 
     it('should handle optional Sentry config', () => {

--- a/packages/config/src/__tests__/integration.test.ts
+++ b/packages/config/src/__tests__/integration.test.ts
@@ -148,22 +148,22 @@ describe('Config Integration Tests', () => {
   });
 
   describe('Optional Config Usage Pattern', () => {
-    it('should handle optional Supabase config', () => {
+    it('should handle optional Sentry config', () => {
       Object.assign(process.env, validEnv);
-      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://test@sentry.io/123';
       resetConfig();
 
-      const supabaseUrl = config.optional.supabase?.url;
-      expect(supabaseUrl).toBe('https://test.supabase.co');
+      const sentryDsn = config.optional.sentry?.dsn;
+      expect(sentryDsn).toBe('https://test@sentry.io/123');
     });
 
     it('should handle missing optional config gracefully', () => {
       Object.assign(process.env, validEnv);
       resetConfig();
 
-      // Optional configs should be falsy (undefined or empty string) when not set
-      const supabaseUrl = config.optional.supabase?.url;
-      expect(supabaseUrl || undefined).toBeUndefined();
+      // Optional configs should be undefined when not set
+      const sentryDsn = config.optional.sentry?.dsn;
+      expect(sentryDsn || undefined).toBeUndefined();
     });
   });
 

--- a/packages/config/src/__tests__/modules.test.ts
+++ b/packages/config/src/__tests__/modules.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getBrandingConfig } from '../modules/branding';
 import { getDatabaseConfig } from '../modules/database';
-import { getDevToolsConfig, getSentryConfig, getSupabaseConfig } from '../modules/optional';
+import { getDevToolsConfig, getSentryConfig } from '../modules/optional';
 import { getRevealConfig } from '../modules/reveal';
 import { getStorageConfig } from '../modules/storage';
 import { getStripeConfig } from '../modules/stripe';
@@ -73,14 +73,6 @@ describe('config modules', () => {
       (env as Record<string, unknown>).DATABASE_URL = 'postgresql://fallback:5432/db';
       const config = getDatabaseConfig(env);
       expect(config.url).toBe('postgresql://fallback:5432/db');
-    });
-
-    it('falls back to SUPABASE_DATABASE_URI', () => {
-      const env = makeEnv();
-      delete (env as Record<string, unknown>).POSTGRES_URL;
-      (env as Record<string, unknown>).SUPABASE_DATABASE_URI = 'postgresql://supabase:5432/db';
-      const config = getDatabaseConfig(env);
-      expect(config.url).toBe('postgresql://supabase:5432/db');
     });
 
     it('returns empty string when no DB URL set', () => {
@@ -193,42 +185,6 @@ describe('config modules', () => {
     it('returns undefined when not set', () => {
       const config = getStorageConfig(makeEnv());
       expect(config.blobToken).toBeUndefined();
-    });
-  });
-
-  describe('getSupabaseConfig', () => {
-    it('returns all Supabase fields when set', () => {
-      const config = getSupabaseConfig(
-        makeEnv({
-          NEXT_PUBLIC_SUPABASE_URL: 'https://abc.supabase.co',
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'publishable-key',
-          SUPABASE_SECRET_KEY: 'secret-key',
-          SUPABASE_DATABASE_URI: 'postgresql://supabase:5432/db',
-        }),
-      );
-      expect(config.url).toBe('https://abc.supabase.co');
-      expect(config.publishableKey).toBe('publishable-key');
-      expect(config.secretKey).toBe('secret-key');
-      expect(config.databaseUri).toBe('postgresql://supabase:5432/db');
-    });
-
-    it('returns undefined for unset fields', () => {
-      const config = getSupabaseConfig(makeEnv());
-      expect(config.url).toBeUndefined();
-      expect(config.publishableKey).toBeUndefined();
-      expect(config.secretKey).toBeUndefined();
-      expect(config.databaseUri).toBeUndefined();
-    });
-
-    it('treats empty strings as undefined', () => {
-      const config = getSupabaseConfig(
-        makeEnv({
-          NEXT_PUBLIC_SUPABASE_URL: '',
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: '',
-        }),
-      );
-      expect(config.url).toBeUndefined();
-      expect(config.publishableKey).toBeUndefined();
     });
   });
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,7 +42,6 @@ import {
   getOptionalConfig,
   type OptionalConfig,
   type SentryConfig,
-  type SupabaseConfig,
 } from './modules/optional.js';
 import { getRevealConfig, type RevealConfig } from './modules/reveal.js';
 import { getStorageConfig, type StorageConfig } from './modules/storage.js';
@@ -344,7 +343,6 @@ export type {
   SentryConfig,
   StorageConfig,
   StripeConfig,
-  SupabaseConfig,
 };
 // Export validation functions
 export { formatValidationErrors, validateAndThrow, validateEnvVars };

--- a/packages/config/src/modules/database.ts
+++ b/packages/config/src/modules/database.ts
@@ -10,8 +10,8 @@ export interface DatabaseConfig {
 }
 
 export function getDatabaseConfig(env: EnvConfig): DatabaseConfig {
-  // Accept POSTGRES_URL, DATABASE_URL (as fallback), or SUPABASE_DATABASE_URI
-  const url = env.POSTGRES_URL || env.DATABASE_URL || env.SUPABASE_DATABASE_URI || '';
+  // Accept POSTGRES_URL or DATABASE_URL (as fallback)
+  const url = env.POSTGRES_URL || env.DATABASE_URL || '';
 
   return {
     url,

--- a/packages/config/src/modules/optional.ts
+++ b/packages/config/src/modules/optional.ts
@@ -4,13 +4,6 @@
 
 import type { EnvConfig } from '../schema.js';
 
-export interface SupabaseConfig {
-  url?: string;
-  publishableKey?: string;
-  secretKey?: string;
-  databaseUri?: string;
-}
-
 export interface SentryConfig {
   dsn?: string;
   authToken?: string;
@@ -24,18 +17,8 @@ export interface DevToolsConfig {
 }
 
 export interface OptionalConfig {
-  supabase: SupabaseConfig;
   sentry: SentryConfig;
   devTools: DevToolsConfig;
-}
-
-export function getSupabaseConfig(env: EnvConfig): SupabaseConfig {
-  return {
-    url: env.NEXT_PUBLIC_SUPABASE_URL || undefined,
-    publishableKey: env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || undefined,
-    secretKey: env.SUPABASE_SECRET_KEY || undefined,
-    databaseUri: env.SUPABASE_DATABASE_URI || undefined,
-  };
 }
 
 export function getSentryConfig(env: EnvConfig): SentryConfig {
@@ -56,7 +39,6 @@ export function getDevToolsConfig(env: EnvConfig): DevToolsConfig {
 
 export function getOptionalConfig(env: EnvConfig): OptionalConfig {
   return {
-    supabase: getSupabaseConfig(env),
     sentry: getSentryConfig(env),
     devTools: getDevToolsConfig(env),
   };

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -120,13 +120,7 @@ const optionalSchema = z.object({
   REVEALUI_WHITELISTORIGINS: z.string().optional(), // Deprecated  -  use CORS_ORIGIN
 
   // Database
-  DATABASE_URL: postgresUrlSchema.optional(), // Fallback for POSTGRES_URL (REST) or SUPABASE_DATABASE_URL (vector)
-  SUPABASE_DATABASE_URL: postgresUrlSchema.optional(), // Preferred: Supabase vector database connection
-
-  // Supabase
-  NEXT_PUBLIC_SUPABASE_URL: urlSchema.optional(),
-  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().optional(),
-  SUPABASE_DATABASE_URI: postgresUrlSchema.optional(),
+  DATABASE_URL: postgresUrlSchema.optional(), // Fallback for POSTGRES_URL
 
   // Electric
   NEXT_PUBLIC_ELECTRIC_SERVICE_URL: z.string().optional(),
@@ -144,7 +138,6 @@ const optionalSchema = z.object({
 
   // Dev Tools
   NEON_API_KEY: z.string().optional(),
-  SUPABASE_SECRET_KEY: z.string().optional(),
   STRIPE_PROXY: z.enum(['0', '1']).optional(),
   SKIP_ONINIT: z.enum(['true', 'false']).optional(),
 

--- a/packages/scripts/database/connection.ts
+++ b/packages/scripts/database/connection.ts
@@ -1,7 +1,8 @@
 /**
  * Database Connection Factory
  *
- * Provides connection utilities for both Neon (REST) and Supabase (Vector) databases.
+ * Provides PostgreSQL connection utilities (NeonDB primary; backward-compatible
+ * with self-hosted Postgres via the same connection string).
  *
  * @dependencies
  * - scripts/lib/index.ts - Logger and database provider detection
@@ -87,51 +88,10 @@ export async function createConnection(config: ConnectionConfig): Promise<Databa
 }
 
 /**
- * Gets the REST database connection string from environment.
+ * Gets the database connection string from environment.
  */
 export function getRestConnectionString(): string | undefined {
   return process.env.POSTGRES_URL || process.env.DATABASE_URL;
-}
-
-/**
- * Gets the Vector database connection string from environment.
- */
-export function getVectorConnectionString(): string | undefined {
-  return (
-    process.env.SUPABASE_DATABASE_URL ||
-    process.env.DATABASE_URL ||
-    process.env.SUPABASE_DATABASE_URI
-  );
-}
-
-/**
- * Creates connections for both REST and Vector databases.
- */
-export async function createDualConnections(
-  options: { logger?: Logger } = {},
-): Promise<{ rest?: DatabaseConnection; vector?: DatabaseConnection }> {
-  const { logger = defaultLogger } = options;
-  const connections: { rest?: DatabaseConnection; vector?: DatabaseConnection } = {};
-
-  const restUrl = getRestConnectionString();
-  if (restUrl) {
-    connections.rest = await createConnection({
-      connectionString: restUrl,
-      type: 'rest',
-      logger,
-    });
-  }
-
-  const vectorUrl = getVectorConnectionString();
-  if (vectorUrl && vectorUrl !== restUrl) {
-    connections.vector = await createConnection({
-      connectionString: vectorUrl,
-      type: 'vector',
-      logger,
-    });
-  }
-
-  return connections;
 }
 
 /**

--- a/packages/setup/src/validators/env.ts
+++ b/packages/setup/src/validators/env.ts
@@ -162,17 +162,6 @@ export const OPTIONAL_ENV_VARS: EnvVariable[] = [
     required: false,
   },
   {
-    name: 'NEXT_PUBLIC_SUPABASE_URL',
-    description: 'Supabase project URL',
-    required: false,
-    validator: validators.url,
-  },
-  {
-    name: 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
-    description: 'Supabase publishable key (sb_publishable_...)',
-    required: false,
-  },
-  {
     name: 'REVEALUI_ADMIN_EMAIL',
     description: 'Initial admin email',
     required: false,

--- a/scripts/setup/validate-env.ts
+++ b/scripts/setup/validate-env.ts
@@ -56,9 +56,6 @@ const optional: string[] = [
   'REVEALUI_ADMIN_PASSWORD',
   'REVEALUI_CORS_ORIGINS',
   'REVEALUI_WHITELISTORIGINS', // Deprecated but still supported
-  'NEXT_PUBLIC_SUPABASE_URL',
-  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  'SUPABASE_DATABASE_URI',
   'NEXT_PUBLIC_ELECTRIC_SERVICE_URL',
   'ELECTRIC_SERVICE_URL',
   'NEXT_PUBLIC_SENTRY_DSN',
@@ -66,7 +63,6 @@ const optional: string[] = [
   'SENTRY_ORG',
   'SENTRY_PROJECT',
   'NEON_API_KEY',
-  'SUPABASE_SERVICE_ROLE_KEY',
   'STRIPE_PROXY',
   'SKIP_ONINIT',
 ];
@@ -75,7 +71,7 @@ const optional: string[] = [
 const namingConventions = {
   revealUI: /^REVEALUI_/, // RevealUI-specific server-side variables
   nextPublic: /^NEXT_PUBLIC_/, // Next.js client-side variables
-  standard: /^(STRIPE_|BLOB_|SENTRY_|SUPABASE_|NEON_|ELECTRIC_|SKIP_|NODE_)/, // Standard third-party prefixes
+  standard: /^(STRIPE_|BLOB_|SENTRY_|NEON_|ELECTRIC_|SKIP_|NODE_)/, // Standard third-party prefixes
 };
 
 async function validateEnvironment() {


### PR DESCRIPTION
## Summary

Drops SUPABASE_* env-var validation from `@revealui/config` plus the unused dual-DB connection factory in `packages/scripts/database/connection.ts`. Continues the Supabase phase-out from #694 and #695.

The dual-DB client at `packages/db/src/client/index.ts` still reads `process.env.SUPABASE_DATABASE_URL` directly — that's PR-C scope (gated on Phase 2 RAG-data parity verify). Production behavior is unchanged for any deployment where SUPABASE_DATABASE_URL is still set; only config-validation surface and dead scripts factory change here.

## Changes

### Config schema + modules
| File | Change |
|---|---|
| `packages/config/src/schema.ts` | Drop SUPABASE_DATABASE_URL, SUPABASE_DATABASE_URI, NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY, SUPABASE_SECRET_KEY from `optionalSchema` |
| `packages/config/src/modules/database.ts` | Drop `\|\| env.SUPABASE_DATABASE_URI` fallback |
| `packages/config/src/modules/optional.ts` | Delete `SupabaseConfig` interface, `getSupabaseConfig`, `supabase` field on `OptionalConfig` (zero product-code consumers) |
| `packages/config/src/index.ts` | Drop `SupabaseConfig` from imports + re-exports |

### Scripts + setup
| File | Change |
|---|---|
| `packages/scripts/database/connection.ts` | Delete `getVectorConnectionString` + `createDualConnections` (zero callers); reframe header docstring |
| `packages/setup/src/validators/env.ts` | Drop 2 `NEXT_PUBLIC_SUPABASE_*` validator entries |
| `scripts/setup/validate-env.ts` | Drop SUPABASE_* env names from optional list + `SUPABASE_` from naming-convention regex |

### .env.example files
| File | Lines dropped |
|---|---|
| `apps/admin/.env.example` | 13 |
| `apps/admin/.env.production.template` | 7 |
| `apps/server/.env.example` | 8 |

### Tests
| File | Change |
|---|---|
| `packages/config/src/__tests__/config.test.ts` | Delete "should handle optional Supabase config" test; drop `config.optional.supabase` assertion |
| `packages/config/src/__tests__/integration.test.ts` | Replace Supabase-config test with Sentry-config equivalent |
| `packages/config/src/__tests__/modules.test.ts` | Delete `getSupabaseConfig` block (3 tests) + the `falls back to SUPABASE_DATABASE_URI` test |

Net: **+15 / −181** across 13 files.

## Verification

- [x] `pnpm turbo run typecheck --filter @revealui/config --filter @revealui/setup --filter @revealui/scripts --filter @revealui/db --filter server` → 19/19 tasks green
- [x] `pnpm turbo run test` (same filters): 18/19 cached + server fresh. Server: 2604/2607 pass + 1 pre-existing skip + 2 hook timeouts in `metering.test.ts` and `mcp-usage.test.ts` (PGlite cold-start exceeded default 10s hookTimeout under parallel-test load). Both files pass cleanly with `--hookTimeout=30000` (13/13 tests). Unrelated to this PR — neither file references SUPABASE/vector/dual-DB.
- [x] `pnpm exec biome check --write` on all 13 files: clean
- [x] Pre-push gate ran on push (`Result: PASS`)
- [ ] CI green (full gate runs on PR)

## What's NOT in this PR

- **`packages/db/src/client/index.ts`** still reads `process.env.SUPABASE_DATABASE_URL` directly — PR-C scope (medium risk, gated on Phase 2 RAG-data parity verify).
- **`packages/db/src/cleanup/cross-db-cleanup.ts`** — single-DB collapse already shipped in PR-B (#695).
- **Defensive env cleanup at `packages/config/src/__tests__/setup.ts:18,41`** — keeps the `SUPABASE_` prefix filter to scrub leaked env state between tests; harmless to leave.

## Refs

- #687 — CLAUDE.md Supabase framing alignment
- #694 — PR-A (drift correction)
- #695 — PR-B (cleanup module → single-DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
