### PR TITLE
docs(architecture): lead with NeonDB; strip stale Supabase pillar claims (keep MCP adapter)

### DIFF
--- a/apps/marketing/app/routes/PrivacyPage.tsx
+++ b/apps/marketing/app/routes/PrivacyPage.tsx
@@ -35,7 +35,7 @@ export function PrivacyPage() {
         <h3>Content Data</h3>
         <p>
           Any content you create through the admin (posts, pages, media) is stored in your database.
-          For hosted plans, this data is stored in NeonDB (PostgreSQL) and Supabase.
+          For hosted plans, this data is stored in NeonDB (PostgreSQL).
         </p>
 
         <h2>2. How We Use Your Information</h2>

--- a/docs/JOSHUA.md
+++ b/docs/JOSHUA.md
@@ -54,7 +54,7 @@ Your infrastructure, your data, your rules. Deploy anywhere. Fork anything. No v
 **Evidence:**
 - MIT license on the 22 OSS packages; 3 Pro packages (`@revealui/ai`, `@revealui/harnesses`, `@revealui/engines`) are Fair Source (FSL-1.1-MIT, MIT after 2 years)
 - No vendor-specific APIs in core (Vercel adapters are optional, in `@revealui/cache`)
-- Dual-database architecture: NeonDB (primary) + Supabase (vectors)  -  both replaceable
+- NeonDB (Postgres) is the primary store via vendor-agnostic Drizzle ORM  -  replaceable with any Postgres provider
 - Open-model AI default: Ubuntu Inference Snaps, Ollama, and open source models. Cloud-compatible providers (Groq, Vultr, HuggingFace, OpenAI-compatible, Anthropic for prompt caching) are pluggable but opt-in via env vars — there is no vendor lock-in
 - Self-hostable: Docker Compose, Railway, bare metal  -  documented in CI/CD guide
 - Stripe is the only commercial dependency in the billing path, and it's behind an interface

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -51,7 +51,7 @@ This guide covers the full Pro surface area, not just MCP setup:
 - MCP servers and developer tooling
 - Open-model inference (Ollama shipped; Ubuntu Inference Snaps on roadmap)
 - editor and harness workflows
-- Stripe, Supabase, and x402 payment features
+- Stripe and x402 payment features
 - marketplace monetization
 - perpetual and Forge licensing
 
@@ -75,7 +75,7 @@ RevealUI Pro is the commercial layer that runs *inside* the RevealUI runtime —
 - Pro packages (Fair Source / FSL-1.1-MIT): `@revealui/ai`, `@revealui/harnesses`
 - MCP servers and developer tooling
 - Open-model inference configuration per deployment
-- Stripe and Supabase service integrations
+- Stripe service integrations
 - x402 micropayments and paid API support
 - Marketplace and self-hosted commercial deployment options
 
@@ -1156,11 +1156,11 @@ syncConfig("claude-code", "push");
 
 # @revealui/services
 
-Stripe payment processing and Supabase client integrations for RevealUI Pro.
+Stripe payment processing for RevealUI Pro.
 
 ## Overview
 
-`@revealui/services` provides pre-wired Stripe and Supabase integrations with auth-aware clients, webhook handlers, and billing flow helpers.
+`@revealui/services` provides pre-wired Stripe integrations with auth-aware clients, webhook handlers, and billing flow helpers. Also exports Solana (RevealCoin / RVC) and Vercel (deploy + DNS) helpers.
 
 **Requires a Pro or Forge license** (`isFeatureEnabled('payments')`).
 
@@ -1204,58 +1204,6 @@ Full checkout/portal/webhook route handlers are wired at the application layer (
 STRIPE_SECRET_KEY=sk_test_...   # Use sk_live_... once billing-readiness sign-off lands
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PRICE_ID=price_...       # Your Pro tier price
-```
-
-## Supabase
-
-### Server client (Next.js App Router)
-
-```typescript
-import { createServerClient } from "@revealui/services";
-import { cookies } from "next/headers";
-
-// In a Server Component or Route Handler
-const supabase = createServerClient(cookies());
-const { data } = await supabase.from("profiles").select("*");
-```
-
-### Browser client
-
-```typescript
-import { createBrowserClient } from "@revealui/services";
-
-// In a Client Component
-const supabase = createBrowserClient();
-const {
-  data: { session },
-} = await supabase.auth.getSession();
-```
-
-### Request client (Hono / Edge)
-
-```typescript
-import { createServerClientFromRequest } from "@revealui/services";
-
-// In a Hono handler
-app.get("/me", async (c) => {
-  const supabase = createServerClientFromRequest(c.req.raw);
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  return c.json({ user });
-});
-```
-
-### Resilience wrapper
-
-Wraps any Supabase operation with automatic retry on transient errors:
-
-```typescript
-import { withSupabaseResilience } from "@revealui/services";
-
-const data = await withSupabaseResilience(() =>
-  supabase.from("posts").select("*").limit(10),
-);
 ```
 
 ## Environment configuration

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -8,7 +8,7 @@ Database schemas and Drizzle ORM integration for RevealUI.
 
 - **Drizzle ORM**: Type-safe database queries with Drizzle
 - **Schema Management**: Database schema definitions for all RevealUI tables
-- **Multiple Providers**: Works with Neon, Supabase, and Vercel Postgres
+- **Postgres-compatible**: NeonDB primary; works with any Postgres provider via Drizzle
 - **Type Generation**: Auto-generate TypeScript types from database schema
 - **Migrations**: Database migration management with Drizzle Kit
 - **Type-safe**: Full TypeScript support with inferred types

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/db",
   "version": "0.4.0",
-  "description": "Drizzle ORM schema (86 tables) and dual-DB client for NeonDB (REST) and Supabase (vectors/auth). Ships with RevealUI.",
+  "description": "Drizzle ORM schema (86 tables) for RevealUI on NeonDB (Postgres). Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {
     "@neondatabase/serverless": "catalog:",

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -3,13 +3,14 @@
 > **Commercial package**  -  requires a [RevealUI Pro license](https://revealui.com/pro). Free to install and evaluate; a license key is required for production use.
 
 
-External service integrations for RevealUI  -  Stripe, Supabase, and Vercel.
+External service integrations for RevealUI  -  Stripe (billing + circuit breaker), Solana (RVC token), Vercel (deploy + DNS), and Gmail API (transactional email).
 
 ## Features
 
-- **Stripe Integration**: Payment processing and billing operations
-- **Supabase Integration**: Database and auth client utilities
-- **Vercel Integration**: Blob storage and deployment management
+- **Stripe Integration**: Payment processing and billing operations with circuit breaker
+- **Solana / RevealCoin (RVC)**: Token-2022 helpers for the customer-facing on-chain ticker
+- **Vercel Integration**: Deploy + DNS helpers
+- **Gmail API**: Transactional email via Google Workspace
 - **Type-safe**: Full TypeScript support
 - **Server & Client**: Separate exports for server-side and client-side usage
 
@@ -31,36 +32,14 @@ const customer = await stripeClient.customers.create({
 })
 ```
 
-### Client-side
-
-```typescript
-import { createSupabaseClient } from '@revealui/services/client'
-
-const supabase = createSupabaseClient()
-
-// Query data
-const { data, error } = await supabase
-  .from('posts')
-  .select('*')
-  .eq('published', true)
-```
-
 ## Available Exports
 
-### `@revealui/services/server`
+Server-side integrations (Node.js / Hono routes):
 
-Server-side integrations (Node.js/Next.js API routes only):
-
-- Stripe client
-- Supabase admin client
-- Vercel API client
-
-### `@revealui/services/client`
-
-Client-side integrations (browser-safe):
-
-- Supabase client factory
-- Browser-compatible utilities
+- Stripe client (`./stripe/stripeClient`)
+- Stripe payment intents (`./stripe/payment-intent`)
+- RevealCoin / Solana helpers (`./revealcoin`)
+- Gmail API helpers (`./email`)
 
 ## Stripe Integration
 
@@ -86,38 +65,6 @@ const subscription = await stripeClient.subscriptions.create({
 })
 ```
 
-## Supabase Integration
-
-```typescript
-import { createSupabaseClient } from '@revealui/services/client'
-
-const supabase = createSupabaseClient()
-
-// Query data
-const { data: posts } = await supabase
-  .from('posts')
-  .select('*')
-  .order('created_at', { ascending: false })
-
-// Insert data
-const { data: newPost } = await supabase
-  .from('posts')
-  .insert({ title: 'New Post', content: 'Content here' })
-  .select()
-  .single()
-
-// Real-time subscription
-const channel = supabase
-  .channel('posts-changes')
-  .on('postgres_changes', {
-    event: '*',
-    schema: 'public',
-    table: 'posts'
-  }, (payload) => {
-    console.log('Change detected:', payload)
-  })
-  .subscribe()
-```
 
 ## Environment Variables
 

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -110,7 +110,10 @@
     "revealui",
     "services",
     "stripe",
-    "supabase",
+    "solana",
+    "revealcoin",
+    "vercel",
+    "gmail",
     "integrations"
   ]
 }


### PR DESCRIPTION
## Summary

Aligns customer-facing architecture and services documentation with current code reality: lead with NeonDB as the primary store, strip stale Supabase claims from internal architecture pillars and the `@revealui/services` package surface. The customer-facing **Supabase MCP adapter** (`packages/mcp/src/servers/supabase.ts`) is **explicitly preserved** per the retention note in `revealui/CLAUDE.md`.

## Why

The Supabase phase-out has been internally documented (per `revealui/CLAUDE.md`: *"legacy Supabase code remains in tree during phase-out — new features must not depend on Supabase-specific behavior"*) but has NOT propagated to customer-facing copy. Symptoms:

- `docs/JOSHUA.md` Sovereign pillar still presents Supabase as a defining architectural element ("Dual-database architecture: NeonDB (primary) + Supabase (vectors)")
- `docs/PRO.md` lists Supabase as a Pro feature in the `@revealui/services` package, with a ~50-line code-example section documenting Supabase clients that the package **does not ship** (per `packages/services/package.json` exports — only Stripe + Solana + Vercel + email)
- `@revealui/db` and `@revealui/services` package metadata + READMEs claim Supabase support that doesn't match shipped code
- `apps/marketing/.../PrivacyPage.tsx` claims hosted-plan data is stored in *"NeonDB (PostgreSQL) and Supabase"* — actively misleading on data residency

## What changed (7 files)

| File | Change |
|---|---|
| `docs/JOSHUA.md` | Sovereign pillar: dual-DB framing → NeonDB primary via Drizzle |
| `docs/PRO.md` | Drop Supabase from Pro feature list (×2 lines); strip 50-line `@revealui/services` Supabase section (server / browser / request / resilience clients that don't ship) |
| `packages/services/README.md` | Rewrite around shipped exports (Stripe + Solana/RVC + Vercel + Gmail); strip Supabase example block |
| `packages/services/package.json` | Drop "supabase" keyword; add "solana", "revealcoin", "vercel", "gmail" |
| `packages/db/package.json` | Description: "Drizzle ORM schema (86 tables) for RevealUI on NeonDB (Postgres)" |
| `packages/db/README.md` | "Multiple Providers" → "Postgres-compatible: NeonDB primary" |
| `apps/marketing/app/routes/PrivacyPage.tsx` | Data residency: "NeonDB (PostgreSQL) and Supabase" → "NeonDB (PostgreSQL)" |

## Explicitly preserved (out of scope per CLAUDE.md retention note)

- `packages/mcp/src/servers/supabase.ts` — the Supabase MCP adapter (customer integration for connecting their own Supabase project)
- All Supabase MCP documentation in `docs/PRO.md` (lines 130-160, 239-352, 576-623, 904-923)
- `apps/marketing/app/routes/PricingPage.tsx:367` MCP server listing — Supabase as MCP adapter, kept
- `apps/marketing/app/routes/MarketplacePage.tsx` Supabase entry — describes the MCP adapter, kept
- `apps/marketing/app/components/landing/Faq.tsx:3` — competitive comparison FAQ, not a usage claim

## Test plan

- [x] `pnpm turbo typecheck --filter=marketing --filter=@revealui/services --filter=@revealui/db` — 14/14 tasks passing
- [ ] CI gate runs full quality + typecheck + tests + build on PR
- [ ] Post-merge: visit `revealui.com/privacy` to confirm "NeonDB (PostgreSQL)" only

## Out of scope (follow-up)

- `packages/db/cleanup` — `revealui/CLAUDE.md` notes this exists for "orphaned legacy-Supabase data after site deletion (relevant during migration; will retire once phase-out completes)". Retiring this is a separate, larger PR once Phase 7 closes.
- `apps/docs/public/JOSHUA.md` and `apps/docs/public/PRO.md` build-artifact mirrors will regenerate from the canonical sources edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
