### PR TITLE
chore(contracts): rename Forge tier display label to Enterprise

### DIFF
--- a/apps/server/src/routes/__tests__/billing-services-renewal.test.ts
+++ b/apps/server/src/routes/__tests__/billing-services-renewal.test.ts
@@ -193,12 +193,12 @@ describe('Perpetual tiers  -  launch enabled', () => {
     expect(agency!.ctaHref).toBeTruthy();
   });
 
-  it('Forge Perpetual is purchasable', () => {
-    const forge = PERPETUAL_TIERS.find((t) => t.name === 'Forge Perpetual');
-    expect(forge).toBeDefined();
-    expect(forge!.comingSoon).toBe(false);
-    expect(forge!.cta).toBeTruthy();
-    expect(forge!.ctaHref).toBeTruthy();
+  it('Enterprise Perpetual is purchasable', () => {
+    const enterprise = PERPETUAL_TIERS.find((t) => t.name === 'Enterprise Perpetual');
+    expect(enterprise).toBeDefined();
+    expect(enterprise!.comingSoon).toBe(false);
+    expect(enterprise!.cta).toBeTruthy();
+    expect(enterprise!.ctaHref).toBeTruthy();
   });
 });
 

--- a/apps/server/src/routes/__tests__/billing-ui-accuracy.test.ts
+++ b/apps/server/src/routes/__tests__/billing-ui-accuracy.test.ts
@@ -181,7 +181,7 @@ describe('Billing UI Accuracy  -  admin Billing Page vs API + Contracts', () => 
     });
   });
 
-  describe('Forge "What\'s Included" matches contracts', () => {
+  describe('Enterprise "What\'s Included" matches contracts', () => {
     it('enterprise sites are unlimited (null in contracts)', () => {
       expect(TIER_LIMITS.enterprise.sites).toBeNull();
       expect(UI_ENTERPRISE_CLAIMS.unlimitedSites).toBe(true);
@@ -274,7 +274,7 @@ describe('Billing UI Accuracy  -  admin Billing Page vs API + Contracts', () => 
   });
 
   describe('Usage display correctness', () => {
-    it('quota of -1 means unlimited (Forge tier)', () => {
+    it('quota of -1 means unlimited (Enterprise tier)', () => {
       // The billing page treats usage.quota === -1 as unlimited
       const isUnlimited = (quota: number) => quota === -1;
       expect(isUnlimited(-1)).toBe(true);

--- a/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
@@ -86,9 +86,9 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
       }
     });
 
-    it('enterprise is labeled "Forge" in subscription tiers', () => {
+    it('enterprise is labeled "Enterprise" in subscription tiers', () => {
       const enterprise = SUBSCRIPTION_TIERS.find((t) => t.id === 'enterprise');
-      expect(enterprise?.name).toBe('Forge');
+      expect(enterprise?.name).toBe('Enterprise');
     });
   });
 
@@ -289,7 +289,7 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
       expect(getTierLabel('free')).toBe('Free (OSS)');
       expect(getTierLabel('pro')).toBe('Pro');
       expect(getTierLabel('max')).toBe('Max');
-      expect(getTierLabel('enterprise')).toBe('Forge (Enterprise)');
+      expect(getTierLabel('enterprise')).toBe('Enterprise');
     });
   });
 

--- a/apps/server/src/routes/__tests__/pricing.test.ts
+++ b/apps/server/src/routes/__tests__/pricing.test.ts
@@ -792,7 +792,7 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
           revealui_price_note: 'one-time',
           revealui_renewal: '$199/yr',
         }),
-        makeStripeProduct('Forge Perpetual', 'perpetual', 'forge_perpetual', 199900, undefined, {
+        makeStripeProduct('Enterprise Perpetual', 'perpetual', 'enterprise_perpetual', 199900, undefined, {
           revealui_price_note: 'one-time',
           revealui_renewal: '$499/yr',
         }),
@@ -807,8 +807,8 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
     expect(pro.price).toBe('$299');
     const agency = data.perpetual.find((t: { name: string }) => t.name === 'Agency Perpetual');
     expect(agency.price).toBe('$799');
-    const forge = data.perpetual.find((t: { name: string }) => t.name === 'Forge Perpetual');
-    expect(forge.price).toBe('$1999');
+    const enterprise = data.perpetual.find((t: { name: string }) => t.name === 'Enterprise Perpetual');
+    expect(enterprise.price).toBe('$1999');
   });
 
   it('mixes Stripe enrichment with fallback across tracks', async () => {

--- a/apps/server/src/routes/__tests__/pricing.test.ts
+++ b/apps/server/src/routes/__tests__/pricing.test.ts
@@ -792,10 +792,17 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
           revealui_price_note: 'one-time',
           revealui_renewal: '$199/yr',
         }),
-        makeStripeProduct('Enterprise Perpetual', 'perpetual', 'enterprise_perpetual', 199900, undefined, {
-          revealui_price_note: 'one-time',
-          revealui_renewal: '$499/yr',
-        }),
+        makeStripeProduct(
+          'Enterprise Perpetual',
+          'perpetual',
+          'enterprise_perpetual',
+          199900,
+          undefined,
+          {
+            revealui_price_note: 'one-time',
+            revealui_renewal: '$499/yr',
+          },
+        ),
       ],
     });
 
@@ -807,7 +814,9 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
     expect(pro.price).toBe('$299');
     const agency = data.perpetual.find((t: { name: string }) => t.name === 'Agency Perpetual');
     expect(agency.price).toBe('$799');
-    const enterprise = data.perpetual.find((t: { name: string }) => t.name === 'Enterprise Perpetual');
+    const enterprise = data.perpetual.find(
+      (t: { name: string }) => t.name === 'Enterprise Perpetual',
+    );
     expect(enterprise.price).toBe('$1999');
   });
 

--- a/packages/contracts/src/__tests__/pricing.test.ts
+++ b/packages/contracts/src/__tests__/pricing.test.ts
@@ -347,9 +347,9 @@ describe('PERPETUAL_TIERS  -  comingSoon status', () => {
     expect(agency?.comingSoon).toBe(false);
   });
 
-  it('Forge Perpetual is not coming soon', () => {
-    const forge = PERPETUAL_TIERS.find((t) => t.name === 'Forge Perpetual');
-    expect(forge).toBeDefined();
-    expect(forge?.comingSoon).toBe(false);
+  it('Enterprise Perpetual is not coming soon', () => {
+    const enterprise = PERPETUAL_TIERS.find((t) => t.name === 'Enterprise Perpetual');
+    expect(enterprise).toBeDefined();
+    expect(enterprise?.comingSoon).toBe(false);
   });
 });

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -45,7 +45,7 @@ export const TIER_LABELS: Record<LicenseTierId, string> = {
   free: 'Free (OSS)',
   pro: 'Pro',
   max: 'Max',
-  enterprise: 'Forge (Enterprise)',
+  enterprise: 'Enterprise',
 };
 
 export const TIER_COLORS: Record<LicenseTierId, string> = {
@@ -182,7 +182,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
   },
   {
     id: 'enterprise',
-    name: 'Forge',
+    name: 'Enterprise',
     description: 'Full ecosystem access with scale, compliance, and agent payments.',
     features: [
       'Everything in Max',
@@ -199,7 +199,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Full source code access',
     ],
     cta: 'Contact Sales',
-    ctaHref: 'mailto:support@revealui.com?subject=Forge%20Inquiry',
+    ctaHref: 'mailto:support@revealui.com?subject=Enterprise%20Tier%20Inquiry',
     highlighted: false,
   },
 ];
@@ -386,18 +386,18 @@ export const PERPETUAL_TIERS: PerpetualTier[] = [
     comingSoon: false,
   },
   {
-    name: 'Forge Perpetual',
-    description: 'Full self-hosted Forge with unlimited deployments.',
+    name: 'Enterprise Perpetual',
+    description: 'Full self-hosted Enterprise tier with unlimited deployments.',
     features: [
-      'All Forge tier features',
+      'All Enterprise tier features',
       'License key  -  never expires',
       'Unlimited self-hosted deployments',
       '1 year priority support included',
-      'All Forge updates released during support period',
+      'All Enterprise tier updates released during support period',
       'Private GitHub repo + Docker image access',
     ],
     cta: 'Contact Sales',
-    ctaHref: 'mailto:support@revealui.com?subject=Forge%20Perpetual%20License%20Inquiry',
+    ctaHref: 'mailto:support@revealui.com?subject=Enterprise%20Perpetual%20License%20Inquiry',
     comingSoon: false,
   },
 ];


### PR DESCRIPTION
## Summary

Renames the customer-facing **tier display label** from "Forge" to "Enterprise" in `@revealui/contracts/pricing`. The tier id (`enterprise`) is the code-stable name; the display label "Forge" was reusing the runtime/repo name and creating two ambiguities:

1. Customers couldn't tell whether they were buying a *tier of access* or the *Forge self-host runtime kit*.
2. The Forge runtime is documented as pre-launch (Docker images not yet on GHCR per `apps/docs/public/SUITE.md`); selling a tier under that name without that gating in the label is a trust risk.

Decoupling the SaaS tier name from the runtime name lets the runtime rename (currently in flight) proceed without churning the tier name a second time.

## What changed

`packages/contracts/src/pricing.ts`:
- `TIER_LABELS.enterprise`: `'Forge (Enterprise)'` → `'Enterprise'`
- `SUBSCRIPTION_TIERS[enterprise].name`: `'Forge'` → `'Enterprise'`
- `PERPETUAL_TIERS` Forge Perpetual entry: name, description, and feature lines → `'Enterprise Perpetual'` / `'Enterprise tier'`
- 2 mailto subject lines updated for consistency

Tests updated to match:
- `packages/contracts/src/__tests__/pricing.test.ts` — Enterprise Perpetual lookup
- `apps/server/src/routes/__tests__/pricing-accuracy.test.ts` — name + label assertions
- `apps/server/src/routes/__tests__/billing-ui-accuracy.test.ts` — describe/it labels

## Out of scope (follow-up PRs)

- `~/suite/forge` repo and `FORGE.md` runtime guide — those describe the *runtime product*, not the SaaS tier. Untouched.
- Hardcoded `"Forge tier"` strings in apps that don't import the constants:
  - `apps/admin/src/app/(frontend)/account/billing/page.tsx` (button label, agent-tasks footnote)
  - `apps/marketing/app/routes/PricingPage.tsx` (FAQ)
  - `apps/marketing/app/routes/ComingSoonPage.tsx`
  - `apps/docs/app/showcase/{table,timeline}.showcase.tsx`
- Public docs (`AGENTS.md`, `README.md`, `docs/agent-rules/*`, `docs/MASTER_PLAN.md`) — broader docs sweep separate.

## Test plan

- [x] `pnpm --filter @revealui/contracts test` — 767/767 passing
- [x] `pnpm --filter server vitest run src/routes/__tests__/pricing-accuracy.test.ts src/routes/__tests__/billing-ui-accuracy.test.ts` — 93/93 passing
- [ ] CI gate (full quality + typecheck + tests + build) — runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
