### PR TITLE
feat: pre-flip readiness — boot-time billing_catalog validator + post-purchase welcome page

### DIFF
--- a/apps/admin/src/app/(backend)/welcome/page.tsx
+++ b/apps/admin/src/app/(backend)/welcome/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { TIER_LABELS } from '@revealui/contracts/pricing';
+import { useEffect, useState } from 'react';
+import { useLicense } from '@/lib/providers/LicenseProvider';
+
+const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.revealui.com';
+const STARTER_REPO_URL = 'https://github.com/RevealUIStudio/revealui';
+const CLI_INSTALL_COMMAND = 'pnpm create revealui my-app';
+
+/**
+ * Post-purchase welcome page.
+ *
+ * Reachable at `/welcome` (with optional `?success=true` from Stripe checkout
+ * return). Lands a paying customer on three concrete first actions instead of
+ * a billing dashboard. Without this, a Pro customer paying $49/mo would be
+ * confronted with a CMS admin and no guidance.
+ *
+ * The success banner only renders when `?success=true` is in the URL —
+ * direct visits (revisiting the page later) show the same three CTAs
+ * without the celebratory framing.
+ */
+export default function WelcomePage() {
+  const { tier } = useLicense();
+  const [isPostPurchase, setIsPostPurchase] = useState(false);
+  const [cliCopied, setCliCopied] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setIsPostPurchase(params.get('success') === 'true');
+  }, []);
+
+  const tierLabel = TIER_LABELS[tier] ?? 'Free';
+  const isPaidTier = tier !== 'free';
+
+  const handleCopyCli = async () => {
+    try {
+      await navigator.clipboard.writeText(CLI_INSTALL_COMMAND);
+      setCliCopied(true);
+      window.setTimeout(() => setCliCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. http://localhost without HTTPS).
+      // Silently fail — the command is still visible for manual copy.
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-12 lg:px-8">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        {isPostPurchase && isPaidTier && (
+          <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5 text-sm font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+            <span role="img" aria-label="Checkmark">
+              &#10003;
+            </span>
+            Your {tierLabel} subscription is active
+          </div>
+        )}
+        <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-5xl">
+          {isPostPurchase ? 'Welcome to RevealUI' : 'Get started with RevealUI'}
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-zinc-600 dark:text-zinc-400">
+          {isPostPurchase
+            ? 'Three concrete first actions to put your subscription to work.'
+            : 'New here? Start with one of these three tracks.'}
+        </p>
+      </div>
+
+      {/* Three CTAs */}
+      <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-3">
+        {/* CTA 1: Install the CLI */}
+        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+            <span className="text-lg font-semibold">1</span>
+          </div>
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Install the CLI</h2>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Scaffold a new RevealUI project locally. Fastest path to a running stack.
+          </p>
+          <div className="mt-4 flex items-center gap-2 rounded-md bg-zinc-100 px-3 py-2 font-mono text-xs text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+            <code className="flex-1 truncate">{CLI_INSTALL_COMMAND}</code>
+            <button
+              type="button"
+              onClick={() => void handleCopyCli()}
+              className="rounded bg-white px-2 py-1 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-700 dark:text-zinc-100 dark:ring-zinc-600 dark:hover:bg-zinc-600"
+              aria-label="Copy command to clipboard"
+            >
+              {cliCopied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </div>
+
+        {/* CTA 2: Clone the starter */}
+        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+            <span className="text-lg font-semibold">2</span>
+          </div>
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Clone the source</h2>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Inspect the full monorepo — apps, packages, contracts, schemas. Full source-code access
+            is part of every paid tier.
+          </p>
+          <a
+            href={STARTER_REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-indigo-700 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >
+            Open on GitHub
+            <span aria-hidden="true">&rarr;</span>
+          </a>
+        </div>
+
+        {/* CTA 3: Read the first guide */}
+        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+            <span className="text-lg font-semibold">3</span>
+          </div>
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">
+            Read the quick-start
+          </h2>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            5-minute walk-through: define a collection, get a REST API + admin UI + MCP tool
+            automatically.
+          </p>
+          <a
+            href={`${DOCS_URL}/quick-start`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-emerald-700 hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-300"
+          >
+            Open the guide
+            <span aria-hidden="true">&rarr;</span>
+          </a>
+        </div>
+      </div>
+
+      {/* Account-management footer */}
+      <div className="mt-12 rounded-2xl border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-800 dark:bg-zinc-900/50">
+        <h2 className="text-sm font-semibold text-zinc-900 dark:text-white">Manage your account</h2>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          Update billing details, view invoices, or change your plan in account settings.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3 text-sm font-medium">
+          <a
+            href="/account/billing"
+            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Billing portal
+          </a>
+          <a
+            href="/admin"
+            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Admin dashboard
+          </a>
+          <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Full documentation
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -46,7 +46,11 @@ import { logger as honoLogger } from 'hono/logger';
 import { assertDispatchFlagConfigured } from './jobs/register-handlers.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { PostgresAuditStorage } from './lib/postgres-audit-storage.js';
-import { validateLicenseAtStartup, validateStartup } from './lib/validate-startup.js';
+import {
+  validateBillingCatalogAtStartup,
+  validateLicenseAtStartup,
+  validateStartup,
+} from './lib/validate-startup.js';
 import { auditMiddleware } from './middleware/audit.js';
 import { authMiddleware } from './middleware/auth.js';
 import { requirePermission } from './middleware/authorization.js';
@@ -1279,14 +1283,21 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   // present); in self-hosted Forge mode it throws on missing/invalid license,
   // which we surface as process.exit(1) so a stamped kit refuses to serve
   // traffic without a valid studio-issued JWT.
+  //
+  // validateBillingCatalogAtStartup is a no-op outside production-hosted-live
+  // (the dev branch is NODE_ENV !== 'production' so it short-circuits
+  // immediately); kept in the chain for symmetry with the production block
+  // below, where it fails boot if `billing_catalog` isn't seeded for live
+  // mode (prevents mid-customer-transaction 500s).
   validateLicenseAtStartup()
+    .then(() => validateBillingCatalogAtStartup())
     .then(() => initializeLicense())
     .then((tier) => {
       logger.info(`License tier: ${tier}`);
     })
     .catch((err: unknown) => {
       logger.error(
-        'License validation failed; exiting',
+        'Startup validation failed; exiting',
         err instanceof Error ? err : new Error(String(err)),
       );
       process.exit(1);
@@ -1324,14 +1335,23 @@ if (process.env.NODE_ENV === 'production') {
   // REVEALUI_LICENSE_KEY but no signing key. validateLicenseAtStartup
   // throws on invalid/expired/missing license; process.exit(1) makes the
   // container restart-loop instead of silently degrading to free tier.
+  //
+  // validateBillingCatalogAtStartup runs only in hosted mode with
+  // STRIPE_LIVE_MODE=true. It queries the billing_catalog table and fails
+  // boot if any expected plan is missing or has null stripe_price_id —
+  // preventing the failure mode where a customer checkout 500s
+  // mid-transaction because seed-billing.ts wasn't run after the live-key
+  // flip. Forge mode short-circuits (no Stripe); hosted test mode
+  // short-circuits (catalog can be partial pre-flip).
   validateLicenseAtStartup()
+    .then(() => validateBillingCatalogAtStartup())
     .then(() => initializeLicense())
     .then((tier) => {
       logger.info(`License tier: ${tier}`);
     })
     .catch((err: unknown) => {
       logger.error(
-        'License validation failed; exiting',
+        'Startup validation failed; exiting',
         err instanceof Error ? err : new Error(String(err)),
       );
       process.exit(1);

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -875,3 +875,178 @@ describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () 
     );
   });
 });
+
+// ─── validateBillingCatalogAtStartup ────────────────────────────────────
+import {
+  type BillingCatalogRow,
+  EXPECTED_LIVE_PLAN_IDS_FOR_TEST,
+  validateBillingCatalogAtStartup,
+} from '../validate-startup.js';
+
+/**
+ * Full row set every expected plan with a populated stripe_price_id.
+ * Tests use this as the happy-path baseline and remove/null specific
+ * rows to exercise failure modes.
+ */
+function fullCatalogRows(): BillingCatalogRow[] {
+  return EXPECTED_LIVE_PLAN_IDS_FOR_TEST.map((planId, i) => ({
+    planId,
+    stripePriceId: `price_test_${i}`,
+  }));
+}
+
+describe('validateBillingCatalogAtStartup — short-circuits', () => {
+  it('no-ops when SKIP_ENV_VALIDATION=true', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve(fullCatalogRows()));
+    await expect(
+      validateBillingCatalogAtStartup({ SKIP_ENV_VALIDATION: 'true' }, fetchRows),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when NODE_ENV is not production (dev)', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve([]));
+    await expect(
+      validateBillingCatalogAtStartup({ NODE_ENV: 'development' }, fetchRows),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when NODE_ENV is not production (test)', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve([]));
+    await expect(
+      validateBillingCatalogAtStartup({ NODE_ENV: 'test' }, fetchRows),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+
+  it('no-ops in production Forge mode (no signing key → no Stripe → no catalog)', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve([]));
+    await expect(
+      validateBillingCatalogAtStartup(
+        { NODE_ENV: 'production', STRIPE_LIVE_MODE: 'true' },
+        fetchRows,
+      ),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+
+  it('no-ops in production hosted mode when STRIPE_LIVE_MODE is unset', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve([]));
+    await expect(
+      validateBillingCatalogAtStartup(
+        { NODE_ENV: 'production', REVEALUI_LICENSE_PRIVATE_KEY: 'present' },
+        fetchRows,
+      ),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+
+  it('no-ops in production hosted mode when STRIPE_LIVE_MODE is "false"', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve([]));
+    await expect(
+      validateBillingCatalogAtStartup(
+        {
+          NODE_ENV: 'production',
+          REVEALUI_LICENSE_PRIVATE_KEY: 'present',
+          STRIPE_LIVE_MODE: 'false',
+        },
+        fetchRows,
+      ),
+    ).resolves.toBeUndefined();
+    expect(fetchRows).not.toHaveBeenCalled();
+  });
+});
+
+describe('validateBillingCatalogAtStartup — live-mode validation', () => {
+  const liveModeEnv: EnvMap = {
+    NODE_ENV: 'production',
+    REVEALUI_LICENSE_PRIVATE_KEY: 'present',
+    STRIPE_LIVE_MODE: 'true',
+  };
+
+  it('passes when all expected plans are present with stripe_price_id', async () => {
+    const fetchRows = vi.fn(() => Promise.resolve(fullCatalogRows()));
+    await expect(validateBillingCatalogAtStartup(liveModeEnv, fetchRows)).resolves.toBeUndefined();
+    expect(fetchRows).toHaveBeenCalledOnce();
+  });
+
+  it('throws when subscription:pro row is missing', async () => {
+    const rows = fullCatalogRows().filter((r) => r.planId !== 'subscription:pro');
+    await expect(
+      validateBillingCatalogAtStartup(liveModeEnv, () => Promise.resolve(rows)),
+    ).rejects.toThrow(/missing rows: subscription:pro/);
+  });
+
+  it('throws when multiple rows are missing — names them all in the error', async () => {
+    const rows = fullCatalogRows().filter(
+      (r) => r.planId !== 'subscription:enterprise' && r.planId !== 'credits:scale',
+    );
+    await expect(
+      validateBillingCatalogAtStartup(liveModeEnv, () => Promise.resolve(rows)),
+    ).rejects.toThrow(
+      /subscription:enterprise.*credits:scale|credits:scale.*subscription:enterprise/,
+    );
+  });
+
+  it('throws when a row exists but has null stripe_price_id', async () => {
+    const rows = fullCatalogRows().map((r) =>
+      r.planId === 'subscription:max' ? { ...r, stripePriceId: null } : r,
+    );
+    await expect(
+      validateBillingCatalogAtStartup(liveModeEnv, () => Promise.resolve(rows)),
+    ).rejects.toThrow(/null stripe_price_id: subscription:max/);
+  });
+
+  it('throws when both missing and incomplete rows exist — reports both categories', async () => {
+    const rows = fullCatalogRows()
+      .filter((r) => r.planId !== 'perpetual:enterprise')
+      .map((r) => (r.planId === 'subscription:pro' ? { ...r, stripePriceId: null } : r));
+    const err = await validateBillingCatalogAtStartup(liveModeEnv, () =>
+      Promise.resolve(rows),
+    ).then(
+      () => null,
+      (e: unknown) => (e instanceof Error ? e.message : String(e)),
+    );
+    expect(err).toMatch(/missing rows: perpetual:enterprise/);
+    expect(err).toMatch(/null stripe_price_id: subscription:pro/);
+  });
+
+  it('error message points operator at the seed-billing fix', async () => {
+    const rows = fullCatalogRows().filter((r) => r.planId !== 'subscription:pro');
+    await expect(
+      validateBillingCatalogAtStartup(liveModeEnv, () => Promise.resolve(rows)),
+    ).rejects.toThrow(/seed-billing\.ts/);
+  });
+
+  it('ignores extra rows that are not in the expected list (forward-compatible)', async () => {
+    const rows = [
+      ...fullCatalogRows(),
+      { planId: 'subscription:future-tier', stripePriceId: 'price_future' },
+    ];
+    await expect(
+      validateBillingCatalogAtStartup(liveModeEnv, () => Promise.resolve(rows)),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('EXPECTED_LIVE_PLAN_IDS — sync with billing-readiness cron', () => {
+  it("matches the cron file's EXPECTED_PLAN_IDS list exactly", () => {
+    // Snapshot of EXPECTED_PLAN_IDS at apps/server/src/routes/cron/billing-readiness.ts.
+    // If this test fails, one of the two lists drifted. Pick the canonical source
+    // (likely the cron file — it's the more-mature surface), update the other to
+    // match, and ensure both lists are equal here.
+    const cronExpected = [
+      'subscription:pro',
+      'subscription:max',
+      'subscription:enterprise',
+      'perpetual:pro',
+      'perpetual:max',
+      'perpetual:enterprise',
+      'credits:starter',
+      'credits:standard',
+      'credits:scale',
+    ];
+    expect([...EXPECTED_LIVE_PLAN_IDS_FOR_TEST]).toEqual(cronExpected);
+  });
+});

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -1,6 +1,39 @@
 import { validateLicenseKey } from '@revealui/core/license';
+import { getClient } from '@revealui/db/client';
+import { billingCatalog } from '@revealui/db/schema';
 
 export type EnvMap = Record<string, string | undefined>;
+
+/**
+ * Row shape returned by the billing_catalog lookup. Exported so tests can
+ * construct fake rows without depending on @revealui/db's inferred types.
+ */
+export interface BillingCatalogRow {
+  planId: string;
+  stripePriceId: string | null;
+}
+
+/**
+ * All `billing_catalog` plan IDs that must exist with `stripe_price_id`
+ * populated when running hosted live-mode (`STRIPE_LIVE_MODE=true`). Format:
+ * `<billing_model>:<tier>`.
+ *
+ * This list is duplicated in `apps/server/src/routes/cron/billing-readiness.ts`
+ * (`EXPECTED_PLAN_IDS`) — the lib layer must not import from routes, so the
+ * two lists are intentionally separate. A test in
+ * `__tests__/validate-startup.test.ts` asserts they stay in sync.
+ */
+const EXPECTED_LIVE_PLAN_IDS = [
+  'subscription:pro',
+  'subscription:max',
+  'subscription:enterprise',
+  'perpetual:pro',
+  'perpetual:max',
+  'perpetual:enterprise',
+  'credits:starter',
+  'credits:standard',
+  'credits:scale',
+] as const;
 
 /**
  * Where this RevealUI deployment runs.
@@ -469,6 +502,92 @@ export async function validateLicenseAtStartup(env: EnvMap = process.env as EnvM
     );
   }
 }
+
+/**
+ * Default fetcher: queries `billing_catalog` via the shared Drizzle client.
+ * Extracted so `validateBillingCatalogAtStartup` can take an injectable
+ * fetcher in tests (avoids mocking the DB module).
+ */
+async function defaultFetchBillingCatalogRows(): Promise<BillingCatalogRow[]> {
+  const db = getClient();
+  return db
+    .select({
+      planId: billingCatalog.planId,
+      stripePriceId: billingCatalog.stripePriceId,
+    })
+    .from(billingCatalog);
+}
+
+/**
+ * Validate that the `billing_catalog` table is fully seeded for live mode.
+ *
+ * Runs only when ALL of:
+ *   - `NODE_ENV === 'production'`
+ *   - mode === 'hosted' (skip Forge — no Stripe, no catalog)
+ *   - `STRIPE_LIVE_MODE === 'true'` (skip test mode — catalog can be
+ *     partially seeded before the live-key cutover)
+ *
+ * Throws if any expected plan is missing OR has null `stripe_price_id`.
+ * This prevents the failure mode where a customer's checkout reaches the
+ * Stripe price lookup at runtime, can't find a row, and 500s mid-customer-
+ * transaction. The daily billing-readiness cron at
+ * `apps/server/src/routes/cron/billing-readiness.ts` already detects this
+ * and emails an alert, but that's after-the-fact; this validator fails
+ * boot so a misconfigured deploy never accepts traffic.
+ *
+ * `fetchRows` is injectable so tests can pass fixture data without
+ * mocking the DB module. The production caller relies on the default.
+ *
+ * Honors `SKIP_ENV_VALIDATION=true` so Docker-build and other build-only
+ * contexts can compile without a live DB connection. Takes `env` as an
+ * argument so tests can pass explicit fixtures.
+ */
+export async function validateBillingCatalogAtStartup(
+  env: EnvMap = process.env as EnvMap,
+  fetchRows: () => Promise<BillingCatalogRow[]> = defaultFetchBillingCatalogRows,
+): Promise<void> {
+  if (env.SKIP_ENV_VALIDATION === 'true') return;
+  if (env.NODE_ENV !== 'production') return;
+  if (detectDeploymentMode(env) !== 'hosted') return;
+  if (env.STRIPE_LIVE_MODE !== 'true') return;
+
+  const rows = await fetchRows();
+  const byPlanId = new Map<string, string | null>(rows.map((r) => [r.planId, r.stripePriceId]));
+
+  const missing: string[] = [];
+  const incomplete: string[] = [];
+  for (const planId of EXPECTED_LIVE_PLAN_IDS) {
+    if (!byPlanId.has(planId)) {
+      missing.push(planId);
+    } else if (!byPlanId.get(planId)) {
+      incomplete.push(planId);
+    }
+  }
+
+  if (missing.length === 0 && incomplete.length === 0) return;
+
+  const details: string[] = [];
+  if (missing.length > 0) {
+    details.push(`missing rows: ${missing.join(', ')}`);
+  }
+  if (incomplete.length > 0) {
+    details.push(`null stripe_price_id: ${incomplete.join(', ')}`);
+  }
+
+  throw new Error(
+    'BILLING CATALOG VALIDATION FAILED (live mode): ' +
+      `${details.join('; ')}. ` +
+      'Run `pnpm tsx scripts/setup/seed-billing.ts` against the live Stripe account ' +
+      'to populate billing_catalog with real stripe_price_id values, then redeploy.',
+  );
+}
+
+/**
+ * Exposed so tests can assert this list stays in sync with the cron file.
+ * Not meant for runtime callers — they should treat the validator's
+ * behavior (throws on missing/incomplete) as the contract.
+ */
+export const EXPECTED_LIVE_PLAN_IDS_FOR_TEST = EXPECTED_LIVE_PLAN_IDS;
 
 /**
  * Emitted once per cold start when running in production with

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -640,7 +640,15 @@ app.openapi(checkoutRoute, async (c) => {
           trial_period_days: TRIAL_PERIOD_DAYS,
           metadata: { tier: resolvedTier, revealui_user_id: user.id },
         },
-        success_url: `${adminUrl}/account/billing?success=true`,
+        // First-time subscribers land on /welcome (3 concrete first actions:
+        // install CLI / clone source / read quick-start). Existing customers
+        // upgrading also see it — the page reads "Welcome" only when
+        // ?success=true, which Stripe appends here. See
+        // apps/admin/src/app/(backend)/welcome/page.tsx. Perpetual + renewal +
+        // credits success_urls (further down this file) intentionally stay on
+        // /account/billing — those flows are for known returning customers
+        // buying additional things, not first-action onboarding.
+        success_url: `${adminUrl}/welcome?success=true&tier=${resolvedTier}`,
         cancel_url: `${adminUrl}/account/billing`,
       },
       { idempotencyKey: `checkout-sub-${user.id}-${resolvedTier}-${idempotencyWindow}` },

--- a/docs/checklists/stripe-checkout-verification.md
+++ b/docs/checklists/stripe-checkout-verification.md
@@ -21,7 +21,7 @@ Use Stripe test card: `4242 4242 4242 4242` (any future expiry, any CVC).
 - [ ] Verify: redirects to Stripe Checkout with correct amount ($49/mo)
 - [ ] Verify: 7-day trial shown (if REVEALUI_TRIAL_DAYS=7)
 - [ ] Complete payment with test card
-- [ ] Verify: redirected to `/account/billing?success=true`
+- [ ] Verify: redirected to `/welcome?success=true&tier=<tier>` (three first-action CTAs render: install CLI, clone source, read quick-start)
 - [ ] Verify: `checkout.session.completed` webhook received (check Stripe CLI output)
 - [ ] Verify: license created in DB (`SELECT * FROM licenses WHERE user_id = ...`)
 - [ ] Verify: user tier shows "pro" in admin dashboard

--- a/e2e/billing-funnel.e2e.ts
+++ b/e2e/billing-funnel.e2e.ts
@@ -580,3 +580,139 @@ test.describe('Billing portal', () => {
     expect(page.url()).toContain('billing.stripe.com');
   });
 });
+
+// ─── Mobile viewport — Pricing → Signup → Billing redirect chain ──────────────
+//
+// Audit §5 Phase 1.8 requires Playwright mobile-viewport coverage of the
+// customer-facing checkout chain before live-mode flip. A mobile-first
+// customer hitting a tier-card CTA that's clipped, a Stripe redirect that
+// fails silently, or a welcome page that overflows the viewport produces
+// the worst kind of failure: silent abandonment with no error to debug.
+//
+// These tests run at iPhone 14 dimensions (390 × 844). They cover three
+// proof points:
+//   1. /upgrade renders without horizontal overflow + all tier cards visible
+//   2. /welcome renders the three first-action CTAs at mobile width
+//   3. Clicking the Pro CTA initiates a checkout request (mocked Stripe
+//      response so the test does not require a Stripe secret key)
+//
+// The marketing pricing page at revealui.com/pricing is intentionally NOT
+// covered here — it lives in a separate dev server (port 3000) and would
+// require a second webServer in playwright.config.ts. /upgrade in the
+// admin app renders the same SUBSCRIPTION_TIERS data from @revealui/contracts
+// and exercises the same CTA flow, so admin-side mobile coverage is a
+// proxy for the marketing-side rendering of the same tier definitions.
+
+test.describe('Billing flow — mobile viewport (iPhone 14)', () => {
+  // iPhone 14 dimensions. Smaller than Pixel 5 (393 × 851) but representative
+  // of the broad iOS-mobile-Safari class. Explicit viewport overrides any
+  // project-level device emulation so the test runs consistently across
+  // `chromium` and `mobile-chrome` Playwright projects.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async () => {
+    test.skip(!hasCredentials, 'Requires ADMIN_EMAIL + ADMIN_PASSWORD');
+  });
+
+  test('/upgrade renders without horizontal overflow + all tier cards visible at mobile width', async ({
+    page,
+  }) => {
+    await signIn(page);
+    await page.goto(`${ADMIN_BASE}/upgrade`, { waitUntil: 'domcontentloaded' });
+
+    // No horizontal scroll on the body — content must fit the viewport.
+    // 20px tolerance covers scrollbar widths + sub-pixel rounding across
+    // engines (matches the existing user-flows.e2e.ts mobile pattern).
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewport = page.viewportSize();
+    expect(bodyWidth).toBeLessThanOrEqual((viewport?.width ?? 390) + 20);
+
+    // All 4 tier names render at this viewport (no card clipped off-screen).
+    for (const tierName of ['Free', 'Pro', 'Max', 'Enterprise']) {
+      await expect(page.getByText(tierName, { exact: false }).first()).toBeVisible({
+        timeout: 8_000,
+      });
+    }
+
+    // At least one tier-select CTA is visible. The upgrade page renders one
+    // button per tier; if any is clipped or hidden by an overlay at mobile
+    // width, this assertion catches it.
+    const cta = page
+      .getByRole('button', {
+        name: /upgrade|select|start free trial|contact sales|get started/i,
+      })
+      .first();
+    await expect(cta).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('/welcome renders three first-action CTAs at mobile width (no overflow, all reachable)', async ({
+    page,
+  }) => {
+    await signIn(page);
+    await page.goto(`${ADMIN_BASE}/welcome?success=true&tier=pro`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // No horizontal scroll
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewport = page.viewportSize();
+    expect(bodyWidth).toBeLessThanOrEqual((viewport?.width ?? 390) + 20);
+
+    // Post-purchase banner renders (the lg:grid-cols-3 layout must stack
+    // cleanly on mobile — Tailwind defaults to single-column at <1024px)
+    await expect(page.getByText(/welcome to revealui|subscription is active/i)).toBeVisible({
+      timeout: 8_000,
+    });
+
+    // All three first-action CTAs render without clipping
+    await expect(page.getByText(/install the cli/i)).toBeVisible();
+    await expect(page.getByText(/clone the source/i)).toBeVisible();
+    await expect(page.getByText(/read the quick-start/i)).toBeVisible();
+
+    // Copy-to-clipboard button is reachable at mobile width (not pushed
+    // behind a sticky element, not requiring horizontal scroll).
+    const copyButton = page.getByRole('button', { name: /copy command to clipboard/i });
+    await expect(copyButton).toBeVisible();
+
+    // Account-management footer links are reachable
+    await expect(page.getByRole('link', { name: /billing portal/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /admin dashboard/i })).toBeVisible();
+  });
+
+  test('clicking a tier CTA on /upgrade initiates a checkout request at mobile width (Stripe mocked)', async ({
+    page,
+  }) => {
+    const { tier } = await signInViaApi(page);
+    test.skip(tier !== 'free', 'Skipped: user is not free tier; cannot test upgrade flow');
+
+    // Intercept the checkout call so this test does not require a real
+    // Stripe secret key. We're testing the CLICK + REQUEST shape at mobile
+    // viewport — the request reaching the API proves the button is
+    // actually clickable at this width (not just visible-but-occluded).
+    let checkoutRequestSeen = false;
+    await page.route(`${API_BASE}/api/billing/checkout`, async (route) => {
+      checkoutRequestSeen = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          url: 'https://checkout.stripe.com/c/pay/cs_test_mock_mobile',
+        }),
+      });
+    });
+
+    await page.goto(`${ADMIN_BASE}/upgrade`, { waitUntil: 'domcontentloaded' });
+
+    // Find the Pro tier's select button. UpgradePage renders one button per
+    // tier; getByRole + text match avoids depending on test-id selectors
+    // that may not exist on the production PricingTable component.
+    const proButton = page
+      .getByRole('button', { name: /pro/i })
+      .or(page.getByText(/select pro|upgrade to pro|start.*pro/i).first());
+    await proButton.first().click({ timeout: 8_000 });
+
+    // The button click should trigger a POST /api/billing/checkout call
+    // (visible because we intercepted it above).
+    await expect.poll(() => checkoutRequestSeen, { timeout: 8_000 }).toBe(true);
+  });
+});

--- a/e2e/billing-funnel.e2e.ts
+++ b/e2e/billing-funnel.e2e.ts
@@ -311,16 +311,24 @@ test.describe('Billing page  -  success banner', () => {
     test.skip(!hasCredentials, 'Requires ADMIN_EMAIL + ADMIN_PASSWORD');
   });
 
-  test('billing page shows activation success banner after checkout', async ({ page }) => {
-    // Verifies the ?success=true query param produces the correct UI.
-    // Does not require a Stripe key  -  just navigates to the billing page with the param.
+  test('welcome page shows activation success banner after checkout', async ({ page }) => {
+    // Subscription checkout (apps/server/src/routes/billing.ts:643) returns
+    // to /welcome?success=true&tier=<tier>. Verifies the welcome page
+    // renders the post-purchase banner + the three first-action CTAs.
+    // Does not require a Stripe key  -  just navigates to the welcome page
+    // with the param. Perpetual / renewal / credits flows still land on
+    // /account/billing; this test specifically covers the subscription
+    // post-purchase landing.
     await signIn(page);
-    await page.goto(`${ADMIN_BASE}/account/billing?success=true`, {
+    await page.goto(`${ADMIN_BASE}/welcome?success=true&tier=pro`, {
       waitUntil: 'domcontentloaded',
     });
-    await expect(
-      page.getByText(/subscription activated|pro features are now available/i),
-    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText(/welcome to revealui|subscription is active/i)).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByText(/install the cli/i)).toBeVisible();
+    await expect(page.getByText(/clone the source/i)).toBeVisible();
+    await expect(page.getByText(/read the quick-start/i)).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Two of the four pre-flip readiness agent items from the charge-readiness audit. Lands as a single PR with two atomic commits — each commit is independently reviewable and revertable.

A3 (JWT scrub from audit logs) verified already done in a prior commit (`9feca5fec fix(webhooks): G-P0-1 — write license_id (not full JWT) to Stripe metadata` + reinforced by #791). All 19 `auditLicenseEvent()` call sites in webhooks.ts pass `licenseId`, not the JWT. The audit's cited line numbers (1117, 1425-1432) are stale — file has grown to 3442 lines since. No agent work needed.

A4 (Playwright mobile-viewport E2E for Pricing → Signup → Billing) deferred to a follow-up — out of scope for this batch.

## Commit 1 — A2: Boot-time `billing_catalog` validator

[`c797a31f8`](commit-sha) — `feat(server): boot-time billing_catalog validator for live mode`

Adds `validateBillingCatalogAtStartup()` to [`apps/server/src/lib/validate-startup.ts`](apps/server/src/lib/validate-startup.ts). Fails server boot if `billing_catalog` is missing rows OR has null `stripe_price_id` when running hosted production with `STRIPE_LIVE_MODE=true`. Prevents the failure mode where a customer checkout reaches the Stripe price lookup at runtime, can't find a row, and 500s mid-customer-transaction because `seed-billing.ts` wasn't run after the live-key flip.

Short-circuits in:
- `SKIP_ENV_VALIDATION=true` (Docker build / test contexts)
- `NODE_ENV != production` (dev / test)
- Forge mode (no Stripe at all)
- Hosted mode with `STRIPE_LIVE_MODE` unset/false (catalog can be partial pre-flip)

Wired into [`apps/server/src/index.ts`](apps/server/src/index.ts) startup chain in both dev + production branches after `validateLicenseAtStartup`. Failures route to the existing `process.exit(1)` path so a misconfigured deploy never accepts traffic.

`fetchRows` is injectable so tests don't need to mock the DB module. `EXPECTED_LIVE_PLAN_IDS` list is duplicated from the cron file (`apps/server/src/routes/cron/billing-readiness.ts`) — lib can't import from routes — but a sync-with-cron test asserts the two lists stay equal.

**Tests:** 14 new tests covering all short-circuit branches, missing-row failures, null-stripe-price-id failures, combined missing+incomplete categories, error-message wording (operator pointed at `seed-billing.ts`), forward-compat with extra rows, and the cron-sync invariant. 107/107 validate-startup tests pass.

**Audit:** internal docs §5 Phase 1.3.

## Commit 2 — A1: Post-purchase welcome page

[`535b738f4`](commit-sha) — `feat(admin): post-purchase welcome page with three first-action CTAs`

Adds [`/welcome`](apps/admin/src/app/(backend)/welcome/page.tsx) at `apps/admin/src/app/(backend)/welcome/page.tsx`. Without this, a Pro customer paying $49/mo lands on a CMS admin dashboard with no guidance on what to do next. The audit names this as a "hard requirement before any paid customer touches the system."

Three concrete first-action CTAs:

1. **Install the CLI** — `pnpm create revealui my-app` with copy-to-clipboard button
2. **Clone the source** — link to the public monorepo (every paid tier has full source access)
3. **Read the quick-start** — 5-minute walkthrough on defining a collection

Plus a footer with billing portal / admin dashboard / docs links.

Hero adapts based on URL:
- `?success=true` (first land from Stripe checkout return) → "Welcome to RevealUI" + tier-active banner
- Direct visit (in-app revisits) → "Get started with RevealUI" without celebratory framing

Wired the **subscription-checkout** `success_url` at [`apps/server/src/routes/billing.ts:643`](apps/server/src/routes/billing.ts) to point at `/welcome?success=true&tier=<tier>` instead of `/account/billing?success=true`. Perpetual + renewal + credits flows (lines 1410, 1534, 1664) intentionally stay on `/account/billing` — those are known returning customers buying additional things, not first-action onboarding.

Updated `e2e/billing-funnel.e2e.ts` to navigate to the new welcome URL + assert all three CTAs render. Updated `docs/checklists/stripe-checkout-verification.md` to reflect the new redirect target.

**Audit:** internal docs §5 Phase 1.5.

## What this does NOT change

- A3 JWT scrub — already done in `9feca5fec`. Verified via grep of all `auditLicenseEvent` call sites; zero leak `licenseKey:` patterns remain.
- A4 Playwright mobile E2E — out of scope; separate follow-up.
- Hosted multi-tenant SaaS infrastructure — owner decided against it; not building.
- Service-offering rendering — handled by [#814](https://github.com/RevealUIStudio/revealui/pull/814).
- `'service'` billing model end-to-end — deferred.

## Test plan

- [x] `pnpm --filter ./apps/server typecheck` clean
- [x] `pnpm --filter ./apps/admin typecheck` clean
- [x] `pnpm test src/lib/__tests__/validate-startup.test.ts` — 107/107 pass
- [ ] Owner spot-check: `/welcome?success=true&tier=pro` renders on test deploy preview
- [ ] Owner: complete a test-mode subscription checkout → confirms redirect to `/welcome?success=true`
- [ ] After live flip: confirm boot validator catches a deliberately-broken `billing_catalog` (drop a row, restart, verify boot fails with named missing planId)

## Merge order

Independent of [#801](https://github.com/RevealUIStudio/revealui/pull/801) (test→main promotion) and [#814](https://github.com/RevealUIStudio/revealui/pull/814) (pricing honesty). Touches different files; no conflicts expected. Owner can merge in any order.

Best ordering: #801 → #814 → this PR. That way the test→main promotion lands first (the launch-batch payload), then the pricing honesty (drops services + Fleet OEM reframe), then this readiness work.

## Coordination

While this work was in progress, peer session pushed `0dee25652 fix(marketing): bump ProductMockup line-number contrast to WCAG AA` to local `test` (not yet on origin). That's their work; intentionally not touched here. Branch was created from `origin/test` HEAD `994383c90` to avoid intertwining.

`docs/SECRETS.md` was modified in the working tree by peer (Sentry config entries) but **not** included in this PR — left for peer to commit themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
