### PR TITLE
feat(scripts): seed sites row for fleet-marketing (Phase A.2)

### DIFF
--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the `sites` table with the fleet-marketing row (Phase A.2).
+ *
+ * Idempotent: if a row with id='fleet-marketing' already exists, logs and exits 0.
+ * Resolves ownerId by looking up founder@revealui.com in the users table — fails fast
+ * if that user does not exist yet (bootstrap must run first).
+ *
+ * Usage:
+ *   pnpm tsx scripts/seed-fleet-marketing-site.ts
+ *   pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run
+ *
+ * Spec: .jv/docs/spec-2026-05-08-marketing-content-cms.md §2.1 + §9 row A2
+ */
+
+import { resolve } from 'node:path';
+import { config } from 'dotenv';
+
+const rootDir = resolve(import.meta.dirname, '..');
+
+for (const envFile of [
+  '.env',
+  '.env.development.local',
+  '.env.local',
+  'apps/server/.env.vercel',
+  'apps/admin/.env.local',
+]) {
+  config({ path: resolve(rootDir, envFile), override: false });
+}
+
+const SITE_ID = 'fleet-marketing';
+const FOUNDER_EMAIL = 'founder@revealui.com';
+
+const log = {
+  info: (msg: string) => console.log(`  i ${msg}`),
+  success: (msg: string) => console.log(`  + ${msg}`),
+  warn: (msg: string) => console.log(`  ! ${msg}`),
+  error: (msg: string) => console.error(`  x ${msg}`),
+};
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+
+  if (dryRun) {
+    log.warn('DRY RUN — no writes will be made');
+  }
+
+  const { getClient } = await import('@revealui/db/client');
+  const { users, sites } = await import('@revealui/db/schema');
+  const { eq } = await import('drizzle-orm');
+
+  const db = getClient('rest');
+
+  const founderRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, FOUNDER_EMAIL))
+    .limit(1);
+
+  if (founderRows.length === 0) {
+    log.error(`Founder user not found: ${FOUNDER_EMAIL}`);
+    log.error('Run pnpm admin:bootstrap (or pnpm db:seed:admin) first, then re-run this script.');
+    process.exit(1);
+  }
+
+  const ownerId = founderRows[0].id;
+  log.info(`Resolved ownerId for ${FOUNDER_EMAIL}: ${ownerId}`);
+
+  const existing = await db
+    .select({ id: sites.id, slug: sites.slug, status: sites.status })
+    .from(sites)
+    .where(eq(sites.id, SITE_ID))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const row = existing[0];
+    log.info('Already seeded, skipping.');
+    log.info(`  id:     ${row.id}`);
+    log.info(`  slug:   ${row.slug}`);
+    log.info(`  status: ${row.status}`);
+    return;
+  }
+
+  const now = new Date();
+
+  const row = {
+    id: SITE_ID,
+    ownerId,
+    name: 'RevealUI fleet marketing',
+    slug: 'fleet-marketing',
+    description: 'revealui.com customer-facing copy',
+    status: 'published' as const,
+    theme: { brand: 'revealui-fleet' },
+    settings: {
+      cacheStrategy: 'edge-tag',
+      voiceProfile: 'fleet',
+      aiGeneration: {
+        provider: 'inference-snaps',
+        model: 'gemma3',
+        embedModel: 'gemma3',
+      },
+    },
+    publishedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (dryRun) {
+    log.info('Would insert:');
+    log.info(JSON.stringify(row, null, 2));
+    log.success('Dry run complete — no writes made.');
+    return;
+  }
+
+  await db.insert(sites).values(row).onConflictDoNothing({ target: sites.id });
+
+  const inserted = await db
+    .select({ id: sites.id, slug: sites.slug, status: sites.status })
+    .from(sites)
+    .where(eq(sites.id, SITE_ID))
+    .limit(1);
+
+  if (inserted.length === 0) {
+    log.error('Insert reported no conflict but row is not present — unexpected state.');
+    process.exit(1);
+  }
+
+  const seeded = inserted[0];
+  log.success('Seeded fleet-marketing site row.');
+  log.info(`  id:     ${seeded.id}`);
+  log.info(`  slug:   ${seeded.slug}`);
+  log.info(`  status: ${seeded.status}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  log.error(`Fatal: ${error instanceof Error ? error.message : String(error)}`);
+  if (error instanceof Error && error.stack) {
+    log.error(error.stack);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Phase A.2 of the marketing-CMS migration. Closes Phase A row A2 per `spec-2026-05-08-marketing-content-cms.md §9`.

One-time idempotent script writing the `fleet-marketing` row to the existing `sites` table (per spec §2.1). No new schema, no migrations — extends the Content primitive's existing `sites` table with a row that downstream Phase A.3+ work consumes.

## What ships

`scripts/seed-fleet-marketing-site.ts` (~130 LOC):

- Resolves `ownerId` by looking up `founder@revealui.com` in the `users` table — fails fast with bootstrap instructions if not found (admin bootstrap must precede this script).
- Idempotent via `onConflictDoNothing({ target: sites.id })` + post-insert verify; logs `id`/`slug`/`status` on every exit path.
- Supports `--dry-run` flag: prints the row as JSON, makes no DB writes. Useful for safe pre-merge verification.
- Zero authored regex per HARDLINE memory `feedback_no_regex_ast_only`.
- Dynamic imports for `@revealui/db` packages per existing `scripts/setup/seed-billing.ts` + `scripts/admin/bootstrap.ts` conventions.
- Multi-file dotenv loading pattern matched (`.env`, `.env.development.local`, `.env.local`, `apps/server/.env.vercel`, `apps/admin/.env.local`).
- `console.log` via local helper — Biome `scripts/**` override permits `noConsole: "off"`.

## Row shape (matches spec §2.1 byte-exact)

```ts
{
  id: 'fleet-marketing',
  ownerId: <founder user id, resolved at runtime>,
  name: 'RevealUI fleet marketing',
  slug: 'fleet-marketing',
  description: 'revealui.com customer-facing copy',
  status: 'published',
  theme: { brand: 'revealui-fleet' },
  settings: {
    cacheStrategy: 'edge-tag',
    voiceProfile: 'fleet',
    aiGeneration: {
      provider: 'inference-snaps',
      model: 'gemma3',
      embedModel: 'gemma3'
    }
  },
  publishedAt: now,
  createdAt: now,
  updatedAt: now,
}
```

No deviations from spec §2.1. `publishedAt` is set to `new Date()` at script runtime (spec says `<now>` — this is the literal interpretation).

## Verify

```bash
# Dry-run (no writes)
pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run

# Actual seed (writes if not present, skips if present)
pnpm tsx scripts/seed-fleet-marketing-site.ts

# Confirm via API
curl "$API_URL/api/content/sites/fleet-marketing" | jq .
```

## Rollback

```sql
DELETE FROM sites WHERE id = 'fleet-marketing';
```

## Pre-push gate (locally green)

- `pnpm install --frozen-lockfile`: PASS
- `pnpm --filter @revealui/mcp build`: PASS
- `pnpm gate:quick`:
  - Security Gate: PASS (3 warnings, no failures — pre-existing)
  - CI Gate: PASS — **all 17 sub-checks green**
    - Biome lint: ✓
    - Any type audit: ✓
    - Console audit: ✓
    - Claim drift (hard fail): ✓
    - Contracts OpenAPI mirror drift (hard fail): ✓
    - Boundary validation (hard fail): ✓
    - Raw-SQL (hard fail): ✓
    - Empty-catch (hard fail): ✓
    - Stripe-client consolidation (hard fail): ✓
    - + 8 others: ✓

## Test plan

- [ ] CI passes on `test` (full gate including hard-fail claim-drift, typecheck, build)
- [ ] Manual dry-run: `pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run` returns expected row JSON
- [ ] Manual real run (post-merge): `pnpm tsx scripts/seed-fleet-marketing-site.ts` writes the row + verifies via select
- [ ] Manual API verify: `curl /api/content/sites/fleet-marketing` returns the row with the expected shape
- [ ] Idempotency check: re-run the script — should log "Already seeded, skipping" and exit 0

## What's next (Phase A.3+)

Per spec §9 Phase A:
- A3: author one seed `pages` row (Home `/`) with Hero block extracted from current TSX
- A4: implement `fetchSiteContent` shim in `apps/marketing/app/lib/api.ts`
- A5: implement `RenderBlocks` component for Hero block only
- A6: Hono SSR shell at `apps/server/src/routes/marketing/ssr.tsx` for `/`
- A6a: cache-poll-interval = 500ms config
- A6b: visual-regression CI for marketing routes (REQUIRED-as-blocking pre-A.7)

This PR is **A2 only** — strictly the seed-sites-row script. A3-A6+ each get their own PR per spec §9 row-by-row.

## References

- Spec: `spec-2026-05-08-marketing-content-cms.md` §2.1 + §9 row A2
- §11 + §12 sign-off committed at `9e6dcdd63`
- Phase A.1 PR: [revealui#752](https://github.com/RevealUIStudio/revealui/pull/752) (squash f189999c3 on test)
- test→main propagation: [revealui#753](https://github.com/RevealUIStudio/revealui/pull/753)
- EOD coordinated handoff: HANDOFF-2026-05-07-end-of-day-coordinated.md
- Memory: `feedback_no_regex_ast_only` (HARDLINE), `feedback_audit_first_sdlc`, `feedback_verify_before_claiming`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
