### PR TITLE
docs(secrets): add revdev/license-public-key to the RevDev index

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -119,6 +119,7 @@ revealcoin/devnet-addresses              # operational, not a keypair
 
 ```
 revdev/license-signing-key               # when Ed25519 format lands (see license.ts TODO)
+revdev/license-public-key                # paired with signing-key (license verification side, for future format)
 revdev/github-token                      # perpetual license GitHub provisioning
 ```
 


### PR DESCRIPTION
## Summary

One-line addition to `docs/SECRETS.md`: `revdev/license-public-key` exists in revvault but wasn't documented in the RevDev section. Same class of drift as [#700](https://github.com/RevealUIStudio/revealui/pull/700) — closing the loop on the secrets-doc audit.

## Test plan

- [x] Path confirmed present in revvault via `revvault list`
- [x] Diff is one line added (no other changes)
