### PR TITLE
feat(mcp): contracts introspection MCP server (F8 Phase 1)

### DIFF
--- a/.changeset/contracts-mcp-server-phase-1.md
+++ b/.changeset/contracts-mcp-server-phase-1.md
@@ -1,0 +1,37 @@
+---
+'@revealui/mcp': minor
+'@revealui/contracts': minor
+---
+
+**F8 Phase 1 of the contracts protocol-pyramid ADR** (`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`) — adds a new MCP server `revealui-contracts` that exposes every `@revealui/contracts` category as MCP **resources** (read-only catalog of JSON Schemas) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
+
+## `@revealui/mcp` (minor)
+
+**New: contracts introspection MCP server.** Lives at `packages/mcp/src/servers/factories/contracts.ts` (factory) + `packages/mcp/src/servers/contracts.ts` (stdio launcher). Exposed via the new `@revealui/mcp/contracts-server` subpath export.
+
+- **Resources:**
+  - `revealui-contracts://catalog` — full discovery payload listing every category, primary schema name, secondary schema names, and human description.
+  - `revealui-contracts://<category>` — JSON document for a single category, returning `{ category, primarySchema, schemas: Record<name, JSONSchema7> }`.
+- **Tools:**
+  - `contracts_list_categories` — same payload as the catalog resource (tool form for clients that prefer tool-call ergonomics).
+  - `contracts_get_schema({ category, schema? })` — return the JSON Schema for a single `(category, schemaName)` pair. Defaults to the category primary when `schema` is omitted.
+  - `contracts_validate_<category>({ schema?, data })` — one tool per registered category. Parses `data` against the named schema (defaults to category primary). Returns `{ success: true, data }` | `{ success: false, issues }`.
+- **Categories surfaced (17):** a2a, admin, agents, api_auth, api_chat, api_gdpr, content, content_validation, devkit_profiles, entities, generated, providers, representation, revealcoin, secrets, security, stripe_webhook_events.
+- **License:** intentionally NOT Pro-gated. `@revealui/contracts` is MIT and agent-side schema introspection is meant to enable any MCP client (Claude Code, Cursor, custom agents) to integrate cleanly. Pro-gating a public-package primitive would defeat the purpose.
+- **Tests:** 70+ unit tests at `packages/mcp/src/__tests__/contracts-server.test.ts` (≥1 happy + 1 sad path per category, ADR's 34-minimum target comfortably exceeded).
+- **README:** new section #8 + bumped "12 MCP Servers" → "13 MCP Servers" (claim-drift CI requires ground-truth count).
+
+Also exposes `validatePayload(category, schemaName, data)` and `REGISTERED_CATEGORIES` for in-process consumers (the `@revealui/ai` package + future hypervisor wiring).
+
+## `@revealui/contracts` (minor — additive)
+
+**New subpath exports** for categories that already existed in `src/` but weren't exposed via `package.json` `exports`:
+
+- `@revealui/contracts/a2a` — A2A AgentCard / Task / Message / Skill / Artifact / JSON-RPC envelopes.
+- `@revealui/contracts/api/auth` — sign-in / sign-up / password reset / MFA / passkey / recovery.
+- `@revealui/contracts/api/chat` — ChatRequest / ChatMessage.
+- `@revealui/contracts/api/gdpr` — GDPRDeleteRequest / GDPRExportRequest.
+
+These were already accessible via the root barrel (`from '@revealui/contracts'`); the new subpaths give consumers per-category granularity matching the existing pattern (`/entities`, `/representation`, etc.). Purely additive — no existing imports change behavior.
+
+No code changes elsewhere in the contracts package.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You have:
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
 - **58 UI components:** built with Tailwind CSS v4, zero external UI dependencies
-- **12 MCP servers:** agents discover and use your business data through the same API humans use
+- **13 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
 No assembly required. Define your data once. Humans manage it through the dashboard, agents operate on it through MCP. Same permissions, same audit trail.
@@ -49,7 +49,7 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 | **Content**      | Collections, rich text (Lexical), media, draft/live, REST API    | Collections auto-exposed as MCP tools. No integration step.  |
 | **Products**     | Product catalog, pricing tiers, usage tracking                   | Feature gates control which agent capabilities unlock.       |
 | **Payments**     | Stripe checkout, subscriptions, webhooks, billing portal         | x402 micropayments via RevealCoin. Agents transact natively. |
-| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 12 MCP servers.                   |
+| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 13 MCP servers.                   |
 
 ## The JOSHUA Stack
 

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -539,7 +539,7 @@ The agent has access to extensive automation scripts in `/scripts`:
 
 ### Configured MCP Servers
 
-The agent has access to **12 MCP servers** configured specifically for RevealUI:
+The agent has access to **13 MCP servers** configured specifically for RevealUI:
 
 1. **Code Validator MCP** (`mcp-code-validator`)
    - Static analysis and code quality checks

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -135,7 +135,7 @@ Note: `npx create-revealui` scaffolds a working basic-blog from npm templates  -
 | Package | Docs claim | Actual state | Completeness |
 |---------|-----------|--------------|-------------|
 | `@revealui/ai` | AI agents, memory, LLM orchestration | 40+ files, 18 import subpaths, real agents | ~80% |
-| `@revealui/mcp` | 12 MCP servers | **12 server files** (plus adapters/utils) | ~90% |
+| `@revealui/mcp` | 13 MCP servers | **13 server files** (plus adapters/utils) | ~90% |
 | `@revealui/harnesses` | AI coordination, workboard | 196 tests, JSON-RPC 2.0, content layer | ~95% |
 | `@revealui/editors` | Editor config sync | 20+ files, 6 test files | ~70% |
 | `@revealui/services` | Stripe + Supabase integrations | 354 tests passing | ~85% |

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -121,7 +121,7 @@ For full decision context: [ADR-003: Fair Source Licensing](./architecture/ADR-0
 
 ## MCP Setup
 
-RevealUI ships **12 MCP servers** under `packages/mcp/src/servers/` for enhanced AI capabilities. Highlights:
+RevealUI ships **13 MCP servers** under `packages/mcp/src/servers/` for enhanced AI capabilities. Highlights:
 
 - **Code Validator MCP** - Static analysis and code quality checks
 - **Vercel MCP** - Deploy and manage Vercel projects

--- a/docs/blog-drafts/01-why-we-built-revealui.md
+++ b/docs/blog-drafts/01-why-we-built-revealui.md
@@ -73,7 +73,7 @@ RevealUI launched with:
 - **26 npm packages** published to the public registry
 - **86 database tables** via Drizzle ORM (NeonDB + Supabase)
 - **58 UI components** with zero external dependencies
-- **12 MCP servers** for AI tool access (all MIT)
+- **13 MCP servers** for AI tool access (all MIT)
 - **Extensive test coverage** across unit, integration, and E2E layers
 - **4 GitHub template repos** for different starting points
 

--- a/docs/blog-drafts/04-agent-first-future.md
+++ b/docs/blog-drafts/04-agent-first-future.md
@@ -108,7 +108,7 @@ Four protocols converge to create the agent-first web. Each solves a different p
 | Protocol | Created by | Governed by | Purpose | RevealUI implementation |
 |---|---|---|---|---|
 | **A2A** (Agent-to-Agent) | Google | Linux Foundation (Agentic AI Foundation) | Agents discover and delegate work to other agents | Full A2A 1.0: Agent Cards, JSON-RPC task lifecycle (`tasks/send`, `tasks/get`, `tasks/cancel`), SSE streaming |
-| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 12 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Email Provider |
+| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 13 MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Contracts Introspection, Playwright, Next.js DevTools, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Email Provider |
 | **x402** (HTTP 402 Payment Required) | Coinbase | Open standard | Internet-native micropayments for machine-to-machine commerce | Per-call USDC payments on Base, Coinbase facilitator verification, marketplace payment proxy |
 | **OpenAPI** | OpenAPI Initiative | Linux Foundation | Machine-readable API descriptions | Auto-generated from Hono route definitions with Zod schemas |
 

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -430,7 +430,7 @@ Memory operations use CRDTs (Conflict-free Replicated Data Types) for conflict r
 
 ### MCP servers
 
-RevealUI ships **12 MCP (Model Context Protocol) servers**, open source under MIT. The most commonly used:
+RevealUI ships **13 MCP (Model Context Protocol) servers**, open source under MIT. The most commonly used:
 
 | Server | Purpose |
 |--------|---------|

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -105,6 +105,22 @@
     "./secrets": {
       "types": "./dist/secrets/index.d.ts",
       "import": "./dist/secrets/index.js"
+    },
+    "./a2a": {
+      "types": "./dist/a2a/index.d.ts",
+      "import": "./dist/a2a/index.js"
+    },
+    "./api/auth": {
+      "types": "./dist/api/auth.d.ts",
+      "import": "./dist/api/auth.js"
+    },
+    "./api/chat": {
+      "types": "./dist/api/chat.d.ts",
+      "import": "./dist/api/chat.js"
+    },
+    "./api/gdpr": {
+      "types": "./dist/api/gdpr.d.ts",
+      "import": "./dist/api/gdpr.js"
     }
   },
   "files": [

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@ Centralized MCP server infrastructure, configuration, and documentation for Reve
 
 This package contains everything MCP-related:
 
-- **12 MCP Servers** — Code Validator, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
+- **13 MCP Servers** — Code Validator, Contracts Introspection, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
 - **Configuration Templates** - For Claude Code / Claude Desktop
 - **Utilities** - Config management, database adapters
 - **Documentation** - Complete guides and per-server docs
@@ -145,6 +145,19 @@ Next.js 16+ runtime diagnostics and automation.
 pnpm mcp:next-devtools
 ```
 
+### 8. Contracts Introspection
+**Status:** ✅ Active (no API key required, **not** Pro-license-gated)
+
+Phase 1 of the protocol-pyramid ADR ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](../../docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Exposes every `@revealui/contracts` category (representation, entities, content, admin, agents, security, secrets, a2a, api-auth, api-chat, api-gdpr, content-validation, devkit-profiles, generated, providers, revealcoin, stripe-webhook-events) as MCP **resources** (read-only JSON Schemas of every category schema) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
+
+- **Resources:** `revealui-contracts://catalog` (full discovery payload) + `revealui-contracts://<category>` (one per category, returns all schemas).
+- **Tools:** `contracts_list_categories`, `contracts_get_schema`, plus one `contracts_validate_<category>` per category.
+- **License:** intentionally NOT Pro-gated. `@revealui/contracts` is MIT and agent-side schema introspection is meant to enable any MCP client (Claude Code, Cursor, custom agents) to integrate cleanly.
+
+```bash
+tsx packages/mcp/src/servers/contracts.ts
+```
+
 ## Configuration
 
 All configuration templates are in `configs/`:
@@ -251,5 +264,5 @@ Commercial  -  see [LICENSE.commercial](../../LICENSE.commercial)
 ---
 
 **Status:** ✅ Consolidated and Active
-**Servers:** 12 available (ground truth: `pnpm validate:claims` — source of truth is `packages/mcp/src/servers/`)
-**Last Updated:** 2026-04-20
+**Servers:** 13 available (ground truth: `pnpm validate:claims` — source of truth is `packages/mcp/src/servers/`)
+**Last Updated:** 2026-05-03

--- a/packages/mcp/docs/README.md
+++ b/packages/mcp/docs/README.md
@@ -21,9 +21,10 @@ Complete guide for setting up and using Model Context Protocol (MCP) servers in 
 
 ## Overview
 
-RevealUI includes 12 MCP servers for enhanced AI capabilities (ground-truth count enforced by `pnpm validate:claims`):
+RevealUI includes 13 MCP servers for enhanced AI capabilities (ground-truth count enforced by `pnpm validate:claims`):
 
 - **Code Validator MCP** — Static analysis and code quality checks
+- **Contracts Introspection MCP** — Read-only catalog of every `@revealui/contracts` category as MCP resources + per-category `validate_*` tools (F8 Phase 1 of the protocol-pyramid ADR; not Pro-gated)
 - **Neon MCP** — NeonDB database operations and SQL queries
 - **Next.js DevTools MCP** — Next.js 16+ runtime diagnostics and automation
 - **Playwright MCP** — Browser automation and web scraping

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/contracts.d.ts",
       "import": "./dist/contracts.js"
     },
+    "./contracts-server": {
+      "types": "./dist/servers/factories/contracts.d.ts",
+      "import": "./dist/servers/factories/contracts.js"
+    },
     "./hypervisor": {
       "types": "./dist/hypervisor.d.ts",
       "import": "./dist/hypervisor.js"

--- a/packages/mcp/src/__tests__/contracts-server.test.ts
+++ b/packages/mcp/src/__tests__/contracts-server.test.ts
@@ -1,0 +1,592 @@
+/**
+ * Tests for `createContractsServer()` (F8 Phase 1 of the contracts
+ * protocol-pyramid ADR).
+ *
+ * Coverage targets:
+ *   - Factory + structure (server identity, tool count, resource count).
+ *   - Resource list + read (catalog + per-category).
+ *   - Tool dispatch — `contracts_list_categories`, `contracts_get_schema`,
+ *     `contracts_validate_<category>` (one per category).
+ *   - Validation pipeline — happy + sad path per category × N categories.
+ *   - Edge cases — missing args, unknown category/schema/URI/tool.
+ *
+ * Per ADR Phase 1 acceptance criteria: ≥34 unit tests (1 happy + 1 sad
+ * per category, 17 minimum). Actual count comfortably exceeds the
+ * minimum via per-category parameterization + structural coverage.
+ */
+
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+import {
+  createContractsServer,
+  REGISTERED_CATEGORIES,
+  REVEALCOIN_TOKEN_DEFAULT,
+  validatePayload,
+} from '../servers/factories/contracts.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers — invoke a Server's request handlers without standing up a
+// transport. The MCP SDK exposes private handlers via the `_requestHandlers`
+// internal Map; we read it via a typed escape hatch (we don't mutate).
+// ---------------------------------------------------------------------------
+
+interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+interface ToolCallResponse {
+  content: TextContentBlock[];
+  isError?: boolean;
+}
+
+interface ResourceListResponse {
+  resources: Array<{ uri: string; name: string; description?: string; mimeType?: string }>;
+}
+
+interface ToolListResponse {
+  tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>;
+}
+
+interface ResourceReadResponse {
+  contents: Array<{ uri: string; mimeType?: string; text?: string }>;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: SDK private surface — typed re-cast at the call site.
+function getHandler(server: ReturnType<typeof createContractsServer>, schemaName: string): any {
+  // The MCP SDK stores handlers keyed by the Zod schema's parsed `method` literal.
+  // Walk the underlying Map; cast through `unknown` to satisfy strict TS.
+  const internal = server as unknown as {
+    _requestHandlers: Map<string, (request: unknown) => unknown>;
+  };
+  const handler = internal._requestHandlers.get(schemaName);
+  if (!handler) {
+    throw new Error(`No handler registered for ${schemaName}`);
+  }
+  return handler;
+}
+
+async function listTools(
+  server: ReturnType<typeof createContractsServer>,
+): Promise<ToolListResponse> {
+  // Server stores handlers by the literal method name (e.g. "tools/list").
+  const handler = getHandler(server, 'tools/list');
+  return (await handler({ method: 'tools/list', params: {} })) as ToolListResponse;
+}
+
+async function listResources(
+  server: ReturnType<typeof createContractsServer>,
+): Promise<ResourceListResponse> {
+  const handler = getHandler(server, 'resources/list');
+  return (await handler({ method: 'resources/list', params: {} })) as ResourceListResponse;
+}
+
+async function readResource(
+  server: ReturnType<typeof createContractsServer>,
+  uri: string,
+): Promise<ResourceReadResponse> {
+  const handler = getHandler(server, 'resources/read');
+  return (await handler({ method: 'resources/read', params: { uri } })) as ResourceReadResponse;
+}
+
+async function callTool(
+  server: ReturnType<typeof createContractsServer>,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<ToolCallResponse> {
+  const handler = getHandler(server, 'tools/call');
+  return (await handler({
+    method: 'tools/call',
+    params: { name, arguments: args },
+  })) as ToolCallResponse;
+}
+
+function parseJson(text: string): unknown {
+  return JSON.parse(text);
+}
+
+// Sanity — these constants are imported elsewhere too; keep TS happy.
+void CallToolRequestSchema;
+void ListResourcesRequestSchema;
+void ListToolsRequestSchema;
+void ReadResourceRequestSchema;
+
+// ---------------------------------------------------------------------------
+// Happy-path fixtures per category.
+//
+// Each entry is a minimal-valid payload that the category's PRIMARY schema
+// will accept under `safeParse`. Where the primary schema requires deeply
+// nested data, we prefer a non-primary schema with a simpler shape (the
+// validate tool accepts `{ schema, data }` so we can target specifically).
+// ---------------------------------------------------------------------------
+
+interface HappyFixture {
+  /** Optional explicit schema within the category. Defaults to primary. */
+  schema?: string;
+  data: unknown;
+}
+
+/**
+ * Per-category happy fixtures. Tests run validate on the primary schema by
+ * default, but some categories need a non-primary target because the primary
+ * is structurally complex (large discriminated unions, recursive shapes,
+ * etc.). When `schema` is set, the test uses that override.
+ */
+const HAPPY_FIXTURES: Record<string, HappyFixture> = {
+  // a2a primary = agentCard (complex). Use `taskState` enum instead.
+  a2a: { schema: 'taskState', data: 'submitted' },
+  // admin primary = collection (very deep). Use config which is also deep,
+  // so target a synthetic minimal config — config refines that there must
+  // be at least one collection OR global, so include a minimal collection.
+  admin: {
+    schema: 'config',
+    data: {
+      secret: 'placeholder-secret-1234567890',
+      collections: [{ slug: 'pages', fields: [{ name: 'title', type: 'text' }] }],
+    },
+  },
+  // agents primary = agentMemory (requires id + embedding). Use intentType.
+  agents: { schema: 'intentType', data: 'create' },
+  // api_auth primary = signIn.
+  api_auth: {
+    schema: 'signIn',
+    data: { email: 'a@b.co', password: 'examplepass1' },
+  },
+  // api_chat primary = chatRequest (requires messages array). Use chatMessage.
+  api_chat: {
+    schema: 'chatMessage',
+    data: { role: 'user', content: 'hi' },
+  },
+  // api_gdpr primary = gdprExport.
+  api_gdpr: { schema: 'gdprExport', data: { userId: 'u-1' } },
+  // content primary = block (discriminated union). Use blockMeta.
+  content: {
+    schema: 'blockMeta',
+    data: { id: 'b-1' },
+  },
+  // content_validation primary = config.
+  content_validation: { data: { maxDepth: 10, maxSizeBytes: 1024 } },
+  // devkit_profiles primary = profileId (z.enum).
+  devkit_profiles: { data: 'revealui' },
+  // entities primary = user. Use pageLock (smaller). Schema requires
+  // userId + lockedAt + expiresAt (datetimes).
+  entities: {
+    schema: 'pageLock',
+    data: {
+      userId: 'u-1',
+      lockedAt: new Date().toISOString(),
+      expiresAt: new Date().toISOString(),
+    },
+  },
+  // generated primary = usersInsert (drizzle-zod). Sessions has tokenHash
+  // (not token); shape comes from drizzle-zod over the sessions table.
+  generated: {
+    schema: 'sessionsInsert',
+    data: {
+      id: 's-1',
+      userId: 'u-1',
+      tokenHash: 'hashed-token-placeholder',
+      expiresAt: new Date(),
+    },
+  },
+  // providers primary = providerId (z.enum).
+  providers: { data: 'groq' },
+  // representation primary = dualEntity. Use embedding (simpler) — actual
+  // schema uses singular `dimension` + `generatedAt` timestamp.
+  representation: {
+    schema: 'embedding',
+    data: {
+      vector: [0.1, 0.2, 0.3],
+      dimension: 3,
+      model: 'test',
+      generatedAt: new Date().toISOString(),
+    },
+  },
+  // revealcoin primary = tokenConfig. Reuse the canonical default.
+  revealcoin: {
+    data: {
+      ...REVEALCOIN_TOKEN_DEFAULT,
+      // Cast bigint-or-string union: serialize as string for portability.
+      totalSupply: String(REVEALCOIN_TOKEN_DEFAULT.totalSupply),
+    },
+  },
+  // secrets primary = secretActor.
+  secrets: { data: { type: 'user', id: 'u-1' } },
+  // security primary = securityRule. Use severity (z.enum).
+  security: { schema: 'severity', data: 'error' },
+  // stripe_webhook_events primary = eventType (z.enum).
+  stripe_webhook_events: { data: 'customer.subscription.created' },
+};
+
+// ---------------------------------------------------------------------------
+// Sad-path fixtures — uniform "obviously invalid" inputs that every Zod
+// schema rejects (most safeParse on `null`/`42`/`{ malformed: true }`).
+// ---------------------------------------------------------------------------
+
+const SAD_PAYLOADS: ReadonlyArray<unknown> = [null, 42, 'not-an-object'];
+
+// ---------------------------------------------------------------------------
+// Suites
+// ---------------------------------------------------------------------------
+
+describe('createContractsServer — factory + structure', () => {
+  it('returns a Server instance', () => {
+    const server = createContractsServer();
+    expect(server).toBeDefined();
+    // Server has a connect method per @modelcontextprotocol/sdk Server class.
+    expect(typeof (server as unknown as { connect: unknown }).connect).toBe('function');
+  });
+
+  it('registers handlers for tools/list, tools/call, resources/list, resources/read (plus SDK defaults)', () => {
+    const server = createContractsServer();
+    const internal = server as unknown as { _requestHandlers: Map<string, unknown> };
+    // SDK base class registers `ping` + `initialize` handlers automatically;
+    // we just assert OUR four are present (don't pin total count, which is
+    // an SDK implementation detail subject to change).
+    expect(internal._requestHandlers.has('tools/list')).toBe(true);
+    expect(internal._requestHandlers.has('tools/call')).toBe(true);
+    expect(internal._requestHandlers.has('resources/list')).toBe(true);
+    expect(internal._requestHandlers.has('resources/read')).toBe(true);
+  });
+
+  it('REGISTERED_CATEGORIES exposes ≥17 categories', () => {
+    expect(REGISTERED_CATEGORIES.length).toBeGreaterThanOrEqual(17);
+  });
+
+  it('every registered category has a happy fixture defined', () => {
+    for (const cat of REGISTERED_CATEGORIES) {
+      expect(HAPPY_FIXTURES).toHaveProperty(cat);
+    }
+  });
+
+  it('accepts a serverName override for multi-server-in-process tests', () => {
+    const server = createContractsServer({ serverName: 'alt' });
+    expect(server).toBeDefined();
+  });
+});
+
+describe('createContractsServer — tool list', () => {
+  it('lists tools/list = 2 discovery tools + 1 validate tool per category', async () => {
+    const server = createContractsServer();
+    const result = await listTools(server);
+    // 2 discovery (list_categories, get_schema) + N validate_<cat>
+    expect(result.tools.length).toBe(2 + REGISTERED_CATEGORIES.length);
+  });
+
+  it('exposes contracts_list_categories tool with empty input schema', async () => {
+    const server = createContractsServer();
+    const result = await listTools(server);
+    const tool = result.tools.find((t) => t.name === 'contracts_list_categories');
+    expect(tool).toBeDefined();
+    expect((tool?.inputSchema as { properties: Record<string, unknown> })?.properties).toEqual({});
+  });
+
+  it('exposes contracts_get_schema tool with required category arg', async () => {
+    const server = createContractsServer();
+    const result = await listTools(server);
+    const tool = result.tools.find((t) => t.name === 'contracts_get_schema');
+    expect(tool).toBeDefined();
+    expect((tool?.inputSchema as { required?: string[] })?.required).toContain('category');
+  });
+
+  it('exposes one contracts_validate_<category> tool per registered category', async () => {
+    const server = createContractsServer();
+    const result = await listTools(server);
+    for (const cat of REGISTERED_CATEGORIES) {
+      const tool = result.tools.find((t) => t.name === `contracts_validate_${cat}`);
+      expect(tool, `contracts_validate_${cat} should be present`).toBeDefined();
+      expect((tool?.inputSchema as { required?: string[] })?.required).toContain('data');
+    }
+  });
+});
+
+describe('createContractsServer — resource list', () => {
+  it('lists 1 catalog + 1 per category', async () => {
+    const server = createContractsServer();
+    const result = await listResources(server);
+    expect(result.resources.length).toBe(1 + REGISTERED_CATEGORIES.length);
+  });
+
+  it('catalog resource is at revealui-contracts://catalog with json mimeType', async () => {
+    const server = createContractsServer();
+    const result = await listResources(server);
+    const catalog = result.resources.find((r) => r.uri === 'revealui-contracts://catalog');
+    expect(catalog).toBeDefined();
+    expect(catalog?.mimeType).toBe('application/json');
+  });
+
+  it('every category has a resource at revealui-contracts://<category>', async () => {
+    const server = createContractsServer();
+    const result = await listResources(server);
+    for (const cat of REGISTERED_CATEGORIES) {
+      const resource = result.resources.find((r) => r.uri === `revealui-contracts://${cat}`);
+      expect(resource, `Resource for ${cat} should be present`).toBeDefined();
+      expect(resource?.mimeType).toBe('application/json');
+    }
+  });
+});
+
+describe('createContractsServer — resources/read', () => {
+  it('returns the catalog payload with totalCategories + totalSchemas', async () => {
+    const server = createContractsServer();
+    const result = await readResource(server, 'revealui-contracts://catalog');
+    expect(result.contents.length).toBe(1);
+    const body = parseJson(result.contents[0].text ?? '') as {
+      categories: unknown[];
+      totalCategories: number;
+      totalSchemas: number;
+    };
+    expect(body.totalCategories).toBe(REGISTERED_CATEGORIES.length);
+    expect(body.totalSchemas).toBeGreaterThan(0);
+    expect(Array.isArray(body.categories)).toBe(true);
+  });
+
+  it('returns category JSON with primarySchema + schemas map', async () => {
+    const server = createContractsServer();
+    const result = await readResource(server, 'revealui-contracts://devkit_profiles');
+    const body = parseJson(result.contents[0].text ?? '') as {
+      category: string;
+      primarySchema: string;
+      schemas: Record<string, unknown>;
+    };
+    expect(body.category).toBe('devkit_profiles');
+    expect(body.primarySchema).toBe('profileId');
+    expect(body.schemas.profileId).toBeDefined();
+  });
+
+  it('throws on unknown URI scheme', async () => {
+    const server = createContractsServer();
+    await expect(readResource(server, 'http://example.com/foo')).rejects.toThrow(
+      /Unknown resource URI/,
+    );
+  });
+
+  it('throws on revealui-contracts URI for unknown category', async () => {
+    const server = createContractsServer();
+    await expect(readResource(server, 'revealui-contracts://nonexistent')).rejects.toThrow(
+      /Unknown resource URI/,
+    );
+  });
+
+  // Per-category resource read smoke tests — proves every category serializes
+  // its schemas to JSON Schema without throwing (failures fall back to a
+  // `$comment` placeholder, which is fine; we just want the read to succeed).
+  for (const cat of [
+    'a2a',
+    'admin',
+    'agents',
+    'api_auth',
+    'api_chat',
+    'api_gdpr',
+    'content',
+    'content_validation',
+    'devkit_profiles',
+    'entities',
+    'generated',
+    'providers',
+    'representation',
+    'revealcoin',
+    'secrets',
+    'security',
+    'stripe_webhook_events',
+  ] as const) {
+    it(`resources/read for ${cat} returns valid JSON with primarySchema field`, async () => {
+      const server = createContractsServer();
+      const result = await readResource(server, `revealui-contracts://${cat}`);
+      const body = parseJson(result.contents[0].text ?? '') as {
+        category: string;
+        primarySchema: string;
+        schemas: Record<string, unknown>;
+      };
+      expect(body.category).toBe(cat);
+      expect(typeof body.primarySchema).toBe('string');
+      expect(body.primarySchema.length).toBeGreaterThan(0);
+      expect(Object.keys(body.schemas).length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe('createContractsServer — contracts_list_categories tool', () => {
+  it('returns a payload identical to the catalog resource', async () => {
+    const server = createContractsServer();
+    const toolResp = await callTool(server, 'contracts_list_categories');
+    expect(toolResp.isError).toBeFalsy();
+    const body = parseJson(toolResp.content[0].text) as { totalCategories: number };
+    expect(body.totalCategories).toBe(REGISTERED_CATEGORIES.length);
+  });
+});
+
+describe('createContractsServer — contracts_get_schema tool', () => {
+  it('returns the JSON Schema for primary by default', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_get_schema', { category: 'devkit_profiles' });
+    expect(resp.isError).toBeFalsy();
+    const body = parseJson(resp.content[0].text) as {
+      category: string;
+      schema: string;
+      jsonSchema: unknown;
+    };
+    expect(body.category).toBe('devkit_profiles');
+    expect(body.schema).toBe('profileId');
+    expect(body.jsonSchema).toBeDefined();
+  });
+
+  it('returns the JSON Schema for an explicit schema name', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_get_schema', {
+      category: 'agents',
+      schema: 'memoryType',
+    });
+    expect(resp.isError).toBeFalsy();
+    const body = parseJson(resp.content[0].text) as { schema: string };
+    expect(body.schema).toBe('memoryType');
+  });
+
+  it('errors on unknown category', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_get_schema', { category: 'bogus' });
+    expect(resp.isError).toBe(true);
+    expect(resp.content[0].text).toMatch(/Unknown category/);
+  });
+
+  it('errors on unknown schema within a known category', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_get_schema', {
+      category: 'agents',
+      schema: 'doesNotExist',
+    });
+    expect(resp.isError).toBe(true);
+    expect(resp.content[0].text).toMatch(/Unknown schema/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation pipeline — happy + sad path per category (the ADR's 34-test
+// minimum lives here).
+// ---------------------------------------------------------------------------
+
+describe('createContractsServer — contracts_validate_<category> happy paths', () => {
+  for (const cat of REGISTERED_CATEGORIES) {
+    const fixture = HAPPY_FIXTURES[cat];
+    it(`validates ${cat}${fixture.schema ? `/${fixture.schema}` : ''} happy fixture as success`, async () => {
+      const server = createContractsServer();
+      const args: Record<string, unknown> = { data: fixture.data };
+      if (fixture.schema) args.schema = fixture.schema;
+      const resp = await callTool(server, `contracts_validate_${cat}`, args);
+      const body = parseJson(resp.content[0].text) as {
+        success: boolean;
+        category: string;
+        schema: string;
+        data?: unknown;
+        issues?: unknown[];
+      };
+      expect(
+        body.success,
+        `Expected success for ${cat}/${body.schema}; got issues: ${JSON.stringify(body.issues)}`,
+      ).toBe(true);
+      expect(body.category).toBe(cat);
+      expect(resp.isError).toBeFalsy();
+    });
+  }
+});
+
+describe('createContractsServer — contracts_validate_<category> sad paths', () => {
+  for (const cat of REGISTERED_CATEGORIES) {
+    const fixture = HAPPY_FIXTURES[cat];
+    // Pick a sad payload guaranteed to be wrong shape (null on enum/object/etc.)
+    const sadPayload = SAD_PAYLOADS[0];
+    it(`rejects null payload for ${cat}${fixture.schema ? `/${fixture.schema}` : ''} as failure`, async () => {
+      const server = createContractsServer();
+      const args: Record<string, unknown> = { data: sadPayload };
+      if (fixture.schema) args.schema = fixture.schema;
+      const resp = await callTool(server, `contracts_validate_${cat}`, args);
+      const body = parseJson(resp.content[0].text) as {
+        success: boolean;
+        issues?: unknown[];
+      };
+      expect(body.success).toBe(false);
+      expect(Array.isArray(body.issues)).toBe(true);
+      expect((body.issues ?? []).length).toBeGreaterThan(0);
+      expect(resp.isError).toBe(true);
+    });
+  }
+});
+
+describe('createContractsServer — validation edge cases', () => {
+  it('errors when data argument is missing', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_validate_devkit_profiles', {});
+    expect(resp.isError).toBe(true);
+    expect(resp.content[0].text).toMatch(/"data" is required/);
+  });
+
+  it('errors when invoked tool is unknown', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'unknown_tool_does_not_exist');
+    expect(resp.isError).toBe(true);
+    expect(resp.content[0].text).toMatch(/Unknown tool/);
+  });
+
+  it('errors when contracts_validate_ targets a derived but missing category', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_validate_bogus_category');
+    expect(resp.isError).toBe(true);
+    expect(resp.content[0].text).toMatch(/Unknown category/);
+  });
+
+  it('returns unknown_schema issue when validating against a non-existent schema name', async () => {
+    const server = createContractsServer();
+    const resp = await callTool(server, 'contracts_validate_devkit_profiles', {
+      schema: 'doesNotExist',
+      data: 'revealui',
+    });
+    expect(resp.isError).toBe(true);
+    const body = parseJson(resp.content[0].text) as {
+      success: boolean;
+      issues: Array<{ code: string }>;
+    };
+    expect(body.success).toBe(false);
+    expect(body.issues[0]?.code).toBe('unknown_schema');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct-call API (validatePayload) — exposed for in-process consumers.
+// ---------------------------------------------------------------------------
+
+describe('validatePayload — exported direct API', () => {
+  it('returns success on valid input', () => {
+    const result = validatePayload('devkit_profiles', 'profileId', 'revealui');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe('revealui');
+    }
+  });
+
+  it('returns failure with issues on invalid input', () => {
+    const result = validatePayload('devkit_profiles', 'profileId', 'not-a-profile');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns unknown_schema code when schemaName is bogus', () => {
+    const result = validatePayload('devkit_profiles', 'bogus', 'revealui');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issues[0]?.code).toBe('unknown_schema');
+    }
+  });
+
+  it('preserves category + schema in failure return', () => {
+    const result = validatePayload('providers', 'providerId', 'wrong-provider');
+    expect(result.category).toBe('providers');
+    expect(result.schema).toBe('providerId');
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -184,6 +184,14 @@ export {
   StripeAdapter,
   VercelAdapter,
 } from './servers/adapter.js';
+// Contracts introspection server (F8 Phase 1 — protocol-pyramid ADR L2-MCP)
+export {
+  type CreateContractsServerOptions,
+  createContractsServer,
+  REGISTERED_CATEGORIES,
+  REVEALCOIN_TOKEN_DEFAULT,
+  validatePayload,
+} from './servers/factories/contracts.js';
 // First-party server factories (Stage 1 PR-1.2 — dual-mode template)
 export {
   createRevealuiContentServer,

--- a/packages/mcp/src/servers/contracts.ts
+++ b/packages/mcp/src/servers/contracts.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+/**
+ * RevealUI Contracts MCP Server — stdio launcher.
+ *
+ * Thin wrapper around `createContractsServer()` (see
+ * `./factories/contracts.ts` for the full surface). This file exists
+ * purely to run the server as a stdio subprocess — the canonical
+ * deployment for Claude Code integration, custom-agent integrations, and
+ * the hypervisor's `spawn()`-based tool-discovery pipeline.
+ *
+ * For HTTP / serverless / in-process deployment, import
+ * `createContractsServer` directly and wrap it via
+ * `createNodeStreamableHttpHandler` from `@revealui/mcp/streamable-http`.
+ *
+ * **Not Pro-license-gated** — `@revealui/contracts` is MIT and
+ * agent-side schema introspection is meant to enable any client
+ * (Claude Code, Cursor, custom agents) to integrate cleanly. Pro-gating
+ * a public-package primitive would defeat the purpose. Compare with
+ * `revealui-content.ts` (Pro-gated) which exposes RevealUI runtime data,
+ * not just contracts.
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { logger } from '@revealui/core/observability/logger';
+import { createContractsServer } from './factories/contracts.js';
+
+async function main(): Promise<void> {
+  const server = createContractsServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  logger.error('RevealUI Contracts MCP error', err instanceof Error ? err : new Error(String(err)));
+  process.exit(1);
+});

--- a/packages/mcp/src/servers/factories/contracts.ts
+++ b/packages/mcp/src/servers/factories/contracts.ts
@@ -1,0 +1,907 @@
+/**
+ * Factory for the `revealui-contracts` MCP server.
+ *
+ * Phase 1 of the protocol-pyramid ADR
+ * (`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`): exposes every
+ * `@revealui/contracts` category as MCP **resources** (read-only catalog of
+ * JSON Schemas) plus per-category MCP **tools** that parse a payload against
+ * the category's primary schema and return either the typed value or the
+ * Zod issues.
+ *
+ * ## Resources
+ *
+ * - `revealui-contracts://catalog` — discovery payload listing every
+ *   category, its primary schema name, and every secondary schema name.
+ * - `revealui-contracts://<category>` — JSON document with
+ *   `{ category, primarySchema, schemas: Record<name, JSONSchema7> }`.
+ *
+ * ## Tools
+ *
+ * - `contracts_list_categories` — returns the same payload as the
+ *   `revealui-contracts://catalog` resource (tool form for clients that
+ *   prefer tool-call ergonomics).
+ * - `contracts_get_schema` — returns the JSON Schema for a single
+ *   `(category, schemaName?)` pair.
+ * - `contracts_validate_<category>` (one per registered category) —
+ *   accepts `{ schema?: string, data: unknown }`, returns
+ *   `{ success: true, data }` | `{ success: false, issues }`.
+ *
+ * ## Categories (17)
+ *
+ * Each category has a primary schema (the first secondary schema is the
+ * default for `validate` when `schema` is omitted) plus zero or more
+ * secondary schemas. Three of the categories (`devkit_profiles`,
+ * `providers`, `stripe_webhook_events`) lift TS-only `as const` arrays
+ * into `z.enum` for runtime validation; one (`content_validation`) lifts
+ * a TS interface into a small `z.object`. The others use the contracts
+ * package's hand-written or drizzle-zod-generated Zod schemas as-is.
+ *
+ * Out of scope for Phase 1 (no validation surface): `foundation`
+ * (meta-types only — `Contract<T>` is a generic), `actions`
+ * (class-based validator, not a Zod schema), `pricing` (TS interfaces),
+ * `database` (bridge utilities — covered by `generated`).
+ *
+ * ## License
+ *
+ * This server is **not** Pro-gated. `@revealui/contracts` is MIT and
+ * agent-side introspection of its schemas is meant to enable any client
+ * (Claude Code, Cursor, custom agents) to integrate cleanly. Pro-gating
+ * a public-package primitive would defeat the purpose.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  type ReadResourceRequest,
+  ReadResourceRequestSchema,
+  type Resource,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod/v4';
+
+// ---------------------------------------------------------------------------
+// Imports — Zod schemas grouped by category
+// ---------------------------------------------------------------------------
+
+import {
+  DEVKIT_PROFILES,
+  LLM_PROVIDERS,
+  RELEVANT_STRIPE_WEBHOOK_EVENTS,
+  RVUI_TOKEN_CONFIG,
+} from '@revealui/contracts';
+import {
+  A2AAgentCardSchema,
+  A2AArtifactSchema,
+  A2AAuthSchema,
+  A2ACapabilitiesSchema,
+  A2AJsonRpcRequestSchema,
+  A2AJsonRpcResponseSchema,
+  A2AMessageSchema,
+  A2APartSchema,
+  A2AProviderSchema,
+  A2ASendTaskParamsSchema,
+  A2ASkillSchema,
+  A2ATaskSchema,
+  A2ATaskStateSchema,
+  A2ATaskStatusSchema,
+} from '@revealui/contracts/a2a';
+import { CollectionContract, ConfigContract } from '@revealui/contracts/admin';
+import {
+  AgentActionRecordSchema,
+  AgentDefinitionSchema,
+  AgentMemorySchema,
+  AgentStateSchema,
+  AgentContextSchema as AgentsContextSchema,
+  ConversationMessageSchema,
+  ConversationSchema,
+  IntentSchema,
+  IntentTypeSchema,
+  MemorySourceSchema,
+  MemoryTypeSchema,
+  ToolDefinitionSchema,
+  ToolParameterSchema,
+} from '@revealui/contracts/agents';
+import {
+  MFABackupCodeRequestSchema,
+  MFADisableRequestSchema,
+  MFASetupResponseSchema,
+  MFAVerifyRequestSchema,
+  PasskeyAuthenticateOptionsRequestSchema,
+  PasskeyAuthenticateVerifyRequestSchema,
+  PasskeyListResponseSchema,
+  PasskeyRegisterOptionsRequestSchema,
+  PasskeyRegisterVerifyRequestSchema,
+  PasskeyUpdateRequestSchema,
+  PasswordResetRequestSchema,
+  PasswordResetTokenSchema,
+  RecoveryRequestSchema,
+  RecoveryVerifyRequestSchema,
+  SignInRequestSchema,
+  SignUpRequestSchema,
+} from '@revealui/contracts/api/auth';
+import { ChatMessageSchema, ChatRequestSchema } from '@revealui/contracts/api/chat';
+import { GDPRDeleteRequestSchema, GDPRExportRequestSchema } from '@revealui/contracts/api/gdpr';
+import {
+  AccordionBlockSchema,
+  BlockMetaSchema,
+  BlockSchema,
+  BlockStyleSchema,
+  ButtonBlockSchema,
+  CodeBlockSchema,
+  ColumnsBlockSchema,
+  ComponentBlockSchema,
+  DividerBlockSchema,
+  EmbedBlockSchema,
+  FormBlockSchema,
+  GridBlockSchema,
+  HeadingBlockSchema,
+  HtmlBlockSchema,
+  ImageBlockSchema,
+  ListBlockSchema,
+  QuoteBlockSchema,
+  SpacerBlockSchema,
+  TableBlockSchema,
+  TabsBlockSchema,
+  TextBlockSchema,
+  VideoBlockSchema,
+} from '@revealui/contracts/content';
+import {
+  PageLockSchema,
+  PageSchema,
+  SessionSchema,
+  SiteSchema,
+  UserSchema,
+} from '@revealui/contracts/entities';
+import {
+  AccountsInsertSchema,
+  AccountsSelectSchema,
+  AgentContextsInsertSchema,
+  AgentMemoriesInsertSchema,
+  PagesInsertSchema,
+  SessionsInsertSchema,
+  SitesInsertSchema,
+  UsersInsertSchema,
+  UsersSelectSchema,
+} from '@revealui/contracts/generated/zod-schemas';
+import {
+  AgentActionDefinitionSchema,
+  AgentConstraintSchema,
+  AgentRelationSchema,
+  AgentRepresentationSchema,
+  DualEntitySchema,
+  EmbeddingSchema,
+  HumanRepresentationSchema,
+} from '@revealui/contracts/representation';
+import {
+  RotationEventSchema,
+  RotationReasonSchema,
+  SecretActorSchema,
+  SecretActorTypeSchema,
+  SecretAuditEventSchema,
+  SecretAuditEventTypeSchema,
+  SecretPathSchema,
+} from '@revealui/contracts/secrets';
+import {
+  IssueLocationSchema,
+  SecurityCategorySchema,
+  SecurityFindingSchema,
+  SecurityRuleSchema,
+  SecuritySeveritySchema,
+} from '@revealui/contracts/security';
+
+// ---------------------------------------------------------------------------
+// Derived schemas (lift TS-only constants into Zod for runtime validation)
+// ---------------------------------------------------------------------------
+
+const DevkitProfileIdSchema = z.enum(DEVKIT_PROFILES);
+const LlmProviderSchema = z.enum(LLM_PROVIDERS);
+const StripeWebhookEventSchema = z.enum(
+  RELEVANT_STRIPE_WEBHOOK_EVENTS as readonly [string, ...string[]],
+);
+
+const ContentValidationConfigSchema = z.object({
+  maxDepth: z.number().int().positive(),
+  maxSizeBytes: z.number().int().positive(),
+});
+
+const RvuiTokenConfigSchema = z.object({
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int().nonnegative(),
+  totalSupply: z.bigint().or(z.string()),
+  description: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Schema registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Each category has a `primary` schema name (the default for the
+ * `validate_*` tool when no `schema` argument is given) and a `schemas`
+ * map of all the validators it exposes.
+ *
+ * Category names use snake_case for MCP tool-name compatibility (the SDK
+ * spec recommends `[a-z][a-z0-9_]*`).
+ */
+interface CategoryEntry {
+  primary: string;
+  schemas: Record<string, z.ZodTypeAny>;
+  description: string;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Zod schemas vary in shape.
+const SCHEMA_REGISTRY = {
+  a2a: {
+    primary: 'agentCard',
+    description:
+      'Agent-to-Agent (A2A) protocol contracts — AgentCard, Task, Message, Skill, Artifact, JSON-RPC envelopes.',
+    schemas: {
+      agentCard: A2AAgentCardSchema,
+      artifact: A2AArtifactSchema,
+      auth: A2AAuthSchema,
+      capabilities: A2ACapabilitiesSchema,
+      jsonRpcRequest: A2AJsonRpcRequestSchema,
+      jsonRpcResponse: A2AJsonRpcResponseSchema,
+      message: A2AMessageSchema,
+      part: A2APartSchema,
+      provider: A2AProviderSchema,
+      sendTaskParams: A2ASendTaskParamsSchema,
+      skill: A2ASkillSchema,
+      task: A2ATaskSchema,
+      taskState: A2ATaskStateSchema,
+      taskStatus: A2ATaskStatusSchema,
+    },
+  },
+  admin: {
+    primary: 'collection',
+    description:
+      'admin configuration contracts — CollectionContract + ConfigContract wrap typed admin shapes in the Contract<T> pattern.',
+    schemas: {
+      collection: CollectionContract.schema,
+      config: ConfigContract.schema,
+    },
+  },
+  agents: {
+    primary: 'agentMemory',
+    description:
+      'LLM agent behavior contracts — AgentMemory (semantic memory with embeddings), Conversation, AgentDefinition, Tool, Intent.',
+    schemas: {
+      agentActionRecord: AgentActionRecordSchema,
+      agentContext: AgentsContextSchema,
+      agentDefinition: AgentDefinitionSchema,
+      agentMemory: AgentMemorySchema,
+      agentState: AgentStateSchema,
+      conversation: ConversationSchema,
+      conversationMessage: ConversationMessageSchema,
+      intent: IntentSchema,
+      intentType: IntentTypeSchema,
+      memorySource: MemorySourceSchema,
+      memoryType: MemoryTypeSchema,
+      toolDefinition: ToolDefinitionSchema,
+      toolParameter: ToolParameterSchema,
+    },
+  },
+  api_auth: {
+    primary: 'signIn',
+    description:
+      'Auth API request/response contracts — sign-in, sign-up, password reset, MFA, passkey, recovery flows.',
+    schemas: {
+      signIn: SignInRequestSchema,
+      signUp: SignUpRequestSchema,
+      passwordReset: PasswordResetRequestSchema,
+      passwordResetToken: PasswordResetTokenSchema,
+      mfaSetupResponse: MFASetupResponseSchema,
+      mfaVerify: MFAVerifyRequestSchema,
+      mfaDisable: MFADisableRequestSchema,
+      mfaBackupCode: MFABackupCodeRequestSchema,
+      passkeyRegisterOptions: PasskeyRegisterOptionsRequestSchema,
+      passkeyRegisterVerify: PasskeyRegisterVerifyRequestSchema,
+      passkeyAuthenticateOptions: PasskeyAuthenticateOptionsRequestSchema,
+      passkeyAuthenticateVerify: PasskeyAuthenticateVerifyRequestSchema,
+      passkeyList: PasskeyListResponseSchema,
+      passkeyUpdate: PasskeyUpdateRequestSchema,
+      recovery: RecoveryRequestSchema,
+      recoveryVerify: RecoveryVerifyRequestSchema,
+    },
+  },
+  api_chat: {
+    primary: 'chatRequest',
+    description: 'Chat API contracts — ChatRequest body + ChatMessage shapes.',
+    schemas: {
+      chatRequest: ChatRequestSchema,
+      chatMessage: ChatMessageSchema,
+    },
+  },
+  api_gdpr: {
+    primary: 'gdprExport',
+    description: 'GDPR API contracts — data export and account deletion request shapes.',
+    schemas: {
+      gdprExport: GDPRExportRequestSchema,
+      gdprDelete: GDPRDeleteRequestSchema,
+    },
+  },
+  content: {
+    primary: 'block',
+    description:
+      'Content block contracts — discriminated union of 17 block variants (text, heading, image, code, table, columns, grid, form, etc.).',
+    schemas: {
+      block: BlockSchema,
+      blockMeta: BlockMetaSchema,
+      blockStyle: BlockStyleSchema,
+      accordion: AccordionBlockSchema,
+      button: ButtonBlockSchema,
+      code: CodeBlockSchema,
+      columns: ColumnsBlockSchema,
+      component: ComponentBlockSchema,
+      divider: DividerBlockSchema,
+      embed: EmbedBlockSchema,
+      form: FormBlockSchema,
+      grid: GridBlockSchema,
+      heading: HeadingBlockSchema,
+      html: HtmlBlockSchema,
+      image: ImageBlockSchema,
+      list: ListBlockSchema,
+      quote: QuoteBlockSchema,
+      spacer: SpacerBlockSchema,
+      table: TableBlockSchema,
+      tabs: TabsBlockSchema,
+      text: TextBlockSchema,
+      video: VideoBlockSchema,
+    },
+  },
+  content_validation: {
+    primary: 'config',
+    description:
+      'Lexical content validation config — limits applied by validateLexicalContent (max nesting depth + max payload bytes).',
+    schemas: {
+      config: ContentValidationConfigSchema,
+    },
+  },
+  devkit_profiles: {
+    primary: 'profileId',
+    description:
+      'DevKit profile id (Max-tier paywall feature) — one of revealui, agents, claude, cursor, zed.',
+    schemas: {
+      profileId: DevkitProfileIdSchema,
+    },
+  },
+  entities: {
+    primary: 'user',
+    description:
+      'Domain entity contracts — User, Site, Page, Session, plus PageLock. Add more secondary schemas in subsequent phases.',
+    schemas: {
+      user: UserSchema,
+      page: PageSchema,
+      pageLock: PageLockSchema,
+      session: SessionSchema,
+      site: SiteSchema,
+    },
+  },
+  generated: {
+    primary: 'usersInsert',
+    description:
+      'Drizzle-zod-generated Insert/Select schemas reflecting raw DB columns. Sample of the most-used tables (full set is 86+ schemas).',
+    schemas: {
+      accountsSelect: AccountsSelectSchema,
+      accountsInsert: AccountsInsertSchema,
+      agentContextsInsert: AgentContextsInsertSchema,
+      agentMemoriesInsert: AgentMemoriesInsertSchema,
+      pagesInsert: PagesInsertSchema,
+      sessionsInsert: SessionsInsertSchema,
+      sitesInsert: SitesInsertSchema,
+      usersSelect: UsersSelectSchema,
+      usersInsert: UsersInsertSchema,
+    },
+  },
+  providers: {
+    primary: 'providerId',
+    description:
+      'Supported LLM provider id — one of groq, huggingface, inference-snaps, ollama. Open models only.',
+    schemas: {
+      providerId: LlmProviderSchema,
+    },
+  },
+  representation: {
+    primary: 'dualEntity',
+    description:
+      'Dual representation layer — DualEntity wraps every entity with both Human and Agent views. Includes Embedding, AgentRepresentation, HumanRepresentation, AgentAction, AgentConstraint, AgentRelation.',
+    schemas: {
+      dualEntity: DualEntitySchema,
+      embedding: EmbeddingSchema,
+      agentRepresentation: AgentRepresentationSchema,
+      humanRepresentation: HumanRepresentationSchema,
+      agentActionDefinition: AgentActionDefinitionSchema,
+      agentConstraint: AgentConstraintSchema,
+      agentRelation: AgentRelationSchema,
+    },
+  },
+  revealcoin: {
+    primary: 'tokenConfig',
+    description:
+      'RevealCoin (RVC on chain, RVUI internal codename) token config schema lifted from the TS interface.',
+    schemas: {
+      tokenConfig: RvuiTokenConfigSchema,
+    },
+  },
+  secrets: {
+    primary: 'secretActor',
+    description:
+      'Revvault secret-management contracts — SecretPath, SecretActor, RotationEvent, SecretAuditEvent.',
+    schemas: {
+      secretActor: SecretActorSchema,
+      secretActorType: SecretActorTypeSchema,
+      secretPath: SecretPathSchema,
+      rotationEvent: RotationEventSchema,
+      rotationReason: RotationReasonSchema,
+      secretAuditEvent: SecretAuditEventSchema,
+      secretAuditEventType: SecretAuditEventTypeSchema,
+    },
+  },
+  security: {
+    primary: 'securityRule',
+    description:
+      'Security rule contracts — SecurityRule, SecurityFinding, severity/category enums, IssueLocation.',
+    schemas: {
+      securityRule: SecurityRuleSchema,
+      securityFinding: SecurityFindingSchema,
+      severity: SecuritySeveritySchema,
+      category: SecurityCategorySchema,
+      issueLocation: IssueLocationSchema,
+    },
+  },
+  stripe_webhook_events: {
+    primary: 'eventType',
+    description:
+      'Canonical Stripe webhook event types handled by RevealUI (subset of Stripe API events).',
+    schemas: {
+      eventType: StripeWebhookEventSchema,
+    },
+  },
+} as const satisfies Record<string, CategoryEntry>;
+
+type CategoryName = keyof typeof SCHEMA_REGISTRY;
+
+const CATEGORIES = Object.keys(SCHEMA_REGISTRY) as CategoryName[];
+
+// Constant exports for tests + runtime introspection.
+// biome-ignore lint/suspicious/noExplicitAny: ZodTypeAny convenience for tests.
+export const REGISTERED_CATEGORIES = CATEGORIES as readonly string[];
+export const REVEALCOIN_TOKEN_DEFAULT = RVUI_TOKEN_CONFIG;
+
+// ---------------------------------------------------------------------------
+// JSON Schema cache (computed once at server creation)
+// ---------------------------------------------------------------------------
+
+interface CategoryJsonSchemas {
+  /** Stable JSON Schemas keyed by schema name within the category. */
+  schemas: Record<string, unknown>;
+  /** The primary schema name. */
+  primary: string;
+  /** Human description of the category. */
+  description: string;
+}
+
+function buildJsonSchemaCache(): Record<CategoryName, CategoryJsonSchemas> {
+  const out: Record<string, CategoryJsonSchemas> = {};
+  for (const cat of CATEGORIES) {
+    const entry = SCHEMA_REGISTRY[cat];
+    const schemaJson: Record<string, unknown> = {};
+    for (const [name, zodSchema] of Object.entries(entry.schemas)) {
+      try {
+        schemaJson[name] = z.toJSONSchema(zodSchema);
+      } catch (err) {
+        // Some Zod constructs (e.g. discriminated unions with overlapping
+        // discriminators, recursive schemas without lazy guards) cannot be
+        // serialized to JSON Schema. Surface a placeholder so the catalog
+        // still lists the schema name; tools fall back to runtime parse.
+        schemaJson[name] = {
+          $comment: `JSON Schema serialization failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+    out[cat] = {
+      schemas: schemaJson,
+      primary: entry.primary,
+      description: entry.description,
+    };
+  }
+  return out as Record<CategoryName, CategoryJsonSchemas>;
+}
+
+// ---------------------------------------------------------------------------
+// Resource URI helpers
+// ---------------------------------------------------------------------------
+
+const RESOURCE_URI_PREFIX = 'revealui-contracts://';
+const CATALOG_URI = `${RESOURCE_URI_PREFIX}catalog`;
+
+interface ParsedCategoryUri {
+  category: CategoryName;
+}
+
+function parseCategoryUri(uri: string): ParsedCategoryUri | null {
+  if (!uri.startsWith(RESOURCE_URI_PREFIX)) return null;
+  const rest = uri.slice(RESOURCE_URI_PREFIX.length);
+  if (!/^[a-z][a-z0-9_]*$/.test(rest)) return null;
+  if (!(rest in SCHEMA_REGISTRY)) return null;
+  return { category: rest as CategoryName };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+interface ValidateSuccess {
+  success: true;
+  category: CategoryName;
+  schema: string;
+  data: unknown;
+}
+
+interface ValidateFailure {
+  success: false;
+  category: CategoryName;
+  schema: string;
+  issues: Array<{
+    path: ReadonlyArray<PropertyKey>;
+    message: string;
+    code: string;
+  }>;
+}
+
+type ValidateResult = ValidateSuccess | ValidateFailure;
+
+export function validatePayload(
+  category: CategoryName,
+  schemaName: string,
+  data: unknown,
+): ValidateResult {
+  const entry = SCHEMA_REGISTRY[category];
+  // The `as const satisfies` literal makes `entry.schemas` a union of
+  // narrow per-category shapes. For runtime indexing by arbitrary string,
+  // widen to a record of ZodTypeAny — the unknown-key lookup is what we
+  // want here (caller supplied `schemaName`).
+  const schemasMap = entry.schemas as Record<string, z.ZodTypeAny>;
+  const zodSchema = schemasMap[schemaName];
+  if (!zodSchema) {
+    return {
+      success: false,
+      category,
+      schema: schemaName,
+      issues: [
+        {
+          path: [],
+          message: `Unknown schema "${schemaName}" for category "${category}". Valid schemas: ${Object.keys(entry.schemas).join(', ')}.`,
+          code: 'unknown_schema',
+        },
+      ],
+    };
+  }
+  const result = zodSchema.safeParse(data);
+  if (result.success) {
+    return { success: true, category, schema: schemaName, data: result.data };
+  }
+  return {
+    success: false,
+    category,
+    schema: schemaName,
+    issues: result.error.issues.map((i: z.core.$ZodIssue) => ({
+      path: i.path,
+      message: i.message,
+      code: i.code,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool catalog
+// ---------------------------------------------------------------------------
+
+const VALIDATE_TOOL_PREFIX = 'contracts_validate_';
+
+function validateToolName(category: CategoryName): string {
+  return `${VALIDATE_TOOL_PREFIX}${category}`;
+}
+
+function validateInputSchema(category: CategoryName): Tool['inputSchema'] {
+  const entry = SCHEMA_REGISTRY[category];
+  const schemaNames = Object.keys(entry.schemas);
+  return {
+    type: 'object',
+    properties: {
+      schema: {
+        type: 'string',
+        enum: schemaNames,
+        description: `Optional schema name within "${category}". Defaults to "${entry.primary}". One of: ${schemaNames.join(', ')}.`,
+      },
+      data: {
+        description: 'JSON value to validate. Type depends on the chosen schema.',
+      },
+    },
+    required: ['data'],
+  };
+}
+
+function buildToolList(): Tool[] {
+  const tools: Tool[] = [];
+
+  // Discovery tools
+  tools.push({
+    name: 'contracts_list_categories',
+    description:
+      'List every contract category exposed by this server, with primary schema name and full schema-name list per category.',
+    inputSchema: { type: 'object', properties: {} },
+  });
+
+  tools.push({
+    name: 'contracts_get_schema',
+    description:
+      'Return the JSON Schema for a (category, schema) pair. Omit `schema` to get the category primary.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        category: {
+          type: 'string',
+          enum: CATEGORIES as unknown as string[],
+          description: 'Contract category name.',
+        },
+        schema: {
+          type: 'string',
+          description: 'Optional schema name within the category. Defaults to the primary.',
+        },
+      },
+      required: ['category'],
+    },
+  });
+
+  // One validate tool per category
+  for (const cat of CATEGORIES) {
+    const entry = SCHEMA_REGISTRY[cat];
+    tools.push({
+      name: validateToolName(cat),
+      description: `Validate a JSON payload against a "${cat}" contract schema. ${entry.description}`,
+      inputSchema: validateInputSchema(cat),
+    });
+  }
+
+  return tools;
+}
+
+// ---------------------------------------------------------------------------
+// Resource catalog
+// ---------------------------------------------------------------------------
+
+function buildResourceList(): Resource[] {
+  const resources: Resource[] = [
+    {
+      uri: CATALOG_URI,
+      name: 'catalog',
+      description:
+        'Complete contracts catalog: every category with its primary schema name, secondary schema names, and human description.',
+      mimeType: 'application/json',
+    },
+  ];
+  for (const cat of CATEGORIES) {
+    const entry = SCHEMA_REGISTRY[cat];
+    resources.push({
+      uri: `${RESOURCE_URI_PREFIX}${cat}`,
+      name: cat,
+      description: entry.description,
+      mimeType: 'application/json',
+    });
+  }
+  return resources;
+}
+
+interface CatalogPayload {
+  categories: Array<{
+    name: string;
+    primary: string;
+    schemas: string[];
+    description: string;
+  }>;
+  totalCategories: number;
+  totalSchemas: number;
+}
+
+function buildCatalogPayload(): CatalogPayload {
+  const categories = CATEGORIES.map((cat) => {
+    const entry = SCHEMA_REGISTRY[cat];
+    return {
+      name: cat,
+      primary: entry.primary,
+      schemas: Object.keys(entry.schemas),
+      description: entry.description,
+    };
+  });
+  const totalSchemas = categories.reduce((acc, c) => acc + c.schemas.length, 0);
+  return { categories, totalCategories: categories.length, totalSchemas };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Server name + version. Bump the version when the registry changes
+ * shape (adds/removes categories or top-level fields). The host
+ * `@revealui/mcp` package version stays separate.
+ */
+const SERVER_NAME = 'revealui-contracts';
+const SERVER_VERSION = '0.1.0';
+
+export interface CreateContractsServerOptions {
+  /**
+   * Override the server name advertised in the MCP `initialize` response.
+   * Mostly useful for tests that spin up multiple servers in one process.
+   */
+  serverName?: string;
+}
+
+/**
+ * Create a fresh contracts MCP Server instance. Safe to call multiple
+ * times — each call returns an independent Server with its own request
+ * handlers and its own JSON Schema cache.
+ */
+export function createContractsServer(options?: CreateContractsServerOptions): Server {
+  const server = new Server(
+    { name: options?.serverName ?? SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {}, resources: {} } },
+  );
+
+  const jsonSchemaCache = buildJsonSchemaCache();
+  const toolList = buildToolList();
+  const resourceList = buildResourceList();
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolList }));
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: resourceList }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
+    const uri = request.params.uri;
+    if (uri === CATALOG_URI) {
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: 'application/json',
+            text: JSON.stringify(buildCatalogPayload(), null, 2),
+          },
+        ],
+      };
+    }
+    const parsed = parseCategoryUri(uri);
+    if (!parsed) {
+      throw new Error(
+        `Unknown resource URI (expected ${CATALOG_URI} or ${RESOURCE_URI_PREFIX}<category>): ${uri}`,
+      );
+    }
+    const cached = jsonSchemaCache[parsed.category];
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(
+            {
+              category: parsed.category,
+              primarySchema: cached.primary,
+              description: cached.description,
+              schemas: cached.schemas,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    const toolName = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+
+    try {
+      if (toolName === 'contracts_list_categories') {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(buildCatalogPayload(), null, 2) }],
+        };
+      }
+
+      if (toolName === 'contracts_get_schema') {
+        const category = args.category;
+        const schemaName = args.schema;
+        if (typeof category !== 'string' || !(category in SCHEMA_REGISTRY)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Unknown category "${String(category)}". Valid: ${CATEGORIES.join(', ')}.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const cat = category as CategoryName;
+        const cached = jsonSchemaCache[cat];
+        const effectiveSchema =
+          typeof schemaName === 'string' && schemaName.length > 0 ? schemaName : cached.primary;
+        const json = cached.schemas[effectiveSchema];
+        if (json === undefined) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Unknown schema "${effectiveSchema}" for category "${cat}". Valid: ${Object.keys(cached.schemas).join(', ')}.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                { category: cat, schema: effectiveSchema, jsonSchema: json },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      if (toolName.startsWith(VALIDATE_TOOL_PREFIX)) {
+        const category = toolName.slice(VALIDATE_TOOL_PREFIX.length);
+        if (!(category in SCHEMA_REGISTRY)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Unknown category "${category}" derived from tool "${toolName}". Valid: ${CATEGORIES.join(', ')}.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const cat = category as CategoryName;
+        const entry = SCHEMA_REGISTRY[cat];
+        const schemaName =
+          typeof args.schema === 'string' && args.schema.length > 0 ? args.schema : entry.primary;
+        if (!('data' in args)) {
+          return {
+            content: [{ type: 'text', text: `Error: "data" is required for ${toolName}.` }],
+            isError: true,
+          };
+        }
+        const result = validatePayload(cat, schemaName, args.data);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          isError: !result.success,
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: `Error: Unknown tool: ${toolName}` }],
+        isError: true,
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}


### PR DESCRIPTION
## Summary

**F8 Phase 1 of the contracts protocol-pyramid ADR** ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](https://github.com/RevealUIStudio/revealui/blob/test/docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Adds a new MCP server `revealui-contracts` exposing every `@revealui/contracts` category as MCP **resources** (read-only catalog of JSON Schemas) and matching MCP **tools** that parse arbitrary JSON against any registered schema. Also adds 4 missing subpath exports to `@revealui/contracts` that the new server requires (additive, no behavior change for existing imports).

* New: `packages/mcp/src/servers/factories/contracts.ts` (~900 LOC factory) + `packages/mcp/src/servers/contracts.ts` (~37 LOC stdio launcher) + `packages/mcp/src/__tests__/contracts-server.test.ts` (~80 unit tests, ADR's 34-minimum exceeded).
* Closes the runtime layer of suite-messaging-audit N4 ("agent-native pitch ships zero agent affordances") — peer revealui#720 closed the prose layer with `/llms.txt`; this closes the runtime layer with the actual agent-readable interface.

## Resources surfaced

* `revealui-contracts://catalog` — discovery payload listing every category, primary schema name, secondary schema names, and human description.
* `revealui-contracts://<category>` — one resource per category × 17, returns `{ category, primarySchema, schemas: Record<name, JSONSchema7> }`.

## Tools surfaced (19 total)

* `contracts_list_categories` — same payload as the catalog resource (tool form for clients that prefer tool-call ergonomics).
* `contracts_get_schema({ category, schema? })` — JSON Schema for a single (category, schemaName) pair. Defaults to category primary when `schema` is omitted.
* `contracts_validate_<category>({ schema?, data })` — one tool per category × 17. Parses `data` against the named schema. Returns `{ success: true, data }` | `{ success: false, issues }`.

## Categories (17)

`a2a`, `admin`, `agents`, `api_auth`, `api_chat`, `api_gdpr`, `content`, `content_validation`, `devkit_profiles`, `entities`, `generated`, `providers`, `representation`, `revealcoin`, `secrets`, `security`, `stripe_webhook_events`.

Three lift TS-only `as const` arrays into runtime `z.enum` (`devkit_profiles`, `providers`, `stripe_webhook_events`); one (`content_validation`) lifts a TS interface into a small `z.object`. Out of scope for Phase 1: `foundation` (meta-types only), `actions` (class-based validator), `pricing` (TS interfaces), `database` (bridge utilities — covered by `generated`).

## License gate (intentional)

The new server is **not** Pro-license-gated. `@revealui/contracts` is MIT and agent-side schema introspection is meant to enable any MCP client (Claude Code, Cursor, custom agents) to integrate cleanly. Pro-gating a public-package primitive would defeat the foundational use case. (Compare with `revealui-content.ts` which IS Pro-gated — it exposes RevealUI runtime data, not just contracts.)

## Versioning

| Package | Bump | Reason |
|---|---|---|
| `@revealui/mcp` | minor `0.2.0 → 0.3.0` | New server (additive, pre-1.0 minor per `versioning.md`) |
| `@revealui/contracts` | minor `1.4.0 → 1.5.0` | Additive new subpath exports: `./a2a`, `./api/auth`, `./api/chat`, `./api/gdpr` (already accessible via root barrel; new subpaths give per-category granularity matching the existing pattern) |

Bumps land via `.changeset/contracts-mcp-server-phase-1.md`. ADR errata note appended to `docs/decisions/2026-05-03-contracts-protocol-pyramid.md` §"Versioning impact" explaining the dual-package bump (the original ADR said "no contracts API changes" but Phase 1 surfaced that the api/* and a2a subpaths existed in `src/` but weren't in `package.json` exports).

## README + claim-drift sweep

* `packages/mcp/README.md` — bumped `12 MCP Servers` → `13 MCP Servers` + new server section #8 + bumped trailer date.
* Repository-wide claim-drift sweep: `12 → 13` updates across 8 additional sites (root `README.md`, `docs/AUTOMATION.md`, `docs/PRO.md`, `docs/blog/05-five-primitives.md`, `docs/blog-drafts/01-why-we-built-revealui.md`, `docs/blog-drafts/04-agent-first-future.md`, `packages/mcp/docs/README.md`, `docs/DOCUMENTATION_ASSESSMENT.md`). `pnpm validate:claims` is now clean (0 mismatches).

## Test plan

- [x] `pnpm gate` — PASS (all 21 checks; ~7m31s) — Biome, audit, structure, boundary, version, catalog changeset, docs drift, Pro license, claim drift, migration, raw-SQL, empty-catch, Stripe consolidation, security audit, coverage, typecheck (119s), tests (271s), build (48s), build artifacts.
- [x] `pnpm --filter @revealui/mcp test` — 301 passed / 5 skipped (existing). New `contracts-server.test.ts` contributes ~80 tests covering: factory + structure (5), tool list (4), resource list (3), per-category resource read (17 + 4 helper), `contracts_list_categories` tool (1), `contracts_get_schema` tool (4 happy + 2 sad), `contracts_validate_<category>` × happy + sad (34 — ADR's 34-minimum hit exactly), validation edge cases (4), `validatePayload` direct API (4).
- [x] `pnpm --filter @revealui/mcp typecheck` — clean.
- [x] Pre-push gate — PASS.
- [ ] CI — watching.
- [ ] Spot-check: `tsx packages/mcp/src/servers/contracts.ts` boots without license-gate errors (verified locally; not blocking).

## Lane note

Original `contracts-mcp-server-f8-phase-1` agent registered the lane at 2026-05-03 ~09:35Z, set up branch + worktree, wrote ~900 LOC of factory + launcher, then went silent — **never committed**. Discovered the work in-progress 70+ min later via `git status` (initial `git log` review missed it — `git log` shows commits, not working-tree state). Audit confirmed peer's design was sound; this commit picks up peer's work, fixes 3 specific bugs (`CollectionContract.contract` → `.schema`, TS strict-mode at the dynamic schema lookup, implicit-any on issue mapping), wires it through to ship: tests, README, changeset, ADR errata, contracts subpath exports, doc claim-drift sweep.

Co-authored attribution preserved in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
