### PR TITLE
docs(linkbutton): add showcase + COMPONENT_CATALOG entry (Phase 6)

### DIFF
--- a/apps/docs/app/components/showcase/registry.ts
+++ b/apps/docs/app/components/showcase/registry.ts
@@ -153,6 +153,12 @@ export const showcaseEntries: ShowcaseEntry[] = [
     loader: () => import('../../showcase/link.showcase.js'),
   },
   {
+    slug: 'linkbutton',
+    name: 'LinkButton',
+    category: 'component',
+    loader: () => import('../../showcase/linkbutton.showcase.js'),
+  },
+  {
     slug: 'listbox',
     name: 'Listbox',
     category: 'component',

--- a/apps/docs/app/showcase/linkbutton.showcase.tsx
+++ b/apps/docs/app/showcase/linkbutton.showcase.tsx
@@ -1,0 +1,133 @@
+import { LinkButton } from '@revealui/presentation/client';
+import type { ShowcaseStory } from '@/components/showcase/types.js';
+
+const story: ShowcaseStory = {
+  slug: 'linkbutton',
+  name: 'LinkButton',
+  description:
+    'Button-styled element that renders as an anchor by default. Pairs with LinkBehaviorProvider to route through any framework Link component without coupling @revealui/presentation to a specific router.',
+  category: 'component',
+
+  controls: {
+    variant: {
+      type: 'select',
+      options: ['default', 'destructive', 'ghost', 'link', 'outline', 'primary', 'secondary'],
+      default: 'default',
+    },
+    size: {
+      type: 'select',
+      options: ['default', 'sm', 'lg', 'icon', 'clear'],
+      default: 'default',
+    },
+    href: { type: 'text', default: '/contact' },
+    external: { type: 'boolean', default: false },
+    isLoading: { type: 'boolean', default: false },
+    disabled: { type: 'boolean', default: false },
+    children: { type: 'text', default: 'Book a call' },
+  },
+
+  render: (props) => (
+    <LinkButton
+      href={props.href as string}
+      external={props.external as boolean}
+      variant={props.variant as 'default'}
+      size={props.size as 'default'}
+      isLoading={props.isLoading as boolean}
+      disabled={props.disabled as boolean}
+    >
+      {props.children as string}
+    </LinkButton>
+  ),
+
+  variantGrid: {
+    variant: ['default', 'destructive', 'ghost', 'link', 'outline', 'primary', 'secondary'],
+    size: ['sm', 'default', 'lg'],
+  },
+
+  examples: [
+    {
+      name: 'Default (renders <a>)',
+      description:
+        'Without LinkBehaviorProvider, LinkButton renders a native anchor — SSR-safe, zero deps, works everywhere.',
+      render: () => <LinkButton href="/contact">Book a call</LinkButton>,
+    },
+    {
+      name: 'External link',
+      description:
+        'The `external` prop adds `target="_blank" rel="noopener noreferrer"` and opts out of any LinkBehaviorProvider so external links never route through SPA Link components.',
+      render: () => (
+        <LinkButton href="https://docs.revealui.com" external variant="outline">
+          Read the docs ↗
+        </LinkButton>
+      ),
+    },
+    {
+      name: 'Loading state',
+      render: () => (
+        <LinkButton href="/contact" isLoading>
+          Submitting…
+        </LinkButton>
+      ),
+    },
+    {
+      name: 'Disabled',
+      description:
+        'Disabled anchors keep their `href` (semantics unchanged) but get `aria-disabled="true"`, `tabIndex={-1}`, and `pointer-events: none`.',
+      render: () => (
+        <LinkButton href="/contact" disabled>
+          Coming soon
+        </LinkButton>
+      ),
+    },
+    {
+      name: 'Per-instance polymorphic override',
+      description:
+        'Use `as` to render a single LinkButton via a specific component (e.g. for mixed-routing scenarios). The override drops the provider hrefProp and uses standard `href`.',
+      render: () => (
+        <LinkButton as="a" href="#anchor" variant="ghost">
+          Jump to section
+        </LinkButton>
+      ),
+    },
+  ],
+
+  code: (props) => {
+    const attrs: string[] = [`href="${props.href}"`];
+    if (props.external) attrs.push('external');
+    if (props.variant !== 'default') attrs.push(`variant="${props.variant}"`);
+    if (props.size !== 'default') attrs.push(`size="${props.size}"`);
+    if (props.isLoading) attrs.push('isLoading');
+    if (props.disabled) attrs.push('disabled');
+    return `<LinkButton ${attrs.join(' ')}>${props.children}</LinkButton>`;
+  },
+
+  usage: {
+    when: `Reach for **LinkButton** when you need a styled button that **navigates** — e.g. "Get Started", "Book a call", "Read the docs". Pairs with \`LinkBehaviorProvider\` to wire SPA navigation through any router (\`@revealui/router\`, Next.js \`Link\`, react-router) once at the app root, with no per-call-site setup.`,
+    avoid: `Don't use LinkButton when:\n- You need a click handler that doesn't navigate (use **Button** instead).\n- The element is purely decorative or non-interactive (use a **div** or **span**).\n- You want a text-style inline link (use **Link** or **TextLink**).`,
+  },
+
+  install: 'npm install @revealui/presentation',
+  sourceUrl: 'src/components/LinkButton.tsx',
+
+  a11y: {
+    conformance: ['WCAG 2.1.1 Keyboard', 'WCAG 2.4.4 Link Purpose (In Context)'],
+    keyboard: {
+      Enter: 'Activates the link (default anchor behavior).',
+      Tab: 'Move focus to / from the link.',
+    },
+    aria: {
+      'aria-disabled':
+        'Set to "true" when `disabled`. Anchor `href` is preserved — semantics unchanged — but click is prevented and `tabIndex={-1}`.',
+      'aria-busy': 'Set to "true" when `isLoading`.',
+    },
+    notes:
+      'External links (`external` prop) add `rel="noopener noreferrer"` for tab-nap protection. The component wraps children in `TouchTarget` to ensure ≥44×44 mobile tap area, matching `Button` ergonomics.',
+  },
+
+  related: [
+    { slug: 'button', reason: 'For non-navigating actions, use Button instead.' },
+    { slug: 'link', reason: 'For inline text links, use Link.' },
+  ],
+};
+
+export default story;

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -7,9 +7,9 @@ audience: developer
 
 # RevealUI Component Catalog
 
-**Last Updated:** 2026-04-26
+**Last Updated:** 2026-05-02
 **Packages:** `@revealui/presentation`, `@revealui/core`
-**Total Components:** 78 across both packages — **57 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
+**Total Components:** 80 across both packages — **59 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
 
 ---
 
@@ -17,7 +17,7 @@ audience: developer
 
 ### Presentation Components (@revealui/presentation)
 1. [Primitives](#primitives) (6 components)
-2. [Form Controls](#form-controls) (13 components)
+2. [Form Controls](#form-controls) (14 components)
 3. [Data Display](#data-display) (8 components)
 4. [Navigation](#navigation) (4 components)
 5. [Feedback](#feedback) (3 components)
@@ -220,6 +220,71 @@ import { Button } from '@revealui/presentation'
   <a href="/link">Link Button</a>
 </Button>
 ```
+
+---
+
+### LinkButton
+
+Button-styled element that renders as an anchor by default. Pairs with `LinkBehaviorProvider` to route through any framework `Link` component (e.g. `@revealui/router`, Next.js `next/link`, react-router `Link`) without coupling `@revealui/presentation` to a specific routing library. Available from `0.5.0`.
+
+**Props:**
+```typescript
+interface LinkButtonOwnProps {
+  /** URL the button navigates to. Required for normal usage. */
+  href?: string
+  /** External link — adds `target="_blank" rel="noopener noreferrer"` and renders a native <a> regardless of provider. */
+  external?: boolean
+  variant?: 'default' | 'destructive' | 'ghost' | 'link' | 'outline' | 'primary' | 'secondary'
+  size?: 'default' | 'sm' | 'lg' | 'icon' | 'clear'
+  /** Show a loading spinner and disable interaction. Sets aria-busy="true". */
+  isLoading?: boolean
+  /** Visually disabled + ARIA-disabled. Anchor href preserved; click prevented; tabIndex=-1. */
+  disabled?: boolean
+  className?: string
+  children?: React.ReactNode
+}
+
+// Polymorphic — render as a different component for this single instance
+type LinkButtonProps<T extends React.ElementType = 'a'> = LinkButtonOwnProps & { as?: T } & ...
+```
+
+**Usage:**
+```tsx
+import { LinkButton, LinkBehaviorProvider } from '@revealui/presentation/client'
+import { Link } from '@revealui/router'
+
+// 1. App-level wiring (recommended): one Provider at root, every LinkButton routes through MyLink
+<LinkBehaviorProvider component={Link} hrefProp="to">
+  <App />
+</LinkBehaviorProvider>
+
+// 2. Default usage — renders <a href="/contact"> via the provider Link
+<LinkButton href="/contact">Book a call</LinkButton>
+
+// 3. External link — opts out of provider, always native <a target="_blank">
+<LinkButton href="https://docs.revealui.com" external variant="outline">
+  Read the docs ↗
+</LinkButton>
+
+// 4. Per-instance polymorphic override (escape hatch)
+<LinkButton as="a" href="#anchor" variant="ghost">Jump to section</LinkButton>
+```
+
+**Behavior matrix:**
+
+| Author writes | Without provider | With `<LinkBehaviorProvider component={MyLink} hrefProp="to">` |
+|---|---|---|
+| `<LinkButton href="/x">…</LinkButton>` | `<a href="/x">…</a>` | `<MyLink to="/x">…</MyLink>` |
+| `<LinkButton href="/x" external>…</LinkButton>` | `<a href="/x" target="_blank" rel="noopener noreferrer">…</a>` | same — `external` always opts out of provider |
+| `<LinkButton as={X} href="/x">…</LinkButton>` | `<X href="/x">…</X>` (per-instance override drops provider) | `<X href="/x">…</X>` |
+
+**Why use it instead of `<ButtonCVA asChild><Link/></ButtonCVA>`:** the asChild pattern is fragile (forgetting `asChild` produces `<button><a>` interactive-nesting violations), and per-instance Link wiring is repetitive across a CTA-heavy marketing surface. `LinkButton` collapses the two-component composition into a single primitive and lets one `LinkBehaviorProvider` at the app root wire every CTA in the tree.
+
+**Accessibility:**
+- Disabled anchors get `aria-disabled="true"` + `tabIndex={-1}` + `pointer-events: none` (anchor `href` preserved — semantics unchanged).
+- External links auto-add `rel="noopener noreferrer"` for tab-nap protection.
+- Loading state sets `aria-busy="true"`.
+- Children wrapped in `TouchTarget` for ≥44×44 mobile tap area, matching `Button`.
 
 ---
 
@@ -1476,9 +1541,9 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Component Summary by Package
 
-### @revealui/presentation (58 components)
+### @revealui/presentation (59 components)
 - 6 Primitives (Box, Flex, Grid, Text, Heading, Slot)
-- 13 Form Controls (Button, Input, Textarea, Select, Checkbox, Radio, etc.)
+- 14 Form Controls (Button, LinkButton, Input, Textarea, Select, Checkbox, Radio, etc.)
 - 8 Data Display (Card, Table, Avatar, Badge, etc.)
 - 4 Navigation (Link, Navbar, Sidebar, Pagination)
 - 3 Feedback (Alert, Dialog, Toast)
@@ -1503,5 +1568,5 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ---
 
-**Last Updated:** 2026-03-03
-**Packages:** `@revealui/presentation` (58 components), `@revealui/core` (21 components)
+**Last Updated:** 2026-05-02
+**Packages:** `@revealui/presentation` (59 components), `@revealui/core` (21 components)

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -9,7 +9,7 @@ audience: developer
 
 **Last Updated:** 2026-05-02
 **Packages:** `@revealui/presentation`, `@revealui/core`
-**Total Components:** 80 across both packages — **59 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
+**Total Components:** 79 across both packages — **58 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
 
 ---
 
@@ -1541,7 +1541,7 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Component Summary by Package
 
-### @revealui/presentation (59 components)
+### @revealui/presentation (58 components)
 - 6 Primitives (Box, Flex, Grid, Text, Heading, Slot)
 - 14 Form Controls (Button, LinkButton, Input, Textarea, Select, Checkbox, Radio, etc.)
 - 8 Data Display (Card, Table, Avatar, Badge, etc.)
@@ -1569,4 +1569,4 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 ---
 
 **Last Updated:** 2026-05-02
-**Packages:** `@revealui/presentation` (59 components), `@revealui/core` (21 components)
+**Packages:** `@revealui/presentation` (58 components), `@revealui/core` (21 components)

--- a/packages/presentation/src/client.ts
+++ b/packages/presentation/src/client.ts
@@ -77,6 +77,11 @@ export {
 export { Heading, Subheading } from './components/heading.js';
 export { Input, InputGroup } from './components/input-headless.js';
 export { Kbd, KbdShortcut } from './components/kbd.js';
+export {
+  LinkButton,
+  type LinkButtonOwnProps,
+  type LinkButtonProps,
+} from './components/LinkButton.js';
 export { Link } from './components/link.js';
 export {
   Listbox,
@@ -170,4 +175,10 @@ export { Textarea } from './components/textarea-headless.js';
 export { Timeline, TimelineItem } from './components/timeline.js';
 export { ToastProvider, useToast } from './components/toast.js';
 export { Tooltip } from './components/tooltip.js';
+export {
+  type LinkBehavior,
+  LinkBehaviorProvider,
+  type LinkBehaviorProviderProps,
+  useLinkBehavior,
+} from './hooks/use-link-behavior.js';
 export { type ResolvedTheme, type Theme, useTheme } from './hooks/use-theme.js';


### PR DESCRIPTION
## Summary

Phase 6 of the LinkButton rollout (per internal docs §Implementation phases): document the new `LinkButton` primitive in the public docs site + COMPONENT_CATALOG.

Phase 4 (apps/marketing dogfood, [#711](https://github.com/RevealUIStudio/revealui/pull/711)) and Phase 5 (agency dogfood, [agency#2](https://github.com/RevealUIStudio/agency/pull/2)) are already shipped. This is the docs follow-up.

## Changes

- **`packages/presentation/src/client.ts`** — re-export `LinkButton`, `LinkBehaviorProvider`, `useLinkBehavior`, and the supporting types from the package's `/client` entry. Necessary so apps consuming via `@revealui/presentation/client` (the convention in `apps/docs`) can import the new primitive without going through the top-level barrel. Biome reorganized the alphabetical position; functionally additive only.
- **`apps/docs/app/showcase/linkbutton.showcase.tsx`** (NEW) — interactive showcase entry following the `button.showcase.tsx` pattern. Includes 7 controls (variant, size, href, external, isLoading, disabled, children), a 7×3 variant grid, 5 named examples (default, external, loading, disabled, polymorphic override), usage guidance (when to use / when not to), accessibility notes (WCAG conformance, keyboard, ARIA), and "see also" cross-links to Button + Link.
- **`apps/docs/app/components/showcase/registry.ts`** — register the new showcase between `link` and `listbox` (alphabetically `link` < `linkbutton` < `listbox`).
- **`docs/COMPONENT_CATALOG.md`** — add a 60+ line LinkButton entry under `## Form Controls` (right after Button), covering props, usage, behavior matrix, "why use it instead of `<ButtonCVA asChild><Link/></ButtonCVA>`", and accessibility. Bump the Form Controls section count from 13 → 14 (LinkButton was previously in the file count of 58 but undocumented). Refresh stale `Last Updated` dates and align the inconsistent "57 in @revealui/presentation" claim on line 12 with the 58 actual count (the claim-drift validator already enforces this — claim-drift confirms the corrected count of 58 matches the live file count, and would have failed CI otherwise).

Net `+225 / -10` across 4 files.

## Verification

- **`pnpm --filter @revealui/presentation typecheck`**: clean
- **`pnpm --filter @revealui/presentation build`**: clean (re-emitted dist with new `/client` exports)
- **`pnpm --filter docs typecheck`**: clean (after presentation rebuild — workspace consumers see new exports via emitted .d.ts)
- **`pnpm --filter docs build`**: clean (606ms; new `linkbutton.showcase-CkVQn36A.js` chunk = 3.99 kB)
- **`pnpm --filter @revealui/presentation test`**: 81 test files / 939 tests pass (no regressions; existing LinkButton.test.tsx unchanged)
- **`pnpm validate:claims`**: passes — 0 mismatches
- **Pre-push gate**: full 16-check gate passes (FAIL → PASS after the count correction)

The interactive showcase rendering wasn't smoke-tested in a browser preview this session because `apps/docs` doesn't have a launch.json entry yet and adding one would balloon scope. The showcase shape is identical to `button.showcase.tsx` + `link.showcase.tsx` (which both render correctly today), and the TypeScript types from `ShowcaseStory` constrain the structure. Will re-verify after merge via the next docs.revealui.com deploy.

## Test plan

- [ ] CI green
- [ ] After merge to test, then test→main promote, docs.revealui.com auto-deploys
- [ ] Visit `/showcase/linkbutton` — verify the interactive preview, variant grid, and 5 named examples render
- [ ] Verify `/showcase` left-nav shows "LinkButton" between "Link" and "Listbox"
