### PR TITLE
fix(api): close Sentry coverage gaps for live-flip readiness (GAP-S1 + GAP-S2)

### DIFF
--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -19,6 +19,7 @@ function validLiveProdEnv(overrides: EnvMap = {}): EnvMap {
     REVEALUI_KEK: HEX_64,
     REVEALUI_PUBLIC_SERVER_URL: HTTPS_URL,
     NEXT_PUBLIC_SERVER_URL: HTTPS_URL,
+    SENTRY_DSN: 'https://abc123@o123456.ingest.sentry.io/789',
     STRIPE_SECRET_KEY: 'sk_live_deadbeef',
     STRIPE_WEBHOOK_SECRET: 'whsec_deadbeef',
     REVEALUI_LICENSE_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----',
@@ -120,6 +121,12 @@ describe('validateStartup — production presence', () => {
       /REVEALUI_ALERT_EMAIL.*REVEALUI_CRON_SECRET|REVEALUI_CRON_SECRET.*REVEALUI_ALERT_EMAIL/,
     );
   });
+
+  it('rejects missing SENTRY_DSN in production hosted env', () => {
+    const env = validLiveProdEnv();
+    delete env.SENTRY_DSN;
+    expect(() => validateStartup(env)).toThrow(/SENTRY_DSN/);
+  });
 });
 
 describe('validateStartup — production format checks (live mode)', () => {
@@ -180,6 +187,12 @@ describe('validateStartup — production format checks (live mode)', () => {
   it('rejects REVEALUI_ALERT_EMAIL without an @', () => {
     expect(() => validateStartup(validLiveProdEnv({ REVEALUI_ALERT_EMAIL: 'notanemail' }))).toThrow(
       /REVEALUI_ALERT_EMAIL/,
+    );
+  });
+
+  it('rejects malformed SENTRY_DSN (no :// scheme separator)', () => {
+    expect(() => validateStartup(validLiveProdEnv({ SENTRY_DSN: 'not-a-dsn' }))).toThrow(
+      /SENTRY_DSN/,
     );
   });
 
@@ -484,6 +497,10 @@ describe('validateStartup — forge mode', () => {
     expect(() => validateStartup(validForgeProdEnv())).not.toThrow();
   });
 
+  it('does NOT require SENTRY_DSN in forge mode', () => {
+    expect(() => validateStartup(validForgeProdEnv())).not.toThrow();
+  });
+
   it('does NOT enforce HTTPS on REVEALUI_PUBLIC_SERVER_URL in forge mode', () => {
     // Forge default stack uses http://localhost — must not throw.
     expect(() =>
@@ -759,6 +776,7 @@ describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () 
       REVEALUI_LICENSE_PRIVATE_KEY: '',
       REVEALUI_SECRET: '',
       REVEALUI_KEK: '',
+      SENTRY_DSN: '',
       REVEALUI_CRON_SECRET: '',
       REVEALUI_ALERT_EMAIL: '',
       STRIPE_SECRET_KEY: '',

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -82,6 +82,7 @@ const REQUIRED_IN_PRODUCTION_HOSTED = [
   'REVEALUI_KEK',
   'REVEALUI_PUBLIC_SERVER_URL',
   'NEXT_PUBLIC_SERVER_URL',
+  'SENTRY_DSN',
   'STRIPE_SECRET_KEY',
   'STRIPE_WEBHOOK_SECRET',
   'REVEALUI_LICENSE_PRIVATE_KEY',
@@ -306,6 +307,17 @@ export function validateStartup(
     if (!(skipFormat(alertEmail) || alertEmail.includes('@'))) {
       errors.push(
         `REVEALUI_ALERT_EMAIL is not a valid email (got: ${JSON.stringify(alertEmail)}).`,
+      );
+    }
+
+    // Sentry DSN format (hosted-only — Forge customers run self-hosted without
+    // Sentry). A missing DSN silently disables all Sentry capture including the
+    // checkout-route HTTPException path; requiring it forces the operator to
+    // explicitly set it before booting in production.
+    const sentryDsn = env.SENTRY_DSN ?? '';
+    if (!(skipFormat(sentryDsn) || sentryDsn.includes('://'))) {
+      errors.push(
+        `SENTRY_DSN must be a valid DSN URL (e.g. https://<key>@<host>/<project>). Got: ${JSON.stringify(sentryDsn)}.`,
       );
     }
 

--- a/apps/server/src/lib/webhook-emails.ts
+++ b/apps/server/src/lib/webhook-emails.ts
@@ -558,6 +558,53 @@ ${context.customerId ? `<p><strong>Customer ID:</strong> <code>${escapeHtml(cont
   });
 }
 
+export async function sendCronFailureAlert(
+  email: string,
+  ctx: {
+    jobName: string;
+    error: string;
+    severity?: 'critical' | 'warning';
+    details?: Record<string, string | number>;
+  },
+): Promise<void> {
+  const level = ctx.severity ?? 'critical';
+  const prefix = level === 'critical' ? '[CRITICAL]' : '[WARNING]';
+  const detailRows =
+    ctx.details && Object.keys(ctx.details).length > 0
+      ? Object.entries(ctx.details)
+          .map(
+            ([k, v]) =>
+              `<tr><td style="padding:4px 8px;font-weight:bold;">${escapeHtml(k)}</td><td style="padding:4px 8px;">${escapeHtml(String(v))}</td></tr>`,
+          )
+          .join('')
+      : '';
+  const detailTable = detailRows
+    ? `<table style="border-collapse:collapse;margin-top:8px;">${detailRows}</table>`
+    : '';
+
+  await sendEmail({
+    to: email,
+    subject: `${prefix} RevealUI cron job ${ctx.jobName} failure`,
+    html: emailShell(
+      'Cron Job Failure',
+      `<h1 style="color: #dc2626;">Cron Job Failure</h1>
+<p><strong>Job:</strong> <code>${escapeHtml(ctx.jobName)}</code></p>
+<p><strong>Severity:</strong> ${escapeHtml(level.toUpperCase())}</p>
+<p><strong>Error:</strong> ${escapeHtml(ctx.error)}</p>
+<p><strong>Time:</strong> ${escapeHtml(new Date().toISOString())}</p>
+${detailTable ? `<p><strong>Context:</strong></p>${detailTable}` : ''}
+<p style="margin-top:16px;"><a href="${adminUrl()}/ops/cron" style="color:#2563eb;">Review in admin dashboard →</a></p>`,
+    ),
+    text: `${prefix} RevealUI cron job failure\n\nJob: ${ctx.jobName}\nSeverity: ${level.toUpperCase()}\nError: ${ctx.error}\nTime: ${new Date().toISOString()}${
+      ctx.details
+        ? `\n\nContext:\n${Object.entries(ctx.details)
+            .map(([k, v]) => `  ${k}: ${v}`)
+            .join('\n')}`
+        : ''
+    }\n\nReview at ${adminUrl()}/ops/cron`,
+  });
+}
+
 // =============================================================================
 // GitHub team provisioning  -  side-effect triggered by webhook events
 // =============================================================================

--- a/apps/server/src/routes/cron/drain-unreconciled.test.ts
+++ b/apps/server/src/routes/cron/drain-unreconciled.test.ts
@@ -12,6 +12,7 @@ const hoisted = vi.hoisted(() => ({
   updateMock: vi.fn(),
   getClientMock: vi.fn(),
   replayMock: vi.fn(),
+  sendCronFailureAlert: vi.fn().mockResolvedValue(undefined),
 }));
 const loggerMock = hoisted.logger;
 const selectMock = hoisted.selectMock;
@@ -61,6 +62,10 @@ vi.mock('@revealui/services', () => ({
     events: { retrieve: vi.fn() },
     webhooks: { generateTestHeaderStringAsync: vi.fn() },
   },
+}));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  sendCronFailureAlert: (...args: unknown[]) => hoisted.sendCronFailureAlert(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -289,5 +294,74 @@ describe('drain-unreconciled failures', () => {
     expect(body.replayed).toBe(0);
     // No resolved-by update for unresolved replay failures.
     expect(setMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendCronFailureAlert wiring
+// ---------------------------------------------------------------------------
+describe('drain-unreconciled cron alert wiring', () => {
+  const CRON_SECRET = 'test-cron-secret-xxxxxxxxxxxxxxxxxxx';
+
+  it('calls sendCronFailureAlert with severity critical when a >24h event replay fails', async () => {
+    const { db } = buildDbMock([
+      {
+        eventId: 'evt_alert_critical',
+        eventType: 'customer.subscription.deleted',
+        createdAt: new Date(Date.now() - 30 * 60 * 60 * 1000),
+      },
+    ]);
+    getClientMock.mockReturnValue(db);
+    replayMock.mockResolvedValueOnce({
+      kind: 'handler-error',
+      status: 500,
+      body: { error: 'still broken' },
+    });
+
+    await invokeDrain(CRON_SECRET);
+
+    expect(hoisted.sendCronFailureAlert).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        jobName: 'drain-unreconciled',
+        severity: 'critical',
+        details: expect.objectContaining({
+          eventId: 'evt_alert_critical',
+          eventType: 'customer.subscription.deleted',
+        }),
+      }),
+    );
+  });
+
+  it('does NOT call sendCronFailureAlert when a replay failure is not yet critical (<24h)', async () => {
+    const { db } = buildDbMock([
+      {
+        eventId: 'evt_young_fail',
+        eventType: 'invoice.payment_failed',
+        createdAt: new Date(Date.now() - 60_000),
+      },
+    ]);
+    getClientMock.mockReturnValue(db);
+    replayMock.mockResolvedValueOnce({ kind: 'handler-error', status: 500, body: null });
+
+    await invokeDrain(CRON_SECRET);
+
+    expect(hoisted.sendCronFailureAlert).not.toHaveBeenCalled();
+  });
+
+  it('completes without throwing when sendCronFailureAlert rejects (fail-safe)', async () => {
+    hoisted.sendCronFailureAlert.mockRejectedValueOnce(new Error('smtp down'));
+    const { db } = buildDbMock([
+      {
+        eventId: 'evt_alert_failsafe',
+        eventType: 'charge.refunded',
+        createdAt: new Date(Date.now() - 30 * 60 * 60 * 1000),
+      },
+    ]);
+    getClientMock.mockReturnValue(db);
+    replayMock.mockResolvedValueOnce({ kind: 'handler-error', status: 502, body: null });
+
+    const res = await invokeDrain(CRON_SECRET);
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/server/src/routes/cron/drain-unreconciled.ts
+++ b/apps/server/src/routes/cron/drain-unreconciled.ts
@@ -37,6 +37,7 @@ import { unreconciledWebhooks } from '@revealui/db/schema';
 import { protectedStripe } from '@revealui/services';
 import { and, asc, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { sendCronFailureAlert } from '../../lib/webhook-emails.js';
 import { replayStripeEvent } from '../../lib/webhook-replay.js';
 import webhooksApp from '../webhooks.js';
 
@@ -213,6 +214,20 @@ app.post('/drain-unreconciled', async (c) => {
         undefined,
         { eventId: row.eventId, eventType: row.eventType, ageMs, detail },
       );
+      sendCronFailureAlert(process.env.REVEALUI_ALERT_EMAIL || 'founder@revealui.com', {
+        jobName: 'drain-unreconciled',
+        error: detail ?? 'replay failed',
+        severity: 'critical',
+        details: {
+          eventId: row.eventId,
+          eventType: row.eventType,
+          ageHours: Math.floor(ageMs / (60 * 60 * 1000)),
+        },
+      }).catch((err: unknown) => {
+        logger.error('[drain-unreconciled] failed to send cron failure alert', undefined, {
+          alertError: err instanceof Error ? err.message : String(err),
+        });
+      });
     } else {
       logger.warn(`[drain-unreconciled] replay failed for ${row.eventId}`, {
         eventType: row.eventType,

--- a/apps/server/src/routes/cron/reconcile-subscriptions.test.ts
+++ b/apps/server/src/routes/cron/reconcile-subscriptions.test.ts
@@ -8,6 +8,7 @@ const hoisted = vi.hoisted(() => ({
   selectMock: vi.fn(),
   getClientMock: vi.fn(),
   retrieveMock: vi.fn(),
+  sendCronFailureAlert: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({ logger: hoisted.logger }));
@@ -38,6 +39,10 @@ vi.mock('@revealui/services', () => ({
   protectedStripe: {
     subscriptions: { retrieve: hoisted.retrieveMock },
   },
+}));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  sendCronFailureAlert: (...args: unknown[]) => hoisted.sendCronFailureAlert(...args),
 }));
 
 import reconcileApp from './reconcile-subscriptions.js';
@@ -296,5 +301,68 @@ describe('reconcile-subscriptions drift detection', () => {
     // deny service; classify as WARN not CRITICAL.
     expect(body.critical).toBe(0);
     expect(hoisted.logger.error).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendCronFailureAlert wiring
+// ---------------------------------------------------------------------------
+describe('reconcile-subscriptions cron alert wiring', () => {
+  const activeLocal: LocalRow = {
+    accountId: 'acct_alert_1',
+    stripeSubscriptionId: 'sub_alert_1',
+    status: 'active',
+    currentPeriodEnd: new Date('2026-05-01T00:00:00Z'),
+    cancelAtPeriodEnd: false,
+  };
+
+  it('calls sendCronFailureAlert with severity critical on missing-in-stripe', async () => {
+    hoisted.getClientMock.mockReturnValue(buildDbMock([activeLocal]));
+    const err = new Error('No such subscription') as Error & { statusCode: number };
+    err.statusCode = 404;
+    hoisted.retrieveMock.mockRejectedValueOnce(err);
+
+    await invoke(GOOD_SECRET);
+
+    expect(hoisted.sendCronFailureAlert).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        jobName: 'reconcile-subscriptions',
+        severity: 'critical',
+        details: expect.objectContaining({ accountId: 'acct_alert_1' }),
+      }),
+    );
+  });
+
+  it('calls sendCronFailureAlert with severity critical on entitlement-ending status drift', async () => {
+    hoisted.getClientMock.mockReturnValue(buildDbMock([activeLocal]));
+    hoisted.retrieveMock.mockResolvedValueOnce(
+      fakeStripeSub({ status: 'canceled', currentPeriodEndUnix: 1 }),
+    );
+
+    await invoke(GOOD_SECRET);
+
+    expect(hoisted.sendCronFailureAlert).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        jobName: 'reconcile-subscriptions',
+        severity: 'critical',
+      }),
+    );
+  });
+
+  it('does NOT call sendCronFailureAlert on non-critical drift (period-end only)', async () => {
+    hoisted.getClientMock.mockReturnValue(buildDbMock([activeLocal]));
+    hoisted.retrieveMock.mockResolvedValueOnce(
+      fakeStripeSub({
+        status: 'active',
+        currentPeriodEndUnix:
+          Math.floor(activeLocal.currentPeriodEnd!.getTime() / 1000) + 30 * 86400,
+      }),
+    );
+
+    await invoke(GOOD_SECRET);
+
+    expect(hoisted.sendCronFailureAlert).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/routes/cron/reconcile-subscriptions.ts
+++ b/apps/server/src/routes/cron/reconcile-subscriptions.ts
@@ -29,6 +29,7 @@ import { protectedStripe } from '@revealui/services';
 import { and, inArray, isNotNull } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type Stripe from 'stripe';
+import { sendCronFailureAlert } from '../../lib/webhook-emails.js';
 
 const app = new Hono();
 
@@ -202,6 +203,20 @@ app.post('/reconcile-subscriptions', async (c) => {
           undefined,
           { ...report },
         );
+        sendCronFailureAlert(process.env.REVEALUI_ALERT_EMAIL || 'founder@revealui.com', {
+          jobName: 'reconcile-subscriptions',
+          error: report.detail ?? 'missing-in-stripe',
+          severity: 'critical',
+          details: {
+            accountId: report.accountId,
+            stripeSubscriptionId: report.stripeSubscriptionId,
+            localStatus: report.local.status,
+          },
+        }).catch((err: unknown) => {
+          logger.error('[reconcile-subscriptions] failed to send cron failure alert', undefined, {
+            alertError: err instanceof Error ? err.message : String(err),
+          });
+        });
         continue;
       }
 
@@ -269,6 +284,21 @@ app.post('/reconcile-subscriptions', async (c) => {
           undefined,
           { ...report },
         );
+        sendCronFailureAlert(process.env.REVEALUI_ALERT_EMAIL || 'founder@revealui.com', {
+          jobName: 'reconcile-subscriptions',
+          error: `status drift ${row.status}→${stripeStatus ?? 'unknown'} for account ${row.accountId}`,
+          severity: 'critical',
+          details: {
+            accountId: report.accountId,
+            stripeSubscriptionId: report.stripeSubscriptionId,
+            localStatus: report.local.status,
+            stripeStatus: report.stripe?.status ?? 'unknown',
+          },
+        }).catch((err: unknown) => {
+          logger.error('[reconcile-subscriptions] failed to send cron failure alert', undefined, {
+            alertError: err instanceof Error ? err.message : String(err),
+          });
+        });
       } else {
         logger.warn(`[reconcile-subscriptions] status drift ${row.status}→${stripeStatus}`, {
           ...report,


### PR DESCRIPTION
Closes the GAP-S1 / GAP-S2 lane from the 2026-05-05 Sentry coverage audit at internal docs.

Both gaps were triage P1. This is the final agent-actionable code PR before the Stripe live-mode flip — all remaining blockers after this merge are owner-action-only (close old Stripe account, create new under LLC EIN, enable Stripe Tax, Vouch underwriter, mailboxes).

## GAP-S1 — SENTRY_DSN required in production hosted env

**File:** `apps/server/src/lib/validate-startup.ts:80`

- Added `'SENTRY_DSN'` to `REQUIRED_IN_PRODUCTION_HOSTED` list
- Added format check: must include `://` (mirrors existing `REVEALUI_ALERT_EMAIL` pattern)
- Forge mode explicitly excluded — Forge customers run self-hosted without Sentry
- Updated `validLiveProdEnv` fixture + `sensitivePulledEnv` lenient-mode fixture to include `SENTRY_DSN`

**Tests added (3):**
- `rejects missing SENTRY_DSN in production hosted env`
- `rejects malformed SENTRY_DSN (no :// scheme separator)`
- `does NOT require SENTRY_DSN in forge mode`

## GAP-S2 — Cron critical-drift alerts wired

**Files:** `apps/server/src/lib/webhook-emails.ts`, `apps/server/src/routes/cron/reconcile-subscriptions.ts`, `apps/server/src/routes/cron/drain-unreconciled.ts`

- New `sendCronFailureAlert(email, ctx)` exported from `webhook-emails.ts` — semantically distinct from `sendWebhookFailureAlert` (no Stripe event ID shape; cron-appropriate subject/body)
- `reconcile-subscriptions`: alerts on `missing-in-stripe` drift (404 from Stripe against a live-local row) + entitlement-ending status drift (`active → canceled/unpaid/paused`)
- `drain-unreconciled`: alerts on `>24h` replay failure
- All three call sites use fire-and-forget `.catch()` per the `webhooks.ts:3262` fail-safe pattern — alert failure does not crash the cron job

**Tests added (6):**
- `reconcile-subscriptions`: calls alert on missing-in-stripe, calls alert on entitlement-ending drift, does NOT call alert on non-critical drift
- `drain-unreconciled`: calls alert on >24h replay fail, does NOT call alert on <24h fail, completes without throwing when alert rejects (fail-safe)

## Verification

```
pnpm --filter server typecheck    ✓ clean
pnpm exec biome check <7 files>   ✓ clean (4 format fixes applied, re-typecheck clean)
pnpm --filter server test --run   ✓ 0 new failures introduced (8 pre-existing failures unchanged on main)
pre-push gate (CI phase 1)        ✓ PASS
```

Pre-existing failures are in `validate-startup.test.ts` (JWT tests — node:crypto issue unrelated to this PR), `pricing-accuracy.test.ts` (Enterprise label), and `billing-services-renewal.test.ts` (perpetual tier) — all present on `main` before this branch.
