### PR TITLE
chore(docs): sync CLAUDE.md package map to match 26 packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 > via npm rather than via workspace links — same brand surface, decoupled
 > repo + deploy cadence.
 
-### OSS Packages (MIT)
+### OSS Packages (MIT) — 21
 | Package | Purpose |
 |---------|---------|
 | @revealui/core | admin engine, REST API, auth, rich text, admin UI, plugins |
@@ -68,11 +68,14 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/resilience | Circuit breaker, retry, bulkhead patterns |
 | @revealui/security | Headers, CORS, RBAC/ABAC, encryption, audit, GDPR |
 | create-revealui | `npm create revealui` initializer |
-| @revealui/dev | Shared configs (Biome, TS, Tailwind) |
+| revealui | Meta-installer that proxies to `create-revealui` (unpublished — npm name collision) |
+| @revealui/dev | Shared configs (Biome, TS, Tailwind, Vite) + editor config sync (Zed, VS Code) |
 | @revealui/test | E2E specs (Playwright), integration tests, fixtures, mocks, test utilities |
-| @revealui/editors | Editor config sync (Zed, VS Code, Cursor) |
+| @revealui/scripts | Shared utilities for monorepo scripts — logging, paths, exec, workflow state, validation (internal) |
+| @revealui/openapi | Type-safe OpenAPI 3.x for Hono — route definitions, Zod validation, spec generation + Swagger UI |
+| @revealui/paywall | Runtime license enforcement, feature gating, and upgrade UI (Stripe + x402) |
 
-### Pro Packages (Fair Source  -  FSL-1.1-MIT, converts to MIT after 2 years)
+### Pro Packages (Fair Source  -  FSL-1.1-MIT, converts to MIT after 2 years) — 5
 | Package | Purpose |
 |---------|---------|
 | @revealui/ai | AI agents, CRDT memory, LLM providers, orchestration |


### PR DESCRIPTION
## Summary

CLAUDE.md's Package Map listed 22 real packages while `packages/` actually contains 26. This brings the doc back in line with reality.

## What changed

**OSS Packages** (now 21):
- Add `revealui` — meta-installer that proxies to `create-revealui` (unpublished — npm name collision)
- Add `@revealui/openapi` — OpenAPI 3.x for Hono
- Add `@revealui/paywall` — runtime license enforcement, feature gating, upgrade UI (Stripe + x402)
- Add `@revealui/scripts` — internal monorepo script utilities
- Update `@revealui/dev` row to reflect editor-config-sync absorption (also lists Vite)
- Remove `@revealui/editors` — absorbed into `@revealui/dev` via #229

**Pro Packages** unchanged (5: `ai`, `engines`, `harnesses`, `mcp`, `services`). Verified `@revealui/mcp` and `@revealui/services` are both `FSL-1.1-MIT` — the prior move into the Pro table was correct.

Section headers gain explicit row counts (` — N`), matching the `Apps (5)` convention. 21 + 5 = 26, matching `git ls-tree --name-only -d origin/main packages/` and the MASTER_PLAN What-Exists block (internal docs commit `5bf6a2971`).

## Test plan

- [x] Pre-push gate (`pnpm gate --phase=1 --changed`) passed: Biome lint, claim-drift (hard fail), boundary validation, security audit, docs-import-drift — all PASS.
- [ ] Reviewer: spot-check each new row's purpose against its `packages/<name>/package.json` description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
