### PR TITLE
fix(security): stop logging partial API keys in MCP launchers (CodeQL #314/#315)

### DIFF
--- a/packages/mcp/src/servers/neon.ts
+++ b/packages/mcp/src/servers/neon.ts
@@ -59,7 +59,7 @@ async function startNeonMCP() {
 
   const withRestart = process.argv.includes('--restart');
   logger.header('Starting NeonDB MCP Server (Local)');
-  logger.info(`   API Key: ${neonApiKey.substring(0, 12)}...`);
+  logger.info('   API Key: [configured]');
   if (withRestart) logger.info('   Restart mode: enabled (up to 3 attempts)');
 
   let attempt = 0;

--- a/packages/mcp/src/servers/stripe.ts
+++ b/packages/mcp/src/servers/stripe.ts
@@ -55,7 +55,7 @@ async function startStripeMCP() {
 
   const withRestart = process.argv.includes('--restart');
   logger.header('Starting Stripe MCP Server');
-  logger.info(`   Secret Key: ${stripeSecretKey.substring(0, 12)}...`);
+  logger.info('   Secret Key: [configured]');
   if (withRestart) logger.info('   Restart mode: enabled (up to 3 attempts)');
 
   let attempt = 0;

--- a/packages/mcp/src/servers/vercel.ts
+++ b/packages/mcp/src/servers/vercel.ts
@@ -56,7 +56,7 @@ async function startVercelMCP() {
 
   const withRestart = process.argv.includes('--restart');
   logger.header('Starting Vercel MCP Server');
-  logger.info(`   API Key: ${vercelApiKey.substring(0, 8)}...`);
+  logger.info('   API Key: [configured]');
   if (withRestart) logger.info('   Restart mode: enabled (up to 3 attempts)');
 
   let attempt = 0;


### PR DESCRIPTION
## Summary

- Replace partial API key substrings (`key.substring(0, N)...`) with `[configured]` in MCP launcher startup messages for Neon, Vercel, and Stripe servers — closes CodeQL alerts #314/#315 (`js/clear-text-logging`, error severity)
- No functional change: the messages confirm a key is set; the partial key values were never needed for debugging

## What changed

| File | Before | After |
|------|--------|-------|
| `packages/mcp/src/servers/neon.ts` | `API Key: neondb_${first12}...` | `API Key: [configured]` |
| `packages/mcp/src/servers/vercel.ts` | `API Key: ${first8}...` | `API Key: [configured]` |
| `packages/mcp/src/servers/stripe.ts` | `Secret Key: sk_${first12}...` | `Secret Key: [configured]` |

The Supabase launcher (`supabase.ts`) CodeQL alert is a separate won't-fix — that server is not in active internal use and is retained only as a customer-facing adapter.

## Test plan

- [ ] Pre-push gate passed (phase 1: quality, lint, security, claim drift)
- [ ] MCP server startup still logs a meaningful "configured" confirmation
- [ ] No partial key material in stderr output

Closes https://github.com/RevealUIStudio/revealui/security/code-scanning/314
Closes https://github.com/RevealUIStudio/revealui/security/code-scanning/315
