### PR TITLE
chore(presentation): bump 0.4.0 -> 0.4.1 to publish Slot fix

### DIFF
--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/presentation
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix `Slot` primitive to clone children unconditionally when the child is a valid React element, instead of gating on the (often-not-forwarded) `asChild` prop. The 0.4.0 build of `Slot` only cloned when `asChild` was passed in — but `Button`/`ButtonCVA` do not forward `asChild` to `Slot` after destructuring it locally. Result: `<ButtonCVA asChild><AnyComponent /></ButtonCVA>` rendered the child unstyled inside a wrapping `<div>` carrying the button classes, instead of merging the classes onto the child as intended. This fix restores the documented `asChild` composition pattern across all CVA-styled components in the package.
+
+  No public API change. The fix is already on `main`/`test` (Slot's runtime behavior changed to "always clone if children is a valid element"); this release just publishes that runtime to npm.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/presentation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native React UI components built on Tailwind v4 — zero external UI dependencies (only clsx + CVA). Buttons, forms, dialogs, navigation, and more.",
   "keywords": [
     "components",


### PR DESCRIPTION
## Summary

Manual version bump `@revealui/presentation` 0.4.0 → 0.4.1 to publish the Slot primitive fix that's already on `main`/`test` but never made it to npm.

## The bug shipped in 0.4.0

`packages/presentation/dist/skeleton-*.js` (in npm 0.4.0):

```js
function Slot({ children, asChild, ref, ...slotProps }) {
  if (asChild && React.isValidElement(children))
    return React.cloneElement(children, { ...slotProps, ...children.props, ref });
  return jsx("div", { ...slotProps, ref, children });  // ← falls through
}
```

`Button`/`ButtonCVA` destructure `asChild` locally and **do not forward it to `<Slot>`**. So 0.4.0's Slot saw `asChild=undefined` → fell through → rendered a wrapping `<div>` carrying the button classes around an unstyled child.

Net effect: `<ButtonCVA asChild><Link to="/contact">Book a call</Link></ButtonCVA>` rendered `<div class="…button-classes…"><a class="">Book a call</a></div>` — Link's `<a>` had `className=""`, no styling. Surfaced while wiring [agency#1](https://github.com/RevealUIStudio/agency/pull/1) — eval on the rendered DOM showed the empty className.

## The fix (already on main/test)

`packages/presentation/src/primitives/Slot.tsx`:

```tsx
function Slot({ children, asChild: _asChild, ref, ...slotProps }) {
  if (React.isValidElement(children)) {  // always clone if valid
    const mergedClassName = [slotProps.className, childProps.className].filter(Boolean).join(' ');
    const mergedStyle = ...;
    return React.cloneElement(children, { ...slotProps, ...childProps, className: mergedClassName, style: mergedStyle, ref });
  }
  return <div {...slotProps}>{children}</div>;
}
```

Always clones when children is a valid element + explicit className/style merge. No public API change — just runtime correctness.

## Why a manual bump (no changeset)

There are 39 pending changesets in `.changeset/` covering unrelated work (MCP, AI, x402, contracts, etc.). Running `pnpm changeset version` would batch-version all of them at once, which is a much larger release than this hotfix needs to be. Manual `package.json` bump + `CHANGELOG` entry lets us publish a focused 0.4.1 patch now and leave the broader release for separate coordination.

`pnpm changeset publish` (in release.yml) compares local versions to npm and publishes any package whose local version is ahead — so the 0.4.1 bump is sufficient to ship without a "Version Packages" PR. The 39 queued changesets remain untouched for the next coordinated release.

## Test plan

- [ ] CI green on this PR (no functional code change beyond version + CHANGELOG)
- [ ] After merge to test: visual snapshot tests still pass on test branch (no rendering change for default Button usage)
- [ ] After test → main promotion: trigger `release.yml` (Actions tab → Release OSS Packages → Run workflow)
- [ ] Verify `npm view @revealui/presentation@0.4.1` returns the new version
- [ ] Verify `npm view @revealui/presentation@latest` returns 0.4.1
- [ ] Verify `agency` Vercel preview deploy picks up 0.4.1 on next deploy (after `pnpm install` in the agency repo) — `<ButtonCVA asChild><Link/></ButtonCVA>` should now render the Link with merged button classes

## Follow-up companion (separate PR)

`@revealui/presentation` should ship a `LinkButton` primitive that pairs Button styling with anchor semantics natively, sidestepping the asChild + custom-Link composition footgun entirely. Spec landing in an internal repo `docs/specs/linkbutton-primitive.md` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
