### PR TITLE
feat(scripts): seed Stripe Billing Meter + tax categories on products/prices

### DIFF
--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -357,6 +357,31 @@ const PRICE_SERVER_ENV_KEYS: Record<string, string> = {
   revealui_credits_scale: 'STRIPE_CREDITS_SCALE_PRICE_ID',
 };
 
+// ─── Stripe Billing Meter (Track B agent task overage) ──────────────────────
+// The runtime emits meter events at apps/server/src/routes/billing.ts:1894
+// using STRIPE_AGENT_METER_EVENT_NAME (fallback 'agent_task_overage'). The
+// meter must exist BEFORE meter events can land — this seed creates it
+// idempotently. Track B per MASTER_PLAN §5.1.
+const AGENT_METER_EVENT_NAME = 'agent_task_overage';
+const AGENT_METER_DISPLAY_NAME = 'Agent task overage';
+
+// ─── Stripe Tax categories ──────────────────────────────────────────────────
+// Stripe Tax requires explicit tax categories on every product/price before
+// account-level Tax can be enabled cleanly.
+//
+// Per Stripe Tax Code Lookup (https://stripe.com/docs/tax/tax-codes):
+//   txcd_10103000 = "Software as a Service (SaaS)" — RevealUI's product class.
+//
+// tax_behavior: 'exclusive' = tax added on top (B2B norm). NOTE: tax_behavior
+// is IMMUTABLE on Stripe prices once set to a non-'unspecified' value —
+// choose carefully. Owner cross-checks both at dry-run BEFORE the live run.
+const PRODUCT_TAX_CODE = 'txcd_10103000';
+const PRICE_TAX_BEHAVIOR: Stripe.PriceCreateParams.TaxBehavior = 'exclusive';
+
+function productTaxCode(p: Stripe.Product): string | null {
+  return typeof p.tax_code === 'string' ? p.tax_code : (p.tax_code?.id ?? null);
+}
+
 // ─── Logger ─────────────────────────────────────────────────────────────────
 
 const log = {
@@ -379,6 +404,43 @@ function isLocalWebhookUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+// ─── Billing Meter ──────────────────────────────────────────────────────────
+
+async function ensureBillingMeter(
+  stripe: Stripe,
+  dryRun: boolean,
+): Promise<Stripe.Billing.Meter | null> {
+  log.info('');
+  log.info(`Meter event name: ${AGENT_METER_EVENT_NAME}`);
+
+  const existing = await stripe.billing.meters.list({ limit: 100, status: 'active' });
+  const match = existing.data.find((m) => m.event_name === AGENT_METER_EVENT_NAME);
+
+  if (match) {
+    log.success(`Meter exists: ${match.id} (${match.event_name})`);
+    return match;
+  }
+
+  if (dryRun) {
+    log.info(`Would create meter: ${AGENT_METER_EVENT_NAME} (${AGENT_METER_DISPLAY_NAME})`);
+    return null;
+  }
+
+  const meter = await stripe.billing.meters.create({
+    display_name: AGENT_METER_DISPLAY_NAME,
+    event_name: AGENT_METER_EVENT_NAME,
+    default_aggregation: { formula: 'sum' },
+    customer_mapping: {
+      type: 'by_id',
+      event_payload_key: 'stripe_customer_id',
+    },
+    value_settings: { event_payload_key: 'value' },
+  });
+
+  log.success(`Created meter: ${meter.id} (${meter.event_name})`);
+  return meter;
 }
 
 // ─── Products & Prices ───────────────────────────────────────────────────────
@@ -413,7 +475,8 @@ async function syncCatalog(
         existingProduct.metadata?.revealui_track !== productDef.billingModel ||
         existingProduct.metadata?.revealui_tier !== productDef.tier ||
         existingProduct.metadata?.revealui_price_note !== productDef.priceNote ||
-        existingProduct.metadata?.revealui_renewal !== productDef.renewal
+        existingProduct.metadata?.revealui_renewal !== productDef.renewal ||
+        productTaxCode(existingProduct) !== PRODUCT_TAX_CODE
       ) {
         if (dryRun) {
           log.info(`Would update product: ${existingProduct.id}`);
@@ -422,6 +485,7 @@ async function syncCatalog(
           product = await stripe.products.update(existingProduct.id, {
             name: productDef.name,
             description: productDef.description,
+            tax_code: PRODUCT_TAX_CODE,
             metadata: {
               revealui_product_key: productDef.key,
               revealui_track: productDef.billingModel,
@@ -444,6 +508,7 @@ async function syncCatalog(
       product = await stripe.products.create({
         name: productDef.name,
         description: productDef.description,
+        tax_code: PRODUCT_TAX_CODE,
         metadata: {
           revealui_product_key: productDef.key,
           revealui_track: productDef.billingModel,
@@ -520,6 +585,7 @@ async function syncCatalog(
         unit_amount: priceDef.unitAmount,
         currency: priceDef.currency,
         metadata: { revealui_price_key: priceDef.key },
+        tax_behavior: PRICE_TAX_BEHAVIOR,
       };
 
       if (priceDef.mode === 'subscription') {
@@ -897,9 +963,14 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // ── Stripe Billing Meter (Track B agent task overage)
+  log.header('Stripe Billing Meter');
+  await ensureBillingMeter(stripe, dryRun);
+
   // ── Products & prices
   log.header('Products & Prices');
   const { envVars, subscriptionProducts, catalogEntries } = await syncCatalog(stripe, dryRun);
+  envVars.STRIPE_AGENT_METER_EVENT_NAME = AGENT_METER_EVENT_NAME;
 
   await writeLocalStripeEnvCache(envVars, catalogEntries, dryRun);
 


### PR DESCRIPTION
## Summary

Extends `scripts/setup/seed-stripe.ts` with three additions to unlock Stripe Tax enable on the new LLC-EIN Stripe account:

1. **Stripe Billing Meter creation** — idempotent via list-then-reuse on `event_name`. Meter must exist before the runtime cron at `apps/server/src/routes/billing.ts:1894` can land meter events successfully (currently fails silently for any paying customer because the meter has never been created).
2. **`tax_code: 'txcd_10103000'` on every product create + update** — SaaS B2B per [Stripe Tax Code Lookup](https://stripe.com/docs/tax/tax-codes).
3. **`tax_behavior: 'exclusive'` on every price create** — B2B norm. Note: `tax_behavior` is immutable on a Stripe price once set to a non-`unspecified` value.

Tracks GAP-193 in an internal repo — steps 1, 3, 4 shipped here; steps 2 + 5 + 7 deferred to follow-ups (see Deferred section below).

## Audit (audit-first SDLC)

- `apps/server/src/routes/billing.ts:1894` — runtime fires `protectedStripe.billing.meterEvents.create()` BUT the meter doesn't exist in Stripe yet, so events fail silently. Will break for the first paying customer otherwise.
- `apps/server/src/routes/billing.ts:604, 1338, 1462, 1594` — `automatic_tax: { enabled: true }` already wired on subscription checkout + perpetual + credit-bundle + x402-bridge. Surfaces tax automatically once products carry tax categories.
- `scripts/setup/seed-stripe.ts` (957 LOC pre-PR) — created products/prices/webhook/portal but **zero matches** for `meter`, `usage_type`, `tax_code`, `tax_behavior` (verified via grep).
- `packages/db/src/schema/agents.ts:416` `agent_task_usage` — Track B persistence layer real and used by the overage cron.

## Changes (file: `scripts/setup/seed-stripe.ts`, +72/-1 LOC)

| Section | Line | Change |
|---|---|---|
| Constants | ~360-381 | New: `AGENT_METER_EVENT_NAME='agent_task_overage'`, `AGENT_METER_DISPLAY_NAME`, `PRODUCT_TAX_CODE='txcd_10103000'`, `PRICE_TAX_BEHAVIOR='exclusive'`, `productTaxCode()` helper (handles `string` vs expanded `Stripe.TaxCode`) |
| Function | ~411 | New: `ensureBillingMeter(stripe, dryRun)` — lists active meters, reuses if `event_name` matches, else creates with `customer_mapping.type='by_id'`, `event_payload_key='stripe_customer_id'`, `value_settings.event_payload_key='value'`, `default_aggregation.formula='sum'` |
| Product needs-update | ~479 | Adds `productTaxCode(existingProduct) !== PRODUCT_TAX_CODE` to OR chain — re-runs detect tax_code drift |
| Product update | ~488 | Adds `tax_code: PRODUCT_TAX_CODE` to update params |
| Product create | ~511 | Adds `tax_code: PRODUCT_TAX_CODE` to create params |
| Price create | ~588 | Adds `tax_behavior: PRICE_TAX_BEHAVIOR` to priceParams |
| `main()` | ~968 | Calls `ensureBillingMeter` after Stripe connection check, before products section |
| `main()` envVars | ~973 | Adds `STRIPE_AGENT_METER_EVENT_NAME` to envVars (picked up by `--sync-vercel` automatically) |

## Owner-actionable verifications BEFORE live run

1. **Cross-check tax_code `txcd_10103000`** at https://stripe.com/docs/tax/tax-codes — confirm SaaS B2B is the right category for RevealUI products. Wrong code = customers charged wrong tax rates.
2. **Verify `STRIPE_SECRET_KEY` in revvault** points to the new LLC-EIN account: `revvault get revealui/prod/stripe/secret-key`. The seed connects to whichever account the secret key points at — wrong account silently seeds the wrong place.
3. **Run `pnpm stripe:seed -- --dry-run`** first. Output should show:
   - `Would create meter: agent_task_overage (Agent task overage)` (or `Meter exists` on re-run)
   - Per-product `Would create product: <name>` (note: dry-run logs the action without dumping the full params; verify by reading the script source)
   - All env vars including `STRIPE_AGENT_METER_EVENT_NAME=agent_task_overage`
4. **Run `pnpm stripe:seed`** for real after dry-run sign-off.
5. **Click "Enable Stripe Tax"** in dashboard → Tax → Settings (one-time UI, can't be IaC'd).
6. **Smoke-test meter event** via test customer to confirm the meter accepts events end-to-end.

## Deferred (separate follow-ups)

- **Metered Price per tier** (GAP-193 step 2) — adding a metered overage Price alongside each subscription Price requires pricing-strategy decision (per-task rate? volume tiers? per-tier rates for Pro/Max/Enterprise?). Not a Tax prereq.
- **Vercel env auto-add for `STRIPE_AGENT_METER_EVENT_NAME`** beyond what `--sync-vercel` already picks up (GAP-193 step 5) — separable 5-line follow-up.
- **Unit tests for seed-stripe.ts** — script has no existing `__tests__/` directory and adding test infrastructure (mock Stripe SDK, isolate `main()` from import-time execution) is non-trivial. The dry-run + owner review is the primary safety net per the dry-run+backup convention.
- **Backfill of `tax_behavior` on pre-existing prices** — Stripe price `tax_behavior` is immutable once set to a non-`unspecified` value. Pre-existing prices from old test seedings would need archive + recreate. Not relevant for the fresh LLC-EIN account being seeded.

## Verify

- Biome: clean (`pnpm exec biome check scripts/setup/seed-stripe.ts`)
- Typecheck: no errors mentioning seed-stripe.ts (`pnpm exec tsc --noEmit | grep seed-stripe` returned empty)
- CR8 gate (internal docs peer state): preserved — 4 `scripts/cr8-p0-01-smoke/*.sh` + `pre-commit-claude-state-guard.sh` M-untouched

## Test plan

- [ ] CI green
- [ ] Owner cross-checks `txcd_10103000` at Stripe Tax Code Lookup
- [ ] Owner verifies `STRIPE_SECRET_KEY` points at new LLC-EIN account
- [ ] Owner runs `pnpm stripe:seed -- --dry-run` and signs off on output
- [ ] Owner runs `pnpm stripe:seed` for real
- [ ] Owner clicks "Enable Stripe Tax" in dashboard
- [ ] Smoke test: emit a meter event via test customer, verify it lands in Stripe Billing Meters dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
