### PR TITLE
fix(webhooks): handle customer.updated to reconcile users.email with Stripe

### DIFF
--- a/apps/server/src/routes/__tests__/webhooks.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks.test.ts
@@ -1085,4 +1085,77 @@ describe('POST /stripe webhook', () => {
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
   });
+
+  describe('customer.updated', () => {
+    function makeCustomerUpdatedEvent(id: string, email: string | null) {
+      return {
+        id,
+        type: 'customer.updated',
+        livemode: false,
+        data: {
+          object: {
+            id: 'cus_updated_test',
+            object: 'customer',
+            email,
+          },
+        },
+      };
+    }
+
+    it('updates users.email when Stripe customer email changes', async () => {
+      const event = makeCustomerUpdatedEvent('evt_cust_updated_1', 'newemail@example.com');
+      mockConstructEvent.mockReturnValueOnce(event);
+
+      // idempotency INSERT returns undefined (not duplicate)
+      mockDbInsertChain.values.mockResolvedValueOnce(undefined);
+
+      const app = createApp();
+      const res = await app.request(postStripe(event));
+
+      expect(res.status).toBe(200);
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockDbUpdateChain.set).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'newemail@example.com' }),
+      );
+    });
+
+    it('skips users.email update when customer has no email', async () => {
+      const event = makeCustomerUpdatedEvent('evt_cust_updated_noemail', null);
+      mockConstructEvent.mockReturnValueOnce(event);
+
+      mockDbInsertChain.values.mockResolvedValueOnce(undefined);
+
+      const app = createApp();
+      const res = await app.request(postStripe(event));
+
+      expect(res.status).toBe(200);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: duplicate event id returns 200 without re-updating', async () => {
+      const event = makeCustomerUpdatedEvent('evt_cust_updated_idem', 'same@example.com');
+      mockConstructEvent.mockReturnValue(event);
+
+      // First call: idempotency INSERT succeeds (not duplicate)
+      mockDbInsertChain.values.mockResolvedValueOnce(undefined);
+
+      const app = createApp();
+      await app.request(postStripe(event));
+
+      // Second call: idempotency INSERT throws duplicate-key error
+      mockDbInsertChain.values.mockRejectedValueOnce(
+        Object.assign(new Error('duplicate key value violates unique constraint'), {
+          code: '23505',
+        }),
+      );
+
+      const res2 = await app.request(postStripe(event));
+      const body2 = (await res2.json()) as Record<string, unknown>;
+
+      expect(res2.status).toBe(200);
+      expect(body2.duplicate).toBe(true);
+      // update was only called once (first delivery); second is short-circuited
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -1647,6 +1647,32 @@ app.openapi(stripeWebhookRoute, async (c) => {
         break;
       }
 
+      case 'customer.updated': {
+        const updatedCustomer = event.data.object as Stripe.Customer;
+        const updatedCustomerId = updatedCustomer.id;
+        const newEmail = updatedCustomer.email;
+
+        if (!newEmail) {
+          logger.info('customer.updated: no email on customer object, skipping users.email sync', {
+            customerId: updatedCustomerId,
+          });
+          break;
+        }
+
+        await db
+          .update(users)
+          .set({ email: newEmail, updatedAt: new Date() })
+          .where(eq(users.stripeCustomerId, updatedCustomerId));
+
+        logger.info('customer.updated: synced users.email from Stripe', {
+          customerId: updatedCustomerId,
+        });
+        auditLicenseEvent(db, 'customer.email.synced', 'info', {
+          customerId: updatedCustomerId,
+        });
+        break;
+      }
+
       case 'customer.subscription.updated': {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId = resolveCustomerId(subscription.customer);

--- a/packages/contracts/src/stripe-webhook-events.ts
+++ b/packages/contracts/src/stripe-webhook-events.ts
@@ -36,6 +36,7 @@ export const RELEVANT_STRIPE_WEBHOOK_EVENTS = [
 
   // Customer lifecycle
   'customer.deleted',
+  'customer.updated',
 
   // Subscription lifecycle
   'customer.subscription.created',
@@ -67,4 +68,4 @@ export type RelevantStripeWebhookEvent = (typeof RELEVANT_STRIPE_WEBHOOK_EVENTS)
  * Expected event count — acts as a coarse drift detector for reviewers.
  * If you're adjusting the array above, update this too.
  */
-export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 14;
+export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 15;

--- a/packages/openapi/contracts.openapi.json
+++ b/packages/openapi/contracts.openapi.json
@@ -25232,6 +25232,7 @@
         "enum": [
           "checkout.session.completed",
           "customer.deleted",
+          "customer.updated",
           "customer.subscription.created",
           "customer.subscription.deleted",
           "customer.subscription.trial_will_end",


### PR DESCRIPTION
## Summary

Closes internal audit §P0-2 (schemas+validation fleet audit, 2026-05-16).

`customer.updated` was absent from the canonical webhook event list in
`@revealui/contracts` and had no handler in `apps/server`. Once Stripe
live mode opens, customers editing their email in the billing portal
would silently drift from `users.email` in the DB, breaking receipt
delivery.

**Changes:**
- `packages/contracts/src/stripe-webhook-events.ts` — adds
  `customer.updated` to `RELEVANT_STRIPE_WEBHOOK_EVENTS` (14 → 15),
  bumps `RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT` to 15
- `apps/server/src/routes/webhooks.ts` — adds `case 'customer.updated'`
  handler; idempotently updates `users.email` WHERE `stripeCustomerId`
  matches; skips when `customer.email` is null; logs + audits
- `apps/server/src/routes/__tests__/webhooks.test.ts` — 3 new cases:
  email update dispatched, null-email skip, idempotency (duplicate
  event ID returns `{ duplicate: true }` without re-updating)

**Post-merge owner action required:** re-run `pnpm stripe:seed` against
the live Stripe account to register `customer.updated` on the existing
webhook endpoint. The seed script is owner-gated (requires Stripe
credentials); this PR does not run it.

## Test plan

- [x] `pnpm --filter @revealui/contracts build` — clean
- [x] `vitest run src/routes/__tests__/webhooks.test.ts` — 35/35 passed
- [x] `tsc --noEmit` (server) — no new errors
- [ ] Post-merge: `pnpm stripe:seed` (owner action, requires live Stripe creds)
