### PR TITLE
chore(security): scan issue/PR/comment bodies for leaks via gitleaks workflow

### DIFF
--- a/.github/workflows/issue-leak-scan.yml
+++ b/.github/workflows/issue-leak-scan.yml
@@ -1,0 +1,139 @@
+name: Issue + PR Body Leak Scan
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: leak-scan-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan body via gitleaks
+    # Skip bot-authored events to avoid loops on our own remediation comments.
+    if: >-
+      github.actor != 'github-actions[bot]'
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'chatgpt-codex-connector[bot]'
+      && (github.event.comment == null || github.event.comment.user.type != 'Bot')
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GITLEAKS_VERSION: "8.30.0"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan + comment + label on findings
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const fs = require('node:fs/promises');
+            const { spawnSync } = require('node:child_process');
+            const path = require('node:path');
+
+            // Read body via context API — no shell interpolation of user input.
+            const body =
+              context.payload.comment?.body
+              ?? context.payload.issue?.body
+              ?? context.payload.pull_request?.body
+              ?? '';
+            const issueNumber =
+              context.payload.issue?.number
+              ?? context.payload.pull_request?.number;
+
+            if (!body || !issueNumber) {
+              core.info('No body or issue number — nothing to scan.');
+              return;
+            }
+
+            const scanDir = '/tmp/scan-payload';
+            await fs.mkdir(scanDir, { recursive: true });
+            await fs.writeFile(path.join(scanDir, 'body.txt'), body, 'utf8');
+
+            const result = spawnSync('gitleaks', [
+              'detect',
+              '--no-banner',
+              '--redact',
+              '--no-git',
+              '--config', '.gitleaks.issues.toml',
+              '--source', scanDir,
+              '--report-format', 'json',
+              '--report-path', '/tmp/scan-report.json',
+            ], { encoding: 'utf8' });
+
+            core.info(`gitleaks exit: ${result.status}`);
+            if (result.stderr) {
+              core.info(result.stderr.slice(0, 4000));
+            }
+
+            let findings = [];
+            try {
+              const txt = await fs.readFile('/tmp/scan-report.json', 'utf8');
+              findings = JSON.parse(txt || '[]');
+            } catch (_) {
+              findings = [];
+            }
+
+            if (findings.length === 0) {
+              core.info('No findings.');
+              return;
+            }
+
+            const rules = [...new Set(findings.map(f => f.RuleID))].slice(0, 8);
+            const commentBody = [
+              '> [!CAUTION]',
+              '> **Possible sensitive content detected.**',
+              '',
+              `Gitleaks flagged \`${findings.length}\` match(es) across rule(s): \`${rules.join('`, `')}\`.`,
+              '',
+              '**Action required:**',
+              '1. If this contains a **real secret** (`sk_*`, `whsec_*`, password, token, DB URL with credentials, wallet private key): **rotate it now** — editing the body does NOT remove it from GitHub edit history.',
+              '2. Edit the body and replace the sensitive content with placeholders (e.g. `acct_REDACTED`, `<dev-api>`, `<private design doc>`).',
+              '3. To erase the original from edit history entirely, delete + recreate the issue/comment.',
+              '4. Once cleaned, remove the `contains-sensitive-content` label.',
+              '',
+              '_Triggered by `.github/workflows/issue-leak-scan.yml` (rules in `.gitleaks.issues.toml`)._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: commentBody,
+            });
+
+            // Best-effort label add; idempotent — repeated runs won't duplicate.
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['contains-sensitive-content'],
+              });
+            } catch (err) {
+              core.warning(`addLabels failed: ${err.message}`);
+            }
+
+            core.setFailed(`${findings.length} sensitive match(es) flagged. Body/comment labelled.`);

--- a/.gitleaks.issues.toml
+++ b/.gitleaks.issues.toml
@@ -1,0 +1,93 @@
+# Issue/PR/comment-body gitleaks config for RevealUI.
+#
+# REGEX-CONFIG-BOUNDARY — this file contains gitleaks rule patterns per the
+# project no-regex rule (M2). gitleaks is the third-party regex engine; we
+# box its config strings here under the documented boundary exception.
+#
+# Consumer: .github/workflows/issue-leak-scan.yml only.
+# Code-side scanning continues to use .gitleaks.toml (default rules + repo
+# allowlists). This file extends those defaults with patterns that catch
+# the leak classes the 2026-05-11 issue-audit found across the open
+# issue corpus — Stripe object IDs, internal subdomains, private-repo
+# path refs, founder home paths, Sentry DSNs, DB connection strings,
+# EVM wallets, personal-domain emails.
+#
+# Pairs with memory `reference_issue_leak_scan_workflow.md` and the audit
+# punch list at §Pre-Flip Moral Readiness in the internal master plan.
+
+title = "RevealUI issue/PR body leak scan"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "revealui-stripe-customer-correlation"
+description = "Stripe customer / subscription / invoice / charge / payment-intent IDs (correlation risk in public issues)"
+regex = '''\b(cus|sub|in|ch|pi|seti|ba|src|tok)_(test_|live_)?[A-Za-z0-9]{14,}\b'''
+keywords = ["cus_", "sub_", "in_", "ch_", "pi_", "seti_", "ba_", "src_", "tok_"]
+tags = ["pii", "stripe", "boundary-config"]
+
+[[rules]]
+id = "revealui-stripe-account-and-catalog"
+description = "Stripe account / product / price / plan / billing-portal / webhook-endpoint / meter IDs (operator catalog disclosure)"
+regex = '''\b(acct|prod|price|plan|bpc|we|mtr|mtr_test|mtr_live)_(test_|live_)?[A-Za-z0-9_]{14,}\b'''
+keywords = ["acct_", "prod_", "price_", "plan_", "bpc_", "we_", "mtr_"]
+tags = ["operator", "stripe", "boundary-config"]
+
+[[rules]]
+id = "revealui-internal-subdomain"
+description = "Internal RevealUI dev/test/staging/internal API subdomains"
+regex = '''https?://(dev|test|staging|internal|preview)\.api\.revealui\.com'''
+keywords = ["dev.api.revealui", "test.api.revealui", "staging.api.revealui", "internal.api.revealui", "preview.api.revealui"]
+tags = ["internal-url", "boundary-config"]
+
+[[rules]]
+id = "revealui-private-repo-path"
+description = "References to revealui-jv private repo paths or .jv/ trees under fleet"
+regex = '''(revealui-jv/(business|docs/audits|docs/gaps|docs/decisions|\.claude)|~/(revfleet|suite)/\.jv/|/home/joshua-v-dev/(revfleet|suite)/\.jv/)'''
+keywords = ["revealui-jv/", ".jv/", "~/revfleet/.jv", "~/suite/.jv"]
+tags = ["private-repo", "boundary-config"]
+
+[[rules]]
+id = "revealui-founder-home-path"
+description = "Founder absolute filesystem paths (WSL or Windows host)"
+regex = '''(/home/joshua-v-dev/|\\\\wsl\.localhost\\Ubuntu\\home\\joshua-v-dev|C:\\Users\\joshu\\)'''
+keywords = ["/home/joshua-v-dev", "joshua-v-dev", "wsl.localhost\\Ubuntu", "C:\\Users\\joshu"]
+tags = ["pii", "founder-path", "boundary-config"]
+
+[[rules]]
+id = "revealui-sentry-dsn"
+description = "Sentry DSN URL (sender spoof + project disclosure)"
+regex = '''https://[a-f0-9]{32}@[a-z0-9.-]+\.ingest\.(us\.|de\.)?sentry\.io/[0-9]+'''
+keywords = ["ingest.sentry.io", "ingest.us.sentry.io", "ingest.de.sentry.io"]
+tags = ["sentry", "boundary-config"]
+
+[[rules]]
+id = "revealui-postgres-connection-with-credentials"
+description = "Postgres / MySQL / Mongo connection string with embedded credentials"
+regex = '''\b(postgres(ql)?|mysql|mongodb(\+srv)?)://[^/\s:]+:[^@\s]+@'''
+keywords = ["postgres://", "postgresql://", "mysql://", "mongodb://", "mongodb+srv://"]
+tags = ["secret", "boundary-config"]
+
+[[rules]]
+id = "revealui-evm-wallet-address"
+description = "EVM wallet address (e.g. Coinbase x402 receiving wallet)"
+regex = '''\b0x[a-fA-F0-9]{40}\b'''
+keywords = ["0x"]
+tags = ["wallet", "boundary-config"]
+
+[[rules]]
+id = "revealui-personal-domain-email"
+description = "Personal-domain email (customer / staff PII; allowlist covers our public mailboxes)"
+regex = '''\b[A-Za-z0-9._%+-]+@(gmail|hotmail|yahoo|outlook|protonmail|icloud)\.com\b'''
+keywords = ["@gmail.com", "@hotmail.com", "@yahoo.com", "@outlook.com", "@protonmail.com", "@icloud.com"]
+tags = ["pii", "boundary-config"]
+
+[allowlist]
+description = "Public email addresses + canonical zero/null/placeholder values"
+regexes = [
+  '''(founder|support|security|no-reply|noreply|press|hello|admin|legal|privacy)@revealui\.com''',
+  '''0x0{40}''',
+  '''(acct|prod|price|cus|sub|ch|pi|seti|in|ba|src|tok|bpc|we|mtr)_(TEST|REDACTED|PLACEHOLDER|EXAMPLE|REDACTED_[A-Za-z0-9_]+)''',
+  '''(postgres(ql)?|mysql|mongodb)://(user|USER|<user>|REDACTED):(pass|password|<password>|REDACTED)@''',
+]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/issue-leak-scan.yml` that runs gitleaks against the body content of every issue / PR / comment on create+edit.
- Adds `.gitleaks.issues.toml` with custom rules for Stripe object IDs, internal subdomains, private-repo (an internal repo, internal docs/`) paths, founder home paths, Sentry DSNs, DB connection strings, EVM wallets, personal-domain emails — beyond what the default gitleaks ruleset catches.
- Closes the leak gap left by the code-side gitleaks scan (`security.yml`), which only runs against git history and cannot scan GitHub-side artifacts (issue / PR / comment bodies).

## Why

Surfaced by the 2026-05-11 pre-flip moral-readiness audit (tracker #826). Scanning the open-issue corpus found 21 Stripe test-mode object IDs (`acct_*`, `prod_*`, `bpc_*`, `we_*`, `mtr_*`) pasted directly from CLI output, plus private-repo path references (internal docs, an internal repo/business/`) — none are secrets, but together they fingerprint the seller's commerce shape and disclose internal repo structure to anyone browsing public issues.

## Behavior on detection

1. Workflow run fails (visible in PR/issue checks).
2. Bot posts a comment with redaction + rotation instructions (rotate-before-redact warning, since GitHub edit history preserves the original).
3. Bot applies the new `contains-sensitive-content` label.
4. Author (or maintainer) is responsible for editing the body and removing the sensitive content — and, if a real secret leaked, rotating it before redaction.

## Bot-loop avoidance

Workflow `if:` guard skips actors `github-actions[bot]`, `dependabot[bot]`, `chatgpt-codex-connector[bot]`, plus any `event.comment.user.type == 'Bot'`. The workflow's own remediation comments do not re-trigger the scan.

## Concurrent cleanup

- 10 existing leaky issues had bodies redacted in the same audit pass (#402, #404, #405, #406, #407, #408, #451, #480, #486, #528). 36/38 substitutions applied. Edit history preserved per GitHub policy.
- 6 stale-open issues from §CR-8 audit closed (already shipped): #395, #393, #408, #406, #405, #404.
- 16 new P0 issues opened (#827-#842) under tracker #826 with label `blocks-live-flip`.

## Test plan

- [ ] Merge to `test`; verify workflow registers without errors.
- [ ] Open a draft issue containing a fake `cus_TESTLEAKEDID12345678` token; confirm bot comments + labels.
- [ ] Edit the body to remove the token; confirm bot does NOT re-comment (no new finding).
- [ ] Confirm bot's own comment does NOT re-trigger the scan (loop guard).
- [ ] Confirm `pull_request_target` flow works for PRs targeting `test` and `main`.

## Cross-repo rollout (follow-on, separate PRs)

After this lands on `test`, copy both files to `revdev` / `revvault` / `revealcoin` / `revcon` / `revforge` / `revskills` / `revkit`. Each repo needs the `contains-sensitive-content` label created via `gh label create`.

## Related

- Audit tracker: #826
- Memory: `reference_issue_leak_scan_workflow.md` — workflow + config location + known limitations
- Memory: `feedback_no_raw_stripe_output_in_issues.md` — author-side discipline rule