### PR TITLE
fix(ci): skip manually-bumped packages from canary publish

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -89,6 +89,18 @@ jobs:
         if: steps.changesets.outputs.count != '0'
         run: pnpm validate:artifacts
 
+      - name: Skip manually-bumped packages from canary publish
+        # See scripts/canary/skip-manual-bumps.mjs for the why. In short:
+        # `changeset version --snapshot canary` only rewrites versions for
+        # packages with a pending changeset; manual `package.json` bumps
+        # without a changeset would otherwise publish their actual semver
+        # version under the `canary` dist-tag and silently break `latest`
+        # resolution for consumers. Mark such packages private so the
+        # publish step skips them — they'll publish via `release.yml` on
+        # main under `latest` as intended.
+        if: steps.changesets.outputs.count != '0'
+        run: node scripts/canary/skip-manual-bumps.mjs
+
       - name: Publish canary to npm
         if: steps.changesets.outputs.count != '0'
         # --no-git-checks was removed in @changesets/cli 2.x; publish no

--- a/scripts/canary/skip-manual-bumps.mjs
+++ b/scripts/canary/skip-manual-bumps.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * GAP-170 fix — skip manually-bumped packages from the canary publish step.
+ *
+ * Run between `pnpm changeset version --snapshot canary` and
+ * `pnpm changeset publish --tag canary` in `.github/workflows/release-canary.yml`.
+ *
+ * Why this exists:
+ *   `pnpm changeset version --snapshot canary` only rewrites the versions of
+ *   packages with a pending `.changeset/*.md` entry, giving them a
+ *   `0.0.0-canary-<ts>` suffix. Packages whose `package.json` was bumped
+ *   manually (e.g. a hotfix patch from 0.4.0 -> 0.4.1 with no changeset)
+ *   keep their actual semver version. The subsequent
+ *   `pnpm changeset publish --tag canary` publishes ALL non-private
+ *   packages whose version is not yet on the registry — including those
+ *   manual bumps — under the `canary` dist-tag. That mis-tag silently
+ *   breaks `latest` resolution for consumers (`npm install <pkg>` returns
+ *   the prior `latest`, not the bump).
+ *
+ * What we do:
+ *   Walk every workspace package. If its version is missing the
+ *   `-canary-` suffix that snapshot-mode would have inserted, mark the
+ *   package as `private: true` (in-place edit of `package.json`) so
+ *   `changeset publish` skips it. The manual bump still publishes via
+ *   `release.yml` on the eventual main push, landing under `latest` as
+ *   intended.
+ *
+ *   The mutation is CI-only — these workspaces are clones, never
+ *   committed back to git.
+ *
+ * Output: one log line per package skipped, plus a summary count.
+ *   Exit code is always 0 (no fatal conditions); read stderr for unexpected
+ *   parse failures.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** @typedef {{ name: string; path?: string; private?: boolean }} PnpmListEntry */
+
+const CANARY_SUFFIX_PATTERN = /-canary-/;
+
+function listWorkspaces() {
+  const raw = execSync('pnpm -r ls --json --depth -1', { encoding: 'utf8' });
+  /** @type {PnpmListEntry[]} */
+  const entries = JSON.parse(raw);
+  return entries.filter((e) => e.path);
+}
+
+function main() {
+  const workspaces = listWorkspaces();
+  const skipped = [];
+  const kept = [];
+
+  for (const ws of workspaces) {
+    const pkgJsonPath = join(ws.path, 'package.json');
+    let pkgJson;
+    try {
+      pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+    } catch (err) {
+      console.error(`[GAP-170] failed to parse ${pkgJsonPath}:`, err.message);
+      continue;
+    }
+
+    if (pkgJson.private) continue;
+    if (!pkgJson.version) continue;
+
+    if (CANARY_SUFFIX_PATTERN.test(pkgJson.version)) {
+      kept.push(`${pkgJson.name}@${pkgJson.version}`);
+      continue;
+    }
+
+    pkgJson.private = true;
+    writeFileSync(pkgJsonPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+    skipped.push(`${pkgJson.name}@${pkgJson.version}`);
+    console.log(`[GAP-170] skipping ${pkgJson.name}@${pkgJson.version} (no -canary- suffix; manual bump)`);
+  }
+
+  console.log('');
+  console.log(`[GAP-170] ${skipped.length} package(s) marked private to skip canary publish`);
+  console.log(`[GAP-170] ${kept.length} package(s) keeping canary publish:`);
+  for (const k of kept) console.log(`[GAP-170]   ${k}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Fix the canary mis-tag bug surfaced 2026-05-02 with `@revealui/presentation@0.4.1`.

`release-canary.yml` runs `pnpm changeset version --snapshot canary` then `pnpm changeset publish --tag canary` on every push to `test`. The snapshot step only rewrites versions for packages with a pending `.changeset/*.md` entry. Packages whose `package.json` was bumped manually (e.g. a hotfix patch from `0.4.0` → `0.4.1` with no changeset) keep their actual semver. The publish step then pushes that semver to npm under the `canary` dist-tag, silently breaking `latest` resolution for consumers (`npm install <pkg>` returns the prior `latest`, not the bump).

Workaround used 2026-05-02: `pnpm dist-tag add @revealui/presentation@0.4.1 latest`. This PR removes the need for that workaround going forward.

## What changed

- New script: [`scripts/canary/skip-manual-bumps.mjs`](scripts/canary/skip-manual-bumps.mjs). Walks the workspace, identifies any package whose version doesn't carry the `-canary-` suffix that snapshot mode would have inserted, and marks it `private: true` in its in-tree `package.json`. `changeset publish` then skips those packages. The mutation is CI-only — these workspaces are clones, never committed back.
- New step in [`.github/workflows/release-canary.yml`](.github/workflows/release-canary.yml): `Skip manually-bumped packages from canary publish`, gated by the same `steps.changesets.outputs.count != '0'` condition as the rest of the canary path. Inserted between `Validate build artifacts` and `Publish canary to npm`.

## What did not change

- Existing changeset-driven canary cadence (canary suffix versions for in-flight changesets) is unchanged — packages WITH a pending changeset get `-canary-<ts>` versions and pass through the script untouched.
- Manual bumps continue to publish under `latest` via `release.yml` on the eventual main push, as intended.
- No npm-token rotation. No new secrets. No build-graph changes.

## Test plan

- [x] Local dry-run of the script in a fresh worktree off `origin/test` (no snapshot pre-step → script identifies all 21 publishable packages as manual bumps, marks them private, 0 kept for canary). Reverted via `git checkout -- packages/`.
- [x] Pre-push 16-check gate → PASS.
- [x] Console audit: `Production code: 0 (NEEDS MIGRATION)` — script's `console.log` lives under `scripts/` (allowed).
- [ ] CI green on the PR.
- [ ] Integration verification on the next push to `test` containing a manual bump (out-of-band; verify via workflow log "skipping `<pkg>@<version>` (no -canary- suffix; manual bump)" lines in the new step's output, and confirm npm doesn't receive the manual semver under `canary`).

## References

- Audit: `docs/gaps/GAP-170.yml` (private repo).
- Surfacing context: [PR #707](https://github.com/RevealUIStudio/revealui/pull/707) (`@revealui/presentation@0.4.1` Slot fix).
