### PR TITLE
chore(marketing): pillar 4 phase 1 truthing pass

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -143,7 +143,7 @@ export function Footer() {
                   rel="noopener noreferrer"
                   className="hover:text-white transition-colors"
                 >
-                  Studio (agency) →
+                  RevealUI Studio (agency) →
                 </a>
               </li>
               <li>

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -20,8 +20,8 @@ const faqs = [
     a: 'Built behind a full CI gate: Biome lint, Vitest unit and integration, Playwright E2E, CodeQL, Gitleaks, dependency auditing. The full feature set is covered by the test suite, and every PR runs the gate before it can land. Used in production by the team that maintains it.',
   },
   {
-    q: "What's the rest of the suite?",
-    a: 'RevealUI is the runtime. RevVault handles secrets. RevKit is the portable dev environment. RevDev is the AI engineering harness. Forge is a portable demo lab. You can use RevealUI without any of the others — they ship and version independently.',
+    q: "What's the rest of the RevFleet?",
+    a: 'RevealUI is the runtime. RevVault handles secrets. RevKit is the portable dev environment. RevDev is the AI engineering harness. RevForge is the stamping tool that produces branded RevealUI Fleet deployments. You can use RevealUI without any of the others — they ship and version independently.',
   },
 ];
 

--- a/apps/marketing/app/routes/ComingSoonPage.tsx
+++ b/apps/marketing/app/routes/ComingSoonPage.tsx
@@ -42,29 +42,29 @@ const upcoming: Feature[] = [
   {
     name: 'MCP Marketplace',
     description:
-      'A registry where developers publish and discover MCP servers and AI agent capabilities. 80% revenue share for developers. Discoverable via Smithery, mcpt, and the RevealUI marketplace.',
-    status: 'Planned: Q3 2026',
+      'A registry where developers publish and discover MCP servers and AI agent capabilities. Revenue share model for developers. Discoverable via Smithery, mcpt, and the RevealUI registry.',
+    status: 'Planned — in design',
     category: 'AI',
   },
   {
-    name: 'Self-Hosted Docker Images (Forge)',
+    name: 'Self-Hosted Docker Images (RevealUI Fleet)',
     description:
       'Official Docker images published to GitHub Container Registry for fully self-hosted deployment. Domain-locked licensing, air-gap capable.',
-    status: 'Planned: Q3 2026',
+    status: 'Planned — designed, not built',
     category: 'Infrastructure',
   },
   {
     name: 'Visual Builder',
     description:
       'A no-code visual builder for creating RevealUI sites. Drag-and-drop page building, component customization, and one-click deployment.',
-    status: 'Planned: Q4 2026+',
+    status: 'Planned — backlog',
     category: 'Product',
   },
   {
     name: 'Enterprise SSO / SAML',
     description:
       'Single sign-on via SAML for enterprise customers. Advanced audit logging, custom RBAC policy editor, and multi-region deployment support.',
-    status: 'Planned: Q3 2026',
+    status: 'Planned — designed, not built',
     category: 'Enterprise',
   },
 ];

--- a/apps/marketing/app/routes/MarketplacePage.tsx
+++ b/apps/marketing/app/routes/MarketplacePage.tsx
@@ -77,9 +77,9 @@ const mcpServers: McpServer[] = [
     status: 'live',
   },
   {
-    name: 'Email Provider',
-    description: 'Shared helper surface powering the other email-capable MCP servers.',
-    category: 'Communication',
+    name: 'Contracts',
+    description: 'Validate pricing contracts, check OpenAPI mirror drift, and inspect schema.',
+    category: 'Development',
     status: 'live',
   },
 ];
@@ -102,14 +102,14 @@ export function MarketplacePage() {
       <section className="relative overflow-hidden bg-gradient-to-br from-violet-50 via-white to-purple-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
-            Agent-commerce
+            MCP server
             <span className="block bg-gradient-to-r from-violet-600 to-purple-600 bg-clip-text text-transparent">
-              ecosystem
+              catalog
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Agents discover tools via MCP. Developers publish capabilities. Revenue flows
-            automatically through x402 micropayments and RevealCoin.
+            12 first-party MCP servers, RBAC-scoped and audit-logged. Agents discover tools via MCP.
+            RevealUI implements MCP natively.
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-3">
             <a
@@ -119,23 +119,17 @@ export function MarketplacePage() {
               MCP Servers
             </a>
             <a
-              href="#publish"
+              href="#discovery"
               className="rounded-full bg-purple-100 px-4 py-1.5 text-sm font-medium text-purple-700 hover:bg-purple-200 transition-colors"
             >
-              Publish
-            </a>
-            <a
-              href="#payments"
-              className="rounded-full bg-amber-100 px-4 py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-200 transition-colors"
-            >
-              Agent Payments
+              How agents discover tools
             </a>
           </div>
         </div>
       </section>
 
       {/* How agents discover tools */}
-      <section className="py-24 sm:py-32">
+      <section id="discovery" className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-3xl text-center mb-16">
             <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
@@ -152,7 +146,7 @@ export function MarketplacePage() {
                 step: '1',
                 title: 'Discover',
                 description:
-                  'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities, required permissions, and pricing.',
+                  'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities and required permissions.',
               },
               {
                 step: '2',
@@ -229,127 +223,42 @@ export function MarketplacePage() {
         </div>
       </section>
 
-      {/* Publish capabilities */}
-      <section id="publish" className="py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl">
-            <div className="text-center mb-16">
-              <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-                Publish your capabilities
-              </h2>
-              <p className="mt-4 text-lg text-gray-600">
-                Build an MCP server. Publish it to the marketplace. Earn revenue every time an agent
-                uses it.
-              </p>
-            </div>
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-              <div className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200">
-                <h3 className="text-lg font-bold text-gray-900">For developers</h3>
-                <ul className="mt-4 space-y-3">
-                  {[
-                    'Build MCP servers with the RevealUI adapter framework',
-                    'Publish to the marketplace with a single command',
-                    'Set your own pricing per tool call',
-                    'Discoverable via Smithery, mcpt, and the RevealUI registry',
-                    'Analytics dashboard for usage and revenue',
-                  ].map((item) => (
-                    <li key={item} className="flex items-start gap-2 text-sm text-gray-600">
-                      <svg
-                        className="mt-0.5 h-4 w-4 shrink-0 text-violet-500"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        role="img"
-                        aria-label="Included"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="rounded-2xl bg-gradient-to-br from-gray-900 to-gray-800 p-8 shadow-lg">
-                <h3 className="text-lg font-bold text-white">Revenue share</h3>
-                <p className="mt-4 text-5xl font-bold text-white">80/20</p>
-                <p className="mt-2 text-sm text-gray-400">
-                  You keep 80% of every transaction. RevealUI takes 20% for infrastructure,
-                  discovery, and payment processing.
-                </p>
-                <div className="mt-6 rounded-lg bg-white/5 px-4 py-3 ring-1 ring-white/10">
-                  <p className="text-xs text-gray-400">
-                    Revenue settles daily via Stripe Connect or RevealCoin. No minimum payout
-                    threshold.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Agent payments */}
-      <section id="payments" className="bg-gray-950 py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl text-center mb-16">
-            <span className="text-sm font-semibold tracking-wide text-amber-400 uppercase">
-              Agent-Native Payments
+      {/* Publishing & monetization — coming soon callout */}
+      <section className="py-24 sm:py-32">
+        <div className="mx-auto max-w-3xl px-6 lg:px-8">
+          <div className="rounded-2xl bg-violet-50 ring-1 ring-violet-200 p-10 text-center">
+            <span className="inline-block text-xs font-semibold text-violet-700 bg-violet-100 px-3 py-1 rounded-full ring-1 ring-violet-200 mb-4">
+              Coming after marketplace v1
             </span>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-              x402 protocol + RevealCoin
+            <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
+              Publishing and monetization
             </h2>
-            <p className="mt-4 text-lg text-gray-400">
-              Agents pay per task via the HTTP 402 payment protocol. No accounts, no subscriptions -
-              micropayments that settle on Solana.
-            </p>
-            <span className="mt-3 inline-block text-xs font-semibold text-amber-300 bg-amber-400/10 px-3 py-1 rounded-full ring-1 ring-amber-400/20">
-              Coming soon
-            </span>
-          </div>
-          <div className="mx-auto max-w-4xl grid grid-cols-1 gap-6 sm:grid-cols-3">
-            <div className="rounded-2xl bg-gray-900 ring-1 ring-white/10 p-6">
-              <h3 className="text-base font-semibold text-white">HTTP 402</h3>
-              <p className="mt-2 text-sm text-gray-400">
-                Standard HTTP status code for payment required. Agents receive a 402 response with
-                payment instructions, pay, and retry, all programmatically.
-              </p>
-            </div>
-            <div className="rounded-2xl bg-gray-900 ring-1 ring-white/10 p-6">
-              <h3 className="text-base font-semibold text-white">RevealCoin (RVUI)</h3>
-              <p className="mt-2 text-sm text-gray-400">
-                SPL token on Solana optimized for agent-to-agent micropayments. Sub-cent
-                transactions with near-instant settlement. Subscribers get a 15% discount when
-                paying with RVUI.
-              </p>
-            </div>
-            <div className="rounded-2xl bg-gray-900 ring-1 ring-white/10 p-6">
-              <h3 className="text-base font-semibold text-white">Agent Card</h3>
-              <p className="mt-2 text-sm text-gray-400">
-                Agents discover RevealUI via a standard Agent Card at /.well-known/agent.json.
-                Capabilities, skills, and pricing are all machine-readable.
-              </p>
-            </div>
-          </div>
-          <div className="mt-10 text-center">
-            <p className="text-sm text-gray-400">
-              $0.001 per agent task. First 1,000 tasks/month free on every plan.
+            <p className="mt-4 text-base text-gray-600">
+              Third-party MCP server publishing, developer earnings, and marketplace discovery are
+              planned for a future release. See the{' '}
+              <a
+                href="https://github.com/RevealUIStudio/revealui/blob/main/docs/ROADMAP.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-violet-700 underline hover:text-violet-600"
+              >
+                public roadmap
+              </a>{' '}
+              for current status — listed under "Agent Marketplace" in the Mid-Term section.
             </p>
           </div>
         </div>
       </section>
 
       {/* CTA */}
-      <section className="py-24 sm:py-32">
+      <section className="bg-gray-50 py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
           <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-            Build for the marketplace
+            Start with the MCP server catalog
           </h2>
           <p className="mt-6 text-lg leading-8 text-gray-600">
-            Start with the MCP adapter framework. Publish your first server. Earn revenue from every
-            agent that uses it.
+            12 first-party servers ship with every RevealUI install. Read the MCP docs to wire your
+            agents.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -61,7 +61,7 @@ const faqs = [
   {
     question: 'What is the RevealUI ecosystem?',
     answer:
-      'RevealUI is part of a four-project ecosystem. RevVault provides age-encrypted secret management (CLI free, desktop app Pro). RevKit provides portable dev environment provisioning (agent coordination protocol free, full provisioning Max). RevealCoin enables agent-native micropayments via the x402 protocol (Enterprise tier). Each project works independently. Together they cover building, securing, and monetizing agentic software.',
+      'RevealUI is part of a four-project ecosystem. RevVault provides age-encrypted secret management (CLI free, desktop app Pro). RevKit provides portable dev environment provisioning (agent coordination protocol free, full provisioning Max). RevealCoin (RVC) is the Token-2022 on Solana designed for x402 agent micropayments — currently a pre-launch devnet proof-of-concept; public distribution is gated on on-chain vesting and multi-sig. See the roadmap for current status. Each project works independently. Together they cover building, securing, and monetizing agentic software.',
   },
 ];
 
@@ -95,14 +95,14 @@ export function PricingPage() {
       <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
-            Three ways to use
+            Two ways to use
             <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
               RevealUI
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Subscribe monthly, buy a perpetual license, or book expert services. Start free. Upgrade
-            when you need to.
+            Subscribe monthly or book expert services. Perpetual licenses coming soon. Start free.
+            Upgrade when you need to.
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium">
             <a
@@ -341,7 +341,8 @@ export function PricingPage() {
                   No accounts, no subscriptions. Pay exactly for what you use.
                 </p>
                 <p className="mt-3 text-xs text-gray-400">
-                  $0.001 per agent task · First 1,000/month free · Powered by RevealCoin
+                  Pricing model: per-call, paid in RVC. Final pricing locked when RevealCoin mainnet
+                  launches.
                 </p>
               </div>
 
@@ -364,7 +365,7 @@ export function PricingPage() {
                 </div>
                 <h3 className="text-base font-semibold text-white">MCP Servers</h3>
                 <p className="mt-2 text-sm text-gray-400">
-                  11 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright,
+                  12 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright,
                   Next.js DevTools, content management, and email. Marketplace discovery coming
                   soon.
                 </p>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -104,12 +104,12 @@ const primitives: Primitive[] = [
         'Upgrade a customer and their agents get smarter. One product catalog, one billing system, one set of feature gates, applied consistently to every user and every agent.',
     },
     features: [
-      'Three pricing tracks (subscription, perpetual, services)',
+      'Two pricing tracks (subscription, services). Perpetual licenses coming soon.',
       'Feature gating with tier enforcement',
       'Usage tracking and limit enforcement',
       'License key management',
       'Upgrade prompts and billing portal',
-      'Agent task allowances per tier',
+      'Agent task billing in development — unlimited during early access',
     ],
   },
   {
@@ -124,21 +124,21 @@ const primitives: Primitive[] = [
         'Stripe checkout, subscription management, webhooks, and a customer billing portal. Products, prices, and webhooks are wired up. You configure your Stripe keys and start charging.',
     },
     forAgents: {
-      headline: 'x402 protocol enables agent-to-agent micropayments',
+      headline: 'x402 protocol design — coming with RevealCoin mainnet',
       description:
-        'Agents pay per task via the HTTP 402 payment protocol using RevealCoin on Solana. No accounts, no subscriptions, no human intervention required for agent transactions.',
+        'The x402 design routes agent payments via HTTP 402 using RevealCoin on Solana. This is in development and gated on RevealCoin mainnet launch. See the roadmap for current status.',
     },
     together: {
       headline: 'Humans monetize. Agents transact. One billing infrastructure.',
       description:
-        'Human customers pay through Stripe. Agents pay through x402. Both flows settle into the same revenue system. One business, two payment rails.',
+        'Human customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
     },
     features: [
       'Stripe checkout and subscriptions',
       'Webhook handling and event processing',
       'Customer billing portal',
-      'x402 agent-to-agent micropayments',
-      'RevealCoin integration (Solana)',
+      'x402 agent payments (in development)',
+      'RevealCoin on Solana (pre-launch)',
     ],
   },
   {
@@ -155,7 +155,7 @@ const primitives: Primitive[] = [
     forAgents: {
       headline: 'A2A protocol, CRDT memory, and MCP servers',
       description:
-        'Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and 11 production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.',
+        'Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and 12 production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.',
     },
     together: {
       headline: 'Build one business. Agents extend it. Neither locked to any vendor.',
@@ -165,7 +165,7 @@ const primitives: Primitive[] = [
     features: [
       'Open-model inference (Snaps, Ollama)',
       'CRDT-based agent memory (working + episodic + vector)',
-      '11 production MCP servers',
+      '12 production MCP servers',
       'A2A agent-to-agent protocol',
       'Multi-agent coordination and orchestration',
     ],
@@ -319,10 +319,10 @@ export function ProductsPage() {
           </div>
           <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
             {[
-              { stat: '57', label: 'UI components' },
-              { stat: '81', label: 'Database tables' },
-              { stat: '20,000+', label: 'Tests' },
-              { stat: '11', label: 'MCP servers' },
+              { stat: '26', label: 'npm packages' },
+              { stat: '86', label: 'Database tables' },
+              { stat: '187+', label: 'Security tests' },
+              { stat: '12', label: 'MCP servers' },
             ].map((item) => (
               <div key={item.label} className="text-center">
                 <p className="text-4xl font-bold tracking-tight text-white sm:text-5xl">

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -45,8 +45,7 @@ const tiers = [
       'All Gold Sponsor benefits',
       'Logo with link on landing page',
       'Dedicated Discourse channel',
-      'Direct input on architecture decisions',
-      'Custom feature development priority',
+      'Direct line to the founder for prioritized feature requests — implementation scoped separately via RevealUI Studio engagements',
     ],
   },
 ];


### PR DESCRIPTION
Closes #none — internal copy-quality work (no user-facing issue to close).

## Summary

Pillar 4 Phase 1 brutal-truthing pass per `docs/spec-2026-05-05-public-copy-overhaul.md`. Strips false, drift-risk, and aspirational-disguised-as-shipped claims from revealui.com marketing surfaces. No code logic changes — copy strings and component structure only.

All 5 primary + 3 secondary scope-trap decisions confirmed by owner before implementation: M1, M2, M4, M6, M7, M8, M10.

## Changes by M-item

**M1 — /marketplace demoted to server-catalog**
- `MarketplacePage.tsx`: stripped entire publish/earn section (publish flow, 80/20 revenue share, Stripe Connect daily settlement — all unshipped). Added "Publishing and monetization — coming after marketplace v1" callout linking to ROADMAP.md. Hero H1 changed from "Agent-commerce ecosystem" to "MCP server catalog". Updated `mcpServers` array to match `packages/mcp/src/servers/` directory (replaced Email Provider helper entry with Contracts server).

**M2 — Strip all RVC/x402 pricing quotes**
- `MarketplacePage.tsx`: removed `RevealCoin (RVUI)` card entirely, removed `$0.001 per agent task. First 1,000 tasks/month free`, removed "Agents pay per task" agent-payments section
- `PricingPage.tsx`: `$0.001 per agent task · First 1,000/month free · Powered by RevealCoin` replaced with `Pricing model: per-call, paid in RVC. Final pricing locked when RevealCoin mainnet launches.`
- `PricingPage.tsx` FAQ: RevealCoin ecosystem answer now explicitly states pre-launch devnet status, on-chain vesting gate, and links to roadmap
- `ProductsPage.tsx`: Payments primitive `forAgents` card changed from "x402 enables agent-to-agent micropayments" to "x402 design — coming with RevealCoin mainnet"; features updated to "(in development)" / "(pre-launch)" qualifiers

**M4 — Sponsor perk overlap with agency Custom Build**
- `SponsorPage.tsx`: Platinum tier "Custom feature development priority" replaced with "Direct line to the founder for prioritized feature requests — implementation scoped separately via RevealUI Studio engagements."

**M6 — Calendar dates replaced with ROADMAP status labels**
- `ComingSoonPage.tsx`: all "Planned: Q3 2026" / "Planned: Q4 2026+" replaced with ROADMAP-style labels: "Planned — in design", "Planned — designed, not built", "Planned — backlog". Removed "80% revenue share" claim from MCP Marketplace description.

**M7 — Stat block corrected to ground truth**
- `ProductsPage.tsx` stat block: `{ 57, UI components }` → `{ 26, npm packages }` (ROADMAP); `{ 81, Database tables }` → `{ 86 }` (ROADMAP + direct count confirmed); `{ 20,000+, Tests }` → `{ 187+, Security tests }` (verifiable from ROADMAP "187 security tests"); `{ 11, MCP servers }` → `{ 12 }` (direct count of `packages/mcp/src/servers/*.ts` excluding `_*` helpers and `adapter.ts`).
- All inline "11 MCP servers" → "12" fixed across `ProductsPage.tsx` and `PricingPage.tsx`.

**M8 — Track B residue sweep**
- Grep result: zero `credits`/`track-b`/`usage-based`/`meter-bundle` customer-facing references in marketing app. Confirmed clean.

**M10 — Brand rename in public copy strings**
- `Faq.tsx`: "Forge is a portable demo lab" → RevForge description; "What's the rest of the suite?" → "...the RevFleet?"
- `ComingSoonPage.tsx`: "Self-Hosted Docker Images (Forge)" → "Self-Hosted Docker Images (RevealUI Fleet)"
- `Footer.tsx`: "Studio (agency) →" → "RevealUI Studio (agency) →"

**Additional fixes (within M2/M7 scope)**
- `ProductsPage.tsx`: "Three pricing tracks" → "Two pricing tracks... Perpetual licenses coming soon"; "Agent task allowances per tier" → honest early-access copy
- `PricingPage.tsx`: "Three ways to use" → "Two ways to use" in hero + subtext

## Real stat numbers used in M7

- Database tables: **86** — verified via `grep -c 'pgTable' packages/db/src/schema/*.ts` = 86
- MCP servers: **12** — verified via `ls packages/mcp/src/servers/*.ts | grep -v _* | grep -v adapter` = 12 (code-validator, contracts, neon, next-devtools, playwright, revealui-content, revealui-email, revealui-memory, revealui-stripe, stripe, supabase, vercel)
- Security tests: **187+** — from ROADMAP.md "187 security tests"; replaced unverifiable "20,000+" with this verifiable number; total test suite count not claimed

Note: the pre-push gate's `structure.ts` validator reported "MCP servers: 13" — this counts the `adapter.ts` base class as a server. The public-facing count uses 12 (actual server implementations), which matches what ROADMAP.md states and what the spec recommends.

## Verification

- `pnpm --filter marketing typecheck` — clean
- `pnpm exec biome check` on all 7 changed files — clean
- Pre-push gate: all 17 checks pass including `Claim drift (hard fail)` reporting "0 mismatches, Internal $RVUI ticker leaks: 0"
- Post-edit grep: zero residues for `RVUI`, `0.001`, `80.*20.*revenue`, `11 MCP`, `81.*Database`, `20,000`, `Three ways to use`

## Visual verification

Not done — marketing app dev server not started. TypeScript + Biome + claim-drift validator confirm correctness.

## Out of scope — surfaced for follow-up

1. `ProductsPage.tsx:33` — "RBAC with 58 enforcement tests" (spec §2.2 flags as 🔍 unverified against test file count). Not in M1–M10 scope.
2. `ComingSoonPage.tsx` shipped items ("Dashboard Agent Chat") — spec §2.2 flags as 🔍 needs owner verify that it's wired in production admin. Not in scope.
3. `PricingPage.tsx:63-64` — RevKit described as "Max" tier but brand-naming.md says "Pro". Needs reconciliation in Phase 3 copy overhaul.
4. `Hero.tsx:128-130` — "Local dev stack in 60 seconds" — owner verify flag from spec. Not in scope.
5. `FairSourcePage.tsx` FSL package list — spec flags potential drift if a third package went FSL. One-line check deferred.
6. Agency site (`~/suite/agency/`) changes — deferred to a separate PR per spec Phase 2 (fleet-vs-agency conceptual split). This PR is revealui-monorepo marketing only.

## Phase 2 next lane

Fleet-vs-agency conceptual split (agency site scaffold or copy migration). Owner direction required before starting — do NOT auto-proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
