### PR TITLE
feat(marketing): hybrid-noun hero + audience-fork CTA + Fair Source relabel

### DIFF
--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -77,16 +77,27 @@ export function Hero() {
           </p>
 
           <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
-            <span className="block">Stop building the backend.</span>
-            <span className="block">Ship the AI business.</span>
+            The open runtime for AI-native businesses.
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Auth, billing, content, and agents &mdash; wired, audited, yours. From{' '}
+            <strong className="text-gray-900">Yours to install. Ours to build for you.</strong>{' '}
+            Auth, content, products, payments, and intelligence &mdash; five primitives, one policy
+            plane, one hash-chained audit log. For founders shipping AI products who need audit
+            trails and unified governance from day one &mdash; whether you build with{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-base text-gray-900">
               npx create-revealui
             </code>{' '}
-            to a deployed product in a weekend.
+            or hire{' '}
+            <a
+              href="https://revealuistudio.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-700 hover:underline"
+            >
+              RevealUI Studio
+            </a>{' '}
+            to build it for you.
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -125,6 +136,18 @@ export function Hero() {
             </ButtonCVA>
           </div>
 
+          <p className="mt-6 text-sm text-gray-600">
+            Want it built for you?{' '}
+            <a
+              href="https://revealuistudio.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-700 hover:underline"
+            >
+              RevealUI Studio builds AI businesses on RevealUI &rarr;
+            </a>
+          </p>
+
           <div className="mt-10 inline-flex items-center gap-3 rounded-xl bg-gray-950 px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-white/10">
             <span className="select-none text-gray-400">$</span>
             <span className="text-emerald-400">npx</span>
@@ -162,7 +185,7 @@ export function Hero() {
                     'Verified every 5 minutes against the license server. Source at packages/core/src/license.ts.',
                 },
                 {
-                  metric: 'FSL-1.1-MIT on 5 Pro packages',
+                  metric: 'FSL-1.1-MIT on 5 Fair Source packages',
                   detail:
                     'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
                 },


### PR DESCRIPTION
## Summary

Replaces revealui.com hero H1 + subhead with the hybrid-noun framing approved 2026-05-16. Adds a tertiary cross-link CTA to `revealuistudio.com` closing the audience-fork loop. Relabels "Pro packages" → "Fair Source packages" in the proof-points grid per the 2026-05-14 audit §6.3 ruling.

## Owner decision context

Companion PRs:
- an internal repo — ADR `docs/decisions/2026-05-16-hybrid-noun-hero-fork.md` (full decision record)
- an internal repo — voice-rules §4.1 amendment codifying the `framework` hero-only exception

Decision summary:
- **Hybrid noun on THIS hero only**: H1 keeps "runtime" (audit-grade brand spine) + surfaces the framework mental model via "AI-native businesses" outcome framing. Every other surface (docs, blog, READMEs, PricingPage, ProductsPage, FAQs) stays on "runtime" exclusively per §6.2.
- **Audience fork via cross-link**: tertiary CTA → revealuistudio.com. The agency NavBar already links back; loop closes on this single edit. Closes the §6.4 fork-mechanism requirement without a new content lane.
- **Pro → Fair Source relabel**: the runtime feature gates were removed (per §6.3); "Pro packages" is now a misnomer.

## Voice-rule check

Drafted against an internal repo:docs/lanes/_closed/messaging-funnel-audit/voice-and-headline-rules.md` 5 rules + 12-item review checklist:

- ✓ R1 lead-with-shipping: `npx create-revealui` ships; audit log ships; 5 primitives ship
- ✓ R2 specifics-over-adjectives: named artifacts (5 primitives, policy plane, hash-chained audit); zero banned adjectives
- ✓ R3 reader-by-scenario: "founders shipping AI products who need audit trails and unified governance from day one" — filters out vibe-coders, hobbyists, no-AI products
- ✓ R4 surface-the-tradeoff: dual-lane subhead frames the DIY/DFY choice; FSL/MIT ratio in grid below
- ✓ R5 no-marketing-speak: zero banned words from §4.1
- ✓ T1 fleet-register: third-person about runtime + second-person to reader
- ✓ T2 CTA verbs: Start free / See on GitHub / RevealUI Studio builds — all fleet-register
- ✓ S1 no-internal-codenames: no RVUI, no bare Forge, no Stamp

## Scope

`Hero.tsx` only. ~25 lines changed. The other open 2026-05-14 P0s (LicenseGate behavior, `pricing.ts` Start-Free-Trial language, `blog-drafts/` deletion, Next.js self-contradiction in `Proof.tsx`) are explicitly out of scope per owner ruling 2026-05-16 — each lands as its own PR.

## Verification

Vercel preview deployments are not enabled on this project (free plan, deploy-minute conservation). Verification path is:

1. **Pre-push gate (already PASS)** — 17 checks ran on push including Biome lint, Typecheck, Build, claim-drift, Pro license validation, security gate. All green.
2. **CI checks (in flight)** — full GitHub Actions workflow including Quality, Build, Drizzle Migrations, Typecheck, Security Gate, Submodule Audit, Gitleaks. Required: CodeQL + Integration Tests + Unit Tests still pending at PR open time.
3. **Local visual verification** — performed against `pnpm --filter marketing dev` on port 3000. Findings posted in the next comment on this PR (screenshot + DOM snapshot of the rendered hero).
4. **Manual review of diff** — text-only change in an existing JSX pattern; no new components, no routing changes, no structural changes to the proof-points grid.

If the local visual verification surfaces any rendering issue, this PR doesn't merge until resolved. Owner reviews the screenshot before merging.

## Test plan

- [ ] Local Vite preview renders Hero with new H1 + subhead + 3 CTAs visible (see verification comment)
- [ ] All 3 CTAs link to correct destinations (admin signup, GitHub repo, revealuistudio.com)
- [ ] Tertiary "Want it built for you?" link renders below the buttons, visually de-emphasized vs primary/secondary
- [ ] CI green: Biome lint + Vitest + Playwright + CodeQL + Gitleaks + claim-drift
- [ ] No regression on the "What ships today" grid (FSL line now reads "5 Fair Source packages")
