### PR TITLE
fix(server): use trusted-proxy-aware getClientIp in rate-limit

### DIFF
--- a/apps/server/src/middleware/__tests__/rate-limit.test.ts
+++ b/apps/server/src/middleware/__tests__/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mock dependencies
@@ -14,6 +14,7 @@ vi.mock('@revealui/core/license', () => ({
 
 import { checkRateLimit } from '@revealui/auth/server';
 import { getCurrentTier } from '@revealui/core/license';
+import { configureClientIp, resetClientIpConfig } from '@revealui/security';
 import { rateLimitMiddleware, tieredRateLimitMiddleware } from '../rate-limit.js';
 
 const mockedCheckRateLimit = vi.mocked(checkRateLimit);
@@ -22,6 +23,12 @@ const mockedGetCurrentTier = vi.mocked(getCurrentTier);
 beforeEach(() => {
   vi.clearAllMocks();
   mockedGetCurrentTier.mockReturnValue('free');
+  // Match production wiring at apps/server/src/index.ts:1326.
+  configureClientIp({ trustedProxyCount: 1 });
+});
+
+afterEach(() => {
+  resetClientIpConfig();
 });
 
 // ---------------------------------------------------------------------------
@@ -115,8 +122,12 @@ describe('rateLimitMiddleware', () => {
     expect(retryAfter).toBeLessThanOrEqual(30);
   });
 
-  describe('IP extraction', () => {
-    it('uses leftmost X-Forwarded-For entry (client IP)', async () => {
+  describe('IP extraction (trusted-proxy-aware, post-revealui#838)', () => {
+    it('uses the entry written by the trusted edge proxy (X-Forwarded-For)', async () => {
+      // With trustedProxyCount=1 and parts=[1.1.1.1, 2.2.2.2, 3.3.3.3],
+      // the rightmost entry (3.3.3.3) is what our trusted proxy wrote — the
+      // IP of whoever connected to it. The leftmost two entries are
+      // untrusted (could be a client-set spoof + an untrusted upstream).
       mockedCheckRateLimit.mockResolvedValue(allowedResult());
 
       const app = new Hono();
@@ -128,10 +139,36 @@ describe('rateLimitMiddleware', () => {
       });
 
       const key = mockedCheckRateLimit.mock.calls[0]![0];
-      expect(key).toBe('api:1.1.1.1');
+      expect(key).toBe('api:3.3.3.3');
     });
 
-    it('prefers X-Real-IP over X-Forwarded-For', async () => {
+    it('rejects a crafted X-Forwarded-For prefix (spoof bypass attempt)', async () => {
+      // Attacker sets X-Forwarded-For: "9.9.9.9" before the request hits
+      // the trusted proxy. The trusted proxy appends the attacker's TCP
+      // peer IP (5.5.5.5). With trustedProxyCount=1, getClientIp returns
+      // 5.5.5.5 — the real attacker IP, not the spoofed 9.9.9.9.
+      // Per revealui#838 acceptance criterion.
+      mockedCheckRateLimit.mockResolvedValue(allowedResult());
+
+      const app = new Hono();
+      app.use('*', rateLimitMiddleware({ maxRequests: 100, windowMs: 60_000 }));
+      app.get('/test', (c) => c.json({ ok: true }));
+
+      await app.request('/test', {
+        headers: { 'x-forwarded-for': '9.9.9.9, 5.5.5.5' },
+      });
+
+      const key = mockedCheckRateLimit.mock.calls[0]![0];
+      expect(key).toBe('api:5.5.5.5');
+      expect(key).not.toBe('api:9.9.9.9');
+    });
+
+    it('uses X-Forwarded-For over X-Real-IP when both present (trusted-proxy strategy)', async () => {
+      // Behavior change vs the pre-revealui#838 middleware (which preferred
+      // X-Real-IP unconditionally). The trusted-proxy strategy treats
+      // X-Forwarded-For as the canonical source when present, since it
+      // encodes the full proxy chain we can apply trustedProxyCount to.
+      // X-Real-IP is only a fallback when XFF is absent.
       mockedCheckRateLimit.mockResolvedValue(allowedResult());
 
       const app = new Hono();
@@ -146,7 +183,7 @@ describe('rateLimitMiddleware', () => {
       });
 
       const key = mockedCheckRateLimit.mock.calls[0]![0];
-      expect(key).toBe('api:9.9.9.9');
+      expect(key).toBe('api:2.2.2.2');
     });
 
     it('falls back to X-Real-IP when X-Forwarded-For is absent', async () => {

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -3,10 +3,17 @@
  *
  * Adapts the existing checkRateLimit from @revealui/auth for use with Hono.
  * Sets standard rate limit headers and returns 429 when exceeded.
+ *
+ * Client IP extraction uses `getClientIp` from `@revealui/security`
+ * (trusted-proxy-aware). Configured globally at boot via
+ * `configureClientIp({ trustedProxyCount: 1 })` in `apps/server/src/index.ts`.
+ * See revealui#838 — earlier left-most-XFF extraction was trivially
+ * spoofable behind Vercel's edge.
  */
 
 import { checkRateLimit } from '@revealui/auth/server';
 import { getCurrentTier, type LicenseTier } from '@revealui/core/license';
+import { getClientIp } from '@revealui/security';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
@@ -30,30 +37,9 @@ export interface TieredRateLimitOptions {
   failOpen?: boolean;
 }
 
-/**
- * Extract the client IP from request headers.
- *
- * Priority:
- * 1. X-Real-IP  -  set by the edge proxy (Vercel/Cloudflare) to the true client IP
- * 2. X-Forwarded-For  -  first (leftmost) entry is the originating client IP
- * 3. Falls back to 'unknown' when no IP headers are present
- */
-function extractTrustedIp(c: { req: { header: (name: string) => string | undefined } }): string {
-  const realIp = c.req.header('x-real-ip');
-  if (realIp) return realIp.trim();
-
-  const xff = c.req.header('x-forwarded-for');
-  if (xff) {
-    const first = xff.split(',')[0]?.trim();
-    if (first) return first;
-  }
-
-  return 'unknown';
-}
-
 export const rateLimitMiddleware = (options: RateLimitOptions): MiddlewareHandler => {
   return async (c, next) => {
-    const ip = extractTrustedIp(c);
+    const ip = getClientIp(c.req.raw);
     const key = `${options.keyPrefix || 'api'}:${ip}`;
 
     try {
@@ -94,7 +80,7 @@ export const tieredRateLimitMiddleware = (options: TieredRateLimitOptions): Midd
     const tier = getCurrentTier();
     const config = options.tiers[tier] ?? options.tiers.free;
 
-    const ip = extractTrustedIp(c);
+    const ip = getClientIp(c.req.raw);
     const key = `${options.keyPrefix || 'api'}:${tier}:${ip}`;
 
     try {


### PR DESCRIPTION
## Summary

Closes #838 — security cluster PR B.

Replaces the spoofable left-most-XFF extraction in `apps/server/src/middleware/rate-limit.ts` with `getClientIp` from `@revealui/security` (already used by `apps/server/src/lib/request-context.ts`). Boot wiring at `apps/server/src/index.ts:1326` already calls `configureClientIp({ trustedProxyCount: 1 })`, so this PR just routes the middleware through the canonical extractor.

## What changes

- `apps/server/src/middleware/rate-limit.ts`:
  - Drops the local `extractTrustedIp` function.
  - Replaces both call sites (`rateLimitMiddleware` + `tieredRateLimitMiddleware`) with `getClientIp(c.req.raw)`.
- `apps/server/src/middleware/__tests__/rate-limit.test.ts`:
  - Updates IP-extraction tests to assert the new (correct) trusted-proxy behavior.
  - Adds **"rejects a crafted X-Forwarded-For prefix (spoof bypass attempt)"** — covers the AC.
  - Adds `configureClientIp` + `resetClientIpConfig` in `beforeEach`/`afterEach`.

## Behavior change

**Before:** rate-limit middleware took the leftmost X-Forwarded-For entry — client-controlled. An attacker could set `X-Forwarded-For: 1.2.3.4` and either burn through someone else's rate-limit budget or evade their own by rotating prefixes.

**After:** middleware uses the trusted-proxy strategy. With `trustedProxyCount: 1`, the rate-limit key is derived from whatever IP our trusted edge proxy (Vercel) wrote — the actual peer that hit the edge, not the client-supplied prefix.

**Secondary shift:** when both `X-Forwarded-For` and `X-Real-IP` are present, the middleware now prefers `X-Forwarded-For` (it encodes the full proxy chain we can apply `trustedProxyCount` to). `X-Real-IP` remains the fallback when XFF is absent. The old middleware preferred X-Real-IP unconditionally.

## Test plan

- [x] `pnpm --filter ./apps/server typecheck` — clean
- [x] `pnpm --filter ./apps/server test` — 2726 passed / 1 skipped (rate-limit.test.ts: all green including the new spoof-bypass test)
- [ ] Pre-push gate (auto on push)
- [ ] CI on test
- [ ] Manual smoke after merge:
  - Hit a rate-limited route from two different IPs — independent budgets
  - Hit a rate-limited route with crafted `X-Forwarded-For: 1.2.3.4` prefix — per-IP budget tracks the real edge-observed IP, not the prefix

## Related

- Tracker #826
- Closes #838
- Pre-flip moral-readiness audit 2026-05-11
- Previous: PR A merged as `55101e96b` (closed #835 + #836)
- Next: PR C — #832 + #833 (OAuth pair)

13 P0 children + tracker remain after this lands (14 total).