### PR TITLE
docs(secrets): add revealui/dev/founder-license-key to the index

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -54,6 +54,7 @@ revealui/dev/stripe/webhook-secret
 revealui/dev/stripe/publishable-key      # pk_test_*
 revealui/dev/revealui-secret             # JWT/session, ≥32 chars
 revealui/dev/revealui-admin-api-key      # API admin auth
+revealui/dev/founder-license-key         # RVUI-<tier>-<32hex>; founder dev license consumed by revdev daemon (revdev/packages/daemon/src/license.ts)
 revealui/dev/blob/read-write-token       # Vercel Blob file uploads
 revealui/dev/google/client-id            # OAuth SSO
 revealui/dev/google/client-secret


### PR DESCRIPTION
## Summary

One-line addition to the SECRETS.md index for the new canonical revvault path `revealui/dev/founder-license-key`. The value is the founder's local dev RVUI license key (consumed by the revdev daemon — see `revdev/packages/daemon/src/license.ts:30-39`).

Pairs with the personal-machine refactor of `~/.revealui/wsl/bashrc.d/60-license.sh` to source from revvault instead of hard-coding the value (per the secrets hardline rule). Full decision context lives in internal docs `docs/decisions/2026-05-01-license-key-revvault.md`.

## Test plan

- [x] SECRETS.md renders correctly (single new line under Local development section)
- [x] Path matches existing convention (`revealui/dev/<name>`)
- [x] Comment notes the format + the consumer (revdev daemon)
- [x] Value already in revvault (`revvault get revealui/dev/founder-license-key` → 48-char `RVUI-enterprise-…`)
