### PR TITLE
chore(ci): SHA-pin remaining 7 actions in db-backup + webhook-reconciliation

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -60,7 +60,7 @@ jobs:
       # Upload as artifact (retained for 30 days)
       - name: Upload backup artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: db-backup-${{ github.run_id }}
           path: .revealui/backups/

--- a/.github/workflows/webhook-reconciliation.yml
+++ b/.github/workflows/webhook-reconciliation.yml
@@ -26,13 +26,13 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"


### PR DESCRIPTION
## Summary

83 of 90 `uses:` lines across `.github/workflows/*.yml` were already SHA-pinned; these two recently-added workflows missed the convention. This PR pins the remaining 7 references using SHAs already vetted elsewhere in this repo.

## Changes

| File | Lines pinned |
|---|---|
| `.github/workflows/db-backup.yml` | 4 (checkout, pnpm/action-setup, setup-node, upload-artifact) |
| `.github/workflows/webhook-reconciliation.yml` | 3 (checkout, pnpm/action-setup, setup-node) |

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e... # v6` |
| `actions/setup-node` | `@v6` | `@48b55a01... # v6` |
| `pnpm/action-setup` | `@v6` | `@903f9c1a... # v6.0.3` |
| `actions/upload-artifact` | `@v7` | `@043fb46d... # v7` |

All SHAs match references already pinned elsewhere in this repo (`ci.yml`, `deploy.yml`, `release.yml`, `security.yml`, etc.) — zero new SHA discovery, zero behavior change beyond mitigating tag-repoint attacks.

## Why

GitHub Actions tag references (`@v6`) are mutable: an action repo owner — or an attacker who compromises one — can move the tag to a malicious commit. SHA pinning makes the reference content-addressed; a malicious update would have to ship a new SHA, which Dependabot then proposes as an explicit, reviewable PR rather than a silent re-target. Reference: `tj-actions/changed-files` 2025-03 incident.

## Test plan

- [x] Audit script confirmed zero remaining unpinned `uses:` across all 13 workflows after edits (`grep -hE "^\s+(- )?uses: [^@]+@v[0-9]+\s*$" .github/workflows/*.yml` returns nothing)
- [x] Each new SHA matches an SHA already in use elsewhere in the same repo (so the action versions don't actually change)
- [ ] CI green on this PR
- [ ] Both modified workflows trigger correctly on next scheduled run (`db-backup.yml` daily 02:00 UTC; `webhook-reconciliation.yml` weekly Mon 08:00 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
