### PR TITLE
refactor(db): collapse dual-DB client -> Neon-only (GAP-129 PR-C)

### DIFF
--- a/packages/db/__tests__/pool-cleanup.test.ts
+++ b/packages/db/__tests__/pool-cleanup.test.ts
@@ -5,9 +5,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeAllPools, getPoolMetrics, resetClient } from '../src/client/index';
 
-// Mock environment variables for testing
-process.env.DATABASE_URL = 'postgresql://test:test@test.supabase.co:6543/postgres';
-process.env.SUPABASE_DATABASE_URL = 'postgresql://test:test@test.supabase.co:6543/postgres';
+// Use a localhost URL so isLocalhostConnection returns true and a pg Pool is created.
+// Without a pool (Neon HTTP path), pool metrics would always be empty.
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/postgres';
 
 describe('Database Pool Cleanup', () => {
   beforeEach(() => {
@@ -23,8 +23,8 @@ describe('Database Pool Cleanup', () => {
     // Import the client creation (this will create a pool)
     const { getClient } = await import('../src/client/index');
 
-    // Get a client (which creates a pool)
-    getClient('vector');
+    // Get a client (which creates a pool for localhost URLs)
+    getClient('rest');
 
     // Get pool metrics
     const metrics = getPoolMetrics();
@@ -37,7 +37,7 @@ describe('Database Pool Cleanup', () => {
     const { getClient } = await import('../src/client/index');
 
     // Get a client
-    getClient('vector');
+    getClient('rest');
 
     // Get pool metrics
     const metrics = getPoolMetrics();
@@ -54,8 +54,8 @@ describe('Database Pool Cleanup', () => {
   it('should close all pools on closeAllPools', async () => {
     const { getClient } = await import('../src/client/index');
 
-    // Create a client (which creates a pool)
-    getClient('vector');
+    // Create a client (which creates a pool for localhost URLs)
+    getClient('rest');
 
     // Verify pool exists
     let metrics = getPoolMetrics();
@@ -73,13 +73,13 @@ describe('Database Pool Cleanup', () => {
     const { getClient } = await import('../src/client/index');
 
     // Create a client
-    const _client1 = getClient('vector');
+    const _client1 = getClient('rest');
 
     // Close all pools
     await closeAllPools();
 
     // Get client again - should be a new instance
-    const client2 = getClient('vector');
+    const client2 = getClient('rest');
 
     // Note: We can't directly compare instances, but we can verify
     // that we can still get a client after closing

--- a/packages/db/src/__tests__/client/connection-failures.test.ts
+++ b/packages/db/src/__tests__/client/connection-failures.test.ts
@@ -642,18 +642,6 @@ describe('database connection failures', () => {
       expect(drizzlePgMod.drizzle).toHaveBeenCalled();
     });
 
-    it('uses pg Pool for Supabase connections', async () => {
-      const drizzlePgMod = await import('drizzle-orm/node-postgres');
-      const { createClient } = await import('../../client/index.js');
-
-      createClient({
-        connectionString:
-          'postgresql://user:pass@aws-0-us-east-1.pooler.supabase.com:6543/postgres',
-      });
-
-      expect(drizzlePgMod.drizzle).toHaveBeenCalled();
-    });
-
     it('uses Neon driver for NeonDB connections (no pool)', async () => {
       const { neon } = await import('@neondatabase/serverless');
       const { createClient } = await import('../../client/index.js');
@@ -681,14 +669,15 @@ describe('database connection failures', () => {
       expect(() => getClient('rest')).toThrow('Database connection string not provided');
     });
 
-    it('throws when DATABASE_URL is missing for vector client', async () => {
+    it('throws when no connection string is available for vector client (aliased to rest)', async () => {
+      Reflect.deleteProperty(process.env, 'POSTGRES_URL');
       Reflect.deleteProperty(process.env, 'DATABASE_URL');
 
       vi.resetModules();
       const { getClient, resetClient } = await import('../../client/index.js');
       resetClient();
 
-      expect(() => getClient('vector')).toThrow('DATABASE_URL');
+      expect(() => getClient('vector')).toThrow('Database connection string not provided');
     });
   });
 });

--- a/packages/db/src/__tests__/client/pool.test.ts
+++ b/packages/db/src/__tests__/client/pool.test.ts
@@ -120,13 +120,13 @@ describe('client/index  -  pool management', () => {
       expect(drizzleNeon).toHaveBeenCalled();
     });
 
-    it('creates a pg Pool client for Supabase connection strings', () => {
+    it('uses Neon driver for non-localhost connection strings (e.g. Neon cloud)', () => {
       const db = createClient({
-        connectionString: 'postgresql://user:pass@db.project.supabase.co:5432/postgres',
+        connectionString: 'postgresql://user:pass@ep-cool.neon.tech/neondb',
       });
 
       expect(db).toBeDefined();
-      expect(drizzlePg).toHaveBeenCalled();
+      expect(drizzleNeon).toHaveBeenCalled();
     });
 
     it('creates a pg Pool client for localhost connection strings', () => {
@@ -162,9 +162,9 @@ describe('client/index  -  pool management', () => {
 
   describe('getPoolMetrics', () => {
     it('returns metrics for active pools', () => {
-      // Create a Supabase client to register a pool
+      // Create a localhost client to register a pool (only localhost uses pg Pool)
       createClient({
-        connectionString: 'postgresql://user:pass@db.project.supabase.co:5432/postgres',
+        connectionString: 'postgresql://user:pass@localhost:5432/postgres',
       });
 
       const metrics = getPoolMetrics();
@@ -177,7 +177,7 @@ describe('client/index  -  pool management', () => {
     });
 
     it('returns empty array when no pools are active', () => {
-      // Before creating any Supabase/localhost clients, there may be no pools
+      // Before creating any localhost clients, there may be no pools
       // (Neon HTTP clients do not create pools)
       const metrics = getPoolMetrics();
       expect(Array.isArray(metrics)).toBe(true);
@@ -234,10 +234,11 @@ describe('client/index  -  pool management', () => {
       expect(() => getClient('rest')).toThrow('Database connection string not provided');
     });
 
-    it('throws when no connection string is available for vector', () => {
+    it('throws when no connection string is available for vector (aliased to rest)', () => {
+      delete process.env.POSTGRES_URL;
       delete process.env.DATABASE_URL;
 
-      expect(() => getClient('vector')).toThrow('DATABASE_URL environment variable is required');
+      expect(() => getClient('vector')).toThrow('Database connection string not provided');
     });
 
     it('defaults to rest when called without arguments', () => {

--- a/packages/db/src/client/__tests__/dual-client.test.ts
+++ b/packages/db/src/client/__tests__/dual-client.test.ts
@@ -1,8 +1,9 @@
 /**
- * Dual Database Client Tests
+ * Single Database Client Tests
  *
- * Tests that getClient('rest') and getClient('vector') return
- * separate clients with correct schemas.
+ * Tests that getClient('rest') and getClient('vector') both return the same
+ * single Neon-primary client, and that getVectorClient() is a deprecated alias
+ * for getRestClient().
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,69 +29,72 @@ vi.mock('drizzle-orm/neon-http', () => ({
   })),
 }));
 
-describe('Dual Database Client', () => {
+describe('Single Database Client (post-Supabase removal)', () => {
   beforeEach(() => {
     resetClient();
-    // Set up environment variables
     process.env.POSTGRES_URL = 'postgresql://rest-db';
-    process.env.SUPABASE_DATABASE_URL = 'postgresql://vector-db';
   });
 
   afterEach(() => {
     Reflect.deleteProperty(process.env, 'POSTGRES_URL');
-    Reflect.deleteProperty(process.env, 'SUPABASE_DATABASE_URL');
     Reflect.deleteProperty(process.env, 'DATABASE_URL');
   });
 
-  it('should return separate clients for rest and vector', () => {
+  it('getClient("vector") returns the same client as getClient("rest")', () => {
+    const restClient = getClient('rest');
+    const vectorClient = getClient('vector');
+
+    expect(restClient).toBeDefined();
+    expect(vectorClient).toBeDefined();
+    expect(restClient).toBe(vectorClient);
+  });
+
+  it('getVectorClient() is a deprecated alias that equals getRestClient()', () => {
     const restClient = getRestClient();
     const vectorClient = getVectorClient();
 
     expect(restClient).toBeDefined();
     expect(vectorClient).toBeDefined();
-    expect(restClient).not.toBe(vectorClient);
+    expect(restClient).toBe(vectorClient);
   });
 
-  it('should return same client instance for same type', () => {
+  it('returns same client instance for same type (singleton)', () => {
     const client1 = getClient('rest');
     const client2 = getClient('rest');
 
     expect(client1).toBe(client2);
   });
 
-  it('should default to rest client when no type specified', () => {
+  it('defaults to rest client when no type specified', () => {
     const defaultClient = getClient();
     const restClient = getRestClient();
 
     expect(defaultClient).toBe(restClient);
   });
 
-  it('should throw error if SUPABASE_DATABASE_URL not set for vector client', () => {
-    resetClient(); // Reset cached client to force re-initialization
-    Reflect.deleteProperty(process.env, 'SUPABASE_DATABASE_URL');
-
-    expect(() => getVectorClient()).toThrow('SUPABASE_DATABASE_URL');
-  });
-
-  it('should throw error if POSTGRES_URL not set for rest client', () => {
-    resetClient(); // Reset cached client to force re-initialization
+  it('throws error if POSTGRES_URL not set for rest client', () => {
+    resetClient();
     Reflect.deleteProperty(process.env, 'POSTGRES_URL');
     Reflect.deleteProperty(process.env, 'DATABASE_URL');
 
     expect(() => getRestClient()).toThrow('POSTGRES_URL');
   });
 
-  it('should reset both clients', () => {
-    const restClient1 = getRestClient();
-    const vectorClient1 = getVectorClient();
+  it('throws error if POSTGRES_URL not set for vector client (alias of rest)', () => {
+    resetClient();
+    Reflect.deleteProperty(process.env, 'POSTGRES_URL');
+    Reflect.deleteProperty(process.env, 'DATABASE_URL');
+
+    expect(() => getVectorClient()).toThrow('POSTGRES_URL');
+  });
+
+  it('resets client so a new instance is created after reset', () => {
+    const client1 = getRestClient();
 
     resetClient();
 
-    const restClient2 = getRestClient();
-    const vectorClient2 = getVectorClient();
+    const client2 = getRestClient();
 
-    // New instances should be created
-    expect(restClient1).not.toBe(restClient2);
-    expect(vectorClient1).not.toBe(vectorClient2);
+    expect(client1).not.toBe(client2);
   });
 });

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -1,22 +1,20 @@
 /**
  * @revealui/db - Database Client
  *
- * Provides a configured Drizzle ORM client for PostgreSQL databases.
- * Supports dual database architecture:
- * - REST Database (NeonDB): Uses @neondatabase/serverless with drizzle-orm/neon-http
- * - Vector Database (Supabase): Uses postgres-js with drizzle-orm/postgres-js
+ * Provides a configured Drizzle ORM client for a single PostgreSQL database (Neon-primary).
+ * Uses @neondatabase/serverless with drizzle-orm/neon-http for Neon connections.
+ * Uses node-postgres (pg Pool) with drizzle-orm/node-postgres for localhost / 127.0.0.1
+ * connections (development and test environments).
  *
- * This dual-driver approach avoids the Neon driver's compatibility issue with Supabase,
- * where it incorrectly transforms Supabase hostnames (aws-0-*.pooler.supabase.com → api.pooler.supabase.com).
+ * The 'vector' database type is a deprecated alias for 'rest' following Supabase removal
+ * per docs/decisions/2026-05-01-supabase-removal.md (GAP-129 PR-C). See getVectorClient().
  *
  * Connection String Format:
  * - NeonDB: postgresql://...@neon.tech/...
- * - Supabase: postgresql://...@*.supabase.co:6543/postgres (transaction pooler)
- * - Supabase: postgresql://...@*.supabase.co:5432/postgres (direct/session pooler)
+ * - Localhost (dev/test): postgresql://...@localhost:5432/...
  *
  * Reference:
  * - Neon: https://orm.drizzle.team/docs/connect-neon
- * - Supabase: https://orm.drizzle.team/docs/tutorials/drizzle-with-supabase
  */
 
 import { neon } from '@neondatabase/serverless';
@@ -53,16 +51,15 @@ export interface PoolMetrics {
 // =============================================================================
 
 let restSupportsTransactions = false;
-let vectorSupportsTransactions = false;
 
 // =============================================================================
 // Types
 // =============================================================================
 
 /**
- * Database type selector for dual database architecture
- * - 'rest': NeonDB for transactional REST API operations
- * - 'vector': Supabase for vector search operations
+ * Database type selector.
+ * - 'rest': Neon-primary Postgres connection
+ * - 'vector': deprecated alias for 'rest'; will be removed after 1-2 release cycles (GAP-129 PR-C)
  */
 export type DatabaseType = 'rest' | 'vector';
 
@@ -87,62 +84,23 @@ export interface DatabaseConfig {
 // =============================================================================
 
 /**
- * Creates a Drizzle database client for Neon Postgres.
- *
- * Uses the official Drizzle pattern for neon-http driver:
- * https://orm.drizzle.team/docs/connect-neon
- *
- * @param config - Database configuration
- * @param dbSchema - Optional schema to use (defaults to full schema for backward compatibility)
- *
- * @example
- * ```typescript
- * import { createClient } from '@revealui/db/client'
- *
- * const db = createClient({
- *   connectionString: process.env.POSTGRES_URL!,
- * })
- *
- * // Query users
- * const users = await db.query.users.findMany()
- * ```
+ * Detects if a connection string targets localhost / 127.0.0.1.
+ * Returns true only for local development / test connections.
+ * These use node-postgres (pg Pool) because the Neon HTTP driver requires a Neon endpoint.
  */
-/**
- * Detects if a connection string requires node-postgres driver.
- * Returns true for Supabase connections and localhost/test connections.
- * Supabase connection strings contain '.supabase.co' or 'pooler.supabase.com'.
- * Localhost connections are used for testing and development.
- */
-function isSupabaseConnection(connectionString: string): boolean {
+function isLocalhostConnection(connectionString: string): boolean {
   try {
     const host = new URL(connectionString).hostname;
-    return (
-      host.endsWith('.supabase.co') ||
-      host === 'supabase.co' ||
-      host.endsWith('.supabase.com') ||
-      host === 'supabase.com' ||
-      host === 'localhost' ||
-      host === '127.0.0.1'
-    );
+    return host === 'localhost' || host === '127.0.0.1';
   } catch {
-    // Fallback for non-URL connection strings (e.g., plain host:port format)
-    return (
-      connectionString.includes('.supabase.co') ||
-      connectionString.includes('pooler.supabase.com') ||
-      connectionString.includes('localhost') ||
-      connectionString.includes('127.0.0.1')
-    );
+    return connectionString.includes('localhost') || connectionString.includes('127.0.0.1');
   }
 }
 
 /**
  * Creates a Drizzle database client, automatically selecting the appropriate driver:
- * - Supabase/localhost connections: Uses node-postgres with drizzle-orm/node-postgres
- * - NeonDB connections: Uses @neondatabase/serverless with drizzle-orm/neon-http
- *
- * This dual-driver approach fixes the Neon driver's compatibility issue with Supabase,
- * where it incorrectly transforms Supabase hostnames. It also enables local testing
- * with localhost PostgreSQL databases.
+ * - Localhost connections: Uses node-postgres with drizzle-orm/node-postgres (dev/test)
+ * - All other connections: Uses @neondatabase/serverless with drizzle-orm/neon-http (Neon-primary)
  *
  * @param config - Database configuration
  * @param dbSchema - Optional schema to use (defaults to full schema for backward compatibility)
@@ -150,11 +108,6 @@ function isSupabaseConnection(connectionString: string): boolean {
  * @example
  * ```typescript
  * import { createClient } from '@revealui/db/client'
- *
- * // Automatically uses node-postgres for Supabase
- * const supabaseDb = createClient({
- *   connectionString: process.env.DATABASE_URL!, // Supabase URL
- * })
  *
  * // Automatically uses node-postgres for localhost (testing)
  * const testDb = createClient({
@@ -171,11 +124,10 @@ export function createClient(
   config: DatabaseConfig,
   dbSchema: typeof restSchema | typeof vectorSchema | typeof schema = schema,
 ): Database {
-  const isSupabase = isSupabaseConnection(config.connectionString);
+  const isLocalhost = isLocalhostConnection(config.connectionString);
 
-  if (isSupabase) {
-    // Use pg for Supabase connections
-    // This avoids the Neon driver's hostname transformation bug
+  if (isLocalhost) {
+    // Use pg for localhost connections — Neon HTTP driver requires a Neon endpoint
     const poolMax = parseInt(process.env.DB_POOL_MAX || '10', 10);
     const poolIdleTimeout = parseInt(process.env.DB_POOL_IDLE_TIMEOUT || '30000', 10);
 
@@ -214,7 +166,6 @@ export function createClient(
 // =============================================================================
 
 let restClient: Database | null = null;
-let vectorClient: Database | null = null;
 
 // The REST pool, stored for sharing with the CMS adapter (universal-postgres).
 // When the admin app passes this pool to universalPostgresAdapter({ pool }),
@@ -241,24 +192,20 @@ function registerPoolCleanup() {
 }
 
 /**
- * Gets or creates a global database client.
- * Supports dual database architecture with separate clients for REST and Vector operations.
+ * Gets or creates a global database client (single Neon-primary Postgres connection).
  * Uses config module if available, otherwise falls back to process.env for backward compatibility.
  *
- * @param typeOrConnectionString - Database type ('rest' | 'vector') or connection string (legacy API)
+ * @param typeOrConnectionString - Database type ('rest') or connection string (legacy API).
+ *   'vector' is a deprecated alias for 'rest' (GAP-129 PR-C); prefer 'rest' in new code.
  * @returns Database client instance
  *
  * @example
  * ```typescript
  * import { getClient } from '@revealui/db/client'
  *
- * // New API: Specify database type
- * const restDb = getClient('rest')
- * const vectorDb = getClient('vector')
- *
- * // Legacy API: Still supported for backward compatibility
- * const db = getClient() // defaults to 'rest'
- * const db2 = getClient('postgresql://...') // uses provided connection string as 'rest'
+ * const db = getClient('rest')
+ * const db2 = getClient() // defaults to 'rest'
+ * const db3 = getClient('postgresql://...') // legacy: connection string as 'rest'
  * ```
  */
 // Note: DatabaseType | string union is intentional for backward compatibility (allows both type strings and connection strings)
@@ -286,29 +233,12 @@ export function getClient(typeOrConnectionString?: DatabaseType | string): Datab
 }
 
 /**
- * Internal function to get client by type
+ * Internal function to get client by type.
+ * 'vector' is aliased to 'rest' (Supabase removed per GAP-129 PR-C).
  */
 function getClientByType(type: DatabaseType): Database {
   if (type === 'vector') {
-    if (!vectorClient) {
-      const url = process.env.SUPABASE_DATABASE_URL;
-      if (!url && process.env.DATABASE_URL) {
-        throw new Error(
-          'SUPABASE_DATABASE_URL is not set but DATABASE_URL is. Vector queries require a ' +
-            'dedicated Supabase connection — falling back to DATABASE_URL would silently route ' +
-            'vector data to NeonDB. Set SUPABASE_DATABASE_URL explicitly.',
-        );
-      }
-      if (!url || typeof url !== 'string') {
-        throw new Error(
-          'SUPABASE_DATABASE_URL environment variable is required for vector database. ' +
-            'Set SUPABASE_DATABASE_URL to your Supabase connection string.',
-        );
-      }
-      vectorClient = createClient({ connectionString: url }, vectorSchema);
-      vectorSupportsTransactions = isSupabaseConnection(url);
-    }
-    return vectorClient;
+    return getClientByType('rest');
   }
 
   // type === 'rest'
@@ -335,9 +265,9 @@ function getClientByType(type: DatabaseType): Database {
       );
     }
 
-    // For pg-backed connections (Supabase, localhost), create the pool
+    // For pg-backed connections (localhost), create the pool
     // externally so it can be shared with the CMS adapter via getRestPool().
-    if (isSupabaseConnection(url)) {
+    if (isLocalhostConnection(url)) {
       const poolMax = parseInt(process.env.DB_POOL_MAX || '10', 10);
       const poolIdleTimeout = parseInt(process.env.DB_POOL_IDLE_TIMEOUT || '30000', 10);
       const pool = new Pool({
@@ -359,7 +289,7 @@ function getClientByType(type: DatabaseType): Database {
     } else {
       restClient = createClient({ connectionString: url }, restSchema);
     }
-    restSupportsTransactions = isSupabaseConnection(url);
+    restSupportsTransactions = isLocalhostConnection(url);
   }
   return restClient;
 }
@@ -381,31 +311,28 @@ export function getRestClient(): Database {
 }
 
 /**
- * Gets or creates the Vector database client (Supabase).
- * Convenience function for accessing the vector database.
+ * @deprecated Use getClient('rest') or getRestClient().
+ * The 'vector' database type is collapsed in the Supabase removal (GAP-129 PR-C).
+ * This alias will be removed after 1-2 release cycles.
  *
  * @example
  * ```typescript
- * import { getVectorClient } from '@revealui/db/client'
- *
- * const db = getVectorClient()
- * const memories = await db.query.agentMemories.findMany()
+ * // Preferred replacement
+ * import { getRestClient } from '@revealui/db/client'
+ * const db = getRestClient()
  * ```
  */
 export function getVectorClient(): Database {
-  return getClient('vector');
+  return getClient('rest');
 }
 
 /**
- * Resets the global clients (useful for testing).
- * Clears both REST and Vector client instances.
+ * Resets the global client (useful for testing).
  */
 export function resetClient(): void {
   restClient = null;
-  vectorClient = null;
   restPool = null;
   restSupportsTransactions = false;
-  vectorSupportsTransactions = false;
 }
 
 /**
@@ -497,9 +424,8 @@ export async function closeAllPools(): Promise<void> {
   await Promise.all(closePromises);
   activePools.clear();
 
-  // Reset global clients
+  // Reset global client
   restClient = null;
-  vectorClient = null;
 }
 
 // =============================================================================
@@ -507,66 +433,46 @@ export async function closeAllPools(): Promise<void> {
 // =============================================================================
 
 /**
+ * Asserts that the database supports transactions. Call at app startup to fail fast.
+ *
+ * @param dbType - Database type to check ('rest', or deprecated 'vector' alias)
+ * @throws {Error} If the database driver does not support transactions
+ *
+ * @example
+ * ```typescript
+ * // At app startup
+ * requiresTransactions('rest') // throws if DB is Neon HTTP
+ * ```
+ */
+export function requiresTransactions(dbType: DatabaseType = 'rest'): void {
+  // Force client creation so we know the driver type
+  getClient(dbType);
+  if (!restSupportsTransactions) {
+    throw new Error(
+      `Transaction support required but not available for '${dbType}' database. ` +
+        'The Neon HTTP driver does not support transactions. ' +
+        'Use a localhost pg driver for transaction support.',
+    );
+  }
+}
+
+/**
  * Execute a database transaction with automatic BEGIN/COMMIT/ROLLBACK.
  *
  * ⚠️ IMPORTANT: Transaction support depends on the database driver:
- * - ✅ Supabase/localhost (pg Pool): Full transaction support
+ * - ✅ Localhost (pg Pool): Full transaction support (dev/test)
  * - ❌ NeonDB (HTTP driver): Transactions NOT supported
  *
  * The Neon HTTP driver (@neondatabase/serverless with neon-http) does not support
  * transactions because it uses stateless HTTP requests. Each query is independent.
- *
- * For transaction support, use:
- * 1. Supabase with connection pooling (recommended for production)
- * 2. Localhost PostgreSQL (for development/testing)
- * 3. Neon with WebSocket driver (coming in future versions)
+ * Use withSaga() for NeonDB-safe multi-step writes.
  *
  * @param db - Database client (must be created with pg Pool driver)
  * @param fn - Transaction callback that receives a transaction context
  * @returns Result from the transaction callback
  * @throws {Error} If using Neon HTTP driver (no transaction support)
  * @throws {Error} If transaction fails (automatic ROLLBACK is performed)
- *
- * @example
- * ```typescript
- * // ✅ Works with Supabase/localhost (pg Pool driver)
- * const supabaseDb = getClient('vector') // Uses pg Pool
- * const result = await withTransaction(supabaseDb, async (tx) => {
- *   const site = await tx.insert(sites).values({ ... }).returning()
- *   await tx.insert(pages).values({ siteId: site[0].id, ... })
- *   return site[0]
- * })
- *
- * // ❌ Throws error with NeonDB (HTTP driver)
- * const neonDb = getClient('rest') // Uses Neon HTTP
- * await withTransaction(neonDb, async (tx) => { ... }) // Error!
- * ```
  */
-/**
- * Asserts that a database type supports transactions. Call at app startup to fail fast.
- *
- * @param dbType - Database type to check ('rest' or 'vector')
- * @throws {Error} If the database driver does not support transactions
- *
- * @example
- * ```typescript
- * // At app startup
- * requiresTransactions('rest') // throws if REST DB is Neon HTTP
- * ```
- */
-export function requiresTransactions(dbType: DatabaseType = 'rest'): void {
-  // Force client creation so we know the driver type
-  getClient(dbType);
-  const supports = dbType === 'vector' ? vectorSupportsTransactions : restSupportsTransactions;
-  if (!supports) {
-    throw new Error(
-      `Transaction support required but not available for '${dbType}' database. ` +
-        'The Neon HTTP driver does not support transactions. ' +
-        'Switch to Supabase pooler or pg driver for transaction support.',
-    );
-  }
-}
-
 export async function withTransaction<T>(
   db: Database,
   fn: (tx: Database) => Promise<T>,
@@ -574,14 +480,8 @@ export async function withTransaction<T>(
   // Early check: fail fast with clear message based on tracked driver type
   if (db === restClient && !restSupportsTransactions) {
     throw new Error(
-      'Transaction not supported: REST database is using Neon HTTP driver. ' +
-        'Use withSaga() for NeonDB-safe multi-step writes, or switch to Supabase pooler / pg driver for transaction support.',
-    );
-  }
-  if (db === vectorClient && !vectorSupportsTransactions) {
-    throw new Error(
-      'Transaction not supported: Vector database is using Neon HTTP driver. ' +
-        'Use withSaga() for NeonDB-safe multi-step writes, or switch to Supabase pooler / pg driver for transaction support.',
+      'Transaction not supported: database is using Neon HTTP driver. ' +
+        'Use withSaga() for NeonDB-safe multi-step writes, or use a localhost pg driver for transaction support.',
     );
   }
 
@@ -590,8 +490,8 @@ export async function withTransaction<T>(
 
   if (!hasPgTransaction) {
     throw new Error(
-      'Transaction not supported: Database client is using Neon HTTP driver which does not support transactions. ' +
-        'Use withSaga() for NeonDB-safe multi-step writes, or configure your database with Supabase / localhost connection string. ' +
+      'Transaction not supported: database client is using Neon HTTP driver which does not support transactions. ' +
+        'Use withSaga() for NeonDB-safe multi-step writes, or use a localhost pg driver. ' +
         'Neon HTTP driver uses stateless requests and cannot maintain transaction state.',
     );
   }

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -67,10 +67,11 @@ export type DatabaseType = 'rest' | 'vector';
  * Database client type (Drizzle ORM client)
  *
  * This is the actual database client returned by createClient/getClient.
- * For the centralized Database type matching Supabase structure, see @revealui/db/types
+ * For the centralized Database type, see @revealui/db/types
  *
- * Note: This is a union type to support both Neon (REST) and Postgres (Vector) drivers.
- * The actual type will be NeonHttpDatabase for REST and PgDatabase for Vector.
+ * Note: This is a union type to support both Neon (cloud) and Postgres (localhost dev) drivers.
+ * The actual type is NeonHttpDatabase for cloud Neon connections and NodePgDatabase for
+ * localhost connections (where the pg driver is used for transaction support).
  */
 export type Database = NeonHttpDatabase<typeof schema> | NodePgDatabase<typeof schema>;
 

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -28,7 +28,7 @@ import { drizzle as drizzlePg, type NodePgDatabase } from 'drizzle-orm/node-post
 import { Pool } from 'pg';
 import * as schema from '../schema/index.js'; // Full schema for backward compatibility
 import * as restSchema from '../schema/rest.js';
-import * as vectorSchema from '../schema/vector.js';
+import type * as vectorSchema from '../schema/vector.js';
 
 // Monitoring integration is handled by the application layer to avoid
 // circular dependency (db <-> core)

--- a/packages/db/src/transaction-blocker.test.ts
+++ b/packages/db/src/transaction-blocker.test.ts
@@ -2,7 +2,7 @@
  * Transaction Implementation Test - Critical Fix #1 Verification
  *
  * Verifies that withTransaction():
- * 1. Works correctly with pg Pool driver (Supabase/localhost)
+ * 1. Works correctly with pg Pool driver (localhost dev/test)
  * 2. Throws clear error with Neon HTTP driver (no transaction support)
  *
  * This prevents data corruption in multi-step operations.
@@ -39,7 +39,7 @@ describe('Critical Fix #1: Transaction Implementation', () => {
         await withTransaction(neonMockDb, async () => ({ success: true }));
         expect.fail('Should have thrown');
       } catch (error) {
-        expect((error as Error).message).toContain('Supabase / localhost');
+        expect((error as Error).message).toContain('withSaga()');
       }
     });
 


### PR DESCRIPTION
## Summary

GAP-129 PR-C — collapses the dual-DB client in `packages/db/src/client/index.ts` to Neon-only. Closes the final pending PR in the Supabase removal arc (PR-A/B/D/E shipped 2026-05-01).

**Draft until owner verifies gates 1 + 2 per [#799](https://github.com/RevealUIStudio/revealui/issues/799).**

## Pre-flight gates

| # | Gate | Status |
|---|---|---|
| 1 | RAG data on Neon (parity vs Supabase) | ⏳ Owner-blocked — needs row-count parity query |
| 2 | Phase 3 `REVEALUI_DB_DUAL_WRITE` soak | ❓ Flag absent from codebase — likely never shipped; needs owner confirmation |
| 3 | Stripe webhook destination repointed | ✅ Verified clean (zero `supabase` refs in `apps/server/src/routes/webhooks.ts`) |
| 4 | AI ingestion uses `getVectorClient()` (not hardcoded Supabase) | ✅ Verified — `packages/ai/src/ingestion/rag-vector-service.ts:8` + `packages/ai/src/memory/vector/vector-memory-service.ts:17` |

Full gate audit: [#799](https://github.com/RevealUIStudio/revealui/issues/799).

## Changes

### `packages/db/src/client/index.ts` (−106 net lines)

- `isSupabaseConnection()` → renamed `isLocalhostConnection()` + scope-narrowed to `localhost` / `127.0.0.1` only (drops `.supabase.co` / `pooler.supabase.com` patterns). Preserves local-dev pg-driver path.
- `vectorClient` global + `vectorSupportsTransactions` flag → **deleted**
- `getClientByType('vector')` branch → aliased to `getClientByType('rest')`
- `SUPABASE_DATABASE_URL` env-var read → **deleted** (PR-D dropped it from the config schema 2026-05-01; this drops the runtime read that was still present)
- `getVectorClient()` → kept as `@deprecated` alias returning `getClient('rest')`; JSDoc flags removal after 1-2 release cycles per GAP-129 PR-C spec §"Optional"
- `withTransaction()`, `requiresTransactions()` → vector-side branches dropped; rest-side unchanged
- File-level JSDoc reframed from "dual-DB" to "single Postgres DB (Neon-primary, pg driver for localhost)"

### Tests

- **`packages/db/src/client/__tests__/dual-client.test.ts`** — rewritten for single-client. New assertions: `getClient('vector') === getClient('rest')`, `getVectorClient() === getRestClient()`. Removed `SUPABASE_DATABASE_URL`-error assertions (env var no longer read).
- **`packages/db/src/__tests__/client/connection-failures.test.ts`** — vector error assertion updated to match rest behavior (line 684-692); stale Supabase-URL pg-Pool test removed (line 645-655) since `*.supabase.co` URLs no longer trigger pg-Pool path.
- **`packages/db/src/__tests__/client/pool.test.ts`** — vector assertion updated to match rest (line 237-241); Supabase test → Neon cloud test (line 123); localhost URL added (line 165).
- **`packages/db/__tests__/pool-cleanup.test.ts`** — `test.supabase.co` URL → `localhost:5432` (only localhost triggers pg-Pool post-collapse); `SUPABASE_DATABASE_URL` setup line removed; `getClient('vector')` → `getClient('rest')`.
- **`packages/db/src/transaction-blocker.test.ts`** — error message assertion updated `'Supabase / localhost'` → `'withSaga()'`; JSDoc updated.

### Production callsites unchanged

`packages/ai/src/ingestion/rag-vector-service.ts` + `packages/ai/src/memory/vector/vector-memory-service.ts` still import `getVectorClient()` from `@revealui/db/client` — the deprecated alias preserves the import without behavior change. No edits needed in `@revealui/ai`.

## Verification (already done locally by implementer)

| Step | Result |
|---|---|
| `pnpm --filter @revealui/db typecheck` | Clean |
| `pnpm --filter @revealui/db build` | Clean |
| `pnpm --filter @revealui/db test` | 52 files, 1174 passed, 5 skipped |
| `pnpm --filter @revealui/ai typecheck` | Clean |
| `pnpm --filter @revealui/ai test` | 61 files, 937 passed, 5 skipped |
| Pre-push gate (all 3 phases) | PASS |

## Test plan

- [ ] CI green
- [ ] Codex review (if any findings: verify against actual code before treating as authoritative per `feedback_codex_review_can_hallucinate`)
- [ ] **Owner verifies gate 1** — RAG row-count parity (Supabase vs Neon) for `rag_documents` / `rag_chunks` / `rag_workspaces`. Acceptable outcomes:
  - Counts match → safe to flip Draft → Ready and merge.
  - Counts diverge → migration step needed before merging.
- [ ] **Owner confirms gate 2** — `REVEALUI_DB_DUAL_WRITE` was intentionally skipped (flag absence in code is consistent with this; just needs confirmation).
- [ ] After merge: monitor RAG ingestion + memory-service flows for 24h; revert path is `git revert` + restore the dual-client branch.

## Out-of-scope / followups (NOT in this PR)

- `Database` type union JSDoc at `packages/db/src/client/index.ts:70-73` still says "The actual type will be NeonHttpDatabase for REST and PgDatabase for Vector." Stale comment; trivial follow-up edit.
- Phase 6 decommission (pause Supabase project, cancel subscription) — owner-only, separate from this PR per the ADR.
- revvault `revealui/supabase/*` stale credentials cleanup — Thread C, separate concern.

---

🤖 Pre-staged by `agent-system` (master thread + `implementer` subagent). Closes [#799](https://github.com/RevealUIStudio/revealui/issues/799) when gates 1 + 2 resolve.
