### PR TITLE
chore(ui): sweep hardcoded Forge tier strings to Enterprise

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -495,7 +495,7 @@ function BillingContent() {
             {tier === 'max' && (
               <div className="space-y-3">
                 <p className="text-sm text-zinc-600">
-                  Upgrade to Forge for unlimited projects and users, SSO, white-label branding,
+                  Upgrade to Enterprise for unlimited projects and users, SSO, white-label branding,
                   multi-tenant isolation, and self-hosted deployment.
                 </p>
                 <Button
@@ -506,8 +506,8 @@ function BillingContent() {
                   {actionLoading
                     ? 'Upgrading...'
                     : upgradeSuccess
-                      ? 'Upgraded to Forge'
-                      : `Upgrade to Forge — ${getPrice('enterprise')}`}
+                      ? 'Upgraded to Enterprise'
+                      : `Upgrade to Enterprise — ${getPrice('enterprise')}`}
                 </Button>
                 <Button
                   onClick={handleManageBilling}
@@ -560,7 +560,7 @@ function BillingContent() {
             <CardTitle>Agent Task Usage</CardTitle>
             <CardDescription>
               {usage.quota === -1
-                ? 'Unlimited agent tasks (Forge tier).'
+                ? 'Unlimited agent tasks (Enterprise tier).'
                 : `${usage.quota.toLocaleString()} tasks included per month. Resets ${new Date(usage.resetAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}.`}
             </CardDescription>
           </CardHeader>

--- a/apps/docs/app/showcase/table.showcase.tsx
+++ b/apps/docs/app/showcase/table.showcase.tsx
@@ -104,7 +104,7 @@ const story: ShowcaseStory = {
               { tier: 'Free', sites: '1', users: '3', rate: '200/min' },
               { tier: 'Pro', sites: '5', users: '25', rate: '300/min' },
               { tier: 'Max', sites: '15', users: '100', rate: '600/min' },
-              { tier: 'Forge', sites: 'Unlimited', users: 'Unlimited', rate: 'Unlimited' },
+              { tier: 'Enterprise', sites: 'Unlimited', users: 'Unlimited', rate: 'Unlimited' },
             ].map((row) => (
               <TableRow key={row.tier}>
                 <TableCell className="font-medium">{row.tier}</TableCell>

--- a/apps/docs/app/showcase/timeline.showcase.tsx
+++ b/apps/docs/app/showcase/timeline.showcase.tsx
@@ -25,7 +25,11 @@ const story: ShowcaseStory = {
       { title: 'Beta release', date: 'Mar 1', description: 'Public beta with 50+ components' },
       { title: 'v1.0 Launch', date: 'Mar 20', description: 'Production release on npm' },
       { title: 'Community milestone', date: 'Apr 5', description: '1,000 GitHub stars' },
-      { title: 'Enterprise tier', date: 'May 1', description: 'Enterprise tier with unlimited sites' },
+      {
+        title: 'Enterprise tier',
+        date: 'May 1',
+        description: 'Enterprise tier with unlimited sites',
+      },
     ].slice(0, count);
 
     return (

--- a/apps/docs/app/showcase/timeline.showcase.tsx
+++ b/apps/docs/app/showcase/timeline.showcase.tsx
@@ -25,7 +25,7 @@ const story: ShowcaseStory = {
       { title: 'Beta release', date: 'Mar 1', description: 'Public beta with 50+ components' },
       { title: 'v1.0 Launch', date: 'Mar 20', description: 'Production release on npm' },
       { title: 'Community milestone', date: 'Apr 5', description: '1,000 GitHub stars' },
-      { title: 'Enterprise tier', date: 'May 1', description: 'Forge tier with unlimited sites' },
+      { title: 'Enterprise tier', date: 'May 1', description: 'Enterprise tier with unlimited sites' },
     ].slice(0, count);
 
     return (

--- a/apps/marketing/app/routes/ComingSoonPage.tsx
+++ b/apps/marketing/app/routes/ComingSoonPage.tsx
@@ -42,7 +42,7 @@ const upcoming: Feature[] = [
   {
     name: 'Perpetual Licenses (Track C)',
     description:
-      'One-time purchase for lifetime access to Pro, Max, or Forge tier features. No subscription required. Includes 1 year of priority support and updates.',
+      'One-time purchase for lifetime access to Pro, Max, or Enterprise tier features. No subscription required. Includes 1 year of priority support and updates.',
     status: 'Coming soon',
     category: 'Billing',
   },

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -56,12 +56,12 @@ const faqs = [
   {
     question: 'Do you offer custom pricing for large teams?',
     answer:
-      'Yes! If you need more than what the Forge tier offers, contact us at support@revealui.com to discuss custom pricing and SLAs.',
+      'Yes! If you need more than what the Enterprise tier offers, contact us at support@revealui.com to discuss custom pricing and SLAs.',
   },
   {
     question: 'What is the RevealUI ecosystem?',
     answer:
-      'RevealUI is part of a four-project ecosystem. RevVault provides age-encrypted secret management (CLI free, desktop app Pro). RevKit provides portable dev environment provisioning (agent coordination protocol free, full provisioning Max). RevealCoin enables agent-native micropayments via the x402 protocol (Forge). Each project works independently. Together they cover building, securing, and monetizing agentic software.',
+      'RevealUI is part of a four-project ecosystem. RevVault provides age-encrypted secret management (CLI free, desktop app Pro). RevKit provides portable dev environment provisioning (agent coordination protocol free, full provisioning Max). RevealCoin enables agent-native micropayments via the x402 protocol (Enterprise tier). Each project works independently. Together they cover building, securing, and monetizing agentic software.',
   },
 ];
 

--- a/apps/marketing/app/routes/TermsPage.tsx
+++ b/apps/marketing/app/routes/TermsPage.tsx
@@ -19,7 +19,7 @@ export function TermsPage() {
         <p>
           RevealUI is an open-source agentic business runtime for software companies. It includes a
           content engine, authentication, billing integration, AI agents, and UI components. The
-          Service is available in four tiers: Free (OSS), Pro, Max, and Forge.
+          Service is available in four tiers: Free (OSS), Pro, Max, and Enterprise.
         </p>
 
         <h2>2. Accounts</h2>


### PR DESCRIPTION
## Summary

Follow-up to #719. Sweeps the hardcoded `"Forge"` tier strings in UIs that don't import from `@revealui/contracts/pricing` (so they didn't auto-cascade when the constants renamed in #719).

## What changed (6 files, 9 strings)

- `apps/admin/src/app/(frontend)/account/billing/page.tsx` (3)
  - Upgrade-to-Max-tier description: `"Upgrade to Forge for unlimited..."` → `"Upgrade to Enterprise..."`
  - Stripe-checkout CTA states: `"Upgrade to Forge — $X"` / `"Upgraded to Forge"` → `Enterprise`
  - Agent-tasks footnote: `"Unlimited agent tasks (Forge tier)."` → `"(Enterprise tier)"`
- `apps/marketing/app/routes/TermsPage.tsx` (1)
  - Tiers enumeration in §1 Service Description
- `apps/marketing/app/routes/PricingPage.tsx` (2)
  - "Custom pricing" FAQ
  - "RevealUI ecosystem" FAQ — `(Forge)` parenthetical for x402 → `(Enterprise tier)`
- `apps/marketing/app/routes/ComingSoonPage.tsx` (1)
  - Perpetual licenses description
- `apps/docs/app/showcase/timeline.showcase.tsx` (1)
- `apps/docs/app/showcase/table.showcase.tsx` (1)

## Out of scope (intentional)

- The `~/suite/forge` repo, `FORGE.md` runtime guide, and `apps/docs/public/SUITE.md` Forge entry — those describe the *deployable runtime kit*, not the SaaS tier label. Untouched.
- Internal code comments referencing "Forge" in test files / `apps/server/src/lib/tier-limits.ts:9` — developer-facing, explain the tier→runtime relationship, not customer-facing.
- Public documentation (`README.md`, `AGENTS.md`, `docs/agent-rules/*`, `docs/MASTER_PLAN.md`, agent-rules markdown) — broader docs sweep separate.
- `apps/server/src/routes/__tests__/billing-ui-accuracy.test.ts:277` — owned by #719's change set; leaving alone here to avoid merge conflict.

## Test plan

- [x] `pnpm turbo typecheck --filter=admin --filter=marketing --filter=docs` — 21/21 tasks passing
- [ ] CI gate runs full quality + typecheck + tests + build on PR
- [ ] After #719 merges: visual smoke test on admin billing page (Max tier user sees "Upgrade to Enterprise") and marketing pricing page

## Stacks on

This PR is independent of #719 — both can merge in either order. (#719 changes constants + 3 test files; this PR changes UI string literals; no overlapping lines.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
