### PR TITLE
feat(contracts): add @revealui/contracts/marketing-voice primitives

### DIFF
--- a/.changeset/contracts-marketing-voice-primitives.md
+++ b/.changeset/contracts-marketing-voice-primitives.md
@@ -1,0 +1,5 @@
+---
+"@revealui/contracts": minor
+---
+
+feat(contracts): add @revealui/contracts/marketing-voice — shared primitives (Token + tokenize, typed predicate library, Rule discriminated union, checkRule dispatcher with 4 claim-drift variant checkers; CMS-content variants throw deferred-to-Phase-B). Used by CI claim-drift retirement (GAP-192) and the marketing-CMS spec Phase B runtime validators.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -59,6 +59,10 @@
       "types": "./dist/database/index.d.ts",
       "import": "./dist/database/index.js"
     },
+    "./marketing-voice": {
+      "types": "./dist/marketing-voice/index.d.ts",
+      "import": "./dist/marketing-voice/index.js"
+    },
     "./actions": {
       "types": "./dist/actions/index.d.ts",
       "import": "./dist/actions/index.js"

--- a/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize } from '../tokenize.js';
+import { checkRule, runTier1, walkLexicalAst } from '../check-rule.js';
+import type { Rule } from '../rules.js';
+
+describe('checkRule — banned-tokens', () => {
+  it('flags a banned word (case-sensitive match)', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'test.rvui',
+      tokens: ['RVUI'],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('Do not use RVUI in copy');
+    const violations = checkRule(rule, tokens, { field: 'body' });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe('test.rvui');
+    expect(violations[0].field).toBe('body');
+    expect(violations[0].message).toContain('RVUI');
+  });
+
+  it('does not flag if case does not match (case-sensitive)', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'test.rvui',
+      tokens: ['RVUI'],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('rvui is fine here');
+    expect(checkRule(rule, tokens, {})).toHaveLength(0);
+  });
+
+  it('flags case-insensitively when caseInsensitive is true', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'test.rvui',
+      tokens: ['rvui'],
+      caseInsensitive: true,
+    };
+    const tokens = tokenize('Do not use RVUI in copy');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('flags multiple occurrences', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'test.sla',
+      tokens: ['SLA'],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('SLA and then another SLA mention');
+    expect(checkRule(rule, tokens, {})).toHaveLength(2);
+  });
+
+  it('includes span on violation', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'test.t',
+      tokens: ['bad'],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('this is bad');
+    const violations = checkRule(rule, tokens, {});
+    expect(violations[0].span).toBeDefined();
+    expect(violations[0].span?.start).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns empty field string when ctx.field not provided', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens',
+      ruleId: 'r',
+      tokens: ['x'],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('x');
+    expect(checkRule(rule, tokens, {})[0].field).toBe('');
+  });
+});
+
+describe('checkRule — banned-tokens-with-context', () => {
+  it('flags "Studio" alone (no preceding word)', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.studio',
+      tokens: ['Studio'],
+      unlessPrecededByContiguous: ['RevealUI'],
+    };
+    const tokens = tokenize('We are Studio');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('does not flag "RevealUI Studio" (preceded by RevealUI)', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.studio',
+      tokens: ['Studio'],
+      unlessPrecededByContiguous: ['RevealUI'],
+    };
+    const tokens = tokenize('RevealUI Studio');
+    expect(checkRule(rule, tokens, {})).toHaveLength(0);
+  });
+
+  it('flags "the Studio" (preceded by "the", not RevealUI)', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.studio',
+      tokens: ['Studio'],
+      unlessPrecededByContiguous: ['RevealUI'],
+    };
+    const tokens = tokenize('the Studio is great');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('does not flag when unlessFollowedBy matches next word', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.coming',
+      tokens: ['coming'],
+      unlessFollowedBy: ['soon'],
+    };
+    const tokens = tokenize('coming soon');
+    expect(checkRule(rule, tokens, {})).toHaveLength(0);
+  });
+
+  it('flags when unlessFollowedBy does not match next word', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.coming',
+      tokens: ['coming'],
+      unlessFollowedBy: ['soon'],
+    };
+    const tokens = tokenize('coming later');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('is case-insensitive on the banned token itself', () => {
+    const rule: Rule = {
+      kind: 'banned-tokens-with-context',
+      ruleId: 'test.studio',
+      tokens: ['Studio'],
+      unlessPrecededByContiguous: ['RevealUI'],
+    };
+    const tokens = tokenize('We are studio');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+});
+
+describe('checkRule — banned-token-sequences', () => {
+  it('flags "managed hosting" sequence', () => {
+    const rule: Rule = {
+      kind: 'banned-token-sequences',
+      ruleId: 'test.managed-hosting',
+      sequences: [['managed', 'hosting']],
+      caseInsensitive: true,
+    };
+    const tokens = tokenize('We offer managed hosting for everyone');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('does not flag "hosting management" (wrong order)', () => {
+    const rule: Rule = {
+      kind: 'banned-token-sequences',
+      ruleId: 'test.managed-hosting',
+      sequences: [['managed', 'hosting']],
+      caseInsensitive: true,
+    };
+    const tokens = tokenize('hosting management services');
+    expect(checkRule(rule, tokens, {})).toHaveLength(0);
+  });
+
+  it('flags case-insensitively when caseInsensitive is true', () => {
+    const rule: Rule = {
+      kind: 'banned-token-sequences',
+      ruleId: 'test.mh',
+      sequences: [['managed', 'hosting']],
+      caseInsensitive: true,
+    };
+    const tokens = tokenize('MANAGED HOSTING');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('does not flag when caseInsensitive is false and case differs', () => {
+    const rule: Rule = {
+      kind: 'banned-token-sequences',
+      ruleId: 'test.mh',
+      sequences: [['managed', 'hosting']],
+      caseInsensitive: false,
+    };
+    const tokens = tokenize('MANAGED HOSTING');
+    expect(checkRule(rule, tokens, {})).toHaveLength(0);
+  });
+
+  it('handles multi-word sequences with intervening non-word tokens skipped (word-only window)', () => {
+    const rule: Rule = {
+      kind: 'banned-token-sequences',
+      ruleId: 'test.sso',
+      sequences: [['single', 'sign', 'on']],
+      caseInsensitive: true,
+    };
+    const tokens = tokenize('single sign-on authentication');
+    const wordTexts = tokens.filter((t) => t.kind === 'word').map((t) => t.text.toLowerCase());
+    expect(wordTexts).toContain('single');
+    expect(wordTexts).toContain('sign');
+    expect(wordTexts).toContain('on');
+    const violations = checkRule(rule, tokens, {});
+    expect(violations).toHaveLength(1);
+  });
+});
+
+describe('checkRule — banned-token-near', () => {
+  it('flags RVC near a numeric token within 3 tokens', () => {
+    const rule: Rule = {
+      kind: 'banned-token-near',
+      ruleId: 'test.rvc-price',
+      anchor: { tokens: ['RVC'], caseInsensitive: false },
+      near: { tokens: ['0.10'] },
+      withinTokens: 3,
+    };
+    const tokens = tokenize('Buy RVC at 0.10');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('does not flag when tokens are too far apart', () => {
+    const rule: Rule = {
+      kind: 'banned-token-near',
+      ruleId: 'test.rvc-price',
+      anchor: { tokens: ['RVC'], caseInsensitive: false },
+      near: { tokens: ['cheap'] },
+      withinTokens: 2,
+    };
+    const tokens = tokenize('RVC is a great way to access cheap services eventually');
+    const violations = checkRule(rule, tokens, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  it('is bidirectional — near token can precede anchor', () => {
+    const rule: Rule = {
+      kind: 'banned-token-near',
+      ruleId: 'test.rvc-price',
+      anchor: { tokens: ['RVC'], caseInsensitive: false },
+      near: { tokens: ['cheap'] },
+      withinTokens: 2,
+    };
+    const tokens = tokenize('cheap RVC here');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+
+  it('respects caseInsensitive on anchor', () => {
+    const rule: Rule = {
+      kind: 'banned-token-near',
+      ruleId: 'test.rvc-near',
+      anchor: { tokens: ['rvc'], caseInsensitive: true },
+      near: { tokens: ['cheap'] },
+      withinTokens: 3,
+    };
+    const tokens = tokenize('buy RVC cheap');
+    expect(checkRule(rule, tokens, {})).toHaveLength(1);
+  });
+});
+
+describe('checkRule — deferred variants throw', () => {
+  const deferredKinds: Rule['kind'][] = [
+    'h2-shape',
+    'fake-trust',
+    'pricing-proximity',
+    'rvc-pricing-proximity',
+    'unicode-range-tokens',
+  ];
+
+  it.each(deferredKinds)('"%s" throws with Phase B message', (kind) => {
+    const rule = { kind, ruleId: 'test' } as unknown as Rule;
+    expect(() => checkRule(rule, [], {})).toThrow('deferred to CMS-spec Phase B');
+  });
+});
+
+describe('runTier1 — deferred stub', () => {
+  it('throws with Phase B message', () => {
+    expect(() => runTier1({}, [])).toThrow('deferred to CMS-spec Phase B');
+  });
+});
+
+describe('walkLexicalAst — deferred stub', () => {
+  it('throws with Phase B message', () => {
+    expect(() => walkLexicalAst({})).toThrow('deferred to CMS-spec Phase B');
+  });
+});

--- a/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { tokenize } from '../tokenize.js';
+import { describe, expect, it } from 'vitest';
 import { checkRule, runTier1, walkLexicalAst } from '../check-rule.js';
 import type { Rule } from '../rules.js';
+import { tokenize } from '../tokenize.js';
 
 describe('checkRule — banned-tokens', () => {
   it('flags a banned word (case-sensitive match)', () => {

--- a/packages/contracts/src/marketing-voice/__tests__/predicates.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/predicates.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import type { Token } from '../tokenize.js';
+import { describe, expect, it } from 'vitest';
 import {
-  stripCommas,
-  isDollarShape,
-  isPercentShape,
-  isUsdShape,
-  isEngagementUnit,
-  isPositiveIntegerToken,
-  isIntegerWithCommas,
-  isTrackerToken,
-  isRepoLinkToken,
-  isAdrFilename,
-  isAdrCitePath,
-  isPricingTierSourceBlock,
   ENGAGEMENT_UNITS,
+  isAdrCitePath,
+  isAdrFilename,
+  isDollarShape,
+  isEngagementUnit,
+  isIntegerWithCommas,
+  isPercentShape,
+  isPositiveIntegerToken,
+  isPricingTierSourceBlock,
+  isRepoLinkToken,
+  isTrackerToken,
+  isUsdShape,
   PRICING_TIER_BLOCK_KINDS,
+  stripCommas,
 } from '../predicates.js';
+import type { Token } from '../tokenize.js';
 
 function word(text: string, offset = 0): Token {
   return { text, kind: 'word', offset };

--- a/packages/contracts/src/marketing-voice/__tests__/predicates.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/predicates.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import type { Token } from '../tokenize.js';
+import {
+  stripCommas,
+  isDollarShape,
+  isPercentShape,
+  isUsdShape,
+  isEngagementUnit,
+  isPositiveIntegerToken,
+  isIntegerWithCommas,
+  isTrackerToken,
+  isRepoLinkToken,
+  isAdrFilename,
+  isAdrCitePath,
+  isPricingTierSourceBlock,
+  ENGAGEMENT_UNITS,
+  PRICING_TIER_BLOCK_KINDS,
+} from '../predicates.js';
+
+function word(text: string, offset = 0): Token {
+  return { text, kind: 'word', offset };
+}
+
+function sym(text: string, offset = 0): Token {
+  return { text, kind: 'symbol', offset };
+}
+
+describe('stripCommas', () => {
+  it('removes all commas', () => {
+    expect(stripCommas('1,676')).toBe('1676');
+  });
+  it('handles string without commas', () => {
+    expect(stripCommas('1000')).toBe('1000');
+  });
+  it('handles empty string', () => {
+    expect(stripCommas('')).toBe('');
+  });
+});
+
+describe('isDollarShape', () => {
+  it('accepts $100', () => expect(isDollarShape(sym('$100'))).toBe(true));
+  it('accepts $0.10', () => expect(isDollarShape(sym('$0.10'))).toBe(true));
+  it('accepts $1,000', () => expect(isDollarShape(sym('$1,000'))).toBe(true));
+  it('rejects plain number', () => expect(isDollarShape(word('100'))).toBe(false));
+  it('rejects $abc', () => expect(isDollarShape(sym('$abc'))).toBe(false));
+  it('rejects empty string', () => expect(isDollarShape(sym(''))).toBe(false));
+});
+
+describe('isPercentShape', () => {
+  it('accepts "5%"', () => expect(isPercentShape(word('5%'), undefined)).toBe(true));
+  it('accepts number followed by "%" token', () => {
+    expect(isPercentShape(word('5'), sym('%'))).toBe(true);
+  });
+  it('rejects word followed by non-% token', () => {
+    expect(isPercentShape(word('5'), word('percent'))).toBe(false);
+  });
+  it('rejects "abc%"', () => expect(isPercentShape(word('abc%'), undefined)).toBe(false));
+});
+
+describe('isUsdShape', () => {
+  it('accepts number followed by "usd"', () => {
+    expect(isUsdShape(word('100'), word('usd'))).toBe(true);
+  });
+  it('accepts number followed by "USD"', () => {
+    expect(isUsdShape(word('100'), word('USD'))).toBe(true);
+  });
+  it('rejects word token', () => {
+    expect(isUsdShape(word('price'), word('usd'))).toBe(false);
+  });
+  it('rejects number without following usd', () => {
+    expect(isUsdShape(word('100'), undefined)).toBe(false);
+  });
+});
+
+describe('isEngagementUnit', () => {
+  it('accepts "engagement"', () => expect(isEngagementUnit(word('engagement'))).toBe(true));
+  it('accepts "project"', () => expect(isEngagementUnit(word('project'))).toBe(true));
+  it('accepts "mo"', () => expect(isEngagementUnit(word('mo'))).toBe(true));
+  it('accepts "week"', () => expect(isEngagementUnit(word('week'))).toBe(true));
+  it('accepts uppercase "WEEK"', () => expect(isEngagementUnit(word('WEEK'))).toBe(true));
+  it('rejects "month"', () => expect(isEngagementUnit(word('month'))).toBe(false));
+});
+
+describe('ENGAGEMENT_UNITS constant', () => {
+  it('is a Set', () => expect(ENGAGEMENT_UNITS).toBeInstanceOf(Set));
+});
+
+describe('PRICING_TIER_BLOCK_KINDS constant', () => {
+  it('contains PricingTracks', () =>
+    expect(PRICING_TIER_BLOCK_KINDS.has('PricingTracks')).toBe(true));
+});
+
+describe('isPositiveIntegerToken', () => {
+  it('accepts "1"', () => expect(isPositiveIntegerToken(word('1'))).toBe(true));
+  it('accepts "99"', () => expect(isPositiveIntegerToken(word('99'))).toBe(true));
+  it('rejects "0"', () => expect(isPositiveIntegerToken(word('0'))).toBe(false));
+  it('rejects negative', () => expect(isPositiveIntegerToken(word('-1'))).toBe(false));
+  it('rejects float', () => expect(isPositiveIntegerToken(word('1.5'))).toBe(false));
+  it('rejects word', () => expect(isPositiveIntegerToken(word('abc'))).toBe(false));
+});
+
+describe('isIntegerWithCommas', () => {
+  it('accepts "1,676"', () => expect(isIntegerWithCommas(word('1,676'))).toBe(true));
+  it('accepts "10,000"', () => expect(isIntegerWithCommas(word('10,000'))).toBe(true));
+  it('accepts plain "1000"', () => expect(isIntegerWithCommas(word('1000'))).toBe(true));
+  it('rejects "1,abc"', () => expect(isIntegerWithCommas(word('1,abc'))).toBe(false));
+  it('rejects "1,,2"', () => expect(isIntegerWithCommas(word('1,,2'))).toBe(false));
+});
+
+describe('isTrackerToken', () => {
+  it('accepts "#" when next is digits', () => {
+    expect(isTrackerToken(sym('#'), word('123'))).toBe(true);
+  });
+  it('rejects "#" when next is word', () => {
+    expect(isTrackerToken(sym('#'), word('foo'))).toBe(false);
+  });
+  it('rejects "#" when next is undefined', () => {
+    expect(isTrackerToken(sym('#'), undefined)).toBe(false);
+  });
+  it('accepts "milestone"', () => expect(isTrackerToken(word('milestone'), undefined)).toBe(true));
+  it('accepts "milestones"', () =>
+    expect(isTrackerToken(word('milestones'), undefined)).toBe(true));
+  it('accepts "Milestone" (case insensitive)', () =>
+    expect(isTrackerToken(word('Milestone'), undefined)).toBe(true));
+  it('accepts token ending in .yml', () =>
+    expect(isTrackerToken(word('deploy.yml'), undefined)).toBe(true));
+  it('accepts token ending in .yaml', () =>
+    expect(isTrackerToken(word('config.yaml'), undefined)).toBe(true));
+  it('rejects plain word', () => expect(isTrackerToken(word('roadmap'), undefined)).toBe(false));
+});
+
+describe('isRepoLinkToken', () => {
+  it('accepts github.com/RevealUIStudio URL', () => {
+    expect(isRepoLinkToken('https://github.com/RevealUIStudio/revealui/pull/865')).toBe(true);
+  });
+  it('accepts issues URL', () => {
+    expect(isRepoLinkToken('https://github.com/foo/bar/issues/42')).toBe(true);
+  });
+  it('accepts pull URL', () => {
+    expect(isRepoLinkToken('https://github.com/foo/bar/pull/1')).toBe(true);
+  });
+  it('accepts pulls URL', () => {
+    expect(isRepoLinkToken('https://github.com/foo/bar/pulls/5')).toBe(true);
+  });
+  it('rejects non-matching URL', () => {
+    expect(isRepoLinkToken('https://example.com/foo')).toBe(false);
+  });
+  it('rejects plain text', () => {
+    expect(isRepoLinkToken('not a url')).toBe(false);
+  });
+});
+
+describe('isAdrFilename', () => {
+  it('accepts valid ADR filename', () => {
+    expect(isAdrFilename('2026-05-12-rvc-pricing.md')).toBe(true);
+  });
+  it('accepts multi-word slug', () => {
+    expect(isAdrFilename('2026-01-01-some-adr-name.md')).toBe(true);
+  });
+  it('rejects invalid month (13)', () => {
+    expect(isAdrFilename('2026-13-99-bogus.md')).toBe(false);
+  });
+  it('rejects missing slug', () => {
+    expect(isAdrFilename('2026-05-12.md')).toBe(false);
+  });
+  it('rejects wrong extension', () => {
+    expect(isAdrFilename('2026-05-12-foo.txt')).toBe(false);
+  });
+  it('rejects date with wrong digit counts', () => {
+    expect(isAdrFilename('26-5-1-foo.md')).toBe(false);
+  });
+  it('rejects non-date prefix', () => {
+    expect(isAdrFilename('foo-bar-baz-qux.md')).toBe(false);
+  });
+});
+
+describe('isAdrCitePath', () => {
+  it('accepts valid docs/decisions path', () => {
+    expect(isAdrCitePath('../docs/decisions/2026-05-12-rvc-pricing.md')).toBe(true);
+  });
+  it('rejects path without docs/decisions', () => {
+    expect(isAdrCitePath('../some-other-doc.md')).toBe(false);
+  });
+  it('rejects docs/decisions with invalid ADR filename', () => {
+    expect(isAdrCitePath('../docs/decisions/2026-13-99-bogus.md')).toBe(false);
+  });
+  it('rejects plain text', () => {
+    expect(isAdrCitePath('not a path')).toBe(false);
+  });
+});
+
+describe('isPricingTierSourceBlock', () => {
+  it('accepts PricingTracks block type', () => {
+    expect(isPricingTierSourceBlock({ type: 'PricingTracks' })).toBe(true);
+  });
+  it('rejects other block types', () => {
+    expect(isPricingTierSourceBlock({ type: 'Hero' })).toBe(false);
+    expect(isPricingTierSourceBlock({ type: 'ContentSection' })).toBe(false);
+  });
+});

--- a/packages/contracts/src/marketing-voice/__tests__/tokenize.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/tokenize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { tokenize } from '../tokenize.js';
 
 describe('tokenize', () => {

--- a/packages/contracts/src/marketing-voice/__tests__/tokenize.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/tokenize.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize } from '../tokenize.js';
+
+describe('tokenize', () => {
+  it('classifies plain words as word kind', () => {
+    const tokens = tokenize('hello world');
+    expect(tokens.filter((t) => t.kind === 'word').map((t) => t.text)).toEqual(['hello', 'world']);
+  });
+
+  it('classifies whitespace correctly', () => {
+    const tokens = tokenize('a b');
+    const ws = tokens.find((t) => t.kind === 'whitespace');
+    expect(ws).toBeDefined();
+    expect(ws?.text).toBe(' ');
+  });
+
+  it('classifies punctuation as symbol', () => {
+    const tokens = tokenize('hello!');
+    const sym = tokens.find((t) => t.kind === 'symbol');
+    expect(sym).toBeDefined();
+    expect(sym?.text).toBe('!');
+  });
+
+  it('records correct character offsets', () => {
+    const tokens = tokenize('foo bar');
+    const foo = tokens.find((t) => t.text === 'foo');
+    const bar = tokens.find((t) => t.text === 'bar');
+    expect(foo?.offset).toBe(0);
+    expect(bar?.offset).toBe(4);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(tokenize('')).toEqual([]);
+  });
+
+  it('handles digits as word-like tokens', () => {
+    const tokens = tokenize('99 packages');
+    const nums = tokens.filter((t) => t.kind === 'word');
+    expect(nums[0].text).toBe('99');
+  });
+
+  it('handles dollar sign as symbol', () => {
+    const tokens = tokenize('$100');
+    expect(tokens[0].kind).toBe('symbol');
+    expect(tokens[0].text).toBe('$');
+  });
+
+  it('splits auto-scaling on hyphen — Intl.Segmenter treats each part as word-like', () => {
+    const tokens = tokenize('auto-scaling');
+    const wordTexts = tokens.filter((t) => t.kind === 'word').map((t) => t.text);
+    expect(wordTexts).toContain('auto');
+    expect(wordTexts).toContain('scaling');
+  });
+
+  it('splits sign-on — both parts are word-like', () => {
+    const tokens = tokenize('single sign-on');
+    const wordTexts = tokens.filter((t) => t.kind === 'word').map((t) => t.text);
+    expect(wordTexts).toContain('single');
+    expect(wordTexts).toContain('sign');
+    expect(wordTexts).toContain('on');
+  });
+
+  it('splits air-gapped — both parts are word-like', () => {
+    const tokens = tokenize('air-gapped');
+    const wordTexts = tokens.filter((t) => t.kind === 'word').map((t) => t.text);
+    expect(wordTexts).toContain('air');
+    expect(wordTexts).toContain('gapped');
+  });
+
+  it('splits on-prem — both parts are word-like', () => {
+    const tokens = tokenize('on-prem');
+    const wordTexts = tokens.filter((t) => t.kind === 'word').map((t) => t.text);
+    expect(wordTexts).toContain('on');
+    expect(wordTexts).toContain('prem');
+  });
+
+  it('handles multi-byte characters without crashing', () => {
+    const tokens = tokenize('café résumé');
+    expect(tokens.length).toBeGreaterThan(0);
+    const words = tokens.filter((t) => t.kind === 'word');
+    expect(words.length).toBeGreaterThan(0);
+  });
+
+  it('handles emoji without crashing', () => {
+    const tokens = tokenize('hello 🎉 world');
+    expect(tokens.length).toBeGreaterThan(0);
+    const words = tokens.filter((t) => t.kind === 'word').map((t) => t.text);
+    expect(words).toContain('hello');
+    expect(words).toContain('world');
+  });
+
+  it('offset of first token is 0', () => {
+    const tokens = tokenize('test');
+    expect(tokens[0].offset).toBe(0);
+  });
+
+  it('tokens cover consecutive ranges', () => {
+    const text = 'foo bar baz';
+    const tokens = tokenize(text);
+    for (const t of tokens) {
+      expect(text.slice(t.offset, t.offset + t.text.length)).toBe(t.text);
+    }
+  });
+});

--- a/packages/contracts/src/marketing-voice/check-rule.ts
+++ b/packages/contracts/src/marketing-voice/check-rule.ts
@@ -1,5 +1,5 @@
+import type { Rule, ValidationResult, Violation } from './rules.js';
 import type { Token } from './tokenize.js';
-import type { Rule, Violation, ValidationResult } from './rules.js';
 
 export interface CheckContext {
   blockType?: string;

--- a/packages/contracts/src/marketing-voice/check-rule.ts
+++ b/packages/contracts/src/marketing-voice/check-rule.ts
@@ -1,0 +1,207 @@
+import type { Token } from './tokenize.js';
+import type { Rule, Violation, ValidationResult } from './rules.js';
+
+export interface CheckContext {
+  blockType?: string;
+  field?: string;
+}
+
+export function checkRule(rule: Rule, tokens: Token[], ctx: CheckContext): Violation[] {
+  switch (rule.kind) {
+    case 'banned-tokens':
+      return checkBannedTokens(rule, tokens, ctx);
+    case 'banned-tokens-with-context':
+      return checkBannedTokensWithContext(rule, tokens, ctx);
+    case 'banned-token-sequences':
+      return checkBannedTokenSequences(rule, tokens, ctx);
+    case 'banned-token-near':
+      return checkBannedTokenNear(rule, tokens, ctx);
+    case 'h2-shape':
+    case 'fake-trust':
+    case 'pricing-proximity':
+    case 'rvc-pricing-proximity':
+    case 'unicode-range-tokens':
+      throw new Error(
+        `Rule kind '${rule.kind}' is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)`,
+      );
+  }
+}
+
+function makeViolation(rule: Rule, ctx: CheckContext, message: string, token?: Token): Violation {
+  return {
+    rule: rule.ruleId,
+    field: ctx.field ?? '',
+    message,
+    ...(token !== undefined
+      ? { span: { start: token.offset, end: token.offset + token.text.length } }
+      : {}),
+  };
+}
+
+function wordTokens(tokens: Token[]): Token[] {
+  return tokens.filter((t) => t.kind === 'word');
+}
+
+function checkBannedTokens(
+  rule: Extract<Rule, { kind: 'banned-tokens' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const violations: Violation[] = [];
+  const banned = new Set(
+    rule.caseInsensitive ? rule.tokens.map((t) => t.toLowerCase()) : rule.tokens,
+  );
+  for (const token of tokens) {
+    if (token.kind !== 'word') continue;
+    const candidate = rule.caseInsensitive ? token.text.toLowerCase() : token.text;
+    if (banned.has(candidate)) {
+      violations.push(makeViolation(rule, ctx, `Banned token: "${token.text}"`, token));
+    }
+  }
+  return violations;
+}
+
+function prevWordToken(tokens: Token[], idx: number): Token | undefined {
+  for (let i = idx - 1; i >= 0; i--) {
+    const t = tokens[i];
+    if (t !== undefined && t.kind === 'word') return t;
+  }
+  return undefined;
+}
+
+function nextWordToken(tokens: Token[], idx: number): Token | undefined {
+  for (let i = idx + 1; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t !== undefined && t.kind === 'word') return t;
+  }
+  return undefined;
+}
+
+function checkBannedTokensWithContext(
+  rule: Extract<Rule, { kind: 'banned-tokens-with-context' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const violations: Violation[] = [];
+  const bannedSet = new Set(rule.tokens.map((t) => t.toLowerCase()));
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === undefined) continue;
+    if (token.kind !== 'word') continue;
+    if (!bannedSet.has(token.text.toLowerCase())) continue;
+
+    if (rule.unlessFollowedBy !== undefined) {
+      const next = nextWordToken(tokens, i);
+      if (
+        next !== undefined &&
+        rule.unlessFollowedBy.some((u) => u.toLowerCase() === next.text.toLowerCase())
+      ) {
+        continue;
+      }
+    }
+
+    if (rule.unlessPrecededByContiguous !== undefined) {
+      const prev = prevWordToken(tokens, i);
+      if (prev !== undefined && rule.unlessPrecededByContiguous.includes(prev.text)) {
+        continue;
+      }
+    }
+
+    violations.push(makeViolation(rule, ctx, `Banned token: "${token.text}"`, token));
+  }
+  return violations;
+}
+
+function checkBannedTokenSequences(
+  rule: Extract<Rule, { kind: 'banned-token-sequences' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const violations: Violation[] = [];
+  const words = wordTokens(tokens);
+
+  for (const seq of rule.sequences) {
+    if (seq.length === 0) continue;
+    for (let i = 0; i <= words.length - seq.length; i++) {
+      let match = true;
+      for (let j = 0; j < seq.length; j++) {
+        const w = words[i + j];
+        const s = seq[j];
+        if (w === undefined || s === undefined) {
+          match = false;
+          break;
+        }
+        const wordText = rule.caseInsensitive ? w.text.toLowerCase() : w.text;
+        const seqText = rule.caseInsensitive ? s.toLowerCase() : s;
+        if (wordText !== seqText) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        const anchor = words[i];
+        if (anchor !== undefined) {
+          violations.push(
+            makeViolation(rule, ctx, `Banned token sequence: "${seq.join(' ')}"`, anchor),
+          );
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+function checkBannedTokenNear(
+  rule: Extract<Rule, { kind: 'banned-token-near' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const violations: Violation[] = [];
+  const words = wordTokens(tokens);
+  const anchorSet = new Set(
+    rule.anchor.caseInsensitive
+      ? rule.anchor.tokens.map((t) => t.toLowerCase())
+      : rule.anchor.tokens,
+  );
+  const nearSet = new Set(rule.near.tokens.map((t) => t.toLowerCase()));
+
+  for (let i = 0; i < words.length; i++) {
+    const anchorWord = words[i];
+    if (anchorWord === undefined) continue;
+    const candidate = rule.anchor.caseInsensitive ? anchorWord.text.toLowerCase() : anchorWord.text;
+    if (!anchorSet.has(candidate)) continue;
+
+    const lo = Math.max(0, i - rule.withinTokens);
+    const hi = Math.min(words.length - 1, i + rule.withinTokens);
+    for (let j = lo; j <= hi; j++) {
+      if (j === i) continue;
+      const nearWord = words[j];
+      if (nearWord === undefined) continue;
+      if (nearSet.has(nearWord.text.toLowerCase())) {
+        violations.push(
+          makeViolation(
+            rule,
+            ctx,
+            `Banned token "${anchorWord.text}" near "${nearWord.text}"`,
+            anchorWord,
+          ),
+        );
+        break;
+      }
+    }
+  }
+  return violations;
+}
+
+export function runTier1(_block: unknown, _rules: Rule[]): ValidationResult {
+  throw new Error(
+    'runTier1 is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)',
+  );
+}
+
+export function walkLexicalAst(_block: unknown): IterableIterator<unknown> {
+  throw new Error(
+    'walkLexicalAst is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)',
+  );
+}

--- a/packages/contracts/src/marketing-voice/index.ts
+++ b/packages/contracts/src/marketing-voice/index.ts
@@ -1,4 +1,4 @@
-export * from './tokenize.js';
+export * from './check-rule.js';
 export * from './predicates.js';
 export * from './rules.js';
-export * from './check-rule.js';
+export * from './tokenize.js';

--- a/packages/contracts/src/marketing-voice/index.ts
+++ b/packages/contracts/src/marketing-voice/index.ts
@@ -1,0 +1,4 @@
+export * from './tokenize.js';
+export * from './predicates.js';
+export * from './rules.js';
+export * from './check-rule.js';

--- a/packages/contracts/src/marketing-voice/predicates.ts
+++ b/packages/contracts/src/marketing-voice/predicates.ts
@@ -89,9 +89,7 @@ export function isAdrFilename(filename: string): boolean {
   const rest = parts.slice(3);
   if (yyyy.length !== 4 || mm.length !== 2 || dd.length !== 2) return false;
   if (
-    !Number.isFinite(Number(yyyy)) ||
-    !Number.isFinite(Number(mm)) ||
-    !Number.isFinite(Number(dd))
+    !(Number.isFinite(Number(yyyy)) && Number.isFinite(Number(mm)) && Number.isFinite(Number(dd)))
   )
     return false;
   if (Number.isNaN(Date.parse(`${yyyy}-${mm}-${dd}`))) return false;

--- a/packages/contracts/src/marketing-voice/predicates.ts
+++ b/packages/contracts/src/marketing-voice/predicates.ts
@@ -1,0 +1,120 @@
+import type { Token } from './tokenize.js';
+
+export const ENGAGEMENT_UNITS: Set<string> = new Set(['engagement', 'project', 'mo', 'week']);
+export const PRICING_TIER_BLOCK_KINDS: Set<string> = new Set(['PricingTracks']);
+
+export function stripCommas(s: string): string {
+  return s.split(',').join('');
+}
+
+export function isDollarShape(t: Token): boolean {
+  if (!t.text.startsWith('$')) return false;
+  const num = Number(stripCommas(t.text.slice(1)));
+  return Number.isFinite(num);
+}
+
+export function isPercentShape(t: Token, next: Token | undefined): boolean {
+  if (t.text.endsWith('%')) {
+    return Number.isFinite(Number(t.text.slice(0, -1)));
+  }
+  return Number.isFinite(Number(t.text)) && next?.text === '%';
+}
+
+export function isUsdShape(t: Token, next: Token | undefined): boolean {
+  return Number.isFinite(Number(t.text)) && next?.text.toLowerCase() === 'usd';
+}
+
+export function isEngagementUnit(t: Token): boolean {
+  return ENGAGEMENT_UNITS.has(t.text.toLowerCase());
+}
+
+export function isPositiveIntegerToken(t: Token): boolean {
+  const n = Number(t.text);
+  return Number.isInteger(n) && n > 0;
+}
+
+export function isIntegerWithCommas(t: Token): boolean {
+  const segments = t.text.split(',');
+  if (!segments.every((seg) => seg.length > 0 && Number.isInteger(Number(seg)))) return false;
+  return Number.isFinite(Number(stripCommas(t.text)));
+}
+
+function isAllDigits(s: string): boolean {
+  if (s.length === 0) return false;
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}
+
+export function isTrackerToken(t: Token, next: Token | undefined): boolean {
+  if (t.text === '#' && next !== undefined && isAllDigits(next.text)) return true;
+  const lower = t.text.toLowerCase();
+  if (lower === 'milestone' || lower === 'milestones') return true;
+  if (t.text.endsWith('.yml') || t.text.endsWith('.yaml')) return true;
+  return false;
+}
+
+export function isRepoLinkToken(text: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(text, 'file:///').pathname;
+  } catch {
+    return false;
+  }
+  const segments = pathname.split('/').filter(Boolean);
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (segments[i] === 'RevealUIStudio') return true;
+  }
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const next = segments[i + 1];
+    if (next === undefined) continue;
+    if (seg === 'issues' || seg === 'pull' || seg === 'pulls') {
+      if (isAllDigits(next)) return true;
+    }
+  }
+  return false;
+}
+
+export function isAdrFilename(filename: string): boolean {
+  if (!filename.endsWith('.md')) return false;
+  const stem = filename.slice(0, -3);
+  const parts = stem.split('-');
+  if (parts.length < 4) return false;
+  const yyyy = parts[0] ?? '';
+  const mm = parts[1] ?? '';
+  const dd = parts[2] ?? '';
+  const rest = parts.slice(3);
+  if (yyyy.length !== 4 || mm.length !== 2 || dd.length !== 2) return false;
+  if (
+    !Number.isFinite(Number(yyyy)) ||
+    !Number.isFinite(Number(mm)) ||
+    !Number.isFinite(Number(dd))
+  )
+    return false;
+  if (Number.isNaN(Date.parse(`${yyyy}-${mm}-${dd}`))) return false;
+  return rest.length > 0 && rest.every((seg) => seg.length > 0);
+}
+
+export function isAdrCitePath(linkUrl: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(linkUrl, 'file:///').pathname;
+  } catch {
+    return false;
+  }
+  const segments = pathname.split('/').filter(Boolean);
+  const idxDecisions = segments.findIndex(
+    (s, i) => s === 'docs' && segments[i + 1] === 'decisions',
+  );
+  if (idxDecisions === -1) return false;
+  const last = segments[segments.length - 1];
+  if (last === undefined) return false;
+  return isAdrFilename(last);
+}
+
+export function isPricingTierSourceBlock(block: { type: string }): boolean {
+  return PRICING_TIER_BLOCK_KINDS.has(block.type);
+}

--- a/packages/contracts/src/marketing-voice/rules.ts
+++ b/packages/contracts/src/marketing-voice/rules.ts
@@ -1,0 +1,82 @@
+export type Rule =
+  | { kind: 'banned-tokens'; ruleId: string; tokens: string[]; caseInsensitive: boolean }
+  | {
+      kind: 'banned-tokens-with-context';
+      ruleId: string;
+      tokens: string[];
+      unlessFollowedBy?: string[];
+      unlessPrecededByContiguous?: string[];
+    }
+  | {
+      kind: 'banned-token-sequences';
+      ruleId: string;
+      sequences: string[][];
+      caseInsensitive: boolean;
+    }
+  | {
+      kind: 'banned-token-near';
+      ruleId: string;
+      anchor: { tokens: string[]; caseInsensitive: boolean };
+      near: { tokens: string[] };
+      withinTokens: number;
+    }
+  | {
+      kind: 'h2-shape';
+      ruleId: string;
+      predicates: H2ShapePredicate[];
+      requiresSuffixToken?: string;
+    }
+  | {
+      kind: 'fake-trust';
+      ruleId: string;
+      anchor: { tokenSequence: string[]; caseInsensitive: boolean };
+      requiresProximity: 'positive-integer-token';
+      withinTokens: number;
+      unless: 'adr-cite-in-block';
+    }
+  | {
+      kind: 'pricing-proximity';
+      ruleId: string;
+      anchorPredicate: PredicateName;
+      proximityPredicate: PredicateName;
+      withinTokens: number;
+      unless: ProximityException[];
+    }
+  | {
+      kind: 'rvc-pricing-proximity';
+      ruleId: string;
+      anchorTokenLowercase: string;
+      proximityPredicates: PredicateName[];
+      withinTokens: number;
+      unless: 'adr-cite-in-block';
+    }
+  | {
+      kind: 'unicode-range-tokens';
+      ruleId: string;
+      codepointRanges: Array<{ startInclusive: number; endInclusive: number }>;
+    };
+
+export type H2ShapePredicate =
+  | { kind: 'startsWithToken'; token: string }
+  | { kind: 'startsWithTokenSequence'; tokens: string[] };
+
+export type PredicateName =
+  | 'isDollarShape'
+  | 'isPercentShape'
+  | 'isUsdShape'
+  | 'isEngagementUnit'
+  | 'isPositiveIntegerToken';
+
+export type ProximityException = 'adr-cite-in-block' | 'pricing-tier-source';
+
+export interface Violation {
+  rule: string;
+  field: string;
+  message: string;
+  span?: { start: number; end: number };
+}
+
+export interface ValidationResult {
+  passed: boolean;
+  violations: Violation[];
+}

--- a/packages/contracts/src/marketing-voice/tokenize.ts
+++ b/packages/contracts/src/marketing-voice/tokenize.ts
@@ -1,0 +1,18 @@
+export interface Token {
+  text: string;
+  kind: 'word' | 'symbol' | 'whitespace';
+  offset: number;
+}
+
+export function tokenize(text: string): Token[] {
+  const seg = new Intl.Segmenter('en', { granularity: 'word' });
+  const tokens: Token[] = [];
+  for (const part of seg.segment(text)) {
+    tokens.push({
+      text: part.segment,
+      kind: part.isWordLike ? 'word' : part.segment.trim() === '' ? 'whitespace' : 'symbol',
+      offset: part.index,
+    });
+  }
+  return tokens;
+}


### PR DESCRIPTION
## Summary

NET-NEW shared primitives at `packages/contracts/src/marketing-voice/` — `Token` + `tokenize` (`Intl.Segmenter`), typed predicate library, `Rule` discriminated union, and `checkRule(rule, tokens, ctx)` dispatcher. **Zero authored regex** (verified via the fleet's regex-authored audit script).

Implements GAP-204 (internal gap tracker). Prerequisite for GAP-192 (`claim-drift.ts` regex retirement). Foundation for the marketing-CMS spec Phase B runtime validators (`runTier1` + Lexical walker).

- Execution spec lives in the internal coordination repo
- Architecture: marketing-CMS spec §5.2.1 — shapes built **exactly** so Phase B consumes, doesn't redefine

## What's implemented (the 4 claim-drift-needed variants)

`checkRule(rule, tokens, ctx)` dispatches on `rule.kind`:
- `banned-tokens` — `Set` lookup, optional case-insensitive
- `banned-tokens-with-context` — `unlessFollowedBy` + `unlessPrecededByContiguous` (e.g. `Studio` unless preceded by `RevealUI`)
- `banned-token-sequences` — word-only sliding window
- `banned-token-near` — bidirectional window via `withinTokens` (spec was silent on direction; bidirectional is the defensive choice)

## What's deferred to CMS-spec Phase B (throws explicit error)

- `h2-shape`, `fake-trust`, `pricing-proximity`, `rvc-pricing-proximity`, `unicode-range-tokens` — variant types exist in the `Rule` union (Phase B will add the checkers); dispatch throws `'… not yet implemented — deferred to CMS-spec Phase B'`
- `runTier1` + `walkLexicalAst` — Block-walking surfaces; also throw deferred. The signatures Phase B will use are in §5.2.1.

## Zero authored regex (verified)

Audit invoked against `packages/contracts/src/marketing-voice` reports:
- Total regex:   0
- Authored:      0

## Tests

`packages/contracts/src/marketing-voice/__tests__/` — **107 new tests** (15 tokenize + 64 predicates + 28 check-rule). All green.

```
Test Files  33 passed (33)
Tests       946 passed (946)
```

Coverage notes:
- Tokenizer hyphenation behavior pinned by tests (`auto-scaling`, `sign-on`, `air-gapped`, `on-prem` all split as `word`+`symbol`+`word` — claim-drift configs should list each segment)
- `banned-tokens-with-context` validates the `Studio` / `RevealUI Studio` case-sensitive precedence rule end-to-end
- `banned-token-near` covers bidirectional + too-far-apart + case-insensitive anchor
- Deferred variants assert the explicit throw message

## Pre-existing build error (not caused by this PR)

`pnpm --filter @revealui/contracts build` surfaces ONE pre-existing error:

```
src/generated/zod-schemas.ts(14,25): TS2307 Cannot find module '@revealui/db/schema'
```

Verified unchanged by this PR: `git diff origin/test..HEAD -- packages/contracts/src/generated/zod-schemas.ts` is empty. The error exists on `origin/test` independently of these changes. Flagging so reviewers don't attribute it to this PR.

## Test plan

- [ ] CI: Quality (Biome / claim-drift hard-fail / boundary)
- [ ] CI: Typecheck across affected workspaces
- [ ] CI: Unit + Integration tests
- [ ] CI: CodeQL + security
- [ ] Confirm GAP-185 inventory tool reports 0 authored regex in CI
- [ ] Build step may surface the pre-existing `zod-schemas.ts` TS2307 — tracked separately, not in this PR's scope
- [ ] Verify the new `@revealui/contracts/marketing-voice` subpath resolves from a consumer (will land when GAP-192's claim-drift refactor imports it)
