### PR TITLE
chore(marketing,docs): sweep M10 brand-rename residues missed in #745

### DIFF
--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -216,7 +216,7 @@ export function FairSourcePage() {
               Which RevealUI packages are Fair Source.
             </h2>
             <p className="mt-6 text-base leading-7 text-gray-600">
-              Two packages today. Every other package in the suite is plain MIT — no non-compete, no
+              Two packages today. Every other package in RevFleet is plain MIT — no non-compete, no
               time limit, fully open source.
             </p>
           </div>

--- a/docs/suite/revdev.md
+++ b/docs/suite/revdev.md
@@ -52,5 +52,5 @@ Active. Pre-launch (no published binaries). The harness daemon is documented in 
 ## See also
 
 - [RevealUI Pro overview](../PRO) — what the Pro tier unlocks (including Studio's Pro features)
-- [Suite overview](../SUITE) — how RevDev relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevDev relates to the rest of RevFleet
 - [RevDev README](https://github.com/RevealUIStudio/revdev/blob/main/README.md) — canonical product docs

--- a/docs/suite/revealcoin.md
+++ b/docs/suite/revealcoin.md
@@ -65,7 +65,7 @@ Pre-launch (mainnet mint deployed, public distribution gated).
 
 ## See also
 
-- [Suite overview](../SUITE) — how RevealCoin relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevealCoin relates to the rest of RevFleet
 - [Marketplace](../MARKETPLACE) — where RVC pricing flows in once public distribution opens
 - [HTTP 402 Payments blog post](../blog/02-http-402-payments) — payment-protocol context
 - [RevealCoin README](https://github.com/RevealUIStudio/revealcoin/blob/main/README.md) — canonical product docs


### PR DESCRIPTION
## Summary

Three customer-facing prose hits the prior Phase-1 truthing PR ([#745](https://github.com/RevealUIStudio/revealui/pull/745)) didn't catch. Closes the M10 brand-rename gap so Phase 1 of the Pillar 4 public-copy overhaul is genuinely complete.

## Surfaces touched

| File | Line | Change |
|------|------|--------|
| `apps/marketing/app/routes/FairSourcePage.tsx` | 219 | "Every other package in **the suite** is plain MIT" → "Every other package in **RevFleet** is plain MIT" |
| `docs/suite/revdev.md` | 55 | "how RevDev relates to the rest of **the suite**" → "rest of **RevFleet**" |
| `docs/suite/revealcoin.md` | 68 | "how RevealCoin relates to the rest of **the suite**" → "rest of **RevFleet**" |

Per the rename memory: "the Suite" → "RevFleet" is the locked rename for public copy.

## Intentionally NOT in this PR

- The link text "Suite overview" and the link target `../SUITE` are unchanged. The canonical [`docs/suite/SUITE.md`](docs/suite/SUITE.md) still has title "RevealUI Studio Suite"; renaming the doc + the cross-link sweep across every page that links to `../SUITE` is a **separate Phase 2 follow-up**.
- The two `apps/docs/public/suite/{revdev,revealcoin}.md` files are gitignored (they're build-time copies of `docs/suite/`); editing the canonical sources here is enough.
- `apps/docs/public/SECRETS.md` "every secret the suite depends on" prose is left as-is — technical / developer docs in the docs site, not customer marketing. Out of scope.

## Phase 1 truthing pass — status after this PR merges

| Item | Status |
|------|--------|
| M1 marketplace demote | ✅ #745 |
| M2 RVC/x402 pricing strip | ✅ #745 |
| M4 sponsor perk softening | ✅ #745 |
| M6 calendar dates → status labels | ✅ #745 |
| M7 stat block fixed | ✅ #745 |
| M8 Track-B residue swept | ✅ #745 + this |
| M10 brand renames | ✅ #745 + this |
| M3 agency pricing-floor ADR | ✅ internal docs `2e24c2f2a` |

## Verification

- `pnpm --filter marketing typecheck` — clean
- `pnpm exec biome check apps/marketing/app/routes/FairSourcePage.tsx` — clean (autofix applied to line wrap)
- `grep -rn 'in the suite\|rest of the suite' apps/marketing/app docs/suite` — 0 matches in the touched scope
- **Did NOT visually verify in browser preview.** Preview tooling started the agency-dev server (a different repo) instead of the marketing dev server despite an explicit launch.json override; static-string prose edits are sufficiently verified by typecheck + biome + post-edit grep, but flagging this honestly per the verify-before-claiming discipline.

## Test plan

- [x] Typecheck clean
- [x] Biome clean
- [x] Post-edit grep confirms zero residue in scope
- [ ] CI green
