### PR TITLE
chore(contracts): demote 1.4.0 to 0.4.0 per versioning conventions

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @revealui/contracts
 
+## 0.4.0
+
+### Retroactive demotion: 1.4.0 → 0.4.0
+
+This package never met the 1.0.0 promotion criteria laid out in `docs/methodology.md` versioning conventions (real external consumers, stable contract across multiple release cycles, breaking-change discipline). It should have stayed pre-1.0 like every other `@revealui/*` package (`@revealui/core` at 0.6.0, `@revealui/db` at 0.4.0, etc.).
+
+Per the April 2026 precedent (`revealui-doctor` / `-handoff` / `-sync-lts` demoted from `2.0.0` to `0.2.0`), the iteration count is preserved as the minor: `1.4.0` → `0.4.0`.
+
+**Action required for npm consumers:**
+
+- Published `1.x` versions on npm have been deprecated.
+- Install `^0.4.0` going forward.
+- API surface is unchanged — this is a version-string fix, not a behavior change.
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/contracts",
-  "version": "1.4.0",
+  "version": "0.4.0",
   "description": "Single source of truth for Zod schemas and TypeScript types shared across packages and apps. Ships with RevealUI.",
   "keywords": [
     "contracts",

--- a/packages/openapi/contracts.openapi.json
+++ b/packages/openapi/contracts.openapi.json
@@ -3,7 +3,7 @@
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "info": {
     "title": "RevealUI Contracts (Types Mirror)",
-    "version": "1.4.0",
+    "version": "0.4.0",
     "description": "OpenAPI 3.1 mirror of `@revealui/contracts` Zod schemas, emitted by `@revealui/openapi`'s `scripts/emit-from-mcp.ts` from the MCP contracts catalog. Drives cross-language codegen (Go via `oapi-codegen`, Rust via `progenitor`) so per-language consumers replace hand-mirrors with generated types from a single source of truth. See `docs/decisions/2026-05-03-contracts-protocol-pyramid.md` §Phase 3 in the revealui-jv repo.",
     "license": {
       "name": "MIT",


### PR DESCRIPTION
## Summary

- Demote `@revealui/contracts` from `1.4.0` → `0.4.0`. It's the only `@revealui/*` package above `0.x`; every other (core 0.6.0, db 0.4.0, ai 0.4.0, etc.) is correctly pre-1.0.
- Per April 2026 precedent (revealui-doctor / -handoff / -sync-lts demoted `2.0.0` → `0.2.0`), iteration count preserved as the minor.
- Regenerate `packages/openapi/contracts.openapi.json` mirror to match (one-line diff: `info.version`).

## Why now

- M11 charge-readiness has subscription billing days away; demoting before paid users exist is strictly cheaper than after.
- API surface unchanged — this is a version-string fix, not a behavior change.

## Test plan

- [x] Full repo build green (`pnpm build`, 30/30)
- [x] Pre-push gate PASS (17/17 checks including version policy + contracts OpenAPI mirror drift)
- [ ] CI on `test` re-runs the same gate (sanity)
- [ ] After `0.4.0` lands on npm via `pnpm changeset:publish`, run `npm deprecate "@revealui/contracts@>=1.0.0 <2.0.0" "Demoted to 0.x per versioning conventions; install ^0.4.0"`
- [ ] Update revealuistudio.com agency-site pin in its repo (separate PR)

## Notes

- Two pending changesets are queued (`contracts-add-secrets-subpath` minor, `contracts-drop-dead-agent-memory` patch). They'll bump `0.4.0` → `0.5.0` on the next `pnpm changeset version`. That's fine — the demotion gives a clean baseline for those normal forward bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
