### PR TITLE
docs(master-plan): fix missing paren in UI components row

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -38,7 +38,7 @@
 |---------|--------|------------|
 | admin engine (core) | Built | High  -  237 files, deep implementation |
 | AI agent system | Built | Medium  -  untested in production |
-| UI components 58) | Built | High  -  native hooks, no external deps |
+| UI components (58) | Built | High  -  native hooks, no external deps |
 | Database schema (86 tables) | Built | High  -  migration 0001 applied, 61 CHECK constraints enforced |
 | Auth (sessions, rate limiting) | Built | Medium  -  code exists, no production verification |
 | Stripe integration | Built | Medium  -  DB-backed circuit breaker (circuit_breaker_state table) |


### PR DESCRIPTION
## Summary

One-character fix in `docs/MASTER_PLAN.md:41` — the "UI components" row was missing its opening paren after an over-greedy sed in an earlier `chore(claims,biome): bump UI component count 57 → 58` commit.

Before:
```
| UI components 58) | Built | High  -  native hooks, no external deps |
```

After:
```
| UI components (58) | Built | High  -  native hooks, no external deps |
```

Verified clean in the internal docs canonical copy of MASTER_PLAN — no parallel fix needed there.

## Test plan

- [ ] CI green (full gate runs on PR to test)
- [ ] No other rendered changes in the markdown (1 char, 1 line)
