### PR TITLE
fix(db): default to pg driver for non-Neon hosts

### DIFF
--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -85,16 +85,25 @@ export interface DatabaseConfig {
 // =============================================================================
 
 /**
- * Detects if a connection string targets localhost / 127.0.0.1.
- * Returns true only for local development / test connections.
- * These use node-postgres (pg Pool) because the Neon HTTP driver requires a Neon endpoint.
+ * Returns true when the connection string targets a Postgres endpoint we should
+ * reach with the standard `pg` (node-postgres) driver rather than the Neon HTTP
+ * driver. The Neon HTTP driver speaks a Neon-specific protocol and fails
+ * silently against vanilla Postgres (errors surface as empty `NeonDbError`).
+ *
+ * Default to `pg` for anything that isn't an explicit Neon endpoint. This makes
+ * self-hosted Fleet kits, RDS, Supabase Postgres, docker-compose stacks, and
+ * any other self-hosted Postgres work out of the box. Only `*.neon.tech`
+ * hosts (or `wss://` Neon WebSocket endpoints) route through the Neon driver.
  */
 function isLocalhostConnection(connectionString: string): boolean {
   try {
-    const host = new URL(connectionString).hostname;
-    return host === 'localhost' || host === '127.0.0.1';
+    const url = new URL(connectionString);
+    const host = url.hostname;
+    if (host === 'localhost' || host === '127.0.0.1') return true;
+    // Any non-Neon host should use pg — Neon HTTP driver requires a Neon endpoint.
+    return !host.endsWith('.neon.tech') && url.protocol !== 'wss:';
   } catch {
-    return connectionString.includes('localhost') || connectionString.includes('127.0.0.1');
+    return !connectionString.includes('.neon.tech') && !connectionString.startsWith('wss://');
   }
 }
 


### PR DESCRIPTION
## Summary

`packages/db/src/client/index.ts` routes every connection that isn't `localhost` / `127.0.0.1` through the Neon HTTP driver. That driver requires a real Neon endpoint and fails silently against vanilla Postgres — errors surface as `NeonDbError { name: 'NeonDbError', sourceError: {} }`.

This breaks **every self-hosted Fleet kit** (admin connects to `postgres:5432` from inside docker), and would equally break any non-Neon hosted Postgres (RDS, Supabase Postgres, self-hosted on a real FQDN) the moment the admin app runs a query.

This PR inverts the heuristic: anything that isn't an explicit Neon endpoint (`*.neon.tech` host, or `wss://` Neon WebSocket URL) uses node-postgres. Neon HTTP only fires for actual Neon connections.

## Why

Discovered while standing up a stamped Fleet kit against its docker-compose pgvector container. The rate-limit middleware returned 503 (`fail-closed`) because every `rate_limits` query threw `NeonDbError` before reaching the table. Same pattern would hit auth queries, sessions, content reads — basically every DB-bound admin route on a non-Neon kit.

Existing comment on `createClient` even calls this out:

> All other connections: Uses @neondatabase/serverless with drizzle-orm/neon-http (Neon-primary)

The "Neon-primary" assumption is incompatible with the Fleet posture (self-hosted, BYO Postgres). This PR makes the default `pg`-primary, with Neon as the explicit opt-in by hostname.

## Behaviour change

| Connection string | Before | After |
|---|---|---|
| `postgresql://...@localhost:5432/db` | `pg` | `pg` ✅ |
| `postgresql://...@127.0.0.1:5432/db` | `pg` | `pg` ✅ |
| `postgresql://...@ep-xyz.us-east-2.aws.neon.tech/db` | Neon HTTP | Neon HTTP ✅ |
| `wss://...neon.tech/...` | Neon HTTP | Neon HTTP ✅ |
| `postgresql://...@postgres:5432/db` (docker svc) | Neon HTTP ❌ | `pg` ✅ |
| `postgresql://...@mydb.cluster-abc.us-east-1.rds.amazonaws.com/db` | Neon HTTP ❌ | `pg` ✅ |
| `postgresql://...@db.project.supabase.co:5432/db` | Neon HTTP ❌ | `pg` ✅ |

The last three rows are the bug — they were silently routed through Neon HTTP and failed at first query.

## Test plan

- [ ] CI: existing test suite (`packages/db/src/__tests__/client/*.test.ts`) — should still pass since localhost behaviour is unchanged
- [ ] Manual: verified end-to-end against a stamped Fleet kit's docker-compose stack — sign-up route now reaches the validator (was returning 503 from rate-limit middleware)
- [ ] Follow-up (separate PR if accepted): rename `isLocalhostConnection` → `shouldUsePgDriver` for clarity, add unit tests for the new non-Neon-non-localhost cases

No regex authored. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
