### PR TITLE
chore(docs,ai): default to gemma3 + surface all 5 Canonical snaps + add nemotron-3-nano-omni

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The [Pro tier](https://revealui.com/pro) adds AI agents and automation that work
 
 - **AI agent system** _(beta — works in staging, production usage is early)_: build and deploy purpose-built agents for your workflows
 - **MCP framework:** hypervisor, adapter framework, and tool discovery for connecting agents to external services
-- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install nemotron-3-nano` for instant local AI. No proprietary APIs, no vendor lock-in, zero API bills
+- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install gemma3` for instant local AI (or any of `deepseek-r1`, `qwen-vl`, `nemotron-3-nano`, `nemotron-3-nano-omni`). No proprietary APIs, no vendor lock-in, zero API bills
 - **Task history:** every agent action logged, auditable, and visible in the dashboard
 - **Editor config sync:** generate and sync settings for Zed, VS Code, Cursor, and Antigravity
 

--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -30,7 +30,7 @@ ollama pull gemma4:e2b
 ollama pull nomic-embed-text
 
 # OR planned path (run + manage the snap yourself for now)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 ```
 
 ```typescript

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -7,14 +7,14 @@ RevealUI AI defaults to open-model inference (Snaps, Ollama). Cloud-compatible p
 **Inference Snaps** from Canonical are the planned recommended path for local AI with RevealUI. Today, you install + run the snap yourself, then point RevealUI at it via `INFERENCE_SNAPS_BASE_URL`. Studio lifecycle management (start / stop / health / model discovery) is on the roadmap; until that ships, treat Snap operations as standalone (Ollama is the practical default for most users today).
 
 ```bash
-# Install the free tier default model
-sudo snap install nemotron-3-nano
+# Install the default model
+sudo snap install gemma3
 
 # Check status and endpoint
-nemotron-3-nano status
+gemma3 status
 
 # Optional: change the HTTP port (default 9090)
-nemotron-3-nano set http.port=9090
+gemma3 set http.port=9090
 ```
 
 The snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`  -  the RevealUI AI provider uses this directly with zero additional configuration.
@@ -23,10 +23,11 @@ The snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`  -  the
 
 | Snap | Type | RAM | Use Case |
 |------|------|-----|----------|
-| `nemotron-3-nano` | General (reasoning + non-reasoning) | ~4 GB | **Free tier default**  -  fast, lightweight |
-| `gemma3` | General + vision | ~8 GB | Image understanding, multimodal tasks |
+| `gemma3` | General + vision | ~8 GB | **Default**  -  vision-capable, Apache 2.0 |
 | `deepseek-r1` | Reasoning | ~16 GB | Complex analysis, chain-of-thought |
 | `qwen-vl` | Vision-language | ~8 GB | Document parsing, visual Q&A |
+| `nemotron-3-nano` | General (text-only) | ~4 GB | Lightweight alternative for low-resource hosts |
+| `nemotron-3-nano-omni` | Multimodal | ~4 GB | Text/image/video/audio in, text out |
 
 ### Configuration
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -33,8 +33,11 @@ pnpm add @revealui/ai
 Install a model via Ubuntu Inference Snaps (canonical default — install + run yourself today; Studio lifecycle pending):
 
 ```bash
-sudo snap install nemotron-3-nano   # general-purpose, low resource
-# or: sudo snap install gemma3      # general + vision
+sudo snap install gemma3             # default — general + vision (~8 GB, Apache 2.0)
+# or: sudo snap install deepseek-r1            # reasoning, chain-of-thought
+# or: sudo snap install qwen-vl                # vision-language, document parsing
+# or: sudo snap install nemotron-3-nano        # text-only, lightweight (~4 GB)
+# or: sudo snap install nemotron-3-nano-omni   # multimodal — text/image/video/audio in, text out
 ```
 
 ```typescript
@@ -103,10 +106,11 @@ const memory = {
 
 | Snap | Type | Use Case |
 | ---- | ---- | -------- |
-| `nemotron-3-nano` | General (reasoning + non-reasoning) | **Free tier default**  -  lightweight, fast |
-| `gemma3` | General + vision | Image understanding, multimodal tasks |
+| `gemma3` | General + vision | **Default**  -  vision-capable, Apache 2.0 (~8 GB) |
 | `deepseek-r1` | Reasoning | Complex analysis, chain-of-thought |
 | `qwen-vl` | Vision-language | Document parsing, visual Q&A |
+| `nemotron-3-nano` | General (text-only) | Lightweight alternative for low-resource hosts (~4 GB) |
+| `nemotron-3-nano-omni` | Multimodal | Text/image/video/audio in, text out |
 
 Install: `sudo snap install <name>`. Each snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`.
 
@@ -146,11 +150,11 @@ The default and recommended path is open-model inference: **Ollama** (any open s
 For the planned recommended path (when you're ready to install + run a Canonical Inference Snap yourself):
 
 ```bash
-# Install your first model (free tier default)
-sudo snap install nemotron-3-nano
+# Install your first model (default)
+sudo snap install gemma3
 
 # Check status
-nemotron-3-nano status
+gemma3 status
 ```
 
 ```typescript

--- a/docs/LOCAL_FIRST.md
+++ b/docs/LOCAL_FIRST.md
@@ -60,13 +60,16 @@ The Nix flake activates: Node 24, pnpm 10, Biome, and all build dependencies are
 Inference snaps are the canonical local-AI path for RevealUI. Canonical's snap-packaged model serving provides hardware-aware engine selection, signed packages, and zero configuration. Today, you install + run the snap yourself; Studio lifecycle management (start / stop / health / model discovery) is on the roadmap.
 
 ```bash
-sudo snap install nemotron-3-nano   # general-purpose, low resource
-# or: sudo snap install gemma3      # general + vision
+sudo snap install gemma3             # default — general + vision (~8 GB, Apache 2.0)
+# or: sudo snap install deepseek-r1            # reasoning
+# or: sudo snap install qwen-vl                # vision-language
+# or: sudo snap install nemotron-3-nano        # text-only, lightweight (~4 GB)
+# or: sudo snap install nemotron-3-nano-omni   # multimodal — text/image/video/audio
 ```
 
 Verify the snap is running:
 ```bash
-nemotron-3-nano status
+gemma3 status
 ```
 
 Each snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`.

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -30,7 +30,7 @@ Five primitives:
 
 4. **Payments** -- Stripe end-to-end: checkout, portal, subscriptions, usage metering, webhook idempotency, circuit breaker protection. Chargebacks auto-revoke licenses. Failed payments trigger grace periods. Every webhook is deduplicated at the database level.
 
-5. **Intelligence** -- AI agent orchestration with streaming, CRDT-based memory, open-model inference (Ubuntu Inference Snaps as the canonical default, Ollama as a fallback), MCP servers for tool access, and A2A protocol for inter-agent communication. Pro tier only, because running AI costs real money. Free tier ships with `sudo snap install nemotron-3-nano`  -  on-device inference, zero API bills.
+5. **Intelligence** -- AI agent orchestration with streaming, CRDT-based memory, open-model inference (Ubuntu Inference Snaps as the canonical default, Ollama as a fallback), MCP servers for tool access, and A2A protocol for inter-agent communication. Pro tier only, because running AI costs real money. Free tier ships with `sudo snap install gemma3`  -  on-device inference, zero API bills.
 
 These five are not independent features bolted together. They form a directed graph of dependencies: Users author Content. Users purchase Products. Products gate Content and Intelligence. Payments generate Products. Intelligence creates Content and bills through Payments. Every edge in that graph is integration code you do not have to write.
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -48,10 +48,10 @@ RevealUI's AI agents run on open source models locally. The recommended path is 
 
 ```bash
 # Install a model (one command)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 
 # Check status
-nemotron-3-nano status
+gemma3 status
 ```
 
 Each snap serves an OpenAI-compatible API locally. The `@revealui/ai` package auto-detects the running snap and routes agent calls to it. The same agent orchestration, memory system, and MCP integrations work with any supported inference path  -  because they all expose OpenAI-compatible `/v1/chat/completions` endpoints.
@@ -76,7 +76,7 @@ cd RevealUI
 direnv allow        # Nix builds and activates the full dev environment
 
 # Install a model via inference snaps (recommended)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 
 # Or use Ollama
 ollama pull gemma4:e2b
@@ -96,7 +96,7 @@ flake.nix
 └── devShell
     └── nodejs, pnpm, biome          # Standard RevealUI toolchain
 
-sudo snap install nemotron-3-nano    # Or: ollama pull gemma4:e2b
+sudo snap install gemma3             # Or: ollama pull gemma4:e2b
 └── OpenAI-compatible API served locally
 
 @revealui/ai                         # Agent orchestration routes to local model

--- a/packages/harnesses/src/server/inference-service.ts
+++ b/packages/harnesses/src/server/inference-service.ts
@@ -39,10 +39,11 @@ export interface SnapModel {
 // ── Configuration ───────────────────────────────────────────────────
 
 const KNOWN_SNAPS: Array<[string, string]> = [
-  ['nemotron-3-nano', 'General (reasoning + non-reasoning)  -  free tier default'],
-  ['gemma3', 'General + vision  -  image understanding, multimodal'],
+  ['gemma3', 'General + vision  -  default; image understanding, multimodal (Apache 2.0)'],
   ['deepseek-r1', 'Reasoning  -  complex analysis, chain-of-thought'],
   ['qwen-vl', 'Vision-language  -  document parsing, visual Q&A'],
+  ['nemotron-3-nano', 'General (text-only)  -  lightweight alternative for low-resource hosts'],
+  ['nemotron-3-nano-omni', 'Multimodal  -  text/image/video/audio in, text out'],
 ];
 
 // ── Helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Aligns customer-facing snap install commands across the suite to `gemma3` as the marquee default, with all 5 Canonical Inference Snaps surfaced as user-selectable alternatives. Owner directive in a parallel agent session.

Closes the inconsistency left after [#722](https://github.com/RevealUIStudio/revealui/pull/722) restored the canonical `nemotron-3-nano` name: marketing pricing + `.env.example` already used `gemma3 --beta`, but README + 5 docs surfaces still led with `nemotron-3-nano`. Three different "default" install commands across customer surfaces.

## Why `gemma3` as default

- **Apache 2.0 license** — clean license story; OSS-friendly.
- **Vision-capable out of the box** — broader use-case fit than text-only.
- **~8 GB** — bigger than nemotron-3-nano (~4 GB) but reasonable for a marquee default; lightweight alternative is one line down.
- **Already the default in `apps/server/src/routes/admin/inference-config.ts:40`** + `apps/server/src/routes/agent-stream.ts:280` (`process.env.LLM_MODEL ?? 'gemma3'`); prose now matches code.

## Canonical 5-snap catalog (verified)

Per [`documentation.ubuntu.com/inference-snaps/reference/snaps/`](https://documentation.ubuntu.com/inference-snaps/reference/snaps/) and [`github.com/canonical/inference-snaps`](https://github.com/canonical/inference-snaps):

| Snap | Type | Size | Notes |
|---|---|---|---|
| `gemma3` | General + vision | ~8 GB | **Default** — vision-capable, Apache 2.0 |
| `deepseek-r1` | Reasoning | ~16 GB | Complex analysis, chain-of-thought |
| `qwen-vl` | Vision-language | ~8 GB | Document parsing, visual Q&A |
| `nemotron-3-nano` | General (text-only) | ~4 GB | Lightweight alternative for low-resource hosts |
| `nemotron-3-nano-omni` | Multimodal | ~4 GB | Text/image/video/audio in, text out |

## Changes (8 files, +34 / −25)

| File | Change |
|---|---|
| `README.md` | Marquee install switched to `gemma3` + all alternatives listed inline |
| `docs/AI.md` | Quick-start swap + comparison table reordered (gemma3 first) + nemotron-3-nano-omni row added + duplicate install reframed |
| `docs/LOCAL_FIRST.md` | Option A install + status command updated |
| `docs/blog-drafts/01-why-we-built-revealui.md` | "Free tier ships with…" line updated |
| `docs/blog/04-local-first-ai-stack.md` | 3 install command sites updated |
| `apps/docs/public/docs-pro/ai/index.md` | Quick-start install updated |
| `apps/docs/public/docs-pro/inference/index.md` | Install + status + port + comparison table updated (5 rows total) |
| `packages/harnesses/src/server/inference-service.ts` | `KNOWN_SNAPS` reordered (gemma3 first as default) + `nemotron-3-nano-omni` added as 5th entry |

`packages/ai/src/llm/providers/inference-snaps.ts` already lists all 5 snaps in the docstring (per #722).

## Out of scope

- `apps/server/.env.example:71` already says `gemma3 --beta` — kept the `--beta` flag where it exists; mixed `--beta` vs no-flag usage in the codebase is a separate cleanup if owner directs.
- Phase B (RevForge tool repo rename per `2026-05-03-revfleet-rename.md` §Phase B) — separate ADR-driven track, not bundled here.

## Test plan

- [x] `pnpm exec biome check --write packages/harnesses/src/server/inference-service.ts` — 1 file checked, no fixes
- [x] `pnpm gate:quick` — 16/16 quality checks PASS
- [x] `pnpm --filter @revealui/harnesses test --run` — 256/256 tests pass across 18 test files (no regression)
- [ ] CI gate runs full quality + typecheck + tests + build on PR
- [ ] After merge → next test→main promote carries to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
