### PR TITLE
feat(server): /.well-known/mcp.json — public MCP discovery manifest (closes audit N4)

### DIFF
--- a/apps/server/src/lib/mcp-manifest.ts
+++ b/apps/server/src/lib/mcp-manifest.ts
@@ -1,0 +1,246 @@
+/**
+ * MCP server discovery manifest.
+ *
+ * Authoritative list of MCP servers exposed by this RevealUI deployment,
+ * served at GET /.well-known/mcp.json so agents can enumerate available
+ * tool surfaces without prior knowledge.
+ *
+ * Closes suite-messaging audit N4 ("agent-native pitch ships zero agent
+ * affordances") at the discovery layer; complement to the /llms.txt prose
+ * layer (revealui#720) and the existing /.well-known/agent.json A2A layer.
+ *
+ * Source of truth: `packages/mcp/README.md` ("13 MCP Servers" — enforced
+ * by `pnpm validate:claims`). This manifest mirrors that list 1:1 and
+ * MUST be updated alongside any addition or removal in
+ * `packages/mcp/src/servers/`.
+ *
+ * License model: every server is MIT-licensed (per @revealui/mcp's
+ * package.json). The `proGated` field reflects whether the server's
+ * runtime calls `checkMcpLicense()` at startup, not the source license
+ * itself; the `contracts` server is the public exception
+ * (see `packages/mcp/src/servers/factories/contracts.ts`).
+ */
+
+export type McpServerCategory =
+  | 'introspection'
+  | 'platform'
+  | 'integration'
+  | 'development'
+  | 'helper';
+
+export type McpServerTransport = 'stdio';
+
+export interface McpServerEntry {
+  /** Stable identifier; matches the file basename in packages/mcp/src/servers/ */
+  id: string;
+  /** Human-readable name as published in `packages/mcp/README.md` */
+  name: string;
+  /** One-line description of what this server exposes */
+  description: string;
+  /** Functional category for filtering / grouping */
+  category: McpServerCategory;
+  /** MCP transport mechanism (all first-party servers are stdio today) */
+  transport: McpServerTransport;
+  /** Module path for stdio invocation (matches the @revealui/mcp dist layout) */
+  modulePath: string;
+  /** SPDX license identifier of the server's source */
+  license: 'MIT';
+  /**
+   * Whether the server's runtime gates on a Pro/Enterprise license check.
+   * Source license is always MIT; this reflects runtime activation, not
+   * source visibility.
+   */
+  proGated: boolean;
+  /** Whether the server requires external API credentials to function */
+  requiresCredentials: boolean;
+}
+
+export interface McpDiscoveryManifest {
+  /** Manifest schema version */
+  version: '1.0';
+  /** This deployment's platform identifier */
+  platform: 'revealui';
+  /** Catalog documentation URL (the @revealui/mcp README) */
+  documentationUrl: string;
+  /** List of MCP servers exposed by this deployment */
+  servers: McpServerEntry[];
+}
+
+/**
+ * Canonical list of MCP servers exposed by this RevealUI deployment.
+ *
+ * Order: introspection first (public + foundational), then platform
+ * (first-party RevealUI integrations), then integration (third-party
+ * adapters), then development tools, then helpers. Within each
+ * category, alphabetical.
+ */
+export const MCP_SERVERS: readonly McpServerEntry[] = [
+  {
+    id: 'contracts',
+    name: 'Contracts Introspection',
+    description:
+      'Read-only resources and validators for every @revealui/contracts category (entities, agents, A2A, admin, billing, pricing, RevealCoin, security, content, etc.). Public — not Pro-gated. Phase 1 of the protocol-pyramid ADR.',
+    category: 'introspection',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/contracts.js',
+    license: 'MIT',
+    proGated: false,
+    requiresCredentials: false,
+  },
+  {
+    id: 'revealui-content',
+    name: 'RevealUI Content',
+    description:
+      'Manage RevealUI content collections (sites, pages, posts) via MCP. Backed by Drizzle on Neon.',
+    category: 'platform',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/revealui-content.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: false,
+  },
+  {
+    id: 'revealui-email',
+    name: 'RevealUI Email',
+    description: 'Send transactional and marketing emails through the RevealUI mailer pipeline.',
+    category: 'platform',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/revealui-email.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'revealui-memory',
+    name: 'RevealUI Memory',
+    description:
+      'CRDT-backed semantic memory for agents — write, read, and search long-term context across sessions.',
+    category: 'platform',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/revealui-memory.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: false,
+  },
+  {
+    id: 'revealui-stripe',
+    name: 'RevealUI Stripe',
+    description:
+      'RevealUI-native billing operations layered on Stripe (subscriptions, customers, invoices, dunning).',
+    category: 'platform',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/revealui-stripe.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'neon',
+    name: 'Neon',
+    description: 'Neon (Postgres) database operations and SQL queries.',
+    category: 'integration',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/neon.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'stripe',
+    name: 'Stripe',
+    description:
+      'Direct Stripe API operations — payments, subscriptions, products, prices, webhooks.',
+    category: 'integration',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/stripe.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    description:
+      'Supabase project management and CRUD operations. Legacy adapter retained for migrating customers; new RevealUI deployments default to Neon.',
+    category: 'integration',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/supabase.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    description: 'Deploy and manage Vercel projects, domains, and environment variables.',
+    category: 'integration',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/vercel.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+  {
+    id: 'code-validator',
+    name: 'Code Validator',
+    description:
+      'Validates code patterns and prevents AI-generated technical debt before code is written.',
+    category: 'development',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/code-validator.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: false,
+  },
+  {
+    id: 'next-devtools',
+    name: 'Next.js DevTools',
+    description: 'Next.js 16+ runtime diagnostics and automation.',
+    category: 'development',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/next-devtools.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: false,
+  },
+  {
+    id: 'playwright',
+    name: 'Playwright',
+    description: 'Browser automation, end-to-end testing, and web scraping.',
+    category: 'development',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/playwright.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: false,
+  },
+  {
+    id: 'email-provider',
+    name: 'Email Provider',
+    description:
+      'Internal helper for resolving email provider credentials and routing decisions across the suite.',
+    category: 'helper',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/_email-provider.js',
+    license: 'MIT',
+    proGated: true,
+    requiresCredentials: true,
+  },
+];
+
+const DOC_URL = 'https://github.com/RevealUIStudio/revealui/blob/main/packages/mcp/README.md';
+
+/**
+ * Build the MCP discovery manifest for `/.well-known/mcp.json`.
+ *
+ * Pure function — no I/O, no side effects. Safe to call per-request;
+ * callers can memoize for hot paths.
+ */
+export function buildMcpManifest(): McpDiscoveryManifest {
+  return {
+    version: '1.0',
+    platform: 'revealui',
+    documentationUrl: DOC_URL,
+    servers: [...MCP_SERVERS],
+  };
+}

--- a/apps/server/src/routes/__tests__/a2a.test.ts
+++ b/apps/server/src/routes/__tests__/a2a.test.ts
@@ -299,6 +299,101 @@ describe('GET /.well-known/agents/:id/agent.json', () => {
   });
 });
 
+// ─── GET /.well-known/mcp.json ────────────────────────────────────────────────
+
+describe('GET /.well-known/mcp.json', () => {
+  beforeEach(resetMocks);
+
+  it('returns the MCP discovery manifest with required top-level fields', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      version: string;
+      platform: string;
+      documentationUrl: string;
+      servers: unknown[];
+    };
+    expect(body.version).toBe('1.0');
+    expect(body.platform).toBe('revealui');
+    expect(body.documentationUrl).toContain('packages/mcp/README.md');
+    expect(Array.isArray(body.servers)).toBe(true);
+  });
+
+  it('lists exactly 13 MCP servers (matches packages/mcp/README.md ground truth)', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    const body = (await res.json()) as { servers: unknown[] };
+    expect(body.servers).toHaveLength(13);
+  });
+
+  it('serves the manifest as public — no auth, no Pro license required', async () => {
+    // Per audit N4 / protocol-pyramid framing, discovery must be public.
+    // Even when isFeatureEnabled returns false, the route must succeed.
+    mockIsFeatureEnabled.mockReturnValue(false);
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    expect(res.status).toBe(200);
+  });
+
+  it('sets Cache-Control: public, max-age=300', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
+  });
+
+  it('lists the contracts server as not Pro-gated (the public exception)', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    const body = (await res.json()) as {
+      servers: Array<{ id: string; proGated: boolean; category: string }>;
+    };
+    const contracts = body.servers.find((s) => s.id === 'contracts');
+    expect(contracts).toBeDefined();
+    expect(contracts?.proGated).toBe(false);
+    expect(contracts?.category).toBe('introspection');
+  });
+
+  it('every server entry declares required fields with correct shapes', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    const body = (await res.json()) as {
+      servers: Array<{
+        id: string;
+        name: string;
+        description: string;
+        category: string;
+        transport: string;
+        modulePath: string;
+        license: string;
+        proGated: unknown;
+        requiresCredentials: unknown;
+      }>;
+    };
+    for (const server of body.servers) {
+      expect(server.id).toBeTruthy();
+      expect(server.name).toBeTruthy();
+      expect(server.description).toBeTruthy();
+      expect(['introspection', 'platform', 'integration', 'development', 'helper']).toContain(
+        server.category,
+      );
+      expect(server.transport).toBe('stdio');
+      expect(server.modulePath).toContain('@revealui/mcp');
+      expect(server.license).toBe('MIT');
+      expect(typeof server.proGated).toBe('boolean');
+      expect(typeof server.requiresCredentials).toBe('boolean');
+    }
+  });
+
+  it('server ids are unique', async () => {
+    const app = makeWellKnownApp();
+    const res = await app.request(get('/mcp.json'));
+    const body = (await res.json()) as { servers: Array<{ id: string }> };
+    const ids = body.servers.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
 // ─── GET /agents ──────────────────────────────────────────────────────────────
 
 describe('GET /agents', () => {

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -25,6 +25,7 @@ import { getClient } from '@revealui/db';
 import { agentActions, marketplaceServers, registeredAgents } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { desc, eq } from 'drizzle-orm';
+import { buildMcpManifest } from '../lib/mcp-manifest.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { requireFeature } from '../middleware/license.js';
 import { requireTaskQuota } from '../middleware/task-quota.js';
@@ -348,18 +349,10 @@ app.openapi(
     },
   }),
   (c) => {
-    // WIP-skeleton  -  full manifest builder lands in the implementation commit.
-    return c.json(
-      {
-        version: '1.0',
-        servers: [],
-      },
-      200,
-      {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300',
-      },
-    );
+    return c.json(buildMcpManifest(), 200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=300',
+    });
   },
 );
 

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -318,6 +318,51 @@ app.openapi(
   },
 );
 
+/**
+ * MCP server discovery manifest.
+ * GET /.well-known/mcp.json
+ *
+ * Returns the MCP servers exposed by this RevealUI deployment so agents
+ * can enumerate available tool surfaces without prior knowledge.
+ *
+ * Public  -  no auth, no license gating; the response describes what
+ * exists, not what the caller is licensed to invoke. Per-server
+ * licensing is enforced at the tool-invocation layer.
+ *
+ * Closes suite-messaging audit N4 ("agent-native pitch ships zero
+ * agent affordances") at the discovery layer; complement to the
+ * /llms.txt prose layer (PR #720) and the /.well-known/agent.json
+ * A2A discovery layer.
+ */
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/mcp.json',
+    tags: ['a2a'],
+    summary: 'MCP server discovery manifest',
+    responses: {
+      200: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'MCP server manifest',
+      },
+    },
+  }),
+  (c) => {
+    // WIP-skeleton  -  full manifest builder lands in the implementation commit.
+    return c.json(
+      {
+        version: '1.0',
+        servers: [],
+      },
+      200,
+      {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=300',
+      },
+    );
+  },
+);
+
 // =============================================================================
 // A2A task API  -  /a2a/*
 // =============================================================================


### PR DESCRIPTION
## Summary

New public route `GET /.well-known/mcp.json` serving an authoritative manifest of the MCP servers exposed by this RevealUI deployment. **Closes suite-messaging audit N4** (the named `/.well-known/mcp.json` gap at `docs/audits/suite-messaging-audit-2026-05-02.md:147`) at the MCP-discovery layer.

This is the third leg of the "agent-native" trilogy:
- **Prose layer** — `/llms.txt` shipped via [revealui#720](https://github.com/RevealUIStudio/revealui/pull/720)
- **A2A layer** — `/.well-known/agent.json` already exists in `apps/server/src/routes/a2a.ts:90`
- **MCP layer** — `/.well-known/mcp.json` (this PR) ✅

No auth, no Pro-license gate at the manifest layer — discovery describes what exists, not what the caller is licensed to invoke. Per-server licensing is enforced at the tool-invocation layer (each launcher's `checkMcpLicense()` call).

## What ships

### New file: `apps/server/src/lib/mcp-manifest.ts`

`McpDiscoveryManifest` + `McpServerEntry` types and the canonical `MCP_SERVERS` array. **13 entries**, mirroring the [@revealui/mcp README ground-truth list](https://github.com/RevealUIStudio/revealui/blob/main/packages/mcp/README.md) 1:1:

| Category | Servers |
|---|---|
| introspection | contracts |
| platform | revealui-content, revealui-email, revealui-memory, revealui-stripe |
| integration | neon, stripe, supabase, vercel |
| development | code-validator, next-devtools, playwright |
| helper | email-provider |

Each entry declares `id` / `name` / `description` / `category` / `transport: 'stdio'` / `modulePath` / `license: 'MIT'` / `proGated` / `requiresCredentials`.

The contracts server is the public exception (`proGated: false`) — Phase 1 of the protocol-pyramid ADR shipped in [revealui#731](https://github.com/RevealUIStudio/revealui/pull/731) explicitly does NOT call `checkMcpLicense()`, making it agent-discoverable without a Pro tier.

### Route wiring: `apps/server/src/routes/a2a.ts`

New `app.openapi(...)` block added to the existing `wellKnownRoutes` app between the `/.well-known/payment-methods.json` route and the A2A task-API section. Returns `buildMcpManifest()` with `Cache-Control: public, max-age=300` (matches the existing well-known route convention).

### 7 new Vitest tests in `apps/server/src/routes/__tests__/a2a.test.ts`

- Top-level fields (`version`, `platform`, `documentationUrl`, `servers` array)
- Exact-13 server count (regression pin against README ground-truth)
- Public access — works even when `isFeatureEnabled('ai')` returns false
- `Cache-Control: public, max-age=300` header
- Contracts server is `proGated: false` (the public exception)
- Every server entry has all required fields with correct shapes
- Server ids are unique

## Audit-first finding driving lane scope

The existing `/.well-known/agent.json` route at [`apps/server/src/routes/a2a.ts:90`](https://github.com/RevealUIStudio/revealui/blob/test/apps/server/src/routes/a2a.ts#L90) already publishes a **Pro-gated AI-agent card** via `aiMod.agentCardRegistry.getCard('revealui-creator')`. The protocol-pyramid ADR's Phase 2 framing of "each fleet member publishes its AgentCard at `/.well-known/agent.json`" has design tension with that existing implementation — replacing the AI-agent card with a fleet-member card would be a breaking change to existing tests + consumers.

3 paths surfaced before code touched:
- **Path A** (this PR): `/.well-known/mcp.json` new URL — narrowest scope, closes named audit gap directly, doesn't lock the agent.json design call
- Path B: Modernize `/.well-known/agent.json` per A2A spec (breaking)
- Path C: Both new URLs (more surface area)

Owner picked **Path A**. The fleet-member-card decision is deferred to a future ADR amendment.

## Test plan

- [x] `pnpm --filter ./apps/server typecheck` — clean exit
- [x] `pnpm --filter ./apps/server test` — 2613 passed (1 skipped baseline) including 7 new mcp.json tests
- [x] `pnpm exec biome check apps/server/src/lib/mcp-manifest.ts apps/server/src/routes/a2a.ts apps/server/src/routes/__tests__/a2a.test.ts` — clean (after import-order auto-fix)
- [x] Pre-push gate — PASS in 17.6s (Phase 1 quality + lint)
- [ ] CI: Quality, Typecheck, Unit Tests, Integration Tests, Build, Security Gate, CodeQL, Submodule Audit, Drizzle Migrations, Secret Scanning, Dependency Review

## Refs

- Audit: `docs/audits/suite-messaging-audit-2026-05-02.md` §N4 line 147
- ADR: `docs/decisions/2026-05-03-contracts-protocol-pyramid.md`
- Complement to: [revealui#720](https://github.com/RevealUIStudio/revealui/pull/720) (/llms.txt prose layer)
- Builds on: [revealui#731](https://github.com/RevealUIStudio/revealui/pull/731) (contracts MCP server, `getContractsCatalog()`)
- Adjacent: [revealui#732](https://github.com/RevealUIStudio/revealui/pull/732) (F8 Phase 3 Stage 1 — OpenAPI mirror)
