### PR TITLE
chore(deps): bump zod 4.3.6 → 4.4.3

### DIFF
--- a/.changeset/deps-zod-4.4.3.md
+++ b/.changeset/deps-zod-4.4.3.md
@@ -1,0 +1,9 @@
+---
+'@revealui/auth': patch
+'@revealui/config': patch
+'@revealui/utils': patch
+---
+
+Bump `zod` to `^4.4.3` (from `^4.3.6`) via the workspace catalog.
+
+These packages declare `zod` as a `catalog:` runtime dependency, so the catalog bump changes their published dependency range. No source changes — `zod` 4.4.x is API-compatible for their usage (workspace `typecheck:all` and per-package tests green).

--- a/apps/server/src/routes/content/media.ts
+++ b/apps/server/src/routes/content/media.ts
@@ -56,7 +56,8 @@ app.openapi(
         content: {
           'multipart/form-data': {
             schema: z.object({
-              file: z.any().openapi({ type: 'string', format: 'binary' }),
+              // z.any() is non-optional-when-absent in zod 4.4+; the handler owns the real "no file" 400
+              file: z.any().optional().openapi({ type: 'string', format: 'binary' }),
               alt: z.string().max(500).optional(),
             }),
           },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ catalogs:
       specifier: ^4.1.5
       version: 4.1.5
     zod:
-      specifier: ^4.3.6
-      version: 4.3.6
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   form-data: '>=4.0.4'
@@ -134,7 +134,7 @@ importers:
         version: 0.4.4
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(zod@4.4.3)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.1
@@ -146,7 +146,7 @@ importers:
         version: 12.1.0(esbuild@0.28.0)(size-limit@12.1.0(jiti@2.7.0))
       '@stripe/mcp':
         specifier: ^0.3.3
-        version: 0.3.3(zod@4.3.6)
+        version: 0.3.3(zod@4.4.3)
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
@@ -239,7 +239,7 @@ importers:
         version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.12(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   apps/admin:
     dependencies:
@@ -344,7 +344,7 @@ importers:
         version: 0.34.5
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^16.2.6
@@ -499,7 +499,7 @@ importers:
         version: 4.0.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -569,7 +569,7 @@ importers:
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -696,7 +696,7 @@ importers:
         version: 13.6.30
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -797,7 +797,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -912,7 +912,7 @@ importers:
         version: 17.4.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -934,7 +934,7 @@ importers:
         version: 0.1.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/db':
         specifier: workspace:*
@@ -947,7 +947,7 @@ importers:
         version: 25.6.0
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1037,7 +1037,7 @@ importers:
         version: 13.6.30
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -1092,7 +1092,7 @@ importers:
         version: 8.20.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -1102,7 +1102,7 @@ importers:
         version: 0.31.10
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.4.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -1185,7 +1185,7 @@ importers:
         version: link:../core
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -1268,7 +1268,7 @@ importers:
         version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.12(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   packages/paywall:
     devDependencies:
@@ -1558,7 +1558,7 @@ importers:
         version: 9.3.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/inquirer':
         specifier: ^9.0.9
@@ -1665,7 +1665,7 @@ importers:
         version: 22.1.1(@types/node@25.6.0)
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
         specifier: ^0.4.4
@@ -1711,7 +1711,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -10578,28 +10578,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
@@ -12630,9 +12608,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stripe/mcp@0.3.3(zod@4.3.6)':
+  '@stripe/mcp@0.3.3(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       colors: 1.4.0
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -13382,8 +13360,8 @@ snapshots:
 
   '@vercel/sdk@1.19.29':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      zod: 4.3.6
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -14205,10 +14183,10 @@ snapshots:
       '@types/pg': 8.20.0
       pg: 8.20.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0))(zod@4.4.3):
     dependencies:
       drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
-      zod: 4.3.6
+      zod: 4.4.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -17682,10 +17660,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,4 +29,4 @@ catalog:
   typescript: ^6.0.3
   vite: ^8.0.12
   vitest: ^4.1.5
-  zod: ^4.3.6
+  zod: ^4.4.3


### PR DESCRIPTION
Closes #856

## Summary

Bumps `zod` to `^4.4.3` (from `^4.3.6`) via the workspace catalog.

**zod 4.4 changed `z.any()` semantics inside `z.object()`** — a bare `z.any()` key is now non-optional-when-absent. Confirmed with a focused repro:

| input | zod 4.3 | zod 4.4 |
|---|---|---|
| `{}` (key absent) | pass | **fail** — `expected: nonoptional` |
| `{ file: undefined }` (key present) | pass | pass |
| `z.any().optional()` + `{}` | pass | pass |

### The actual failure vs. what the issue anticipated

#856 expected an "error-shape migration" — assertions across the repo updated for a new error object shape. Scoping it empirically (bump zod, run all three suites) was narrower: **exactly one** test failed — `content-media-upload.test.ts` — and the root cause was the `z.any()` change, not error-shape.

The `POST /media` request schema had `file: z.any()`. With zod 4.4, an empty upload form fails OpenAPIHono request validation *before* reaching the handler's own `if (!(file instanceof File))` check (which returns the friendly `400 "No file provided"`).

### Fix

`file: z.any()` → `z.any().optional()` in the media POST schema. That field was only ever a passthrough for OpenAPI doc generation — the handler re-parses the body itself (`c.req.parseBody()`) and owns the real file validation — so `.optional()` restores the intended behavior. **The route test passes unchanged; no error-shape assertion migration was needed anywhere.**

Blast-radius check: `z.any()` appears in exactly one server-source request schema (`media.ts`, fixed here) and one `.refine()`-wrapped numeric schema in `@revealui/contracts` (not a missing-key case; `contracts test` green).

### Changeset

`@revealui/auth`, `@revealui/config`, `@revealui/utils` declare `zod` as a `catalog:` runtime dependency and had no pending changeset, so `scripts/validate/catalog-changeset.ts` flagged them — patch changeset added. (`@revealui/contracts` and others are already covered by existing pending changesets.)

## Test plan

Verified on a worktree off `origin/test`:

- [x] `pnpm typecheck:all` — 51/51 turbo tasks
- [x] `pnpm --filter @revealui/contracts test` — 30/30 files
- [x] `pnpm --filter server test` — 139/139 files
- [x] `pnpm install --frozen-lockfile` — consistent
- [x] `pnpm-lock.yaml` diff reviewed — zod-only (catalog + per-package `catalog:` re-resolution + peer re-resolution for MCP SDK / Stripe MCP / Vercel SDK / drizzle-zod / zod-to-json-schema)
- [x] Pre-push quality gate — PASS (17/17 checks, incl. catalog-changeset)

> Note: `metering.test.ts` flaked once on an unrelated `beforeEach` PGlite-bootstrap 10s hook timeout under concurrent load — passed cleanly on an isolated re-run (at 18.9s). Pre-existing test fragility, not zod-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
