### PR TITLE
fix(marketing): strip credits pricing track claim from public copy

### DIFF
--- a/apps/marketing/app/routes/ComingSoonPage.tsx
+++ b/apps/marketing/app/routes/ComingSoonPage.tsx
@@ -22,13 +22,6 @@ const shipped: Feature[] = [
     status: 'Shipped',
     category: 'Docs',
   },
-  {
-    name: 'Agent Credits (Track B)',
-    description:
-      'Pay-per-task billing for AI agent execution. Buy credit bundles that never expire and stack with your monthly subscription allowance.',
-    status: 'Coming Soon',
-    category: 'Billing',
-  },
 ];
 
 const upcoming: Feature[] = [

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -104,7 +104,7 @@ const primitives: Primitive[] = [
         'Upgrade a customer and their agents get smarter. One product catalog, one billing system, one set of feature gates, applied consistently to every user and every agent.',
     },
     features: [
-      'Four pricing tracks (subscription, credits, perpetual, services)',
+      'Three pricing tracks (subscription, perpetual, services)',
       'Feature gating with tier enforcement',
       'Usage tracking and limit enforcement',
       'License key management',
@@ -139,7 +139,6 @@ const primitives: Primitive[] = [
       'Customer billing portal',
       'x402 agent-to-agent micropayments',
       'RevealCoin integration (Solana)',
-      'Credit bundle purchasing',
     ],
   },
   {


### PR DESCRIPTION
## Summary

Strip the "credits" pricing track claim from customer-facing marketing copy. Track B (meter billing) infrastructure exists in `apps/server` (events emit at `apps/server/src/routes/billing.ts`) but no admin UI surfaces meter-bundle purchase, so customers can't actually buy "credits" today. Advertising it breaks the moral-charge floor.

This is the last Phase-0 ethics-gate item before Stripe live-flip can proceed. Per the 2026-05-04 charge-readiness re-audit finding **CR8-P0-02**, with this PR merged the Phase-0 gate is clear.

## Surfaces touched

| File | Change |
|------|--------|
| `apps/marketing/app/routes/ProductsPage.tsx:107` | `'Four pricing tracks (subscription, credits, perpetual, services)'` → `'Three pricing tracks (subscription, perpetual, services)'` |
| `apps/marketing/app/routes/ProductsPage.tsx:142` | Removed `'Credit bundle purchasing'` feature bullet |
| `apps/marketing/app/routes/ComingSoonPage.tsx:25–30` | Removed `'Agent Credits (Track B)'` entry from `shipped` array |

## What is intentionally NOT touched

- `apps/server/src/routes/billing.ts` meter-event emission stays wired (future credits ship is a separate effort)
- `packages/billing/**` internal billing logic
- Tests for meter billing / Track B
- Database schemas / migrations referencing credits

When credits ships as a real customer-purchasable surface, the marketing claims can come back.

## Verification

```
pnpm --filter marketing typecheck   # clean (tsc --noEmit, 0 errors)
pnpm exec biome check apps/marketing/app/routes/ProductsPage.tsx apps/marketing/app/routes/ComingSoonPage.tsx   # Checked 2 files. No fixes applied.
grep -rn -iE '(credits|track.?b)' apps/marketing/app   # 0 matches
```

## Test plan

- [x] Typecheck clean
- [x] Biome clean
- [x] No remaining customer-facing references to credits/Track B in `apps/marketing`
- [ ] CI green

## Phase-0 ethics gate impact

After merge, all Phase-0 (ethics-gate) items in CR8 are closed. Remaining blockers for Stripe live-flip are owner-only operational queue items (LLC-EIN Stripe account, BOI filing, TN sales tax registration, E&O insurance) — none are agent-actionable.

Closes #391
