### PR TITLE
chore: sync test → main 2026-05-07 (Phase A.1 GAP-179 + Phase C2 Ed25519 docs)

### DIFF
--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -15,7 +15,7 @@ RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on to
 
 ## License
 
-The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (RS256).
+The two Pro packages (`@revealui/ai`, `@revealui/harnesses`) are **Fair Source (FSL-1.1-MIT)** — source is visible in the public repo, the package is installable from npm, and each release converts to plain MIT after 2 years. Runtime feature gates verify your Pro / Forge / perpetual license via JWT (Ed25519).
 
 `@revealui/mcp` and `@revealui/services` are MIT — free for any tier, including the Free plan.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -11,7 +11,7 @@
 
 ## The five primitives
 
-- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, RS256)
+- [Auth](https://docs.revealui.com/AUTH): Session-only auth, bcrypt 12 rounds, OAuth, passkeys (license JWT is a separate surface, Ed25519)
 - [AI](https://docs.revealui.com/AI): LLM providers, MCP, A2A, agents, RAG, memory layers
 - [Database](https://docs.revealui.com/DATABASE): Drizzle ORM on NeonDB; legacy Supabase code remaining in tree during phase-out
 - [Billing (Stripe)](https://docs.revealui.com/PRO#billing): Stripe webhooks, circuit breaker, metered billing

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -82,7 +82,7 @@ const faqs = [
   },
   {
     q: 'How is the Pro tier enforced if the source is visible?',
-    a: 'License enforcement is at runtime, not at the source level. Pro packages check RS256-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
+    a: 'License enforcement is at runtime, not at the source level. Pro packages check Ed25519-signed license JWTs, gate features per entry point, and validate against the license server every five minutes. FSL is the legal backstop; runtime enforcement is the real protection. Cracking the license is technically possible (you have the source) — but doing so commercially is exactly what the FSL non-compete clause prohibits, with civil remedies available.',
   },
   {
     q: 'What about the rest of the RevealUI packages?',

--- a/apps/marketing/app/routes/MarketplacePage.tsx
+++ b/apps/marketing/app/routes/MarketplacePage.tsx
@@ -187,7 +187,7 @@ export function MarketplacePage() {
               Open Source
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              12 MCP Servers
+              12 First-Party MCP Servers
             </h2>
             <p className="mt-4 text-lg text-gray-600">
               MCP servers included with RevealUI. Each server is rate-limited, audited, and governed

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -51,7 +51,7 @@ const faqs = [
   {
     question: 'What is Fair Source (FSL-1.1-MIT)?',
     answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (RS256-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
+      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. The Pro tier gate is enforced at runtime (Ed25519-signed license JWTs, 6-layer middleware, per-entry-point feature checks), not at the source level — so FSL is the legal backstop, and runtime enforcement is the real protection. Full explainer at /fair-source.",
   },
   {
     question: 'Do you offer custom pricing for large teams?',

--- a/docs/blog-drafts/02-five-primitives.md
+++ b/docs/blog-drafts/02-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -196,9 +196,9 @@ Content is authored by Users (the `authorId` foreign key). Premium content can b
 
 Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
 
-### License keys: RSA-signed JWTs
+### License keys: Ed25519-signed JWTs
 
-License keys are JWT tokens signed with RS256 (RSA + SHA-256). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
+License keys are JWT tokens signed with EdDSA (Ed25519). The payload contains the tier, customer ID, domain restrictions, site and user limits, and an optional perpetual flag. The private key signs; the public key verifies. This means license verification can happen offline, without calling home to a license server.
 
 ```typescript
 // packages/core/src/license.ts
@@ -350,7 +350,7 @@ If the INSERT succeeds, this is the first time we have seen this event. If it hi
 
 The webhook handler covers the full subscription lifecycle:
 
-- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an RSA-signed license key, inserts it into the licenses table, and sends the activation email.
+- **`checkout.session.completed`** -- Creates the Stripe customer record, generates an Ed25519-signed license key, inserts it into the licenses table, and sends the activation email.
 - **`customer.subscription.updated`** -- Handles tier upgrades (new license key at the higher tier) and reactivation (payment recovered after a failed charge). On successful payment recovery, the license is re-activated and the user gets a recovery notification.
 - **`customer.subscription.deleted`** -- Revokes the license and downgrades to free.
 - **`invoice.payment_failed`** -- Sends a payment failure notification with a link to update billing details.

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the `sites` table with the fleet-marketing row (Phase A.2).
+ *
+ * Idempotent: if a row with id='fleet-marketing' already exists, logs and exits 0.
+ * Resolves ownerId by looking up founder@revealui.com in the users table — fails fast
+ * if that user does not exist yet (bootstrap must run first).
+ *
+ * Usage:
+ *   pnpm tsx scripts/seed-fleet-marketing-site.ts
+ *   pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run
+ *
+ * Spec: .jv/docs/spec-2026-05-08-marketing-content-cms.md §2.1 + §9 row A2
+ */
+
+import { resolve } from 'node:path';
+import { config } from 'dotenv';
+
+const rootDir = resolve(import.meta.dirname, '..');
+
+for (const envFile of [
+  '.env',
+  '.env.development.local',
+  '.env.local',
+  'apps/server/.env.vercel',
+  'apps/admin/.env.local',
+]) {
+  config({ path: resolve(rootDir, envFile), override: false });
+}
+
+const SITE_ID = 'fleet-marketing';
+const FOUNDER_EMAIL = 'founder@revealui.com';
+
+const log = {
+  info: (msg: string) => console.log(`  i ${msg}`),
+  success: (msg: string) => console.log(`  + ${msg}`),
+  warn: (msg: string) => console.log(`  ! ${msg}`),
+  error: (msg: string) => console.error(`  x ${msg}`),
+};
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+
+  if (dryRun) {
+    log.warn('DRY RUN — no writes will be made');
+  }
+
+  const { getClient } = await import('@revealui/db/client');
+  const { users, sites } = await import('@revealui/db/schema');
+  const { eq } = await import('drizzle-orm');
+
+  const db = getClient('rest');
+
+  const founderRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, FOUNDER_EMAIL))
+    .limit(1);
+
+  if (founderRows.length === 0) {
+    log.error(`Founder user not found: ${FOUNDER_EMAIL}`);
+    log.error('Run pnpm admin:bootstrap (or pnpm db:seed:admin) first, then re-run this script.');
+    process.exit(1);
+  }
+
+  const ownerId = founderRows[0].id;
+  log.info(`Resolved ownerId for ${FOUNDER_EMAIL}: ${ownerId}`);
+
+  const existing = await db
+    .select({ id: sites.id, slug: sites.slug, status: sites.status })
+    .from(sites)
+    .where(eq(sites.id, SITE_ID))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const row = existing[0];
+    log.info('Already seeded, skipping.');
+    log.info(`  id:     ${row.id}`);
+    log.info(`  slug:   ${row.slug}`);
+    log.info(`  status: ${row.status}`);
+    return;
+  }
+
+  const now = new Date();
+
+  const row = {
+    id: SITE_ID,
+    ownerId,
+    name: 'RevealUI fleet marketing',
+    slug: 'fleet-marketing',
+    description: 'revealui.com customer-facing copy',
+    status: 'published' as const,
+    theme: { brand: 'revealui-fleet' },
+    settings: {
+      cacheStrategy: 'edge-tag',
+      voiceProfile: 'fleet',
+      aiGeneration: {
+        provider: 'inference-snaps',
+        model: 'gemma3',
+        embedModel: 'gemma3',
+      },
+    },
+    publishedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (dryRun) {
+    log.info('Would insert:');
+    log.info(JSON.stringify(row, null, 2));
+    log.success('Dry run complete — no writes made.');
+    return;
+  }
+
+  await db.insert(sites).values(row).onConflictDoNothing({ target: sites.id });
+
+  const inserted = await db
+    .select({ id: sites.id, slug: sites.slug, status: sites.status })
+    .from(sites)
+    .where(eq(sites.id, SITE_ID))
+    .limit(1);
+
+  if (inserted.length === 0) {
+    log.error('Insert reported no conflict but row is not present — unexpected state.');
+    process.exit(1);
+  }
+
+  const seeded = inserted[0];
+  log.success('Seeded fleet-marketing site row.');
+  log.info(`  id:     ${seeded.id}`);
+  log.info(`  slug:   ${seeded.slug}`);
+  log.info(`  status: ${seeded.status}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  log.error(`Fatal: ${error instanceof Error ? error.message : String(error)}`);
+  if (error instanceof Error && error.stack) {
+    log.error(error.stack);
+  }
+  process.exit(1);
+}

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -154,9 +154,37 @@ interface ClaimMatch {
   metricName: string;
 }
 
+/**
+ * Throw with a descriptive error if any configured scan-dir does not exist
+ * on disk. Closes GAP-179 — the validator silently exempted marketing-app
+ * stat-block claims since #639 (Vite migration moved apps/marketing/src/
+ * to apps/marketing/app/) because the consumer loops use try/catch + skip.
+ *
+ * Calling this at validator entry surfaces stale SCAN_DIRS as a fatal error
+ * so future tree refactors cannot silently re-introduce the same exemption.
+ */
+function assertScanDirsExist(scanDirs: string[], arrayName: string): void {
+  for (const dir of scanDirs) {
+    const full = path.join(ROOT, dir);
+    try {
+      const stat = fs.statSync(full);
+      if (!(stat.isFile() || stat.isDirectory())) {
+        throw new Error(`claim-drift ${arrayName} entry is neither file nor directory: ${dir}`);
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `claim-drift ${arrayName} entry does not exist on disk: ${dir}. ` +
+          `Likely cause: source tree refactored without updating ${arrayName} in scripts/validate/claim-drift.ts. ` +
+          `Update the array and re-run. (${reason})`,
+      );
+    }
+  }
+}
+
 const SCAN_DIRS = [
   'docs',
-  'apps/marketing/src',
+  'apps/marketing/app',
   'README.md',
   'CLAUDE.md',
   'CONTRIBUTING.md',
@@ -239,6 +267,7 @@ function scanForClaims(metrics: Metric[]): ClaimMatch[] {
     }
   }
 
+  assertScanDirsExist(SCAN_DIRS, 'SCAN_DIRS');
   for (const p of SCAN_DIRS) {
     scanPath(p);
   }
@@ -346,8 +375,8 @@ interface AspirationalMatch {
 /** Files scanned for aspirational features without qualifiers. */
 const ASPIRATIONAL_SCAN_FILES = [
   // Marketing surfaces (existing — marketing-claims-2026-04-25)
-  'apps/marketing/src/components/landing',
-  'apps/marketing/src/components/GetStarted.tsx',
+  'apps/marketing/app/components/landing',
+  'apps/marketing/app/components/GetStarted.tsx',
   // Docs surfaces (PR-D continuation, docs-claims-2026-04-26)
   // High-visibility orientation + tutorial pages where the same blocklist applies.
   // Deeper technical docs (AI.md, DATABASE.md, etc.) are tuned in a follow-up.
@@ -498,17 +527,14 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
     }
   }
 
+  assertScanDirsExist(ASPIRATIONAL_SCAN_FILES, 'ASPIRATIONAL_SCAN_FILES');
   for (const rel of ASPIRATIONAL_SCAN_FILES) {
     const full = path.join(ROOT, rel);
-    try {
-      const stat = fs.statSync(full);
-      if (stat.isFile()) {
-        scanFile(full);
-      } else if (stat.isDirectory()) {
-        walk(full);
-      }
-    } catch {
-      // path missing, skip
+    const stat = fs.statSync(full);
+    if (stat.isFile()) {
+      scanFile(full);
+    } else if (stat.isDirectory()) {
+      walk(full);
     }
   }
 


### PR DESCRIPTION
## Summary

Periodic `test → main` propagation. Carries 2 commits accumulated on `test` since the last sync.

| # | Commit | Subject | Author | Lane |
|---|---|---|---|---|
| 1 | [`f189999c3`](https://github.com/RevealUIStudio/revealui/commit/f189999c3) | `fix(scripts): claim-drift scan-dir post-Vite migration + path-existence guard (GAP-179)` | RevealUI Studio | Pillar 4 marketing-CMS Phase A.1 |
| 2 | [`7ea272d1e`](https://github.com/RevealUIStudio/revealui/commit/7ea272d1e) | `chore(docs,marketing): Phase C2 customer-facing copy sweep — RSA/RS256 → Ed25519 (#742)` | RevealUI Studio | Customer-facing copy sweep |

## What lands in production

### Commit 1 — GAP-179 (Phase A.1 of the marketing-CMS migration)

`scripts/validate/claim-drift.ts` (+39/-13) + `apps/marketing/app/routes/MarketplacePage.tsx` (+1/-1):

- **Path fix:** SCAN_DIRS + ASPIRATIONAL_SCAN_FILES references `apps/marketing/src` → `apps/marketing/app` (post-Vite-migration paths). Validator was silently exempting marketing-app stat-block claims since #639 because both consumer loops `try/catch + skip` on missing paths.
- **Path-existence guard:** new `assertScanDirsExist()` function called at the top of both consumer loops. Throws descriptive error if any configured path is missing — prevents future tree refactors from silently re-introducing the same exemption.
- **Marketing copy:** `MarketplacePage.tsx:190` `12 MCP Servers` → `12 First-Party MCP Servers` (qualifier matches Phase 3.3 [#751](https://github.com/RevealUIStudio/revealui/pull/751) ProductsPage convention; the now-functional validator surfaced this drift on first run + would have hard-fail-blocked the PR otherwise).

**Production effect:** the claim-drift validator becomes operational against marketing-app routes for the first time since #639. Future drift on customer-facing stat blocks will be caught at PR time instead of shipping silently.

### Commit 2 — Phase C2 Ed25519 docs sweep (#742)

Customer-facing copy update from RSA/RS256 to Ed25519 per the license-key signing migration. Doc-only change; no runtime impact.

## Why this is safe for production

- **Commit 1** = CI infrastructure (validator script) + 1-line marketing copy change. No runtime code path. Already test-baked since merge to `test`.
- **Commit 2** = doc-only. Already test-baked.
- **Combined diff** = ~40 LOC across 2 files in `scripts/` + 1 file in `apps/marketing/app/routes/` + the docs sweep.

## Test plan

- [ ] CI passes on `main` (full gate including hard-fail claim-drift now operational against marketing-app routes)
- [ ] Vercel production deploy succeeds (no runtime code touched; deploy is essentially a doc + script update)
- [ ] Manual: post-merge, `pnpm tsx scripts/validate/claim-drift.ts` on `main` returns exit 0, 0 mismatches
- [ ] Manual: revealui.com/marketplace renders `12 First-Party MCP Servers` (visual regression handled by E2E if applicable)

## Merge method

**Merge commit** (not squash) — preserves individual commit history on `main`. Matches prior sync pattern (e.g. `787089c5a Merge pull request #741 from RevealUIStudio/chore/sync-main-into-test-2026-05-04`).

## References

- Spec: `docs/spec-2026-05-08-marketing-content-cms.md` §12 two-stage flow (`feature/* → test → main`)
- GAP-179: docs/gaps/GAP-179.yml
- Phase A.1 PR: [revealui#752](https://github.com/RevealUIStudio/revealui/pull/752)
- EOD coordinated handoff: HANDOFF-2026-05-07-end-of-day-coordinated.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
