### PR TITLE
chore(docs): finish M10 brand-rename sweep across docs/suite

### DIFF
--- a/docs/suite/revcon.md
+++ b/docs/suite/revcon.md
@@ -57,6 +57,6 @@ Active.
 
 ## See also
 
-- [Suite overview](../SUITE) — how RevCon relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevCon relates to the rest of RevFleet
 - [`/pro/editors`](/pro/editors) — Pro-docs page that points back to RevCon
 - [RevCon README](https://github.com/RevealUIStudio/revcon/blob/main/README.md) — canonical product docs

--- a/docs/suite/revkit.md
+++ b/docs/suite/revkit.md
@@ -50,7 +50,7 @@ echo 'for f in ~/.revealui/wsl/bashrc.d/*.sh; do source "$f"; done' >> ~/.bashrc
 ## How it composes with RevealUI
 
 - **New contributor onboarding**: Joshua's standing pattern — plug a USB into a Windows host, boot WSL, run the RevKit bootstrap, you have the studio's full environment in minutes instead of hours.
-- **Reproducibility**: every dev workstation in the suite builds from the same RevKit profile, so behaviour is consistent (Nix version, Node version, pnpm version, shell aliases, PATH order).
+- **Reproducibility**: every dev workstation in RevFleet builds from the same RevKit profile, so behaviour is consistent (Nix version, Node version, pnpm version, shell aliases, PATH order).
 - **Pairs with RevVault**: RevKit sets up the age-identity mount path RevVault expects (`~/.age-identity/keys.txt`); RevVault provides the secrets RevKit's CI tasks need.
 
 ## Status
@@ -59,6 +59,6 @@ Active.
 
 ## See also
 
-- [Suite overview](../SUITE) — how RevKit relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevKit relates to the rest of RevFleet
 - [Local-first setup](../LOCAL_FIRST) — running RevealUI itself locally (separate concern; RevKit is the *workstation*, LOCAL_FIRST is the *runtime*)
 - [RevKit README](https://github.com/RevealUIStudio/revkit/blob/main/README.md) — canonical product docs

--- a/docs/suite/revskills.md
+++ b/docs/suite/revskills.md
@@ -57,7 +57,7 @@ Active.
 
 ## See also
 
-- [Suite overview](../SUITE) — how RevSkills relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevSkills relates to the rest of RevFleet
 - [RevCon](./revcon) — symlink machinery for editor configs and agent rules
 - [RevSkills README](https://github.com/RevealUIStudio/revskills/blob/main/README.md) — canonical product docs
 - [agentskills.io](https://agentskills.io) — the upstream Agent Skills standard

--- a/docs/suite/revvault.md
+++ b/docs/suite/revvault.md
@@ -47,6 +47,6 @@ Active. Production-grade for personal / studio use; commercial offering wraps ex
 
 ## See also
 
-- [Suite overview](../SUITE) — how RevVault relates to the rest of the suite
+- [Suite overview](../SUITE) — how RevVault relates to the rest of RevFleet
 - [Credential rotation runbook](../CREDENTIAL-ROTATION-RUNBOOK) — RevVault paths per credential type
 - [RevVault README](https://github.com/RevealUIStudio/revvault/blob/main/README.md) — canonical product docs


### PR DESCRIPTION
## Summary

Verify-twice on main after [#746](https://github.com/RevealUIStudio/revealui/pull/746) surfaced 5 more sibling files in `docs/suite/` carrying the same "rest of the suite" prose. Closes the M10 brand-rename gap at the `docs/suite/` layer so Phase 1 of Pillar 4 is genuinely complete.

## Surfaces touched

| File | Change |
|------|--------|
| `docs/suite/revcon.md` | "relates to the rest of **the suite**" → "rest of **RevFleet**" |
| `docs/suite/revvault.md` | same |
| `docs/suite/revkit.md` | same (line 62) AND "every dev workstation in **the suite** builds" → "in **RevFleet** builds" (line 53) |
| `docs/suite/revskills.md` | same |

Pure prose sweep — link text "Suite overview" and target `../SUITE` unchanged, consistent with #746's scope decision.

## Verification

```
grep -rn -iE 'in the suite|rest of the suite' docs/suite --include='*.md'
# → 0 matches
```

The canonical [`docs/suite/SUITE.md`](docs/suite/SUITE.md) rename + cross-link sweep remains a separate Phase 2 follow-up.

## Test plan

- [x] Pre-push gate passed (no TS files; gate emitted "no leaks found" + "no TypeScript/JavaScript files to validate")
- [x] Post-edit grep returns zero residue
- [ ] CI green
