### PR TITLE
fix(marketing): make Problem.tsx comparison table scrollable-region focusable

### DIFF
--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -63,7 +63,12 @@ export function Problem() {
         </div>
 
         <div className="mx-auto mt-16 max-w-6xl overflow-hidden rounded-2xl ring-1 ring-gray-950/10 shadow-sm">
-          <div className="overflow-x-auto">
+          <section
+            // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable comparison table — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally on narrow viewports
+            tabIndex={0}
+            aria-label="Vendor sprawl vs agent-framework vs RevealUI comparison"
+            className="overflow-x-auto"
+          >
             <table className="w-full text-left text-sm">
               <thead>
                 <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-widest text-gray-500">
@@ -97,7 +102,7 @@ export function Problem() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </section>
         </div>
 
         <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-gray-500">


### PR DESCRIPTION
## Summary

Third scrollable-region-focusable violation in the #801 E2E sweep.

After [#816](https://github.com/RevealUIStudio/revealui/pull/816) (line-number contrast) and [#817](https://github.com/RevealUIStudio/revealui/pull/817) (`<pre>` keyboard-focusable) cleared the first two violations, axe-core surfaces a third:

```
[SERIOUS] scrollable-region-focusable
  Target: .max-w-6xl.ring-gray-950\/10.overflow-hidden > .overflow-x-auto
```

That selector matches `apps/marketing/app/components/landing/Problem.tsx:65-66` — the comparison `<table>` wrapper.

Fix: promote the wrapping `<div className="overflow-x-auto">` to `<section tabIndex={0} aria-label="...">`. `<section>` because Biome's `useSemanticElements` rule prefers semantic landmarks over `<div role="region">`. The `tabIndex={0}` is the axe-core scrollable-region-focusable fix; the contradicting `noNoninteractiveTabindex` flag is silenced with a contextual biome-ignore matching #817's pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)