### PR TITLE
fix(canary): mark packages/revealui private until name dispute resolves

### DIFF
--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,7 +1,8 @@
 {
   "name": "revealui",
   "version": "0.1.0",
-  "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui.",
+  "private": true,
+  "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [
     "revealui",
     "agentic",


### PR DESCRIPTION
## Summary

Mark `packages/revealui` as `"private": true` so the release-canary workflow stops failing on it.

## Root cause (investigation in [revealui#702](https://github.com/RevealUIStudio/revealui/pull/702) thread)

Bare `revealui` has **never been published** to npm — the registry rejects it with:

```
E403 403 Forbidden - PUT https://registry.npmjs.org/revealui -
Package name too similar to existing package reveal-ui;
try renaming your package to '@revealui-org/revealui' and
publishing with 'npm publish --access=public' instead
```

The release-canary workflow has been failing on **every push to test for 20+ runs going back to 2026-04-29** because changesets tries to publish this package and gets E403, even though the 14 sibling scoped packages (`@revealui/*`) succeed.

Verified npm registry state:
- `https://registry.npmjs.org/revealui` → `{"error":"Not found"}`
- `https://registry.npmjs.org/@revealui/core` → returns metadata (scoped names work)

## Fix

Smallest possible change: add `"private": true` to `packages/revealui/package.json`. Changesets skips private packages on publish. Update the description to document the NOT-published status so future readers don't waste cycles retrying.

## What this is NOT

- Not a user-facing UX break — bare `revealui` was never on npm, so no install path breaks. Documented paths remain `npm create revealui` (→ `create-revealui`) and the scoped `@revealui/*` packages.
- Not a permanent verdict on the name — reversible by dropping `"private": true` if/when the name gets unblocked via npm support OR we rename to `@revealui/revealui`. Tracking the deferred decision separately.

## Test plan

- [ ] CI green on this PR
- [ ] After merge to test: confirm `Release Canary` workflow turns from failure → success on next push
- [ ] Confirm 14 sibling `@revealui/*` packages still publish their canary snapshots
- [ ] No `npx revealui` regression (was never working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
