### PR TITLE
fix(scripts): claim-drift scan-dir post-Vite migration + path-existence guard (GAP-179)

### DIFF
--- a/apps/marketing/app/routes/MarketplacePage.tsx
+++ b/apps/marketing/app/routes/MarketplacePage.tsx
@@ -187,7 +187,7 @@ export function MarketplacePage() {
               Open Source
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              12 MCP Servers
+              12 First-Party MCP Servers
             </h2>
             <p className="mt-4 text-lg text-gray-600">
               MCP servers included with RevealUI. Each server is rate-limited, audited, and governed

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -168,7 +168,7 @@ function assertScanDirsExist(scanDirs: string[], arrayName: string): void {
     const full = path.join(ROOT, dir);
     try {
       const stat = fs.statSync(full);
-      if (!stat.isFile() && !stat.isDirectory()) {
+      if (!(stat.isFile() || stat.isDirectory())) {
         throw new Error(`claim-drift ${arrayName} entry is neither file nor directory: ${dir}`);
       }
     } catch (err) {

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -154,9 +154,37 @@ interface ClaimMatch {
   metricName: string;
 }
 
+/**
+ * Throw with a descriptive error if any configured scan-dir does not exist
+ * on disk. Closes GAP-179 — the validator silently exempted marketing-app
+ * stat-block claims since #639 (Vite migration moved apps/marketing/src/
+ * to apps/marketing/app/) because the consumer loops use try/catch + skip.
+ *
+ * Calling this at validator entry surfaces stale SCAN_DIRS as a fatal error
+ * so future tree refactors cannot silently re-introduce the same exemption.
+ */
+function assertScanDirsExist(scanDirs: string[], arrayName: string): void {
+  for (const dir of scanDirs) {
+    const full = path.join(ROOT, dir);
+    try {
+      const stat = fs.statSync(full);
+      if (!stat.isFile() && !stat.isDirectory()) {
+        throw new Error(`claim-drift ${arrayName} entry is neither file nor directory: ${dir}`);
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `claim-drift ${arrayName} entry does not exist on disk: ${dir}. ` +
+          `Likely cause: source tree refactored without updating ${arrayName} in scripts/validate/claim-drift.ts. ` +
+          `Update the array and re-run. (${reason})`,
+      );
+    }
+  }
+}
+
 const SCAN_DIRS = [
   'docs',
-  'apps/marketing/src',
+  'apps/marketing/app',
   'README.md',
   'CLAUDE.md',
   'CONTRIBUTING.md',
@@ -239,6 +267,7 @@ function scanForClaims(metrics: Metric[]): ClaimMatch[] {
     }
   }
 
+  assertScanDirsExist(SCAN_DIRS, 'SCAN_DIRS');
   for (const p of SCAN_DIRS) {
     scanPath(p);
   }
@@ -346,8 +375,8 @@ interface AspirationalMatch {
 /** Files scanned for aspirational features without qualifiers. */
 const ASPIRATIONAL_SCAN_FILES = [
   // Marketing surfaces (existing — marketing-claims-2026-04-25)
-  'apps/marketing/src/components/landing',
-  'apps/marketing/src/components/GetStarted.tsx',
+  'apps/marketing/app/components/landing',
+  'apps/marketing/app/components/GetStarted.tsx',
   // Docs surfaces (PR-D continuation, docs-claims-2026-04-26)
   // High-visibility orientation + tutorial pages where the same blocklist applies.
   // Deeper technical docs (AI.md, DATABASE.md, etc.) are tuned in a follow-up.
@@ -498,17 +527,14 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
     }
   }
 
+  assertScanDirsExist(ASPIRATIONAL_SCAN_FILES, 'ASPIRATIONAL_SCAN_FILES');
   for (const rel of ASPIRATIONAL_SCAN_FILES) {
     const full = path.join(ROOT, rel);
-    try {
-      const stat = fs.statSync(full);
-      if (stat.isFile()) {
-        scanFile(full);
-      } else if (stat.isDirectory()) {
-        walk(full);
-      }
-    } catch {
-      // path missing, skip
+    const stat = fs.statSync(full);
+    if (stat.isFile()) {
+      scanFile(full);
+    } else if (stat.isDirectory()) {
+      walk(full);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes GAP-179 — `scripts/validate/claim-drift.ts` SCAN_DIRS reference `apps/marketing/src/` which doesn't exist post-#639 Vite migration (path is now `apps/marketing/app/`). Validator was silently exempting every marketing-app stat-block claim since #639, because both consumer loops `try/catch + skip` on missing paths. Surfaced 2026-05-07 by reviewer pre-merge gate on [revealui#751](https://github.com/RevealUIStudio/revealui/pull/751) (Phase 3.3) where `26 npm packages` and `12 MCP servers` labels shipped without claim-drift CI catching the inflation.

This is **Phase A.1** of the marketing-content-CMS migration per `docs/spec-2026-05-08-marketing-content-cms.md` §9 Phase A row A1.

## Three changes

### 1. Path fixes (3 strings)

`scripts/validate/claim-drift.ts`:
- Line 159: `'apps/marketing/src'` → `'apps/marketing/app'` (SCAN_DIRS)
- Line 349: `'apps/marketing/src/components/landing'` → `'apps/marketing/app/components/landing'` (ASPIRATIONAL_SCAN_FILES)
- Line 350: `'apps/marketing/src/components/GetStarted.tsx'` → `'apps/marketing/app/components/GetStarted.tsx'` (ASPIRATIONAL_SCAN_FILES)

Verified on disk:
```
$ ls ~/revfleet/revealui/apps/marketing/app/components/landing
Demo.tsx Faq.tsx Hero.tsx Persona.tsx PricingTeaser.tsx
$ ls ~/revfleet/revealui/apps/marketing/app/components/GetStarted.tsx
[exists]
```

### 2. Path-existence guard at validator startup

New `assertScanDirsExist(scanDirs, arrayName)` function called at the top of BOTH consumer loops (SCAN_DIRS at line 242, ASPIRATIONAL_SCAN_FILES at line 501). Throws descriptive error if any configured path is missing — prevents future tree refactors from silently re-introducing the same exemption.

Also removed the in-loop `try/catch { /* path missing, skip */ }` around `ASPIRATIONAL_SCAN_FILES` since the upfront assert makes it redundant + silently-skipping is the bug class GAP-179 was filed to close.

### 3. Fix the FIRST drift the now-functional validator surfaced

`apps/marketing/app/routes/MarketplacePage.tsx:190`: `12 MCP Servers` → `12 First-Party MCP Servers`

The qualifier matches the Phase 3.3 ProductsPage stat-block convention shipped via [revealui#751](https://github.com/RevealUIStudio/revealui/pull/751). Without this fix, the now-functional validator's hard-fail gate would block this PR (validator counts 13 servers including `supabase.ts` adapter; "first-party" framing excludes adapters at 12).

This is a **scope expansion** from "narrow path fix" to "narrow path fix + first surfaced drift" because the claim-drift gate is hard-fail. The drift was silently riding in production marketing copy until this PR; surfacing + fixing it as the first act of the now-functional validator is the right shape.

## Voice rules check (per internal docs §5)

- **R1** (lead with shipping artifact): MarketplacePage:190 H2 names a verifiable artifact (the 12 first-party MCP server set). ✅
- **R2** (specifics over adjectives): Pure metric + qualifier. ✅
- **S2** (no inflated stat blocks): Drift removed — 12 first-party is verifiable via `ls ~/revfleet/revealui/packages/mcp/src/servers/factories/`. ✅
- **S1** (no codename leaks): No RVUI / bare Forge / Stamp / forge-stamp / the Suite. ✅

## Pre-push gate (locally green)

- `pnpm install --frozen-lockfile`: PASS
- `pnpm --filter @revealui/mcp build`: PASS (OpenAPI mirror drift defense)
- `pnpm gate:quick`:
  - Security Gate: PASS (4 warnings, no failures)
  - CI Gate: PASS — **all 17 sub-checks green**, including:
    - Claim drift (hard fail): ✓ PASS
    - Contracts OpenAPI mirror drift (hard fail): ✓ PASS
    - Boundary validation (hard fail): ✓ PASS
    - Stripe-client consolidation (hard fail): ✓ PASS

## What's NOT in this PR

- **LEGACY-REGEX markers** for the ~18 authored regex patterns in `claim-drift.ts` itself. Per GAP-186 (fleet regex retirement Q-baseline), these markers get added across the WHOLE fleet at Q1 baseline establishment, not opportunistically per touching PR. This PR keeps scope narrow.
- **AST refactor** of `claim-drift.ts` to remove regex authoring entirely. Tracked in GAP-192 — companion to this PR. The architectural pattern (typed Rule discriminated-union + AST walker) is specified in the marketing-CMS spec §5.2.1.

## Test plan

- [ ] CI passes (claim-drift hard fail + 16 other sub-checks)
- [ ] Manual: post-merge, run `pnpm tsx scripts/validate/claim-drift.ts` → exit 0, 0 mismatches
- [ ] Manual: post-merge, plant a missing-path in SCAN_DIRS locally → assert throws with descriptive error (not silent skip)

## References

- Closes GAP-179
- Refs GAP-186 (LEGACY-REGEX markers backfill)
- Refs GAP-192 (AST refactor follow-up)
- Spec: `docs/spec-2026-05-08-marketing-content-cms.md` §9 Phase A row A1
- Memory: `feedback_no_regex_ast_only`, `project_filesystem_renamed_to_revfleet`, `feedback_no_risk_too_small_to_fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
