### PR TITLE
fix(deploy): use PROD_POSTGRES_URL secret for Sensitive POSTGRES_URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,24 +140,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Vercel CLI
-        run: pnpm add -g vercel@latest
-
       - name: Build DB package
         run: pnpm turbo build --filter=@revealui/db
-
-      - name: Pull POSTGRES_URL from Vercel (API project is DB owner)
-        # Single source of truth: Vercel project env. Avoids maintaining
-        # POSTGRES_URL as a separate GitHub secret that can drift on rotation.
-        run: |
-          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-          if [ ! -f .vercel/.env.production.local ]; then
-            echo "::error::vercel pull produced no .env.production.local"
-            exit 1
-          fi
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: prj_zk6EQijYXwd9L7BccuBssi436ktM # api
 
       - name: Run migrations
         # Runs drizzle-kit migrate (non-interactive, applies pending SQL
@@ -186,13 +170,15 @@ jobs:
         env:
           NO_COLOR: "1"
           FORCE_COLOR: "0"
+          # PROD_POSTGRES_URL mirrors Vercel revealui-api POSTGRES_URL (Sensitive),
+          # because `vercel env pull` returns empty strings for Sensitive vars and
+          # this step needs the actual value to run drizzle-kit migrate. Long-term:
+          # revvault-vercel-sync Phase 5 replaces this mirror with revvault as
+          # the canonical source for both Vercel + this secret.
+          POSTGRES_URL: ${{ secrets.PROD_POSTGRES_URL }}
         run: |
-          set -a
-          # shellcheck disable=SC1091
-          . .vercel/.env.production.local
-          set +a
           if [ -z "${POSTGRES_URL:-}" ]; then
-            echo "::error::POSTGRES_URL not found in pulled Vercel env"
+            echo "::error::PROD_POSTGRES_URL secret not set on the repo"
             exit 1
           fi
           echo "::group::Backfill check (pre-migrate)"


### PR DESCRIPTION
## Summary

Fixes the production deploy pipeline so it works with `POSTGRES_URL` marked Sensitive on Vercel.

The `Apply Migrations` job pulled the connection string via `vercel env pull`, which returns empty strings for Sensitive vars. After today's Neon credential rotation + Vercel update, both `POSTGRES_URL` and `DATABASE_URL` were re-added as Sensitive (correct posture, reinforced by the recent account-leak incident). The migration step then failed with `POSTGRES_URL not found in pulled Vercel env` — see [run 25224736794](https://github.com/RevealUIStudio/revealui/actions/runs/25224736794/job/74008798084).

This PR mirrors the value to a GitHub Actions Repository Secret (`PROD_POSTGRES_URL`) and reads it directly on the migration step. Vercel runtime keeps Sensitive; the Vercel CLI + the pull-and-source plumbing are no longer involved in the migration step.

## Changes

- Remove `Install Vercel CLI` step from the `migrate` job (only used by the next step)
- Remove `Pull POSTGRES_URL from Vercel` step (returned empty for Sensitive vars)
- Replace `set -a; . .vercel/.env.production.local; set +a` with `POSTGRES_URL: ${{ secrets.PROD_POSTGRES_URL }}` in the `Run migrations` step's `env:` block

Net: `-25 / +7`. Drizzle migration call, `NO_COLOR` / `FORCE_COLOR` guard rails, and the GAP-168 backfill+assert sandwich are untouched.

The `Validate Migrations` job (separate, before `migrate`) still uses `vercel env pull` — that's intentional. Its `validateStartup` step is `lenient`-mode (#690) which accepts Sensitive empty strings as "present" for presence-only validation. Only the migration step needs the actual value.

## Long-term plan

This is a bridge until `docs/revvault-vercel-sync.md` Phase 5 (revvault canonical → both Vercel + secrets sync from revvault) lands. The doc is currently DRAFT awaiting owner sign-off; B1 review caveats apply.

## Test plan

- [x] Diff reviewed locally (`-25 / +7`, only `migrate` job affected)
- [x] `PROD_POSTGRES_URL` secret added on the repo (manual, by owner)
- [ ] CI green on this PR (lint, quality, typecheck, unit tests, build — `deploy.yml` itself does not run on PRs)
- [ ] Post-merge: deploy auto-triggers on push to `main`; `Apply Migrations` succeeds; full deploy completes
- [ ] Smoke-test `https://api.revealui.com/api/contact` for CR7-01 (founder@ inbox-receipt — owner verification)
