### PR TITLE
chore(sync): declare Sentry env vars in revvault-vercel manifest

### DIFF
--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -59,6 +59,10 @@ STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price
 STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/prod/stripe/max-annual-price-id"
 
+# Observability — Sentry (server-side error capture; required by validate-startup.ts
+# REQUIRED_IN_PRODUCTION_HOSTED per revealui#787)
+SENTRY_DSN = "revealui/prod/sentry/dsn"
+
 # Admin API key (parity with admin)
 REVEALUI_ADMIN_API_KEY = "revealui/prod/admin/api-key"
 
@@ -182,6 +186,13 @@ REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 # CMS bootstrap creds (canonical paths under cms/)
 CMS_ADMIN_EMAIL    = "revealui/prod/cms/admin-email"
 CMS_ADMIN_PASSWORD = "revealui/prod/cms/admin-password"
+
+# Observability — Sentry (Next.js admin; DSN is client-bundled via NEXT_PUBLIC_,
+# auth-token + org + project are build-time for source-map upload via withSentryConfig)
+NEXT_PUBLIC_SENTRY_DSN = "revealui/prod/sentry/dsn-admin"
+SENTRY_AUTH_TOKEN      = "revealui/prod/sentry/auth-token"
+SENTRY_ORG             = "revealui/prod/sentry/org"
+SENTRY_PROJECT         = "revealui/prod/sentry/project-admin"
 
 # Admin-specific (no parity — kebab paths under admin/ for consistency with secrets.md)
 REVEALUI_ADMIN_EMAIL         = "revealui/prod/admin/email"


### PR DESCRIPTION
## Summary
- Declares 5 Sentry env vars in `scripts/sync/revvault-vercel.toml` so future `revvault sync vercel --apply` keeps revvault (canonical) ↔ Vercel aligned.
- 1 entry on `revealui-api` (server `SENTRY_DSN`), 4 on `revealui-admin` (`NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`).
- Bootstrap of these 5 vars to Vercel itself was already done out-of-band (surgical REST API delete + create), so this PR is **declarative only** — no sync is triggered by merging.

## Why declarative-only

`revvault sync vercel --apply` runs in push mode that issues a Vercel UPDATE for every manifest var that exists in both vault and Vercel, **with no value comparison**. Source: [`crates/cli/src/commands/sync.rs:366-378`](https://github.com/RevealUIStudio/revvault/blob/main/crates/cli/src/commands/sync.rs#L366-L378) — `DiffAction::Update` is dispatched whenever `remote_map.contains_key(var_name)`. No value diff, no skip-if-matches.

This means a single `--apply` would rewrite ~50 non-Sentry vars on Vercel with whatever revvault holds. We haven't confirmed vault ↔ Vercel parity across those 50 (Stripe keys, license keys, KEK, electric secrets, etc.), so running broad `--apply` carries silent-clobber risk. A separate "broad parity audit" PR will handle that. For this PR, we add the entries but don't trigger sync.

## What was actually done out-of-band (recorded here for audit trail)

1. Wrote 5 canonical values to revvault:
   - `revealui/prod/sentry/dsn` → server DSN
   - `revealui/prod/sentry/dsn-admin` → admin DSN
   - `revealui/prod/sentry/auth-token` → org-scoped Sentry auth token (`sntrys_...`)
   - `revealui/prod/sentry/org` → `revealui-studio-llc`
   - `revealui/prod/sentry/project-admin` → `revealui-admin`
   - `revealui/prod/sentry/project-server` → `revealui-server` (documentation-only — Hono server has no SENTRY_PROJECT env consumer today, but kept canonical for parity)
2. Pushed to Vercel via direct REST API calls:
   - Admin: deleted wrong-name `SENTRY_DSN` orphan (sensitive, empty); created `NEXT_PUBLIC_SENTRY_DSN` (encrypted), `SENTRY_AUTH_TOKEN` (encrypted), `SENTRY_ORG` (plain — slug), `SENTRY_PROJECT` (plain — slug).
   - Server: deleted old `SENTRY_DSN` (sensitive type — Vercel rejected PATCH to change type); created new `SENTRY_DSN` (encrypted).
3. All Vercel entries now `encrypted` (retrievable for future rotations) — no more sensitive write-only blockers.

## Pairs with

- [revealui#823](https://github.com/RevealUIStudio/revealui/pull/823) — admin server-side Sentry capture wiring (merged 15:44Z).

## Test plan
- [x] Pre-push gate — passes (this is a config-only doc/manifest change; no code path affected)
- [x] Vercel API audit confirms 5 Sentry entries land as expected types in both projects
- [x] revvault `--json get` confirms all 6 canonical paths populated
- [ ] CI green on this PR (config-only — should be uneventful)
- [ ] Post-merge: rotate the Sentry auth token (it appeared in chat during setup — hygiene cleanup, not a security incident). Revoke the chat-exposed token in Sentry → create a fresh one → `revvault set --force revealui/prod/sentry/auth-token` → re-push to Vercel via the same surgical pattern.
