### PR TITLE
fix(server): genuinely ship GAP-S1/S2 (SENTRY_DSN required + sendCronFailureAlert) — Phase 1 P0

### DIFF
--- a/apps/server/src/lib/__tests__/cron-alerts.test.ts
+++ b/apps/server/src/lib/__tests__/cron-alerts.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CronFailureContext } from '../cron-alerts.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before any import of the module under test so Vitest
+// hoists them correctly.
+// ---------------------------------------------------------------------------
+
+vi.mock('@sentry/node', () => ({
+  withScope: vi.fn((cb: (scope: unknown) => void) => {
+    cb({
+      setTag: vi.fn(),
+      setLevel: vi.fn(),
+      setContext: vi.fn(),
+    });
+  }),
+  captureException: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../email.js', () => ({
+  sendEmail: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import * as Sentry from '@sentry/node';
+import { logger } from '@revealui/core/observability/logger';
+import { sendEmail } from '../email.js';
+import { sendCronFailureAlert } from '../cron-alerts.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<CronFailureContext> = {}): CronFailureContext {
+  return {
+    jobName: 'test-job',
+    error: new Error('something broke'),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendCronFailureAlert', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.REVEALUI_ALERT_EMAIL = 'ops@revealui.com';
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.sentry.io/1';
+  });
+
+  afterEach(() => {
+    delete process.env.REVEALUI_ALERT_EMAIL;
+    delete process.env.SENTRY_DSN;
+  });
+
+  it('success-all-paths: logs, captures to Sentry, and sends email', async () => {
+    const ctx = makeContext({ metadata: { accountId: 'acc_1', count: 3 } });
+    await sendCronFailureAlert(ctx);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('test-job'),
+      ctx.error,
+      expect.objectContaining({ jobName: 'test-job', accountId: 'acc_1', count: 3 }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(ctx.error);
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'ops@revealui.com',
+        subject: expect.stringContaining('[CRON FAILURE] test-job'),
+      }),
+    );
+  });
+
+  it('Sentry-down: still logs and sends email', async () => {
+    vi.mocked(Sentry.withScope).mockImplementation(() => {
+      throw new Error('sentry unavailable');
+    });
+
+    const ctx = makeContext();
+    await expect(sendCronFailureAlert(ctx)).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Sentry capture failed'),
+      expect.any(Object),
+    );
+    expect(sendEmail).toHaveBeenCalled();
+  });
+
+  it('email-down: still logs and captures to Sentry', async () => {
+    vi.mocked(sendEmail).mockRejectedValue(new Error('smtp timeout'));
+
+    const ctx = makeContext();
+    await expect(sendCronFailureAlert(ctx)).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('email delivery failed'),
+      expect.any(Object),
+    );
+  });
+
+  it('all-down: still logs and does not throw', async () => {
+    vi.mocked(Sentry.withScope).mockImplementation(() => {
+      throw new Error('sentry gone');
+    });
+    vi.mocked(sendEmail).mockRejectedValue(new Error('email gone'));
+
+    const ctx = makeContext();
+    await expect(sendCronFailureAlert(ctx)).resolves.toBeUndefined();
+
+    // logger.error fires first (step 1), then two logger.warn calls for
+    // Sentry + email failure.
+    expect(logger.error).toHaveBeenCalled();
+    const warnCalls = vi.mocked(logger.warn).mock.calls.map((c) => String(c[0]));
+    expect(warnCalls.some((m) => m.includes('Sentry capture failed'))).toBe(true);
+    expect(warnCalls.some((m) => m.includes('email delivery failed'))).toBe(true);
+  });
+
+  it('uses warn severity when context.severity is "warn"', async () => {
+    const ctx = makeContext({ severity: 'warn' });
+    await sendCronFailureAlert(ctx);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('test-job'),
+      expect.any(Object),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('skips email when REVEALUI_ALERT_EMAIL is not set', async () => {
+    delete process.env.REVEALUI_ALERT_EMAIL;
+    await sendCronFailureAlert(makeContext());
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('includes metadata in email subject context and Sentry scope', async () => {
+    const ctx = makeContext({
+      jobName: 'reconcile-subscriptions',
+      metadata: { criticalCount: 5, scanned: 100 },
+    });
+    await sendCronFailureAlert(ctx);
+
+    const emailCall = vi.mocked(sendEmail).mock.calls[0]?.[0];
+    expect(emailCall?.subject).toContain('reconcile-subscriptions');
+    expect(emailCall?.html).toContain('criticalCount');
+    expect(emailCall?.html).toContain('5');
+  });
+});

--- a/apps/server/src/lib/__tests__/cron-alerts.test.ts
+++ b/apps/server/src/lib/__tests__/cron-alerts.test.ts
@@ -34,10 +34,10 @@ vi.mock('../email.js', () => ({
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import * as Sentry from '@sentry/node';
 import { logger } from '@revealui/core/observability/logger';
-import { sendEmail } from '../email.js';
+import * as Sentry from '@sentry/node';
 import { sendCronFailureAlert } from '../cron-alerts.js';
+import { sendEmail } from '../email.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -25,6 +25,7 @@ function validLiveProdEnv(overrides: EnvMap = {}): EnvMap {
     REVEALUI_CRON_SECRET: CRON_32,
     CORS_ORIGIN: 'https://app.revealui.com,https://admin.revealui.com',
     REVEALUI_ALERT_EMAIL: 'ops@revealui.com',
+    SENTRY_DSN: 'https://abc123@o123456.ingest.sentry.io/456789',
     ...overrides,
   };
 }
@@ -187,6 +188,32 @@ describe('validateStartup — production format checks (live mode)', () => {
     expect(() => validateStartup(validLiveProdEnv({ REVEALUI_CRON_SECRET: 'short' }))).toThrow(
       /REVEALUI_CRON_SECRET/,
     );
+  });
+
+  it('throws when SENTRY_DSN is missing in hosted production (J-P0-1)', () => {
+    const env = validLiveProdEnv();
+    delete env.SENTRY_DSN;
+    expect(() => validateStartup(env)).toThrow(/SENTRY_DSN/);
+  });
+
+  it('rejects SENTRY_DSN that is not a valid HTTPS URL', () => {
+    expect(() => validateStartup(validLiveProdEnv({ SENTRY_DSN: 'not-a-url' }))).toThrow(
+      /SENTRY_DSN/,
+    );
+  });
+
+  it('rejects SENTRY_DSN with http:// (must be https)', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ SENTRY_DSN: 'http://abc@o123.ingest.sentry.io/456' })),
+    ).toThrow(/SENTRY_DSN/);
+  });
+
+  it('accepts a well-formed Sentry DSN', () => {
+    expect(() =>
+      validateStartup(
+        validLiveProdEnv({ SENTRY_DSN: 'https://abc123@o123456.ingest.sentry.io/456789' }),
+      ),
+    ).not.toThrow();
   });
 
   it('rejects CORS_ORIGIN containing an http:// origin', () => {
@@ -761,6 +788,7 @@ describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () 
       REVEALUI_KEK: '',
       REVEALUI_CRON_SECRET: '',
       REVEALUI_ALERT_EMAIL: '',
+      SENTRY_DSN: '',
       STRIPE_SECRET_KEY: '',
       STRIPE_WEBHOOK_SECRET: '',
       STRIPE_LIVE_MODE: '',

--- a/apps/server/src/lib/cron-alerts.ts
+++ b/apps/server/src/lib/cron-alerts.ts
@@ -1,0 +1,117 @@
+import * as Sentry from '@sentry/node';
+import { logger } from '@revealui/core/observability/logger';
+import { sendEmail } from './email.js';
+
+export interface CronFailureContext {
+  jobName: string;
+  error: Error;
+  severity?: 'warn' | 'error' | 'fatal';
+  metadata?: Record<string, unknown>;
+}
+
+function buildEmailBody(context: CronFailureContext): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const { jobName, error, severity = 'error', metadata } = context;
+  const subject = `[CRON FAILURE] ${jobName}: ${error.message}`;
+  const metaRows = metadata
+    ? Object.entries(metadata)
+        .map(
+          ([k, v]) =>
+            `<tr><td style="padding:2px 8px;font-weight:bold">${k}</td><td style="padding:2px 8px">${String(v)}</td></tr>`,
+        )
+        .join('')
+    : '';
+  const metaSection = metaRows
+    ? `<h3>Metadata</h3><table style="border-collapse:collapse">${metaRows}</table>`
+    : '';
+  const metaText = metadata
+    ? `\nMetadata:\n${Object.entries(metadata)
+        .map(([k, v]) => `  ${k}: ${String(v)}`)
+        .join('\n')}`
+    : '';
+
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>${subject}</title></head>
+<body style="font-family:Arial,sans-serif;line-height:1.6;color:#333;max-width:600px;margin:0 auto;padding:20px">
+  <h1 style="color:#dc2626">Cron Job Failure</h1>
+  <p><strong>Job:</strong> ${jobName}</p>
+  <p><strong>Severity:</strong> ${severity}</p>
+  <p><strong>Error:</strong> ${error.message}</p>
+  ${error.stack ? `<pre style="background:#f5f5f5;padding:12px;overflow:auto;font-size:12px">${error.stack}</pre>` : ''}
+  ${metaSection}
+  <p style="color:#666;font-size:12px">Automated alert from api.revealui.com — ${new Date().toISOString()}</p>
+</body>
+</html>`;
+
+  const text = `Cron Job Failure\n\nJob: ${jobName}\nSeverity: ${severity}\nError: ${error.message}${metaText}\n\nTimestamp: ${new Date().toISOString()}`;
+
+  return { subject, html, text };
+}
+
+/**
+ * Centralized alert path for cron failures. Always logs at the chosen
+ * severity. When SENTRY_DSN is present, captures to Sentry. When
+ * REVEALUI_ALERT_EMAIL is present, sends a structured email via the
+ * existing email service.
+ *
+ * Never throws — each step is independent. A failure in one step is logged
+ * and does not prevent the others.
+ */
+export async function sendCronFailureAlert(context: CronFailureContext): Promise<void> {
+  const { jobName, error, severity = 'error', metadata } = context;
+
+  // Step 1 — always log
+  try {
+    const logPayload = { jobName, ...(metadata ?? {}) };
+    if (severity === 'fatal' || severity === 'error') {
+      logger.error(`[cron-alert] ${jobName} failed: ${error.message}`, error, logPayload);
+    } else {
+      logger.warn(`[cron-alert] ${jobName} failed: ${error.message}`, logPayload);
+    }
+  } catch (logErr) {
+    // Last-resort: if the logger itself is broken, write directly to stderr
+    // so the failure is at least visible in Vercel function logs.
+    process.stderr.write(
+      `[cron-alert] logger failed while reporting ${jobName}: ${logErr instanceof Error ? logErr.message : String(logErr)}\n`,
+    );
+  }
+
+  // Step 2 — Sentry (no-op when SENTRY_DSN is absent or Sentry is uninitialised)
+  try {
+    Sentry.withScope((scope) => {
+      scope.setTag('cron_job', jobName);
+      scope.setTag('alert_severity', severity);
+      if (metadata) {
+        scope.setContext('metadata', metadata);
+      }
+      if (severity === 'fatal') {
+        scope.setLevel('fatal');
+      } else if (severity === 'warn') {
+        scope.setLevel('warning');
+      }
+      Sentry.captureException(error);
+    });
+  } catch (sentryErr) {
+    logger.warn(`[cron-alert] Sentry capture failed for ${jobName}`, {
+      detail: sentryErr instanceof Error ? sentryErr.message : String(sentryErr),
+    });
+  }
+
+  // Step 3 — email alert
+  const alertEmail = process.env.REVEALUI_ALERT_EMAIL;
+  if (!alertEmail) {
+    return;
+  }
+  try {
+    const { subject, html, text } = buildEmailBody(context);
+    await sendEmail({ to: alertEmail, subject, html, text });
+  } catch (emailErr) {
+    logger.warn(`[cron-alert] email delivery failed for ${jobName}`, {
+      detail: emailErr instanceof Error ? emailErr.message : String(emailErr),
+    });
+  }
+}

--- a/apps/server/src/lib/cron-alerts.ts
+++ b/apps/server/src/lib/cron-alerts.ts
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/node';
 import { logger } from '@revealui/core/observability/logger';
+import * as Sentry from '@sentry/node';
 import { sendEmail } from './email.js';
 
 export interface CronFailureContext {

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -91,6 +91,13 @@ const REQUIRED_IN_PRODUCTION_HOSTED = [
   // signals. Without it, ops email falls back to a hard-coded default; making
   // this required forces an explicit decision per environment.
   'REVEALUI_ALERT_EMAIL',
+  // Sentry DSN for error capture. The Sentry init in apps/server/src/index.ts
+  // is guarded by `if (process.env.SENTRY_DSN)`, so a missing value silently
+  // drops all Sentry coverage with no boot-time failure. Making this required
+  // ensures we never boot a hosted production deployment without Sentry wired —
+  // the checkout-route HTTPException capture and sendCronFailureAlert Sentry
+  // path both depend on it. GAP-S1 / Phase 1 audit J-P0-1.
+  'SENTRY_DSN',
 ] as const;
 
 const REQUIRED_IN_PRODUCTION_FORGE = [
@@ -307,6 +314,27 @@ export function validateStartup(
       errors.push(
         `REVEALUI_ALERT_EMAIL is not a valid email (got: ${JSON.stringify(alertEmail)}).`,
       );
+    }
+
+    // Sentry DSN format — must be a valid URL. Sentry DSNs follow the shape
+    // https://<key>@<org>.ingest.sentry.io/<projectId>. Rather than encoding
+    // that shape as a regex (no-regex-authored rule), we parse with the URL
+    // constructor: any valid DSN is also a valid HTTPS URL, and anything that
+    // fails URL parsing is definitely wrong. GAP-S1 / Phase 1 audit J-P0-1.
+    const sentryDsn = env.SENTRY_DSN ?? '';
+    if (!skipFormat(sentryDsn)) {
+      let sentryDsnValid = false;
+      try {
+        const parsed = new URL(sentryDsn);
+        sentryDsnValid = parsed.protocol === 'https:';
+      } catch {
+        sentryDsnValid = false;
+      }
+      if (!sentryDsnValid) {
+        errors.push(
+          `SENTRY_DSN must be a valid HTTPS URL (e.g. https://<key>@<org>.ingest.sentry.io/<projectId>). Got: ${JSON.stringify(sentryDsn)}.`,
+        );
+      }
     }
 
     // CORS_ORIGIN is comma-separated; every origin must be HTTPS in hosted prod.

--- a/apps/server/src/routes/cron/billing-readiness.ts
+++ b/apps/server/src/routes/cron/billing-readiness.ts
@@ -18,6 +18,7 @@ import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
 import { Hono } from 'hono';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
 import { MRR_TIER_PRICE_FALLBACK_CENTS, type SubscriptionTierId } from '../../lib/tier-pricing.js';
 
@@ -214,6 +215,15 @@ app.post('/billing-readiness', async (c) => {
     logger.error('Billing readiness check failed', undefined, {
       failureCount: failures.length,
       failures: failures.map((f) => `${f.check}: ${f.detail}`),
+    });
+    void sendCronFailureAlert({
+      jobName: 'billing-readiness',
+      error: new Error(`Billing readiness check failed: ${failures.length} issue(s)`),
+      severity: 'error',
+      metadata: {
+        failureCount: failures.length,
+        failures: failures.map((f) => `${f.check}: ${f.detail}`).join('; '),
+      },
     });
 
     // Send alert email (fire-and-forget, don't fail the cron)

--- a/apps/server/src/routes/cron/drain-unreconciled.ts
+++ b/apps/server/src/routes/cron/drain-unreconciled.ts
@@ -36,6 +36,7 @@ import { getClient } from '@revealui/db';
 import { unreconciledWebhooks } from '@revealui/db/schema';
 import { and, asc, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
 import { replayStripeEvent } from '../../lib/webhook-replay.js';
 import webhooksApp from '../webhooks.js';
@@ -217,6 +218,17 @@ app.post('/drain-unreconciled', async (c) => {
         undefined,
         { eventId: row.eventId, eventType: row.eventType, ageMs, detail },
       );
+      void sendCronFailureAlert({
+        jobName: 'drain-unreconciled',
+        error: new Error(`CRITICAL: event ${row.eventId} unresolved >24h and replay failed`),
+        severity: 'error',
+        metadata: {
+          eventId: row.eventId,
+          eventType: row.eventType,
+          ageMs,
+          detail: detail ?? 'unknown',
+        },
+      });
     } else {
       logger.warn(`[drain-unreconciled] replay failed for ${row.eventId}`, {
         eventType: row.eventType,

--- a/apps/server/src/routes/cron/marketplace-payouts.ts
+++ b/apps/server/src/routes/cron/marketplace-payouts.ts
@@ -21,6 +21,7 @@ import { getClient } from '@revealui/db/client';
 import { marketplaceServers, marketplaceTransactions } from '@revealui/db/schema';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
 
 const app = new Hono();
@@ -164,6 +165,12 @@ app.post('/marketplace-payouts', async (c) => {
           developerCents,
           error: message,
         });
+        void sendCronFailureAlert({
+          jobName: 'marketplace-payouts',
+          error: err instanceof Error ? err : new Error(message),
+          severity: 'error',
+          metadata: { stripeAccountId, developerCents, transactionCount: payout.transactionCount },
+        });
         results.push({
           stripeAccountId,
           developerCents,
@@ -203,6 +210,12 @@ app.post('/marketplace-payouts', async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error('Marketplace payout cron failed', undefined, { error: message });
+    void sendCronFailureAlert({
+      jobName: 'marketplace-payouts',
+      error: err instanceof Error ? err : new Error(message),
+      severity: 'fatal',
+      metadata: { phase: 'cron-outer' },
+    });
     return c.json({ error: 'Internal error during marketplace payout processing' }, 500);
   }
 });

--- a/apps/server/src/routes/cron/reconcile-customers.ts
+++ b/apps/server/src/routes/cron/reconcile-customers.ts
@@ -47,6 +47,7 @@ import { accountSubscriptions, unreconciledWebhooks, users } from '@revealui/db/
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type Stripe from 'stripe';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
 
 const app = new Hono();
@@ -236,6 +237,16 @@ app.post('/reconcile-customers', async (c) => {
           createdUnix: customer.created,
         },
       );
+      void sendCronFailureAlert({
+        jobName: 'reconcile-customers',
+        error: new Error(`CRITICAL: orphaned Stripe customer ${customer.id}`),
+        severity: 'error',
+        metadata: {
+          customerId: customer.id,
+          email: customer.email ?? null,
+          createdUnix: customer.created,
+        },
+      });
       results.push({
         customerId: customer.id,
         email: customer.email ?? null,

--- a/apps/server/src/routes/cron/reconcile-subscriptions.ts
+++ b/apps/server/src/routes/cron/reconcile-subscriptions.ts
@@ -28,6 +28,7 @@ import { accountSubscriptions } from '@revealui/db/schema';
 import { and, inArray, isNotNull } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type Stripe from 'stripe';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
 
 const app = new Hono();
@@ -206,6 +207,16 @@ app.post('/reconcile-subscriptions', async (c) => {
           undefined,
           { ...report },
         );
+        void sendCronFailureAlert({
+          jobName: 'reconcile-subscriptions',
+          error: new Error(`CRITICAL: missing-in-stripe for account ${row.accountId}`),
+          severity: 'error',
+          metadata: {
+            accountId: row.accountId,
+            stripeSubscriptionId: row.stripeSubscriptionId,
+            drift: 'missing-in-stripe',
+          },
+        });
         continue;
       }
 
@@ -273,6 +284,20 @@ app.post('/reconcile-subscriptions', async (c) => {
           undefined,
           { ...report },
         );
+        void sendCronFailureAlert({
+          jobName: 'reconcile-subscriptions',
+          error: new Error(
+            `CRITICAL: status drift ${row.status}→${stripeStatus} for account ${row.accountId}`,
+          ),
+          severity: 'error',
+          metadata: {
+            accountId: row.accountId,
+            stripeSubscriptionId: row.stripeSubscriptionId,
+            localStatus: row.status,
+            stripeStatus: stripeStatus ?? 'null',
+            drift: 'status-mismatch',
+          },
+        });
       } else {
         logger.warn(`[reconcile-subscriptions] status drift ${row.status}→${stripeStatus}`, {
           ...report,

--- a/docs/runbooks/stripe-post-flip-72h-monitor.md
+++ b/docs/runbooks/stripe-post-flip-72h-monitor.md
@@ -1,0 +1,174 @@
+# Stripe Post-Flip 72h Monitor Runbook
+
+**Who:** On-call operator (founder during initial live phase)
+**When:** Immediately after setting `STRIPE_LIVE_MODE=true` and deploying to production
+**Duration:** First 72 hours of live-mode operation
+**Goal:** Confirm every real-money path produces the expected signals; catch any silent failure within minutes rather than days
+
+---
+
+## Pre-requisites (gate before flipping)
+
+Before starting this runbook, confirm:
+
+- [ ] `SENTRY_DSN` is set in the Vercel production environment and appears in `REQUIRED_IN_PRODUCTION_HOSTED` (validated at boot by `apps/server/src/lib/validate-startup.ts`)
+- [ ] `REVEALUI_ALERT_EMAIL` is set and routes to a monitored mailbox
+- [ ] At least one test transaction completed successfully in Stripe test mode (full checkout → license issuance → customer portal)
+- [ ] The billing-readiness cron (`/api/cron/billing-readiness`) returned `status: ok` within the last 24h
+- [ ] Stripe webhook endpoint is registered and receiving events (verify in Stripe Dashboard → Developers → Webhooks)
+
+---
+
+## Alert wiring (as of Phase 1 audit fix — J-P0-1 / J-P0-2)
+
+All critical cron failures now route through `sendCronFailureAlert` (implemented in `apps/server/src/lib/cron-alerts.ts`). This function:
+
+1. **Always logs** at the configured severity via `@revealui/core/observability/logger` (visible in Vercel function logs)
+2. **Captures to Sentry** via `Sentry.captureException` when `SENTRY_DSN` is set — tagged with `cron_job` and `alert_severity`
+3. **Sends email** to `REVEALUI_ALERT_EMAIL` with structured subject `[CRON FAILURE] <jobName>: <error.message>`
+
+The five reconciliation crons now call `sendCronFailureAlert` on critical failures:
+
+| Cron | File | Alert trigger |
+|------|------|---------------|
+| `reconcile-subscriptions` | `apps/server/src/routes/cron/reconcile-subscriptions.ts` | `missing-in-stripe` drift; `status-mismatch` that ends entitlement |
+| `drain-unreconciled` | `apps/server/src/routes/cron/drain-unreconciled.ts` | Event unresolved >24h and replay failed |
+| `reconcile-customers` | `apps/server/src/routes/cron/reconcile-customers.ts` | Newly-detected orphaned Stripe customer |
+| `marketplace-payouts` | `apps/server/src/routes/cron/marketplace-payouts.ts` | Individual transfer failure; outer cron crash |
+| `billing-readiness` | `apps/server/src/routes/cron/billing-readiness.ts` | Any check failure |
+
+**Important:** `sendCronFailureAlert` is additive — it runs alongside the existing `logger.error` call and never replaces it. Vercel function logs are always populated regardless of whether Sentry or email delivery succeeds.
+
+---
+
+## Hour 0–4: Immediately post-flip
+
+### 1. Confirm Sentry is receiving events
+
+Trigger a synthetic error by hitting an authenticated route with a deliberately malformed payload and checking Sentry for the capture:
+
+```bash
+# Confirm the server is up and Sentry is initialised (look for DSN in startup log)
+curl -s https://api.revealui.com/health | jq .
+
+# Check Sentry project for any boot-time issues
+# Sentry Dashboard → Issues → filter by environment:production, last 1h
+```
+
+Sentry should show at least one event from the server startup within the first deploy. If the Issues list is completely empty after 30 minutes, verify `SENTRY_DSN` is set correctly and the Vercel deployment picked it up (`vercel env ls --environment production`).
+
+### 2. Confirm webhook endpoint is live
+
+```bash
+# Stripe CLI — forward events and confirm revealui's handler returns 200
+stripe listen --forward-to https://api.revealui.com/api/webhooks
+```
+
+Or verify in Stripe Dashboard: Developers → Webhooks → your endpoint → Recent deliveries. Every delivery should show `200` status. Any `4xx`/`5xx` means the handler is broken.
+
+### 3. Confirm billing-readiness cron passes
+
+Trigger manually:
+
+```bash
+curl -s -X POST https://api.revealui.com/api/cron/billing-readiness \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq .status
+# Expected: "ok"
+```
+
+If `status: failed`, check the `failures` array in the response. Common causes: missing Stripe price IDs, missing `billing_catalog` DB rows, Stripe key mismatch. Fix before accepting real traffic.
+
+---
+
+## Hour 4–24: First real-transaction window
+
+### 4. Watch reconciliation crons
+
+The reconciliation crons run on Vercel's cron schedule (see `vercel.json`). During the first 24h, manually trigger each one and confirm clean output:
+
+```bash
+# reconcile-subscriptions
+curl -s -X POST https://api.revealui.com/api/cron/reconcile-subscriptions \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, drift, critical}'
+# Expected: critical: 0
+
+# drain-unreconciled
+curl -s -X POST https://api.revealui.com/api/cron/drain-unreconciled \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, replayed, critical}'
+# Expected: critical: 0 (or 0 scanned if queue is empty)
+
+# reconcile-customers
+curl -s -X POST https://api.revealui.com/api/cron/reconcile-customers \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, orphaned, alerted}'
+# Expected: alerted: 0
+```
+
+**If `critical > 0`:** you will have already received an alert email and a Sentry event via `sendCronFailureAlert`. Check those for the specific account IDs / event IDs and investigate in Stripe Dashboard before the customer notices.
+
+### 5. Monitor alert email inbox
+
+Check `REVEALUI_ALERT_EMAIL` inbox. Expected subject patterns that indicate real problems:
+
+- `[CRON FAILURE] reconcile-subscriptions: CRITICAL: missing-in-stripe for account ...` — a customer's subscription exists in our DB but not in Stripe. Manual fix required.
+- `[CRON FAILURE] drain-unreconciled: CRITICAL: event ... unresolved >24h and replay failed` — a webhook event is stuck. Investigate the `unreconciledWebhooks` table.
+- `[CRON FAILURE] reconcile-customers: CRITICAL: orphaned Stripe customer ...` — Stripe customer with no local row. Check if checkout completed without webhook delivery.
+- `[CRON FAILURE] marketplace-payouts: ...` — a Stripe Connect transfer failed.
+- `[CRITICAL] RevealUI: Webhook handler crashed — checkout.session.completed` — sent by `sendWebhookFailureAlert` (separate from the cron alerts); means a customer paid but may not have received their license. **Act within 1 hour.**
+
+---
+
+## Hour 24–72: Steady-state monitoring
+
+### 6. Check Sentry error volume
+
+Sentry Dashboard → Performance and Issues. Acceptable error volume in the first 72h:
+
+- `0` fatal issues
+- `< 5` distinct error types (mostly expected: 4xx client errors, occasional Stripe network hiccup)
+
+If you see payment-path errors clustering (e.g., multiple `checkout.session.completed` failures), the webhook handler has a bug. Take the site to maintenance mode (`STRIPE_LIVE_MODE=false` redeploy) rather than letting customers hit broken checkout.
+
+### 7. Confirm no silent cron drift
+
+After 72h, run the reconciliation suite one more time and confirm `critical: 0` across all three crons. If `drain-unreconciled` shows `critical > 0`, at least one webhook event has been stuck for >24h — investigate before the 72h window closes.
+
+---
+
+## Verifying alerts work (smoke test)
+
+To confirm `sendCronFailureAlert` is wired end-to-end before a real incident:
+
+```bash
+# 1. Trigger a synthetic billing-readiness failure by temporarily removing a
+#    required env var in a preview deployment (NOT production):
+#    Remove STRIPE_PRO_PRICE_ID from the preview environment.
+
+# 2. Trigger the cron in the preview deployment:
+curl -s -X POST https://<preview-url>/api/cron/billing-readiness \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq .
+
+# 3. Confirm within 2 minutes:
+#    a. REVEALUI_ALERT_EMAIL inbox has a message with subject
+#       "[CRON FAILURE] billing-readiness: Billing readiness check failed: ..."
+#    b. Sentry shows a new issue tagged cron_job=billing-readiness
+#    c. Vercel function logs show the logger.error line
+
+# 4. Restore the env var before the preview deployment is used for anything else.
+```
+
+This smoke test validates all three legs of `sendCronFailureAlert` (log → Sentry → email) without touching production.
+
+---
+
+## Escalation
+
+If any critical alert fires and you cannot identify the root cause within 30 minutes:
+
+1. Set `STRIPE_LIVE_MODE=false` and redeploy — this stops new live charges while you investigate
+2. Check Stripe Dashboard → Events for any failed charges or webhook delivery failures in the last hour
+3. Check `unreconciledWebhooks` table for new rows
+4. Open a GitHub issue in `RevealUIStudio/revealui` tagged `severity:critical billing`
+
+---
+
+*Runbook created 2026-05-09 as part of Phase 1 audit P0 fix (J-P0-3). Alert wiring (J-P0-1 / J-P0-2) implemented in the same PR.*


### PR DESCRIPTION
## Summary

Genuinely ships GAP-S1 + GAP-S2 — both were declared RESOLVED in internal docs:1-9` (claiming closure via [revealui#744](https://github.com/RevealUIStudio/revealui/pull/744)) but neither change was actually present in `origin/test` HEAD before this PR. Discovered during the Phase 1 payment-surface audit.

Closes audit findings **J-P0-1**, **J-P0-2**, **J-P0-3** from `docs/audits/2026-05-09-payment-surface-phase-1-audit.md` (sister internal docs repo).

## What was actually missing

- **`SENTRY_DSN` was NOT in `REQUIRED_IN_PRODUCTION_HOSTED`** in `apps/server/src/lib/validate-startup.ts`. Production servers could boot without Sentry configured. Confirmed via `grep -n SENTRY_DSN apps/server/src/lib/validate-startup.ts` → zero hits before this PR.
- **`sendCronFailureAlert` did not exist in code.** Confirmed via `grep -rn sendCronFailureAlert apps/server/src/` → zero hits before this PR. Reconciliation crons only `logger.error` on critical failures with no Sentry capture and no email path.
- **Post-flip 72h runbook treated those as canary signals** — following the runbook gave a false-green signal because the alerts could not fire.

## What this PR ships

1. `apps/server/src/lib/validate-startup.ts` — adds `SENTRY_DSN` to `REQUIRED_IN_PRODUCTION_HOSTED` with URL-format check (`URL` constructor — no regex per the M2 no-regex-authored rule).
2. `apps/server/src/lib/cron-alerts.ts` — new module exporting `sendCronFailureAlert({ jobName, error, severity?, metadata? })`. Each step (logger → Sentry capture → ops email) wraps in try/catch so a failing one doesn't block the others. Never throws. Reuses existing `@revealui/core/observability/logger` + Sentry SDK + Resend email helper.
3. Wires `sendCronFailureAlert` into 5 reconciliation crons:
   - `reconcile-subscriptions.ts`
   - `reconcile-customers.ts`
   - `drain-unreconciled.ts`
   - `marketplace-payouts.ts`
   - `billing-readiness.ts`
4. `docs/runbooks/stripe-post-flip-72h-monitor.md` — updates canary-signal language to reference the actual `sendCronFailureAlert` path; adds a "Verifying alerts work" smoke-test section.
5. Tests:
   - `apps/server/src/lib/__tests__/cron-alerts.test.ts` (new) — 4 cases: success-all-paths, Sentry-down (still logs + emails), email-down (still logs + Sentry), all-down (still logs + doesn't throw).
   - `apps/server/src/lib/__tests__/validate-startup.test.ts` (extended) — adds `SENTRY_DSN` to `validProdEnv()` + a missing-`SENTRY_DSN` test.

## Why this is the highest-priority Phase 1 fix

Audit-trail drift undermines trust in every other "✅ shipped" claim across the audit corpus. Until this lands, no later P0 fix verification is reliable. Per the consolidated audit's fix sequencing: **fix audit-trail drift FIRST**, then revenue-accuracy, then JWT hardening, then misc, then UI honesty.

## Test plan

- [x] `pnpm --filter server typecheck` — passes
- [x] `pnpm --filter server test` — passes (existing + 4 new cron-alerts tests + 2 new validate-startup cases)
- [x] Biome lint — passes
- [ ] CI green on this PR
- [ ] After merge: internal docs correction lands separately (sister-repo doc fix, not part of this code PR)
- [ ] Post-merge to test, verify `pnpm dev:api` boots; `SENTRY_DSN` missing from env should fail boot with a clear name

## Follow-up

Companion internal docs PR will correct `docs/billing-audit/sentry-coverage-audit.md:1-9` (the misleading "RESOLVED via #744" claim) — the doc lied about #744 shipping these fixes. The companion PR will land after this PR merges so the audit doc references the real merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
