### PR TITLE
fix(server): unescape \n in REVEALUI_LICENSE_PRIVATE_KEY for /api/license/generate

### DIFF
--- a/apps/server/src/routes/__tests__/license.test.ts
+++ b/apps/server/src/routes/__tests__/license.test.ts
@@ -265,6 +265,30 @@ describe('POST /generate', () => {
     expect(res.status).toBe(401);
   });
 
+  it('unescapes literal \\n in REVEALUI_LICENSE_PRIVATE_KEY before signing', async () => {
+    // Vercel stores multi-line PEM with \n escaped in the .env format.
+    // The route must convert literal \n back to real newlines before passing
+    // the key to jose.importPKCS8 — same unescape pattern as the webhook
+    // handlers at apps/server/src/routes/webhooks.ts:1009, 1229, 1847, 2391.
+    process.env.REVEALUI_ADMIN_API_KEY = ADMIN_KEY;
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY =
+      '-----BEGIN PRIVATE KEY-----\\nMC4CAQA\\n-----END PRIVATE KEY-----';
+    mockedGenerate.mockClear();
+    mockedGenerate.mockResolvedValue('jwt.token');
+
+    const app = createApp();
+    const res = await app.request(
+      '/generate',
+      post('/generate', { tier: 'pro', customerId: 'cus_unesc' }, { 'X-Admin-API-Key': ADMIN_KEY }),
+    );
+    expect(res.status).toBe(201);
+
+    // generateLicenseKey must receive REAL newlines, not literal \n
+    const [, normalizedKey] = mockedGenerate.mock.calls[0]!;
+    expect(normalizedKey).toContain('\n');
+    expect(normalizedKey).not.toContain('\\n');
+  });
+
   it('generates a max tier license', async () => {
     process.env.REVEALUI_ADMIN_API_KEY = ADMIN_KEY;
     process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'priv-key';

--- a/apps/server/src/routes/license.ts
+++ b/apps/server/src/routes/license.ts
@@ -365,6 +365,12 @@ app.openapi(generateRoute, async (c) => {
     throw new HTTPException(500, { message: 'License signing not configured' });
   }
 
+  // Unescape literal \n sequences  -  Vercel stores multi-line PEM keys
+  // with \n escaped in the .env format; the runtime preserves the literal
+  // \n chars, so we must convert them to real newlines for jose/importPKCS8.
+  // Matches the unescape pattern at routes/webhooks.ts:1009, 1229, 1847, 2391.
+  const normalizedKey = privateKey.replaceAll('\\n', '\n');
+
   const { tier, customerId, domains, maxSites, maxUsers, expiresInDays } = c.req.valid('json');
 
   const payload: Omit<LicensePayload, 'iat' | 'exp'> = {
@@ -376,7 +382,7 @@ app.openapi(generateRoute, async (c) => {
   };
 
   const expiresInSeconds = (expiresInDays ?? 365) * 24 * 60 * 60;
-  const licenseKey = await generateLicenseKey(payload, privateKey, expiresInSeconds);
+  const licenseKey = await generateLicenseKey(payload, normalizedKey, expiresInSeconds);
 
   logger.info('License key generated', { tier, customerId });
 


### PR DESCRIPTION
## Summary

`POST /api/license/generate` was the only `REVEALUI_LICENSE_PRIVATE_KEY` consumer in the API that did not unescape literal `\n` before signing. The four webhook call sites in [`apps/server/src/routes/webhooks.ts`](apps/server/src/routes/webhooks.ts) (lines 1009, 1229, 1847, 2391) all properly call `privateKey.replaceAll('\\n', '\n')`. The admin route at [`routes/license.ts:361`](apps/server/src/routes/license.ts#L361) did not — a pre-existing inconsistency, not introduced by Phase A.

The Vercel env templates explicitly state the env var stores PEM as a single-line string with `\n` escaped:

```
# IMPORTANT: Vercel stores multi-line PEM as single-line with literal \n.
#            Paste the key with newlines replaced by \n (the webhook handler
#            calls .replace(/\\n/g, '\n') to restore them before use).
REVEALUI_LICENSE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMC4CAQ...\n-----END PRIVATE KEY-----
```

If the operator follows that template guidance, the webhook flow works but `POST /api/license/generate` returns HTTP 500 at `jose.importPKCS8` because the imported PEM string contains literal `\n` (two chars) instead of real newlines (one char).

Surfaced during CR8-P0-01 Phase D operator runbook prep (an internal repo@04e5c522b — see `docs/runbooks/CR8-P0-01-PHASE-D-CUTOVER.md` Finding 2). Fixing now so the Phase D cutover Smoke #1 passes regardless of paste format (literal newlines or `\n`-escaped — both work after this).

## Changes

- [`apps/server/src/routes/license.ts`](apps/server/src/routes/license.ts) — add the same comment block + `replaceAll` call mirrored from `webhooks.ts`. Cross-references all four webhook line numbers for future-reader parity.
- [`apps/server/src/routes/__tests__/license.test.ts`](apps/server/src/routes/__tests__/license.test.ts) — regression test: sets `REVEALUI_LICENSE_PRIVATE_KEY` to a `\n`-escaped PEM and asserts `generateLicenseKey()` receives a string with real newlines and zero literal `\n` sequences.

## Test plan

- [x] `pnpm --filter server typecheck` — clean
- [x] `pnpm --filter server test` — 2614/2614 pass (one skipped is pre-existing)
- [x] `pnpm exec biome check apps/server/src/routes/license.ts apps/server/src/routes/__tests__/license.test.ts` — no fixes applied
- [x] Pre-push gate passed locally
- [ ] Full CI gate green
- [ ] Manual squash-merge to `test`

## Audit context

This is a follow-up to CR8-P0-01 Phase A (revealui#735, [`6c728d582`](https://github.com/RevealUIStudio/revealui/commit/6c728d582)) and Phase B (revdev#42, [`7d8039bf1`](https://github.com/RevealUIStudio/revdev/commit/7d8039bf1)). Phase D cutover (Vercel env rotation + redeploy) is owner-actionable and unblocked once this lands.

Closes Cleanup Chore #1 from the Phase D runbook.
