### PR TITLE
fix(revealcoin): scope turbo build outputs + complete M6 whitepaper demote

### DIFF
--- a/apps/revealcoin/public/whitepaper.md
+++ b/apps/revealcoin/public/whitepaper.md
@@ -1,6 +1,6 @@
 # RevealCoin (RVC): A Hybrid Utility, Governance, and Reward Token for the RevealUI Ecosystem
 
-**Version 1.0  -  March 2026**
+**Version 0.1.0  -  May 2026**
 **RevealUI Studio | founder@revealui.com**
 
 ---
@@ -545,7 +545,7 @@ Critical operations require multi-signature approval:
 - [x] Full supply minted to treasury
 - [x] On-chain metadata (name, symbol, extensions)
 - [x] Verification tooling
-- [x] White paper v1.0
+- [x] White paper v0.1.0
 - [ ] Token logo and visual identity
 - [ ] Community channels (Discourse governance forum, X/Twitter)
 

--- a/apps/revealcoin/turbo.json
+++ b/apps/revealcoin/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two coupled fixes, scope of the RVC whitepaper M6 retroactive-demote track:

1. **Per-package `apps/revealcoin/turbo.json`** narrows build outputs to `dist/**`, removing the `public/**` cache trap inherited from the root `turbo.json`. Mirrors the existing override pattern at `apps/admin/turbo.json` and `apps/docs/turbo.json`.
2. **Demote `apps/revealcoin/public/whitepaper.md`** L3 + L548 from `1.0` -> `0.1.0` per audit Finding 8.

Source-side already demoted in revealcoin#14 (merged as `4a4de84`).

## Why the prior "auto-regen" diagnosis was wrong

[revealui#775](https://github.com/RevealUIStudio/revealui/pull/775) originally bundled this destination demote, observed CI fail at "Validate generated types are in sync" with diff `apps/revealcoin/public/whitepaper.md | 2 +-`, and reverted in commit [`ee3263a5`](https://github.com/RevealUIStudio/revealui/commit/ee3263a52e3326bd53698cc158974716210ae66b) citing an "auto-regen pulling from revealcoin/docs/whitepaper.md -> revealui/apps/revealcoin/public/whitepaper.md during build."

**There is no such auto-regen.** revealui has:
- No copy/sync script (`grep -r "whitepaper" scripts/ .github/workflows/ .husky/` -> empty)
- No git submodule (`.gitmodules` empty; `no-submodules.yml` actively forbids them)
- No postinstall, no husky CI hook
- None of `pnpm --filter @revealui/db generate:*` touch markdown

The two files are not even in sync — the source uses em-dashes (`—`), the destination uses spaced hyphens (`  -  `) per the [21f8bcb6c](https://github.com/RevealUIStudio/revealui/commit/21f8bcb6c) em-dash sweep.

The "regen" is the **turbo build cache**:
- Root [`turbo.json`](https://github.com/RevealUIStudio/revealui/blob/test/turbo.json) declares `outputs: ["dist/**", ".next/**", "output/**", "public/**"]`
- `apps/revealcoin` uses Vite — `public/` is a static-asset SOURCE, not an output. Vite emits to `dist/`.
- The failed CI run [25599175551](https://github.com/RevealUIStudio/revealui/actions/runs/25599175551) shows `cache hit, replaying logs ...` for revealcoin's build task.
- With `public/**` in outputs, turbo restored the cached `whitepaper.md` (stale Version 1.0) over the in-PR edit. The next-step `git diff --name-only` then saw the unexpected diff and hard-failed.

[`a273a8205`](https://github.com/RevealUIStudio/revealui/commit/a273a8205) (PR #729) hit the same trap and explicitly punted diagnosis as a follow-up:

> Diagnose what regenerates apps/revealcoin/public/whitepaper.md in CI (postinstall? prebuild? turbo task before generate:all?)

This PR closes that follow-up.

## Files Changed

- `apps/revealcoin/turbo.json` (new, 9 lines) — extends root, narrows build `outputs` to `["dist/**"]`. Mirrors `apps/admin/turbo.json`.
- `apps/revealcoin/public/whitepaper.md` (2 line change) — L3 header + L548 roadmap checklist demoted, em-dash-clean form preserved.

## Risk + Verification

- The override is scoped to `apps/revealcoin` only. apps/docs (which legitimately writes to `public/docs/`) keeps its own override. apps/admin keeps its `[".next/**"]` override.
- After this lands, the next CI run will cache-miss on revealcoin's build (different turbo task definition -> different cache key) and re-bake with the demoted whitepaper. Future builds remain stable since vite never emits to `public/`.
- No other apps inheriting the root turbo config (marketing, server, revealcoin) emit to `public/` at build time, but this PR doesn't change root behavior — only adds a per-app override.

## Audit Doc Follow-up

internal docs Finding 7 inherited the misdiagnosis ("auto-regen mechanism that pulls from source"). A correction PR will land in an internal repo to update Finding 7 with the actual root cause (turbo cache trap) and document the closure.

## Companion + Closure

- Companion: revealcoin#14 (source side, merged).
- Closes M6 retroactive-demote track for the RVC whitepaper artifact.
