### PR TITLE
chore(dependabot): split production group into 5 reviewable buckets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,18 +26,63 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Group all production dependencies together
-      production:
+      # Production deps split into reviewable groups so a single weekly run
+      # produces ~5 tractable PRs instead of one 43-update mega-PR (see #785/
+      # #795/#797 — closed/recreated three times because the batch was too
+      # large to fix the one inevitable broken test without owner triage).
+      production-frontend:
         patterns:
-          - "*"
-        exclude-patterns:
-          - "@types/*"
-          - "@testing-library/*"
-          - "@vitest/*"
-          - "vitest"
-          - "@biomejs/*"
-          - "typescript"
-          - "tsx"
+          - "react"
+          - "react-dom"
+          - "next"
+          - "@next/*"
+          - "lexical"
+          - "@lexical/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "vite"
+          - "@vitejs/*"
+          - "postcss"
+          - "framer-motion"
+          - "three"
+        update-types:
+          - "minor"
+          - "patch"
+      production-server:
+        patterns:
+          - "hono"
+          - "@hono/*"
+          - "drizzle-orm"
+          - "@neondatabase/*"
+          - "pg"
+          - "jose"
+          - "lru-cache"
+        update-types:
+          - "minor"
+          - "patch"
+      production-billing-and-observability:
+        patterns:
+          - "stripe"
+          - "@sentry/*"
+          - "swagger-ui-dist"
+        update-types:
+          - "minor"
+          - "patch"
+      production-tooling:
+        patterns:
+          - "turbo"
+          - "syncpack"
+          - "semver"
+          - "zod"
+          - "ora"
+          - "@clack/*"
+          - "react-hook-form"
+        update-types:
+          - "minor"
+          - "patch"
+      production-electric-sql:
+        patterns:
+          - "@electric-sql/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

The single `production` group (`patterns: ['*']`) produced 43-update mega-PRs
that none of #785 / #795 / #797 could land — each recreate cycle broke on one
test (most recently `content-media-upload.test.ts` body-shape assertion) that
couldn't be fixed without owner triage on every dep in the batch.

Splits the group into 5 review-surface buckets:

| Group | Packages |
|-------|----------|
| `production-frontend` | react, next, tailwind, lexical, vite, postcss, framer, three |
| `production-server` | hono, drizzle, neon, pg, jose, lru-cache |
| `production-billing-and-observability` | stripe, sentry, swagger-ui-dist |
| `production-tooling` | turbo, syncpack, semver, zod, ora, clack, react-hook-form |
| `production-electric-sql` | @electric-sql/* (sync engine, isolated) |

Patterns are explicit allowlists — anything new lands as ungrouped, which
forces an explicit decision before silent inclusion in a `production-*`
bucket on first appearance. (`exclude-patterns` from the old config dropped
because no `*` catch-all remains.)

Closes the follow-up note on #797.

## Test plan

- [ ] Quality + Typecheck + dependency-config validators pass on this PR
- [ ] After merge, next weekly Dependabot run (Monday 09:00 UTC) produces 5 small PRs instead of one 43-update PR
- [ ] #797 can be closed once the new groups start producing tractable PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)