### PR TITLE
fix(admin): wire Sentry server-side error capture

### DIFF
--- a/apps/admin/sentry.server.config.ts
+++ b/apps/admin/sentry.server.config.ts
@@ -16,11 +16,14 @@ Sentry.init({
   integrations: [
     // HTTP integration for tracking API calls
     Sentry.httpIntegration(),
-    // Node profiling for performance insights
-    Sentry.nodeProfilingIntegration(),
+    // Node profiling moved out of @sentry/nextjs in v10. Re-enable by
+    // installing @sentry/profiling-node and importing nodeProfilingIntegration
+    // from there. Disabled for now — profiling is opt-in optimization, not a
+    // baseline requirement.
   ],
 
-  // Profile sample rate (only in production)
+  // profilesSampleRate stays defined for when nodeProfilingIntegration is
+  // re-introduced; currently inert because no profiling integration is loaded.
   profilesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
 
   // Additional server context
@@ -33,8 +36,14 @@ Sentry.init({
 
   // Capture all unhandled rejections
   beforeSend(event, hint) {
-    // Call the base beforeSend from sentryConfig
-    const filteredEvent = sentryConfig.beforeSend?.(event, hint);
+    // Call the base beforeSend from sentryConfig. Sentry's BeforeSend type
+    // widens to `Event | PromiseLike<Event | null> | null`; our shared
+    // sentryConfig.beforeSend is synchronous (see src/lib/config/sentry.ts),
+    // so narrow back to the sync ErrorEvent union.
+    const filteredEvent = sentryConfig.beforeSend?.(event, hint) as
+      | Sentry.ErrorEvent
+      | null
+      | undefined;
     if (!filteredEvent) return null;
 
     // Add server-specific context

--- a/apps/admin/src/app/global-error.tsx
+++ b/apps/admin/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 
 export default function GlobalError({
@@ -10,7 +11,13 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Fire-and-forget  -  never let capture failure affect the error UI
+    // Send to Sentry (client SDK; uses NEXT_PUBLIC_SENTRY_DSN). Pattern
+    // per getsentry/sentry-for-ai skills/sentry-nextjs-sdk/SKILL.md.
+    // Fire-and-forget; the SDK handles transport + retry internally.
+    Sentry.captureException(error);
+
+    // Also POST to admin's server-side log transport (separate from Sentry).
+    // Fire-and-forget  -  never let capture failure affect the error UI.
     // Route through the admin server-side proxy (same origin) which adds the
     // X-Internal-Token header. Sending REVEALUI_SECRET from the client would
     // expose it in the browser bundle.

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -8,6 +8,24 @@
  */
 
 export async function register() {
+  // Sentry initialization — load runtime-specific config FIRST so server
+  // actions / RSC / route handlers / middleware are instrumented before
+  // any other module runs. Pattern per getsentry/sentry-for-ai
+  // skills/sentry-nextjs-sdk/SKILL.md. Wrapped in try/catch: the
+  // instrumentation.ts contract is "never throw — it kills the runtime".
+  try {
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+      await import('../sentry.server.config');
+    }
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      await import('../sentry.edge.config');
+    }
+  } catch (err) {
+    process.stderr.write(
+      `Sentry init failed (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
   // Only run in the Node.js runtime  -  Edge loads this file during build analysis.
   if ('EdgeRuntime' in globalThis) {
     return;
@@ -194,3 +212,8 @@ export async function register() {
     void error;
   }
 }
+
+// Auto-capture server-side request errors (server actions, RSC, route
+// handlers, middleware). Requires @sentry/nextjs >= 8.28.0; we have ^10.49.0.
+// Pattern per getsentry/sentry-for-ai skills/sentry-nextjs-sdk/SKILL.md.
+export { captureRequestError as onRequestError } from '@sentry/nextjs';

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -95,7 +95,12 @@ revealui/prod/google/service-account-from # From address (Workspace user w/ doma
 revealui/prod/google/private-key         # Gmail API service-account PKCS8 PEM
 revealui/prod/github/client-id
 revealui/prod/github/client-secret
-revealui/prod/sentry/auth-token          # CI/CD error tracking
+revealui/prod/sentry/dsn                 # server SENTRY_DSN (apps/server, Hono); required by validate-startup.ts in REQUIRED_IN_PRODUCTION_HOSTED
+revealui/prod/sentry/dsn-admin           # admin NEXT_PUBLIC_SENTRY_DSN (apps/admin, Next.js); enables withSentryConfig wrapper
+revealui/prod/sentry/auth-token          # CI/CD source-map upload (admin build) + error tracking
+revealui/prod/sentry/org                 # Sentry org slug, e.g. revealui-studio (SENTRY_ORG)
+revealui/prod/sentry/project-server      # server project slug, e.g. revealui-server
+revealui/prod/sentry/project-admin       # admin project slug, e.g. revealui-admin (SENTRY_PROJECT)
 revealui/prod/x402/receiving-address     # Base mainnet EVM USDC receiving wallet — X402_RECEIVING_ADDRESS
 revealui/prod/rvui/receiving-wallet      # Solana mainnet RVC receiving wallet (post-launch) — RVUI_RECEIVING_WALLET
 ```


### PR DESCRIPTION
## Summary
- **Wire Sentry server-side capture in admin** — three load-bearing P1 fixes that take Sentry from "DSN configured but events not firing" to "events fire for every server-side error path"
- Per the [getsentry/sentry-for-ai SKILL.md](https://github.com/getsentry/sentry-for-ai/blob/main/skills/sentry-nextjs-sdk/SKILL.md) baseline pattern
- Also fixes two pre-existing type errors in `apps/admin/sentry.server.config.ts` that surfaced under typecheck (no functional change before this PR — those configs typechecked dirty since the `@sentry/nextjs` v10 bump)

## Why now
Audit during Sentry account setup found:
1. `src/instrumentation.ts` had no explicit Sentry runtime imports — relying on the `@sentry/nextjs` build plugin to auto-inject. Skill recommends explicit imports for forward-compat + safety.
2. No `onRequestError` export — server actions, RSC, route handlers, and middleware were NOT auto-capturing errors to Sentry.
3. `global-error.tsx` POSTed to admin's internal `/api/capture-error` only — Sentry client SDK never saw root-layout errors.

Without these three, the DSN flowing to Vercel envs would have led to a quiet "no events appear" state on the Sentry dashboard — false-green for the pre-flip observability gate.

## Changes
- `apps/admin/src/instrumentation.ts`:
  - Add explicit `await import("../sentry.server.config")` / `../sentry.edge.config` in `register()` gated on `NEXT_RUNTIME`, wrapped in try/catch (instrumentation.ts contract is "never throw")
  - Add `export { captureRequestError as onRequestError } from "@sentry/nextjs"` for auto-capture of all server-side request errors
- `apps/admin/src/app/global-error.tsx`:
  - Add `Sentry.captureException(error)` alongside the existing `/api/capture-error` POST (kept for the admin server-side log transport — separate concern)
- `apps/admin/sentry.server.config.ts`:
  - Remove `Sentry.nodeProfilingIntegration()` — moved out of `@sentry/nextjs` in v10 to a separate `@sentry/profiling-node` package. Disabled with a re-enable note; profiling is opt-in optimization, not baseline.
  - Narrow `sentryConfig.beforeSend` result via type assertion — the SDK widened `BeforeSend` return type to include `PromiseLike`; our shared `beforeSend` is sync.
- `docs/SECRETS.md`:
  - Document 5 new revvault paths for the Sentry deploy (`dsn`, `dsn-admin`, `org`, `project-server`, `project-admin`), alongside the existing `auth-token`

## Test plan
- [x] `pnpm --filter admin typecheck` — green
- [x] `pnpm biome check` on touched files — green
- [x] Pre-push gate — PASS (15.3s)
- [ ] CI on `test` PR — confirms full gate (lint + boundary + typecheck + test + build)
- [ ] Post-merge: redeploy admin + server via Vercel; verify events appear in both Sentry projects within 30 min
- [ ] Manual smoke: trigger a deliberate error in an admin route + RSC; confirm Sentry capture
