### PR TITLE
fix(server/cors): allow http://tauri.localhost origin (Windows Studio)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -305,14 +305,25 @@ function isVercelPreviewOrigin(origin: string): boolean {
 /**
  * Check if origin is a trusted desktop-app client (RevealUI Studio).
  *
- * Tauri webviews issue requests from `tauri://localhost` (Linux/Windows) or
- * `https://tauri.localhost` (macOS/Windows HTTPS mode). The Studio app ships
- * signed binaries and talks to the public API on behalf of authenticated
- * users, so its origin is allow-listed here rather than via CORS_ORIGIN env
- * (which is reserved for HTTPS web clients).
+ * Tauri 2 webviews issue requests from one of three origins depending on
+ * platform and scheme registration:
+ *   - `tauri://localhost`        — Linux + macOS (custom scheme)
+ *   - `https://tauri.localhost`  — Windows when HTTPS asset protocol enabled
+ *   - `http://tauri.localhost`   — Windows WebView2 default (HTTP asset protocol)
+ *
+ * The third was missing originally (2026-05-10 discovery via Windows Studio
+ * dogfood — CORS preflight returned no Allow-Origin → `TypeError: Failed to
+ * fetch` for every request). The Studio app ships signed binaries and talks
+ * to the public API on behalf of authenticated users, so its origin is
+ * allow-listed here rather than via CORS_ORIGIN env (which is reserved for
+ * HTTPS web clients).
  */
 function isDesktopClientOrigin(origin: string): boolean {
-  return origin === 'tauri://localhost' || origin === 'https://tauri.localhost';
+  return (
+    origin === 'tauri://localhost' ||
+    origin === 'https://tauri.localhost' ||
+    origin === 'http://tauri.localhost'
+  );
 }
 
 /** Check if origin matches test/dev subdomain: https://(dev|test).(admin.|api.|docs.)?revealui.com */


### PR DESCRIPTION
## Summary

Tauri 2 on Windows WebView2 issues requests from origin `http://tauri.localhost` by default (HTTP asset protocol), not the `https://tauri.localhost` form the original allowlist assumed. Without this entry the manual CORS middleware returned no `Access-Control-Allow-Origin` header → every Studio request failed with `TypeError: Failed to fetch` before the auth handshake could even begin.

One-line fix: add `'http://tauri.localhost'` to the `isDesktopClientOrigin` allowlist in `apps/server/src/index.ts`.

## Why a hotfix off `main` (not `test`)

This was found tonight during the first end-to-end Windows-native Studio dogfood. Unblocking Studio dogfood requires this to land on `main` and auto-deploy to `api.revealui.com`. The existing pre-flip merge train (`#801 → #814 → #815`) doesn't touch this file, so a parallel hotfix is the cleanest path and doesn't interfere.

## Diagnostic chain (for future debugging)

1. Studio shows generic "Unable to reach the RevealUI API"
2. Patched `use-auth.ts` catch block to surface the underlying error → `TypeError: Failed to fetch`
3. Added connectivity probe + origin capture in the catch block →
   - `origin=http://tauri.localhost`
   - `probe=FAILED(TypeError:Failed to fetch)`
4. PowerShell CORS probe sending `Origin: http://tauri.localhost` confirmed the server returned only `Vary: Origin` with no Allow-Origin header (compared to `https://tauri.localhost` which DID receive Allow-Origin).

## Test plan

- [x] CORS preflight + simple POST verified from PowerShell using `Origin: http://tauri.localhost`; expect Allow-Origin to come back after this change
- [ ] CI green on PR
- [ ] After merge: redeploy auto-fires; Studio dogfood retry succeeds (login → OTP → authenticated)
- [ ] Follow-up PR: export `isDesktopClientOrigin` and add unit tests covering all three allowed origins

## Out of scope (intentional)

- The `verifyOtp` and other auth endpoints — same CORS middleware applies, no per-endpoint changes needed.
- Test branch — `test` doesn't touch `apps/server/src/index.ts` per `git log`. If a conflict appears during a future `test → main` merge, it'll be trivial.
