### PR TITLE
chore(sync): remove dead --pull consumers after revvault 0.2.0

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -409,7 +409,7 @@ Phase B  -  Implementation (agent):
 - [x] Audit log integration (`rotation-log.jsonl`)  -  append_audit_log() JSONL entries  -  2026-04-07
 
 Phase C  -  Migration (owner):
-- [ ] `revvault sync vercel --pull` to import existing Vercel vars
+- [ ] Bootstrap vault from existing Vercel vars  -  one-shot manual `revvault set` per path (`--pull` was removed in revvault 0.2.0; `sync` is one-way vault → Vercel)
 - [ ] Clean up vault (remove dead vars, consolidate duplicates)
 - [ ] `revvault sync vercel --apply` to push clean state
 - [ ] All future env changes go through vault first, then sync

--- a/docs/runbooks/vercel-env-sync.md
+++ b/docs/runbooks/vercel-env-sync.md
@@ -56,18 +56,19 @@ pnpm vercel:sync:apply
 # 4. Redeploy
 ```
 
-### Backfill (import existing Vercel vars into revvault)
+### Backfill (bootstrap a fresh vault from existing Vercel vars)
 
-Use this to seed revvault when a Vercel project has secrets revvault doesn't yet know about — typically a one-time bootstrap.
+There is **no `--pull` command.** `revvault sync` is strictly one-way —
+vault → Vercel — as of revvault 0.2.0. The reverse direction was removed
+in the durable redesign after the 2026-05-09 corruption incident, where a
+Vercel API change caused `--pull` to overwrite canonical vault paths with
+ciphertext/empty values. See the revvault `CHANGELOG.md` for the rationale.
 
-```bash
-# Dry-run shows what'd be imported and to which paths
-pnpm vercel:sync:pull
-
-# Apply — writes to <vault_prefix>/<VAR_NAME> by default,
-# OR to override paths if a [projects.<slug>.vars] entry exists
-pnpm vercel:sync:pull:apply
-```
+Seeding a fresh vault from secrets that currently only exist on Vercel is a
+deliberate **one-shot manual operation**, not a recurring sync command — for
+each var, read the value out of Vercel and `revvault set` it at its canonical
+path. Once the vault holds the value, `pnpm vercel:sync:apply` keeps Vercel in
+sync from then on.
 
 ### Drift check (read-only)
 

--- a/package.json
+++ b/package.json
@@ -209,8 +209,6 @@
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
     "vercel:sync": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
     "vercel:sync:apply": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
-    "vercel:sync:pull": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --pull",
-    "vercel:sync:pull:apply": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --pull --apply",
     "vercel:drift-check": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json"
   },
   "type": "module"


### PR DESCRIPTION
## Summary

Follow-up to [revvault#47](https://github.com/RevealUIStudio/revvault/pull/47) (revvault 0.2.0), which removed `revvault sync vercel --pull` — `sync` is now strictly one-way (vault → Vercel). This sweeps the revealui-side consumers that still referenced the removed command, so nothing points at a flag that no longer exists.

## Changes

- **`package.json`** — drop `vercel:sync:pull` and `vercel:sync:pull:apply` scripts. Running either today would error (`--pull` is gone). `vercel:sync`, `vercel:sync:apply`, `vercel:drift-check` are unaffected.
- **`docs/runbooks/vercel-env-sync.md`** — rewrite the "Backfill" section. Bootstrapping a fresh vault from secrets that only exist on Vercel is now a deliberate one-shot manual `revvault set` operation, not a recurring `--pull` command. Links the rationale to the revvault `CHANGELOG.md`.
- **`docs/MASTER_PLAN.md`** — fix the Phase C migration item that listed `revvault sync vercel --pull` as a live bootstrap step.

## Deliberately not changed

- `docs/MASTER_PLAN.md` lines 397 / 408 — dated Phase A/B `[x]` completion-log entries. `--pull` genuinely *was* designed and built on 2026-04-06/07; these are an accurate historical record, not live consumers. Rewriting dated history would be dishonest.

## Note for the owner

The revealui `docs/MASTER_PLAN.md` snapshot is stale vs. the internal docs canonical, which already marks Phase C **SUPERSEDED** (by §5.23, per the 2026-05-01 incident note). This PR only fixes the dead `--pull` line; a full snapshot re-sync is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
