### PR TITLE
fix(services): RFC 2047 encode email Subject for non-ASCII (em-dash mojibake fix)

### DIFF
--- a/packages/services/src/email/__tests__/headers.test.ts
+++ b/packages/services/src/email/__tests__/headers.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { encodeHeaderValue, sanitizeEmailHeader } from '../index';
+
+describe('sanitizeEmailHeader', () => {
+  it('strips CR and LF to block header injection', () => {
+    expect(sanitizeEmailHeader('hello\r\nBcc: attacker@example.com')).toBe(
+      'helloBcc: attacker@example.com',
+    );
+    expect(sanitizeEmailHeader('a\nb\rc')).toBe('abc');
+  });
+
+  it('passes pure ASCII through unchanged', () => {
+    expect(sanitizeEmailHeader('Plain ASCII Subject')).toBe('Plain ASCII Subject');
+  });
+});
+
+describe('encodeHeaderValue', () => {
+  function decodeEncodedWord(encoded: string): string {
+    const match = encoded.match(/^=\?UTF-8\?B\?(.+?)\?=$/);
+    if (!match || match[1] === undefined) throw new Error(`not an encoded-word: ${encoded}`);
+    const binary = atob(match[1]);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder('utf-8').decode(bytes);
+  }
+
+  it('returns ASCII subjects unchanged (no unnecessary encoded-word wrap)', () => {
+    expect(encodeHeaderValue('Plain ASCII Subject')).toBe('Plain ASCII Subject');
+    expect(encodeHeaderValue('Hello, world! 1+2=3 (yes).')).toBe('Hello, world! 1+2=3 (yes).');
+    expect(encodeHeaderValue('')).toBe('');
+  });
+
+  it('encodes em-dash subjects as RFC 2047 base64 encoded-word', () => {
+    const subject = '[agency] CR7-01 post-Phase-0 verification — Claude Code';
+    const encoded = encodeHeaderValue(subject);
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/);
+    expect(decodeEncodedWord(encoded)).toBe(subject);
+  });
+
+  it('encodes accented characters', () => {
+    const subject = 'Bonjour, école ouverte — réponse en français';
+    const encoded = encodeHeaderValue(subject);
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+    expect(decodeEncodedWord(encoded)).toBe(subject);
+  });
+
+  it('encodes emoji', () => {
+    const subject = 'Order received ✓ confirmed';
+    const encoded = encodeHeaderValue(subject);
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+    expect(decodeEncodedWord(encoded)).toBe(subject);
+  });
+
+  it('encodes a subject containing only non-ASCII', () => {
+    const subject = '日本語の件名';
+    const encoded = encodeHeaderValue(subject);
+    expect(decodeEncodedWord(encoded)).toBe(subject);
+  });
+
+  it('strips CR/LF before encoding so injected headers cannot escape the encoded-word', () => {
+    const malicious = 'Subject — legit\r\nBcc: attacker@example.com';
+    const encoded = encodeHeaderValue(malicious);
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+    const decoded = decodeEncodedWord(encoded);
+    expect(decoded).toBe('Subject — legitBcc: attacker@example.com');
+    expect(decoded).not.toContain('\r');
+    expect(decoded).not.toContain('\n');
+  });
+
+  it('handles a non-ASCII char at the very last byte', () => {
+    const subject = 'trailing em-dash —';
+    const encoded = encodeHeaderValue(subject);
+    expect(decodeEncodedWord(encoded)).toBe(subject);
+  });
+});

--- a/packages/services/src/email/index.ts
+++ b/packages/services/src/email/index.ts
@@ -74,6 +74,32 @@ export function sanitizeEmailHeader(value: string): string {
   return value.replace(/[\r\n]/g, '');
 }
 
+/**
+ * RFC 2047 encoded-word for header values that may contain non-ASCII.
+ *
+ * Pure-ASCII (printable + space) input is returned unchanged. Anything
+ * with a byte outside U+0020..U+007E is sanitized for CR/LF, then UTF-8
+ * + base64 encoded and wrapped in `=?UTF-8?B?...?=` so MIME-aware mail
+ * clients render it as the original Unicode rather than mojibake.
+ *
+ * Use on values that legitimately carry user-visible text (Subject,
+ * display names). Do NOT use on bare email addresses — those follow
+ * RFC 5322 escaping rules and this codebase emits them as raw
+ * `local@domain` strings without display names.
+ *
+ * Edge-compatible: uses TextEncoder + btoa, no Node Buffer.
+ */
+export function encodeHeaderValue(value: string): string {
+  const sanitized = sanitizeEmailHeader(value);
+  if (/^[\x20-\x7E]*$/.test(sanitized)) return sanitized;
+  const bytes = new TextEncoder().encode(sanitized);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return `=?UTF-8?B?${btoa(binary)}?=`;
+}
+
 // ---------------------------------------------------------------------------
 // Gmail REST API provider (edge-compatible)
 // ---------------------------------------------------------------------------
@@ -131,7 +157,7 @@ export class GmailProvider implements EmailProvider {
     const lines = [
       `From: ${this.delegateEmail}`,
       `To: ${sanitizeEmailHeader(options.to)}`,
-      `Subject: ${sanitizeEmailHeader(options.subject)}`,
+      `Subject: ${encodeHeaderValue(options.subject)}`,
       'MIME-Version: 1.0',
       `Content-Type: multipart/alternative; boundary="${boundary}"`,
     ];


### PR DESCRIPTION
## Summary

Fix MIME Subject mojibake on the Gmail REST email path. Subjects containing non-ASCII (em-dash, accented Latin-1, emoji, CJK, etc.) now arrive as the original Unicode rather than `Ã¢Â€Â"`-style mangling.

Surfaced 2026-05-02 during a contact-form smoke test: the topic field contained an em-dash (`—`, U+2014) and the inbox-rendered Subject came through as `Ã¢Â€Â"`. Root cause: `GmailProvider.buildRawMessage()` was emitting the raw Subject header without RFC 2047 encoding, so receiving clients interpreted the UTF-8 bytes in their default header charset (usually Latin-1).

## What changed

- New exported helper `encodeHeaderValue(value)` in `packages/services/src/email/index.ts`. Sanitizes for CR/LF, then if any byte falls outside `U+0020..U+007E` it emits a base64 RFC 2047 encoded-word `=?UTF-8?B?...?=`. Pure-ASCII subjects pass through unchanged so the wire format for the common case is unaffected.
- Subject line in `GmailProvider.buildRawMessage()` now goes through `encodeHeaderValue()` instead of `sanitizeEmailHeader()`.
- New unit tests at `packages/services/src/email/__tests__/headers.test.ts` cover ASCII passthrough, em-dash, accented Latin-1, emoji, all-non-ASCII (Japanese), trailing non-ASCII, and CR/LF stripping before encode (so injected headers cannot escape the encoded-word).

## What did not change

- `From`, `To`, `Reply-To` are still emitted as bare `local@domain` addresses with no display names, which don't need RFC 2047 encoding (RFC 5322 escaping rules apply, and this codebase doesn't use display names on those headers). The helper is exported so future display-name surfaces can reuse it.
- Edge-compatibility preserved (`TextEncoder` + `btoa`, no Node `Buffer`).
- No deps changed; no schema changes; no env-var changes.

## Test plan

- [x] `pnpm --filter "@revealui/services" test` → 175 passed | 3 skipped (3 stripe-integration skipped on missing live env), including the 9 new `headers.test.ts` cases
- [x] `pnpm --filter "@revealui/services" typecheck` → clean
- [x] `pnpm --filter "@revealui/services" lint` (Biome) → clean
- [x] Pre-push 16-check gate → PASS
- [ ] CI green
- [ ] Post-merge end-to-end: send a contact-form submission with an em-dash Subject; observe the Subject renders correctly in the receiving inbox (founder@). Tracked outside this PR — production behavior verification, not blocker for merge.
