### PR TITLE
fix(cache): bump 3 PGlite test timeouts from 5s to 30s

### DIFF
--- a/packages/cache/src/__tests__/adapters-supplemental.test.ts
+++ b/packages/cache/src/__tests__/adapters-supplemental.test.ts
@@ -107,6 +107,11 @@ if (pgliteAvailable) {
   const { PGlite } = await import('@electric-sql/pglite');
   const { PGliteCacheStore } = await import('../adapters/pglite.js');
 
+  // Timeout bumped from the 5s vitest default to 30s: each test does
+  // `new PGlite()`, an in-memory Postgres cold-start that takes 2-4s in
+  // isolation but pushes past 5s under parallel-load pre-push gate runs on
+  // RAM-constrained hosts. 30s gives plenty of headroom without masking
+  // real regressions (tests still complete in <5s when nothing else competes).
   describe('PGliteCacheStore  -  closeOnDestroy:true', () => {
     it('calls db.close() when closeOnDestroy is true', async () => {
       const db = new PGlite();
@@ -116,7 +121,7 @@ if (pgliteAvailable) {
       await store.close();
 
       expect(closeSpy).toHaveBeenCalledOnce();
-    });
+    }, 30_000);
 
     it('does not call db.close() when closeOnDestroy is false', async () => {
       const db = new PGlite();
@@ -127,7 +132,7 @@ if (pgliteAvailable) {
 
       expect(closeSpy).not.toHaveBeenCalled();
       await db.close();
-    });
+    }, 30_000);
   });
 
   describe('PGliteCacheStore  -  delete with zero keys', () => {
@@ -146,7 +151,7 @@ if (pgliteAvailable) {
       expect(querySpy).not.toHaveBeenCalled();
 
       await store.close();
-    });
+    }, 30_000);
   });
 } else {
   describe.skip('PGliteCacheStore supplemental (skipped  -  @electric-sql/pglite not available)', () => {


### PR DESCRIPTION
## What

Bumps test timeouts from the 5000ms vitest default to 30_000ms on the 3 PGlite tests in `packages/cache/src/__tests__/adapters-supplemental.test.ts` that intermittently time out under parallel-load pre-push gate runs.

## Why

Each affected test does `new PGlite()` — an in-memory Postgres cold-start that takes 2-4s in isolation but pushes past 5s under parallel-load contention with the other 30+ packages testing simultaneously. RAM pressure on dev hosts (~4 GB WSL allocation, ~700 MB free at gate run time) tips it over the timeout.

GitHub CI has more headroom and historically passes; the failure is local-only but blocks `pre-push` legitimately (the gate runs the same test set as CI).

## Verification

| Run | Result |
|---|---|
| Isolated: `pnpm --filter @revealui/cache test src/__tests__/adapters-supplemental.test.ts` | ✅ 9/9 pass in 8.88s |
| Parallel pre-push gate (full 31-package run) | ❌ 3 timeouts before this fix |
| Affected test wall-clock in isolation | 3.86s / 2.04s / 2.24s — under 5s but borderline |

The bumped timeout (30s) gives ~6-10x headroom without masking real regressions; tests still complete in <5s when nothing competes.

## Scope

- **Touched:** `packages/cache/src/__tests__/adapters-supplemental.test.ts` only.
- **Untouched:** `PGliteCacheStore` implementation, other cache tests, vitest config, other packages.
- **Lines changed:** ~50 (the 3 `it()` calls reformatted to add the 3rd positional `timeout` arg + a docstring comment above the describe block).

## Why not bump vitest.config.ts package-wide

- Targeted is better than broad: only the slow PGlite tests get the longer budget; the other tests retain the 5s discipline.
- Discoverable: a future maintainer reading the test sees the explicit timeout + comment and knows why; a config-default is invisible at the call site.
- Reversible: when WSL/CI resources improve or PGlite cold-start speeds up, remove the timeout (one line per test + the comment).

## Context

Surfaced while attempting a force-push to `test` for an unrelated PR ([#881](https://github.com/RevealUIStudio/revealui/pull/881) cleanup) — pre-push gate failed on this flake. Filed as its own change rather than mixing in unrelated edits.

## Test plan

- [ ] CI green on this PR (Quality, Build, Typecheck, Tests, Security Gate, etc.)
- [ ] Cache package tests pass without timeout in CI
- [ ] No regression in other packages' tests (cache change is isolated)
