### PR TITLE
fix(marketing): Hero proof-points 21 npm packages → 26 workspace packages (claim-drift)

### DIFF
--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -136,9 +136,9 @@ export function Hero() {
             <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
               {[
                 {
-                  metric: '21 npm packages',
+                  metric: '26 workspace packages',
                   detail:
-                    '20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui.',
+                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private. Source at packages/.',
                 },
                 {
                   metric: '86 database tables',


### PR DESCRIPTION
## Summary

Single-line marketing copy fix. Aligns the fleet IndexPage Hero proof-points block with the Phase 3.3 ProductsPage convention (`26 workspace packages`) shipped via [revealui#751](https://github.com/RevealUIStudio/revealui/pull/751) fixup.

## Why now

[revealui#753](https://github.com/RevealUIStudio/revealui/pull/753) (test→main propagation of Phase A.1 GAP-179 + Phase C2 Ed25519 docs) is **BLOCKED** on a real claim-drift: the now-functional validator (post-#752 scan-dir fix on test branch) sees the merged state of test+main and flags `Hero.tsx:139` `'21 npm packages'` as understated vs actual 26.

This is **pre-existing drift on main** — Phase 3.1 [revealui#750](https://github.com/RevealUIStudio/revealui/pull/750) shipped the proof-points block direct to main with `21 npm packages`. main's own claim-drift validator was scan-dir broken (per GAP-179) so it never caught the drift. Now that #752 fixes the validator on test, #753's merged-state CI exposes the existing main drift.

Fix path: branch from `main` (not `test` — test doesn't have this code), fix the metric, merge to main, #753 picks up + becomes mergeable.

## Diff

```diff
- metric: '21 npm packages',
- detail: '20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui.',
+ metric: '26 workspace packages',
+ detail: '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private. Source at packages/.',
```

## Convention alignment

Phase 3.3 ProductsPage stat block ([`apps/marketing/app/routes/ProductsPage.tsx:319`](https://github.com/RevealUIStudio/revealui/blob/main/apps/marketing/app/routes/ProductsPage.tsx#L319)) uses `{ stat: '26', label: 'workspace packages' }`. This PR brings Hero.tsx into the same framing — single source of truth for the count + framing across fleet marketing.

## Voice rules check

- **R2 (specifics over adjectives):** still concrete numbers + named source path. ✅
- **R5 (no marketing-speak):** no hype words; "26 workspace packages" + math-explanation in detail. ✅
- **S2 (no inflated stat blocks):** drift removed. Detail line cites the verify path (`packages/`) for re-verification. ✅
- **S1 (no codename leaks):** N/A. ✅

## Pre-push gate (locally green)

- `pnpm install --frozen-lockfile`: PASS
- `pnpm gate:quick`:
  - Phase 1 Security Gate: PASS (3 warnings, no failures)
  - CI Gate: PASS — **all 17 sub-checks green**, including:
    - Claim drift (hard fail): ✓ PASS
    - Biome lint: ✓
    - Typecheck: ✓
    - Boundary validation (hard fail): ✓
    - All other hard-fail gates: ✓

## Test plan

- [ ] CI passes on `main` (full gate)
- [ ] Vercel production deploy succeeds (single-line marketing copy change; no runtime code touched)
- [ ] Manual: revealui.com `/` renders `26 workspace packages` in the Hero proof-points block
- [ ] [revealui#753](https://github.com/RevealUIStudio/revealui/pull/753) auto-rebuilds + CI re-runs against merged state — should now be green

## Why not via `test → main` two-stage flow

Per spec §12 the canonical flow is `feature/* → test → main`. But this PR is fixing a bug that only exists on `main` (not on `test`). Going through test would mean:
1. Bring main's Hero.tsx into test (not currently there)
2. Fix it on test
3. Propagate via test→main

That's mechanically equivalent but adds 1-2 PR cycles. Direct `feature → main` is the consistent hot-fix workflow when the buggy code only exists on main. Same precedent as Phase 3.1 #750 itself, which was also `feature → main` direct.

## References

- Closes: nothing formally — this is a hot-fix to unblock #753
- Refs: [revealui#750](https://github.com/RevealUIStudio/revealui/pull/750) (the original PR that shipped the drift), [revealui#751](https://github.com/RevealUIStudio/revealui/pull/751) (the convention this aligns with), [revealui#752](https://github.com/RevealUIStudio/revealui/pull/752) (the validator fix that surfaced the drift), [revealui#753](https://github.com/RevealUIStudio/revealui/pull/753) (the propagation PR this unblocks)
- Voice spec: `spec-2026-05-06-voice-and-headline-rules.md` §4.2 (inflated-stat-blocks rule)
- Memory: `feedback_no_risk_too_small_to_fix`, `feedback_verify_before_claiming`, `feedback_audit_first_sdlc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
