### PR TITLE
chore(docs,marketing): Phase C2 customer-facing copy sweep — RSA/RS256 → Ed25519

### DIFF
--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -15,7 +15,7 @@ RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on to
 
 ## License
 
-The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (RS256).
+The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (Ed25519).
 
 `@revealui/mcp` and `@revealui/services` are MIT — free for any tier, including the Free plan.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -11,7 +11,7 @@
 
 ## The five primitives
 
-- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, RS256)
+- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, Ed25519)
 - [AI](https://docs.revealui.com/AI): LLM providers, MCP, A2A, agents, RAG, memory layers
 - [Database](https://docs.revealui.com/DATABASE): Drizzle ORM on NeonDB; legacy Supabase code remaining in tree during phase-out
 - [Billing (Stripe)](https://docs.revealui.com/PRO#billing): Stripe webhooks, circuit breaker, metered billing

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -82,7 +82,7 @@ const faqs = [
   },
   {
     q: 'How is the Pro tier enforced if the source is visible?',
-    a: 'License enforcement is at runtime, not at the source level. Pro packages check RS256-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
+    a: 'License enforcement is at runtime, not at the source level. Pro packages check Ed25519-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
   },
   {
     q: 'What about the rest of the RevealUI packages?',

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -51,7 +51,7 @@ const faqs = [
   {
     question: 'What is Fair Source (FSL-1.1-MIT)?',
     answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (Ed25519-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/docs/blog-drafts/02-five-primitives.md
+++ b/docs/blog-drafts/02-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.


### PR DESCRIPTION
## Summary

CR8-P0-01 Phase D smoke is GREEN end-to-end. Per Q3 split (owner-confirmed 2026-05-04), this PR ships the customer-facing copy sweep now that production reality is Ed25519.

## Phase D smoke verification

- [revealui#740](https://github.com/RevealUIStudio/revealui/pull/740) merged at [`818206850`](https://github.com/RevealUIStudio/revealui/commit/818206850) — Phase A (Ed25519 issuer + verifier) + #736 unescape fix + 8 other test-branch commits.
- `deploy.yml` SUCCESS at [run 25323325464](https://github.com/RevealUIStudio/revealui/actions/runs/25323325464) — all 5 apps deployed.
- Surfaced + filled missing `REVEALUI_ADMIN_API_KEY` env var on `revealui-api` Production scope (pre-existing P1 — admin issuance was unconditionally 401 because the var was unset; not a Phase D regression). Re-deployed via [run 25355805808](https://github.com/RevealUIStudio/revealui/actions/runs/25355805808).
- **Smoke #1** (`POST /api/license/generate`): HTTP 201, JWT header `{ alg: 'EdDSA', typ: 'JWT', kid: '...' }`, payload tier=pro + iss/aud match Phase A spec.
- **Smoke #2** (daemon `verifyLicenseJWT()`): `{ tier: 'pro', valid: true }` against the API-issued JWT. Issuer + verifier mathematically aligned end-to-end.

## Changes

6 files, 10 string substitutions (zero behavior change, copy-only):

| File | Substitution |
|---|---|
| [`apps/marketing/app/routes/FairSourcePage.tsx`](apps/marketing/app/routes/FairSourcePage.tsx) | `RS256-signed license JWTs` → `Ed25519-signed license JWTs` |
| [`apps/marketing/app/routes/PricingPage.tsx`](apps/marketing/app/routes/PricingPage.tsx) | `RS256-signed license JWTs` → `Ed25519-signed license JWTs` |
| [`docs/blog/05-five-primitives.md`](docs/blog/05-five-primitives.md) | Heading `RSA-signed JWTs` + body `signed with RS256 (RSA + SHA-256)` + `RSA-signed license key` |
| [`docs/blog-drafts/02-five-primitives.md`](docs/blog-drafts/02-five-primitives.md) | Same 3 substitutions |
| [`apps/docs/public/docs-pro/index.md`](apps/docs/public/docs-pro/index.md) | `JWT (RS256)` → `JWT (Ed25519)` |
| [`apps/docs/public/llms.txt`](apps/docs/public/llms.txt) | `license JWT … RS256` → `license JWT … Ed25519` |

Targets become `Ed25519-signed` / `EdDSA (Ed25519)` / `JWT (Ed25519)` / `Ed25519` respectively.

## Files in spec but not edited

The original spec listed `docs/blog/08-getting-started.md:598` and `docs/blog-drafts/05-getting-started.md:598`. Inspection of those line ranges shows no `RS256`/`RSA` references — pointers were stale. No edits needed.

## Test plan

- [x] grep confirms zero `RS256` / `RSA-signed` / `RSA-2048` references remain in the 6 edited files
- [ ] CI green (Quality, Typecheck, Build, Unit Tests)
- [ ] Manual `gh pr merge --squash --delete-branch`

## Audit context

Closes Phase C2 portion of CR8-P0-01. Spec at `docs/specs/cr8-p0-01-api-ed25519-migration.md`, runbook at `docs/runbooks/CR8-P0-01-PHASE-D-CUTOVER.md`. MASTER_PLAN closure commit on internal docs:main` follows separately after this merges.
