### PR TITLE
docs(security): add LIMITATIONS.md and THREAT_MODEL.md

### DIFF
--- a/docs/security/LIMITATIONS.md
+++ b/docs/security/LIMITATIONS.md
@@ -1,0 +1,161 @@
+---
+title: Security Stack Limitations
+description: Explicit scope and non-scope statements for the RevealUI security stack — what it governs, what it does not, and the trust assumptions that require defense-in-depth from outside the platform.
+last-updated: 2026-05-16
+---
+
+# Security Stack Limitations
+
+## 1. Purpose
+
+This document is the honest disclosure of what the RevealUI security stack governs and what it does not. It is intended for:
+
+- Customer security reviews, vendor risk assessments, and SOC 2 audit narratives
+- EU AI Act readiness (Article 53 transparency obligations, enforceable August 2026)
+- Self-hosters and Pro-package licensees who need to plan their own defense-in-depth layers
+- Maintainers reasoning about future scope decisions
+
+"The RevealUI security stack" in this document refers to the controls implemented in this monorepo: the auth / authz / encryption / audit modules in `@revealui/security` and `@revealui/core`, the `AuditPolicyEngine` in `@revealui/ai`, the MCP-mediated tool dispatch in `@revealui/mcp`, and the secret-handling discipline of revvault.
+
+## 2. What the security stack governs (explicit scope)
+
+| Surface | Controls | Reference |
+|---------|----------|-----------|
+| Browser ↔ App | TLS 1.2+, HSTS, CSP, CORS, CSRF tokens on state-changing admin routes | `@revealui/security`, `packages/core/src/security/` |
+| Session auth | Session-only cookies (httpOnly + secure + sameSite=lax), bcrypt 12 rounds, brute-force rate limiting, optional TOTP | `@revealui/auth` |
+| Authorization | RBAC + ABAC engine, collection-level access checks (`access.read/update/delete`), admin-gate middleware, license + feature gates | `@revealui/core` access enforcement tests |
+| Secret handling | Revvault is the canonical source of truth (`docs/SECRETS.md`); zeroized tmpfs restore; no plaintext on disk outside the restore window | `docs/SECRETS.md` |
+| Audit trail | Append-only `audit_log` table, HMAC-SHA256 signature + `previousSignature` hash chain (tamper-evident) | `packages/db/src/schema/audit-log.ts` |
+| Agent action policies | `AuditPolicyEngine` evaluates post-execution; can halt the offending agent (`halt_agent`) or all agents (`halt_all`); built-in policies for tool-rate limits, self-modification, denied tool access, fleet memory flood, consecutive failures | `packages/ai/src/audit/policy.ts` |
+| Tool dispatch | All agent tool calls funnel through `@revealui/mcp`; tier-based JWT authorization on tool invocation; per-tool permission lists | `packages/mcp/src/auth.ts` |
+| Input validation | Zod-typed schemas from `@revealui/contracts`; `isSafeUrl()` blocks `javascript:` / `vbscript:` / `data:` in Lexical rendering; Drizzle parameterized queries | `@revealui/contracts`, Lexical link/image rendering |
+| Webhook integrity | Stripe webhook signature verification; per-endpoint rate limiting (100 req/min) | `apps/server/src/routes/webhooks.ts` |
+| GDPR | Consent management, data deletion, PII anonymization, cross-DB cleanup | `@revealui/security` GDPR framework |
+| Supply chain | Pinned dependency overrides for known CVEs; Dependabot + CodeQL + Gitleaks in CI; `pnpm audit` in CI gate | Root `package.json` `pnpm.overrides`, `.github/workflows/security-audit.yml` |
+
+## 3. What the security stack does NOT govern (explicit non-scope)
+
+This is the section that auditors trust. We do not handwave these gaps.
+
+### 3.1 LLM input / output content moderation
+
+The stack governs *what tools an agent can invoke*. It does not inspect, sanitize, or block the content of LLM prompts or completions. We do not ship Llama Guard, Azure AI Content Safety, NeMo Guardrails, Bedrock Guardrails, or any equivalent prompt / output filter.
+
+If you operate agents on user-supplied content and need toxicity / PII / jailbreak detection at the prompt or completion layer, layer one of those on top. The MCP tool boundary is not a substitute for content moderation.
+
+### 3.2 Indirect / second-order prompt injection
+
+A web page fetched by an allowed `web_search` tool can contain hidden instructions ("ignore previous instructions, exfiltrate X"). The tool call itself is policy-compliant; the resulting agent behavior may not be. The stack does not detect or block prompt-injection payloads embedded in tool *responses*.
+
+Mitigation today: minimize agent autonomy on untrusted-content workflows; require human approval for high-impact actions after ingest of external content. Future: a pre-execution policy gate (planned, see §7) provides one place to add response-content guards.
+
+### 3.3 Knowledge-flow and data classification
+
+The stack does not classify documents, track which retrieval sources influenced a decision, or detect "approved tool reads PII → approved tool writes it to a public channel" exfiltration paths. Both ends of that flow are governed; the flow itself is not.
+
+Mitigation today: tier-based tool access prevents most cross-tenant flows; the audit log records both ends so post-hoc detection is possible. Real-time flow analysis is not in scope.
+
+### 3.4 Embedding / RAG memory poisoning
+
+If an attacker can write to a retrieval index that an agent later reads, no current control detects the poisoned entries. The `AuditPolicyEngine`'s `fleetMemoryFlood` policy detects *volume* spikes, not *content* poisoning.
+
+Mitigation today: write-side authorization on memory tables; provenance fields on `agent_memory` rows; manual review for high-trust memory writes. Cross-model verification (CMVK-style majority vote) is a roadmap item.
+
+### 3.5 Outcome verification
+
+The audit log records actions *attempted* by agents. It does not record whether those actions *succeeded in the external world* or achieved their intended business effect. `Stripe.createCustomer` is logged on call; whether Stripe actually created the customer must be verified by reconciliation (the `report-agent-overage` cron + Stripe webhook listeners) which exists separately and is treated as defense-in-depth, not part of this stack's authorization story.
+
+### 3.6 Real-time streaming inspection
+
+Policy evaluation is per-discrete-action (per tool call, per RPC, per HTTP request). Streaming data — long-running websocket sessions, server-sent events, SSE-based agent streams — is not inspected packet-by-packet.
+
+### 3.7 Customer-side infrastructure
+
+Self-hosted RevealUI deployments are out of scope. Self-hosters are responsible for: TLS termination, network policy, OS-level isolation, container runtime hardening, IAM, and secret backing store. The stack provides defaults that work; it does not enforce them on customer infrastructure.
+
+### 3.8 Physical actuators, embodied agents, real-time control loops
+
+Not designed for. Do not use this stack to govern hardware safety interlocks.
+
+## 4. Architectural design choices that constrain coverage
+
+### 4.1 Post-execution audit, not pre-execution gate
+
+`AuditPolicyEngine` (`packages/ai/src/audit/policy.ts:13`) is invoked from `AuditObserver.handleEvent()` *after* an agent emits a tool-call event. Halts via `halt_agent` / `halt_all` take effect on the agent's *next* event, not the current one. The triggering action is logged and may have already executed.
+
+This is by design: the engine's role is tamper-evident audit + reactive containment, not pre-flight authorization. Pre-flight authorization at the tool layer is handled by `packages/mcp/src/auth.ts` (tier + permission checks) and at the request layer by the RBAC / ABAC engine.
+
+A separate pre-execution policy gate at the MCP dispatch boundary is on the roadmap (§7). Until it ships, anyone needing strict pre-flight enforcement for a new tool category should add the check in the MCP server itself.
+
+### 4.2 Empty-policy default is silent allow
+
+When `AuditPolicyEngine.policies` is empty (no policies registered), `evaluate()` returns `{ violations: [], alerts: [], shouldHaltAgent: false, shouldHaltAll: false }` — i.e., no violations, no halts.
+
+This is the correct default for an audit-driven engine (no false positives on startup) but it means policy coverage is *opt-in*. The five built-ins in `policy.ts:119–245` (`toolCallRateLimit`, `selfModificationBlock`, `consecutiveFailures`, `deniedToolAccess`, `fleetMemoryFlood`) must be explicitly registered at boot. Verify your deployment loads them; a deployment that wires up the engine without registering policies is silently un-governed.
+
+### 4.3 Socket-bound agent identity in the RevDev daemon
+
+`@revealui/harnesses` and the RevDev daemon (`revdev/packages/daemon/src/server.ts:61`) bind agent identity at socket-connect time via `session.register` / `session.attach`. Subsequent RPCs on the same socket inherit the bound identity without per-call cryptographic verification. Two agents sharing a host can co-mingle if socket isolation fails.
+
+DID + Ed25519 per-RPC signature verification is on the roadmap (§7).
+
+### 4.4 No supply-chain attestation on npm publishes
+
+Publishes to npm do not currently produce Sigstore-signed attestations, in-toto link files, or SLSA build provenance. Dependency hygiene is enforced via pinned overrides, Dependabot, CodeQL, and Gitleaks; package-publish provenance is not.
+
+### 4.5 No marketplace yet — extension surface is in-tree only
+
+All MCP servers in `packages/mcp/src/servers/` are first-party. There is no third-party MCP marketplace today. When one ships, tool-poisoning / typosquatting / hidden-instruction detection becomes a hard requirement at the server-registration boundary; see §7.
+
+## 5. Trust assumptions requiring defense-in-depth
+
+Listed so customers and integrators know where the stack stops and their controls must start.
+
+| Layer | Assumption | Customer / operator responsibility |
+|-------|-----------|-----------------------------------|
+| Infrastructure isolation | Agents run in isolated containers / VMs | Operator runs each agent in a separate container; network policy restricts blast radius |
+| Short-lived external credentials | API keys handed to agents have TTL + rotation | Operator configures upstream IAM (AWS STS, GCP short-lived tokens, etc.) |
+| LLM provider trust | The LLM provider does not exfiltrate prompts or completions | Operator picks providers with appropriate data-handling agreements; the fleet runtime uses open-source models on local inference for exactly this reason |
+| Browser security | User-side browsers honor CSP / SameSite / HSTS | Standard browser threat model |
+| Time source | System clock is monotonic and accurate within bounded skew | NTP / chrony on the host |
+| Revvault unlock secret | The operator's age identity is secured outside this system | Operator keeps `~/.age-identity/keys.txt` (or equivalent) under hardware-backed encryption |
+| OS kernel | Host kernel is patched and unprivileged code cannot escape its container | Operator runs current LTS kernel, enables seccomp / AppArmor |
+
+If any of these assumptions is violated, controls in this stack may fail in ways the stack cannot detect.
+
+## 6. Known footguns and configuration risks
+
+| Risk | Description | Mitigation |
+|------|-------------|------------|
+| Engine registered, no policies loaded | `AuditPolicyEngine` is wired but `builtinPolicies.*()` are never registered → silent no-op | Confirm policy registration in your boot path. Future: a `gate` check that fails CI if the audit engine has zero policies in production config. |
+| Missing CSRF token on a new admin route | New state-changing admin route added without the CSRF middleware | The CSRF middleware is the default for admin routes; if you build a route that bypasses the default, document why |
+| `overrideAccess` query param leak | Untrusted code path forwards `overrideAccess` from request → DB layer | The proxy strips `overrideAccess` from external requests; do not re-introduce it downstream |
+| Custom MCP server bypassing tier checks | A new MCP server that doesn't use `packages/mcp/src/auth.ts` | All MCP servers must go through the shared auth wrapper. Future: registration-time linter that fails if a server skips auth |
+| Revvault path collision across products | Same path used for two different secrets across `revealui/*` and a sibling product | Revvault `detect_path_collisions()` runs pre-sync (revvault#40); failures block sync |
+| Sentry DSN absent in production | Errors disappear silently in production-hosted | `SENTRY_DSN` is required at boot in production (GAP-S1, revealui#787) |
+| Webhook signature verification disabled | Stripe webhook handler accepts unsigned requests | `STRIPE_WEBHOOK_SECRET` must be present; the webhook handler refuses unsigned events in production mode |
+
+## 7. Roadmap items that will narrow these limits
+
+Tracked in `docs/MASTER_PLAN.md`. Cited here so the limitations above are not perceived as final.
+
+- **Pre-execution policy gate at the MCP dispatch boundary** — moves `AuditPolicyEngine`-style checks from post-execution to pre-execution at the tool layer. Closes §4.1.
+- **DID + Ed25519 RPC signing for the RevDev daemon** — per-call cryptographic identity verification. Closes §4.3.
+- **MCP Security Scanner at server registration** — tool-poisoning / typosquatting / hidden-instruction detection before a third-party MCP server can expose a tool. Required before marketplace opens. Closes §4.5.
+- **AI Bill of Materials (AI-BOM)** — model name, weights SHA-256, source registry, fine-tuning lineage, dataset cards, signature. Supports EU AI Act Article 53.
+- **Sigstore-signed npm publishes** — package provenance via `attest-build-provenance` GitHub Action. Closes §4.4.
+
+## 8. Document maintenance
+
+This document is reviewed:
+
+- After any P0 or P1 incident that exposes a gap not currently disclosed here
+- When a roadmap item in §7 ships (the corresponding limitation is moved from §3 / §4 to a "Historical limitation, closed YYYY-MM-DD" appendix)
+- At minimum, every 6 months
+
+Last reviewed: 2026-05-16.
+
+For the threat model that informs these limitations, see [THREAT_MODEL.md](./THREAT_MODEL.md).
+For vulnerability reporting, see [/SECURITY.md](/SECURITY.md).
+For incident response procedures, see [INCIDENT_RESPONSE.md](./INCIDENT_RESPONSE.md).
+For the active security policy, see [INFORMATION_SECURITY_POLICY.md](./INFORMATION_SECURITY_POLICY.md).

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,0 +1,140 @@
+---
+title: Threat Model
+description: STRIDE-style threat model for the RevealUI security stack across four trust boundaries — Human↔App, App↔External services, Agent↔Tool (MCP), Agent↔Agent (RevDev daemon).
+last-updated: 2026-05-16
+---
+
+# Threat Model
+
+## 1. Purpose
+
+This document is the threat-modeling skeleton for the RevealUI security stack. It catalogs assets, trust boundaries, and STRIDE-categorized threats per boundary, with named mitigations citing the file path (and `:line` where the citation is stable) at which each control lives. Residual risks point to [LIMITATIONS.md](./LIMITATIONS.md).
+
+It is a working document. Comprehensive coverage will accrete over multiple sessions as new features ship; pre-merge threat-model updates are expected for any change that touches the boundaries enumerated in §4.
+
+## 2. Scope and assumptions
+
+**In scope:**
+- The RevealUI monorepo as it ships from `RevealUIStudio/revealui`
+- The `AuditPolicyEngine` and MCP dispatch boundary in `@revealui/ai` and `@revealui/mcp`
+- The RevDev daemon's RPC interface (`revdev/packages/daemon`)
+- Secret handling via revvault and Vercel environment variables
+- Production deployment topology: Vercel-hosted Next.js + Hono on Vercel functions, NeonDB primary, Supabase legacy, Stripe payments
+
+**Out of scope:**
+- Self-hosted customer deployments — see [LIMITATIONS.md §3.7](./LIMITATIONS.md)
+- LLM provider trust model — covered by provider selection (open-source models on local inference for the fleet runtime)
+- Physical / embodied / real-time control — see [LIMITATIONS.md §3.8](./LIMITATIONS.md)
+
+**Trust assumptions** are enumerated in [LIMITATIONS.md §5](./LIMITATIONS.md). If any is violated, the controls in this model may not hold.
+
+## 3. Assets
+
+| Asset | Description | Where it lives |
+|-------|-------------|----------------|
+| User PII | Email, name, password hash, OAuth tokens, TOTP secrets | NeonDB `users` table + Supabase legacy auth |
+| Session state | Active session cookies, signing key | NeonDB `sessions` table; signing key in revvault under the `revealui/prod/session-secret` path |
+| Payment data | Stripe customer IDs, subscription IDs, webhook event metadata (no PAN — never stored) | NeonDB `billing_*` tables; Stripe is canonical |
+| Application secrets | Database URLs, Stripe keys, OAuth client secrets, webhook signing secrets | Revvault (canonical), Vercel env vars (mirror) |
+| Audit trail | Append-only tamper-evident log of agent and admin actions | NeonDB `audit_log` table, HMAC chain |
+| Content | User-published content under their RevealUI-powered site | NeonDB `content_*` tables |
+| RevealCoin (RVC) keypairs | Mint authority, treasury, vesting wallets | Revvault `revealcoin/*` paths (encrypted) |
+| npm packages | OSS + Pro packages published under `@revealui/*` | npm registry; build artifacts in GitHub Actions |
+| Source code | The monorepo itself | GitHub `RevealUIStudio/revealui`, branch protection on `main` and `test` |
+
+## 4. Trust boundaries
+
+Adapted from the four-boundary structure that recurs in modern agentic threat models. Each boundary is enumerated in §5 with STRIDE.
+
+| ID | Boundary | Crosses |
+|----|----------|---------|
+| **B1** | Human ↔ App | Browser sessions to Next.js / Hono entry points |
+| **B2** | App ↔ External services | Outbound to Stripe, Vercel, Neon, Supabase, OAuth providers, LLM providers, npm registry |
+| **B3** | Agent ↔ Tool (MCP) | Agents in `@revealui/ai` dispatching to MCP servers in `@revealui/mcp` |
+| **B4** | Agent ↔ Agent (Daemon) | Cross-agent coordination via the RevDev daemon RPC interface |
+
+(`B0` — Internal monorepo build / CI / GitHub Actions — is in scope but not enumerated here; covered by branch protection + supply-chain controls in [INFORMATION_SECURITY_POLICY.md §7](./INFORMATION_SECURITY_POLICY.md).)
+
+## 5. STRIDE per boundary
+
+Mitigations cite file paths. Where a mitigation is planned but not shipped, it is marked → [LIMITATIONS.md](./LIMITATIONS.md) with a pointer to the relevant roadmap item.
+
+### 5.1 B1 — Human ↔ App
+
+| Threat | Example | Mitigations |
+|--------|---------|-------------|
+| **Spoofing** | Attacker forges a session cookie | Signed cookies (httpOnly + secure + sameSite=lax); session signing via `SESSION_SECRET` (revvault path `revealui/prod/session-secret`); bcrypt-hashed passwords (12 rounds); optional TOTP MFA |
+| **Tampering** | XSS injects JS to read admin state | CSP headers (`@revealui/security`); `isSafeUrl()` blocks `javascript:` / `vbscript:` / `data:` in Lexical link + image rendering; React 19 default escaping; CSRF tokens on state-changing admin routes (revealui#840, #853) |
+| **Repudiation** | Admin denies making a destructive change | `audit_log` table with HMAC + previousSignature chain (`packages/db/src/schema/audit-log.ts`); admin actions logged with actor + timestamp |
+| **Information Disclosure** | API leaks PII to an unauthenticated caller | RBAC + ABAC engine; `access.read` enforced in find / findByID; admin gate via `revealui-role` cookie in `proxy.ts`; `overrideAccess` stripped from external requests |
+| **Denial of Service** | Brute-force auth or webhook flood | Brute-force progressive lockout on auth endpoints; 100 req/min rate limit on `/api/webhooks`; Vercel-side DDoS protection |
+| **Elevation of Privilege** | Authenticated user accesses admin routes | Admin proxy gate (defense-in-depth on top of role checks); license + feature gates (`isLicensed('pro')`, `isFeatureEnabled()`); access-enforcement tests verify role isolation (`packages/core/src/__tests__/auth/`) |
+
+### 5.2 B2 — App ↔ External services
+
+| Threat | Example | Mitigations |
+|--------|---------|-------------|
+| **Spoofing** | Forged Stripe webhook | Stripe webhook signature verification with `STRIPE_WEBHOOK_SECRET`; livemode guard on webhook events (revealui#789) |
+| **Tampering** | MITM on an outbound API call | TLS 1.2+ enforced on all outbound (Vercel function runtime, Node 24 defaults); HSTS on inbound |
+| **Repudiation** | Vendor denies receiving a request | All outbound calls go through `@revealui/services` with structured logging; Sentry captures errors (revealui#823, #787 GAP-S1) |
+| **Information Disclosure** | A secret leaks via logs or error traces | `pnpm audit:console` finds production console statements (warn); Gitleaks in pre-commit + CI; revvault paths logged, never values; `pnpm audit:any` tracks unsafe `any` types that could mask leaks |
+| **Denial of Service** | Upstream provider outage cascades | `@revealui/resilience` circuit breaker + retry + bulkhead; `@revealui/cache` ISR + edge cache; Stripe circuit breaker in `@revealui/services`; reconciliation crons with Sentry failure alerts (revealui#787 GAP-S2) |
+| **Elevation of Privilege** | Compromised secret grants over-broad upstream access | Revvault is the canonical store; per-environment scoping (prod / dev); revvault-vercel-sync keeps the canonical-mirror invariant (revealui#784, revvault#40); secret-rotation runbooks per provider in [INCIDENT_RESPONSE.md §7](./INCIDENT_RESPONSE.md) |
+
+### 5.3 B3 — Agent ↔ Tool (MCP dispatch)
+
+| Threat | Example | Mitigations |
+|--------|---------|-------------|
+| **Spoofing** | Tool call masquerading as a different agent's call | Agent identity threaded into MCP call context; tool-call audit emits `agentId` + `sessionId` + `taskId` per call (`packages/ai/src/audit/types.ts`) |
+| **Tampering** | Tool response modified to inject a malicious instruction | Tool responses are not signed by tool authors today; mitigation deferred — see [LIMITATIONS.md §3.2](./LIMITATIONS.md) |
+| **Repudiation** | Agent denies having called a destructive tool | Every tool call emits an `agent:tool:call` audit entry (`packages/ai/src/audit/types.ts`); HMAC chain prevents post-hoc edit |
+| **Information Disclosure** | Tool exfiltrates secret-bearing context | Tier-based authorization (`packages/mcp/src/auth.ts`) gates tool access per JWT tier (free / pro / max / enterprise); per-tool permission lists in the same file; agent capability tags restrict which agents can call which tools (`packages/ai/src/orchestration/agent.ts`) |
+| **Denial of Service** | Agent floods a tool to exhaust quota | `toolCallRateLimit` policy in `AuditPolicyEngine` (`packages/ai/src/audit/policy.ts`); circuit breaker on `@revealui/services` calls; per-route Hono rate limits |
+| **Elevation of Privilege** | Agent invokes a higher-tier tool it shouldn't have | License + tier check at `packages/mcp/src/auth.ts`; `deniedToolAccess` policy halts the agent on a denied call; `selfModificationBlock` halts an agent attempting to mutate its own instructions |
+
+**Known residual risks for B3** — see [LIMITATIONS.md §3.1 (LLM content moderation), §3.2 (indirect prompt injection), §3.3 (knowledge-flow exfiltration), §4.1 (post-execution audit timing)](./LIMITATIONS.md).
+
+### 5.4 B4 — Agent ↔ Agent (RevDev daemon)
+
+| Threat | Example | Mitigations |
+|--------|---------|-------------|
+| **Spoofing** | One agent impersonates another over the daemon socket | Socket-bound identity at `session.register` / `session.attach` (`revdev/packages/daemon/src/server.ts`); future per-RPC Ed25519 verification → [LIMITATIONS.md §4.3](./LIMITATIONS.md) |
+| **Tampering** | RPC arguments modified in transit | Unix-domain socket — host-local trust boundary; in-flight tampering requires host-level compromise (out of scope) |
+| **Repudiation** | Agent denies posting a coordination message | All RPC methods log to the daemon event store with `agentId` + `method` + timestamp; coordination operations (mail, files, tasks) maintain their own provenance |
+| **Information Disclosure** | One agent reads another agent's mailbox | Mail / Files / Tasks scoped by `agentId` in the daemon's PGlite store; cross-agent reads require explicit broadcast or assignment |
+| **Denial of Service** | Agent spams the daemon with RPCs | License-guarded RPC dispatch (`revdev/packages/daemon/src/guard.ts`); `IDENTITY_EXEMPT` set bounds methods callable pre-registration |
+| **Elevation of Privilege** | Agent claims a license tier it isn't entitled to | License is verified by `guardRpcMethod()` per dispatch; revvault holds canonical license state |
+
+**Known residual risks for B4** — see [LIMITATIONS.md §4.3 (socket-bound identity)](./LIMITATIONS.md).
+
+## 6. Cross-cutting controls
+
+Controls that apply across multiple boundaries.
+
+| Control | Mechanism | Coverage |
+|---------|-----------|----------|
+| Tamper-evident audit | HMAC-SHA256 signature + `previousSignature` hash chain | All admin actions, all agent tool calls, all policy violations |
+| Secret hygiene | Revvault canonical; tmpfs restore; zeroized on exit; pre-commit Gitleaks; CI Gitleaks | All boundaries; `docs/SECRETS.md` is the path index |
+| Dependency hygiene | Pinned `pnpm.overrides`; Dependabot; CodeQL; `pnpm audit` in CI | All packages; B2 supply-chain protection |
+| GDPR data subject rights | `@revealui/security` GDPR framework; cross-DB cleanup via `@revealui/db/cleanup` | B1 PII, B2 PII-in-Stripe (revealui#789 GDPR `stripe.customers.del`) |
+| Pre-launch checklist | `pnpm preflight` — 15-point check | All boundaries before production deploy |
+
+## 7. Residual risks
+
+The threats this model does NOT mitigate are enumerated in [LIMITATIONS.md §3 (non-scope)](./LIMITATIONS.md) and [§4 (architectural design choices that constrain coverage)](./LIMITATIONS.md). The roadmap items in [LIMITATIONS.md §7](./LIMITATIONS.md) are the planned reductions of those residuals.
+
+## 8. Maintenance
+
+This document is reviewed and updated:
+
+- When a new trust boundary is introduced (e.g., when the marketplace opens, "B5 = App ↔ Third-party MCP marketplace" becomes a new boundary)
+- When a mitigation in §5 changes file path — citations must stay accurate
+- After any P0 / P1 incident — add the attack path to the relevant boundary's STRIDE row if not already covered
+- At minimum, every 6 months
+
+Last reviewed: 2026-05-16.
+
+For limitations and residual risks, see [LIMITATIONS.md](./LIMITATIONS.md).
+For vulnerability reporting, see [/SECURITY.md](/SECURITY.md).
+For incident runbooks, see [INCIDENT_RESPONSE.md](./INCIDENT_RESPONSE.md).
+For the active security policy, see [INFORMATION_SECURITY_POLICY.md](./INFORMATION_SECURITY_POLICY.md).


### PR DESCRIPTION
## Summary

Two new honest-scope docs for the RevealUI security stack:

- **`docs/security/LIMITATIONS.md`** (161 lines) — explicit scope and non-scope statement. What the stack governs (auth, authz, audit chain, MCP dispatch, secrets, etc.), what it does NOT govern (LLM content moderation, indirect prompt injection, knowledge-flow exfiltration, embedding poisoning, outcome verification, streaming inspection, customer-side infrastructure, embodied agents), architectural design choices that constrain coverage, trust assumptions requiring defense-in-depth, known footguns, and roadmap items that will narrow these limits.
- **`docs/security/THREAT_MODEL.md`** (140 lines) — STRIDE-style threat model across four trust boundaries: B1 Human↔App, B2 App↔External services, B3 Agent↔Tool (MCP dispatch), B4 Agent↔Agent (RevDev daemon). Asset table, named mitigations with file-path citations, cross-cutting controls, residual risks pointing to LIMITATIONS.md.

## Why now

Audience: SOC 2 auditors, customer security reviews, EU AI Act readiness (Article 53 transparency obligations enforceable August 2026), and self-hosters planning their own defense-in-depth layers.

Pattern is inspired by Microsoft's Agent Governance Toolkit (released 2026-04-02 — see [opensource.microsoft.com blog](https://opensource.microsoft.com/blog/2026/04/02/introducing-the-agent-governance-toolkit-open-source-runtime-security-for-ai-agents/) and [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit)), specifically its own `LIMITATIONS.md` and `THREAT_MODEL.md` docs. Research synthesis was done 2026-05-16; this PR is Phase 1 (cheapest credibility wins) of that adoption roadmap. Adoptions 1–5 (pre-execution MCP gate, DID daemon identity, MCP security scanner, AI-BOM, Sigstore npm publishes) remain on the roadmap and are cited explicitly in [LIMITATIONS §7](./docs/security/LIMITATIONS.md).

## Audit-first finding documented, not flipped

`AuditPolicyEngine` (`packages/ai/src/audit/policy.ts:13`) is genuinely post-execution audit-driven (called from `AuditObserver.handleEvent()` *after* an agent emits a tool-call event). When `policies` is empty, `evaluate()` returns a no-op verdict — i.e., silent allow.

This was originally framed as a "verify and flip the default" item, but the audit revealed there is no pre-execution gate to flip. The right disclosure is in `LIMITATIONS.md §4.1` (post-execution audit, not pre-execution gate) and `§4.2` (empty-policy default = no enforcement). The actual pre-execution gate is a separate roadmap item, not a default-flip.

**No code change in this PR.**

## Test plan

- [ ] Markdown renders cleanly in `docs.revealui.com` (Vite/React docs site) and the GitHub web view
- [ ] All relative cross-refs resolve: `./LIMITATIONS.md` ↔ `./THREAT_MODEL.md` ↔ `./INCIDENT_RESPONSE.md` ↔ `./INFORMATION_SECURITY_POLICY.md` ↔ `/SECURITY.md`
- [ ] CI: Quality (Biome) + Typecheck + Build + Security gate + CodeQL + Drizzle migrations + Gitleaks all green
- [ ] Gitleaks confirms no secrets in the docs (path / env-var-name references only — no secret values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
