### PR TITLE
fix(marketing): bump ProductMockup line-number contrast to WCAG AA

### DIFF
--- a/apps/marketing/app/components/ProductMockup.tsx
+++ b/apps/marketing/app/components/ProductMockup.tsx
@@ -161,7 +161,7 @@ export function ProductMockup() {
           {codeLines.map((line, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: static display list, no reordering
             <div key={i} className="flex">
-              <span className="select-none w-6 shrink-0 text-gray-600 text-right mr-4">
+              <span className="select-none w-6 shrink-0 text-gray-400 text-right mr-4">
                 {i + 1}
               </span>
               <span>


### PR DESCRIPTION
## Summary

One-line CSS fix to unblock the test→main promotion PR [#801](https://github.com/RevealUIStudio/revealui/pull/801).

`apps/marketing/app/components/ProductMockup.tsx:164` — line-number gutter span used `text-gray-600` (#4a5565) on `bg-gray-950` (#030712), yielding **2.66:1 contrast** — below WCAG 2 AA's 4.5:1 threshold. axe-core flagged this as SERIOUS in the smoke test, which buckets SERIOUS into critical, failing the \"Marketing homepage has no critical accessibility violations\" assertion.

```diff
- <span className=\"select-none w-6 shrink-0 text-gray-600 text-right mr-4\">
+ <span className=\"select-none w-6 shrink-0 text-gray-400 text-right mr-4\">
```

`text-gray-400` (#99a1af) gives ~7:1 contrast on the dark code-panel background. Still subdued relative to the syntax-highlighted code (which uses text-gray-300 + token colors) so the visual hierarchy is preserved.

## Unblocks

All 3 currently-failing required checks on [#801](https://github.com/RevealUIStudio/revealui/pull/801) (E2E Smoke / Accessibility (E2E) / Coverage all rolled up the same Playwright failure on `smoke.e2e.ts:138` — `Marketing page > Marketing homepage has no critical accessibility violations`).

## Test plan

- [ ] Quality + Typecheck + Unit Tests pass on this PR (single-file CSS change, no logic affected)
- [ ] After merge, #801's E2E re-runs and the `Marketing page` accessibility assertion passes
- [ ] Owner reviews #801's operator pre-deploy checklist before that merge fires production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)