### PR TITLE
fix(validate): handle Vercel v2 encryption envelope in pre-deploy gate

### DIFF
--- a/scripts/validate/__tests__/prod-env.test.ts
+++ b/scripts/validate/__tests__/prod-env.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseDotenv, validatePulledEnv } from '../prod-env';
+import {
+  isVercelEncryptedBlob,
+  parseDotenv,
+  scrubVercelEncryptedBlobs,
+  validatePulledEnv,
+} from '../prod-env';
 
 const VALID_KEK = 'a'.repeat(64);
 const VALID_SECRET = 's'.repeat(32);
@@ -13,6 +18,7 @@ function validHostedEnv(overrides: Record<string, string | undefined> = {}) {
     REVEALUI_KEK: VALID_KEK,
     REVEALUI_PUBLIC_SERVER_URL: 'https://api.revealui.com',
     NEXT_PUBLIC_SERVER_URL: 'https://api.revealui.com',
+    SENTRY_DSN: 'https://abcdef0123456789@o123456.ingest.sentry.io/4505123456789012',
     STRIPE_SECRET_KEY: 'sk_test_abc',
     STRIPE_WEBHOOK_SECRET: 'whsec_xyz',
     REVEALUI_LICENSE_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\nAAA\n-----END PRIVATE KEY-----',
@@ -22,6 +28,14 @@ function validHostedEnv(overrides: Record<string, string | undefined> = {}) {
     ...overrides,
   };
 }
+
+/**
+ * A real-world Vercel v2 encryption envelope shape, base64 of
+ * `{"v":"v2","c":"<ciphertext>","k":[...]}`. Used to verify the blob
+ * detector — must NOT be confused with a regular env value.
+ */
+const SAMPLE_V2_BLOB = 'eyJ2IjoidjIiLCJjIjoiYWJjZGVmZ2hpamtsbW5vcCIsImsiOlsxLDIsM119';
+// Decoded: {"v":"v2","c":"abcdefghijklmnop","k":[1,2,3]}
 
 describe('parseDotenv', () => {
   it('parses simple KEY=value pairs', () => {
@@ -168,5 +182,121 @@ describe('validatePulledEnv', () => {
     const result = validatePulledEnv(validHostedEnv({ REVEALUI_SECRET: 'short' }));
     expect(result.ok).toBe(false);
     expect(result.message).toContain('REVEALUI_SECRET must be at least 32 characters');
+  });
+});
+
+describe('isVercelEncryptedBlob', () => {
+  it('detects a Vercel v2 envelope by prefix + JSON structure', () => {
+    expect(isVercelEncryptedBlob(SAMPLE_V2_BLOB)).toBe(true);
+  });
+
+  it('rejects plaintext values that happen to be valid HTTPS URLs', () => {
+    expect(isVercelEncryptedBlob('https://api.revealui.com')).toBe(false);
+  });
+
+  it('rejects comma-separated origin lists', () => {
+    expect(isVercelEncryptedBlob('https://revealui.com,https://admin.revealui.com')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isVercelEncryptedBlob('')).toBe(false);
+  });
+
+  it('rejects the v2 prefix without valid JSON body', () => {
+    // Prefix-only collision — must NOT pass detection.
+    expect(isVercelEncryptedBlob('eyJ2IjoidjIimalformed')).toBe(false);
+  });
+
+  it('rejects valid base64 JSON with the wrong version', () => {
+    // {"v":"v1","c":"..."} — Vercel's older format; our scrub is targeted at v2 only.
+    const v1 = Buffer.from('{"v":"v1","c":"xyz"}').toString('base64');
+    expect(isVercelEncryptedBlob(v1)).toBe(false);
+  });
+
+  it('rejects valid base64 JSON missing the c (ciphertext) field', () => {
+    const noCiphertext = Buffer.from('{"v":"v2"}').toString('base64');
+    expect(isVercelEncryptedBlob(noCiphertext)).toBe(false);
+  });
+
+  it('rejects valid base64 of a non-object (defensive)', () => {
+    const arrayShape = Buffer.from('["v2"]').toString('base64');
+    expect(isVercelEncryptedBlob(arrayShape)).toBe(false);
+  });
+});
+
+describe('scrubVercelEncryptedBlobs', () => {
+  it('replaces encrypted blob values with empty strings', () => {
+    const { env, scrubbedKeys } = scrubVercelEncryptedBlobs({
+      CORS_ORIGIN: SAMPLE_V2_BLOB,
+      OTHER: 'plaintext',
+    });
+    expect(env.CORS_ORIGIN).toBe('');
+    expect(env.OTHER).toBe('plaintext');
+    expect(scrubbedKeys).toEqual(['CORS_ORIGIN']);
+  });
+
+  it('leaves plaintext values untouched', () => {
+    const input = {
+      POSTGRES_URL: 'postgresql://example.com/prod',
+      CORS_ORIGIN: 'https://revealui.com',
+      SENTRY_DSN: 'https://abc@o123.ingest.sentry.io/456',
+    };
+    const { env, scrubbedKeys } = scrubVercelEncryptedBlobs(input);
+    expect(env).toEqual(input);
+    expect(scrubbedKeys).toEqual([]);
+  });
+
+  it('returns an empty key list when no blobs are present', () => {
+    const { scrubbedKeys } = scrubVercelEncryptedBlobs({ FOO: 'bar' });
+    expect(scrubbedKeys).toEqual([]);
+  });
+
+  it('handles an env with multiple blobs', () => {
+    const { env, scrubbedKeys } = scrubVercelEncryptedBlobs({
+      A: SAMPLE_V2_BLOB,
+      B: 'plaintext',
+      C: SAMPLE_V2_BLOB,
+    });
+    expect(env.A).toBe('');
+    expect(env.B).toBe('plaintext');
+    expect(env.C).toBe('');
+    expect(scrubbedKeys.sort()).toEqual(['A', 'C']);
+  });
+});
+
+describe('validatePulledEnv (Vercel v2 envelope integration)', () => {
+  it('passes when CORS_ORIGIN is a v2 envelope (treated as opaque; runtime decrypts)', () => {
+    // This is the 2026-05-11 regression: Vercel CLI started returning
+    // ciphertext for `encrypted`-type vars, breaking every main Deploy.
+    // After the scrub fix, the CI gate skips format check (presence still
+    // counts) and lets deploy proceed; runtime validateStartup() catches
+    // any real misconfig with decrypted values.
+    const result = validatePulledEnv(validHostedEnv({ CORS_ORIGIN: SAMPLE_V2_BLOB }));
+    expect(result.ok).toBe(true);
+    expect(result.scrubbedBlobKeys).toEqual(['CORS_ORIGIN']);
+  });
+
+  it('lists every scrubbed key so CI logs can report the platform-encrypted footprint', () => {
+    const result = validatePulledEnv(
+      validHostedEnv({
+        CORS_ORIGIN: SAMPLE_V2_BLOB,
+        REVEALUI_PUBLIC_SERVER_URL: SAMPLE_V2_BLOB,
+        NEXT_PUBLIC_SERVER_URL: SAMPLE_V2_BLOB,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.scrubbedBlobKeys.sort()).toEqual([
+      'CORS_ORIGIN',
+      'NEXT_PUBLIC_SERVER_URL',
+      'REVEALUI_PUBLIC_SERVER_URL',
+    ]);
+  });
+
+  it('still fails on missing required vars even with blobs present (presence > format)', () => {
+    const env = validHostedEnv({ CORS_ORIGIN: SAMPLE_V2_BLOB });
+    delete (env as Record<string, string | undefined>).REVEALUI_ALERT_EMAIL;
+    const result = validatePulledEnv(env);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/REVEALUI_ALERT_EMAIL/);
   });
 });

--- a/scripts/validate/prod-env.ts
+++ b/scripts/validate/prod-env.ts
@@ -54,11 +54,70 @@ export function parseDotenv(content: string): EnvMap {
   return env;
 }
 
+/**
+ * Detect Vercel's v2 encryption envelope.
+ *
+ * Around 2026-05-05/06 Vercel rolled out a change where `vercel pull`
+ * returns ciphertext for `encrypted`-type env vars (previously plaintext).
+ * The value comes back as base64 of `{"v":"v2","c":"<ciphertext>","k":[...]}`
+ * — server-side decryption happens at runtime in the Vercel platform, not
+ * client-side in the CLI. Every revealui main Deploy from 2026-05-06
+ * onward failed `validate:prod-env` because the validator tried to URL-
+ * parse and HTTPS-check what is actually opaque ciphertext.
+ *
+ * This helper detects the envelope so the CI gate can treat such values
+ * as opaque (skip format checks; presence-by-name still passes). The
+ * apps/server runtime continues to receive decrypted plaintext from
+ * Vercel and runs strict validateStartup() there, so the real production
+ * gate is unaffected.
+ *
+ * The prefix `eyJ2IjoidjIi` is the base64 encoding of `{"v":"v2"` — a
+ * 12-char marker with ~10^17 entropy; accidental collision with a real
+ * env value is impossible in practice. We additionally JSON-decode and
+ * check for `v: 'v2'` + a `c` field to eliminate any residual ambiguity.
+ */
+export function isVercelEncryptedBlob(value: string): boolean {
+  if (!value.startsWith('eyJ2IjoidjIi')) return false;
+  try {
+    const decoded = Buffer.from(value, 'base64').toString('utf8');
+    const parsed: unknown = JSON.parse(decoded);
+    if (typeof parsed !== 'object' || parsed === null) return false;
+    if (!('v' in parsed) || !('c' in parsed)) return false;
+    return (parsed as { v: unknown }).v === 'v2';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scrub Vercel v2 encryption envelopes from a pulled env map. Each opaque
+ * value is replaced with an empty string so the lenient validator skips
+ * format checks (same path Vercel-Sensitive vars already take). Returns
+ * the new map plus a list of keys that were scrubbed (for diagnostics).
+ */
+export function scrubVercelEncryptedBlobs(env: EnvMap): {
+  env: EnvMap;
+  scrubbedKeys: string[];
+} {
+  const scrubbedKeys: string[] = [];
+  const result: EnvMap = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isVercelEncryptedBlob(value)) {
+      result[key] = '';
+      scrubbedKeys.push(key);
+    } else {
+      result[key] = value;
+    }
+  }
+  return { env: result, scrubbedKeys };
+}
+
 export interface ValidateResult {
   ok: boolean;
   message: string;
   mode: 'forge' | 'hosted';
   stripeLiveMode: boolean;
+  scrubbedBlobKeys: string[];
 }
 
 /**
@@ -69,7 +128,14 @@ export interface ValidateResult {
  * a production env that contains the bypass flag is itself a config bug.
  */
 export function validatePulledEnv(pulled: EnvMap): ValidateResult {
-  const env: EnvMap = { ...pulled, NODE_ENV: 'production' };
+  // Vercel rolled out v2 envelope encryption for `encrypted`-type env
+  // vars around 2026-05-06. The CLI pull now returns ciphertext; treat
+  // these as opaque so format checks skip on them (presence still passes).
+  // The apps/server runtime still receives decrypted values from Vercel
+  // and runs strict validateStartup() there. See isVercelEncryptedBlob
+  // for the detection contract.
+  const { env: scrubbed, scrubbedKeys } = scrubVercelEncryptedBlobs(pulled);
+  const env: EnvMap = { ...scrubbed, NODE_ENV: 'production' };
 
   // Vercel-Sensitive vars pull as empty strings even though they're
   // populated at runtime. Run validateStartup in lenient mode here so
@@ -87,6 +153,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       ok: false,
       mode,
       stripeLiveMode,
+      scrubbedBlobKeys: scrubbedKeys,
       message:
         'pulled env contains SKIP_ENV_VALIDATION=true. This bypasses every check at runtime; remove it from Vercel before deploying.',
     };
@@ -98,6 +165,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       ok: true,
       mode,
       stripeLiveMode,
+      scrubbedBlobKeys: scrubbedKeys,
       message: 'all production env presence + format checks satisfied.',
     };
   } catch (err) {
@@ -105,6 +173,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       ok: false,
       mode,
       stripeLiveMode,
+      scrubbedBlobKeys: scrubbedKeys,
       message: err instanceof Error ? err.message : String(err),
     };
   }
@@ -127,6 +196,12 @@ function main(): void {
   process.stdout.write(
     `validate:prod-env mode=${result.mode} STRIPE_LIVE_MODE=${result.stripeLiveMode}\n`,
   );
+
+  if (result.scrubbedBlobKeys.length > 0) {
+    process.stdout.write(
+      `validate:prod-env note: ${result.scrubbedBlobKeys.length} Vercel v2 encryption envelope(s) treated as opaque (presence checked, format skipped — runtime gets decrypted values). Keys: ${result.scrubbedBlobKeys.join(', ')}\n`,
+    );
+  }
 
   if (!result.ok) {
     process.stderr.write(`validate:prod-env FAIL\n${result.message}\n`);


### PR DESCRIPTION
## Summary

Unblocks every revealui production Deploy since 2026-05-06 (10+ stuck main commits including PR #801's Phase 1 P0 promotion and PR #820's `http://tauri.localhost` CORS fix).

**Root cause**: Vercel rolled out a platform change around 2026-05-05/06 where `vercel pull --environment=production` returns ciphertext for env vars of type `encrypted` (previously plaintext). The ciphertext is base64 of `{"v":"v2","c":"<...>","k":[...]}` and is decrypted server-side by the Vercel runtime, not by the CLI. The pre-deploy validator tried to URL-parse and HTTPS-check what is actually opaque ciphertext, failing on `CORS_ORIGIN` for every main commit since.

Last successful Deploy: `cdd7fbf6` (2026-05-05 21:56Z). All 10+ subsequent Deploy runs failed at `Validate Migrations / Validate prod env`.

## Fix

Two new exported helpers in `scripts/validate/prod-env.ts`:

- `isVercelEncryptedBlob(value)` — base64 prefix check + JSON structural check (`v === 'v2'` AND `c` field present)
- `scrubVercelEncryptedBlobs(env)` — replace blob values with empty strings, return scrubbed-key list

`validatePulledEnv` now scrubs blobs before running the lenient `validateStartup()` — same path Vercel-Sensitive vars already take (presence-by-name counts, format check skips on empty). The apps/server production runtime still receives decrypted plaintext from Vercel and runs strict `validateStartup()` there, so the real production gate is unchanged.

Scrubbed key list is surfaced in CI logs so operators can spot when something flips from plaintext to encrypted unexpectedly.

## Test fixture fix (drive-by)

`validHostedEnv()` helper hadn't been updated when #787 added `SENTRY_DSN` to `REQUIRED_IN_PRODUCTION_HOSTED` — 13 of 23 tests were silently failing locally. Added `SENTRY_DSN` so the suite is green again.

## Tests

**38 passing** (15 new + 13 previously failing now fixed + 10 unchanged):

- `isVercelEncryptedBlob`: 8 cases (real envelope, plaintext URLs, prefix-only collision, wrong version, missing `c` field, non-object, etc.)
- `scrubVercelEncryptedBlobs`: 4 cases (single blob, mixed, no blob, multiple blobs)
- `validatePulledEnv` integration: 3 cases (single-blob pass, multi-blob accounting, presence-still-enforced)

## Risk

- **Detection false-positive**: ~10^17 entropy on the prefix marker plus JSON structural validation; effectively impossible for a real env value to false-positive.
- **Gate weakening**: format checks skip on blobs, but presence still passes AND runtime `validateStartup()` (strict) runs with decrypted values. A misconfigured value reaches runtime but is caught there, surfacing as a `FUNCTION_INVOCATION_FAILED` startup crash — exactly the pre-2026-04-25 posture before #540's gate was added. Net: this is informational degradation in CI, not a real production weakening.

## Out of scope (deferred follow-up)

The proper long-term fix is one of:
- Pin Vercel CLI to a known-working version in `deploy.yml` (currently `vercel@latest` — that's how this regression slipped in)
- Rework `validate:prod-env` to fetch decrypted values via the Vercel API with a properly-scoped token

Both are bigger and don't need to land tonight.

## Test plan

- [x] All 38 unit tests pass locally (`pnpm exec vitest run scripts/validate/__tests__/prod-env.test.ts`)
- [ ] CI green on PR
- [ ] After merge: Deploy workflow runs and the validate step passes for the first time since 2026-05-06
- [ ] After deploy: `https://api.revealui.com/api/studio-auth/link` returns `Access-Control-Allow-Origin: http://tauri.localhost` for OPTIONS preflight (proves CORS fix from #820 is live + Studio dogfood unblocked)
