### PR TITLE
feat(admin): TestModeBanner on billing + upgrade pages

### DIFF
--- a/apps/admin/src/app/(backend)/upgrade/page.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/page.tsx
@@ -9,6 +9,7 @@ import {
 import type { FeatureFlags } from '@revealui/core/features';
 import { PricingTable } from '@revealui/presentation/client';
 import { useState } from 'react';
+import { TestModeBanner } from '@/components/TestModeBanner';
 import { useLicense } from '@/lib/providers/LicenseProvider';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
@@ -69,6 +70,10 @@ export default function UpgradePage() {
         <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
           Upgrade to unlock more features, higher limits, and priority support.
         </p>
+      </div>
+
+      <div className="mx-auto max-w-2xl mb-8">
+        <TestModeBanner />
       </div>
 
       {error && (

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -18,6 +18,7 @@ import {
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { TestModeBanner } from '@/components/TestModeBanner';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 interface SubscriptionData {
@@ -256,6 +257,8 @@ function BillingContent() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-12">
       <h1 className="text-2xl font-bold">Billing</h1>
+
+      <TestModeBanner />
 
       {subscription?.status === 'trialing' && subscription.expiresAt && (
         <div className="rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300">

--- a/apps/admin/src/components/TestModeBanner.tsx
+++ b/apps/admin/src/components/TestModeBanner.tsx
@@ -27,10 +27,9 @@ export function TestModeBanner({ className = '' }: { className?: string }) {
     >
       <p className="font-medium">Stripe is in test mode</p>
       <p className="mt-1 text-xs leading-relaxed">
-        No card will be charged. Live billing is gated on the internal
-        billing-readiness audit; this surface uses Stripe test mode in
-        production until that lands. Trial flows, checkout sessions, and
-        webhooks all run end-to-end against the test environment.
+        No card will be charged. Live billing is gated on the internal billing-readiness audit; this
+        surface uses Stripe test mode in production until that lands. Trial flows, checkout
+        sessions, and webhooks all run end-to-end against the test environment.
       </p>
     </div>
   );

--- a/apps/admin/src/components/TestModeBanner.tsx
+++ b/apps/admin/src/components/TestModeBanner.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+/**
+ * TestModeBanner
+ *
+ * Shows a warning above billing CTAs when Stripe is running in test mode
+ * (publishable key prefix `pk_test_*` OR no key configured). Live mode is
+ * gated on the billing-readiness audit per the locked posture in
+ * `revealui-jv` MASTER_PLAN; this banner makes the test-mode posture
+ * explicit so users do not assume cards will be charged.
+ *
+ * Detection: client-side `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` prefix.
+ * Server-side enforcement of the test/live invariant lives in
+ * `apps/server/src/lib/validate-startup.ts` (matched against
+ * `STRIPE_LIVE_MODE`).
+ */
+export function TestModeBanner({ className = '' }: { className?: string }) {
+  const pk = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
+  const isTestMode = pk === '' || pk.startsWith('pk_test_');
+  if (!isTestMode) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-100 ${className}`}
+    >
+      <p className="font-medium">Stripe is in test mode</p>
+      <p className="mt-1 text-xs leading-relaxed">
+        No card will be charged. Live billing is gated on the internal
+        billing-readiness audit; this surface uses Stripe test mode in
+        production until that lands. Trial flows, checkout sessions, and
+        webhooks all run end-to-end against the test environment.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a visible test-mode warning above billing CTAs in admin (billing page + upgrade page) so users do not assume cards will be charged. Closes a P0 finding from the recent suite messaging audit and aligns the user-facing surface with the locked posture in an internal repo MASTER_PLAN: *"Stripe runs in TEST mode in production with loud warning."*

## Why

Today's admin billing + upgrade pages route customers to Stripe Checkout with no indication that the underlying mode is `pk_test_*`. Per `feedback_stripe_live_mode_gating` memory and the GAP-124 billing-readiness audit gate, live mode flip is blocked until the audit closes. Without a visible banner, a user clicking "Upgrade to Pro — $X" reasonably assumes their card will be charged. This PR makes the test-mode posture explicit at the surface level so the user-facing reality matches the server-enforced invariant in `apps/server/src/lib/validate-startup.ts`.

## What changed

**New file** `apps/admin/src/components/TestModeBanner.tsx`:
- Client-side detection via `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` prefix (`pk_test_*` or empty → test mode → render; `pk_live_*` → hidden)
- Tailwind amber styling, role=status + aria-live=polite
- Returns null in live mode, so no DOM noise post-cutover

**Mount points:**
- `apps/admin/src/app/(frontend)/account/billing/page.tsx` — between the "Billing" page heading and the trial/active/expired/revoked status banners
- `apps/admin/src/app/(backend)/upgrade/page.tsx` — between the "Choose Your Plan" header and the PricingTable, `max-w-2xl` to match the pricing card width

## Out of scope (follow-up)

- Marketing landing CTAs (`apps/marketing/.../Demo.tsx:12`, `GetStarted.tsx:13-14`) currently say *"Switch to live mode when you're ready to take real money"* / *"flip to live mode when you are ready"*. Those will be reworked as part of a separate PR that aligns the marketing copy with the test-mode posture. Same theme, different repo surface (Vite/React vs Next.js).
- A user-facing "What does test mode mean?" doc page (could link from the banner). Could ship in a follow-up.

## Test plan

- [x] `pnpm turbo typecheck --filter=admin` — 18/18 tasks passing
- [ ] CI gate runs full quality + typecheck + tests + build on PR
- [ ] Post-merge: visit `admin.revealui.com/account/billing` (test-mode env) — expect amber banner above subscription card
- [ ] Post-merge: visit `admin.revealui.com/upgrade` — expect amber banner between header and pricing table
- [ ] When `STRIPE_LIVE_MODE=true` flip eventually lands (gated on GAP-124): banner returns null automatically, no PR needed to remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)
