### PR TITLE
promote: test -> main (claim-drift gate + CLAUDE.md package map sync)

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -6,7 +6,6 @@
       "dependencies": [
         "@revealui/ai",
         "@revealui/mcp",
-        "@revealui/editors",
         "@revealui/services",
         "@revealui/harnesses"
       ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 > via npm rather than via workspace links — same brand surface, decoupled
 > repo + deploy cadence.
 
-### OSS Packages (MIT)
+### OSS Packages (MIT) — 21
 | Package | Purpose |
 |---------|---------|
 | @revealui/core | admin engine, REST API, auth, rich text, admin UI, plugins |
@@ -68,11 +68,14 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/resilience | Circuit breaker, retry, bulkhead patterns |
 | @revealui/security | Headers, CORS, RBAC/ABAC, encryption, audit, GDPR |
 | create-revealui | `npm create revealui` initializer |
-| @revealui/dev | Shared configs (Biome, TS, Tailwind) |
+| revealui | Meta-installer that proxies to `create-revealui` (unpublished — npm name collision) |
+| @revealui/dev | Shared configs (Biome, TS, Tailwind, Vite) + editor config sync (Zed, VS Code) |
 | @revealui/test | E2E specs (Playwright), integration tests, fixtures, mocks, test utilities |
-| @revealui/editors | Editor config sync (Zed, VS Code, Cursor) |
+| @revealui/scripts | Shared utilities for monorepo scripts — logging, paths, exec, workflow state, validation (internal) |
+| @revealui/openapi | Type-safe OpenAPI 3.x for Hono — route definitions, Zod validation, spec generation + Swagger UI |
+| @revealui/paywall | Runtime license enforcement, feature gating, and upgrade UI (Stripe + x402) |
 
-### Pro Packages (Fair Source  -  FSL-1.1-MIT, converts to MIT after 2 years)
+### Pro Packages (Fair Source  -  FSL-1.1-MIT, converts to MIT after 2 years) — 5
 | Package | Purpose |
 |---------|---------|
 | @revealui/ai | AI agents, CRDT memory, LLM providers, orchestration |

--- a/apps/docs/public/fleet/revcon.md
+++ b/apps/docs/public/fleet/revcon.md
@@ -1,0 +1,62 @@
+---
+title: "RevCon"
+description: "Centralized editor configurations and agent-rule sync for RevealUI projects. Symlinks edit propagate instantly without committing downstream."
+category: fleet
+audience: developer
+---
+
+# RevCon
+
+**Centralized editor configurations for RevealUI projects.**
+
+> RevCon is a separate fleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revcon](https://github.com/RevealUIStudio/revcon) (its package historically shipped under the name `editor-configs`). This page summarises what RevCon is; the canonical product README lives in the RevCon repo.
+
+## What RevCon is
+
+A **non-monorepo, non-published convention bundle** that ships:
+
+- **Editor configs** for Zed, VS Code, and Cursor — symlinked into target projects so edits propagate instantly without commits to the target repo.
+- **Profiles** — per-project rule packs (e.g. `revealui` profile applies RevFleet's Claude Code rules + Cursor rules + agent skill files).
+- **`link.sh` / `unlink.sh`** — installer + remover. Supports `--target`, `--profile`, `--editor`, and `--dry-run`.
+
+```bash
+# Link into a project with the revealui profile
+./link.sh --target ~/revfleet/revealui --profile revealui
+
+# Link base configs only (no profile)
+./link.sh --target ~/projects/RevealCoin
+
+# Link a single editor
+./link.sh --target ~/revfleet/revealui --profile revealui --editor zed
+
+# Preview without changes
+./link.sh --dry-run --target ~/revfleet/revealui --profile revealui
+
+# Remove symlinks
+./unlink.sh --target ~/revfleet/revealui
+
+# List available profiles
+./link.sh --list
+```
+
+## How it composes with RevealUI
+
+- **New contributor flow**: clone RevealUI, then `pnpm dlx revcon sync` (or run RevCon's `link.sh` against the checkout). They get the team's editing posture, agent rules, and convention files. No drift.
+- **Cross-fleet consistency**: the same RevCon profile installs Claude Code rules into RevealUI, RevDev, RevVault, RevealCoin, and RevForge. One source of truth for *"how do agents behave in our codebases."*
+- **Symlinks, not copies**: edits to RevCon master files propagate to every linked project on filesystem refresh — no per-repo PRs to keep configs in sync.
+
+## Important: not gated by Pro license
+
+There is no `@revealui/editors` package inside the RevealUI monorepo. RevCon is intentionally decoupled from the RevealUI runtime — editor profiles evolve on a different cadence than the core packages and are not gated by the Pro license. Anyone can install RevCon against any project, paid tier or not.
+
+If a doc on this site says *"the `@revealui/editors` package"*, that's stale text — the canonical product is RevCon.
+
+## Status
+
+Active.
+
+## See also
+
+- [RevFleet overview](../REVFLEET) — how RevCon relates to the rest of RevFleet
+- [`/pro/editors`](/pro/editors) — Pro-docs page that points back to RevCon
+- [RevCon README](https://github.com/RevealUIStudio/revcon/blob/main/README.md) — canonical product docs

--- a/apps/docs/public/fleet/revdev.md
+++ b/apps/docs/public/fleet/revdev.md
@@ -1,0 +1,56 @@
+---
+title: "RevDev"
+description: "Native developer tools for RevealUI: Studio (Tauri 2 desktop) and Console (Go SSH TUI), backed by a shared harness daemon."
+category: fleet
+audience: developer
+---
+
+# RevDev
+
+**Native developer tools for [RevealUI](https://github.com/RevealUIStudio/revealui). One product, two interfaces.**
+
+> RevDev is a separate RevFleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev). This page summarises what RevDev is and how it composes with RevealUI; the canonical product README lives in the RevDev repo.
+
+## What RevDev ships
+
+| Interface | Stack | Use case |
+|---|---|---|
+| **Studio** | Tauri 2 + React 19 (desktop) | AI editor + agent coordination dashboard. Visual hypervisor view, agent task feed, manual approvals, tool routing. Daily-driver UI for someone running RevealUI agents. |
+| **Console** | Go + Bubble Tea (SSH TUI) | Ops cockpit. Agent health, deploys, billing, alerts. Designed to run inside an SSH session for production triage. |
+| **Harness Daemon** | Node.js | Shared backend for both UIs. Coordinates AI agents, manages PTY sessions, routes JSON-RPC tool calls. Talks to the RevealUI API (Hono on Vercel) for everything customer-data-shaped. |
+
+```
+┌─────────┐     ┌──────────┐
+│ Studio  │     │ Console  │
+│ (Tauri) │     │   (Go)   │
+└────┬────┘     └────┬─────┘
+     │   JSON-RPC    │
+     └───────┬───────┘
+             │
+     ┌───────┴────────┐
+     │ Harness Daemon  │
+     │   (Node.js)     │
+     └───────┬────────┘
+             │
+     ┌───────┴────────┐
+     │  RevealUI API   │
+     │ (Hono / Vercel) │
+     └────────────────┘
+```
+
+## How it composes with RevealUI
+
+- **Studio talks to your RevealUI deployment.** Point Studio at `https://your-api.example.com`; Studio reads agent tasks, marketplace transactions, license state, and content collections through the RevealUI API.
+- **The harness daemon is where Claude Code / Cursor / other AI agents plug in.** Agents launched from Studio use the daemon's JSON-RPC tool registry to call RevealUI primitives (sign in as a user, create a content row, refund a charge, publish an MCP server, etc.).
+- **A RevealUI Pro license unlocks Studio's commercial features.** The harness daemon and Studio shell are usable against any RevealUI install (including the OSS-only Free tier); Pro-tier interactions (RAG, multi-agent orchestration, billing dashboards) require a Pro license at runtime.
+- **Console is the right tool for production incidents.** When you're on-call and SSH'd into a jump box, you don't want a desktop GUI — Console gives you the same agent / deploy / billing telemetry over a TUI.
+
+## Status
+
+Active. Pre-launch (no published binaries). The harness daemon is documented in the RevDev repo's `apps/harness/` tree; Studio in `apps/studio/`; Console in `apps/console/`.
+
+## See also
+
+- [RevealUI Pro overview](../PRO) — what the Pro tier unlocks (including Studio's Pro features)
+- [RevFleet overview](../REVFLEET) — how RevDev relates to the rest of RevFleet
+- [RevDev README](https://github.com/RevealUIStudio/revdev/blob/main/README.md) — canonical product docs

--- a/apps/docs/public/fleet/revealcoin.md
+++ b/apps/docs/public/fleet/revealcoin.md
@@ -1,0 +1,72 @@
+---
+title: "RevealCoin (RVC)"
+description: "Hybrid utility/governance/reward token on Solana Token-2022. RVC is the customer-facing on-chain ticker."
+category: fleet
+audience: developer
+---
+
+# RevealCoin
+
+**Hybrid utility / governance / reward token for the RevealUI ecosystem, built on Solana's Token-2022 program.**
+
+> RevealCoin is a separate RevFleet product. The repo is at [RevealUIStudio/revealcoin](https://github.com/RevealUIStudio/revealcoin). The customer-facing landing page is [revealcoin.revealui.com](https://revealcoin.revealui.com), deployed from `apps/revealcoin` in the RevealUI monorepo.
+
+## Token spec
+
+| Field | Value |
+|---|---|
+| **Name** | RevealCoin |
+| **Symbol (customer-facing)** | `RVC` |
+| **Decimals** | 6 |
+| **Total Supply** | 58,906,000,000 |
+| **Program** | Solana Token-2022 (Token Extensions) |
+| **Extensions** | MetadataPointer, TokenMetadata |
+| **Freeze Authority** | None (permanently renounced) |
+
+> 58,906,000,000 — US currency in circulation on August 14, 1971, the day before Nixon ended dollar–gold convertibility.
+
+## Mainnet deployment
+
+| Parameter | Value |
+|---|---|
+| **Network** | Solana Mainnet-Beta |
+| **Mint Address** | `4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo` |
+
+The mint is deployed and metadata is on-chain. **RevealCoin is pre-launch for public distribution.** The following gates are open:
+
+- **On-chain vesting** schedules for team / contributor / treasury allocations
+- **Multi-sig** controls for treasury operations
+- **Raydium pool** initialization for public liquidity
+
+Until those gates close, the token is not publicly distributed and live trading is not enabled.
+
+## Internal vs external naming
+
+This is the most common drift point in the docs surface — worth memorising:
+
+- **`RVC`** is the **customer-facing on-chain ticker.** Marketing copy, customer-facing API messages, public docs, and Solana Explorer all use `RVC`.
+- **`$RVUI`** is the **internal codename.** It appears in code constants, env-var prefixes (`REVEALUI_RVUI_*`), database column names, and route paths (e.g. `/api/billing/rvui-payment`). Internal Kingdom-taxonomy lore preserved this naming through the rename to RevealCoin.
+
+Both are correct *in their respective contexts* — but a public doc that says *"RVUI payment is not available"* is leaking internal naming. Customer-visible strings should always say `RVC`.
+
+## How it composes with RevealUI
+
+When public distribution opens (post-vesting / multi-sig / Raydium gates), the integration story is:
+
+- **MCP marketplace per-call pricing in `RVC`** via the x402 protocol. Agents pay other agents in tokens.
+- **Tier-gated `RVC` rewards** for ecosystem participation (open question per pricing docs).
+- **`RVC` payment endpoint**: `POST /api/billing/rvui-payment` (route slug retains internal `rvui-` codename) — currently returns `501 RVC payment is not yet available`.
+
+None of this is live yet. Treat any doc that says *"agents can pay in `RVC` today"* as drift.
+
+## Status
+
+Devnet preview; mainnet pending 2026-Q4 per charge-readiness audit. Mint is deployed on Mainnet-Beta but public distribution is gated (vesting + multi-sig + Raydium pool not yet open).
+
+## See also
+
+- [RevFleet overview](../REVFLEET) — how RevealCoin relates to the rest of RevFleet
+- [Marketplace](../MARKETPLACE) — where RVC pricing flows in once public distribution opens
+- [HTTP 402 Payments blog post](../blog/02-http-402-payments) — payment-protocol context
+- [RevealCoin README](https://github.com/RevealUIStudio/revealcoin/blob/main/README.md) — canonical product docs
+- [revealcoin.revealui.com](https://revealcoin.revealui.com) — public landing page + tokenomics

--- a/apps/docs/public/fleet/revkit.md
+++ b/apps/docs/public/fleet/revkit.md
@@ -1,0 +1,64 @@
+---
+title: "RevKit"
+description: "Portable WSL development environment toolkit. Profile-based bootstrap for a RevealUI Studio-grade workstation."
+category: fleet
+audience: developer
+---
+
+# RevKit
+
+**Portable WSL development environment toolkit for RevealUI projects.**
+
+> RevKit is a separate fleet product. The repo is at [RevealUIStudio/revkit](https://github.com/RevealUIStudio/revkit) (product name: RevealUI DevKit). This page summarises what RevKit is; the canonical product README lives in the RevKit repo.
+
+## What RevKit is
+
+A bootstrap toolkit that takes a Windows host with WSL2 and turns it into a RevealUI Studio-grade workstation. Configurable via TOML profile presets:
+
+| Profile | Tier | RAM | Cores | Docker | Studio Drive | Ollama |
+|---|---|---|---|---|---|---|
+| `solo-dev.toml` | T0 | 8 GB | 4 | No | No | No |
+| `full-stack.toml` | T1 | 12 GB | 8 | Yes | Yes | No |
+| `ai-studio.toml` | T1+ | 16 GB | 8 | Yes | Yes | Yes |
+| `team.toml` | T1 | 16 GB | 8 | Yes | Yes | No |
+
+## Quick start
+
+```bash
+# 1. Copy a profile preset
+cp profiles/solo-dev.toml config.toml
+
+# 2. Edit your identity
+$EDITOR config.toml
+
+# 3. Render templates
+./scripts/render.sh --config config.toml --output ~/.revealui
+
+# 4. Source the environment
+echo 'for f in ~/.revealui/wsl/bashrc.d/*.sh; do source "$f"; done' >> ~/.bashrc
+```
+
+## What it ships
+
+- **Bootstrap scripts** — set up WSL2, install Nix + direnv, fnm, pnpm, Node 24, base shell aliases
+- **Shell config fragments** — sourced from `~/.revealui/wsl/bashrc.d/*.sh`
+- **Boot optimization** — `setup-wsl-boot.sh` masks 23 hardware/desktop services, disables Docker/snap auto-start (sockets preserved); cuts cold-boot time materially
+- **Editor configs** — portable Zed settings (and integrates with RevCon for the rest)
+- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Sync-AllRepos`, `Mount-WSLDev`, etc.)
+- **Sandbox drive support** — optional ext4 USB mount at `/mnt/sandbox` for offloading Docker data, models, databases, caches off the C: drive (renamed from "Forge drive" via revkit#13 MERGED 2026-05-02)
+
+## How it composes with RevealUI
+
+- **New contributor onboarding**: Joshua's standing pattern — plug a USB into a Windows host, boot WSL, run the RevKit bootstrap, you have the studio's full environment in minutes instead of hours.
+- **Reproducibility**: every dev workstation in RevFleet builds from the same RevKit profile, so behaviour is consistent (Nix version, Node version, pnpm version, shell aliases, PATH order).
+- **Pairs with RevVault**: RevKit sets up the age-identity mount path RevVault expects (`~/.age-identity/keys.txt`); RevVault provides the secrets RevKit's CI tasks need.
+
+## Status
+
+Active.
+
+## See also
+
+- [RevFleet overview](../REVFLEET) — how RevKit relates to the rest of RevFleet
+- [Local-first setup](../LOCAL_FIRST) — running RevealUI itself locally (separate concern; RevKit is the *workstation*, LOCAL_FIRST is the *runtime*)
+- [RevKit README](https://github.com/RevealUIStudio/revkit/blob/main/README.md) — canonical product docs

--- a/apps/docs/public/fleet/revskills.md
+++ b/apps/docs/public/fleet/revskills.md
@@ -1,0 +1,63 @@
+---
+title: "RevSkills"
+description: "Curated Agent Skills for modern web development. Compatible with Claude Code, Cursor, and any tool supporting the Agent Skills standard."
+category: fleet
+audience: developer
+---
+
+# RevSkills
+
+**Curated [Agent Skills](https://agentskills.io) for modern web development. Built by RevealUI Studio.**
+
+> RevSkills is a separate fleet product. The repo is at [RevealUIStudio/revskills](https://github.com/RevealUIStudio/revskills). This page summarises what RevSkills is; the canonical product README lives in the RevSkills repo.
+
+## What RevSkills is
+
+A curated collection of **`SKILL.md`-format Agent Skills** packaged for distribution. Compatible with:
+
+- **Claude Code** — load skills via the agent-skills standard
+- **Cursor** — same SKILL.md format
+- **Any tool** supporting the Agent Skills standard at [agentskills.io](https://agentskills.io)
+
+Each skill is independently versioned (per the fleet-wide pre-1.0 SemVer rule) and reviewed before publication.
+
+## Install
+
+```bash
+# All skills
+npx skills add RevealUIStudio/revskills
+
+# Single skill
+npx skills add RevealUIStudio/revskills --skill next-best-practices
+```
+
+## What's in the catalog
+
+The RevSkills repo organises skills by surface area. Representative entries (the canonical list lives in the RevSkills repo `skills/` directory):
+
+### Framework + app patterns
+
+- **`next-best-practices`** — Next.js 15+ App Router (RSC, PPR, caching, server actions, metadata)
+- **`tailwind-v4`** — Tailwind CSS v4 (`@theme`, CSS-first config, CVA, migration from v3)
+- **`security-hardening`** — OWASP Top 10 (CSP, CORS, auth, rate limiting, XSS, CSRF)
+
+### Data + sync
+
+(See the RevSkills repo for the full per-skill list — this is a representative sample, not exhaustive.)
+
+## How it composes with RevealUI
+
+- **Agents working inside RevealUI repos** inherit consistent behaviour by loading the relevant RevSkills entries — no per-developer skill duplication.
+- **Cross-suite consistency**: the same skills are loaded into RevealUI, RevDev, RevVault, RevForge etc. when an agent works against any fleet product.
+- **Pairs with RevCon**: RevCon ships the *symlink mechanism* for editor configs and rule files; RevSkills ships the *content* of agent skills. Together they give a new contributor the full agent posture in one bootstrap.
+
+## Status
+
+Active.
+
+## See also
+
+- [RevFleet overview](../REVFLEET) — how RevSkills relates to the rest of RevFleet
+- [RevCon](./revcon) — symlink machinery for editor configs and agent rules
+- [RevSkills README](https://github.com/RevealUIStudio/revskills/blob/main/README.md) — canonical product docs
+- [agentskills.io](https://agentskills.io) — the upstream Agent Skills standard

--- a/apps/docs/public/fleet/revvault.md
+++ b/apps/docs/public/fleet/revvault.md
@@ -1,0 +1,52 @@
+---
+title: "RevVault"
+description: "Age-encrypted secret vault. CLI plus Tauri 2 desktop app. 100% passage-compatible. Source of truth for every secret in RevFleet."
+category: fleet
+audience: developer
+---
+
+# RevVault
+
+**Age-encrypted secret vault with CLI and Tauri desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.**
+
+> RevVault is a separate RevFleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revvault](https://github.com/RevealUIStudio/revvault). This page summarises what RevVault is and how it composes with RevealUI; the canonical product README lives in the RevVault repo.
+
+## What RevVault is
+
+- **Encrypted at rest.** Secrets stored as `.age` files using x25519 key exchange. The age identity (`~/.age-identity/keys.txt` by convention) gates every secret in the vault.
+- **CLI**: `revvault get`, `set`, `list`, `search`, `delete`, `edit`, `export-env`. Implemented in Rust (workspace under `crates/`).
+- **Desktop app**: Tauri 2 + React 19. Search, browse, create, reveal, copy, delete, with secret-shape detection.
+- **Namespaces**: secrets organized by first path segment — `credentials/`, `ssh/`, `revealui/`, `revealcoin/`, etc.
+- **Fuzzy search**: find secrets by partial path match.
+- **Import**: migrate plaintext secret files with automatic categorisation.
+- **Path validation**: directory traversal and injection attacks blocked at the API layer.
+
+## How it composes with RevealUI
+
+RevealUI's [secrets convention](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md) is hard-rule:
+
+> Every secret RevFleet depends on lives in RevVault. Full stop.
+
+That includes API keys, database URLs, webhook secrets, JWT/session secrets, signing keys, Solana keypairs, license keys, Vercel tokens, Railway tokens, Supabase credentials, Stripe keys, OAuth client secrets, age identities, SSH keys — anything else.
+
+In practice:
+
+- **Local dev**: `revvault export-env` materializes `.env`-shaped output that direnv loads at session start. The `.env` files exist as a convenience; the RevVault entry is authoritative.
+- **CI**: GitHub Actions secrets are mirrored from RevVault by a publish step, never hand-typed.
+- **Rotation**: each credential type has a runbook entry under [`docs/CREDENTIAL-ROTATION-RUNBOOK`](../CREDENTIAL-ROTATION-RUNBOOK). Rotation updates RevVault first; downstream re-reads from the same source.
+
+The trust story compresses to one sentence: *"Secrets live in RevVault, encrypted by an age identity that doesn't leave the developer's machine."*
+
+## Pro-tier integration
+
+Per [`/docs/PRO`](../PRO), a RevealUI Pro license unlocks the **RevVault desktop app** and **rotation engine** as Pro-tier features in the Ecosystem Features table. The CLI and core crate are MIT and free for any tier.
+
+## Status
+
+Active. Production-grade for personal / studio use; commercial offering wraps existing RevealUI Pro tier.
+
+## See also
+
+- [RevFleet overview](../REVFLEET) — how RevVault relates to the rest of RevFleet
+- [Credential rotation runbook](../CREDENTIAL-ROTATION-RUNBOOK) — RevVault paths per credential type
+- [RevVault README](https://github.com/RevealUIStudio/revvault/blob/main/README.md) — canonical product docs

--- a/apps/docs/public/runbooks/checkout-smoke-production.md
+++ b/apps/docs/public/runbooks/checkout-smoke-production.md
@@ -1,0 +1,232 @@
+# Production Checkout Smoke Runbook
+
+**Who:** Owner / on-call operator (founder during initial live phase)
+**When:** Immediately after promoting `test → main` to production (post-deploy of any payment-lane change)
+**Duration:** ~10 minutes per smoke pass
+**Goal:** Confirm a real customer can complete checkout end-to-end and receive an active license. If this smoke passes, the checkout flow is revenue-ready. If it fails partially, you stop before any real customer hits the broken path.
+
+This runbook covers the **per-deploy verification smoke**. For ongoing first-72h monitoring after the initial live flip, see [`stripe-post-flip-72h-monitor.md`](./stripe-post-flip-72h-monitor.md). The two are complementary — this one runs every deploy; the other runs once after `STRIPE_LIVE_MODE=true`.
+
+---
+
+## Pre-flight (gate before running the smoke)
+
+### Required env vars (revvault-sourced — see `~/revfleet/.claude/rules/secrets.md`)
+
+| Purpose | Revvault path | Where it lands |
+|---|---|---|
+| Stripe live secret key | `revealui/prod/stripe/secret-key` | Vercel `STRIPE_SECRET_KEY` |
+| Stripe webhook secret | `revealui/prod/stripe/webhook-secret` | Vercel `STRIPE_WEBHOOK_SECRET` |
+| Cron auth secret | `revealui/prod/stripe/cron-secret` | Vercel `REVEALUI_CRON_SECRET` |
+| License signing key (Ed25519 PKCS8) | `revealui/prod/license/signing-key` | Vercel `REVEALUI_LICENSE_PRIVATE_KEY` |
+| Postgres URL | `revealui/prod/neon/postgres-url` | Vercel `DATABASE_URL` |
+| Sentry DSN | `revealui/prod/sentry/dsn` | Vercel `SENTRY_DSN` |
+| Alert email destination | `revealui/prod/alerts/email` | Vercel `REVEALUI_ALERT_EMAIL` |
+
+> **First-run verify:** the exact revvault path for `cron-secret` follows the canonical convention but should be confirmed against `revvault list revealui/prod/stripe/` on first run. If the path is different, update this table and the post-flip runbook in lockstep.
+
+Confirm each is set in Vercel:
+
+```bash
+vercel env ls --environment production | grep -E "STRIPE_|REVEALUI_|SENTRY_DSN|DATABASE_URL"
+```
+
+### Required service state
+
+- [ ] Server is running and answering `/health` (post-#796 fix; see `apps/server/src/index.ts:1339-1357` — production branch now binds the listener)
+- [ ] Stripe webhook endpoint is registered and pointing at `https://api.revealui.com/api/webhooks` (Stripe Dashboard → Developers → Webhooks)
+- [ ] All live Stripe products have `metadata.revealui_tier` set (seeded by `scripts/setup/seed-stripe.ts`; check Stripe Dashboard → Products → any product → Metadata tab)
+- [ ] The checkout session creation code sets `metadata.tier` (see Failure Mode #4 — this is a **different** metadata bag from `revealui_tier` above)
+- [ ] `pnpm stripe:seed` has run against the **production** Stripe account at least once (idempotent; safe to re-run)
+- [ ] `STRIPE_LIVE_MODE=true` is set in Vercel production environment
+
+### Health-check the server
+
+```bash
+curl -s https://api.revealui.com/health | jq .
+```
+
+> **First-run verify:** confirm the response includes a `stripe_live_mode: true` field (or equivalent). Note the exact field name and update this runbook if it differs. The startup validator at `apps/server/src/lib/validate-startup.ts:237` reads `env.STRIPE_LIVE_MODE === 'true'` — the health endpoint should surface the same boolean.
+
+### DB-backed circuit breaker status
+
+```bash
+# Query the breaker table to confirm Stripe API path is CLOSED (= healthy).
+# Schema: packages/services/src/stripe/db-circuit-breaker.ts (DB-backed; do
+# NOT use the in-memory CircuitBreaker class at packages/resilience/src/
+# circuit-breaker.ts — that's a separate implementation used elsewhere).
+psql "$DATABASE_URL" -c \
+  "SELECT name, state, failure_count, last_failure_at FROM stripe_circuit_breakers ORDER BY name;"
+```
+
+Expected: every row has `state = 'closed'` and `failure_count = 0`. If any row is `open`, the smoke will fail at Step 8 — investigate the breaker first before testing checkout.
+
+---
+
+## Customer journey (run as a real signed-in user, real card)
+
+> Use a **real card** in **live mode**. The test card numbers (`4242 4242 4242 4242`) only work in test mode and won't exercise the live webhook path. Use a personal card and refund the charge in §Rollback below.
+
+1. **Sign in** at `https://revealui.com/sign-in` as an account that does NOT currently hold a Pro license (verify in admin: user row's `tier = 'free'`).
+2. Navigate to the **pricing page** at `https://revealui.com/pricing`.
+3. Click **Get Pro** (the $49/mo subscription tier). 📸 **Screenshot:** the pricing page before clicking, to capture the rendered tier list.
+4. The frontend POSTs to the checkout-session creation endpoint, which builds a Stripe checkout session with `metadata = { tier: 'pro', revealui_user_id: <your user id> }` and returns the Stripe-hosted URL. Browser redirects to `https://checkout.stripe.com/...`.
+5. **Stripe Checkout (hosted page)** — enter your real card. 📸 **Screenshot:** the Stripe checkout page before submitting (mask the card number — keep last 4 digits visible).
+6. Submit. Stripe processes the charge and fires `checkout.session.completed` to your webhook endpoint.
+7. Browser redirects back to `https://revealui.com/checkout/success` (the configured `success_url`). 📸 **Screenshot:** the success page.
+8. Navigate to `https://app.revealui.com/` (or wherever the post-checkout app lives). Confirm a Pro-gated feature is now accessible (e.g., the AI agents panel that requires `isLicensed('pro')`). 📸 **Screenshot:** the Pro feature rendering.
+
+**Wall-clock budget:** end-to-end (steps 1-8) should complete in **under 30 seconds** on a healthy production. If step 8 doesn't show Pro features within 60 seconds, jump to the failure-mode triage below.
+
+---
+
+## Server-side observability (run in parallel with the customer journey)
+
+### Log lines to grep (Vercel function logs for the server function)
+
+```
+# Webhook received (signature OK):
+"Stripe webhook received" eventType=checkout.session.completed eventId=evt_...
+
+# License issued:
+"License generated" tier=pro customerId=cus_... userId=...
+
+# Subscription row written:
+"Subscription created" stripeSubscriptionId=sub_... tier=pro
+```
+
+If you see `"Webhook handler error"` or `"resolveTier: missing or unknown tier metadata"` in the same window — jump to the matching failure mode below.
+
+### DB state to verify (run after step 7)
+
+```bash
+# 1. Webhook event was recorded as processed
+psql "$DATABASE_URL" -c \
+  "SELECT id, type, status, created_at FROM webhook_events
+   WHERE type = 'checkout.session.completed'
+   ORDER BY created_at DESC LIMIT 5;"
+# Expected: most recent row has status='processed' and created_at within
+# the last 60 seconds.
+
+# 2. License was minted
+psql "$DATABASE_URL" -c \
+  "SELECT id, tier, revoked_at, created_at FROM licenses
+   WHERE customer_id = '<your stripe customer id>'
+   ORDER BY created_at DESC LIMIT 5;"
+# Expected: most recent row has tier='pro', revoked_at IS NULL.
+
+# 3. Subscription row exists and is active
+psql "$DATABASE_URL" -c \
+  "SELECT id, stripe_subscription_id, tier, status FROM subscriptions
+   WHERE user_id = '<your user id>' ORDER BY created_at DESC LIMIT 5;"
+# Expected: most recent row has tier='pro' and status='active'.
+
+# 4. Unreconciled-webhooks queue stayed empty (= no fallback fired)
+psql "$DATABASE_URL" -c \
+  "SELECT id, event_type, status, created_at FROM unreconciled_webhooks
+   WHERE created_at > NOW() - INTERVAL '5 minutes';"
+# Expected: zero rows. If a row appears, jump to Failure Mode #7.
+```
+
+The schema for these tables lives in `packages/db/src/schema/` (`webhook_events`, `licenses`, `subscriptions`) and `packages/db/src/schema/webhook-reconciliation.ts` (`unreconciled_webhooks`).
+
+### Sentry breadcrumb expectations
+
+Sentry (production environment, last 5 minutes) should show:
+
+- **Zero new fatal/error issues** in the webhook tag
+- A breadcrumb chain: `webhook.received` → `license.generated` → `subscription.created`
+- No `resolveTier` or `unreconciled` warnings
+
+If new errors appear, the failure mode below names the most likely root cause.
+
+---
+
+## Failure modes (7) — symptom → diagnosis → remediation
+
+### 1. Webhook signature mismatch
+
+- **Symptom:** Stripe Dashboard → Webhooks → Recent deliveries shows `400`. Server logs show `"Webhook signature verification failed"`.
+- **Cause:** `STRIPE_WEBHOOK_SECRET` in Vercel doesn't match the secret Stripe is signing with (e.g., the webhook endpoint was rotated in Stripe but Vercel wasn't updated).
+- **Fix:** Pull the current signing secret from Stripe Dashboard → Webhooks → your endpoint → Signing secret. Update via revvault: `revvault set revealui/prod/stripe/webhook-secret`. Push to Vercel: `revvault sync vercel`. Redeploy.
+
+### 2. Livemode mismatch
+
+- **Symptom:** Server logs show `"Livemode mismatch — webhook from test mode hit live handler"` (or vice versa). The webhook handler refuses the event with HTTP 400.
+- **Cause:** Test-mode events being delivered to the live endpoint, or live events to test endpoint. Usually a misconfigured Stripe webhook endpoint, or the wrong Stripe secret key in Vercel.
+- **Fix:** Confirm `STRIPE_SECRET_KEY` in Vercel starts with `sk_live_` (not `sk_test_`). Confirm Stripe Dashboard → Webhooks → your endpoint is in **Live mode** (top-right toggle). The new livemode-guard email alerts (#789, when merged) will fire to `REVEALUI_ALERT_EMAIL` for this case.
+
+### 3. DB circuit breaker open
+
+- **Symptom:** Webhook handler returns 503 with `"Circuit breaker open"`. Stripe Dashboard shows webhook delivery retries.
+- **Cause:** Repeated Stripe API failures in the last N minutes tripped the breaker (see `packages/services/src/stripe/db-circuit-breaker.ts` for thresholds + `resetTimeout`).
+- **Fix:** Investigate the underlying Stripe API failure first (Stripe status page, your error rate dashboard). Once the upstream is healthy, the breaker auto-resets after `resetTimeout`. To force-reset before then: `UPDATE stripe_circuit_breakers SET state='closed', failure_count=0 WHERE name='<breaker name>';` — but only after confirming Stripe is healthy.
+
+### 4. `resolveTier` ALERT path (session metadata missing `tier`)
+
+- **Symptom:** Server logs show `"resolveTier: missing or unknown tier metadata"` followed by the webhook handler throwing. Customer paid but no license was issued.
+- **Cause:** This is the **most-likely-to-bite** failure mode. There are **two distinct metadata bags** in Stripe:
+  - **Stripe Product** metadata: `revealui_tier`, `revealui_track`, `revealui_price_note`, `revealui_renewal` — set by `scripts/setup/seed-stripe.ts:466-478` when seeding products.
+  - **Stripe Checkout Session** metadata: `tier`, `revealui_user_id`, `github_username` — set by **the checkout-session creation endpoint** when a customer clicks "Get Pro". This is what `resolveTier` (at `apps/server/src/routes/webhooks.ts:193`, called from line 985 perpetual / line 1193 subscription) reads via `session.metadata?.tier`.
+- **Fix:** Audit the checkout-session creation endpoint (typically in `apps/server/src/routes/checkout/...` or `apps/admin/...`) and confirm the call to `stripe.checkout.sessions.create({...})` includes `metadata: { tier: 'pro' | 'max' | 'enterprise', revealui_user_id: ... }`. If missing, the server's checkout creation code shipped without that field — needs a code fix, not a config change. Until fixed, every paid checkout will hit this ALERT path.
+- **Manual recovery for the customer who already paid:** mint a license manually via the admin (`pnpm cli:license:mint --customer-id=cus_... --tier=pro`) and confirm with them.
+
+### 5. License mint failure
+
+- **Symptom:** Server logs show `"generateLicenseKey: failed"` with a JOSE/Ed25519 error.
+- **Cause:** `REVEALUI_LICENSE_PRIVATE_KEY` is malformed, missing, or the wrong key (e.g., test key in prod). License generation lives at `packages/core/src/license.ts:521` — Ed25519 JWT via `jose.SignJWT` with `jose.importPKCS8`.
+- **Fix:** Confirm the PKCS8 PEM is valid: `revvault get --full revealui/prod/license/signing-key | head -3` should start with `-----BEGIN PRIVATE KEY-----`. If malformed, regenerate per the license-key rotation runbook (see `docs/SECRETS.md`).
+
+### 6. Stripe API timeout
+
+- **Symptom:** Webhook handler logs show `"Stripe API timeout"` after 30s. Handler returns 5xx; Stripe retries.
+- **Cause:** Stripe upstream slow, network blip, or RevealUI server saturated.
+- **Fix:** Usually self-heals on Stripe's retry. If repeated, check the DB circuit breaker (Failure Mode #3) — it should be tripping. If breaker is closed but timeouts persist, scale up the server function or check Stripe status page.
+
+### 7. Unreconciled fallback
+
+- **Symptom:** Server logs show the handler returning `200 status='unreconciled'` and `sendWebhookFailureAlert` email arrived. Stripe shows the delivery as `200` (no retry from Stripe). A row appears in the `unreconciled_webhooks` table.
+- **Cause:** The handler succeeded at the outer level but failed at the inner reconciliation step (e.g., couldn't write a downstream row). This is the **intentional design** at `apps/server/src/routes/webhooks.ts:3317` — return 200 to acknowledge receipt, queue the event for replay via the `drain-unreconciled` cron, alert the operator immediately.
+- **Fix:** The `drain-unreconciled` cron will replay automatically (runs hourly per `vercel.json`). Manual replay: `curl -s -X POST https://api.revealui.com/api/cron/drain-unreconciled -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq .`. Investigate the inner error from the alert email's `Metadata` section — most common cause is a downstream DB schema mismatch.
+
+---
+
+## Success criteria (every box must be ✅)
+
+- [ ] Customer journey steps 1-8 complete in under 30 seconds
+- [ ] `/app/` shows the Pro-gated feature rendering correctly post-checkout
+- [ ] `webhook_events` row exists with `status='processed'` for the `checkout.session.completed` event
+- [ ] `licenses` row exists with `tier='pro'`, `revoked_at IS NULL`, `customer_id = <stripe customer id>`
+- [ ] `subscriptions` row exists with `status='active'` and `tier='pro'`
+- [ ] `unreconciled_webhooks` table is empty for the last 5 minutes
+- [ ] Sentry shows the expected breadcrumb chain, zero new error issues
+- [ ] Vercel function logs show the three expected log lines (webhook received, license generated, subscription created)
+- [ ] Stripe Dashboard → Recent deliveries shows the webhook delivery as `200`
+- [ ] All four screenshots captured (pricing, Stripe checkout, success page, app Pro feature)
+
+If every box is ✅, the production checkout flow is **revenue-ready**.
+
+---
+
+## Rollback (if smoke fails partially)
+
+If the smoke fails after the Stripe charge has gone through (i.e., your card was charged but you didn't get a Pro license, or the license is wrong):
+
+1. **Refund the test charge** — Stripe Dashboard → Payments → find your charge → Refund full. This is the operator's own card; refund is safe.
+2. **Void the license (if one was minted with wrong tier or for the wrong user)** — admin UI: Licenses → find the row → Revoke. Or: `UPDATE licenses SET revoked_at = NOW() WHERE id = '<license id>';`
+3. **Cancel the subscription (if one was created)** — Stripe Dashboard → Subscriptions → find → Cancel immediately, no proration.
+4. **Clean the unreconciled queue (if a row was created)** — `DELETE FROM unreconciled_webhooks WHERE event_id = '<evt_...>';` after confirming the underlying issue is fixed.
+5. **If the failure was severe (e.g., resolveTier missing on every checkout)** — set `STRIPE_LIVE_MODE=false` in Vercel and redeploy to stop accepting any new charges until the fix lands. This mirrors the post-flip runbook's escalation step.
+
+---
+
+## When to re-run this smoke
+
+- After every `test → main` promote that touches `apps/server/src/routes/webhooks.ts`, `apps/server/src/routes/checkout/`, `packages/core/src/license.ts`, `packages/services/src/stripe/`, or `scripts/setup/seed-stripe.ts`.
+- After any Vercel env var change in the `STRIPE_*` / `REVEALUI_LICENSE_*` / `DATABASE_URL` / `SENTRY_DSN` set.
+- After any Stripe Dashboard change to webhook endpoints, products, or prices.
+- Once a week at minimum during the launch window (first 30 days post-flip).
+
+---
+
+*Runbook created 2026-05-10 as part of the overnight launch convergence push. Pairs with [`stripe-post-flip-72h-monitor.md`](./stripe-post-flip-72h-monitor.md) (which covers ongoing first-72h monitoring after `STRIPE_LIVE_MODE=true`). Audit-first SDLC: every file:line citation in this runbook was grep-confirmed against `origin/test` HEAD `78387802a` before commit; the `metadata.tier` vs `metadata.revealui_tier` distinction at Failure Mode #4 was surfaced by verify-twice and is documented as the most-likely-to-bite failure mode.*

--- a/apps/docs/public/runbooks/gitleaks.md
+++ b/apps/docs/public/runbooks/gitleaks.md
@@ -1,0 +1,61 @@
+# Gitleaks scan (workflow + cutoff)
+
+The weekly Gitleaks scan (`Security` workflow → `gitleaks` job, cron Mon 09:00 UTC) walks git history. Without a cutoff, every historical finding from a long-since-rotated key reappears every Monday → alert fatigue → real new leaks risk being missed in the wash.
+
+The workflow uses `gitleaks detect --log-opts="--since=$GITLEAKS_HISTORY_SINCE"` to skip all commits dated before the cutoff. The cutoff is set to the post-#540 rotation date (2026-04-25). All known historical findings predate the cutoff and have been rotated; new commits past the cutoff still get scanned, so any newly-introduced secret fails the job.
+
+## Why date cutoff (and not `--baseline-path`)
+
+A commit-SHA-based baseline (`gitleaks detect --baseline-path baseline.json`) would suppress findings by `<commit-SHA>:<file>:<rule>:<line>` fingerprint. That fingerprint includes the commit SHA, which **changes whenever the ancestor commit graph is rewritten** — peer rebases, merge trains, force-pushes, history surgery. Each rewrite renders the baseline stale and must be regenerated.
+
+The date cutoff has no SHA dependency. As long as the historical commit's *date* stays before the cutoff (which it always will — git commit dates don't move under rebases), it stays suppressed. The cost: a leak someone intentionally backdates via interactive rebase to a pre-cutoff commit would not be caught by the weekly scheduled scan. That is a narrow attack surface; the working-tree scan (`.gitleaks.toml` `[allowlist]`) still catches active leaks.
+
+## When to bump the cutoff
+
+Raise `GITLEAKS_HISTORY_SINCE` in `.github/workflows/security.yml` after **any major credential rotation** that introduces a transient leak commit. The cutoff makes the rotation commit itself invisible to future scheduled scans, so the per-rotation rotation noise stops repeating every Monday.
+
+Don't bump for routine PRs or doc changes — the cutoff only needs to move when a real-but-rotated secret has just landed in git history.
+
+Don't lower it. The window between the previous cutoff and any newer cutoff is unscanned by scheduled jobs; that's only safe if the leaks in that window have all been rotated.
+
+## Verify the gate still catches new leaks
+
+After any workflow change, prove detection still works on a throwaway branch:
+
+```bash
+git checkout -b chore/gitleaks-smoke
+
+# Add a synthetic test secret with an obvious sentinel
+cat > /tmp/leak-test.ts <<'EOF'
+const fake = "sk_live_LEAKED_TEST_VALUE_DELETE_ME_BEFORE_PUSH"
+EOF
+git add /tmp/leak-test.ts && git commit -m 'test: gitleaks smoke (DELETE ME)'
+
+# Run the same command CI uses (skip --since to scan working tree too)
+gitleaks detect --no-banner --redact --config .gitleaks.toml
+# Expected: leaks found: 1, exit non-zero
+
+# Clean up — never push the smoke commit
+git reset --hard HEAD~1
+git checkout test
+git branch -D chore/gitleaks-smoke
+```
+
+## How to tell if the workflow regressed
+
+After any change to `.github/workflows/security.yml` `gitleaks` job, watch the next Monday scheduled run output. The healthy pattern is a small commit count + `INF no leaks found` + exit 0:
+
+```
+INF 88 commits scanned.
+INF scanned ~1.6 MB in 1.5s
+INF no leaks found
+```
+
+A failure dumps a JSON report as the `gitleaks-report` artifact (uploaded on failure only, 7-day retention) — download from the run page and inspect with `jq`.
+
+## Cross-references
+
+- Workflow: `.github/workflows/security.yml` → `gitleaks` job
+- Working-tree allowlist (paths/patterns): `.gitleaks.toml` `[allowlist]`
+- Per-finding allowlist: `.gitleaksignore`
+- Rotation prerequisite: rotate the leaked credential *before* bumping the cutoff (rotation procedures live in the private `~/revfleet/.jv/scripts/rotation/` toolkit; follow whichever script matches the credential class)

--- a/apps/docs/public/runbooks/stripe-post-flip-72h-monitor.md
+++ b/apps/docs/public/runbooks/stripe-post-flip-72h-monitor.md
@@ -1,0 +1,174 @@
+# Stripe Post-Flip 72h Monitor Runbook
+
+**Who:** On-call operator (founder during initial live phase)
+**When:** Immediately after setting `STRIPE_LIVE_MODE=true` and deploying to production
+**Duration:** First 72 hours of live-mode operation
+**Goal:** Confirm every real-money path produces the expected signals; catch any silent failure within minutes rather than days
+
+---
+
+## Pre-requisites (gate before flipping)
+
+Before starting this runbook, confirm:
+
+- [ ] `SENTRY_DSN` is set in the Vercel production environment and appears in `REQUIRED_IN_PRODUCTION_HOSTED` (validated at boot by `apps/server/src/lib/validate-startup.ts`)
+- [ ] `REVEALUI_ALERT_EMAIL` is set and routes to a monitored mailbox
+- [ ] At least one test transaction completed successfully in Stripe test mode (full checkout → license issuance → customer portal)
+- [ ] The billing-readiness cron (`/api/cron/billing-readiness`) returned `status: ok` within the last 24h
+- [ ] Stripe webhook endpoint is registered and receiving events (verify in Stripe Dashboard → Developers → Webhooks)
+
+---
+
+## Alert wiring (as of Phase 1 audit fix — J-P0-1 / J-P0-2)
+
+All critical cron failures now route through `sendCronFailureAlert` (implemented in `apps/server/src/lib/cron-alerts.ts`). This function:
+
+1. **Always logs** at the configured severity via `@revealui/core/observability/logger` (visible in Vercel function logs)
+2. **Captures to Sentry** via `Sentry.captureException` when `SENTRY_DSN` is set — tagged with `cron_job` and `alert_severity`
+3. **Sends email** to `REVEALUI_ALERT_EMAIL` with structured subject `[CRON FAILURE] <jobName>: <error.message>`
+
+The five reconciliation crons now call `sendCronFailureAlert` on critical failures:
+
+| Cron | File | Alert trigger |
+|------|------|---------------|
+| `reconcile-subscriptions` | `apps/server/src/routes/cron/reconcile-subscriptions.ts` | `missing-in-stripe` drift; `status-mismatch` that ends entitlement |
+| `drain-unreconciled` | `apps/server/src/routes/cron/drain-unreconciled.ts` | Event unresolved >24h and replay failed |
+| `reconcile-customers` | `apps/server/src/routes/cron/reconcile-customers.ts` | Newly-detected orphaned Stripe customer |
+| `marketplace-payouts` | `apps/server/src/routes/cron/marketplace-payouts.ts` | Individual transfer failure; outer cron crash |
+| `billing-readiness` | `apps/server/src/routes/cron/billing-readiness.ts` | Any check failure |
+
+**Important:** `sendCronFailureAlert` is additive — it runs alongside the existing `logger.error` call and never replaces it. Vercel function logs are always populated regardless of whether Sentry or email delivery succeeds.
+
+---
+
+## Hour 0–4: Immediately post-flip
+
+### 1. Confirm Sentry is receiving events
+
+Trigger a synthetic error by hitting an authenticated route with a deliberately malformed payload and checking Sentry for the capture:
+
+```bash
+# Confirm the server is up and Sentry is initialised (look for DSN in startup log)
+curl -s https://api.revealui.com/health | jq .
+
+# Check Sentry project for any boot-time issues
+# Sentry Dashboard → Issues → filter by environment:production, last 1h
+```
+
+Sentry should show at least one event from the server startup within the first deploy. If the Issues list is completely empty after 30 minutes, verify `SENTRY_DSN` is set correctly and the Vercel deployment picked it up (`vercel env ls --environment production`).
+
+### 2. Confirm webhook endpoint is live
+
+```bash
+# Stripe CLI — forward events and confirm revealui's handler returns 200
+stripe listen --forward-to https://api.revealui.com/api/webhooks
+```
+
+Or verify in Stripe Dashboard: Developers → Webhooks → your endpoint → Recent deliveries. Every delivery should show `200` status. Any `4xx`/`5xx` means the handler is broken.
+
+### 3. Confirm billing-readiness cron passes
+
+Trigger manually:
+
+```bash
+curl -s -X POST https://api.revealui.com/api/cron/billing-readiness \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq .status
+# Expected: "ok"
+```
+
+If `status: failed`, check the `failures` array in the response. Common causes: missing Stripe price IDs, missing `billing_catalog` DB rows, Stripe key mismatch. Fix before accepting real traffic.
+
+---
+
+## Hour 4–24: First real-transaction window
+
+### 4. Watch reconciliation crons
+
+The reconciliation crons run on Vercel's cron schedule (see `vercel.json`). During the first 24h, manually trigger each one and confirm clean output:
+
+```bash
+# reconcile-subscriptions
+curl -s -X POST https://api.revealui.com/api/cron/reconcile-subscriptions \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, drift, critical}'
+# Expected: critical: 0
+
+# drain-unreconciled
+curl -s -X POST https://api.revealui.com/api/cron/drain-unreconciled \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, replayed, critical}'
+# Expected: critical: 0 (or 0 scanned if queue is empty)
+
+# reconcile-customers
+curl -s -X POST https://api.revealui.com/api/cron/reconcile-customers \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq '{scanned, orphaned, alerted}'
+# Expected: alerted: 0
+```
+
+**If `critical > 0`:** you will have already received an alert email and a Sentry event via `sendCronFailureAlert`. Check those for the specific account IDs / event IDs and investigate in Stripe Dashboard before the customer notices.
+
+### 5. Monitor alert email inbox
+
+Check `REVEALUI_ALERT_EMAIL` inbox. Expected subject patterns that indicate real problems:
+
+- `[CRON FAILURE] reconcile-subscriptions: CRITICAL: missing-in-stripe for account ...` — a customer's subscription exists in our DB but not in Stripe. Manual fix required.
+- `[CRON FAILURE] drain-unreconciled: CRITICAL: event ... unresolved >24h and replay failed` — a webhook event is stuck. Investigate the `unreconciledWebhooks` table.
+- `[CRON FAILURE] reconcile-customers: CRITICAL: orphaned Stripe customer ...` — Stripe customer with no local row. Check if checkout completed without webhook delivery.
+- `[CRON FAILURE] marketplace-payouts: ...` — a Stripe Connect transfer failed.
+- `[CRITICAL] RevealUI: Webhook handler crashed — checkout.session.completed` — sent by `sendWebhookFailureAlert` (separate from the cron alerts); means a customer paid but may not have received their license. **Act within 1 hour.**
+
+---
+
+## Hour 24–72: Steady-state monitoring
+
+### 6. Check Sentry error volume
+
+Sentry Dashboard → Performance and Issues. Acceptable error volume in the first 72h:
+
+- `0` fatal issues
+- `< 5` distinct error types (mostly expected: 4xx client errors, occasional Stripe network hiccup)
+
+If you see payment-path errors clustering (e.g., multiple `checkout.session.completed` failures), the webhook handler has a bug. Take the site to maintenance mode (`STRIPE_LIVE_MODE=false` redeploy) rather than letting customers hit broken checkout.
+
+### 7. Confirm no silent cron drift
+
+After 72h, run the reconciliation suite one more time and confirm `critical: 0` across all three crons. If `drain-unreconciled` shows `critical > 0`, at least one webhook event has been stuck for >24h — investigate before the 72h window closes.
+
+---
+
+## Verifying alerts work (smoke test)
+
+To confirm `sendCronFailureAlert` is wired end-to-end before a real incident:
+
+```bash
+# 1. Trigger a synthetic billing-readiness failure by temporarily removing a
+#    required env var in a preview deployment (NOT production):
+#    Remove STRIPE_PRO_PRICE_ID from the preview environment.
+
+# 2. Trigger the cron in the preview deployment:
+curl -s -X POST https://<preview-url>/api/cron/billing-readiness \
+  -H "X-Cron-Secret: $REVEALUI_CRON_SECRET" | jq .
+
+# 3. Confirm within 2 minutes:
+#    a. REVEALUI_ALERT_EMAIL inbox has a message with subject
+#       "[CRON FAILURE] billing-readiness: Billing readiness check failed: ..."
+#    b. Sentry shows a new issue tagged cron_job=billing-readiness
+#    c. Vercel function logs show the logger.error line
+
+# 4. Restore the env var before the preview deployment is used for anything else.
+```
+
+This smoke test validates all three legs of `sendCronFailureAlert` (log → Sentry → email) without touching production.
+
+---
+
+## Escalation
+
+If any critical alert fires and you cannot identify the root cause within 30 minutes:
+
+1. Set `STRIPE_LIVE_MODE=false` and redeploy — this stops new live charges while you investigate
+2. Check Stripe Dashboard → Events for any failed charges or webhook delivery failures in the last hour
+3. Check `unreconciledWebhooks` table for new rows
+4. Open a GitHub issue in `RevealUIStudio/revealui` tagged `severity:critical billing`
+
+---
+
+*Runbook created 2026-05-09 as part of Phase 1 audit P0 fix (J-P0-3). Alert wiring (J-P0-1 / J-P0-2) implemented in the same PR.*

--- a/apps/docs/public/runbooks/vercel-env-sync.md
+++ b/apps/docs/public/runbooks/vercel-env-sync.md
@@ -1,0 +1,118 @@
+# Vercel env sync — operator runbook
+
+`revvault` is the canonical store for every Vercel-runtime secret in this monorepo. This runbook covers the day-to-day workflow.
+
+## Prerequisites (one-time)
+
+1. **revvault binary** with PR [RevealUIStudio/revvault#40](https://github.com/RevealUIStudio/revvault/pull/40) (per-var path overrides).
+
+   ```bash
+   cd ~/revfleet/revvault && cargo install --path crates/cli
+   revvault --version  # 0.1.0+ with `vars` table support
+   ```
+
+2. **VERCEL_TOKEN** environment variable. Create at [Vercel → Settings → Tokens](https://vercel.com/account/tokens) (scope: project access, `revealuistudio` org). Export from your shell profile:
+
+   ```bash
+   export VERCEL_TOKEN=...
+   ```
+
+   Or pass `--token` per-command.
+
+3. **Manifest:** [`scripts/sync/revvault-vercel.toml`](../../scripts/sync/revvault-vercel.toml). Drives sync — see comments inside for the schema.
+
+## Common workflows
+
+### Add a new secret
+
+```bash
+# 1. Add the value to revvault at its canonical path
+revvault set revealui/prod/<subsystem>/<name-kebab>
+
+# 2. Map it in the manifest (scripts/sync/revvault-vercel.toml)
+#    Add a [projects.<slug>.vars] entry: VERCEL_VAR_NAME = "revealui/prod/..."
+
+# 3. Dry-run first to see what'd change
+pnpm vercel:sync
+
+# 4. Apply
+pnpm vercel:sync:apply
+
+# 5. Redeploy the affected Vercel project so the new env hits runtime
+```
+
+### Rotate an existing secret
+
+```bash
+# 1. Set the new value in revvault (overwrites old)
+revvault set <canonical-path> --force
+
+# 2. Dry-run shows it as Update
+pnpm vercel:sync
+
+# 3. Apply
+pnpm vercel:sync:apply
+
+# 4. Redeploy
+```
+
+### Backfill (bootstrap a fresh vault from existing Vercel vars)
+
+There is **no `--pull` command.** `revvault sync` is strictly one-way —
+vault → Vercel — as of revvault 0.2.0. The reverse direction was removed
+in the durable redesign after the 2026-05-09 corruption incident, where a
+Vercel API change caused `--pull` to overwrite canonical vault paths with
+ciphertext/empty values. See the revvault `CHANGELOG.md` for the rationale.
+
+Seeding a fresh vault from secrets that currently only exist on Vercel is a
+deliberate **one-shot manual operation**, not a recurring sync command — for
+each var, read the value out of Vercel and `revvault set` it at its canonical
+path. Once the vault holds the value, `pnpm vercel:sync:apply` keeps Vercel in
+sync from then on.
+
+### Drift check (read-only)
+
+For CI or pre-deploy validation:
+
+```bash
+pnpm vercel:drift-check
+```
+
+Outputs JSON describing every variable's diff state per project (Add / Update / Orphan / Skip). Non-blocking — sync drift is a warning, not a build failure.
+
+## What the diff actions mean
+
+| Symbol | Action | Meaning |
+|---|---|---|
+| `+` | Add | Vault has a value, Vercel doesn't — push will create |
+| `~` | Update | Both sides have the value — push will overwrite Vercel from vault |
+| `!` | Orphan | Vercel has a value, vault doesn't — manual cleanup needed (sync never deletes from Vercel) |
+| `-` | Skip | In manifest's `skip` list — sync never touches |
+
+## Anti-patterns to avoid
+
+- **Editing Vercel env directly via the dashboard** — sync drift inevitable. Always go through revvault + `pnpm vercel:sync:apply`.
+- **Storing secrets in `.env.local` or env files committed to git** — pre-commit hook blocks `.env*`; if the hook ever fails, the file becomes the canonical source instead of revvault. Revvault first, always.
+- **`pnpm vercel:sync:apply` without a dry-run first** — habit, not a hard rule. Dry-run is the default for a reason.
+
+## When sync goes sideways
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Cannot read manifest` | working directory mismatch | run from `~/revfleet/revealui` (root); pnpm scripts handle this |
+| `403 Forbidden` from Vercel | `VERCEL_TOKEN` wrong/expired | regenerate token; export new value |
+| Var shows as `Add` even though it's already on Vercel | `vault_prefix` mismatch | check the manifest's project block matches the actual Vercel project ID |
+| `Orphan` warnings stack up | values added directly via Vercel UI | for each: add to manifest's `vars` table OR add to `skip` list with reason |
+| Vault path resolution surprises | `vars` override vs. prefix-derived collision | run `pnpm vercel:sync` (dry-run, JSON mode) and check the resolved paths in the diff |
+
+## Out of scope (deferred to v2)
+
+- Preview + development env target sync — production-only in v1 per [`vercel-env-canonical-mapping.md`](../../../revealui-jv/docs/vercel-env-canonical-mapping.md) Q4
+- Per-var Sensitive flag policy — gated on revvault adding `var_type` plumbing per concern C2 in the design doc
+- Auto-rotation chain — `revvault rotate <path>` triggering Vercel sync; design doc Phase 5
+
+## See also
+
+- Design doc: [`~/revfleet/.jv/docs/revvault-vercel-sync.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/revvault-vercel-sync.md)
+- Canonical env-var mapping: [`~/revfleet/.jv/docs/vercel-env-canonical-mapping.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/vercel-env-canonical-mapping.md)
+- Secrets rule: [`~/revfleet/.claude/rules/secrets.md`](../../../.claude/rules/secrets.md)

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -137,8 +137,9 @@ Note: `npx create-revealui` scaffolds a working basic-blog from npm templates  -
 | `@revealui/ai` | AI agents, memory, LLM orchestration | 40+ files, 18 import subpaths, real agents | ~80% |
 | `@revealui/mcp` | 13 MCP servers | **13 server files** (plus adapters/utils) | ~90% |
 | `@revealui/harnesses` | AI coordination, workboard | 196 tests, JSON-RPC 2.0, content layer | ~95% |
-| `@revealui/editors` | Editor config sync | 20+ files, 6 test files | ~70% |
 | `@revealui/services` | Stripe + Supabase integrations | 354 tests passing | ~85% |
+
+> Editor config sync ships as [**RevCon**](https://github.com/RevealUIStudio/revcon), a separate fleet repo — not in this monorepo.
 
 Overall Pro tier: **~80% complete** (not 50% as a surface scan might suggest).
 

--- a/docs/FAIR_SOURCE.md
+++ b/docs/FAIR_SOURCE.md
@@ -11,13 +11,16 @@ The narrative version of this page lives at [revealui.com/fair-source](https://r
 
 ## What's licensed how
 
-Two RevealUI packages ship under **FSL-1.1-MIT** (Fair Source). Every other package in RevFleet is plain MIT.
+Five RevealUI packages ship under **FSL-1.1-MIT** (Fair Source). Every other package in RevFleet is plain MIT.
 
 | Package | License | Source | npm |
 |---------|---------|--------|-----|
 | `@revealui/ai` | FSL-1.1-MIT | [packages/ai](https://github.com/RevealUIStudio/revealui/tree/main/packages/ai) | [npm](https://www.npmjs.com/package/@revealui/ai) |
+| `@revealui/engines` | FSL-1.1-MIT | [packages/engines](https://github.com/RevealUIStudio/revealui/tree/main/packages/engines) | _private — not published_ |
 | `@revealui/harnesses` | FSL-1.1-MIT | [packages/harnesses](https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses) | [npm](https://www.npmjs.com/package/@revealui/harnesses) |
-| Everything else (`@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/presentation`, `@revealui/router`, `@revealui/security`, `@revealui/utils`, `@revealui/cache`, `@revealui/resilience`, `@revealui/sync`, `@revealui/cli`, `@revealui/setup`, `@revealui/dev`, `@revealui/test`, `@revealui/editors`, `@revealui/mcp`, `@revealui/services`, `@revealui/openapi`, `@revealui/config`, `create-revealui`) | MIT | [packages/](https://github.com/RevealUIStudio/revealui/tree/main/packages) | [npm registry](https://www.npmjs.com/org/revealui) |
+| `@revealui/mcp` | FSL-1.1-MIT | [packages/mcp](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp) | [npm](https://www.npmjs.com/package/@revealui/mcp) |
+| `@revealui/services` | FSL-1.1-MIT | [packages/services](https://github.com/RevealUIStudio/revealui/tree/main/packages/services) | [npm](https://www.npmjs.com/package/@revealui/services) |
+| Everything else (`@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/presentation`, `@revealui/router`, `@revealui/security`, `@revealui/utils`, `@revealui/cache`, `@revealui/resilience`, `@revealui/sync`, `@revealui/cli`, `@revealui/setup`, `@revealui/dev`, `@revealui/test`, `@revealui/openapi`, `@revealui/config`, `@revealui/paywall`, `create-revealui`) | MIT | [packages/](https://github.com/RevealUIStudio/revealui/tree/main/packages) | [npm registry](https://www.npmjs.com/org/revealui) |
 
 To verify any package's license:
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -106,8 +106,8 @@ The MIT-licensed components (RevVault CLI, RevKit agent coordination) are free f
 
 RevealUI publishes every package to npm from the same public repo. There are two source licenses in play:
 
-- **OSS packages (MIT):** `@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/security`, `@revealui/utils`, `@revealui/config`, `@revealui/cache`, `@revealui/resilience`, `@revealui/openapi`, `@revealui/sync`, `@revealui/mcp`, and the rest of the public infrastructure. Use them however you want — commercial products, forks, SaaS, whatever.
-- **Pro packages (Fair Source, FSL-1.1-MIT):** `@revealui/ai` and `@revealui/harnesses`. Source-visible in the public repo, installable from npm like any other package, with one legal constraint: you can't build a product that competes directly with RevealUI on top of them. Two years after each release the license on that release automatically converts to plain MIT. FSL-1.1 is the same license used by Sentry, GitButler, and Keygen.
+- **OSS packages (MIT):** `@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/security`, `@revealui/utils`, `@revealui/config`, `@revealui/cache`, `@revealui/resilience`, `@revealui/openapi`, `@revealui/sync`, `@revealui/paywall`, and the rest of the public infrastructure. Use them however you want — commercial products, forks, SaaS, whatever.
+- **Pro packages (Fair Source, FSL-1.1-MIT):** `@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, and `@revealui/services` (note: `@revealui/engines` is `"private": true` and not published on npm). Source-visible in the public repo, installable from npm like any other package, with one legal constraint: you can't build a product that competes directly with RevealUI on top of them. Two years after each release the license on that release automatically converts to plain MIT. FSL-1.1 is the same license used by Sentry, GitButler, and Keygen.
 
 **What this means in practice:**
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -67,11 +67,11 @@ Prerequisites (one-time setup per package on npmjs.org):
    - Environment: `npm-publish`
 
 Packages that need this configured:
-`@revealui/animations`, `@revealui/auth`, `@revealui/cache`, `@revealui/cli`,
+`@revealui/ai`, `@revealui/auth`, `@revealui/cache`, `@revealui/cli`,
 `@revealui/config`, `@revealui/contracts`, `@revealui/core`, `@revealui/db`,
-`@revealui/editors`, `@revealui/mcp`, `@revealui/openapi`, `@revealui/presentation`,
-`@revealui/resilience`, `@revealui/router`, `@revealui/security`, `@revealui/services`,
-`@revealui/setup`, `@revealui/sync`, `@revealui/utils`, `create-revealui`
+`@revealui/harnesses`, `@revealui/mcp`, `@revealui/openapi`, `@revealui/paywall`,
+`@revealui/presentation`, `@revealui/resilience`, `@revealui/router`, `@revealui/security`,
+`@revealui/services`, `@revealui/setup`, `@revealui/sync`, `@revealui/utils`, `create-revealui`
 
 ### Local
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -86,8 +86,8 @@ See [`docs/methodology.md`](methodology.md) for the canonical M2-M12 statement �
 
 ## Licensing
 
-- **MIT**: `@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/presentation`, `@revealui/router`, `@revealui/config`, `@revealui/utils`, `@revealui/cli`, `@revealui/setup`, `@revealui/sync`, `@revealui/cache`, `@revealui/resilience`, `@revealui/security`, `@revealui/mcp`, `@revealui/services`, `@revealui/editors`, and all other OSS packages
-- **FSL-1.1-MIT**: `@revealui/ai`, `@revealui/harnesses` — source-visible, non-compete, converts to MIT after 2 years per release
+- **MIT**: `@revealui/core`, `@revealui/auth`, `@revealui/db`, `@revealui/contracts`, `@revealui/presentation`, `@revealui/router`, `@revealui/config`, `@revealui/utils`, `@revealui/cli`, `@revealui/setup`, `@revealui/sync`, `@revealui/cache`, `@revealui/resilience`, `@revealui/security`, `@revealui/openapi`, `@revealui/paywall`, and all other OSS packages
+- **FSL-1.1-MIT**: `@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services` — source-visible, non-compete, converts to MIT after 2 years per release (`@revealui/engines` is `"private": true` and not published on npm)
 
 ---
 

--- a/docs/agent-rules/feature-gating.md
+++ b/docs/agent-rules/feature-gating.md
@@ -33,10 +33,13 @@ if (isFeatureEnabled('ai')) {
 - `@revealui/core`, `@revealui/contracts`, `@revealui/db`, `@revealui/auth`
 - `@revealui/presentation`, `@revealui/router`, `@revealui/config`, `@revealui/utils`
 - `@revealui/cli`, `@revealui/setup`, `@revealui/sync`, `@revealui/dev`, `@revealui/test`
+- `@revealui/cache`, `@revealui/resilience`, `@revealui/security`, `@revealui/openapi`, `@revealui/paywall`
 
-### Pro Packages (Commercial)
-- `@revealui/ai`, `@revealui/mcp`, `@revealui/editors`
-- `@revealui/services`, `@revealui/harnesses`
+### Pro Packages (Commercial — FSL-1.1-MIT)
+- `@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`
+- `@revealui/mcp`, `@revealui/services`
+
+> Editor config sync ships as [**RevCon**](https://github.com/RevealUIStudio/revcon), a separate fleet repo — not gated by Pro, not in this monorepo.
 
 ## Rules
 

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -49,7 +49,6 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | PKG-014 | @revealui/security | Headers, CORS, RBAC/ABAC, encryption, audit, GDPR | npm | Public |
 | PKG-015 | @revealui/dev | Shared configs (Biome, TS, Tailwind) | npm | Public |
 | PKG-016 | @revealui/test | E2E specs, integration tests, fixtures, mocks | npm | Public |
-| PKG-017 | @revealui/editors | Editor config sync (Zed, VS Code, Cursor) | npm | Public |
 | PKG-018 | @revealui/mcp | MCP hypervisor, adapter framework, tool discovery | npm | Public |
 | PKG-019 | @revealui/services | Stripe + Supabase integrations | npm | Public |
 | PKG-020 | create-revealui | `npm create revealui` initializer | npm | Public |

--- a/packages/dev/README.md
+++ b/packages/dev/README.md
@@ -139,7 +139,7 @@ This package is named `dev` (unscoped) in the monorepo workspace. Use `dev/...` 
 - You want consistent formatting and linting rules across all workspaces
 - You need a base Vite config with common aliases and build settings
 - **Not** for runtime configuration  -  use `@revealui/config` for environment variables
-- **Not** for editor-specific settings  -  use `@revealui/editors` for VS Code, Zed, and Cursor configs
+- **Not** for editor-specific settings  -  see [RevCon](https://github.com/RevealUIStudio/revcon) (separate fleet repo) for VS Code, Zed, and Cursor configs
 
 ## JOSHUA Alignment
 

--- a/packages/engines/LICENSE
+++ b/packages/engines/LICENSE
@@ -1,0 +1,109 @@
+Functional Source License, Version 1.1, MIT Future License
+
+Abbreviation
+
+FSL-1.1-MIT
+
+Notice
+
+Copyright 2025-2026 RevealUI Studio (founder@revealui.com)
+
+Terms and Conditions
+
+Licensor:             RevealUI Studio
+
+Licensed Work:        @revealui/ai
+                      The Licensed Work is copyright 2025-2026 RevealUI Studio.
+
+Change Date:          2028-04-08
+
+Change License:       MIT
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact: founder@revealui.com
+
+License text below is the Functional Source License, Version 1.1, MIT Future
+License, as published at https://fsl.software/FSL-1.1-MIT.template.md
+
+---
+
+## Terms and Conditions
+
+### Acceptance
+
+In order to get any license under these terms, you must agree to them as
+both strict obligations and conditions to all your licenses.
+
+### Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the licensed work, in each case
+subject to the limitations and conditions below.
+
+### Limitations
+
+You may not make the functionality of the licensed work or a modified
+version available to third parties as a service, or distribute the
+licensed work or a modified version in a way that makes the functionality
+of the software available to third parties. Making the functionality of
+the licensed work available to third parties includes, without limitation,
+enabling third parties to interact with the functionality of the licensed
+work remotely through a computer network, offering a service the value of
+which entirely or primarily derives from the value of the licensed work,
+or offering a service that accomplishes for users the primary purpose of
+the licensed work or a modified version.
+
+### Patents
+
+The licensor grants you a license, under any patent claims the licensor
+can license, or becomes able to license, to make, have made, use, sell,
+offer for sale, import and have imported the licensed work, in each case
+subject to the limitations and conditions in this license. This license
+does not cover any patent claims that you cause to be infringed by
+modifications or additions to the licensed work. If you or your company
+make any written claim that the licensed work infringes or contributes to
+infringement of any patent, your patent license for the licensed work
+granted under these terms ends immediately. If your company makes such a
+claim, your patent license ends immediately for work on behalf of your
+company.
+
+### Fair Use
+
+This license is not intended to limit any right of fair use, fair
+dealing, or other applicable copyright exception or limitation.
+
+### No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your
+licenses to anyone else, or prevent the licensor from granting licenses
+to anyone else. These terms do not imply any other licenses.
+
+### Termination
+
+If you use the licensed work in violation of these terms, such use is
+not licensed, and your licenses may be revoked if you do not cure the
+violation.
+
+The licensor may also revoke your licenses if you fail to comply with
+these terms.
+
+### No Liability
+
+***As far as the law allows, the licensed work comes as is, without any
+warranty or condition, and the licensor will not be liable to you for any
+damages arising out of these terms or the use or nature of the licensed
+work, under any kind of legal claim.***
+
+### Change Date
+
+On the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under
+this License, whichever comes first, the Licensor hereby grants you
+rights under the terms of the Change License, and the rights granted in
+the paragraphs above terminate.
+
+### Change License
+
+On the Change Date, the Licensed Work will be made available under the
+Change License specified above (MIT).

--- a/scripts/setup/configure-trusted-publishers.sh
+++ b/scripts/setup/configure-trusted-publishers.sh
@@ -19,7 +19,6 @@ PACKAGES=(
   "@revealui/contracts"
   "@revealui/core"
   "@revealui/db"
-  "@revealui/editors"
   "@revealui/mcp"
   "@revealui/openapi"
   "@revealui/presentation"

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -143,6 +143,330 @@ function countDbTables(): number {
 }
 
 // ---------------------------------------------------------------------------
+// License-split collector (added 2026-05-14 — closes a fleet drift class)
+//
+// Walks `packages/*/package.json` and groups by the `license` field. The
+// fleet's licensing posture is:
+//   - MIT for OSS packages
+//   - FSL-1.1-MIT for Pro packages (Fair Source; converts to MIT after 2y)
+//   - Internal `"private": true` packages may have no `license` field
+//
+// Docs have historically drifted from package.json reality — the 2026-05-14
+// audit found `mcp`, `services`, `engines` stated as OSS in CLAUDE.md and
+// MASTER_PLAN while their package.json files carry FSL-1.1-MIT. Codifying
+// the split here closes that drift class for the canonical doc shape
+// "N OSS (MIT)" / "N Pro (FSL...)" / "N internal".
+// ---------------------------------------------------------------------------
+
+interface LicenseSplit {
+  mit: number;
+  fsl: number;
+  internal: number;
+}
+
+function countLicenseSplit(): LicenseSplit {
+  const split: LicenseSplit = { mit: 0, fsl: 0, internal: 0 };
+  const pkgDir = path.join(ROOT, 'packages');
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(pkgDir, { withFileTypes: true });
+  } catch {
+    return split;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const pj = path.join(pkgDir, e.name, 'package.json');
+    let content: string;
+    try {
+      content = fs.readFileSync(pj, 'utf8');
+    } catch {
+      continue;
+    }
+    let parsed: { license?: string };
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      continue;
+    }
+    const lic = parsed.license;
+    if (lic === 'MIT') split.mit++;
+    else if (lic === 'FSL-1.1-MIT') split.fsl++;
+    else split.internal++; // missing or unknown license -> internal bucket
+  }
+  return split;
+}
+
+// ---------------------------------------------------------------------------
+// Package-license inventory (used by phantom + membership detectors below).
+//
+// Built once per run from packages/*/package.json — the audit-first source
+// of truth — so the gates auto-track future license changes.
+// ---------------------------------------------------------------------------
+
+interface PackageLicenseMap {
+  mit: Set<string>;
+  fsl: Set<string>;
+  internal: Set<string>;
+  all: Set<string>;
+}
+
+function buildPackageLicenseMap(): PackageLicenseMap {
+  const map: PackageLicenseMap = {
+    mit: new Set(),
+    fsl: new Set(),
+    internal: new Set(),
+    all: new Set(),
+  };
+  const pkgDir = path.join(ROOT, 'packages');
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(pkgDir, { withFileTypes: true });
+  } catch {
+    return map;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const pj = path.join(pkgDir, e.name, 'package.json');
+    let parsed: { name?: string; license?: string };
+    try {
+      parsed = JSON.parse(fs.readFileSync(pj, 'utf8'));
+    } catch {
+      continue;
+    }
+    const name = parsed.name ?? `@revealui/${e.name}`;
+    map.all.add(name);
+    const lic = parsed.license;
+    if (lic === 'MIT') map.mit.add(name);
+    else if (lic === 'FSL-1.1-MIT') map.fsl.add(name);
+    else map.internal.add(name);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Shared walker for the phantom + membership detectors.
+//
+// Scope: docs/, apps/marketing/app/, apps/docs/public/, root-level
+// CLAUDE.md / README.md / CONTRIBUTING.md / .syncpackrc.json, scripts/,
+// and packages/ (README .md only — source code is out of scope for license-
+// drift checks; packages/* is huge and would slow the gate).
+// ---------------------------------------------------------------------------
+
+const LICENSE_SCAN_ROOTS = [
+  'docs',
+  'apps/marketing/app',
+  'apps/docs/public',
+  'README.md',
+  'CLAUDE.md',
+  'CONTRIBUTING.md',
+  '.syncpackrc.json',
+  'scripts',
+  'packages',
+];
+
+const LICENSE_SCAN_EXTENSIONS_FULL = ['.md', '.txt', '.ts', '.tsx', '.json', '.sh'];
+const LICENSE_SCAN_EXTENSIONS_PACKAGES = ['.md']; // packages/* is huge; restrict to docs
+
+function walkLicenseScanFiles(callback: (filePath: string, rel: string) => void): void {
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === 'dist' || e.name === '.git') continue;
+      const full = path.join(dir, e.name);
+      const rel = path.relative(ROOT, full).replace(/\\/g, '/');
+      if (e.isDirectory()) {
+        walk(full);
+      } else {
+        const inPackages = rel.startsWith('packages/');
+        const exts = inPackages ? LICENSE_SCAN_EXTENSIONS_PACKAGES : LICENSE_SCAN_EXTENSIONS_FULL;
+        if (exts.some((ext) => e.name.endsWith(ext))) {
+          callback(full, rel);
+        }
+      }
+    }
+  }
+  for (const root of LICENSE_SCAN_ROOTS) {
+    const full = path.join(ROOT, root);
+    try {
+      const stat = fs.statSync(full);
+      const rel = path.relative(ROOT, full).replace(/\\/g, '/');
+      if (stat.isFile()) callback(full, rel);
+      else if (stat.isDirectory()) walk(full);
+    } catch {
+      // path missing, skip
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phantom-package detector
+//
+// Catches mentions of packages that don't live in this monorepo. The known
+// phantom is @revealui/editors — editor config sync ships as RevCon (a
+// separate fleet repo), but historical docs sometimes describe a phantom
+// in-monorepo package. Allowlist: files whose purpose is the redirect.
+//
+// REGEX-CONFIG-BOUNDARY — pre-existing convention in this file; AST refactor
+// queued under GAP-192.
+// ---------------------------------------------------------------------------
+
+interface PhantomMatch {
+  file: string;
+  line: number;
+  pkg: string;
+  hint: string;
+  text: string;
+}
+
+interface PhantomPackage {
+  pattern: RegExp;
+  pkg: string;
+  hint: string;
+  allowlist: Set<string>;
+}
+
+const PHANTOM_PACKAGES: PhantomPackage[] = [
+  {
+    pattern: /@revealui\/editors\b/,
+    pkg: '@revealui/editors',
+    hint: 'package does not exist in this monorepo; editor sync ships as RevCon (separate fleet repo)',
+    allowlist: new Set([
+      // Canonical pages that exist precisely to document the redirect:
+      'apps/docs/public/docs-pro/editors/index.md',
+      'docs/fleet/revcon.md',
+      'docs/REVFLEET.md',
+      // Synced copies of the canonical pages above
+      // (apps/docs/scripts/copy-docs.sh mirrors docs/* → apps/docs/public/*):
+      'apps/docs/public/REVFLEET.md',
+      'apps/docs/public/fleet/revcon.md',
+      // The validator itself — its FLEET_PRODUCTS table lists the phantom
+      // by design (as the regex token to detect leaks elsewhere):
+      'scripts/validate/claim-drift.ts',
+    ]),
+  },
+];
+
+function scanForPhantomPackages(): PhantomMatch[] {
+  const matches: PhantomMatch[] = [];
+  walkLicenseScanFiles((filePath, rel) => {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (const phantom of PHANTOM_PACKAGES) {
+      if (phantom.allowlist.has(rel)) continue;
+      for (let i = 0; i < lines.length; i++) {
+        if (phantom.pattern.test(lines[i])) {
+          matches.push({
+            file: rel,
+            line: i + 1,
+            pkg: phantom.pkg,
+            hint: phantom.hint,
+            text: lines[i].trim(),
+          });
+        }
+      }
+    }
+  });
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// License-membership detector
+//
+// Same-line check: when a line names a @revealui/<pkg> alongside a license
+// label, verify the named package's actual license matches the claimed one.
+// Catches "MIT: ..., @revealui/mcp, ..." when mcp is FSL-1.1-MIT.
+//
+// Heuristics by design — table headers in adjacent rows and prior-line
+// section context are out of scope to keep false positives low. Headings are
+// skipped. Bare package names (e.g. "core" without the @revealui/ prefix)
+// are out of scope; this catches the >90% of fleet doc shapes that use the
+// scoped form.
+//
+// REGEX-CONFIG-BOUNDARY — pre-existing convention; AST refactor under GAP-192.
+// ---------------------------------------------------------------------------
+
+interface MembershipMatch {
+  file: string;
+  line: number;
+  pkg: string;
+  claimedLicense: 'MIT' | 'FSL-1.1-MIT';
+  actualLicense: 'MIT' | 'FSL-1.1-MIT' | 'internal/none';
+  text: string;
+}
+
+// Strict label shapes — tight enough to dodge "MIT-licensed" / "MIT-style"
+// / general prose, broad enough to catch table cells, bold labels, prefix
+// colons, and parentheticals.
+//
+// FSL pattern intentionally rejects bare `Fair Source` / `Pro packages` /
+// `FSL-1.1-MIT` mentions without a label structure — that shape appears in
+// explanatory prose like "Pro packages (@revealui/ai, @revealui/harnesses)
+// ship under Fair Source (FSL-1.1-MIT)" where treating the line as a single-
+// license claim produces false positives for the MIT-licensed packages
+// named earlier on the same line. Requires `**bold**`, `| table-cell |`,
+// `colon:` suffix, or `Pro packages (FSL...` prefix to fire.
+//
+// Table-cell variants accept extra content inside the cell (e.g.
+// `| MIT (free for any tier) |`, `| Fair Source (FSL-1.1-MIT, MIT after 2 years) |`)
+// — common in customer-facing docs that annotate the license with a note.
+const MIT_LABEL_PATTERN = /\*\*MIT\*\*|\|\s*MIT\b[^|]*\||\bMIT:|\(MIT\)/;
+const FSL_LABEL_PATTERN =
+  /\*\*FSL[-\s]?1\.1[-\s]?MIT\*\*|\|\s*(?:FSL[-\s]?1\.1[-\s]?MIT|Fair[-\s]?Source)\b[^|]*\||\bFSL[-\s]?1\.1[-\s]?MIT:|\bPro packages?:|\bPro packages? \(FSL/i;
+
+function scanForLicenseMembershipDrift(map: PackageLicenseMap): MembershipMatch[] {
+  const matches: MembershipMatch[] = [];
+  walkLicenseScanFiles((filePath, rel) => {
+    // Skip the validator itself — its own pattern definitions are not claims
+    if (rel === 'scripts/validate/claim-drift.ts') return;
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (/^#{1,6}\s/.test(line)) continue; // skip headings
+      const hasFSL = FSL_LABEL_PATTERN.test(line);
+      const hasMIT = MIT_LABEL_PATTERN.test(line) && !hasFSL;
+      if (!(hasMIT || hasFSL)) continue;
+      const pkgRegex = /@revealui\/([a-z][a-z0-9-]*)\b/g;
+      for (const match of line.matchAll(pkgRegex)) {
+        const pkgName = match[0];
+        let actual: 'MIT' | 'FSL-1.1-MIT' | 'internal/none' | null;
+        if (map.mit.has(pkgName)) actual = 'MIT';
+        else if (map.fsl.has(pkgName)) actual = 'FSL-1.1-MIT';
+        else if (map.internal.has(pkgName)) actual = 'internal/none';
+        else continue; // phantom — handled by phantom detector
+        const claimed: 'MIT' | 'FSL-1.1-MIT' = hasMIT ? 'MIT' : 'FSL-1.1-MIT';
+        if (actual !== claimed) {
+          matches.push({
+            file: rel,
+            line: i + 1,
+            pkg: pkgName,
+            claimedLicense: claimed,
+            actualLicense: actual,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  });
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Claim scanner
 // ---------------------------------------------------------------------------
 
@@ -833,6 +1157,7 @@ function run(): void {
   const uiComponents = countUIComponents();
   const mcpServers = countMCPServers();
   const dbTables = countDbTables();
+  const licenseSplit = countLicenseSplit();
 
   console.log('Actual metrics:');
   console.log(`  Packages:      ${packages}`);
@@ -842,6 +1167,9 @@ function run(): void {
   console.log(`  UI components: ${uiComponents}`);
   console.log(`  MCP servers:   ${mcpServers}`);
   console.log(`  DB tables:     ${dbTables}`);
+  console.log(
+    `  License split: ${licenseSplit.mit} MIT | ${licenseSplit.fsl} FSL-1.1-MIT | ${licenseSplit.internal} internal/none`,
+  );
   console.log();
 
   const metrics: Metric[] = [
@@ -892,6 +1220,24 @@ function run(): void {
         // "Schema (85 tables)" parenthetical
         /\(\s*([1-9]\d{1,2})\s+tables?\s*\)/i,
       ],
+    },
+    // License-split metrics (REGEX-CONFIG-BOUNDARY — pre-existing convention
+    // in this file; AST-refactor pending GAP-192). Patterns target the
+    // canonical fleet doc shape: "N OSS (MIT)" / "N Pro (FSL...)" / "N internal".
+    {
+      name: 'MIT packages',
+      actual: licenseSplit.mit,
+      claimPatterns: [/\b([1-9]\d?)\s+OSS\s*\(MIT\)/],
+    },
+    {
+      name: 'FSL packages',
+      actual: licenseSplit.fsl,
+      claimPatterns: [/\b([1-9]\d?)\s+Pro\s*\(\s*(?:Fair\s+Source\s+)?FSL/],
+    },
+    {
+      name: 'internal packages',
+      actual: licenseSplit.internal,
+      claimPatterns: [/\b([1-9]\d?)\s+internal\s*\(/i],
     },
   ];
 
@@ -947,6 +1293,11 @@ function run(): void {
   // $RVUI internal-ticker leak guard (PR-D)
   const rvuiLeaks = scanForRvuiTickerLeaks();
 
+  // License-membership gates (added 2026-05-14)
+  const pkgMap = buildPackageLicenseMap();
+  const phantomMatches = scanForPhantomPackages();
+  const membershipMatches = scanForLicenseMembershipDrift(pkgMap);
+
   console.log('====================');
   console.log(`Claims scanned: ${claims.length}`);
   console.log(`Mismatches:     ${mismatches}`);
@@ -956,6 +1307,8 @@ function run(): void {
   console.log(`Unqualified aspirational features: ${aspirationalClaims.length}`);
   console.log(`Unattributed fleet-product mentions: ${fleetLeaks.length}`);
   console.log(`Internal $RVUI ticker leaks: ${rvuiLeaks.length}`);
+  console.log(`Phantom-package mentions: ${phantomMatches.length}`);
+  console.log(`License-membership mismatches: ${membershipMatches.length}`);
 
   if (futureClaims.length > 0) {
     console.log('\nUnlinked future-tense claims (convention: CONTRIBUTING.md):');
@@ -1001,12 +1354,38 @@ function run(): void {
     );
   }
 
+  if (phantomMatches.length > 0) {
+    console.log('\nPhantom-package mentions (package does not live in this monorepo):');
+    for (const c of phantomMatches) {
+      console.log(`  ${c.file}:${c.line}  ${c.pkg} — ${c.hint}`);
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nRemove the reference, replace with a pointer to the canonical location, or add the file to PHANTOM_PACKAGES allowlist if it explicitly documents the redirect.',
+    );
+  }
+
+  if (membershipMatches.length > 0) {
+    console.log('\nLicense-membership mismatches (package listed under wrong license):');
+    for (const c of membershipMatches) {
+      console.log(
+        `  ${c.file}:${c.line}  ${c.pkg}: claims ${c.claimedLicense}, actually ${c.actualLicense}`,
+      );
+      console.log(`    ${c.text.substring(0, 140)}`);
+    }
+    console.log(
+      '\nEach line that names a @revealui/<pkg> alongside a license label must match the package.json license. Move the package to the correct license section or remove the claim.',
+    );
+  }
+
   const anyFailures =
     mismatches > 0 ||
     futureClaims.length > 0 ||
     aspirationalClaims.length > 0 ||
     fleetLeaks.length > 0 ||
-    rvuiLeaks.length > 0;
+    rvuiLeaks.length > 0 ||
+    phantomMatches.length > 0 ||
+    membershipMatches.length > 0;
 
   if (anyFailures) {
     if (mismatches > 0) {
@@ -1027,10 +1406,16 @@ function run(): void {
     if (rvuiLeaks.length > 0) {
       console.log('\nFailed: $RVUI internal-codename leaks in public docs.');
     }
+    if (phantomMatches.length > 0) {
+      console.log('\nFailed: phantom-package mentions in docs.');
+    }
+    if (membershipMatches.length > 0) {
+      console.log('\nFailed: license-membership mismatches in docs.');
+    }
     process.exit(1);
   } else {
     console.log(
-      '\nAll claims match codebase reality, future-tense markers are tracked, aspirational features are qualified, fleet products are attributed, and no $RVUI ticker leaks were found.',
+      '\nAll claims match codebase reality, future-tense markers are tracked, aspirational features are qualified, fleet products are attributed, no $RVUI ticker leaks were found, no phantom-package mentions were found, and license membership matches package.json reality.',
     );
   }
 }

--- a/scripts/validate/gitignore-pro.ts
+++ b/scripts/validate/gitignore-pro.ts
@@ -3,9 +3,16 @@
 /**
  * Pro Package License Validation
  *
- * Verifies that Pro packages (ai, harnesses) have valid FSL-1.1-MIT
- * license files. Pro packages are Fair Source  -  source visible in the
- * public repo, commercially licensed, converting to MIT after 2 years.
+ * Verifies that every Pro (FSL-1.1-MIT) package has a valid LICENSE file
+ * and matching package.json license field. Pro packages are Fair Source  -
+ * source visible in the public repo, commercially licensed, converting to
+ * plain MIT two years after each release.
+ *
+ * The Pro set is derived from packages/*\/package.json `license` field at
+ * runtime (rather than hardcoded here) so this gate auto-tracks future
+ * license rebalances. Precedent: until 2026-05-14 this script hardcoded
+ * `[ai, harnesses]` and silently skipped engines/mcp/services after they
+ * were promoted to FSL-1.1-MIT — the discovery walk closes that drift class.
  *
  * Previously this script validated gitignore entries (Issue #100).
  * After the Fair Source migration (April 2026), Pro source is public
@@ -16,15 +23,45 @@
  *   1  -  one or more license files missing
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
 
-const PRO_PACKAGES = [
-  { name: '@revealui/ai', dir: 'packages/ai' },
-  { name: '@revealui/harnesses', dir: 'packages/harnesses' },
-];
+interface ProPackage {
+  name: string;
+  dir: string;
+}
+
+/**
+ * Walk packages/*\/package.json and select every package whose `license`
+ * field references FSL. Source of truth = the package.json files
+ * themselves, so license rebalances are picked up automatically.
+ */
+function discoverProPackages(): ProPackage[] {
+  const pkgRoot = join(REPO_ROOT, 'packages');
+  const out: ProPackage[] = [];
+  for (const entry of readdirSync(pkgRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const pjPath = join(pkgRoot, entry.name, 'package.json');
+    if (!existsSync(pjPath)) continue;
+    try {
+      const pj = JSON.parse(readFileSync(pjPath, 'utf8')) as { name?: string; license?: string };
+      if (typeof pj.license === 'string' && pj.license.includes('FSL')) {
+        out.push({
+          name: pj.name ?? `@revealui/${entry.name}`,
+          dir: `packages/${entry.name}`,
+        });
+      }
+    } catch {
+      // skip unreadable / malformed package.json
+    }
+  }
+  // Stable ordering keeps log output deterministic across runs
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const PRO_PACKAGES: ProPackage[] = discoverProPackages();
 
 function validateProLicenses(): boolean {
   const Sep = '='.repeat(60);


### PR DESCRIPTION
## Summary

3 commits landing from test:

- **[revealui#873](https://github.com/RevealUIStudio/revealui/pull/873)** `chore(claim-drift)`: close license-drift class (count + phantom + membership). Extends `scripts/validate/claim-drift.ts` with three new detectors derived from `packages/*/package.json` (`licenseSplit`, `scanForPhantomPackages`, `scanForLicenseMembershipDrift`); switches `scripts/validate/gitignore-pro.ts` to dynamic Pro discovery; corrects license claims across customer-facing + internal docs; adds `packages/engines/LICENSE` (was missing — surfaced by the closed coverage gap); deletes legacy orphan dirs `apps/docs/public/{suite,docs}/`.
- **[revealui#869](https://github.com/RevealUIStudio/revealui/pull/869)** `docs`: sync CLAUDE.md package map to match 26 packages.
- **[revealui#870](https://github.com/RevealUIStudio/revealui/pull/870)** sync test with main (meta-merge).

## Behavior change

- **CI**: claim-drift gate now hard-fails on phantom-package mentions outside the allowlist, license-membership mismatches (`@revealui/<pkg>` near a license label whose value disagrees with `package.json`), and `N OSS (MIT)` / `N Pro (FSL…)` / `N internal` count claims that disagree with `packages/*/package.json` reality.
- **Validators**: `gitignore-pro.ts` now derives the Pro package set from `package.json` (no more hardcoded `[ai, harnesses]`).
- **Source code**: no runtime behavior change.

## Test plan
- [ ] All required CI checks pass on this promotion PR
- [ ] `pnpm gate` runs green on `main` post-merge
- [ ] Claim-drift validator green on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)