### PR TITLE
fix(admin): wire cron alerts + REVEALUI_KEK boot validation

### DIFF
--- a/apps/admin/src/app/api/cron/cleanup-all/route.ts
+++ b/apps/admin/src/app/api/cron/cleanup-all/route.ts
@@ -20,6 +20,7 @@
  */
 import { cleanupStaleTokens } from '@revealui/db/cleanup';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendCronFailureAlert } from '@/lib/utils/cron-alert';
 import { verifyCronAuth } from '@/lib/utils/cron-auth';
 
 export const dynamic = 'force-dynamic';
@@ -44,7 +45,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       },
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const err = error instanceof Error ? error : new Error(String(error));
+    await sendCronFailureAlert({
+      jobName: 'admin:cleanup-all',
+      error: err,
+      severity: 'error',
+    });
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 }

--- a/apps/admin/src/app/api/cron/cleanup-magic-links/route.ts
+++ b/apps/admin/src/app/api/cron/cleanup-magic-links/route.ts
@@ -9,6 +9,7 @@
  */
 import { cleanupStaleTokens } from '@revealui/db/cleanup';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendCronFailureAlert } from '@/lib/utils/cron-alert';
 import { verifyCronAuth } from '@/lib/utils/cron-auth';
 
 export const dynamic = 'force-dynamic';
@@ -23,7 +24,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const result = await cleanupStaleTokens({ tables: ['magicLinks'] });
     return NextResponse.json({ deleted: result.magicLinks });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const err = error instanceof Error ? error : new Error(String(error));
+    await sendCronFailureAlert({
+      jobName: 'admin:cleanup-magic-links',
+      error: err,
+      severity: 'error',
+    });
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 }

--- a/apps/admin/src/app/api/cron/cleanup-password-reset-tokens/route.ts
+++ b/apps/admin/src/app/api/cron/cleanup-password-reset-tokens/route.ts
@@ -9,6 +9,7 @@
  */
 import { cleanupStaleTokens } from '@revealui/db/cleanup';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendCronFailureAlert } from '@/lib/utils/cron-alert';
 import { verifyCronAuth } from '@/lib/utils/cron-auth';
 
 export const dynamic = 'force-dynamic';
@@ -23,7 +24,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const result = await cleanupStaleTokens({ tables: ['passwordResetTokens'] });
     return NextResponse.json({ deleted: result.passwordResetTokens });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const err = error instanceof Error ? error : new Error(String(error));
+    await sendCronFailureAlert({
+      jobName: 'admin:cleanup-password-reset-tokens',
+      error: err,
+      severity: 'error',
+    });
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 }

--- a/apps/admin/src/app/api/cron/cleanup-rate-limits/route.ts
+++ b/apps/admin/src/app/api/cron/cleanup-rate-limits/route.ts
@@ -9,6 +9,7 @@
  */
 import { cleanupStaleTokens } from '@revealui/db/cleanup';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendCronFailureAlert } from '@/lib/utils/cron-alert';
 import { verifyCronAuth } from '@/lib/utils/cron-auth';
 
 export const dynamic = 'force-dynamic';
@@ -23,7 +24,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const result = await cleanupStaleTokens({ tables: ['rateLimits'] });
     return NextResponse.json({ deleted: result.rateLimits });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const err = error instanceof Error ? error : new Error(String(error));
+    await sendCronFailureAlert({
+      jobName: 'admin:cleanup-rate-limits',
+      error: err,
+      severity: 'error',
+    });
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 }

--- a/apps/admin/src/app/api/cron/cleanup-sessions/route.ts
+++ b/apps/admin/src/app/api/cron/cleanup-sessions/route.ts
@@ -9,6 +9,7 @@
  */
 import { cleanupStaleTokens } from '@revealui/db/cleanup';
 import { type NextRequest, NextResponse } from 'next/server';
+import { sendCronFailureAlert } from '@/lib/utils/cron-alert';
 import { verifyCronAuth } from '@/lib/utils/cron-auth';
 
 export const dynamic = 'force-dynamic';
@@ -23,7 +24,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const result = await cleanupStaleTokens({ tables: ['sessions'] });
     return NextResponse.json({ deleted: result.sessions });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const err = error instanceof Error ? error : new Error(String(error));
+    await sendCronFailureAlert({
+      jobName: 'admin:cleanup-sessions',
+      error: err,
+      severity: 'error',
+    });
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 }

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -126,6 +126,23 @@ export async function register() {
       if (!result.valid) {
         const message = `Missing required environment variables: ${result.missing.join(', ')}`;
         logger.error('Environment validation failed', new Error(message));
+
+        // Per revealui#836: missing critical env vars (notably REVEALUI_KEK)
+        // in production MUST fail-fast so the deploy surfaces the error in
+        // Vercel deploy logs rather than booting into a broken state (e.g.
+        // encryptApiKey throws on first request to /api/user/api-keys/value).
+        // SKIP_ENV_VALIDATION=true is the documented escape hatch and
+        // matches the RevForge license-validation block above.
+        //
+        // process.exit(1) is the *intentional* kill (vs throw, which the
+        // surrounding try/catch swallows per Next.js instrumentation
+        // contract — "never throw, it kills the runtime").
+        if (environment === 'production' && process.env.SKIP_ENV_VALIDATION !== 'true') {
+          process.stderr.write(
+            `ENV VALIDATION FAILED in production:\n  - ${result.missing.join('\n  - ')}\n`,
+          );
+          process.exit(1);
+        }
       }
 
       if (result.warnings.length > 0) {

--- a/apps/admin/src/lib/utils/__tests__/cron-alert.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/cron-alert.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CronFailureContext } from '../cron-alert';
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before module-under-test import.
+// ---------------------------------------------------------------------------
+
+vi.mock('@sentry/nextjs', () => ({
+  withScope: vi.fn((cb: (scope: unknown) => void) => {
+    cb({
+      setTag: vi.fn(),
+      setLevel: vi.fn(),
+      setContext: vi.fn(),
+    });
+  }),
+  captureException: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { logger } from '@revealui/core/observability/logger';
+import * as Sentry from '@sentry/nextjs';
+import { sendCronFailureAlert } from '../cron-alert';
+
+function makeContext(overrides: Partial<CronFailureContext> = {}): CronFailureContext {
+  return {
+    jobName: 'admin:test-job',
+    error: new Error('something broke'),
+    ...overrides,
+  };
+}
+
+describe('admin sendCronFailureAlert', () => {
+  it('logs error + captures to Sentry on success', async () => {
+    vi.mocked(logger.error).mockClear();
+    vi.mocked(Sentry.captureException).mockClear();
+
+    const ctx = makeContext({ metadata: { accountId: 'acc_1', count: 3 } });
+    await sendCronFailureAlert(ctx);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('admin:test-job'),
+      ctx.error,
+      expect.objectContaining({ jobName: 'admin:test-job', accountId: 'acc_1', count: 3 }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(ctx.error);
+  });
+
+  it('uses logger.warn when severity is "warn"', async () => {
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.error).mockClear();
+
+    await sendCronFailureAlert(makeContext({ severity: 'warn' }));
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('admin:test-job'),
+      expect.any(Object),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('still resolves when Sentry throws', async () => {
+    vi.mocked(logger.error).mockClear();
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(Sentry.withScope).mockImplementationOnce(() => {
+      throw new Error('sentry unavailable');
+    });
+
+    await expect(sendCronFailureAlert(makeContext())).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    // Sentry failure is logged as a separate warn entry — same pattern as
+    // apps/server/src/lib/cron-alerts.ts.
+    expect(
+      vi.mocked(logger.warn).mock.calls.some((c) => String(c[0]).includes('Sentry capture failed')),
+    ).toBe(true);
+  });
+
+  it('falls back to stderr when logger itself throws', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    vi.mocked(logger.error).mockImplementationOnce(() => {
+      throw new Error('logger down');
+    });
+
+    await expect(sendCronFailureAlert(makeContext())).resolves.toBeUndefined();
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('logger failed while reporting admin:test-job'),
+    );
+    // Sentry still ran because step 2 is independent of step 1.
+    expect(Sentry.captureException).toHaveBeenCalled();
+
+    stderrSpy.mockRestore();
+  });
+
+  it('tags Sentry scope with cron_job + severity + metadata', async () => {
+    const setTag = vi.fn();
+    const setLevel = vi.fn();
+    const setContext = vi.fn();
+    // Sentry.withScope is overloaded ((cb) => T) | ((scope, cb) => T) in
+    // @sentry/nextjs typings; cast to the single-arg overload via the
+    // mock factory signature for this test.
+    vi.mocked(Sentry.withScope).mockImplementationOnce(((cb: (s: unknown) => void) => {
+      cb({ setTag, setLevel, setContext });
+    }) as typeof Sentry.withScope);
+
+    await sendCronFailureAlert(
+      makeContext({
+        jobName: 'admin:cleanup-sessions',
+        severity: 'fatal',
+        metadata: { failedAt: 'sessions-delete' },
+      }),
+    );
+
+    expect(setTag).toHaveBeenCalledWith('cron_job', 'admin:cleanup-sessions');
+    expect(setTag).toHaveBeenCalledWith('alert_severity', 'fatal');
+    expect(setLevel).toHaveBeenCalledWith('fatal');
+    expect(setContext).toHaveBeenCalledWith('metadata', { failedAt: 'sessions-delete' });
+  });
+});

--- a/apps/admin/src/lib/utils/cron-alert.ts
+++ b/apps/admin/src/lib/utils/cron-alert.ts
@@ -1,0 +1,71 @@
+/**
+ * Admin-side cron failure alert helper.
+ *
+ * Mirrors `apps/server/src/lib/cron-alerts.ts` minus the email-fanout step
+ * (admin doesn't have a server-equivalent email transport today). Logger
+ * + Sentry coverage is the critical path; email fan-out can be added in
+ * a follow-up once the helper is extracted to a shared package.
+ *
+ * TODO (revealui#835 follow-up): extract to `@revealui/observability`
+ * (or `@revealui/security/cron`) so apps/server + apps/admin share one
+ * caller. The duplication is intentional for the P0 batch — minimizes
+ * blast radius.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+import * as Sentry from '@sentry/nextjs';
+
+export interface CronFailureContext {
+  jobName: string;
+  error: Error;
+  severity?: 'warn' | 'error' | 'fatal';
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Centralized alert path for admin cron failures. Always logs at the chosen
+ * severity. When Sentry is initialised, captures with tags + severity scope.
+ *
+ * Never throws — each step is independent. A failure in one step is logged
+ * and does not prevent the others.
+ */
+export async function sendCronFailureAlert(context: CronFailureContext): Promise<void> {
+  const { jobName, error, severity = 'error', metadata } = context;
+
+  // Step 1 — always log
+  try {
+    const logPayload = { jobName, ...(metadata ?? {}) };
+    if (severity === 'fatal' || severity === 'error') {
+      logger.error(`[cron-alert] ${jobName} failed: ${error.message}`, error, logPayload);
+    } else {
+      logger.warn(`[cron-alert] ${jobName} failed: ${error.message}`, logPayload);
+    }
+  } catch (logErr) {
+    // Last-resort: if the logger itself is broken, write directly to stderr
+    // so the failure is at least visible in Vercel function logs.
+    process.stderr.write(
+      `[cron-alert] logger failed while reporting ${jobName}: ${logErr instanceof Error ? logErr.message : String(logErr)}\n`,
+    );
+  }
+
+  // Step 2 — Sentry capture (no-op when SENTRY_DSN absent / not initialised)
+  try {
+    Sentry.withScope((scope) => {
+      scope.setTag('cron_job', jobName);
+      scope.setTag('alert_severity', severity);
+      if (metadata) {
+        scope.setContext('metadata', metadata);
+      }
+      if (severity === 'fatal') {
+        scope.setLevel('fatal');
+      } else if (severity === 'warn') {
+        scope.setLevel('warning');
+      }
+      Sentry.captureException(error);
+    });
+  } catch (sentryErr) {
+    logger.warn(`[cron-alert] Sentry capture failed for ${jobName}`, {
+      detail: sentryErr instanceof Error ? sentryErr.message : String(sentryErr),
+    });
+  }
+}

--- a/apps/admin/src/lib/utils/env-validation.ts
+++ b/apps/admin/src/lib/utils/env-validation.ts
@@ -6,6 +6,21 @@
  */
 
 /**
+ * Literal hex-set check (no regex). Returns true when value is exactly 64
+ * characters and every character is in [0-9a-fA-F]. Mirrors the format
+ * check in `apps/server/src/lib/validate-startup.ts:240-242` but uses a
+ * Set lookup instead of regex per the project no-regex rule (M2).
+ */
+const HEX_CHARS = new Set('0123456789abcdefABCDEF');
+function isHex64(value: string): boolean {
+  if (value.length !== 64) return false;
+  for (const char of value) {
+    if (!HEX_CHARS.has(char)) return false;
+  }
+  return true;
+}
+
+/**
  * Validate required environment variables
  *
  * @param options - Validation options
@@ -33,8 +48,19 @@ export function validateRequiredEnvVars(
 
   const isFleetMode = Boolean(process.env.REVEALUI_FLEET_MODE);
 
-  // Base required variables
-  const baseRequired: string[] = ['REVEALUI_SECRET', 'REVEALUI_PUBLIC_SERVER_URL', 'POSTGRES_URL'];
+  // Base required variables — apply in all environments (hosted + Fleet).
+  //
+  // REVEALUI_KEK encrypts API keys + MFA secrets via AES-256-GCM
+  // (packages/db/src/crypto.ts). Missing KEK = silent encryption failure
+  // on the first encryptApiKey/decryptApiKey call. Per revealui#836,
+  // admin must validate at startup parity with apps/server's
+  // validate-startup.ts:240-242.
+  const baseRequired: string[] = [
+    'REVEALUI_SECRET',
+    'REVEALUI_PUBLIC_SERVER_URL',
+    'POSTGRES_URL',
+    'REVEALUI_KEK',
+  ];
 
   const missing: string[] = [];
   const warnings: string[] = [];
@@ -77,6 +103,24 @@ export function validateRequiredEnvVars(
         warnings.push(`${key} should start with http:// or https://`);
       }
     }
+  }
+
+  // REVEALUI_KEK — 64 hex characters (32 bytes / 256 bits). Required in
+  // both hosted + Fleet modes (missing-presence is caught above). When
+  // set but malformed, surface as missing-equivalent (set-but-unusable).
+  // Mirrors apps/server/src/lib/validate-startup.ts:240-242.
+  if (process.env.REVEALUI_KEK && !isHex64(process.env.REVEALUI_KEK)) {
+    missing.push('REVEALUI_KEK (must be exactly 64 hexadecimal characters)');
+  }
+
+  // REVEALUI_KEK_NEXT — optional dual-key boot for zero-downtime KEK
+  // rotation. Format-when-present; empty/unset is the steady state. See
+  // docs/runbooks/rotate-kek.md §Zero-downtime path.
+  const kekNext = (process.env.REVEALUI_KEK_NEXT ?? '').trim();
+  if (kekNext && !isHex64(kekNext)) {
+    warnings.push(
+      'REVEALUI_KEK_NEXT must be exactly 64 hexadecimal characters when set (transitional key during dual-key rotation).',
+    );
   }
 
   // Production-specific validations — skipped in Fleet mode. Fleet deployments


### PR DESCRIPTION
## Summary

Closes #835 and #836 — the safest two items in the pre-flip P0 batch (tracker #826).

## What changes

### Cron failure alerts (closes #835)

- New helper `apps/admin/src/lib/utils/cron-alert.ts` — subset of `apps/server/src/lib/cron-alerts.ts` (logger + Sentry only; no email fan-out).
- All 5 admin cron routes now call `sendCronFailureAlert` in their catch block before returning 500:
  - `/api/cron/cleanup-all` → `admin:cleanup-all`
  - `/api/cron/cleanup-sessions` → `admin:cleanup-sessions`
  - `/api/cron/cleanup-password-reset-tokens` → `admin:cleanup-password-reset-tokens`
  - `/api/cron/cleanup-magic-links` → `admin:cleanup-magic-links`
  - `/api/cron/cleanup-rate-limits` → `admin:cleanup-rate-limits`
- New test `apps/admin/src/lib/utils/__tests__/cron-alert.test.ts` covers: logger+Sentry happy path, warn-severity routing, Sentry-throws-still-resolves, logger-throws falls-back-to-stderr, Sentry scope tagging (cron_job + alert_severity + metadata).

Helper is intentionally a subset (no email) because admin lacks `apps/server`'s `email.js` transport. TODO comment points at #835 follow-up to extract to a shared `@revealui/observability` package once a third caller appears. Per project audit-first discipline: copy-with-TODO is preferable to a new package boundary on a single duplication.

### REVEALUI_KEK boot validation (closes #836)

- `apps/admin/src/lib/utils/env-validation.ts`:
  - `REVEALUI_KEK` added to `baseRequired` (parity with `apps/server/src/lib/validate-startup.ts:240-242`).
  - 64-hex-character format check via new `isHex64` predicate (Set lookup, no regex authored — `// REGEX-CONFIG-BOUNDARY` not needed since this is literal-character iteration).
  - `REVEALUI_KEK_NEXT` format-when-present (transitional key during dual-key rotation; mirrors server pattern).
- `apps/admin/src/instrumentation.ts`:
  - After `validateRequiredEnvVars` reports missing/malformed env, if `environment === 'production'` and `SKIP_ENV_VALIDATION !== 'true'`, write a clear error to stderr and call `process.exit(1)`.
  - Consistent with the existing RevForge license-validation block (same file, lines 49-89) which already uses `process.exit(1)` as the intentional kill (vs throw, which Next.js instrumentation contract forbids).

## Behavior change

Previously: admin booted with missing critical env vars (`REVEALUI_KEK`, etc.) and broke silently on first user request — e.g. `encryptApiKey` threw on the first `/api/user/api-keys/value` call, returning 500 to the user.

After this PR: admin refuses to boot in production with a clear error in Vercel deploy logs. The broken deploy surfaces immediately at deploy time. Dev / preview / Fleet remain tolerant.

Escape hatch: `SKIP_ENV_VALIDATION=true` for emergency debug deploys (documented; matches the existing RevForge convention).

## Test plan

- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter admin test` — 1627 passed / 10 skipped (new cron-alert.test.ts: 5 passing)
- [ ] Pre-push gate (auto on `git push`) — Phase 1 quality + typecheck + test + build
- [ ] CI on `test` branch — Phase 1 + 2 + 3 + integration + security gate + gitleaks
- [ ] Manual smoke after merge to `test`:
  - Trigger one admin cron with `REVEALUI_CRON_SECRET` to confirm 200 happy path still works
  - Trigger with invalid auth to confirm 401 still works (alert NOT fired on auth failure)
  - Force a runtime failure (e.g. broken DB env) to confirm Sentry receives the event + 500 returned

## Related

- Tracker #826
- Closes #835
- Closes #836
- Pre-flip moral-readiness audit 2026-05-11 (see an internal repo:docs/MASTER_PLAN.md §Pre-Flip Moral Readiness`)
- 14 P0 P0s remaining after this lands

## Sequencing

Per "safer over faster" plan: this is PR A of 5 in the security cluster. Next up (one PR at a time):
- PR B: #838 trusted-proxy XFF in `apps/server` rate-limit
- PR C: #832 + #833 OAuth pair (unverified emails + isSignupAllowed)
- PR D: #840 CSRF on admin API
- PR E: #839 CSP unsafe-inline drop