### PR TITLE
docs(secrets): align Licensing section with actual revvault paths

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -125,8 +125,9 @@ revdev/github-token                      # perpetual license GitHub provisioning
 ### Licensing (RevealUI)
 
 ```
-revealui/license/private-key             # RS256 license signing key
-revealui/license/public-key              # RS256 license verification key
+revealui/env/license                     # Multi-key bundle for local dev: REVEALUI_LICENSE_PRIVATE_KEY + REVEALUI_LICENSE_PUBLIC_KEY (consumed by ~/suite/revealui/.envrc via `revvault export-env`)
+revealui/prod/license/private-key        # RS256 license signing key (production; mirrored to Vercel `revealui-api` + `revealui-admin`)
+revealui/prod/license/public-key         # RS256 license verification key (production; mirrored to Vercel `revealui-api` + `revealui-admin`)
 ```
 
 ### LLM / AI providers


### PR DESCRIPTION
## Summary

Single-section update to `docs/SECRETS.md`: the `### Licensing (RevealUI)` block listed `revealui/license/private-key` and `revealui/license/public-key` — neither exists in revvault. The actual populated paths are:

```
revealui/env/license                     # Multi-key bundle for local dev (PRIVATE + PUBLIC)
revealui/prod/license/private-key        # Production signing key
revealui/prod/license/public-key         # Production verification key
```

The two prod paths are properly mirrored to Vercel `revealui-api` + `revealui-admin` production env (verified via `vercel env ls production`).

Surfaced during the production-side audit that closed the loop on the 2026-05-01-license-key-revvault ADR.

## Test plan

- [x] Diff is one section, three lines changed (2 deleted + 3 added)
- [x] All three new paths confirmed present in revvault via `revvault list`
- [x] Both prod paths confirmed present in Vercel via `vercel env ls production` for `revealui-api` (apps/server) and `revealui-admin` (apps/admin)
- [ ] (out of scope) Broader path-drift cleanup — `revdev/license-public-key` is also in revvault but undocumented; left for a separate sweep
