### PR TITLE
chore(marketing): dogfood LinkButton in NavBar (Phase 4)

### DIFF
--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import { ButtonCVA } from '@revealui/presentation';
+import { LinkButton } from '@revealui/presentation';
 import { useState } from 'react';
 
 const navLinks = [
@@ -51,9 +51,7 @@ export function NavBar() {
           >
             Log in
           </a>
-          <ButtonCVA asChild>
-            <a href="https://admin.revealui.com/signup">Get Started</a>
-          </ButtonCVA>
+          <LinkButton href="https://admin.revealui.com/signup">Get Started</LinkButton>
 
           {/* Hamburger - mobile only */}
           <button
@@ -126,11 +124,13 @@ export function NavBar() {
             >
               Log in
             </a>
-            <ButtonCVA asChild className="w-full">
-              <a href="https://admin.revealui.com/signup" onClick={() => setOpen(false)}>
-                Get Started
-              </a>
-            </ButtonCVA>
+            <LinkButton
+              href="https://admin.revealui.com/signup"
+              onClick={() => setOpen(false)}
+              className="w-full"
+            >
+              Get Started
+            </LinkButton>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Migrate `apps/marketing` NavBar "Get Started" CTA from `<ButtonCVA asChild><a/></ButtonCVA>` to `<LinkButton href>`. Phase 4 of linkbutton-primitive spec.

Two replacements: desktop CTA + mobile drawer CTA. Identical rendered output (LinkButton resolves to the same `buttonVariants()` class string applied to an `<a>`). Cleaner API + sidesteps the asChild composition pattern.

## Test plan

- [ ] CI green
- [ ] Vercel preview: revealui.com renders correctly with the same nav UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)
