### PR TITLE
fix(marketing): Hero proof-points 26 workspace packages → 26 packages (validator regex collision)

### DIFF
--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -136,9 +136,9 @@ export function Hero() {
             <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
               {[
                 {
-                  metric: '26 workspace packages',
+                  metric: '26 packages',
                   detail:
-                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private. Source at packages/.',
+                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private workspace packages. Source at packages/.',
                 },
                 {
                   metric: '86 database tables',


### PR DESCRIPTION
## Summary

Hot-fix on top of [#755](https://github.com/RevealUIStudio/revealui/pull/755). The previous Hero proof-points claim-drift fix (`21 npm packages` → `26 workspace packages`) introduced a second drift the validator hard-flags: the regex `\b(\d+)\s*workspaces?\b` matches `26 workspace` inside the single-string metric, interpreting it as a workspaces claim (26) vs actual 31 (= 26 packages + 5 apps).

Fix: change `'26 workspace packages'` → `'26 packages'`. Matches the actual packages count exactly, avoids the workspaces false-match, stays voice-spec compliant.

## Why ProductsPage's `'26 workspace packages'` passes but Hero's didn't

ProductsPage Phase 3.3 stat block uses `{ stat: '26', label: 'workspace packages' }` — the digit and "workspace" sit on the same line but split across JSX keys with `', label: '` between them. The validator's `\s*` between digit and "workspace" can't span that, so the regex doesn't match.

Hero.tsx uses a single `metric` string. Splitting across JSX keys would require restructuring the proof-points data shape — bigger surgery than this fix warrants. Simpler to phrase the metric so the false-match doesn't happen.

## Diff

```diff
                 {
-                  metric: '26 workspace packages',
+                  metric: '26 packages',
                   detail:
-                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private. Source at packages/.',
+                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private workspace packages. Source at packages/.',
                 },
```

The "workspace" framing is preserved by moving it into the detail line ("5 private workspace packages") on a separate string so the regex still doesn't match.

## Verify

```bash
pnpm validate:claims
# Mismatches: 0 across 72 claims
```

Local result: ✅ all clean.

## Why this branches from `main`, not `test`

Same hot-fix path peer used for [#755](https://github.com/RevealUIStudio/revealui/pull/755) — the buggy Hero.tsx exists on `main` only (Phase 3.1 [#750](https://github.com/RevealUIStudio/revealui/pull/750) + [#755](https://github.com/RevealUIStudio/revealui/pull/755) both merged direct to main, not via test). Test doesn't have a different Hero.tsx to patch.

## Unblocks

[revealui#753](https://github.com/RevealUIStudio/revealui/pull/753) (test→main propagation, OPEN, BLOCKED on this exact regex collision). After this lands on main, #753's merge-state CI runs against fresh main + test, validator passes, #753 unblocks for manual merge per its PR body (merge commit, NOT squash, to preserve history).

## Test plan

- [ ] CI passes (full gate including hard-fail claim-drift)
- [ ] Manual: post-merge, `pnpm validate:claims` returns exit 0 across 72 claims with 0 mismatches
- [ ] Manual: revealui.com/ Hero proof-points block renders "26 packages" with the detail line "21 published on npm... + 5 private workspace packages" (visual regression handled by E2E)

## Merge method

**Squash + delete-branch** per locked posture (single-PR fix to main; standard squash workflow; matches [#755](https://github.com/RevealUIStudio/revealui/pull/755) merge pattern).

## References

- Prior fix that introduced the regex collision: [#755](https://github.com/RevealUIStudio/revealui/pull/755) ([`3de4c975f`](https://github.com/RevealUIStudio/revealui/commit/3de4c975f))
- Phase 3.3 ProductsPage convention this aligned with (correctly, but with regex pitfall): [`a9ed4456a`](https://github.com/RevealUIStudio/revealui/commit/a9ed4456a)
- Phase 3.1 origin of the "21 npm packages" claim: [#750](https://github.com/RevealUIStudio/revealui/pull/750)
- Test→main propagation blocked on this: [#753](https://github.com/RevealUIStudio/revealui/pull/753)
- Validator: `scripts/validate/claim-drift.ts` (workspaces rule at line 819-823, packages rule earlier in same metrics array)
