### PR TITLE
promote: test -> main (presentation 0.4.1 Slot fix publish)

### DIFF
--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/presentation
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix `Slot` primitive to clone children unconditionally when the child is a valid React element, instead of gating on the (often-not-forwarded) `asChild` prop. The 0.4.0 build of `Slot` only cloned when `asChild` was passed in — but `Button`/`ButtonCVA` do not forward `asChild` to `Slot` after destructuring it locally. Result: `<ButtonCVA asChild><AnyComponent /></ButtonCVA>` rendered the child unstyled inside a wrapping `<div>` carrying the button classes, instead of merging the classes onto the child as intended. This fix restores the documented `asChild` composition pattern across all CVA-styled components in the package.
+
+  No public API change. The fix is already on `main`/`test` (Slot's runtime behavior changed to "always clone if children is a valid element"); this release just publishes that runtime to npm.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/presentation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native React UI components built on Tailwind v4 — zero external UI dependencies (only clsx + CVA). Buttons, forms, dialogs, navigation, and more.",
   "keywords": [
     "components",


### PR DESCRIPTION
## Summary

Promote single commit from `test` to `main`:

- `8179bdbad` [#707](https://github.com/RevealUIStudio/revealui/pull/707) `chore(presentation): bump 0.4.0 -> 0.4.1 to publish Slot fix`

Once merged to `main`, manually trigger `release.yml` (Actions → Release OSS Packages → Run workflow) to publish `@revealui/presentation@0.4.1` to npm.

## Why this flows now

The 0.4.1 patch publishes the Slot primitive fix that's already on main/test as runtime behavior but never made it to a published version. Need it on npm so [agency#1](https://github.com/RevealUIStudio/agency/pull/1) consumers (and any other Vite SPA pinning `@revealui/presentation@^0.4.0`) pick up the asChild composition fix.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: trigger `release.yml` → `pnpm changeset publish` detects 0.4.1 > registry's 0.4.0 → publishes
- [ ] Verify `npm view @revealui/presentation@0.4.1` returns metadata
- [ ] Verify `npm view @revealui/presentation@latest` returns 0.4.1
- [ ] Verify `agency` repo's next deploy picks up 0.4.1 via lockfile resolution of `^0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
