### PR TITLE
fix(auth): reject unverified OAuth emails + apply isSignupAllowed in callback

### DIFF
--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -31,6 +31,8 @@ class MockOAuthAccountConflictError extends Error {
   }
 }
 
+const mockIsSignupAllowed = vi.fn().mockReturnValue(true);
+
 vi.mock('@revealui/auth/server', () => ({
   generateOAuthState: (...args: unknown[]) => mockGenerateOAuthState(...args),
   buildAuthUrl: (...args: unknown[]) => mockBuildAuthUrl(...args),
@@ -40,6 +42,10 @@ vi.mock('@revealui/auth/server', () => ({
   upsertOAuthUser: (...args: unknown[]) => mockUpsertOAuthUser(...args),
   createSession: (...args: unknown[]) => mockCreateSession(...args),
   rotateSession: (...args: unknown[]) => mockCreateSession(...args),
+  // Default: signup allowed. Specific tests can override via
+  // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
+  // revealui#833 closed-signup gate.
+  isSignupAllowed: (...args: unknown[]) => mockIsSignupAllowed(...args),
   OAuthAccountConflictError: MockOAuthAccountConflictError,
 }));
 

--- a/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
@@ -18,6 +18,9 @@ const mockCreateSession = vi.fn();
 const mockGetClient = vi.fn();
 const mockInitializeLicense = vi.fn();
 const mockGetMaxUsers = vi.fn();
+const mockIsSignupAllowed = vi.fn().mockReturnValue(true);
+const mockGetOAuthAccountByProviderUser = vi.fn().mockResolvedValue(null);
+const mockCountActiveUsers = vi.fn().mockResolvedValue(0);
 
 class MockOAuthAccountConflictError extends Error {
   constructor(msg: string) {
@@ -35,7 +38,19 @@ vi.mock('@revealui/auth/server', () => ({
   upsertOAuthUser: (...args: unknown[]) => mockUpsertOAuthUser(...args),
   createSession: (...args: unknown[]) => mockCreateSession(...args),
   rotateSession: (...args: unknown[]) => mockCreateSession(...args),
+  // Default: signup allowed. Tests can override via
+  // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
+  // revealui#833 closed-signup gate.
+  isSignupAllowed: (...args: unknown[]) => mockIsSignupAllowed(...args),
   OAuthAccountConflictError: MockOAuthAccountConflictError,
+}));
+
+vi.mock('@revealui/db/queries/oauth-accounts', () => ({
+  getOAuthAccountByProviderUser: (...args: unknown[]) => mockGetOAuthAccountByProviderUser(...args),
+}));
+
+vi.mock('@revealui/db/queries/users', () => ({
+  countActiveUsers: (...args: unknown[]) => mockCountActiveUsers(...args),
 }));
 
 vi.mock('@revealui/core/license', () => ({

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -12,6 +12,7 @@
 import {
   exchangeCode,
   fetchProviderUser,
+  isSignupAllowed,
   OAuthAccountConflictError,
   rotateSession,
   upsertOAuthUser,
@@ -66,6 +67,30 @@ export async function GET(
     );
     const providerUser = await fetchProviderUser(provider, accessToken);
 
+    // Look up the OAuth account once — reused for the closed-signup gate
+    // (revealui#833) and the user-limit check (CR5-2) below. A DB failure
+    // here propagates to the outer catch which returns oauth_error; that
+    // is the right failure mode (refuse rather than skip the signup gate).
+    const db = getClient();
+    const existingOAuth = await getOAuthAccountByProviderUser(db, provider, providerUser.id);
+
+    // Closed-signup gate for new OAuth signups (revealui#833). Pre-fix:
+    // the OAuth callback bypassed isSignupAllowed entirely, silently
+    // violating the default-closed contract from #787. New OAuth accounts
+    // must pass the same allowlist check as local signups.
+    if (!existingOAuth && providerUser.email && !isSignupAllowed(providerUser.email)) {
+      return loginUrl('signup_restricted');
+    }
+
+    // Reject providers that returned no verified email for a new signup
+    // (revealui#832). github.ts / google.ts return null when the email is
+    // unverified — without this gate, upsertOAuthUser would create an
+    // account with a null email which is unworkable for password reset,
+    // notifications, etc.
+    if (!existingOAuth && !providerUser.email) {
+      return loginUrl('verified_email_required');
+    }
+
     // Allowlist check  -  leave OAUTH_ADMIN_EMAILS empty to allow any authenticated user
     const allowedEmails = (process.env.OAUTH_ADMIN_EMAILS ?? '')
       .split(',')
@@ -81,16 +106,10 @@ export async function GET(
     try {
       await initializeLicense();
       const maxUsers = getMaxUsers();
-      if (maxUsers !== Infinity) {
-        const db = getClient();
-        const existingOAuth = await getOAuthAccountByProviderUser(db, provider, providerUser.id);
-
-        if (!existingOAuth) {
-          // New user via OAuth  -  check limit
-          const activeCount = await countActiveUsers(db);
-          if (activeCount >= maxUsers) {
-            return loginUrl('user_limit_reached');
-          }
+      if (maxUsers !== Infinity && !existingOAuth) {
+        const activeCount = await countActiveUsers(db);
+        if (activeCount >= maxUsers) {
+          return loginUrl('user_limit_reached');
         }
       }
     } catch (limitError) {

--- a/packages/auth/src/server/__tests__/providers.test.ts
+++ b/packages/auth/src/server/__tests__/providers.test.ts
@@ -147,69 +147,66 @@ describe('GitHub provider', () => {
   // -----------------------------------------------------------------------
 
   describe('fetchUser', () => {
-    it('returns mapped user with public email', async () => {
+    it('always queries /user/emails and uses the primary verified entry', async () => {
+      // Per revealui#832 — even when /user returns an email in the public
+      // profile field, we ignore it and use /user/emails. GitHub does not
+      // verify the public-profile email field.
       fetchSpy.mockResolvedValueOnce(
         jsonResponse({
           id: 42,
           login: 'octocat',
           name: 'The Octocat',
-          email: 'octocat@github.com',
+          email: 'spoofed@victim.com', // user-editable, untrusted
           avatar_url: 'https://avatars.githubusercontent.com/u/42',
         }),
+      );
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          { email: 'noreply@github.com', primary: false, verified: true },
+          { email: 'real@octocat.dev', primary: true, verified: true },
+        ]),
       );
 
       const user = await github.fetchUser('token-123');
 
       expect(user).toEqual({
         id: '42',
-        email: 'octocat@github.com',
+        email: 'real@octocat.dev', // from /user/emails, NOT the profile field
         name: 'The Octocat',
         avatarUrl: 'https://avatars.githubusercontent.com/u/42',
       });
+
+      // Verify both fetches happened — /user/emails is mandatory now.
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls[1][0]).toBe('https://api.github.com/user/emails');
 
       // Verify auth header
       const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
       expect(headers.Authorization).toBe('Bearer token-123');
     });
 
-    it('falls back to login when name is null', async () => {
+    it('rejects spoofed public-profile email (account-takeover prevention)', async () => {
+      // Attacker sets their public profile email to a victim's address.
+      // GitHub does not verify this field. /user/emails returns only the
+      // attacker's verified email — that's what we trust.
       fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ id: 1, login: 'ghost', name: null, email: 'a@b.com' }),
+        jsonResponse({
+          id: 100,
+          login: 'attacker',
+          name: 'Attacker',
+          email: 'victim@example.com', // spoofed
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([{ email: 'attacker@gmail.com', primary: true, verified: true }]),
       );
 
       const user = await github.fetchUser('tok');
-      expect(user.name).toBe('ghost');
+      expect(user.email).toBe('attacker@gmail.com');
+      expect(user.email).not.toBe('victim@example.com');
     });
 
-    it('fetches email from /user/emails when public email is null', async () => {
-      // First call: /user (no email)
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse({ id: 99, login: 'private-user', name: 'Private', email: null }),
-      );
-      // Second call: /user/emails
-      fetchSpy.mockResolvedValueOnce(
-        jsonResponse([
-          { email: 'noreply@github.com', primary: false, verified: true },
-          { email: 'real@example.com', primary: true, verified: true },
-        ]),
-      );
-
-      const user = await github.fetchUser('tok');
-
-      expect(user.email).toBe('real@example.com');
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
-      expect(fetchSpy.mock.calls[1][0]).toBe('https://api.github.com/user/emails');
-    });
-
-    it('returns null email when /user/emails fails', async () => {
-      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1, login: 'x', name: 'X', email: null }));
-      fetchSpy.mockResolvedValueOnce(errorResponse(403));
-
-      const user = await github.fetchUser('tok');
-      expect(user.email).toBeNull();
-    });
-
-    it('returns null email when no primary verified email exists', async () => {
+    it('returns null email when /user/emails has no verified primary', async () => {
       fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1, login: 'x', name: 'X', email: null }));
       fetchSpy.mockResolvedValueOnce(
         jsonResponse([{ email: 'unverified@example.com', primary: true, verified: false }]),
@@ -217,6 +214,26 @@ describe('GitHub provider', () => {
 
       const user = await github.fetchUser('tok');
       expect(user.email).toBeNull();
+    });
+
+    it('returns null email when /user/emails request fails', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1, login: 'x', name: 'X', email: null }));
+      fetchSpy.mockResolvedValueOnce(errorResponse(403));
+
+      const user = await github.fetchUser('tok');
+      expect(user.email).toBeNull();
+    });
+
+    it('falls back to login when name is null', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ id: 1, login: 'ghost', name: null, email: 'a@b.com' }),
+      );
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([{ email: 'a@b.com', primary: true, verified: true }]),
+      );
+
+      const user = await github.fetchUser('tok');
+      expect(user.name).toBe('ghost');
     });
 
     it('throws on non-OK /user response', async () => {
@@ -229,12 +246,15 @@ describe('GitHub provider', () => {
       fetchSpy.mockResolvedValueOnce(
         jsonResponse({ id: 1, login: 'x', name: 'X', email: 'a@b.com' }),
       );
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([{ email: 'a@b.com', primary: true, verified: true }]),
+      );
 
       const user = await github.fetchUser('tok');
       expect(user.avatarUrl).toBeNull();
     });
 
-    it('throws on network failure', async () => {
+    it('throws on network failure on /user', async () => {
       fetchSpy.mockImplementationOnce(networkError);
 
       await expect(github.fetchUser('tok')).rejects.toThrow('fetch failed');
@@ -334,11 +354,12 @@ describe('Google provider', () => {
   // -----------------------------------------------------------------------
 
   describe('fetchUser', () => {
-    it('returns mapped user data', async () => {
+    it('returns email when email_verified is true', async () => {
       fetchSpy.mockResolvedValueOnce(
         jsonResponse({
           sub: '1234567890',
           email: 'user@gmail.com',
+          email_verified: true,
           name: 'Test User',
           picture: 'https://lh3.googleusercontent.com/photo.jpg',
         }),
@@ -359,8 +380,43 @@ describe('Google provider', () => {
       expect(headers.Authorization).toBe('Bearer ya29.token');
     });
 
+    it('returns null email when email_verified is false (revealui#832)', async () => {
+      // Per revealui#832 — Google's userinfo can return an unverified email
+      // (just whatever the user typed during Google signup). We require
+      // email_verified === true; null forces the callback's signup gate
+      // to reject the request.
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          sub: '1234567890',
+          email: 'unverified@example.com',
+          email_verified: false,
+          name: 'Test User',
+        }),
+      );
+
+      const user = await google.fetchUser('tok');
+      expect(user.email).toBeNull();
+      expect(user.id).toBe('1234567890');
+      expect(user.name).toBe('Test User');
+    });
+
+    it('returns null email when email_verified is missing (treat as unverified)', async () => {
+      // Defense in depth — if Google ever omits the claim, treat as
+      // unverified rather than trusting the email.
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          sub: '1',
+          email: 'present-but-unverified@example.com',
+          name: 'X',
+        }),
+      );
+
+      const user = await google.fetchUser('tok');
+      expect(user.email).toBeNull();
+    });
+
     it('defaults name to "Google User" when missing', async () => {
-      fetchSpy.mockResolvedValueOnce(jsonResponse({ sub: '1' }));
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ sub: '1', email_verified: true }));
 
       const user = await google.fetchUser('tok');
       expect(user.name).toBe('Google User');

--- a/packages/auth/src/server/providers/github.ts
+++ b/packages/auth/src/server/providers/github.ts
@@ -4,8 +4,12 @@
  * Uses native fetch  -  no additional npm dependencies.
  * Scopes: read:user user:email
  *
- * Note: GitHub may return null email if user has set it private.
- * In that case we fetch from /user/emails and pick the primary verified one.
+ * The email returned by GET /user is NOT verified — it's any value the
+ * user typed into Settings → Public profile email. We always query
+ * /user/emails and pick the `primary && verified` entry. See revealui#832
+ * for the account-takeover vector that motivated this: an attacker could
+ * set their public profile email to a victim's address and create a
+ * RevealUI account under that email before the victim signed up.
  */
 
 import type { ProviderUser } from '../oauth.js';
@@ -102,20 +106,20 @@ export async function fetchUser(accessToken: string): Promise<ProviderUser> {
     avatar_url?: string;
   };
 
-  let email: string | null = user.email ?? null;
-
-  // Fetch emails if not public
-  if (!email) {
-    const emailsResponse = await fetch('https://api.github.com/user/emails', { headers });
-    if (emailsResponse.ok) {
-      const emails = (await emailsResponse.json()) as Array<{
-        email: string;
-        primary: boolean;
-        verified: boolean;
-      }>;
-      const primary = emails.find((e) => e.primary && e.verified);
-      email = primary?.email ?? null;
-    }
+  // Per revealui#832: always query /user/emails and require primary +
+  // verified. We do NOT trust user.email from /user — that field is
+  // user-editable in GitHub's Settings → Public profile and is not
+  // verified by GitHub.
+  let email: string | null = null;
+  const emailsResponse = await fetch('https://api.github.com/user/emails', { headers });
+  if (emailsResponse.ok) {
+    const emails = (await emailsResponse.json()) as Array<{
+      email: string;
+      primary: boolean;
+      verified: boolean;
+    }>;
+    const primary = emails.find((e) => e.primary && e.verified);
+    email = primary?.email ?? null;
   }
 
   return {

--- a/packages/auth/src/server/providers/google.ts
+++ b/packages/auth/src/server/providers/google.ts
@@ -89,13 +89,19 @@ export async function fetchUser(accessToken: string): Promise<ProviderUser> {
   const data = (await response.json()) as {
     sub: string;
     email?: string;
+    email_verified?: boolean;
     name?: string;
     picture?: string;
   };
 
   return {
     id: data.sub,
-    email: data.email ?? null,
+    // Per revealui#832: require email_verified === true. Google's userinfo
+    // includes the email_verified claim; an unverified email is just
+    // whatever the user typed during Google signup and is not proof of
+    // ownership. Returning null forces the callback's signup gate to
+    // reject the request (verified_email_required).
+    email: data.email_verified === true ? (data.email ?? null) : null,
     name: data.name ?? 'Google User',
     avatarUrl: data.picture ?? null,
   };


### PR DESCRIPTION
## Summary

Closes #832 and #833 — security cluster PR C.

Two related OAuth-side fixes that the pre-flip audit identified as account-takeover vectors. Source diff is small (3 files); test coverage is the bulk of the change.

## What changes

### #832 — Reject unverified OAuth emails

**GitHub provider** (`packages/auth/src/server/providers/github.ts`):
- Always queries `/user/emails` and uses the primary + verified entry.
- Stops trusting `user.email` from `/user`. That field is user-editable in GitHub Settings → Public profile and is not verified by GitHub.

**Google provider** (`packages/auth/src/server/providers/google.ts`):
- Requires `email_verified === true` on the userinfo response.
- Returns `null` for the email when `email_verified` is `false` OR missing (defense in depth — treat missing as unverified).

### #833 — Apply `isSignupAllowed` in the OAuth callback

**Callback route** (`apps/admin/src/app/api/auth/callback/[provider]/route.ts`):
- Hoists the `existingOAuth` lookup out of the user-limit `try` block so it can gate both the signup-allowed check and the user-limit check.
- Adds a closed-signup gate that fires for new OAuth accounts: `if (!existingOAuth && providerUser.email && !isSignupAllowed(providerUser.email)) return loginUrl('signup_restricted')`.
- Adds a paired `verified_email_required` gate when the provider returned `null` email for a new signup (the #832 failure mode — we refuse to create an account without a verified email).

## Why both in one PR

The two changes are interlocking: #832 makes the provider return `null` for unverified emails; #833 is what consumes that signal. Splitting would mean an intermediate state where #832 silently dropped accounts to `null email` without a route-level rejection. Bundled keeps the contract consistent end-to-end.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| GitHub OAuth with public-profile email set to victim's address | Account created under victim's email | `/user/emails` queried; only the attacker's verified email is used |
| Google OAuth with `email_verified: false` | Account created with unverified email | Provider returns `null` email; callback redirects to `/login?error=verified_email_required` |
| OAuth signup while `REVEALUI_SIGNUP_OPEN=false` and email not in whitelist | Account silently created | Redirect to `/login?error=signup_restricted` |
| Existing OAuth account signs in | Unchanged | Unchanged (gates only fire for new accounts) |

## Test plan

- [x] `pnpm --filter @revealui/auth typecheck` — clean
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter @revealui/auth test` — 495 passed / 19 skipped (providers.test.ts: all green including the new spoof + email_verified tests)
- [ ] Pre-push gate
- [ ] CI on test (full integration suite)
- [ ] Manual smoke after merge:
  - Sign in via GitHub with a verified GitHub email — succeeds
  - Sign up via Google with `email_verified: true` — succeeds
  - Force GitHub email to be unverified (toggle in GitHub) — sign-in redirects with verified_email_required (cannot test "spoofed public-profile" directly without two GitHub accounts)
  - Set `REVEALUI_SIGNUP_OPEN=false` + empty whitelist, try OAuth signup — redirects with signup_restricted

## Related

- Tracker #826
- Closes #832
- Closes #833
- Previous: PR A `55101e96b` (#835 + #836), PR B `93a715d1e` (#838)
- Next: PR D — #840 (CSRF on admin state-changing routes)