### PR TITLE
feat(marketing,docs): ship /llms.txt for agent-readable site discovery

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -19,9 +19,9 @@
 
 ## The fleet
 
-- [The RevealUI Studio Fleet](https://docs.revealui.com/SUITE): All eight products, what each does, how they compose
+- [RevFleet](https://docs.revealui.com/SUITE): The eight-product Studio family, what each does, how they compose
 - [Pro packages](https://docs.revealui.com/PRO): `@revealui/ai`, `@revealui/harnesses`, `@revealui/engines` (FSL-1.1-MIT — source-visible, JWT-gated, auto-MIT after 2 years)
-- [Revfleet runtime](https://docs.revealui.com/FORGE): Self-hosted enterprise deployment kit (formerly Forge — rename in flight per ADR `2026-05-01-forge-naming`; preview status)
+- [RevealUI Fleet runtime](https://docs.revealui.com/FORGE): Self-hosted Enterprise-tier deployment kit (formerly RevealUI Forge — renamed per ADR `2026-05-03-revfleet-rename`; deployed via the RevForge stamping tool; preview status)
 - [Component catalog](https://docs.revealui.com/COMPONENT_CATALOG): UI components shipped in `@revealui/presentation`
 - [Examples](https://docs.revealui.com/EXAMPLES): Code examples
 
@@ -52,6 +52,6 @@
 
 - 0 paying customers; A- (8.7/10) on internal honest grading
 - **Stripe** runs in TEST mode in production; live mode gated on billing-readiness audit (see `WHAT_WORKS_TODAY`)
-- **Revfleet** (formerly Forge) Docker images not yet on GHCR (preview status — runs from source today)
+- **RevealUI Fleet** (formerly RevealUI Forge) Docker images not yet on GHCR (preview status — runs from source today)
 - **Ubuntu Inference Snaps** integration in progress; **Ollama** is the shipped open-model path
 - **Supabase** being phased out in favor of NeonDB + ElectricSQL (vector store consolidation in flight)

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # RevealUI Documentation
 
-> Documentation for RevealUI — the agentic business runtime. Architecture, primitives, deployment, suite composition, and agent integration. Honest status throughout.
+> Documentation for RevealUI — the agentic business runtime. Architecture, primitives, deployment, fleet composition, and agent integration. Honest status throughout.
 
 ## Start here
 
@@ -17,11 +17,11 @@
 - [Billing (Stripe)](https://docs.revealui.com/PRO#billing): Stripe webhooks, circuit breaker, metered billing
 - [Local-first](https://docs.revealui.com/LOCAL_FIRST): The whole stack runs on your machine
 
-## The suite
+## The fleet
 
-- [The RevealUI Studio Suite](https://docs.revealui.com/SUITE): All eight products, what each does, how they compose
+- [The RevealUI Studio Fleet](https://docs.revealui.com/SUITE): All eight products, what each does, how they compose
 - [Pro packages](https://docs.revealui.com/PRO): `@revealui/ai`, `@revealui/harnesses`, `@revealui/engines` (FSL-1.1-MIT — source-visible, JWT-gated, auto-MIT after 2 years)
-- [Forge runtime](https://docs.revealui.com/FORGE): Self-hosted enterprise deployment kit (preview status)
+- [Revfleet runtime](https://docs.revealui.com/FORGE): Self-hosted enterprise deployment kit (formerly Forge — rename in flight per ADR `2026-05-01-forge-naming`; preview status)
 - [Component catalog](https://docs.revealui.com/COMPONENT_CATALOG): UI components shipped in `@revealui/presentation`
 - [Examples](https://docs.revealui.com/EXAMPLES): Code examples
 
@@ -52,6 +52,6 @@
 
 - 0 paying customers; A- (8.7/10) on internal honest grading
 - **Stripe** runs in TEST mode in production; live mode gated on billing-readiness audit (see `WHAT_WORKS_TODAY`)
-- **Forge** Docker images not yet on GHCR (preview status — runs from source today)
+- **Revfleet** (formerly Forge) Docker images not yet on GHCR (preview status — runs from source today)
 - **Ubuntu Inference Snaps** integration in progress; **Ollama** is the shipped open-model path
 - **Supabase** being phased out in favor of NeonDB + ElectricSQL (vector store consolidation in flight)

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,0 +1,57 @@
+# RevealUI Documentation
+
+> Documentation for RevealUI — the agentic business runtime. Architecture, primitives, deployment, suite composition, and agent integration. Honest status throughout.
+
+## Start here
+
+- [Index](https://docs.revealui.com/INDEX): Top-level documentation map
+- [Quick start](https://docs.revealui.com/QUICK_START): `npx create-revealui@latest my-app` — local stack in 60 seconds
+- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, app + package map, package boundaries
+- [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest tested-vs-stub-vs-absent status
+
+## The five primitives
+
+- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, RS256)
+- [AI](https://docs.revealui.com/AI): LLM providers, MCP, A2A, agents, RAG, memory layers
+- [Database](https://docs.revealui.com/DATABASE): Drizzle ORM on NeonDB; legacy Supabase code remaining in tree during phase-out
+- [Billing (Stripe)](https://docs.revealui.com/PRO#billing): Stripe webhooks, circuit breaker, metered billing
+- [Local-first](https://docs.revealui.com/LOCAL_FIRST): The whole stack runs on your machine
+
+## The suite
+
+- [The RevealUI Studio Suite](https://docs.revealui.com/SUITE): All eight products, what each does, how they compose
+- [Pro packages](https://docs.revealui.com/PRO): `@revealui/ai`, `@revealui/harnesses`, `@revealui/engines` (FSL-1.1-MIT — source-visible, JWT-gated, auto-MIT after 2 years)
+- [Forge runtime](https://docs.revealui.com/FORGE): Self-hosted enterprise deployment kit (preview status)
+- [Component catalog](https://docs.revealui.com/COMPONENT_CATALOG): UI components shipped in `@revealui/presentation`
+- [Examples](https://docs.revealui.com/EXAMPLES): Code examples
+
+## Agents
+
+- [AI integration](https://docs.revealui.com/AI): How agents talk to a RevealUI runtime
+- [Agent rules](https://docs.revealui.com/agent-rules/): Conventions for agents working in a RevealUI codebase
+- [REST API](https://docs.revealui.com/api/): Hono + OpenAPI endpoints
+
+## Operations
+
+- [Deployment runbook](https://docs.revealui.com/DEPLOYMENT-RUNBOOK): Production deploy procedures
+- [Environment variables](https://docs.revealui.com/ENVIRONMENT-VARIABLES-GUIDE): Full env reference
+- [Credential rotation](https://docs.revealui.com/CREDENTIAL-ROTATION-RUNBOOK): Rotation runbook for every secret type
+
+## Reference
+
+- [Reference index](https://docs.revealui.com/REFERENCE): Type-checked reference
+- [Architecture decisions](https://docs.revealui.com/decisions/): Internal ADRs
+- [Audit status](https://docs.revealui.com/AUDIT_STATUS): Pre-launch audit posture
+
+## Source
+
+- [GitHub](https://github.com/RevealUIStudio/revealui)
+- [Issue tracker](https://github.com/RevealUIStudio/revealui/issues)
+
+## Status (honest, pre-launch)
+
+- 0 paying customers; A- (8.7/10) on internal honest grading
+- **Stripe** runs in TEST mode in production; live mode gated on billing-readiness audit (see `WHAT_WORKS_TODAY`)
+- **Forge** Docker images not yet on GHCR (preview status — runs from source today)
+- **Ubuntu Inference Snaps** integration in progress; **Ollama** is the shipped open-model path
+- **Supabase** being phased out in favor of NeonDB + ElectricSQL (vector store consolidation in flight)

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -7,7 +7,7 @@
 - [Documentation home](https://docs.revealui.com): Architecture, primitives, deployment, agent integration
 - [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest pre-launch status — what's tested, what's stub, what's not yet wired
 - [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 5 apps (admin, server, docs, marketing, revealcoin), 22 packages on npm + 3 internal
-- [Meet the Suite](https://docs.revealui.com/SUITE): Eight products that compose: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), RevealCoin (RVC token), Forge (self-host kit), RevSkills (skills), RevKit (WSL toolkit)
+- [Meet the Fleet](https://docs.revealui.com/SUITE): Eight products that compose the RevealUI Studio Fleet: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), RevealCoin (RVC token), Revfleet (self-host kit, formerly Forge), RevSkills (skills), RevKit (WSL toolkit)
 
 ## Getting started
 
@@ -34,7 +34,7 @@
 
 - Zero paying customers. Code grade: A- (8.7/10) on internal honest assessment.
 - **Stripe live mode** gated on billing-readiness audit. Test mode is current production posture.
-- **Forge runtime kit** is preview — Docker images not yet on GHCR; stack runs from source today.
+- **Revfleet runtime kit** (formerly Forge — rename in flight per ADR `2026-05-01-forge-naming`) is preview — Docker images not yet on GHCR; stack runs from source today.
 - **Ubuntu Inference Snaps** integration is in progress; **Ollama** is the working open-model path today.
 - **RevealCoin (RVC)** is on Solana mainnet; public trading + Raydium pool gate on multi-sig + on-chain vesting.
 - **Supabase** is being phased out in favor of NeonDB + ElectricSQL.

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -7,7 +7,7 @@
 - [Documentation home](https://docs.revealui.com): Architecture, primitives, deployment, agent integration
 - [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest pre-launch status — what's tested, what's stub, what's not yet wired
 - [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 5 apps (admin, server, docs, marketing, revealcoin), 22 packages on npm + 3 internal
-- [Meet the Fleet](https://docs.revealui.com/SUITE): Eight products that compose the RevealUI Studio Fleet: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), RevealCoin (RVC token), Revfleet (self-host kit, formerly Forge), RevSkills (skills), RevKit (WSL toolkit)
+- [Meet the Fleet](https://docs.revealui.com/SUITE): Eight products that compose **RevFleet**: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), RevealCoin (RVC token), **RevealUI Fleet** (self-host runtime kit, deployed via the **RevForge** stamping tool — formerly RevealUI Forge), RevSkills (skills), RevKit (WSL toolkit)
 
 ## Getting started
 
@@ -34,7 +34,7 @@
 
 - Zero paying customers. Code grade: A- (8.7/10) on internal honest assessment.
 - **Stripe live mode** gated on billing-readiness audit. Test mode is current production posture.
-- **Revfleet runtime kit** (formerly Forge — rename in flight per ADR `2026-05-01-forge-naming`) is preview — Docker images not yet on GHCR; stack runs from source today.
+- **RevealUI Fleet runtime kit** (formerly RevealUI Forge — renamed per ADR `2026-05-03-revfleet-rename`; deployed via the RevForge stamping tool) is preview — Docker images not yet on GHCR; stack runs from source today.
 - **Ubuntu Inference Snaps** integration is in progress; **Ollama** is the working open-model path today.
 - **RevealCoin (RVC)** is on Solana mainnet; public trading + Raydium pool gate on multi-sig + on-chain vesting.
 - **Supabase** is being phased out in favor of NeonDB + ElectricSQL.

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -1,0 +1,40 @@
+# RevealUI
+
+> The agentic business runtime. Five primitives — users, content, products, payments, AI — pre-wired for humans and AI agents to build businesses together. Open source (MIT) + Fair Source (FSL-1.1-MIT) Pro packages. Self-hostable. No vendor lock-in.
+
+## Documentation
+
+- [Documentation home](https://docs.revealui.com): Architecture, primitives, deployment, agent integration
+- [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest pre-launch status — what's tested, what's stub, what's not yet wired
+- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 5 apps (admin, server, docs, marketing, revealcoin), 22 packages on npm + 3 internal
+- [Meet the Suite](https://docs.revealui.com/SUITE): Eight products that compose: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), RevealCoin (RVC token), Forge (self-host kit), RevSkills (skills), RevKit (WSL toolkit)
+
+## Getting started
+
+- [Quick start](https://docs.revealui.com/QUICK_START): `npx create-revealui@latest my-app` — local stack in 60 seconds
+- [Local-first](https://docs.revealui.com/LOCAL_FIRST): Run the entire stack on your machine
+
+## Source code
+
+- [GitHub](https://github.com/RevealUIStudio/revealui): All code lives in the public repo. OSS subset under MIT; Pro packages (`@revealui/ai`, `@revealui/harnesses`, `@revealui/engines`) under FSL-1.1-MIT (Fair Source — source-visible, JWT-gated, auto-converts to MIT after 2 years).
+- [Fair Source explainer](https://docs.revealui.com/FAIR_SOURCE): What FSL-1.1-MIT means in practice
+
+## Pricing
+
+- [Pricing page](https://revealui.com/pricing): Free, Pro, Max, Enterprise tiers; perpetual licenses; professional services
+- Stripe billing currently runs in **TEST mode** in production. Live mode is gated on an internal billing-readiness audit. No customer cards are charged today.
+
+## For agents
+
+- [AI integration](https://docs.revealui.com/AI): How agents talk to a RevealUI runtime via MCP, A2A, and harness coordination
+- [Agent rules](https://docs.revealui.com/agent-rules/): Conventions agents follow when contributing to a RevealUI codebase
+- [REST API](https://docs.revealui.com/api/): Hono + OpenAPI endpoints
+
+## Status (honest, pre-launch)
+
+- Zero paying customers. Code grade: A- (8.7/10) on internal honest assessment.
+- **Stripe live mode** gated on billing-readiness audit. Test mode is current production posture.
+- **Forge runtime kit** is preview — Docker images not yet on GHCR; stack runs from source today.
+- **Ubuntu Inference Snaps** integration is in progress; **Ollama** is the working open-model path today.
+- **RevealCoin (RVC)** is on Solana mainnet; public trading + Raydium pool gate on multi-sig + on-chain vesting.
+- **Supabase** is being phased out in favor of NeonDB + ElectricSQL.


### PR DESCRIPTION
## Summary

Ships `/llms.txt` at both customer-facing URLs (`revealui.com` and `docs.revealui.com`) so AI agents arriving at the site can discover the product, doc paths, source repo, and honest status — without parsing HTML or running JS.

## Why

Closes the agent-affordance gap surfaced by the recent suite messaging audit. The marketing copy and blog drafts pitch "agent-native" / "your agents read this" but the customer-facing URLs shipped zero machine-readable surface — no `/llms.txt`, no `/AGENTS.md` published anywhere except the repo root. The product's stated thesis was unbuilt on the surface customers and agents hit first.

`llms.txt` is the proposed agent-discovery standard ([llmstxt.org](https://llmstxt.org)). It's a plain markdown file at site root; agents fetch it once and parse a structured map of the site.

## What changed

Two new files:
- `apps/marketing/public/llms.txt` → surfaced at `https://revealui.com/llms.txt`
- `apps/docs/public/llms.txt` → surfaced at `https://docs.revealui.com/llms.txt`

Both files:
- Lead with the canonical mission frame (humans + AI agents building businesses, five primitives, OSS + Fair Source split)
- Link to the structured doc paths an agent actually wants (architecture, suite map, Pro packages, agent rules, REST API)
- Include an explicit **honest status** section (Stripe test-mode, Forge preview, Inference Snaps in-progress, Supabase phase-out, RevealCoin pre-launch gates) so the spec doesn't mismatch reality

## Test plan

- [x] Both files parse as valid markdown (llms.txt format)
- [x] All linked URLs target canonical docs paths already in tree
- [ ] CI gate runs (pure asset addition — no functional changes)
- [ ] Post-merge: visit `https://revealui.com/llms.txt` and `https://docs.revealui.com/llms.txt` after deploy to confirm Vite copies them as expected (anything in `public/` is copied verbatim)

## Out of scope (follow-up)

- `/AGENTS.md` at customer-facing URLs (the repo-root version exists; could be ported)
- `/.well-known/mcp.json` for MCP server discovery
- Suite glossary page
- A non-developer entry point for the interest-led operator audience corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
