### PR TITLE
feat(sync): revvault to Vercel sync manifest + pnpm scripts

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -86,8 +86,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_...
 NEXT_PRIVATE_STRIPE_PUBLISHABLE_KEY=pk_test_...
 # Enable Stripe proxy for local webhook testing (stripe CLI):
 # STRIPE_PROXY=1
-# Expose whether the key is a test key to the client:
-REVEALUI_PUBLIC_STRIPE_IS_TEST_KEY=true
+# Expose live/test mode to the client (used for the test-mode banner):
 NEXT_PUBLIC_IS_LIVE=false
 
 # -----------------------------------------------------------------------------

--- a/apps/admin/.env.production.template
+++ b/apps/admin/.env.production.template
@@ -69,7 +69,6 @@ NEXT_PUBLIC_STRIPE_PRO_PRICE_ID=price_<your-pro-price-id>
 NEXT_PUBLIC_STRIPE_MAX_PRICE_ID=price_<your-max-price-id>
 NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID=price_<your-enterprise-price-id>
 NEXT_PUBLIC_IS_LIVE=false
-REVEALUI_PUBLIC_STRIPE_IS_TEST_KEY=true
 
 # -----------------------------------------------------------------------------
 # RevealUI License — Ed25519 key pair

--- a/docs/runbooks/vercel-env-sync.md
+++ b/docs/runbooks/vercel-env-sync.md
@@ -1,0 +1,117 @@
+# Vercel env sync — operator runbook
+
+`revvault` is the canonical store for every Vercel-runtime secret in this monorepo. This runbook covers the day-to-day workflow.
+
+## Prerequisites (one-time)
+
+1. **revvault binary** with PR [RevealUIStudio/revvault#40](https://github.com/RevealUIStudio/revvault/pull/40) (per-var path overrides).
+
+   ```bash
+   cd ~/revfleet/revvault && cargo install --path crates/cli
+   revvault --version  # 0.1.0+ with `vars` table support
+   ```
+
+2. **VERCEL_TOKEN** environment variable. Create at [Vercel → Settings → Tokens](https://vercel.com/account/tokens) (scope: project access, `revealuistudio` org). Export from your shell profile:
+
+   ```bash
+   export VERCEL_TOKEN=...
+   ```
+
+   Or pass `--token` per-command.
+
+3. **Manifest:** [`scripts/sync/revvault-vercel.toml`](../../scripts/sync/revvault-vercel.toml). Drives sync — see comments inside for the schema.
+
+## Common workflows
+
+### Add a new secret
+
+```bash
+# 1. Add the value to revvault at its canonical path
+revvault set revealui/prod/<subsystem>/<name-kebab>
+
+# 2. Map it in the manifest (scripts/sync/revvault-vercel.toml)
+#    Add a [projects.<slug>.vars] entry: VERCEL_VAR_NAME = "revealui/prod/..."
+
+# 3. Dry-run first to see what'd change
+pnpm vercel:sync
+
+# 4. Apply
+pnpm vercel:sync:apply
+
+# 5. Redeploy the affected Vercel project so the new env hits runtime
+```
+
+### Rotate an existing secret
+
+```bash
+# 1. Set the new value in revvault (overwrites old)
+revvault set <canonical-path> --force
+
+# 2. Dry-run shows it as Update
+pnpm vercel:sync
+
+# 3. Apply
+pnpm vercel:sync:apply
+
+# 4. Redeploy
+```
+
+### Backfill (import existing Vercel vars into revvault)
+
+Use this to seed revvault when a Vercel project has secrets revvault doesn't yet know about — typically a one-time bootstrap.
+
+```bash
+# Dry-run shows what'd be imported and to which paths
+pnpm vercel:sync:pull
+
+# Apply — writes to <vault_prefix>/<VAR_NAME> by default,
+# OR to override paths if a [projects.<slug>.vars] entry exists
+pnpm vercel:sync:pull:apply
+```
+
+### Drift check (read-only)
+
+For CI or pre-deploy validation:
+
+```bash
+pnpm vercel:drift-check
+```
+
+Outputs JSON describing every variable's diff state per project (Add / Update / Orphan / Skip). Non-blocking — sync drift is a warning, not a build failure.
+
+## What the diff actions mean
+
+| Symbol | Action | Meaning |
+|---|---|---|
+| `+` | Add | Vault has a value, Vercel doesn't — push will create |
+| `~` | Update | Both sides have the value — push will overwrite Vercel from vault |
+| `!` | Orphan | Vercel has a value, vault doesn't — manual cleanup needed (sync never deletes from Vercel) |
+| `-` | Skip | In manifest's `skip` list — sync never touches |
+
+## Anti-patterns to avoid
+
+- **Editing Vercel env directly via the dashboard** — sync drift inevitable. Always go through revvault + `pnpm vercel:sync:apply`.
+- **Storing secrets in `.env.local` or env files committed to git** — pre-commit hook blocks `.env*`; if the hook ever fails, the file becomes the canonical source instead of revvault. Revvault first, always.
+- **`pnpm vercel:sync:apply` without a dry-run first** — habit, not a hard rule. Dry-run is the default for a reason.
+
+## When sync goes sideways
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Cannot read manifest` | working directory mismatch | run from `~/revfleet/revealui` (root); pnpm scripts handle this |
+| `403 Forbidden` from Vercel | `VERCEL_TOKEN` wrong/expired | regenerate token; export new value |
+| Var shows as `Add` even though it's already on Vercel | `vault_prefix` mismatch | check the manifest's project block matches the actual Vercel project ID |
+| `Orphan` warnings stack up | values added directly via Vercel UI | for each: add to manifest's `vars` table OR add to `skip` list with reason |
+| Vault path resolution surprises | `vars` override vs. prefix-derived collision | run `pnpm vercel:sync` (dry-run, JSON mode) and check the resolved paths in the diff |
+
+## Out of scope (deferred to v2)
+
+- Preview + development env target sync — production-only in v1 per [`vercel-env-canonical-mapping.md`](../../../revealui-jv/docs/vercel-env-canonical-mapping.md) Q4
+- Per-var Sensitive flag policy — gated on revvault adding `var_type` plumbing per concern C2 in the design doc
+- Auto-rotation chain — `revvault rotate <path>` triggering Vercel sync; design doc Phase 5
+
+## See also
+
+- Design doc: [`~/revfleet/.jv/docs/revvault-vercel-sync.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/revvault-vercel-sync.md)
+- Canonical env-var mapping: [`~/revfleet/.jv/docs/vercel-env-canonical-mapping.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/vercel-env-canonical-mapping.md)
+- Secrets rule: [`~/revfleet/.claude/rules/secrets.md`](../../../.claude/rules/secrets.md)

--- a/package.json
+++ b/package.json
@@ -206,7 +206,12 @@
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",
     "validate:raw-sql": "tsx scripts/validate/raw-sql.ts",
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
-    "kek:rotate": "tsx scripts/security/rotate-kek.ts"
+    "kek:rotate": "tsx scripts/security/rotate-kek.ts",
+    "vercel:sync": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
+    "vercel:sync:apply": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
+    "vercel:sync:pull": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --pull",
+    "vercel:sync:pull:apply": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --pull --apply",
+    "vercel:drift-check": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json"
   },
   "type": "module"
 }

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -93,7 +93,8 @@ PASSKEY_RP_ID          = "revealui/prod/passkey/rp-id"
 PASSKEY_RP_NAME        = "revealui/prod/passkey/rp-name"
 SESSION_COOKIE_DOMAIN  = "revealui/prod/session-cookie-domain"
 CORS_ORIGIN            = "revealui/prod/cors-origin"
-REVEALUI_CORS_ORIGINS  = "revealui/prod/cors-origins"
+# REVEALUI_CORS_ORIGINS dropped 2026-05-09: code falls back to CORS_ORIGIN
+# when unset. Re-add when admin/api actually need separate cross-origin config.
 
 # Marketplace
 MARKETPLACE_CONNECT_RETURN_URL = "revealui/prod/marketplace-connect-return-url"
@@ -204,10 +205,11 @@ skip = [
 # Mode flags + public URLs (canonical paths shared with admin/api)
 NEXT_PUBLIC_IS_LIVE        = "revealui/prod/public/is-live"
 NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
-NEXT_PUBLIC_ADMIN_URL      = "revealui/prod/public/admin-url"
 REVEALUI_API_URL           = "revealui/prod/public/api-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
 REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
+# NEXT_PUBLIC_ADMIN_URL dropped 2026-05-09: not used in apps/marketing yet.
+# Re-add when CMS_URL → ADMIN_URL rename ships.
 
 
 # ── revealui-docs ───────────────────────────────────────────────────────────

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -1,0 +1,185 @@
+# revvault → Vercel sync manifest
+#
+# Drives `revvault sync vercel --manifest scripts/sync/revvault-vercel.toml`
+# (default path; the pnpm scripts in package.json point at this file).
+#
+# Schema:
+#   - [projects.<slug>]       — one block per Vercel project
+#   - project_id              — Vercel project ID (prj_...)
+#   - vault_prefix            — fallback vault path namespace; vars not listed
+#                               in [projects.<slug>.vars] are read from
+#                               <vault_prefix>/<VAR_NAME>
+#   - targets                 — Vercel envs to sync; production-only in v1
+#                               per Q4 (preview + development deferred)
+#   - skip                    — Vercel var names sync intentionally never touches
+#                               (e.g. STRIPE_LIVE_MODE per Q3 — Vercel-direct
+#                               deployment toggle, not a credential)
+#   - [projects.<slug>.vars]  — per-var path overrides (UPPER_SNAKE → vault path);
+#                               lets multiple Vercel vars feed from one canonical
+#                               kebab path (e.g. POSTGRES_URL + DATABASE_URL both
+#                               read from revealui/prod/db/postgres-url)
+#
+# Owner-ratified conventions: see ~/revfleet/.jv/docs/vercel-env-canonical-mapping.md
+# Design doc: ~/revfleet/.jv/docs/revvault-vercel-sync.md
+# Requires revvault binary with PR #40 (per-var path overrides via `vars` table)
+
+# Personal account — no team_id needed (Vercel team is implicit via the token)
+
+# ── revealui-api ────────────────────────────────────────────────────────────
+[projects.revealui-api]
+project_id = "prj_zk6EQijYXwd9L7BccuBssi436ktM"
+vault_prefix = "revealui/vercel/api"
+targets = ["production"]
+skip = [
+  # NODE_ENV is platform-managed, never user-touched
+  "NODE_ENV",
+  # STRIPE_LIVE_MODE is a Vercel-direct deployment toggle (Q3 owner exception)
+  "STRIPE_LIVE_MODE",
+]
+
+[projects.revealui-api.vars]
+# Stripe — keys + secrets
+STRIPE_SECRET_KEY              = "revealui/prod/stripe/secret-key"
+STRIPE_WEBHOOK_SECRET          = "revealui/prod/stripe/webhook-secret"
+STRIPE_WEBHOOK_SECRET_LIVE     = "revealui/prod/stripe/webhook-secret-live"
+STRIPE_WEBHOOK_SECRET_PREVIOUS = "revealui/prod/stripe/webhook-secret-previous"
+STRIPE_AGENT_METER_EVENT_NAME  = "revealui/prod/stripe/agent-meter-event-name"
+
+# Stripe — price IDs (literal, low-secrecy)
+STRIPE_PRO_PRICE_ID                  = "revealui/prod/stripe/pro-price-id"
+STRIPE_MAX_PRICE_ID                  = "revealui/prod/stripe/max-price-id"
+STRIPE_ENTERPRISE_PRICE_ID           = "revealui/prod/stripe/enterprise-price-id"
+STRIPE_PERPETUAL_PRO_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
+STRIPE_PERPETUAL_MAX_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
+STRIPE_PERPETUAL_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
+STRIPE_CREDITS_STARTER_PRICE_ID      = "revealui/prod/stripe/credits-starter-price-id"
+STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-price-id"
+STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
+STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
+
+# Database
+POSTGRES_URL = "revealui/prod/db/postgres-url"
+DATABASE_URL = "revealui/prod/db/postgres-url"
+
+# Encryption + signing
+REVEALUI_KEK                = "revealui/prod/kek"
+REVEALUI_KEK_NEXT           = "revealui/prod/kek-next"
+REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
+REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
+REVEALUI_AUDIT_HMAC_SECRET   = "revealui/prod/audit-hmac-secret"
+REVEALUI_SECRET              = "revealui/prod/secret"
+
+# Cron + alerting
+REVEALUI_CRON_SECRET = "revealui/prod/cron-secret"
+REVEALUI_ALERT_EMAIL = "revealui/prod/alert-email"
+
+# Storage + CI tokens
+BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
+REVEALUI_NPM_TOKEN    = "revealui/prod/api-keys/npm-automation-token"
+
+# Email transport (Gmail SA)
+GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
+GOOGLE_PRIVATE_KEY            = "revealui/prod/google/private-key"
+EMAIL_FROM                    = "revealui/prod/email/from"
+EMAIL_REPLY_TO                = "revealui/prod/email/reply-to"
+
+# Auth + session
+PASSKEY_ORIGIN         = "revealui/prod/passkey/origin"
+PASSKEY_RP_ID          = "revealui/prod/passkey/rp-id"
+PASSKEY_RP_NAME        = "revealui/prod/passkey/rp-name"
+SESSION_COOKIE_DOMAIN  = "revealui/prod/session-cookie-domain"
+CORS_ORIGIN            = "revealui/prod/cors-origin"
+REVEALUI_CORS_ORIGINS  = "revealui/prod/cors-origins"
+
+# Marketplace
+MARKETPLACE_CONNECT_RETURN_URL = "revealui/prod/marketplace-connect-return-url"
+
+# Electric (real-time sync)
+ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
+ELECTRIC_SECRET      = "revealui/prod/electric/secret"
+
+# Public (bundled into client; not secret, kept canonical for reproducibility)
+NEXT_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
+
+
+# ── revealui-admin ──────────────────────────────────────────────────────────
+[projects.revealui-admin]
+project_id = "prj_7sEFDg4MH6C26nJPjrukK86QdwfG"
+vault_prefix = "revealui/vercel/admin"
+targets = ["production"]
+skip = [
+  "NODE_ENV",
+  # Drop in Q7 — the third "is live" synonym; admin code migrating to
+  # NEXT_PUBLIC_IS_LIVE. Keeping in skip means existing Vercel value is
+  # not tracked by sync and will surface as an Orphan until removed.
+  "REVEALUI_PUBLIC_STRIPE_IS_TEST_KEY",
+]
+
+[projects.revealui-admin.vars]
+# Stripe — keys (parity with api)
+STRIPE_SECRET_KEY     = "revealui/prod/stripe/secret-key"
+STRIPE_WEBHOOK_SECRET = "revealui/prod/stripe/webhook-secret"
+
+# Stripe — publishable key (admin-side client SDK)
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "revealui/prod/stripe/publishable-key"
+
+# Stripe — price IDs (parity twins; same canonical paths as api)
+NEXT_PUBLIC_STRIPE_PRO_PRICE_ID        = "revealui/prod/stripe/pro-price-id"
+NEXT_PUBLIC_STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/enterprise-price-id"
+NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
+
+# Database
+POSTGRES_URL  = "revealui/prod/db/postgres-url"
+NEON_API_KEY  = "revealui/prod/db/neon-api-key"
+
+# Encryption + signing (parity with api — same license keypair)
+REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
+REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
+
+# Storage
+BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
+
+# Mode flags (canonical pair — kept post-Q7)
+NEXT_PUBLIC_IS_LIVE = "revealui/prod/public/is-live"
+
+# Public URLs
+NEXT_PUBLIC_API_URL = "revealui/prod/public/api-url"
+
+# Admin-specific (CMS bootstrap creds — admin-only; canonical paths under cms/)
+CMS_ADMIN_EMAIL    = "revealui/prod/cms/admin-email"
+CMS_ADMIN_PASSWORD = "revealui/prod/cms/admin-password"
+
+
+# ── revealui-marketing ──────────────────────────────────────────────────────
+[projects.revealui-marketing]
+project_id = "prj_frTIYlnONVPLNIjKnQpINiGb5lm0"
+vault_prefix = "revealui/vercel/marketing"
+targets = ["production"]
+skip = [
+  "NODE_ENV",
+  # Audit-flagged dead vars — verify-then-drop in Phase 4 cleanup
+  "POSTGRES_URL",
+  "REVEALUI_SECRET",
+]
+
+[projects.revealui-marketing.vars]
+# Mode flags + public URLs (canonical paths shared with admin/api)
+NEXT_PUBLIC_IS_LIVE  = "revealui/prod/public/is-live"
+NEXT_PUBLIC_API_URL  = "revealui/prod/public/api-url"
+NEXT_PUBLIC_ADMIN_URL = "revealui/prod/public/admin-url"
+REVEALUI_API_URL     = "revealui/prod/public/api-url"
+
+
+# ── revealui-docs ───────────────────────────────────────────────────────────
+[projects.revealui-docs]
+project_id = "prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1"
+vault_prefix = "revealui/vercel/docs"
+targets = ["production"]
+# docs site has zero prod env vars at audit time (2026-05-09); the block exists
+# so future additions get caught in `vercel:drift-check` automatically
+
+
+# ── Future projects ─────────────────────────────────────────────────────────
+# revealcoin (prj_XDiPXngciRytGA8j0vNIDz7hENRM)   — 0 env vars, deferred
+# revealui-agency (prj_GoWIj5g7TsBp4CLmzBSk5CwXG2So) — separate repo, deferred

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -56,6 +56,10 @@ STRIPE_CREDITS_STARTER_PRICE_ID      = "revealui/prod/stripe/credits-starter-pri
 STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-price-id"
 STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
 STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
+STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/prod/stripe/max-annual-price-id"
+
+# Admin API key (parity with admin)
+REVEALUI_ADMIN_API_KEY = "revealui/prod/admin/api-key"
 
 # Database
 POSTGRES_URL = "revealui/prod/db/postgres-url"
@@ -99,7 +103,8 @@ ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
 ELECTRIC_SECRET      = "revealui/prod/electric/secret"
 
 # Public (bundled into client; not secret, kept canonical for reproducibility)
-NEXT_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 
 
 # ── revealui-admin ──────────────────────────────────────────────────────────
@@ -109,6 +114,8 @@ vault_prefix = "revealui/vercel/admin"
 targets = ["production"]
 skip = [
   "NODE_ENV",
+  # Next.js telemetry opt-out — platform-managed, not a credential
+  "NEXT_TELEMETRY_DISABLED",
   # Drop in Q7 — the third "is live" synonym; admin code migrating to
   # NEXT_PUBLIC_IS_LIVE. Keeping in skip means existing Vercel value is
   # not tracked by sync and will surface as an Orphan until removed.
@@ -128,27 +135,57 @@ NEXT_PUBLIC_STRIPE_PRO_PRICE_ID        = "revealui/prod/stripe/pro-price-id"
 NEXT_PUBLIC_STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
 NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/enterprise-price-id"
 NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
+# Bare versions on admin (server-side reads in Next.js api routes; same values)
+STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
+STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
 
 # Database
 POSTGRES_URL  = "revealui/prod/db/postgres-url"
 NEON_API_KEY  = "revealui/prod/db/neon-api-key"
 
-# Encryption + signing (parity with api — same license keypair)
+# Encryption + signing (parity with api — same license keypair + session secret)
 REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
+REVEALUI_SECRET              = "revealui/prod/secret"
+
+# Cron + alerting (parity with api)
+REVEALUI_CRON_SECRET = "revealui/prod/cron-secret"
 
 # Storage
 BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
 
+# Email transport (parity with api — same Gmail SA credentials)
+EMAIL_FROM                   = "revealui/prod/email/from"
+EMAIL_REPLY_TO               = "revealui/prod/email/reply-to"
+GOOGLE_PRIVATE_KEY           = "revealui/prod/google/private-key"
+GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
+
+# Auth + session (parity with api)
+SESSION_COOKIE_DOMAIN = "revealui/prod/session-cookie-domain"
+
+# Electric (parity with api — same realtime sync infrastructure)
+ELECTRIC_SECRET      = "revealui/prod/electric/secret"
+ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
+
 # Mode flags (canonical pair — kept post-Q7)
 NEXT_PUBLIC_IS_LIVE = "revealui/prod/public/is-live"
 
-# Public URLs
-NEXT_PUBLIC_API_URL = "revealui/prod/public/api-url"
+# Public URLs (parity twins across api/admin/marketing)
+NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
+REVEALUI_API_URL           = "revealui/prod/public/api-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 
-# Admin-specific (CMS bootstrap creds — admin-only; canonical paths under cms/)
+# CMS bootstrap creds (canonical paths under cms/)
 CMS_ADMIN_EMAIL    = "revealui/prod/cms/admin-email"
 CMS_ADMIN_PASSWORD = "revealui/prod/cms/admin-password"
+
+# Admin-specific (no parity — kebab paths under admin/ for consistency with secrets.md)
+REVEALUI_ADMIN_EMAIL         = "revealui/prod/admin/email"
+REVEALUI_ADMIN_PASSWORD      = "revealui/prod/admin/password"
+REVEALUI_ADMIN_API_KEY       = "revealui/prod/admin/api-key"
+REVEALUI_REVALIDATION_KEY    = "revealui/prod/admin/revalidation-key"
+REVEALUI_PUBLIC_DRAFT_SECRET = "revealui/prod/admin/draft-secret"
 
 
 # ── revealui-marketing ──────────────────────────────────────────────────────
@@ -165,10 +202,12 @@ skip = [
 
 [projects.revealui-marketing.vars]
 # Mode flags + public URLs (canonical paths shared with admin/api)
-NEXT_PUBLIC_IS_LIVE  = "revealui/prod/public/is-live"
-NEXT_PUBLIC_API_URL  = "revealui/prod/public/api-url"
-NEXT_PUBLIC_ADMIN_URL = "revealui/prod/public/admin-url"
-REVEALUI_API_URL     = "revealui/prod/public/api-url"
+NEXT_PUBLIC_IS_LIVE        = "revealui/prod/public/is-live"
+NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
+NEXT_PUBLIC_ADMIN_URL      = "revealui/prod/public/admin-url"
+REVEALUI_API_URL           = "revealui/prod/public/api-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 
 
 # ── revealui-docs ───────────────────────────────────────────────────────────
@@ -176,8 +215,11 @@ REVEALUI_API_URL     = "revealui/prod/public/api-url"
 project_id = "prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1"
 vault_prefix = "revealui/vercel/docs"
 targets = ["production"]
-# docs site has zero prod env vars at audit time (2026-05-09); the block exists
-# so future additions get caught in `vercel:drift-check` automatically
+# docs site has zero prod env vars at audit time (2026-05-09); preview env
+# carries REVEALUI_API_URL — caught by parity-twin override below
+
+[projects.revealui-docs.vars]
+REVEALUI_API_URL = "revealui/prod/public/api-url"
 
 
 # ── Future projects ─────────────────────────────────────────────────────────

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -42,7 +42,8 @@ skip = [
 STRIPE_SECRET_KEY              = "revealui/prod/stripe/secret-key"
 STRIPE_WEBHOOK_SECRET          = "revealui/prod/stripe/webhook-secret"
 STRIPE_WEBHOOK_SECRET_LIVE     = "revealui/prod/stripe/webhook-secret-live"
-STRIPE_WEBHOOK_SECRET_PREVIOUS = "revealui/prod/stripe/webhook-secret-previous"
+# STRIPE_WEBHOOK_SECRET_PREVIOUS deferred — rotation slot, populated only
+# during webhook-secret rotation. Re-add to manifest at that time.
 STRIPE_AGENT_METER_EVENT_NAME  = "revealui/prod/stripe/agent-meter-event-name"
 
 # Stripe — price IDs (literal, low-secrecy)
@@ -67,7 +68,8 @@ DATABASE_URL = "revealui/prod/db/postgres-url"
 
 # Encryption + signing
 REVEALUI_KEK                = "revealui/prod/kek"
-REVEALUI_KEK_NEXT           = "revealui/prod/kek-next"
+# REVEALUI_KEK_NEXT deferred — rotation slot, populated only during KEK
+# rotation. Re-add to manifest at that time.
 REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
 REVEALUI_AUDIT_HMAC_SECRET   = "revealui/prod/audit-hmac-secret"


### PR DESCRIPTION
## Summary

Phase 2 of `revvault-vercel-sync.md`. Ships the working `revvault → Vercel` sync pipeline with a TOML manifest covering all 4 active RevealUI Vercel projects.

After this lands + the dependency PRs merge, every Vercel-runtime secret has a single canonical kebab-cased path in revvault, and `pnpm vercel:sync:apply` pushes from vault to Vercel atomically.

## Dependencies (must land first)

1. [`RevealUIStudio/revvault#40`](https://github.com/RevealUIStudio/revvault/pull/40) — adds the `vars` per-var path override capability the manifest depends on. Local binary already has it; PR open for review.
2. an internal repo — sister PR with the canonical env-var mapping doc that drove this manifest.

## What's in the PR

### `scripts/sync/revvault-vercel.toml`

TOML manifest with `[projects.<slug>]` blocks for:
- `revealui-api` (38 prod env vars, ~30 mapped, 2 in `skip`)
- `revealui-admin` (38 prod env vars, ~14 mapped, dropped synonym in `skip`)
- `revealui-marketing` (7 vars, audit-flagged dead vars in `skip`)
- `revealui-docs` (0 vars, block exists for future drift-check)

The `[projects.<slug>.vars]` tables route Vercel var names to canonical kebab paths under `revealui/prod/...`, honoring the `secrets.md` convention without value duplication. Same kebab path can feed multiple Vercel vars (e.g. `POSTGRES_URL` + `DATABASE_URL` both → `revealui/prod/db/postgres-url`).

### `package.json` — 5 new scripts

```
pnpm vercel:sync              # dry-run push (default)
pnpm vercel:sync:apply        # push to Vercel
pnpm vercel:sync:pull         # dry-run pull (Vercel → vault)
pnpm vercel:sync:pull:apply   # pull + write
pnpm vercel:drift-check       # dry-run JSON output (CI-friendly)
```

### `docs/runbooks/vercel-env-sync.md`

Operator runbook covering add-secret / rotate-secret / backfill / drift-check workflows, diff-symbol legend, common failure modes, anti-patterns to avoid.

## Decisions baked in

Per owner-ratified Q1-Q7 leans (2026-05-09):
- **Q1** Postgres at `revealui/prod/db/postgres-url` (concern-aligned, provider-agnostic)
- **Q2** Scope: `revealui/prod/*` only
- **Q3** `STRIPE_LIVE_MODE` is Vercel-direct exception → `skip` list
- **Q4** Production-only `targets` in v1
- **Q5** Snapshot-before-write helper deferred (revvault gap)
- **Q6** Sensitive flag deferred (Phase 5 / revvault PR for `var_type` plumbing)
- **Q7** Drop `REVEALUI_PUBLIC_STRIPE_IS_TEST_KEY` synonym → `skip` list (Phase 4 cleanup removes it from Vercel)

## Test plan

- [x] TOML manifest parses cleanly via the new revvault binary (auth-error proves parse succeeded)
- [x] `package.json` is valid JSON
- [x] Biome lint clean
- [x] Pre-push gate passed (gitleaks `no leaks found`)
- [ ] Local dry-run with valid `VERCEL_TOKEN` (owner-action; not in CI yet)
- [ ] Phase 1 backfill: `pnpm vercel:sync:pull:apply` against test mode
- [ ] Phase 2 push: `pnpm vercel:sync:apply` once vault is fully populated
- [ ] Phase 4 Stripe live flip executes through this pipeline

## Out of scope (deferred)

- Phase 4 Stripe live flip — separate change-window after the dependency chain merges + Phase 1 backfill completes
- Phase 5 rotation-chain integration — gated on revvault `var_type` PR
- Preview / development env target sync — production-only in v1 per Q4
- CI workflow_dispatch (`vercel:sync:apply` from GitHub Actions) — design doc Phase 4

## Migration order (for the owner)

1. Merge revvault#40
2. Merge this PR + an internal repo
3. Owner exports `VERCEL_TOKEN`, runs `pnpm vercel:sync:pull:apply` (test mode)
4. Owner sets the ~8 NEW paths that don't exist in any source (`STRIPE_AGENT_OVERAGE_PRICE_ID`, live keys, `REVEALUI_AUDIT_HMAC_SECRET`, etc.)
5. `pnpm vercel:sync` — confirm clean diff
6. `pnpm vercel:sync:apply` — push canonical state to Vercel
7. Phase 4 Stripe live flip executes through this pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
