### PR TITLE
fix(ci): route rollback via --scope slug, not VERCEL_ORG_ID team ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -428,6 +428,15 @@ jobs:
         # roll back, we must pass the previous-good deployment URL. This
         # step pre-fetches it via `vercel ls --prod` and rolls the alias
         # explicitly, then verifies the alias moved.
+        #
+        # Team scope: VERCEL_ORG_ID (team ID secret) is intentionally
+        # cleared here. `vercel rollback <url>` validates the deployment
+        # against the team from VERCEL_ORG_ID, but if the secret holds a
+        # value that doesn't match the team that owns the deployments it
+        # produces "Deployment belongs to a different team" (2026-05-15
+        # incident). The deploy step works because it uses VERCEL_PROJECT_ID
+        # directly and doesn't go through the same team-scope validation.
+        # Fix: route via --scope (team slug) instead of VERCEL_ORG_ID (team ID).
         run: |
           set -uo pipefail
           echo "::warning::Smoke test failed — rolling back affected apps"
@@ -450,7 +459,8 @@ jobs:
 
             # 1. List recent production deployments. Take the second-most-
             #    recent READY one — the most recent IS the broken deploy.
-            DEPLOY_LIST=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod --token="$VERCEL_TOKEN" 2>&1 || true)
+            DEPLOY_LIST=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod \
+              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 || true)
             PREV_URL=$(printf '%s\n' "$DEPLOY_LIST" \
               | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
               | sed -n '2p')
@@ -464,7 +474,8 @@ jobs:
             echo "Previous good deploy: $PREV_URL"
 
             # 2. Roll the alias explicitly to that URL.
-            if ! VERCEL_PROJECT_ID="$PID" vercel rollback "$PREV_URL" --token="$VERCEL_TOKEN" --yes 2>&1; then
+            if ! VERCEL_PROJECT_ID="$PID" vercel rollback "$PREV_URL" \
+              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" --yes 2>&1; then
               echo "::warning::vercel rollback command failed for $app"
               ROLLBACK_FAILED=$((ROLLBACK_FAILED+1))
               continue
@@ -474,7 +485,8 @@ jobs:
             #    project's current production deploy. Wait briefly for
             #    propagation.
             sleep 5
-            CURRENT_URL=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod --token="$VERCEL_TOKEN" 2>&1 \
+            CURRENT_URL=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod \
+              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 \
               | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
               | head -n 1)
 
@@ -503,7 +515,8 @@ jobs:
           exit 1
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_ORG_ID: ""
+          VERCEL_TEAM_SLUG: ${{ vars.TURBO_TEAM || 'revealuistudio' }}
 
   # ---------------------------------------------------------------------------
   # Summary


### PR DESCRIPTION
## Summary

- Clears VERCEL_ORG_ID in the smoke-test "Rollback on failure" step and replaces it with --scope= (backed by the TURBO_TEAM repo var, default revealuistudio) on every vercel ls and vercel rollback call
- VERCEL_TEAM_SLUG step env var added; VERCEL_ORG_ID overridden to empty string to prevent the workflow-level value from leaking into the rollback commands

## Root cause

vercel rollback <url> validates the deployment against the team ID from VERCEL_ORG_ID. The deploy step works because it authenticates via VERCEL_PROJECT_ID directly and bypasses this team-scope check. When VERCEL_ORG_ID does not match the team that owns the deployments the rollback returns 'Deployment belongs to a different team' for every app, leaving the broken deploy live with no automatic mitigation.

Incident: 2026-05-15 05:24Z — api + admin returned 500 after the #874 promotion; all five rollback calls failed with this error. Tracked in #875.

## What changed

.github/workflows/deploy.yml — smoke-test job 'Rollback on failure' step only:
- Step env: VERCEL_ORG_ID empty (overrides workflow-level), VERCEL_TEAM_SLUG from TURBO_TEAM var
- All three vercel ls / vercel rollback invocations now pass --scope=

No runtime code, no schema, no package changes.

## Test plan

- [ ] CI passes on this PR
- [ ] On the next failed smoke test, confirm rollback succeeds (log: 'Rollback verified: \<app\> production now serving \<url\>')
- [ ] Manual: trigger deploy-test.yml against a bad build on a scratch branch to exercise the rollback path

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
