### PR TITLE
chore(docs,marketing): Phase C2 customer-facing copy sweep — RSA/RS25…

### DIFF
--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -15,7 +15,7 @@ RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on to
 
 ## License
 
-The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (RS256).
+The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (Ed25519).
 
 `@revealui/mcp` and `@revealui/services` are MIT — free for any tier, including the Free plan.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -11,7 +11,7 @@
 
 ## The five primitives
 
-- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, RS256)
+- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, Ed25519)
 - [AI](https://docs.revealui.com/AI): LLM providers, MCP, A2A, agents, RAG, memory layers
 - [Database](https://docs.revealui.com/DATABASE): Drizzle ORM on NeonDB; legacy Supabase code remaining in tree during phase-out
 - [Billing (Stripe)](https://docs.revealui.com/PRO#billing): Stripe webhooks, circuit breaker, metered billing

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -82,7 +82,7 @@ const faqs = [
   },
   {
     q: 'How is the Pro tier enforced if the source is visible?',
-    a: 'License enforcement is at runtime, not at the source level. Pro packages check RS256-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
+    a: 'License enforcement is at runtime, not at the source level. Pro packages check Ed25519-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
   },
   {
     q: 'What about the rest of the RevealUI packages?',

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -51,7 +51,7 @@ const faqs = [
   {
     question: 'What is Fair Source (FSL-1.1-MIT)?',
     answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (Ed25519-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/docs/blog-drafts/02-five-primitives.md
+++ b/docs/blog-drafts/02-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.


### PR DESCRIPTION
…6 → Ed25519 (#742)

CR8-P0-01 Phase D smoke is GREEN end-to-end (revealui#740 merged 818206850
+ deploy.yml SUCCESS run 25323325464; api-only redeploy 25355805808 picked up the missing REVEALUI_ADMIN_API_KEY var that smoke surfaced; smoke #1 issued an Ed25519 JWT alg=EdDSA, smoke #2 daemon verifyLicenseJWT() returned tier=pro). Per Q3 split (owner-confirmed 2026-05-04 ~15:32Z), this PR ships customer-facing copy now that production reality is Ed25519.

6 files, 10 string substitutions:

- apps/marketing/app/routes/FairSourcePage.tsx — 'RS256-signed license JWTs'
- apps/marketing/app/routes/PricingPage.tsx    — 'RS256-signed license JWTs'
- docs/blog/05-five-primitives.md              — 'RSA-signed JWTs' heading +
  'signed with RS256 (RSA + SHA-256)' body + 'RSA-signed license key'
- docs/blog-drafts/02-five-primitives.md       — same 3 substitutions
- apps/docs/public/docs-pro/index.md           — 'JWT (RS256)'
- apps/docs/public/llms.txt                    — 'license JWT … RS256'

All change to 'Ed25519-signed' / 'EdDSA (Ed25519)' / 'JWT (Ed25519)' / 'Ed25519' respectively. Zero behavior change; copy-only string replacements that match production runtime as of revealui#740.

Two of the 8 files in the original spec (docs/blog/08-getting-started.md and docs/blog-drafts/05-getting-started.md) had no RS256/RSA references near the spec'd line numbers — pointers were stale. No edits needed there.

Unblocks CR8-P0-01 + CR9-P0-03 closure in MASTER_PLAN.md (separate internal docs commit follows).

## Closes <!-- #issue-number (REQUIRED if fixing a GitHub issue) -->

## Summary

<!-- 1-3 bullet points describing what this PR does and why. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] CI/CD or tooling

## Checklist

- [ ] `pnpm gate:quick` passes (lint + typecheck)
- [ ] Tests added/updated and passing
- [ ] No `any` types or `console.*` in production code
- [ ] Any future-tense claims (`(coming soon)`, `(planned)`, `(roadmap)`, `(TBD)`) cite a tracker — GitHub issue/PR, milestone, or workflow file. See `CONTRIBUTING.md#future-tense-claims`.

## Screenshots / Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the change. -->
