### PR TITLE
feat(cli): starter-native template — Vite + @revealui/router (no Next.js dep)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ pnpm create revealui@latest my-project --template basic-blog
 ## Features
 
 - Interactive project setup with guided prompts
-- Multiple templates: basic-blog, e-commerce, portfolio
+- Multiple templates: basic-blog, e-commerce, portfolio, starter-native (Vite + @revealui/router, no Next.js)
 - Automatic environment configuration
 - Database setup (NeonDB, Supabase, or local PostgreSQL)
 - Storage setup (Vercel Blob or Supabase)
@@ -31,11 +31,20 @@ pnpm create revealui@latest my-project --template basic-blog
 Usage: create-revealui [options] [project-name]
 
 Options:
-  -t, --template <name>   Template to use (basic-blog, e-commerce, portfolio)
+  -t, --template <name>   Template to use (basic-blog, e-commerce, portfolio, starter-native)
   --skip-git              Skip git initialization
   --skip-install          Skip dependency installation
   -h, --help             Display help for command
 ```
+
+### Templates
+
+| Template | Stack | Best for |
+|---|---|---|
+| `basic-blog` | Next.js 16 + @revealui/* | Blogs, content sites — Next.js ecosystem |
+| `e-commerce` | Next.js 16 + @revealui/* + Stripe | Online stores with checkout |
+| `portfolio` | Next.js 16 + @revealui/* | Personal portfolio sites |
+| `starter-native` | Vite + @revealui/router + @revealui/* | RevealUI-native runtime — no Next.js dep. Best when you want to dogfood the full RevealUI stack. |
 
 ## Requirements
 

--- a/packages/cli/src/__tests__/template-structure.test.ts
+++ b/packages/cli/src/__tests__/template-structure.test.ts
@@ -25,7 +25,10 @@ const TSC_BIN = path.resolve(__dirname, '../../../node_modules/.bin/tsc');
 // Shared scaffolding helper
 // ---------------------------------------------------------------------------
 
-function baseConfig(template: 'basic-blog' | 'e-commerce' | 'portfolio', projectPath: string) {
+function baseConfig(
+  template: 'basic-blog' | 'e-commerce' | 'portfolio' | 'starter-native',
+  projectPath: string,
+) {
   return {
     project: {
       projectName: `test-${template}`,
@@ -196,7 +199,7 @@ describe('package.json integrity after scaffolding', () => {
 // ---------------------------------------------------------------------------
 
 describe('tsconfig.json validity', () => {
-  const templates = ['basic-blog', 'e-commerce', 'portfolio', 'starter'] as const;
+  const templates = ['basic-blog', 'e-commerce', 'portfolio', 'starter', 'starter-native'] as const;
 
   for (const template of templates) {
     it(`${template}: tsconfig.json is valid JSON with include field`, async () => {
@@ -279,4 +282,105 @@ describe('TypeScript syntax  -  template source files', () => {
       ).toHaveLength(0);
     });
   }
+
+  // starter-native has a Vite shape (app/ + src/), not the Next.js shape (src/app/).
+  // Scan both directories for syntax errors.
+  it('starter-native: no syntax errors in app/ + src/ .ts/.tsx files', async () => {
+    const templateDir = path.join(TEMPLATES_DIR, 'starter-native');
+    const appFiles = await collectTsFiles(path.join(templateDir, 'app'));
+    const srcFiles = await collectTsFiles(path.join(templateDir, 'src'));
+    const files = [...appFiles, ...srcFiles];
+    expect(files.length).toBeGreaterThan(0);
+
+    const syntaxErrors = collectSyntaxErrors(files);
+    expect(
+      syntaxErrors,
+      `Syntax errors in starter-native template:\n${syntaxErrors.join('\n')}`,
+    ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// starter-native: file structure (differs from Next.js templates — has app/
+// + vite.config.ts + index.html instead of src/app/ + next.config.mjs)
+// ---------------------------------------------------------------------------
+
+describe('Template file structure  -  starter-native (Vite + @revealui/router)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'revealui-struct-native-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copies required root files (Vite shape, no next.config.mjs)', async () => {
+    const projectPath = path.join(tmpDir, 'native');
+    await createProject(baseConfig('starter-native', projectPath));
+
+    const files = await fs.readdir(projectPath);
+    expect(files).toContain('package.json');
+    expect(files).toContain('tsconfig.json');
+    expect(files).toContain('vite.config.ts');
+    expect(files).toContain('vitest.config.ts');
+    expect(files).toContain('index.html');
+    expect(files).toContain('.env.local'); // CLI-generated
+    expect(files).toContain('README.md'); // CLI-generated
+    expect(files).toContain('app');
+    expect(files).toContain('src');
+    expect(files).not.toContain('next.config.mjs');
+  });
+
+  it('has .gitignore (renamed from _gitignore)', async () => {
+    const projectPath = path.join(tmpDir, 'native-gi');
+    await createProject(baseConfig('starter-native', projectPath));
+
+    const files = await fs.readdir(projectPath);
+    expect(files).toContain('.gitignore');
+    expect(files).not.toContain('_gitignore');
+  });
+
+  it('app/ contains App.tsx, main.tsx, routes/, layouts/, styles/', async () => {
+    const projectPath = path.join(tmpDir, 'native-app');
+    await createProject(baseConfig('starter-native', projectPath));
+
+    const appFiles = await fs.readdir(path.join(projectPath, 'app'));
+    expect(appFiles).toContain('App.tsx');
+    expect(appFiles).toContain('main.tsx');
+    expect(appFiles).toContain('routes');
+    expect(appFiles).toContain('layouts');
+    expect(appFiles).toContain('styles');
+  });
+
+  it('package.json declares @revealui/router and not next', async () => {
+    const projectPath = path.join(tmpDir, 'native-deps');
+    await createProject(baseConfig('starter-native', projectPath));
+
+    const pkg = JSON.parse(await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8')) as {
+      name?: string;
+      dependencies?: Record<string, string>;
+    };
+
+    expect(pkg.name).toBe('test-starter-native');
+    expect(pkg.dependencies?.['@revealui/router']).toBeDefined();
+    expect(pkg.dependencies?.['@revealui/core']).toBeDefined();
+    expect(pkg.dependencies?.next).toBeUndefined();
+  });
+
+  it('package.json has Vite scripts (dev/build/preview/typecheck/test)', async () => {
+    const projectPath = path.join(tmpDir, 'native-scripts');
+    await createProject(baseConfig('starter-native', projectPath));
+
+    const pkg = JSON.parse(await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.dev).toMatch(/vite/);
+    expect(pkg.scripts?.build).toMatch(/vite build/);
+    expect(pkg.scripts?.preview).toMatch(/vite preview/);
+    expect(typeof pkg.scripts?.typecheck).toBe('string');
+    expect(typeof pkg.scripts?.test).toBe('string');
+  });
 });

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -153,12 +153,18 @@ async function copyDir(src: string, dest: string): Promise<void> {
 /**
  * Map the CLI template name to the directory name under templates/.
  * All non-starter templates fall back to starter for now.
+ *
+ * `starter-native` is the RevealUI-native variant (Vite + @revealui/router +
+ * no Next.js) — see GAP-194 audit §1.B for the rationale. Customers choose
+ * `starter-native` when they want the framework-not-stack runtime instead of
+ * the default Next.js-based starters.
  */
 function resolveTemplateName(template: ProjectConfig['template']): string {
   const map: Record<ProjectConfig['template'], string> = {
     'basic-blog': 'basic-blog',
     'e-commerce': 'e-commerce',
     portfolio: 'portfolio',
+    'starter-native': 'starter-native',
   };
   return map[template] ?? 'starter';
 }

--- a/packages/cli/src/prompts/project.ts
+++ b/packages/cli/src/prompts/project.ts
@@ -9,10 +9,10 @@ import { isCancel, select, text } from '@clack/prompts';
 export interface ProjectConfig {
   projectName: string;
   projectPath: string;
-  template: 'basic-blog' | 'e-commerce' | 'portfolio';
+  template: 'basic-blog' | 'e-commerce' | 'portfolio' | 'starter-native';
 }
 
-const VALID_TEMPLATES = ['basic-blog', 'e-commerce', 'portfolio'] as const;
+const VALID_TEMPLATES = ['basic-blog', 'e-commerce', 'portfolio', 'starter-native'] as const;
 
 export async function promptProjectConfig(
   defaultName?: string,
@@ -69,6 +69,10 @@ export async function promptProjectConfig(
         { value: 'basic-blog' as const, label: 'Basic Blog - A simple blog with posts and pages' },
         { value: 'e-commerce' as const, label: 'E-commerce - Product catalog with checkout' },
         { value: 'portfolio' as const, label: 'Portfolio - Personal portfolio site' },
+        {
+          value: 'starter-native' as const,
+          label: 'Starter (native) - Vite + @revealui/router, no Next.js',
+        },
       ],
       initialValue: 'basic-blog' as const,
     });

--- a/packages/cli/templates/starter-native/.env.example
+++ b/packages/cli/templates/starter-native/.env.example
@@ -1,0 +1,38 @@
+# RevealUI Environment Variables
+# Copy this file to .env.local and fill in your values before running `pnpm dev`
+
+# ─── Core ────────────────────────────────────────────────────────────────────
+# 32+ character secret used for signing sessions and tokens
+REVEALUI_SECRET=change-me-to-a-long-random-secret-at-least-32-chars
+
+# Public URL of your app server (both names must match — NEXT_PUBLIC_SERVER_URL
+# is read by @revealui/config; the name predates the Vite-native template and
+# is preserved for compatibility across templates).
+REVEALUI_PUBLIC_SERVER_URL=http://localhost:4000
+NEXT_PUBLIC_SERVER_URL=http://localhost:4000
+
+# ─── Database ────────────────────────────────────────────────────────────────
+# PostgreSQL connection string (NeonDB or local Postgres)
+POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/revealui
+
+# ─── Storage ─────────────────────────────────────────────────────────────────
+# Vercel Blob token for file uploads (optional — leave placeholder for local dev)
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_placeholder
+
+# ─── Stripe (optional) ───────────────────────────────────────────────────────
+# Use test keys during development: https://dashboard.stripe.com/test/apikeys
+STRIPE_SECRET_KEY=sk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_placeholder
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
+
+# ─── Admin Bootstrap ─────────────────────────────────────────────────────────
+# Used on first run only to create the initial admin account
+REVEALUI_ADMIN_EMAIL=admin@example.com
+REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+
+# ─── Branding (Enterprise white-label) ───────────────────────────────────────
+# Customize the admin UI for your brand. Enterprise license required for full white-label.
+# REVEALUI_BRAND_NAME=My CMS
+# REVEALUI_BRAND_LOGO_URL=https://example.com/logo.png
+# REVEALUI_BRAND_PRIMARY_COLOR=#10b981
+# REVEALUI_SHOW_POWERED_BY=false

--- a/packages/cli/templates/starter-native/_gitignore
+++ b/packages/cli/templates/starter-native/_gitignore
@@ -1,0 +1,28 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Vite build output
+dist/
+.vite/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Turbo
+.turbo/
+
+# Test artifacts
+coverage/
+
+# Misc
+.DS_Store
+*.pem
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/cli/templates/starter-native/app/App.tsx
+++ b/packages/cli/templates/starter-native/app/App.tsx
@@ -1,0 +1,36 @@
+import { Router, RouterProvider, Routes } from '@revealui/router';
+import { RootLayout } from './layouts/RootLayout.js';
+import { HomePage } from './routes/HomePage.js';
+
+const router = new Router();
+
+router.registerRoutes([
+  {
+    path: '/',
+    component: HomePage,
+    layout: RootLayout,
+  },
+  {
+    path: '/*notfound',
+    component: () => (
+      <main className="mx-auto max-w-xl px-4 py-16">
+        <h1 className="text-2xl font-bold tracking-tight text-gray-900">Page not found</h1>
+        <p className="mt-3 text-gray-600">
+          The page you are looking for does not exist.{' '}
+          <a href="/" className="font-medium text-emerald-600 hover:text-emerald-700">
+            Return home
+          </a>
+        </p>
+      </main>
+    ),
+    layout: RootLayout,
+  },
+]);
+
+export function App(): React.ReactNode {
+  return (
+    <RouterProvider router={router}>
+      <Routes />
+    </RouterProvider>
+  );
+}

--- a/packages/cli/templates/starter-native/app/layouts/RootLayout.tsx
+++ b/packages/cli/templates/starter-native/app/layouts/RootLayout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+export function RootLayout({ children }: { children: ReactNode }): React.ReactNode {
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900 antialiased">
+      <header className="border-b border-gray-200 bg-white">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+          <a href="/" className="text-sm font-semibold tracking-tight text-gray-900">
+            RevealUI
+          </a>
+          <nav className="text-sm text-gray-600">
+            <span className="text-xs uppercase tracking-wide text-gray-400">Starter (native)</span>
+          </nav>
+        </div>
+      </header>
+      <div>{children}</div>
+      <footer className="mt-16 border-t border-gray-200 bg-white">
+        <div className="mx-auto max-w-4xl px-4 py-4 text-xs text-gray-500">
+          Built with RevealUI + Vite + @revealui/router.
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/packages/cli/templates/starter-native/app/main.tsx
+++ b/packages/cli/templates/starter-native/app/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App.js';
+import './styles/globals.css';
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element #root not found in index.html');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/cli/templates/starter-native/app/routes/HomePage.tsx
+++ b/packages/cli/templates/starter-native/app/routes/HomePage.tsx
@@ -1,0 +1,55 @@
+import { Link } from '@revealui/router';
+
+export function HomePage(): React.ReactNode {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-bold tracking-tight text-gray-900">RevealUI</h1>
+      <p className="mt-3 text-gray-600">
+        Your project is running on the RevealUI-native runtime — Vite + @revealui/router. No Next.js
+        dependency.
+      </p>
+
+      <section className="mt-10 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Next steps</h2>
+        <ul className="mt-3 space-y-2 text-sm text-gray-700">
+          <li>
+            Edit{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">
+              app/routes/HomePage.tsx
+            </code>{' '}
+            to customize this page.
+          </li>
+          <li>
+            Add routes in{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">app/App.tsx</code> via{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">router.registerRoutes</code>
+            .
+          </li>
+          <li>
+            Initialize the CMS database with{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">pnpm db:init</code> once
+            your <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">.env.local</code> is
+            filled in.
+          </li>
+        </ul>
+      </section>
+
+      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-gray-900">Try the router</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Click a link below to see client-side navigation in action (a stub 404 page rendered by
+          the catch-all route in <code>app/App.tsx</code>):
+        </p>
+        <div className="mt-3 flex gap-3 text-sm">
+          <Link to="/not-yet-built" className="font-medium text-emerald-600 hover:text-emerald-700">
+            /not-yet-built →
+          </Link>
+        </div>
+      </section>
+
+      <p className="mt-10 text-xs text-gray-500">
+        Powered by RevealUI — primitives for users, content, products, payments, and intelligence.
+      </p>
+    </main>
+  );
+}

--- a/packages/cli/templates/starter-native/app/styles/globals.css
+++ b/packages/cli/templates/starter-native/app/styles/globals.css
@@ -1,0 +1,27 @@
+@import 'tailwindcss';
+
+/*
+  Tailwind v4 ships with a sensible default theme. Customize via @theme directive
+  if needed. See https://tailwindcss.com/docs/theme for full token reference.
+
+  Example:
+  @theme {
+    --color-brand-500: oklch(0.723 0.177 163);
+  }
+*/
+
+html,
+body,
+#root {
+  min-height: 100vh;
+  background-color: #f9fafb;
+  color: #111827;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/packages/cli/templates/starter-native/app/types.d.ts
+++ b/packages/cli/templates/starter-native/app/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/cli/templates/starter-native/index.html
+++ b/packages/cli/templates/starter-native/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RevealUI App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/app/main.tsx"></script>
+  </body>
+</html>

--- a/packages/cli/templates/starter-native/package.json
+++ b/packages/cli/templates/starter-native/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "{{PROJECT_NAME}}",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev --port 4000",
+    "build": "vite build",
+    "preview": "vite preview --port 4000",
+    "start": "vite preview --port 4000",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "db:init": "revealui cms",
+    "db:migrate": "drizzle-kit migrate",
+    "db:seed": "tsx src/seed.ts"
+  },
+  "dependencies": {
+    "@revealui/auth": "latest",
+    "@revealui/config": "latest",
+    "@revealui/contracts": "latest",
+    "@revealui/core": "latest",
+    "@revealui/db": "latest",
+    "@revealui/presentation": "latest",
+    "@revealui/router": "latest",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "@tailwindcss/vite": "^4.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "jsdom": "^28.0.0",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/cli/templates/starter-native/revealui.config.ts
+++ b/packages/cli/templates/starter-native/revealui.config.ts
@@ -1,0 +1,16 @@
+import config from '@revealui/config';
+import { buildConfig, universalPostgresAdapter } from '@revealui/core';
+
+export default buildConfig({
+  serverURL: config.reveal.publicServerURL || 'http://localhost:4000',
+  secret: config.reveal.secret,
+  db: config.database.url
+    ? universalPostgresAdapter({ connectionString: config.database.url })
+    : universalPostgresAdapter({ provider: 'electric' }),
+  admin: {
+    user: 'users',
+  },
+  collections: [],
+  globals: [],
+  plugins: [],
+});

--- a/packages/cli/templates/starter-native/src/seed.ts
+++ b/packages/cli/templates/starter-native/src/seed.ts
@@ -1,0 +1,40 @@
+/**
+ * Database seed script
+ *
+ * Run with: pnpm db:seed
+ *
+ * Customize this file to populate your database with initial data.
+ * The examples below show common patterns  -  uncomment and adapt as needed.
+ */
+
+// import { getClient } from '@revealui/db/client';
+// import { users, posts } from '@revealui/db/schema';
+
+async function seed(): Promise<void> {
+  // const db = getClient();
+
+  // Example: create an admin user
+  // await db.insert(users).values({
+  //   id: crypto.randomUUID(),
+  //   email: 'admin@example.com',
+  //   name: 'Admin',
+  //   role: 'admin',
+  //   status: 'active',
+  //   emailVerified: true,
+  // });
+
+  // Example: create sample content
+  // await db.insert(posts).values({
+  //   id: crypto.randomUUID(),
+  //   title: 'Welcome to RevealUI',
+  //   slug: 'welcome',
+  //   status: 'published',
+  // });
+
+  process.stdout.write('Seed complete.\n');
+}
+
+seed().catch((error: unknown) => {
+  process.stderr.write(`Seed failed: ${error}\n`);
+  process.exit(1);
+});

--- a/packages/cli/templates/starter-native/tsconfig.json
+++ b/packages/cli/templates/starter-native/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "resolvePackageJsonExports": true,
+    "target": "ES2022",
+    "noEmit": true,
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./app/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["app", "src", "revealui.config.ts", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/templates/starter-native/vite.config.ts
+++ b/packages/cli/templates/starter-native/vite.config.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [tailwindcss(), react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './app'),
+    },
+  },
+  server: {
+    port: 4000,
+    open: false,
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
+  publicDir: 'public',
+});

--- a/packages/cli/templates/starter-native/vitest.config.ts
+++ b/packages/cli/templates/starter-native/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['app/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './app'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a 4th CLI template — **`starter-native`** — alongside the existing 3 (basic-blog / e-commerce / portfolio). Customers scaffold via:

```bash
pnpm create revealui@latest my-project --template starter-native
```

…and get a **Vite + `@revealui/router` + Tailwind v4 + Vitest** project — zero Next.js dependency. The existing 3 Next.js templates are unchanged.

## Why

Customer-facing dogfood of the full RevealUI runtime — "RevealUI runs on RevealUI" demonstrable without waiting for the multi-month admin migration. Templates don't need RSC, so this ships independently of (and before) any Phase 2 RSC implementation work elsewhere. Aligns with the recent internal Next.js → RevealUI-native audit's Posture A recommendation (additive, keeps Next.js customers working).

## What ships

**Template (15 files at `packages/cli/templates/starter-native/`):**

| Layer | Files |
|---|---|
| Build config | `package.json`, `vite.config.ts`, `vitest.config.ts`, `tsconfig.json`, `index.html` |
| Conventions | `_gitignore` (renamed to `.gitignore` on scaffold), `.env.example`, `revealui.config.ts` |
| App source | `app/main.tsx`, `app/App.tsx`, `app/types.d.ts`, `app/routes/HomePage.tsx`, `app/layouts/RootLayout.tsx`, `app/styles/globals.css` |
| Server | `src/seed.ts` |

The CLI's existing `buildEnvLocal` / `generateReadme` / `pullContentRules` flows work unchanged — they generate `.env.local` / `README.md` / AI rules into the scaffolded project root regardless of template shape.

**No `biome.json` shipped with the template** — matches existing template convention. Biome runs with sensible defaults via the customer's `pnpm lint` script. (Shipping a nested `biome.json` triggers Biome 2.x's "nested root config" error when the monorepo's Biome scans the template directory.)

**CLI registration (4 files):**

- `packages/cli/src/prompts/project.ts` — type union, `VALID_TEMPLATES` array, interactive `select` option
- `packages/cli/src/commands/create.ts` — `resolveTemplateName` map entry
- `packages/cli/README.md` — Features list, Options list, new **Templates comparison table**
- `packages/cli/src/__tests__/template-structure.test.ts` — `baseConfig` type union, `tsconfig` validity templates, syntax-check (scans both `app/` and `src/` for Vite shape), new `starter-native` describe block (5 assertions covering root files / `.gitignore` / `app/` contents / `@revealui/router` dep present + `next` dep absent / Vite scripts present)

## Test plan

- [x] `pnpm --filter @revealui/cli typecheck` — PASS
- [x] `pnpm --filter @revealui/cli build` — PASS (tsup ESM + DTS, 307KB)
- [x] `pnpm --filter @revealui/cli test` — **201/201 PASS** across 20 files
  - 36 template-structure tests (the 5 new `starter-native` assertions all green)
  - `template-clean` forbidden-pattern check passed (no `workspace:*`, no `founder@`, no `RevealUIStudio/`, no machine-specific paths)
  - All 3 existing Next.js template test suites still pass
- [x] Pre-push gate (CI Phase 1): **17/17 PASS** in 13.1s
- [ ] CI on this PR — pending

## Behavior change

- **For existing customers** (basic-blog/e-commerce/portfolio): no change. Their workflows untouched.
- **For new customers**: 4 options in the interactive prompt instead of 3. The new option is at the bottom of the list and labeled clearly.
- **Public API additions only**: `'starter-native'` added to the `template` union type in `ProjectConfig`. No removals, no breaking changes.
