### PR TITLE
chore(contracts): patch bump to rebuild revealcoin manifest dist

### DIFF
--- a/.changeset/contracts-revealcoin-dist-rebuild.md
+++ b/.changeset/contracts-revealcoin-dist-rebuild.md
@@ -1,0 +1,11 @@
+---
+'@revealui/contracts': patch
+---
+
+Fix: RVUI_MINT_ADDRESSES dist regenerated from manifest source. Pre-fix dist had hardcoded mainnet-beta=devnet-address. Affects only external npm consumers; in-tree consumers always read src/ via workspace links.
+
+The previously published `1.4.0` dist predated the manifest-derived refactor in `packages/contracts/src/revealcoin.ts:59-79` (`deriveNetworkRecord` + the `RVUI_MINT_ADDRESSES` / `RVUI_MINT_AUTHORITY` exports). External consumers of `@revealui/contracts@1.4.0` from npm therefore read the wrong `mainnet-beta` value (the devnet mint address copied across networks). Bumping to `1.4.1` with a clean `pnpm --filter @revealui/contracts build` republishes the correct manifest-derived behavior — empty string for unconfigured networks, the real address only when `REVEALCOIN_MANIFEST.networks[network].mintAddress` is non-empty.
+
+Behavioral fix only. No exported types or schemas change. Per `~/revfleet/.jv/.claude/rules/versioning.md` `@revealui/contracts` exception, patch is the correct semver level (no breaking change).
+
+Audit reference: `~/revfleet/.jv/docs/audits/2026-05-08-charge-readiness-deep-audit.md` §5 Phase 0. Related: revealui#763 (revealcoin frontend mainnet honesty) — same dishonesty class on the frontend; this PR closes the npm-consumer side.


### PR DESCRIPTION
## Summary

Add a patch changeset so the next release publishes `@revealui/contracts@1.4.1` with a freshly-built dist that matches the manifest-derived source. The currently-published `1.4.0` dist on npm predates the `@revealui/revealcoin-manifest` refactor and ships a hardcoded `mainnet-beta` value that is actually the devnet address copied across networks (`4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo`).

## Why this matters

External consumers of `@revealui/contracts@1.4.0` from npm — revealui.com (when consumed via npm rather than workspace links), agency site, marketplace, any third party — currently read a **false mainnet mint address**. Same dishonesty class as #763 (frontend), but on the npm-consumer side.

In-tree consumers are unaffected: their builds resolve `@revealui/contracts` via pnpm workspace links and read `src/` directly. The bug is only visible to npm consumers.

## What changed

- New changeset: `.changeset/contracts-revealcoin-dist-rebuild.md`
- Declared `'@revealui/contracts': patch` per the package's versioning exception in internal docs (no exported types or schemas change; behavior fix only; semver patch is correct).
- No source changes — `packages/contracts/src/revealcoin.ts:59-79` already derives `RVUI_MINT_ADDRESSES` and `RVUI_MINT_AUTHORITY` from `@revealui/revealcoin-manifest`. Only the published `dist/` is stale; `dist/` is gitignored, so the rebuild happens at publish time.

## How the fix lands

1. Merge this PR into `test`, then promote to `main` per release flow.
2. `pnpm changeset:version` (owner action) bumps `1.4.0 → 1.4.1` and writes the CHANGELOG entry from the changeset body.
3. `pnpm changeset:publish` (owner action) rebuilds dist from the manifest-derived source and pushes to npm.

After step 3, external consumers running `pnpm add @revealui/contracts@latest` get an empty `mainnet-beta` string until `REVEALCOIN_MANIFEST.networks` is updated with a real mainnet address.

## Owner action required

- Do **NOT** auto-merge. Owner reviews and merges.
- Do **NOT** publish to npm from this PR — `pnpm changeset:publish` is owner action after the release version bump.

## Audit reference

internal docs §5 Phase 0 (lines 134-147).

Related: #763 (frontend mainnet honesty).

## Test plan

- [x] Local: `pnpm --filter @revealui/contracts build` regenerates dist with manifest-derived form.
- [x] Local: `head -50 packages/contracts/dist/revealcoin.js` shows `deriveNetworkRecord('mintAddress')` and `deriveNetworkRecord('mintAuthority')` instead of hardcoded values.
- [ ] CI: existing `@revealui/contracts` test suite passes (no source changes — should be a no-op).
- [ ] After publish: verify `https://registry.npmjs.org/@revealui/contracts/1.4.1` ships the correct `dist/revealcoin.js` (owner action post-publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
