### PR TITLE
fix(security): gate unsafe-inline to dev-only in admin CSP

### DIFF
--- a/apps/admin/csp.mjs
+++ b/apps/admin/csp.mjs
@@ -16,13 +16,12 @@ if (serverUrl) {
 }
 
 // Build dynamic script-src origins
-// 'unsafe-eval' is required only for Next.js/Turbopack HMR in dev — not in production.
-// Stripe.js and Lexical do not require eval in production builds.
+// Both 'unsafe-inline' and 'unsafe-eval' are required only for Next.js/Turbopack HMR in dev.
+// Stripe.js and Lexical do not require either in production builds.
 const isProduction = process.env.VERCEL_ENV === 'production';
 const scriptOrigins = [
   "'self'",
-  "'unsafe-inline'",
-  ...(isProduction ? [] : ["'unsafe-eval'"]),
+  ...(isProduction ? [] : ["'unsafe-inline'", "'unsafe-eval'"]),
   'https://checkout.stripe.com',
   'https://js.stripe.com',
   'https://maps.googleapis.com',


### PR DESCRIPTION
Closes #839

## Summary
- Moves `'unsafe-inline'` out of the unconditional `scriptOrigins` array in `apps/admin/csp.mjs`
- Both `'unsafe-inline'` and `'unsafe-eval'` are now gated to `isProduction ? [] : [...]`, matching the existing pattern for `'unsafe-eval'`
- Production CSP for the admin app no longer allows inline script execution

## Test plan
- [ ] Local dev: admin app loads, HMR works (both flags present in dev CSP)
- [ ] Production build: verify `Content-Security-Policy` header omits `unsafe-inline` from `script-src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
