### PR TITLE
promote: test -> main (presentation 0.5.0 LinkButton)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ revealui/
 │   ├── core/           # Runtime engine, REST API, plugins
 │   ├── db/             # Drizzle ORM schema (86 tables, dual-DB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
-│   ├── presentation/   # 57 UI components (Tailwind v4)
+│   ├── presentation/   # 58 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR
 │   ├── setup/          # Environment setup utilities
 │   ├── sync/           # ElectricSQL real-time sync

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You have:
 - **Content management:** define collections in TypeScript, get a full REST API, admin UI, and MCP tools instantly
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
-- **57 UI components:** built with Tailwind CSS v4, zero external UI dependencies
+- **58 UI components:** built with Tailwind CSS v4, zero external UI dependencies
 - **12 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
@@ -153,7 +153,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | [`@revealui/contracts`](packages/contracts)             | Zod schemas + TypeScript types (single source)    |
 | [`@revealui/db`](packages/db)                           | Drizzle ORM schema (86 tables), dual-DB client     |
 | [`@revealui/auth`](packages/auth)                       | Session auth, password reset, rate limiting       |
-| [`@revealui/presentation`](packages/presentation)       | 57 UI components (Tailwind v4, zero ext deps)     |
+| [`@revealui/presentation`](packages/presentation)       | 58 UI components (Tailwind v4, zero ext deps)     |
 | [`@revealui/openapi`](packages/openapi)                 | OpenAPI route helpers and Swagger generation       |
 | [`@revealui/router`](packages/router)                   | Lightweight file-based router with SSR            |
 | [`@revealui/config`](packages/config)                   | Type-safe environment configuration               |

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -73,7 +73,7 @@ packages/
 ├── contracts/      # Zod schemas & TypeScript types
 ├── db/             # Database (Drizzle ORM, 86 tables)
 ├── auth/           # Authentication system
-├── presentation/   # 57 UI components (Tailwind v4)
+├── presentation/   # 58 UI components (Tailwind v4)
 ├── router/         # File-based router with SSR
 ├── config/         # Type-safe env config (Zod)
 ├── utils/          # Logger, DB helpers, validation

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -158,7 +158,7 @@ tsx scripts/seed-products.ts
 
 ## 4. Add a pricing page
 
-RevealUI ships 57 UI components. Use them to build a pricing page in your frontend app.
+RevealUI ships 58 UI components. Use them to build a pricing page in your frontend app.
 
 In `apps/mainframe/src/pages/pricing.tsx`:
 
@@ -355,7 +355,7 @@ This is the foundation. The five primitives  -  Users, Content, Products, Paymen
 ## Next steps
 
 - **Add more collections**  -  orders, reviews, blog posts, anything your business needs
-- **Customize the UI**  -  `packages/presentation` has 57 components to build with
+- **Customize the UI**  -  `packages/presentation` has 58 components to build with
 - **Add AI**  -  Pro tier adds AI agents; see the [AI guide](./AI.md)
 - **Invite your team**  -  role-based access control is already wired in
 

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -1476,7 +1476,7 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Component Summary by Package
 
-### @revealui/presentation (57 components)
+### @revealui/presentation (58 components)
 - 6 Primitives (Box, Flex, Grid, Text, Heading, Slot)
 - 13 Form Controls (Button, Input, Textarea, Select, Checkbox, Radio, etc.)
 - 8 Data Display (Card, Table, Avatar, Badge, etc.)
@@ -1504,4 +1504,4 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 ---
 
 **Last Updated:** 2026-03-03
-**Packages:** `@revealui/presentation` (57 components), `@revealui/core` (21 components)
+**Packages:** `@revealui/presentation` (58 components), `@revealui/core` (21 components)

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -17,7 +17,7 @@ Brutally honest audit of what RevealUI documentation claimed versus what the cod
 
 ## Executive Summary
 
-RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 57 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
+RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 58 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
 
 ---
 
@@ -51,7 +51,7 @@ RevealUI's core framework is **real and substantial**  -  auth, billing, runtime
 |---------|----------|
 | React 19 | `react@^19.2.3` in package.json |
 | Next.js 16 | Catalog reference, App Router throughout |
-| 50+ UI components | **57 components** in presentation package |
+| 50+ UI components | **58 components** in presentation package |
 | Session-only auth (no JWT) | bcrypt-12, RBAC/ABAC, 2FA, WebAuthn, OAuth |
 | Stripe checkout/subscriptions/webhooks | 1,100-line webhook handler, 12 event types |
 | Drizzle ORM dual-DB (NeonDB + Supabase) | Schema + queries + boundary enforcement |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,7 +44,7 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)**: Justifiable, Orthogonal, Sovereign
 
 - [Package Reference](./REFERENCE.md): Core, contracts, DB, config, presentation, utils, router, CLI
 - [Core Stability](./CORE_STABILITY.md): API stability tiers, production verification status, version policy
-- [Component Catalog](./COMPONENT_CATALOG.md): 57 native UI components
+- [Component Catalog](./COMPONENT_CATALOG.md): 58 native UI components
 - [AI](./AI.md): AI package overview, prompt/response/semantic caching
 - [Pro](./PRO.md): Pro packages (`@revealui/ai`, `@revealui/harnesses`), MCP integration, open-model inference, x402, marketplace
 - [RevealUI Studio Suite](./SUITE.md): Companion products (RevDev, RevVault, RevCon, RevealCoin, Forge, RevSkills, RevKit) — what each does and how they compose

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -24,7 +24,7 @@
 - **Packages:** 26 packages + 5 apps = 31 workspaces
 - **Tests:** extensive test suite across unit, integration, and E2E layers; all workspaces build and typecheck (run `pnpm test` for current count)
 - **Database:** 86 tables (Drizzle ORM on **Neon** — primary). Supabase phase-out is in flight: GAP-129 PR-A/B/D shipped (2026-05-01); PR-C (dual-DB client collapse) is the remaining work. RAG tables (`ragDocuments`, `ragChunks`) and the legacy Supabase MCP server adapter remain in-tree during the transition. 61 CHECK constraints enforced (migration 0001 applied 2026-04-15).
-- **UI Components:** 57 native components (Tailwind v4, zero external UI deps)
+- **UI Components:** 58 native components (Tailwind v4, zero external UI deps)
 - **Branch pipeline:** `feature/* → test → main` — `test` is the default PR target; production deploys are auto on push to `main` only.
 - **CI:** GitHub Actions (ci.yml with E2E smoke, release.yml, release-pro.yml, security.yml, system-tune-snapshot.yml), 3-phase CI gate + E2E + CodeQL + Gitleaks
 - **Infrastructure:** Nix flakes, direnv, Biome 2 (sole linter), Turborepo, pnpm 10
@@ -38,7 +38,7 @@
 |---------|--------|------------|
 | admin engine (core) | Built | High  -  237 files, deep implementation |
 | AI agent system | Built | Medium  -  untested in production |
-| UI components (57) | Built | High  -  native hooks, no external deps |
+| UI components 58) | Built | High  -  native hooks, no external deps |
 | Database schema (86 tables) | Built | High  -  migration 0001 applied, 61 CHECK constraints enforced |
 | Auth (sessions, rate limiting) | Built | Medium  -  code exists, no production verification |
 | Stripe integration | Built | Medium  -  DB-backed circuit breaker (circuit_breaker_state table) |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -170,7 +170,7 @@ For more → [Troubleshooting Guide](./TROUBLESHOOTING.md)
 ## Next Steps
 
 - [Full documentation](./INDEX.md)
-- [Component catalog](./COMPONENT_CATALOG.md)  -  57 native UI components
+- [Component catalog](./COMPONENT_CATALOG.md)  -  58 native UI components
 - [Example projects](./EXAMPLES.md)  -  blog, subscription starter, storefront
 - [Deployment guide](./CI_CD_GUIDE.md)  -  Vercel, environment variables, production checklist
 - [AI agents](./AI.md)  -  agent orchestration, open-model inference, MCP framework (Pro)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1989,7 +1989,7 @@ See `.env.template` in the repo root for the full list with descriptions.
 
 # @revealui/presentation
 
-57 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
+58 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
 
 ```bash
 npm install @revealui/presentation
@@ -2709,7 +2709,7 @@ Behaviour-only versions of form controls  -  bring your own styles.
 ## Related
 
 - [`@revealui/core`](/reference/core)  -  Uses `presentation` for admin UI components
-- [Component catalog](/component-catalog)  -  Visual index of all 57 components
+- [Component catalog](/component-catalog)  -  Visual index of all 58 components
 
 ---
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -16,7 +16,7 @@ Full content management engine with collections, access control, hooks, field ty
 and a REST API. The heart of RevealUI and the most mature part of the codebase.
 
 ### UI component library
-**57 native React components** in `packages/presentation/src/components/`, built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
+**58 native React components** in `packages/presentation/src/components/`, built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
 **86 PostgreSQL tables** with Drizzle ORM, **61 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
@@ -100,7 +100,7 @@ Honest list of things that are not done, not deployed, or not verified.
 | Apps | 5 (`admin`, `api`, `docs`, `marketing`, `revealcoin`) | Yes |
 | OSS packages (MIT) | 22 | Yes |
 | Pro packages (FSL-1.1-MIT) | 3 (`ai`, `harnesses`, `engines`) | Yes |
-| UI components (`@revealui/presentation`) | 57 | Yes |
+| UI components 58 | Yes |
 | Database tables | 85 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
 | MCP servers (`packages/mcp/src/servers/`) | 13 | Yes |
 | Test cases | run `pnpm test` for current count | Reproducible |

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -60,7 +60,7 @@ Every framework is a set of opinions. Here are ours:
 
 **Lexical over ProseMirror.** Lexical's data model is JSON, not a custom AST. Server-side rendering works without a browser. XSS prevention is structural: every URL is validated before rendering.
 
-**Tailwind over CSS-in-JS.** No runtime cost. No hydration mismatch. The entire component library (57 components) uses only Tailwind utilities, clsx, and CVA. Zero external UI dependencies.
+**Tailwind over CSS-in-JS.** No runtime cost. No hydration mismatch. The entire component library (58 components) uses only Tailwind utilities, clsx, and CVA. Zero external UI dependencies.
 
 **Biome over ESLint + Prettier.** One tool instead of two. Faster. No plugin ecosystem to manage. The formatter and linter share a single AST parse.
 
@@ -72,7 +72,7 @@ RevealUI launched with:
 
 - **26 npm packages** published to the public registry
 - **86 database tables** via Drizzle ORM (NeonDB + Supabase)
-- **57 UI components** with zero external dependencies
+- **58 UI components** with zero external dependencies
 - **12 MCP servers** for AI tool access (all MIT)
 - **Extensive test coverage** across unit, integration, and E2E layers
 - **4 GitHub template repos** for different starting points

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -226,7 +226,7 @@ Some numbers on what's actually shipped:
 
 - **31 workspaces** across the monorepo (5 apps + 26 packages)
 - **86 database tables** via Drizzle ORM
-- **57 UI components** in the presentation layer (zero external UI dependencies  -  just Tailwind v4, clsx, and CVA)
+- **58 UI components** in the presentation layer (zero external UI dependencies  -  just Tailwind v4, clsx, and CVA)
 - **Extensive test coverage** across unit, integration, and E2E layers
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -37,7 +37,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | PKG-002 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) | npm | Public |
 | PKG-003 | @revealui/db | Drizzle ORM schema (86 tables), dual-DB support | npm | Public |
 | PKG-004 | @revealui/auth | Session auth, password reset, rate limiting | npm | Public |
-| PKG-005 | @revealui/presentation | 57 native UI components (Tailwind v4) | npm | Public |
+| PKG-005 | @revealui/presentation | 58 native UI components (Tailwind v4) | npm | Public |
 | PKG-006 | @revealui/router | Lightweight file-based router with SSR | npm | Public |
 | PKG-007 | @revealui/config | Type-safe env config (Zod + lazy Proxy) | npm | Public |
 | PKG-008 | @revealui/utils | Logger, DB helpers, validation | npm | Public |

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @revealui/presentation
 
+## 0.5.0
+
+### Minor Changes
+
+- Add `LinkButton` component + `LinkBehaviorProvider` / `useLinkBehavior` hook for routing-library-agnostic styled CTAs.
+
+  `LinkButton` is a button-styled element that renders as an anchor by default. It eliminates the `<ButtonCVA asChild><Link/></ButtonCVA>` composition footgun (where `asChild` + custom Link components could silently lose styling or produce nested-interactive a11y violations) and gives consumers a one-line API for "styled button that navigates."
+
+  **Default usage** (renders `<a href>` — SSR-safe, zero deps):
+
+  ```tsx
+  import { LinkButton } from '@revealui/presentation';
+
+  <LinkButton href="/contact">Book a call</LinkButton>
+  <LinkButton href="https://docs.revealui.com" external>Docs ↗</LinkButton>
+  <LinkButton href="/contact" variant="outline" size="lg">Talk to founder</LinkButton>
+  ```
+
+  **App-level routing wiring** — wrap once at the root, every downstream `LinkButton` routes via your custom Link:
+
+  ```tsx
+  import { LinkBehaviorProvider, LinkButton } from '@revealui/presentation';
+  import { Link } from '@revealui/router';
+
+  <LinkBehaviorProvider component={Link} hrefProp="to">
+    <App />  {/* every <LinkButton href="/x"> uses @revealui/router */}
+  </LinkBehaviorProvider>
+  ```
+
+  **Per-instance polymorphic override** — escape hatch for one-off cases:
+
+  ```tsx
+  <LinkButton as={Link} to="/contact">Book a call</LinkButton>
+  ```
+
+  Supports all standard `Button` variants (`variant`, `size`, `isLoading`, `disabled`, `external`). Disabled state preserves the anchor's `href` and uses `aria-disabled="true"` + `tabIndex={-1}` + `onClick` preventDefault to enforce the disabled semantics without changing the underlying anchor contract. Loading state shows a spinner + `aria-busy="true"` + `pointer-events:none`.
+
+  Spec: [`docs/specs/linkbutton-primitive.md`](https://github.com/RevealUIStudio/revealui-jv) (revealui-jv).
+
+  Zero new runtime dependencies. The `LinkBehaviorProvider` is a tiny React context — `@revealui/presentation` continues to ship with React/ReactDOM as the only peer deps.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/presentation",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Native React UI components built on Tailwind v4 — zero external UI dependencies (only clsx + CVA). Buttons, forms, dialogs, navigation, and more.",
   "keywords": [
     "components",

--- a/packages/presentation/src/__tests__/components/LinkButton.test.tsx
+++ b/packages/presentation/src/__tests__/components/LinkButton.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * LinkButton Component Tests
+ *
+ * Tests for the LinkButton component exported from
+ * packages/presentation/src/components/LinkButton.tsx.
+ *
+ * Covers: default <a> rendering, LinkBehaviorProvider wiring, polymorphic
+ * `as` override, external links, disabled state, isLoading state.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { LinkButton } from '../../components/LinkButton.js';
+import { LinkBehaviorProvider } from '../../hooks/use-link-behavior.js';
+
+describe('LinkButton', () => {
+  // -------------------------------------------------------------------------
+  // Default rendering — native <a>
+  // -------------------------------------------------------------------------
+
+  describe('Default rendering', () => {
+    it('renders an <a> element with href', () => {
+      render(<LinkButton href="/contact">Book a call</LinkButton>);
+      const link = screen.getByRole('link', { name: /book a call/i });
+      expect(link).toBeInTheDocument();
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', '/contact');
+    });
+
+    it('renders text content', () => {
+      render(<LinkButton href="/x">Get Started</LinkButton>);
+      expect(screen.getByRole('link', { name: 'Get Started' })).toBeInTheDocument();
+    });
+
+    it('applies default variant classes (bg-primary)', () => {
+      render(<LinkButton href="/x">Default</LinkButton>);
+      expect(screen.getByRole('link')).toHaveClass('bg-primary');
+    });
+
+    it('applies size class', () => {
+      render(
+        <LinkButton href="/x" size="lg">
+          Large
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveClass('h-11');
+    });
+
+    it('applies variant class', () => {
+      render(
+        <LinkButton href="/x" variant="outline">
+          Outlined
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveClass('border', 'border-border');
+    });
+
+    it('merges consumer className with button classes', () => {
+      render(
+        <LinkButton href="/x" className="my-extra-class">
+          Merged
+        </LinkButton>,
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveClass('my-extra-class');
+      expect(link).toHaveClass('bg-primary'); // default variant still applied
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // LinkBehaviorProvider — context-based wiring
+  // -------------------------------------------------------------------------
+
+  describe('LinkBehaviorProvider', () => {
+    interface CustomLinkProps {
+      to: string;
+      className?: string;
+      children?: React.ReactNode;
+    }
+    function CustomLink({ to, className, children, ...rest }: CustomLinkProps) {
+      // Renders as a <span> so we can prove it isn't the default <a>
+      return (
+        <span data-testid="custom-link" data-to={to} className={className} {...rest}>
+          {children}
+        </span>
+      );
+    }
+
+    it('renders the provider component instead of <a>', () => {
+      render(
+        <LinkBehaviorProvider component={CustomLink} hrefProp="to">
+          <LinkButton href="/contact">Book</LinkButton>
+        </LinkBehaviorProvider>,
+      );
+      expect(screen.getByTestId('custom-link')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('passes the URL via the configured hrefProp ("to" instead of "href")', () => {
+      render(
+        <LinkBehaviorProvider component={CustomLink} hrefProp="to">
+          <LinkButton href="/contact">Book</LinkButton>
+        </LinkBehaviorProvider>,
+      );
+      const el = screen.getByTestId('custom-link');
+      expect(el).toHaveAttribute('data-to', '/contact');
+    });
+
+    it('still applies button styling on the provider component', () => {
+      render(
+        <LinkBehaviorProvider component={CustomLink} hrefProp="to">
+          <LinkButton href="/contact" variant="primary">
+            Book
+          </LinkButton>
+        </LinkBehaviorProvider>,
+      );
+      const el = screen.getByTestId('custom-link');
+      expect(el).toHaveClass('bg-primary');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Polymorphic `as` prop — per-instance override
+  // -------------------------------------------------------------------------
+
+  describe('Polymorphic `as` prop', () => {
+    it('renders the component passed via `as`', () => {
+      render(
+        <LinkButton as="button" type="button">
+          Button-shaped
+        </LinkButton>,
+      );
+      expect(screen.getByRole('button', { name: /button-shaped/i })).toBeInTheDocument();
+    });
+
+    it('drops back to "href" prop when `as` is set (regardless of provider hrefProp)', () => {
+      function CustomLink(props: { to?: string; href?: string; children?: React.ReactNode }) {
+        return (
+          <span data-testid="instance-link" data-to={props.to} data-href={props.href}>
+            {props.children}
+          </span>
+        );
+      }
+      render(
+        <LinkBehaviorProvider component="span" hrefProp="to">
+          {/* `as` override should use 'href', not 'to' */}
+          <LinkButton as={CustomLink} href="/x">
+            Override
+          </LinkButton>
+        </LinkBehaviorProvider>,
+      );
+      const el = screen.getByTestId('instance-link');
+      expect(el).toHaveAttribute('data-href', '/x');
+      expect(el).not.toHaveAttribute('data-to');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // External links — opt out of provider Link
+  // -------------------------------------------------------------------------
+
+  describe('External links', () => {
+    it('renders a native <a> even inside a LinkBehaviorProvider', () => {
+      function CustomLink(props: { to: string; children?: React.ReactNode }) {
+        return <span data-testid="custom-link">{props.children}</span>;
+      }
+      render(
+        <LinkBehaviorProvider component={CustomLink} hrefProp="to">
+          <LinkButton href="https://x.com" external>
+            Tweet
+          </LinkButton>
+        </LinkBehaviorProvider>,
+      );
+      expect(screen.queryByTestId('custom-link')).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /tweet/i }).tagName).toBe('A');
+    });
+
+    it('adds target="_blank" rel="noopener noreferrer"', () => {
+      render(
+        <LinkButton href="https://x.com" external>
+          Tweet
+        </LinkButton>,
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Disabled state
+  // -------------------------------------------------------------------------
+
+  describe('Disabled state', () => {
+    it('sets aria-disabled="true"', () => {
+      render(
+        <LinkButton href="/x" disabled>
+          Disabled
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('sets tabIndex={-1}', () => {
+      render(
+        <LinkButton href="/x" disabled>
+          Disabled
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('preserves the href (does not silently change anchor semantics)', () => {
+      render(
+        <LinkButton href="/contact" disabled>
+          Disabled
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/contact');
+    });
+
+    it('prevents default on click', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(
+        <LinkButton href="/x" disabled onClick={onClick}>
+          Disabled
+        </LinkButton>,
+      );
+      await user.click(screen.getByRole('link'));
+      // Our onClick is overridden by the disabled handler — the consumer's
+      // onClick is overwritten by the spread order. This is intentional:
+      // disabled means disabled.
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('applies opacity and pointer-events-none styling', () => {
+      render(
+        <LinkButton href="/x" disabled>
+          Disabled
+        </LinkButton>,
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveClass('opacity-50');
+      expect(link).toHaveClass('pointer-events-none');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  describe('Loading state', () => {
+    it('sets aria-busy="true"', () => {
+      render(
+        <LinkButton href="/x" isLoading>
+          Loading
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders a spinner element', () => {
+      const { container } = render(
+        <LinkButton href="/x" isLoading>
+          Loading
+        </LinkButton>,
+      );
+      expect(container.querySelector('svg.animate-spin')).toBeInTheDocument();
+    });
+
+    it('applies pointer-events-none', () => {
+      render(
+        <LinkButton href="/x" isLoading>
+          Loading
+        </LinkButton>,
+      );
+      expect(screen.getByRole('link')).toHaveClass('pointer-events-none');
+    });
+
+    it('does not render spinner when isLoading is false', () => {
+      const { container } = render(<LinkButton href="/x">Idle</LinkButton>);
+      expect(container.querySelector('svg.animate-spin')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/presentation/src/components/LinkButton.tsx
+++ b/packages/presentation/src/components/LinkButton.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import type React from 'react';
+import { type LinkBehavior, useLinkBehavior } from '../hooks/use-link-behavior.js';
+import { cn } from '../utils/cn.js';
+import { type ButtonProps, buttonVariants } from './Button.js';
+import { TouchTarget } from './button-headless.js';
+
+/**
+ * LinkButton — a button-styled element that renders as an anchor by default,
+ * with optional polymorphic override and provider-based routing-library wiring.
+ *
+ * Default usage: `<LinkButton href="/contact">Book a call</LinkButton>` renders
+ * `<a href="/contact" class="…button…">Book a call</a>` — SSR-safe, zero deps.
+ *
+ * App-level wiring (recommended for SPAs):
+ *   <LinkBehaviorProvider component={MyLink} hrefProp="to">
+ *     <App />  // every <LinkButton href="/x"> downstream uses MyLink
+ *   </LinkBehaviorProvider>
+ *
+ * Per-instance override (escape hatch):
+ *   <LinkButton as={MyLink} to="/x">…</LinkButton>
+ */
+export interface LinkButtonOwnProps {
+  /** URL the button navigates to. Required for normal usage; omit only when `as` provides its own URL prop. */
+  href?: string;
+  /** External link — adds `target="_blank" rel="noopener noreferrer"` and renders a native `<a>` regardless of provider. */
+  external?: boolean;
+  /** Button variant (matches `Button` / `buttonVariants`). */
+  variant?: ButtonProps['variant'];
+  /** Button size (matches `Button` / `buttonVariants`). */
+  size?: ButtonProps['size'];
+  /** Show a loading spinner and disable interaction. Sets `aria-busy="true"`. */
+  isLoading?: boolean;
+  /** Visually disabled + ARIA-disabled. Anchor's `href` is preserved (semantics unchanged); click is prevented and `tabIndex` set to -1. */
+  disabled?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export type LinkButtonProps<T extends React.ElementType = 'a'> = LinkButtonOwnProps & {
+  /** Polymorphic override — render as a different component for this single instance. Drops the provider's `hrefProp` and uses `'href'` instead. */
+  as?: T;
+} & Omit<React.ComponentPropsWithoutRef<T>, keyof LinkButtonOwnProps | 'as' | 'ref'> & {
+    ref?: React.Ref<Element>;
+  };
+
+function LoadingSpinner() {
+  return (
+    <svg
+      className="mr-2 size-4 animate-spin"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+const sharedStyle: React.CSSProperties = {
+  transition:
+    'all var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
+  borderRadius: 'var(--rvui-radius-md, 10px)',
+};
+
+function LinkButton<T extends React.ElementType = 'a'>({
+  as,
+  href,
+  external = false,
+  variant,
+  size,
+  isLoading = false,
+  disabled = false,
+  className,
+  children,
+  ref,
+  ...rest
+}: LinkButtonProps<T>) {
+  const provided = useLinkBehavior();
+
+  // External opts out of the provider Link entirely — always renders <a>.
+  // Per-instance `as` override drops back to 'href' as the URL prop (since
+  // the overriding component is unknown to the provider).
+  const finalComponent: React.ElementType = external ? 'a' : (as ?? provided.component);
+  const finalHrefProp = external || as ? 'href' : provided.hrefProp;
+
+  const externalAttrs = external
+    ? { target: '_blank' as const, rel: 'noopener noreferrer' as const }
+    : null;
+
+  const interactionLockClass = disabled || isLoading ? 'pointer-events-none' : '';
+  const opacityClass = disabled ? 'opacity-50' : '';
+
+  // `disabledAttrs` are applied AFTER `...rest` so they always win when the
+  // consumer passes their own `onClick`/`tabIndex`. Disabled means disabled.
+  const disabledAttrs = disabled
+    ? {
+        'aria-disabled': true as const,
+        tabIndex: -1,
+        onClick: (e: React.MouseEvent) => e.preventDefault(),
+      }
+    : null;
+
+  const renderProps = {
+    ...(href !== undefined ? { [finalHrefProp]: href } : {}),
+    ...externalAttrs,
+    'aria-busy': isLoading || undefined,
+    className: cn(buttonVariants({ variant, size }), interactionLockClass, opacityClass, className),
+    style: sharedStyle,
+    ref,
+    ...rest,
+    ...disabledAttrs,
+  };
+
+  const Component = finalComponent as React.ElementType;
+  return (
+    <Component {...renderProps}>
+      {isLoading ? <LoadingSpinner /> : null}
+      <TouchTarget>{children}</TouchTarget>
+    </Component>
+  );
+}
+
+export type { LinkBehavior };
+export { LinkButton };

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -67,6 +67,12 @@ export { Input as InputCVA, type InputProps } from './Input.js';
 export { Input, InputGroup } from './input-headless.js';
 export { Kbd, KbdShortcut } from './kbd.js';
 export { Label, type LabelProps } from './Label.js';
+export {
+  type LinkBehavior,
+  LinkButton,
+  type LinkButtonOwnProps,
+  type LinkButtonProps,
+} from './LinkButton.js';
 export { Link } from './link.js';
 export { Listbox, ListboxDescription, ListboxLabel, ListboxOption } from './listbox.js';
 export {

--- a/packages/presentation/src/hooks/index.ts
+++ b/packages/presentation/src/hooks/index.ts
@@ -17,6 +17,12 @@ export {
   LayoutIndicator,
   useLayoutAnimation,
 } from './use-layout-animation.js';
+export {
+  type LinkBehavior,
+  LinkBehaviorProvider,
+  type LinkBehaviorProviderProps,
+  useLinkBehavior,
+} from './use-link-behavior.js';
 export { usePopover } from './use-popover.js';
 export { useRovingTabindex } from './use-roving-tabindex.js';
 export { useScrollLock } from './use-scroll-lock.js';

--- a/packages/presentation/src/hooks/use-link-behavior.tsx
+++ b/packages/presentation/src/hooks/use-link-behavior.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { createContext, type ElementType, type ReactNode, useContext, useMemo } from 'react';
+
+/**
+ * Configures how `LinkButton` (and other anchor-rendering primitives) wire up
+ * client-side navigation. By default they render a native `<a href>`.
+ * Apps that have their own Link component (e.g. `@revealui/router`'s `Link`,
+ * Next.js `next/link`, react-router's `Link`) can wrap their tree in
+ * `<LinkBehaviorProvider component={MyLink} hrefProp="to">…</LinkBehaviorProvider>`
+ * once at the root, and every downstream `LinkButton` will route via that
+ * Link without per-instance wiring.
+ */
+export interface LinkBehavior {
+  /** Component to render for non-external links. Defaults to native `'a'`. */
+  component: ElementType;
+  /**
+   * Name of the prop on `component` that takes the URL.
+   * `'href'` for native `<a>` and Next.js `next/link`;
+   * `'to'` for `@revealui/router` and react-router's `Link`.
+   * Defaults to `'href'`.
+   */
+  hrefProp: string;
+}
+
+const defaultBehavior: LinkBehavior = { component: 'a', hrefProp: 'href' };
+
+const LinkBehaviorContext = createContext<LinkBehavior>(defaultBehavior);
+
+export interface LinkBehaviorProviderProps extends Partial<LinkBehavior> {
+  children: ReactNode;
+}
+
+export function LinkBehaviorProvider({
+  component,
+  hrefProp = 'href',
+  children,
+}: LinkBehaviorProviderProps) {
+  const value = useMemo<LinkBehavior>(
+    () => ({ component: component ?? 'a', hrefProp }),
+    [component, hrefProp],
+  );
+  return <LinkBehaviorContext.Provider value={value}>{children}</LinkBehaviorContext.Provider>;
+}
+
+export function useLinkBehavior(): LinkBehavior {
+  return useContext(LinkBehaviorContext);
+}


### PR DESCRIPTION
## Summary

Promote single feature commit from `test` to `main`:

- LinkButton primitive + LinkBehaviorProvider (`@revealui/presentation@0.5.0`) — [#709](https://github.com/RevealUIStudio/revealui/pull/709)

After merge, trigger `release.yml` to publish 0.5.0 to npm. Manual `pnpm dist-tag` may be needed to promote `latest` if release-canary mis-tags (per GAP-170).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: trigger `release.yml` → `@revealui/presentation@0.5.0` published with `latest` dist-tag
- [ ] Phase 4 (dogfood marketing NavBar) and Phase 5 (dogfood agency NavBar) follow as separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
