### PR TITLE
docs(config,scripts): GAP-129 PR-E doc sweep — drop stale Supabase refs

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -79,12 +79,9 @@ BLOB_READ_WRITE_TOKEN=vercel_blob_...
 
 # Neon
 NEON_API_KEY=neon_...
-
-# Supabase
-SUPABASE_URL=https://....supabase.co
-SUPABASE_ANON_KEY=eyJ...
-SUPABASE_SERVICE_ROLE_KEY=eyJ...
 ```
+
+> **Note:** prior versions of this list included a `SUPABASE_*` block. Those env vars are not validated by `@revealui/config` and were a stale leak from the customer-facing Supabase MCP adapter (which lives at `packages/mcp/src/servers/supabase.ts` and documents its own env vars in `packages/mcp/README.md`). If you're configuring the Supabase MCP server for customer use, see the MCP README; this package validates only the runtime env that `@revealui/server` and `@revealui/admin` actually read.
 
 ## File Loading Priority
 

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -29,13 +29,11 @@ revealui dev up --include mcp
 
 ### Advanced Database Scripts
 
-| Script                     | Purpose                                        |
-| -------------------------- | ---------------------------------------------- |
-| `setup-dual-database.ts`   | Configure both REST and Vector databases       |
-| `setup-vector-database.ts` | Set up Supabase vector database for embeddings |
-| `migrate-vector-data.ts`   | Migrate data to vector database                |
+| Script                   | Purpose                                  |
+| ------------------------ | ---------------------------------------- |
+| `setup-dual-database.ts` | Configure both REST and Vector databases |
 
-**Note**: Test database utilities have been moved to `scripts/dev-tools/`
+**Note**: Test database utilities have been moved to `scripts/dev-tools/`. Earlier `setup-vector-database.ts` and `migrate-vector-data.ts` scripts were Supabase-vector-specific and were removed during the GAP-129 Supabase phase-out — Postgres-native vector setup runs through the standard `pnpm db:migrate` path against Neon's `pgvector` extension.
 
 ### Database Maintenance
 
@@ -64,8 +62,6 @@ POSTGRES_URL=postgresql://...
 
 # Authentication
 REVEALUI_SECRET=<32-char-secret>
-SUPABASE_URL=https://...
-SUPABASE_ANON_KEY=...
 
 # Optional
 STRIPE_SECRET_KEY=sk_...      # For payment features


### PR DESCRIPTION
## Summary

Doc-only sweep of stale Supabase references in two READMEs, per the GAP-129 PR-E carve-out at `docs/gap-specs/GAP-129-phase-5-execution.md` §PR-E (post-2026-05-01 clarifications).

### Changes

**`packages/config/README.md`** — dropped a stale `# Supabase` env-var block (`SUPABASE_URL` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY`). These names are not validated by `@revealui/config`'s schema; they're a leak from the customer-facing Supabase MCP adapter env-var convention. Added a one-line note pointing readers to `packages/mcp/README.md` for the customer MCP env vars.

**`scripts/setup/README.md`** — dropped:
- 2 table rows referencing missing scripts (`setup-vector-database.ts`, `migrate-vector-data.ts` — both files no longer exist; verified via Glob)
- 2 SUPABASE env-var lines mistakenly placed under "Authentication"

Kept the line `# - Supabase MCP (database management)` in the MCP setup section — accurately describes the customer-facing MCP adapter retained per [#687](https://github.com/RevealUIStudio/revealui/pull/687) carve-out.

### What this PR does NOT touch (intentional, per spec)

| Item | Why |
|---|---|
| `packages/mcp/README.md` | Every Supabase mention is the customer-facing MCP adapter, KEPT per [#687](https://github.com/RevealUIStudio/revealui/pull/687). Already accurate. |
| `apps/admin/src/lib/__tests__/services-integration.test.ts` | Already clean — zero Supabase references; only Stripe imports. Spec line was outdated. |
| `packages/db/CHANGELOG.md` | Could collide with peer [PR-B (#695)](https://github.com/RevealUIStudio/revealui/pull/695) release notes; deferred. |
| `packages/db/__tests__/pool-cleanup.test.ts` | Depends on PR-C single-DB collapse. |
| `~/.claude/hooks/pre-tool-use.js` | Out-of-tree dotfiles; separate session. |
| `packages/mcp/src/config/config.json` Supabase MCP registration | KEPT per [#687](https://github.com/RevealUIStudio/revealui/pull/687); the original PR-E spec line "remove Supabase MCP registration" was wrong post-reframe. |

A companion ADR will land separately on an internal repo at `docs/decisions/2026-05-01-supabase-removal.md`.

## Coordination

Coordinated with peer agent `gap-129-prD-config-schema` (working on `packages/config/src/schema.ts` / `packages/scripts/database/connection.ts` / `.env.example` files / `scripts/setup/validate-env.ts`). Same-package overlap: I edit `packages/config/README.md` (docs), they edit `packages/config/src/schema.ts` (code) — different files, no `package.json` bumps planned, no merge collision expected. Workboard coord note posted at `.claude/workboard.md` 2026-05-01 ~19:15Z.

## GAP-129 Phase 5 status post-merge

| PR | Status |
|---|---|
| [PR-A #694](https://github.com/RevealUIStudio/revealui/pull/694) drift correction + Antigravity | ✅ MERGED (2026-05-01) |
| [PR-B #695](https://github.com/RevealUIStudio/revealui/pull/695) cleanup module → single-DB | ✅ MERGED (2026-05-01) |
| PR-C dual-DB client collapse | ⛔ GATED (Phase 2 + Phase 3 + 7 owner questions) |
| PR-D config + scripts SUPABASE_* drop | ⏸ in flight (peer `gap-129-prD-config-schema`) |
| **PR-E (this PR)** doc sweep | ◐ this PR |

After this lands, only PR-C/D remain on the GAP-129 Phase 5 plan.

## Test plan

- [x] No code paths touched; doc-only changes
- [x] No package.json bumps; no lockfile churn
- [x] Verified deleted files actually missing via Glob (`scripts/setup/setup-vector-database.ts`, `scripts/setup/migrate-vector-data.ts`)
- [x] Verified config schema doesn't validate the dropped `SUPABASE_URL`/`SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY` names (`grep -i supabase packages/config/src/schema.ts`)
- [ ] CI gate green (Quality, Type checking, Test + Build) — to be verified by GitHub Actions
- [ ] Owner manual merge per `feedback_no_auto_merge` once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
