### PR TITLE
feat(auth): SplitAuthLayout + field-border design system + Fleet-mode shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ revealui/
 │   ├── core/           # Runtime engine, REST API, plugins
 │   ├── db/             # Drizzle ORM schema (86 tables, NeonDB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
-│   ├── presentation/   # 58 UI components (Tailwind v4)
+│   ├── presentation/   # 59 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR
 │   ├── setup/          # Environment setup utilities
 │   ├── sync/           # ElectricSQL real-time sync

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You have:
 - **Content management:** define collections in TypeScript, get a full REST API, admin UI, and MCP tools instantly
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
-- **58 UI components:** built with Tailwind CSS v4, zero external UI dependencies
+- **59 UI components:** built with Tailwind CSS v4, zero external UI dependencies
 - **13 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
@@ -153,7 +153,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | [`@revealui/contracts`](packages/contracts)             | Zod schemas + TypeScript types (single source)    |
 | [`@revealui/db`](packages/db)                           | Drizzle ORM schema (86 tables), dual-DB client     |
 | [`@revealui/auth`](packages/auth)                       | Session auth, password reset, rate limiting       |
-| [`@revealui/presentation`](packages/presentation)       | 58 UI components (Tailwind v4, zero ext deps)     |
+| [`@revealui/presentation`](packages/presentation)       | 59 UI components (Tailwind v4, zero ext deps)     |
 | [`@revealui/openapi`](packages/openapi)                 | OpenAPI route helpers and Swagger generation       |
 | [`@revealui/router`](packages/router)                   | Lightweight file-based router with SSR            |
 | [`@revealui/config`](packages/config)                   | Type-safe environment configuration               |

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -71,8 +71,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             rel="stylesheet"
           />
           {primaryColor || tenantFont ? (
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: inline <style> takes a string; both values are server-side env vars (no user-html injection surface)
             <style
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: inline <style> takes a string; both values are server-side env vars, no user-html injection surface
               dangerouslySetInnerHTML={{
                 __html: [
                   ':root {',

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -36,6 +36,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   const primaryColor =
     process.env.REVEALUI_BRAND_PRIMARY_COLOR ?? process.env.REVEALUI_TENANT_BRAND;
+  // Foreground color to use ON the brand color (e.g. for text in a brand-coloured panel).
+  // Customers with light brand colours must override this with a dark value (e.g. '#0f172a')
+  // to maintain WCAG contrast — there is no automatic contrast computation by design.
+  const brandOnColor = process.env.REVEALUI_TENANT_BRAND_ON ?? 'white';
+  // Optional tenant font family — must already be loaded as a stylesheet (see <link> tags below).
+  // Built-in supported values today: 'Inter', 'Mona Sans', 'Geist'. Unset → falls back to Geist.
+  const tenantFont = process.env.REVEALUI_TENANT_FONT?.trim();
+  // Fleet kits hide the RevealUI-branded Header/Footer by default. Customer-side
+  // navigation/footer is out of scope for v1; future work can expose a tenant
+  // header-block + footer-block via env or admin settings.
+  const isFleetMode = process.env.REVEALUI_FLEET_MODE === 'true';
 
   try {
     return (
@@ -59,11 +70,23 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
             rel="stylesheet"
           />
-          {primaryColor ? (
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: inline <style> takes a string; primaryColor is server-validated hex from tenant settings (no user-html injection surface)
+          {primaryColor || tenantFont ? (
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: inline <style> takes a string; both values are server-side env vars (no user-html injection surface)
             <style
               dangerouslySetInnerHTML={{
-                __html: `:root { --tenant-brand: ${primaryColor}; --primary: var(--tenant-brand); }`,
+                __html: [
+                  ':root {',
+                  primaryColor ? `--tenant-brand: ${primaryColor};` : '',
+                  primaryColor ? '--primary: var(--tenant-brand);' : '',
+                  primaryColor ? `--tenant-brand-on: ${brandOnColor};` : '',
+                  tenantFont ? `--tenant-font: '${tenantFont}';` : '',
+                  '}',
+                  tenantFont
+                    ? `body { font-family: var(--tenant-font), system-ui, -apple-system, sans-serif; }`
+                    : '',
+                ]
+                  .filter(Boolean)
+                  .join(' '),
               }}
             />
           ) : null}
@@ -78,9 +101,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               />
               <LivePreviewListener />
 
-              <Header />
+              {isFleetMode ? null : <Header />}
               <main>{children}</main>
-              <Footer />
+              {isFleetMode ? null : <Footer />}
             </ErrorBoundary>
           </Providers>
           {/* Vercel Speed Insights for performance monitoring */}

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { usePasskeySignIn, useSignIn } from '@revealui/auth/react';
+import {
+  ButtonCVA as Button,
+  FormLabel,
+  GitHubIcon,
+  GoogleIcon,
+  Heading,
+  InputCVA as Input,
+  LinkedInIcon,
+  PasskeyIcon,
+  VercelIcon,
+} from '@revealui/presentation/server';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { type FormEvent, Suspense, useState } from 'react';
+import { PasswordInput } from '@/lib/components/PasswordInput';
+
+export type OAuthProvider = 'github' | 'google' | 'vercel' | 'linkedin';
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: 'You cancelled the sign-in. Please try again.',
+  oauth_error: 'The sign-in provider returned an error. Please try again.',
+  provider_error: 'The sign-in provider returned an error. Please try again.',
+  invalid_state: 'The sign-in request expired. Please try again.',
+  account_exists:
+    'An account with this email already exists. Sign in with your password, or link this provider from your account settings.',
+  not_allowed: 'Your account is not authorized. Contact the administrator for access.',
+  unknown_provider: 'Unknown sign-in provider. Please try again.',
+};
+
+const OAUTH_META: Record<
+  OAuthProvider,
+  { label: string; href: string; Icon: typeof GitHubIcon }
+> = {
+  github: { label: 'GitHub', href: '/api/auth/github', Icon: GitHubIcon },
+  google: { label: 'Google', href: '/api/auth/google', Icon: GoogleIcon },
+  vercel: { label: 'Vercel', href: '/api/auth/vercel', Icon: VercelIcon },
+  linkedin: { label: 'LinkedIn', href: '/api/auth/linkedin', Icon: LinkedInIcon },
+};
+
+interface LoginFormProps {
+  /** OAuth providers to render; empty array suppresses the OAuth row entirely. */
+  oauthProviders: OAuthProvider[];
+}
+
+function LoginSkeleton() {
+  return (
+    <div className="w-full max-w-sm space-y-6">
+      <div className="h-7 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      <div className="space-y-4">
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-11 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+    </div>
+  );
+}
+
+export function LoginForm({ oauthProviders }: LoginFormProps) {
+  return (
+    <Suspense fallback={<LoginSkeleton />}>
+      <LoginContent oauthProviders={oauthProviders} />
+    </Suspense>
+  );
+}
+
+function LoginContent({ oauthProviders }: LoginFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { signIn, isLoading } = useSignIn();
+  const {
+    signIn: passkeySignIn,
+    isLoading: isPasskeyLoading,
+    error: passkeyError,
+    supported: passkeySupported,
+  } = usePasskeySignIn();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const oauthError = searchParams.get('error');
+  const [error, setError] = useState<string | null>(
+    oauthError ? (OAUTH_ERROR_MESSAGES[oauthError] ?? 'Sign-in failed. Please try again.') : null,
+  );
+
+  const anyLoading = isLoading || isPasskeyLoading;
+  const hasAlternates = oauthProviders.length > 0 || passkeySupported;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const result = await signIn({ email, password });
+    if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
+      router.push('/rotate-password');
+    } else if (result.success) {
+      router.push('/');
+    } else if ('requiresMfa' in result && result.requiresMfa) {
+      router.push('/mfa');
+    } else {
+      const errorMessage = 'error' in result ? result.error : 'Failed to sign in';
+      setError(errorMessage || 'Failed to sign in');
+    }
+  };
+
+  const handlePasskeySignIn = async () => {
+    setError(null);
+    const success = await passkeySignIn();
+    if (success) {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="w-full max-w-sm space-y-6">
+      <Heading as="h2" size="lg" className="tracking-tight">
+        Sign in
+      </Heading>
+
+      {(error ?? passkeyError) && (
+        <div
+          role="alert"
+          className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400"
+        >
+          {error ?? passkeyError}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <FormLabel htmlFor="email" required>
+            Email
+          </FormLabel>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={anyLoading}
+            autoComplete="email"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <FormLabel htmlFor="password" required>
+            Password
+          </FormLabel>
+          <PasswordInput visible={showPassword} onToggle={() => setShowPassword((v) => !v)}>
+            <Input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={anyLoading}
+              autoComplete="current-password"
+              className="pr-10"
+              aria-label="Password"
+              required
+            />
+          </PasswordInput>
+        </div>
+
+        <Button type="submit" disabled={anyLoading} className="w-full">
+          {isLoading ? 'Signing in…' : 'Sign in'}
+        </Button>
+
+        <p className="text-center text-xs text-muted-foreground">
+          <Link
+            href="/reset-password"
+            className="text-[var(--tenant-brand,#2563eb)] hover:underline"
+          >
+            Forgot password?
+          </Link>
+        </p>
+      </form>
+
+      {hasAlternates ? (
+        <>
+          <p className="text-center text-[11px] uppercase tracking-wider text-muted-foreground">
+            or continue with
+          </p>
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {passkeySupported ? (
+              <Button
+                variant="outline"
+                onClick={handlePasskeySignIn}
+                disabled={anyLoading}
+                className="justify-start gap-2"
+              >
+                <PasskeyIcon className="size-4 shrink-0" />
+                <span>{isPasskeyLoading ? 'Authenticating…' : 'Passkey'}</span>
+              </Button>
+            ) : null}
+
+            {oauthProviders.map((provider) => {
+              const { label, href, Icon } = OAUTH_META[provider];
+              return (
+                <Button
+                  key={provider}
+                  variant="outline"
+                  className="justify-start gap-2"
+                  asChild
+                >
+                  <a href={href}>
+                    <Icon className="size-4 shrink-0" />
+                    <span>{label}</span>
+                  </a>
+                </Button>
+              );
+            })}
+          </div>
+        </>
+      ) : null}
+
+      <p className="text-center text-sm text-muted-foreground">
+        Don&apos;t have an account?{' '}
+        <Link
+          href="/signup"
+          className="text-[var(--tenant-brand,#2563eb)] underline hover:opacity-80"
+        >
+          Sign up
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -30,15 +30,13 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   unknown_provider: 'Unknown sign-in provider. Please try again.',
 };
 
-const OAUTH_META: Record<
-  OAuthProvider,
-  { label: string; href: string; Icon: typeof GitHubIcon }
-> = {
-  github: { label: 'GitHub', href: '/api/auth/github', Icon: GitHubIcon },
-  google: { label: 'Google', href: '/api/auth/google', Icon: GoogleIcon },
-  vercel: { label: 'Vercel', href: '/api/auth/vercel', Icon: VercelIcon },
-  linkedin: { label: 'LinkedIn', href: '/api/auth/linkedin', Icon: LinkedInIcon },
-};
+const OAUTH_META: Record<OAuthProvider, { label: string; href: string; Icon: typeof GitHubIcon }> =
+  {
+    github: { label: 'GitHub', href: '/api/auth/github', Icon: GitHubIcon },
+    google: { label: 'Google', href: '/api/auth/google', Icon: GoogleIcon },
+    vercel: { label: 'Vercel', href: '/api/auth/vercel', Icon: VercelIcon },
+    linkedin: { label: 'LinkedIn', href: '/api/auth/linkedin', Icon: LinkedInIcon },
+  };
 
 interface LoginFormProps {
   /** OAuth providers to render; empty array suppresses the OAuth row entirely. */
@@ -198,12 +196,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
             {oauthProviders.map((provider) => {
               const { label, href, Icon } = OAUTH_META[provider];
               return (
-                <Button
-                  key={provider}
-                  variant="outline"
-                  className="justify-start gap-2"
-                  asChild
-                >
+                <Button key={provider} variant="outline" className="justify-start gap-2" asChild>
                   <a href={href}>
                     <Icon className="size-4 shrink-0" />
                     <span>{label}</span>

--- a/apps/admin/src/app/(frontend)/login/page.tsx
+++ b/apps/admin/src/app/(frontend)/login/page.tsx
@@ -14,7 +14,12 @@ import { LoginForm, type OAuthProvider } from './LoginForm';
  * OAuth row entirely.
  */
 
-const SUPPORTED_PROVIDERS = ['github', 'google', 'vercel', 'linkedin'] as const satisfies readonly OAuthProvider[];
+const SUPPORTED_PROVIDERS = [
+  'github',
+  'google',
+  'vercel',
+  'linkedin',
+] as const satisfies readonly OAuthProvider[];
 
 function parseProviders(raw: string | undefined): OAuthProvider[] {
   if (!raw) return [];

--- a/apps/admin/src/app/(frontend)/login/page.tsx
+++ b/apps/admin/src/app/(frontend)/login/page.tsx
@@ -1,207 +1,38 @@
-'use client';
-
-import { usePasskeySignIn, useSignIn } from '@revealui/auth/react';
-import {
-  ButtonCVA as Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  FormLabel,
-  InputCVA as Input,
-} from '@revealui/presentation/server';
-import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, useState } from 'react';
 import { BrandedAuthLayout } from '@/lib/components/BrandedAuthLayout';
-import { PasswordInput } from '@/lib/components/PasswordInput';
+import { LoginForm, type OAuthProvider } from './LoginForm';
 
-const OAUTH_ERROR_MESSAGES: Record<string, string> = {
-  access_denied: 'You cancelled the sign-in. Please try again.',
-  oauth_error: 'The sign-in provider returned an error. Please try again.',
-  provider_error: 'The sign-in provider returned an error. Please try again.',
-  invalid_state: 'The sign-in request expired. Please try again.',
-  account_exists:
-    'An account with this email already exists. Sign in with your password, or link this provider from your account settings.',
-  not_allowed: 'Your account is not authorized. Contact the administrator for access.',
-  unknown_provider: 'Unknown sign-in provider. Please try again.',
-};
+/**
+ * Server Component shell — critical that this is NOT 'use client'.
+ *
+ * Reads `REVEALUI_OAUTH_PROVIDERS` (comma-separated list, e.g. "github,google,vercel,linkedin")
+ * at request time and passes the parsed allowlist down to the Client form.
+ * Reading env in a Client Component would inline values at build time (when
+ * tenant/admin env isn't set), so this gate must live on the server.
+ *
+ * For Fleet kits that don't configure OAuth, leave `REVEALUI_OAUTH_PROVIDERS`
+ * unset — the form will render email/password + passkey only and skip the
+ * OAuth row entirely.
+ */
 
-export default function LoginPage() {
-  return (
-    <Suspense
-      fallback={
-        <BrandedAuthLayout>
-          <Card className="w-full max-w-sm">
-            <CardHeader>
-              <div className="h-6 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-              <div className="mt-2 h-4 w-64 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-                <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-                <div className="h-10 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-              </div>
-            </CardContent>
-          </Card>
-        </BrandedAuthLayout>
-      }
-    >
-      <LoginContent />
-    </Suspense>
+const SUPPORTED_PROVIDERS = ['github', 'google', 'vercel', 'linkedin'] as const satisfies readonly OAuthProvider[];
+
+function parseProviders(raw: string | undefined): OAuthProvider[] {
+  if (!raw) return [];
+  const tokens = new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
   );
+  return SUPPORTED_PROVIDERS.filter((p) => tokens.has(p));
 }
 
-function LoginContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { signIn, isLoading } = useSignIn();
-  const {
-    signIn: passkeySignIn,
-    isLoading: isPasskeyLoading,
-    error: passkeyError,
-    supported: passkeySupported,
-  } = usePasskeySignIn();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const oauthError = searchParams.get('error');
-  const [error, setError] = useState<string | null>(
-    oauthError ? (OAUTH_ERROR_MESSAGES[oauthError] ?? 'Sign-in failed. Please try again.') : null,
-  );
-
-  const anyLoading = isLoading || isPasskeyLoading;
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    const result = await signIn({ email, password });
-    if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
-      router.push('/rotate-password');
-    } else if (result.success) {
-      router.push('/');
-    } else if ('requiresMfa' in result && result.requiresMfa) {
-      router.push('/mfa');
-    } else {
-      const errorMessage = 'error' in result ? result.error : 'Failed to sign in';
-      setError(errorMessage || 'Failed to sign in');
-    }
-  };
-
-  const handlePasskeySignIn = async () => {
-    setError(null);
-    const success = await passkeySignIn();
-    if (success) {
-      router.push('/');
-    }
-  };
+export default function LoginPage() {
+  const oauthProviders = parseProviders(process.env.REVEALUI_OAUTH_PROVIDERS);
 
   return (
     <BrandedAuthLayout>
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Sign in to your account</CardTitle>
-          <CardDescription>
-            Don&apos;t have an account?{' '}
-            <Link
-              href="/signup"
-              className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-            >
-              Sign up
-            </Link>
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {(error ?? passkeyError) && (
-            <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
-              {error ?? passkeyError}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <FormLabel htmlFor="email" required>
-                Email
-              </FormLabel>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                disabled={anyLoading}
-                autoComplete="email"
-                required
-              />
-            </div>
-
-            <div className="space-y-2">
-              <FormLabel htmlFor="password" required>
-                Password
-              </FormLabel>
-              <PasswordInput visible={showPassword} onToggle={() => setShowPassword((v) => !v)}>
-                <Input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  disabled={anyLoading}
-                  autoComplete="current-password"
-                  className="pr-10"
-                  aria-label="Password"
-                  required
-                />
-              </PasswordInput>
-            </div>
-
-            <Button type="submit" disabled={anyLoading} className="w-full">
-              {isLoading ? 'Signing in...' : 'Sign in'}
-            </Button>
-
-            <p className="text-center text-sm text-zinc-600">
-              <Link
-                href="/reset-password"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                Forgot password?
-              </Link>
-            </p>
-          </form>
-
-          <div className="relative my-4">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t border-border" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            {passkeySupported && (
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={handlePasskeySignIn}
-                disabled={anyLoading}
-              >
-                {isPasskeyLoading ? 'Authenticating...' : 'Sign in with passkey'}
-              </Button>
-            )}
-            <Button variant="outline" className="w-full" asChild>
-              <a href="/api/auth/github">Sign in with GitHub</a>
-            </Button>
-            <Button variant="outline" className="w-full" asChild>
-              <a href="/api/auth/google">Sign in with Google</a>
-            </Button>
-            <Button variant="outline" className="w-full" asChild>
-              <a href="/api/auth/vercel">Sign in with Vercel</a>
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <LoginForm oauthProviders={oauthProviders} />
     </BrandedAuthLayout>
   );
 }

--- a/apps/admin/src/app/(frontend)/signup/page.tsx
+++ b/apps/admin/src/app/(frontend)/signup/page.tsx
@@ -183,7 +183,7 @@ function SignupContent() {
                 Already have an account?{' '}
                 <Link
                   href="/login"
-                  className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  className="text-[var(--tenant-brand,#2563eb)] underline hover:opacity-80"
                 >
                   Sign in
                 </Link>
@@ -260,13 +260,13 @@ function SignupContent() {
                 onChange={(e) => setTosAccepted(e.target.checked)}
                 disabled={anyLoading}
                 required
-                className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-blue-600"
+                className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-[var(--tenant-brand,#2563eb)] accent-[var(--tenant-brand,#2563eb)]"
               />
               <label htmlFor="tos" className="text-sm text-zinc-600 dark:text-zinc-400">
                 I agree to the{' '}
                 <Link
                   href="/legal/terms"
-                  className="text-blue-600 hover:underline dark:text-blue-400"
+                  className="text-[var(--tenant-brand,#2563eb)] hover:underline"
                   target="_blank"
                 >
                   Terms of Service
@@ -274,7 +274,7 @@ function SignupContent() {
                 and{' '}
                 <Link
                   href="/legal/privacy"
-                  className="text-blue-600 hover:underline dark:text-blue-400"
+                  className="text-[var(--tenant-brand,#2563eb)] hover:underline"
                   target="_blank"
                 >
                   Privacy Policy

--- a/apps/admin/src/lib/components/BrandedAuthLayout.tsx
+++ b/apps/admin/src/lib/components/BrandedAuthLayout.tsx
@@ -1,43 +1,77 @@
-import { AuthLayout } from '@revealui/presentation/server';
+import {
+  BuiltWithRevealUI,
+  Heading,
+  SplitAuthLayout,
+} from '@revealui/presentation/server';
 import type React from 'react';
 
+/**
+ * Admin-side configuration shim for `SplitAuthLayout`.
+ *
+ * Reads tenant identity from env vars (set by RevForge stamping or by revealui.com's
+ * own SaaS deployment) and composes the generic `SplitAuthLayout` primitive's
+ * brand + footer slots. No tenant-specific code paths — every Fleet customer
+ * consumes the same shell, only their env-driven bindings differ.
+ *
+ * Env vars consumed:
+ * - `REVEALUI_TENANT_NAME` (or legacy `REVEALUI_BRAND_NAME`) — heading + logo alt text
+ * - `REVEALUI_TENANT_HIDE_NAME` — `'true'` hides the visible heading text (useful when
+ *   the logo already contains the company wordmark, e.g. "alleviatechnology"); alt
+ *   text on the logo stays for screen-reader accessibility regardless
+ * - `REVEALUI_TENANT_TAGLINE` — optional subline; suppressed if unset
+ * - `REVEALUI_BRAND_LOGO_URL` — logo src; defaults to `/logo.webp` (kit-mountable)
+ * - `REVEALUI_SHOW_POWERED_BY` — `'false'` hides the "Built with RevealUI" badge
+ *   (kit-default false; revealui.com SaaS-default true)
+ *
+ * Tenant brand color is consumed via the `--tenant-brand` / `--tenant-brand-on` CSS
+ * vars injected at the root in `apps/admin/src/app/(frontend)/layout.tsx`.
+ */
 export function BrandedAuthLayout({ children }: { children: React.ReactNode }) {
-  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
-  const logoUrl = process.env.REVEALUI_BRAND_LOGO_URL;
+  const name =
+    process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  const hideName = process.env.REVEALUI_TENANT_HIDE_NAME === 'true';
+  const tagline = process.env.REVEALUI_TENANT_TAGLINE;
+  const logoUrl = process.env.REVEALUI_BRAND_LOGO_URL ?? '/logo.webp';
   const showPoweredBy = process.env.REVEALUI_SHOW_POWERED_BY !== 'false';
 
+  const brand = (
+    <>
+      {/* biome-ignore lint/performance/noImgElement: static branding image; Next.js Image overkill for one logo */}
+      <img
+        src={logoUrl}
+        alt={name}
+        className="max-h-24 w-auto max-w-xs object-contain lg:max-h-48 lg:max-w-sm"
+      />
+      {hideName ? null : (
+        <Heading as="h1" size="2xl" className="text-center tracking-tight lg:text-3xl">
+          {name}
+        </Heading>
+      )}
+      {tagline ? (
+        <p className="max-w-[30ch] text-center text-sm opacity-80 lg:text-base">{tagline}</p>
+      ) : null}
+    </>
+  );
+
   return (
-    <AuthLayout
-      header={
-        <div className="flex flex-col items-center gap-2">
-          {/* biome-ignore lint/performance/noImgElement: static branding image in auth layout  -  Next.js Image overkill for a single 48px logo */}
-          <img
-            src={logoUrl ?? '/logo.webp'}
-            alt={name}
-            width={48}
-            height={48}
-            className="h-12 w-12"
-          />
-          <p className="text-sm text-gray-600 dark:text-gray-400">{name}</p>
-        </div>
-      }
-      footer={
+    <SplitAuthLayout
+      brand={brand}
+      brandFooter={
         showPoweredBy ? (
-          <p className="text-center text-xs text-gray-600 dark:text-gray-400">
-            Built with{' '}
-            <a
-              href="https://revealui.com"
-              className="underline hover:text-gray-800 dark:hover:text-gray-300"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              RevealUI
-            </a>
-          </p>
+          <div className="hidden lg:block">
+            <BuiltWithRevealUI colorScheme="dark" />
+          </div>
+        ) : null
+      }
+      formFooter={
+        showPoweredBy ? (
+          <div className="lg:hidden">
+            <BuiltWithRevealUI colorScheme="light" />
+          </div>
         ) : null
       }
     >
       {children}
-    </AuthLayout>
+    </SplitAuthLayout>
   );
 }

--- a/apps/admin/src/lib/components/BrandedAuthLayout.tsx
+++ b/apps/admin/src/lib/components/BrandedAuthLayout.tsx
@@ -1,8 +1,4 @@
-import {
-  BuiltWithRevealUI,
-  Heading,
-  SplitAuthLayout,
-} from '@revealui/presentation/server';
+import { BuiltWithRevealUI, Heading, SplitAuthLayout } from '@revealui/presentation/server';
 import type React from 'react';
 
 /**
@@ -27,8 +23,7 @@ import type React from 'react';
  * vars injected at the root in `apps/admin/src/app/(frontend)/layout.tsx`.
  */
 export function BrandedAuthLayout({ children }: { children: React.ReactNode }) {
-  const name =
-    process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
   const hideName = process.env.REVEALUI_TENANT_HIDE_NAME === 'true';
   const tagline = process.env.REVEALUI_TENANT_TAGLINE;
   const logoUrl = process.env.REVEALUI_BRAND_LOGO_URL ?? '/logo.webp';

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -158,7 +158,7 @@ tsx scripts/seed-products.ts
 
 ## 4. Add a pricing page
 
-RevealUI ships 58 UI components. Use them to build a pricing page in your frontend app.
+RevealUI ships 59 UI components. Use them to build a pricing page in your frontend app.
 
 In `apps/mainframe/src/pages/pricing.tsx`:
 
@@ -355,7 +355,7 @@ This is the foundation. The five primitives  -  Users, Content, Products, Paymen
 ## Next steps
 
 - **Add more collections**  -  orders, reviews, blog posts, anything your business needs
-- **Customize the UI**  -  `packages/presentation` has 58 components to build with
+- **Customize the UI**  -  `packages/presentation` has 59 components to build with
 - **Add AI**  -  Pro tier adds AI agents; see the [AI guide](./AI.md)
 - **Invite your team**  -  role-based access control is already wired in
 

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -9,7 +9,7 @@ audience: developer
 
 **Last Updated:** 2026-05-02
 **Packages:** `@revealui/presentation`, `@revealui/core`
-**Total Components:** 79 across both packages — **58 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
+**Total Components:** 80 across both packages — **59 in `@revealui/presentation`** (the standalone UI library) plus 21 admin / richtext components in `@revealui/core`.
 
 ---
 
@@ -1541,7 +1541,7 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Component Summary by Package
 
-### @revealui/presentation (58 components)
+### @revealui/presentation (59 components)
 - 6 Primitives (Box, Flex, Grid, Text, Heading, Slot)
 - 14 Form Controls (Button, LinkButton, Input, Textarea, Select, Checkbox, Radio, etc.)
 - 8 Data Display (Card, Table, Avatar, Badge, etc.)
@@ -1569,4 +1569,4 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 ---
 
 **Last Updated:** 2026-05-02
-**Packages:** `@revealui/presentation` (58 components), `@revealui/core` (21 components)
+**Packages:** `@revealui/presentation` (59 components), `@revealui/core` (21 components)

--- a/docs/DOCUMENTATION_ASSESSMENT.md
+++ b/docs/DOCUMENTATION_ASSESSMENT.md
@@ -17,7 +17,7 @@ Brutally honest audit of what RevealUI documentation claimed versus what the cod
 
 ## Executive Summary
 
-RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 58 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
+RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 59 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
 
 ---
 
@@ -51,7 +51,7 @@ RevealUI's core framework is **real and substantial**  -  auth, billing, runtime
 |---------|----------|
 | React 19 | `react@^19.2.3` in package.json |
 | Next.js 16 | Catalog reference, App Router throughout |
-| 50+ UI components | **58 components** in presentation package |
+| 50+ UI components | **59 components** in presentation package |
 | Session-only auth (no JWT) | bcrypt-12, RBAC/ABAC, 2FA, WebAuthn, OAuth |
 | Stripe checkout/subscriptions/webhooks | 1,100-line webhook handler, 12 event types |
 | Drizzle ORM dual-DB (NeonDB + Supabase) | Schema + queries + boundary enforcement |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,7 +45,7 @@ Built on the **[JOSHUA Stack](./JOSHUA.md)**: Justifiable, Orthogonal, Sovereign
 
 - [Package Reference](./REFERENCE.md): Core, contracts, DB, config, presentation, utils, router, CLI
 - [Core Stability](./CORE_STABILITY.md): API stability tiers, production verification status, version policy
-- [Component Catalog](./COMPONENT_CATALOG.md): 58 native UI components
+- [Component Catalog](./COMPONENT_CATALOG.md): 59 native UI components
 - [AI](./AI.md): AI package overview, prompt/response/semantic caching
 - [Pro](./PRO.md): Pro packages (`@revealui/ai`, `@revealui/harnesses`), MCP integration, open-model inference, x402, marketplace
 - [RevFleet](./REVFLEET.md): Companion products (RevDev, RevVault, RevCon, RevealCoin, Forge, RevSkills, RevKit) — what each does and how they compose

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -34,7 +34,7 @@ note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (
 - **Packages:** 26 packages + 5 apps = 31 workspaces
 - **Tests:** extensive test suite across unit, integration, and E2E layers; all workspaces build and typecheck (run `pnpm test` for current count)
 - **Database:** 86 tables (Drizzle ORM on **Neon** — primary). Supabase phase-out is in flight: GAP-129 PR-A/B/D shipped (2026-05-01); PR-C (dual-DB client collapse) is the remaining work. RAG tables (`ragDocuments`, `ragChunks`) and the legacy Supabase MCP server adapter remain in-tree during the transition. 61 CHECK constraints enforced (migration 0001 applied 2026-04-15).
-- **UI Components:** 58 native components (Tailwind v4, zero external UI deps)
+- **UI Components:** 59 native components (Tailwind v4, zero external UI deps)
 - **Branch pipeline:** `feature/* → test → main` — `test` is the default PR target; production deploys are auto on push to `main` only.
 - **CI:** GitHub Actions (ci.yml with E2E smoke, release.yml, release-pro.yml, security.yml, system-tune-snapshot.yml), 3-phase CI gate + E2E + CodeQL + Gitleaks
 - **Infrastructure:** Nix flakes, direnv, Biome 2 (sole linter), Turborepo, pnpm 10

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -170,7 +170,7 @@ For more → [Troubleshooting Guide](./TROUBLESHOOTING.md)
 ## Next Steps
 
 - [Full documentation](./INDEX.md)
-- [Component catalog](./COMPONENT_CATALOG.md)  -  58 native UI components
+- [Component catalog](./COMPONENT_CATALOG.md)  -  59 native UI components
 - [Example projects](./EXAMPLES.md)  -  blog, subscription starter, storefront
 - [Deployment guide](./CI_CD_GUIDE.md)  -  Vercel, environment variables, production checklist
 - [AI agents](./AI.md)  -  agent orchestration, open-model inference, MCP framework (Pro)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1989,7 +1989,7 @@ See `.env.template` in the repo root for the full list with descriptions.
 
 # @revealui/presentation
 
-58 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
+59 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
 
 ```bash
 npm install @revealui/presentation
@@ -2709,7 +2709,7 @@ Behaviour-only versions of form controls  -  bring your own styles.
 ## Related
 
 - [`@revealui/core`](/reference/core)  -  Uses `presentation` for admin UI components
-- [Component catalog](/component-catalog)  -  Visual index of all 58 components
+- [Component catalog](/component-catalog)  -  Visual index of all 59 components
 
 ---
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -16,7 +16,7 @@ Full content management engine with collections, access control, hooks, field ty
 and a REST API. The heart of RevealUI and the most mature part of the codebase.
 
 ### UI component library
-**58 native React components** in `packages/presentation/src/components/`, built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
+**59 native React components** in `packages/presentation/src/components/`, built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
 **86 PostgreSQL tables** with Drizzle ORM, **61 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -226,7 +226,7 @@ Some numbers on what's actually shipped:
 
 - **31 workspaces** across the monorepo (5 apps + 26 packages)
 - **86 database tables** via Drizzle ORM
-- **58 UI components** in the presentation layer (zero external UI dependencies  -  just Tailwind v4, clsx, and CVA)
+- **59 UI components** in the presentation layer (zero external UI dependencies  -  just Tailwind v4, clsx, and CVA)
 - **Extensive test coverage** across unit, integration, and E2E layers
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -37,7 +37,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | PKG-002 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) | npm | Public |
 | PKG-003 | @revealui/db | Drizzle ORM schema (86 tables), dual-DB support | npm | Public |
 | PKG-004 | @revealui/auth | Session auth, password reset, rate limiting | npm | Public |
-| PKG-005 | @revealui/presentation | 58 native UI components (Tailwind v4) | npm | Public |
+| PKG-005 | @revealui/presentation | 59 native UI components (Tailwind v4) | npm | Public |
 | PKG-006 | @revealui/router | Lightweight file-based router with SSR | npm | Public |
 | PKG-007 | @revealui/config | Type-safe env config (Zod + lazy Proxy) | npm | Public |
 | PKG-008 | @revealui/utils | Logger, DB helpers, validation | npm | Public |

--- a/packages/presentation/src/__tests__/components/Button.test.tsx
+++ b/packages/presentation/src/__tests__/components/Button.test.tsx
@@ -125,7 +125,7 @@ describe('Button', () => {
     it('applies "outline" variant', () => {
       render(<Button variant="outline">Outline</Button>);
       expect(screen.getByRole('button')).toHaveClass('border');
-      expect(screen.getByRole('button')).toHaveClass('border-border');
+      expect(screen.getByRole('button')).toHaveClass('border-zinc-300', 'dark:border-zinc-700');
     });
 
     it('applies "ghost" variant', () => {

--- a/packages/presentation/src/__tests__/components/LinkButton.test.tsx
+++ b/packages/presentation/src/__tests__/components/LinkButton.test.tsx
@@ -55,7 +55,11 @@ describe('LinkButton', () => {
           Outlined
         </LinkButton>,
       );
-      expect(screen.getByRole('link')).toHaveClass('border', 'border-border');
+      expect(screen.getByRole('link')).toHaveClass(
+        'border',
+        'border-zinc-300',
+        'dark:border-zinc-700',
+      );
     });
 
     it('merges consumer className with button classes', () => {

--- a/packages/presentation/src/components/Button.tsx
+++ b/packages/presentation/src/components/Button.tsx
@@ -27,7 +27,7 @@ const buttonVariants = cva(
         ghost: 'hover:bg-card hover:text-accent-foreground',
         link: 'text-primary items-start justify-start underline-offset-4 hover:underline',
         outline:
-          'border border-border bg-background hover:bg-card hover:text-accent-foreground shadow-sm',
+          'border border-zinc-300 dark:border-zinc-700 hover:border-zinc-400 dark:hover:border-zinc-600 bg-background hover:bg-card hover:text-accent-foreground shadow-sm',
         primary: primaryButtonClasses,
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
       },

--- a/packages/presentation/src/components/Card.tsx
+++ b/packages/presentation/src/components/Card.tsx
@@ -9,7 +9,9 @@ function Card({
   return (
     <div
       className={cn(
-        'rounded-lg border bg-card text-card-foreground shadow-sm hover:shadow-md',
+        // Bare `border` previously fell through to currentColor — visible bug.
+        // Lighter than field borders (cards sit one tier behind interactive fields).
+        'rounded-lg border border-zinc-200 dark:border-zinc-700 bg-card text-card-foreground shadow-sm hover:shadow-md',
         className,
       )}
       style={{

--- a/packages/presentation/src/components/Checkbox.tsx
+++ b/packages/presentation/src/components/Checkbox.tsx
@@ -74,7 +74,22 @@ function Checkbox({
         }}
         onChange={handleChange}
         className={cn(
-          'peer h-4 w-4 shrink-0 rounded border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+          // Layout
+          'peer h-4 w-4 shrink-0 rounded-[var(--rvui-radius-sm,6px)] border',
+          // Default (neutral at rest — fixes prior brand-at-rest semantic bug where
+          // unchecked boxes read as "selected")
+          'border-zinc-300 dark:border-zinc-700',
+          // Hover affordance
+          'hover:border-zinc-400 dark:hover:border-zinc-600',
+          // Focus
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--tenant-brand,var(--ring))] focus-visible:ring-offset-2 ring-offset-background',
+          // Error state
+          'aria-invalid:border-red-500 aria-invalid:focus-visible:ring-red-500',
+          // Disabled state
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          // Checked + indeterminate use tenant brand
+          'data-[state=checked]:bg-[var(--tenant-brand,var(--ring))] data-[state=checked]:border-[var(--tenant-brand,var(--ring))] data-[state=checked]:text-primary-foreground',
+          'data-[state=indeterminate]:bg-[var(--tenant-brand,var(--ring))] data-[state=indeterminate]:border-[var(--tenant-brand,var(--ring))]',
           className,
         )}
         data-state={

--- a/packages/presentation/src/components/Input.tsx
+++ b/packages/presentation/src/components/Input.tsx
@@ -9,7 +9,24 @@ function Input({ type, className, ref, ...props }: InputProps) {
   return (
     <input
       className={cn(
-        'flex h-10 w-full rounded border border-border bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        // Layout + typography
+        'flex h-10 w-full rounded border bg-background px-3 py-2 text-sm',
+        // Border — solid hex tokens (not alpha-translucent OKLCH) for crisp sub-pixel rendering
+        'border-zinc-300 dark:border-zinc-700',
+        // Hover affordance
+        'hover:border-zinc-400 dark:hover:border-zinc-600',
+        // Focus — brand-tinted border + ring derived from --tenant-brand (fallback to --ring)
+        'focus-visible:outline-none focus-visible:border-[var(--tenant-brand,var(--ring))] focus-visible:ring-2 focus-visible:ring-[var(--tenant-brand,var(--ring))] focus-visible:ring-offset-2',
+        // Error state (consumers set aria-invalid on the input)
+        'aria-invalid:border-red-500 aria-invalid:ring-red-500',
+        // Disabled state — keep border neutral on hover when disabled
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-zinc-300 dark:disabled:hover:border-zinc-700',
+        // Read-only state — slightly tinted bg, no hover affordance
+        'read-only:bg-zinc-50 dark:read-only:bg-zinc-900 read-only:cursor-default read-only:hover:border-zinc-300 dark:read-only:hover:border-zinc-700',
+        // File-input chrome reset
+        'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+        // Placeholder + ring offset
+        'placeholder:text-muted-foreground ring-offset-background',
         className,
       )}
       style={{

--- a/packages/presentation/src/components/Select.tsx
+++ b/packages/presentation/src/components/Select.tsx
@@ -100,9 +100,20 @@ function SelectTrigger({ children, className, ref, ...props }: SelectTriggerProp
   return (
     <Box
       className={cn(
-        'flex h-10 w-full items-center justify-between rounded border border-input bg-background px-3 py-2 text-inherit ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+        'flex h-10 w-full items-center justify-between border bg-background px-3 py-2 text-inherit',
+        'border-zinc-300 dark:border-zinc-700',
+        'hover:border-zinc-400 dark:hover:border-zinc-600',
+        'focus-visible:outline-none focus-visible:border-[var(--tenant-brand,var(--ring))] focus-visible:ring-2 focus-visible:ring-[var(--tenant-brand,var(--ring))] focus-visible:ring-offset-2',
+        'aria-invalid:border-red-500 aria-invalid:focus-visible:border-red-500 aria-invalid:focus-visible:ring-red-500',
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-zinc-300 dark:disabled:hover:border-zinc-700',
+        'placeholder:text-muted-foreground ring-offset-background [&>span]:line-clamp-1',
         className,
       )}
+      style={{
+        borderRadius: 'var(--rvui-radius-md, 10px)',
+        transition:
+          'border-color var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)), box-shadow var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
+      }}
       ref={ref}
       {...props}
     >
@@ -152,7 +163,9 @@ function SelectContent({ children, className, ref, ...props }: SelectContentProp
   return (
     <Box
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded border bg-card text-popover-foreground shadow-md',
+        // Popover sits above a solid surface; use a lighter neutral than the trigger
+        // (bare `border` was a bug — would fall through to currentColor)
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded border border-zinc-200 dark:border-zinc-700 bg-card text-popover-foreground shadow-md',
         className,
       )}
       ref={ref}

--- a/packages/presentation/src/components/Textarea.tsx
+++ b/packages/presentation/src/components/Textarea.tsx
@@ -9,9 +9,29 @@ function Textarea({ className, ref, ...props }: TextareaProps) {
   return (
     <textarea
       className={cn(
-        'flex min-h-[80px] w-full rounded border border-border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        // Layout + typography
+        'flex min-h-[80px] w-full border bg-background px-3 py-2 text-sm',
+        // Border — solid hex tokens (not alpha-translucent), matches Input primitive
+        'border-zinc-300 dark:border-zinc-700',
+        // Hover affordance
+        'hover:border-zinc-400 dark:hover:border-zinc-600',
+        // Focus — brand-tinted ring + border via --tenant-brand → --ring fallback chain
+        'focus-visible:outline-none focus-visible:border-[var(--tenant-brand,var(--ring))] focus-visible:ring-2 focus-visible:ring-[var(--tenant-brand,var(--ring))] focus-visible:ring-offset-2',
+        // Error state — solid red border + ring on aria-invalid
+        'aria-invalid:border-red-500 aria-invalid:focus-visible:border-red-500 aria-invalid:focus-visible:ring-red-500',
+        // Disabled state
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-zinc-300 dark:disabled:hover:border-zinc-700',
+        // Read-only state
+        'read-only:bg-zinc-50 dark:read-only:bg-zinc-900 read-only:cursor-default read-only:hover:border-zinc-300 dark:read-only:hover:border-zinc-700',
+        // Placeholder + ring offset
+        'placeholder:text-muted-foreground ring-offset-background',
         className,
       )}
+      style={{
+        borderRadius: 'var(--rvui-radius-md, 10px)',
+        transition:
+          'border-color var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)), box-shadow var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
+      }}
       ref={ref}
       {...props}
     />

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -11,6 +11,10 @@ export { Accordion, AccordionItem } from './accordion.js';
 export { Alert, AlertActions, AlertBody, AlertDescription, AlertTitle } from './alert.js';
 // Layout components
 export { AuthLayout, type AuthLayoutProps } from './auth-layout.js';
+export {
+  SplitAuthLayout,
+  type SplitAuthLayoutProps,
+} from './split-auth-layout.js';
 export { Avatar, AvatarButton } from './avatar.js';
 export { AvatarGroup } from './avatar-group.js';
 export { BuiltWithRevealUI } from './BuiltWithRevealUI.js';

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -11,10 +11,6 @@ export { Accordion, AccordionItem } from './accordion.js';
 export { Alert, AlertActions, AlertBody, AlertDescription, AlertTitle } from './alert.js';
 // Layout components
 export { AuthLayout, type AuthLayoutProps } from './auth-layout.js';
-export {
-  SplitAuthLayout,
-  type SplitAuthLayoutProps,
-} from './split-auth-layout.js';
 export { Avatar, AvatarButton } from './avatar.js';
 export { AvatarGroup } from './avatar-group.js';
 export { BuiltWithRevealUI } from './BuiltWithRevealUI.js';
@@ -146,6 +142,10 @@ export {
 export { SidebarLayout } from './sidebar-layout.js';
 export { Skeleton, SkeletonCard, SkeletonText } from './skeleton.js';
 export { Slider } from './slider.js';
+export {
+  SplitAuthLayout,
+  type SplitAuthLayoutProps,
+} from './split-auth-layout.js';
 export { StackedLayout } from './stacked-layout.js';
 export { Stat, StatGroup } from './stat.js';
 export { Stepper, type StepperStep } from './stepper.js';

--- a/packages/presentation/src/components/split-auth-layout.tsx
+++ b/packages/presentation/src/components/split-auth-layout.tsx
@@ -1,0 +1,74 @@
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+
+export interface SplitAuthLayoutProps {
+  /** Form content rendered in the right panel (desktop) / bottom panel (mobile). */
+  children: React.ReactNode;
+  /** Brand content rendered in the left panel (desktop) / top panel (mobile). Typically logo + name + optional tagline. */
+  brand: React.ReactNode;
+  /** Optional footer slot inside the brand panel. Consumer wraps with `hidden lg:block` if it should only show on desktop. */
+  brandFooter?: React.ReactNode;
+  /** Optional footer slot inside the form panel. Consumer wraps with `lg:hidden` if it should only show on mobile. */
+  formFooter?: React.ReactNode;
+  /**
+   * Background surface for the brand panel.
+   * - `tenant` (default): uses `--tenant-brand` CSS var with `--rvui-surface-3` token fallback.
+   * - `surface-3`: uses the neutral surface token unconditionally (no brand binding).
+   */
+  brandSurface?: 'tenant' | 'surface-3';
+}
+
+/**
+ * Two-column auth shell — mobile-first, split on `lg:` (1024px+) breakpoint.
+ *
+ * Used by sign-in / sign-up / reset-password / mfa / rotate-password / setup pages
+ * in the admin app and (via stamping) in customer Fleet kits.
+ *
+ * Layout:
+ * - Mobile: brand panel stacks on top (full width), form panel below.
+ * - Desktop (`lg:`+): brand panel takes left half, form panel takes right half.
+ *
+ * Theming:
+ * - Brand background pulls from `--tenant-brand` CSS var (set by the consuming app
+ *   at the root level — see `apps/admin/src/app/(frontend)/layout.tsx`), with a
+ *   neutral `--rvui-surface-3` token fallback when no tenant brand is configured.
+ * - Brand text color pulls from `--tenant-brand-on` CSS var (defaults to white).
+ *   Customers with light brand colors must set this to a dark value to maintain
+ *   WCAG contrast — there is no automatic contrast computation by design (avoids
+ *   FOUC + browser-compat issues with color-mix / relative luminance).
+ * - Form panel uses `--background` token so dark/light mode flips correctly.
+ *
+ * Companion centered variant: see `AuthLayout` for single-column non-branded shells.
+ */
+export function SplitAuthLayout({
+  children,
+  brand,
+  brandFooter,
+  formFooter,
+  brandSurface = 'tenant',
+}: SplitAuthLayoutProps) {
+  const brandBgClass =
+    brandSurface === 'tenant'
+      ? 'bg-[var(--tenant-brand,var(--rvui-surface-3))]'
+      : 'bg-[var(--rvui-surface-3)]';
+
+  return (
+    <main className="flex min-h-dvh flex-col lg:flex-row">
+      <aside
+        className={cn(
+          'flex flex-col items-center justify-center gap-6 px-6 py-12 lg:w-1/2 lg:gap-8 lg:py-16',
+          brandBgClass,
+          'text-[var(--tenant-brand-on,white)]',
+        )}
+      >
+        {brand}
+        {brandFooter ? <div className="mt-auto pt-8">{brandFooter}</div> : null}
+      </aside>
+
+      <section className="flex flex-1 flex-col items-center justify-center gap-6 bg-[var(--rvui-surface-1)] px-6 py-10 lg:py-16">
+        {children}
+        {formFooter ? <div className="pt-2">{formFooter}</div> : null}
+      </section>
+    </main>
+  );
+}

--- a/packages/presentation/src/icons/providers.tsx
+++ b/packages/presentation/src/icons/providers.tsx
@@ -1,0 +1,105 @@
+/**
+ * OAuth provider + passkey icons.
+ *
+ * Mono icons in `currentColor` — they inherit the parent button's text color so
+ * the OAuth row reads as a uniform visual family rather than a multi-color grid.
+ * Fleet customers automatically get icons in their brand color when the parent
+ * button uses `text-[var(--tenant-brand)]`. For revealui.com's own SaaS surface
+ * where multi-color provider marks are preferred, swap to a `variant="brand"`
+ * follow-up (separate work).
+ *
+ * Sizing: defaults to 16x16 via `size-4` class on the consumer. Pass `className`
+ * to override (e.g. `className="size-5"`). All paths are simplified for clarity
+ * at 16-24px display sizes.
+ *
+ * Accessibility: rendered as `<svg aria-hidden="true">` since the consuming
+ * button provides the accessible label ("Sign in with GitHub"). The icon is
+ * decorative redundancy.
+ */
+import type React from 'react';
+
+type IconProps = React.SVGAttributes<SVGSVGElement> & {
+  className?: string;
+};
+
+function BaseIcon({
+  children,
+  className,
+  viewBox = '0 0 24 24',
+  ...props
+}: IconProps & { children: React.ReactNode; viewBox?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={viewBox}
+      fill="currentColor"
+      aria-hidden="true"
+      className={className ?? 'size-4'}
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** GitHub mark — simplified Octocat silhouette. */
+export function GitHubIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M12 .297C5.37.297 0 5.67 0 12.297c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.333-1.754-1.333-1.754-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.807 1.305 3.492.997.108-.775.42-1.305.763-1.605-2.665-.305-5.467-1.334-5.467-5.93 0-1.31.467-2.382 1.235-3.222-.124-.303-.535-1.527.117-3.182 0 0 1.008-.323 3.3 1.23.957-.266 1.98-.398 3-.404 1.02.006 2.04.138 3 .404 2.29-1.553 3.296-1.23 3.296-1.23.654 1.655.243 2.879.12 3.182.77.84 1.234 1.912 1.234 3.222 0 4.61-2.807 5.62-5.48 5.92.43.372.815 1.103.815 2.222 0 1.606-.014 2.898-.014 3.293 0 .323.216.7.825.58C20.565 22.092 24 17.598 24 12.297 24 5.67 18.627.297 12 .297z" />
+    </BaseIcon>
+  );
+}
+
+/** Google mark — simplified G (mono; multi-color variant is a follow-up). */
+export function GoogleIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+    </BaseIcon>
+  );
+}
+
+/** LinkedIn mark — square with "in" wordmark. */
+export function LinkedInIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </BaseIcon>
+  );
+}
+
+/** Vercel mark — equilateral triangle. */
+export function VercelIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M24 22.525H0l12-21.05 12 21.05z" />
+    </BaseIcon>
+  );
+}
+
+/**
+ * Passkey icon — fingerprint/key composite. Stroke-based (not filled) for
+ * distinguishability from the filled provider marks.
+ */
+export function PasskeyIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className ?? 'size-4'}
+      {...props}
+    >
+      <circle cx="9" cy="9" r="4" />
+      <path d="m13 11 5.5 5.5" />
+      <path d="m15 14 2.5 2.5L20 14" />
+      <path d="m17 16 2.5 2.5" />
+    </svg>
+  );
+}

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -7,12 +7,7 @@
 
 // Layout Components - Server Safe
 export { AuthLayout, type AuthLayoutProps } from './components/auth-layout.js';
-export {
-  SplitAuthLayout,
-  type SplitAuthLayoutProps,
-} from './components/split-auth-layout.js';
 export { BuiltWithRevealUI } from './components/BuiltWithRevealUI.js';
-
 // CVA Components - Server Safe
 export {
   Button as ButtonCVA,
@@ -52,8 +47,11 @@ export {
   type PricingTableProps,
   type PricingTier,
 } from './components/pricing-table.js';
-
 export { Skeleton, SkeletonCard, SkeletonText } from './components/skeleton.js';
+export {
+  SplitAuthLayout,
+  type SplitAuthLayoutProps,
+} from './components/split-auth-layout.js';
 export { Textarea as TextareaCVA, type TextareaProps } from './components/Textarea.js';
 
 // Note: Checkbox and Select CVA versions use state and are in client.ts

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -7,6 +7,11 @@
 
 // Layout Components - Server Safe
 export { AuthLayout, type AuthLayoutProps } from './components/auth-layout.js';
+export {
+  SplitAuthLayout,
+  type SplitAuthLayoutProps,
+} from './components/split-auth-layout.js';
+export { BuiltWithRevealUI } from './components/BuiltWithRevealUI.js';
 
 // CVA Components - Server Safe
 export {
@@ -102,6 +107,15 @@ export {
   IconUsers,
   IconXCircle,
 } from './components/icon.js';
+// OAuth provider + passkey icons - Server Safe
+export {
+  GitHubIcon,
+  GoogleIcon,
+  LinkedInIcon,
+  PasskeyIcon,
+  VercelIcon,
+} from './icons/providers.js';
+
 // Primitives - Server Safe
 export { Box, type BoxProps } from './primitives/Box.js';
 export { Flex, type FlexProps } from './primitives/Flex.js';


### PR DESCRIPTION
## Summary

End-to-end redesign of the Fleet-customer auth-page surface, delivered as 3 commits:

| Commit | Scope |
|---|---|
| `feat(presentation): add SplitAuthLayout + provider icons` | New `SplitAuthLayout` primitive (mobile-first two-column shell) + 5 mono provider icons (GitHub / Google / LinkedIn / Vercel / Passkey). Re-exports `BuiltWithRevealUI` from `/server`. |
| `fix(presentation): unify form-field borders + state coverage` | Architect-led design spec across Input / Textarea / Select / Checkbox / Button-outline / Card. Solid neutrals replace alpha-translucent OKLCH borders. Brand-tinted focus rings via `--tenant-brand` fallback chain. Fixes 2 bare-`border` bugs + Checkbox brand-at-rest semantic bug. |
| `feat(admin): server-side auth shell + tenant theming env vars` | Split `/login` into Server Component shell (env-reading) + Client Form (interactive). Fixes the client-bundle `process.env` build-time-inlining bug that made the auth page render `'RevealUI'` instead of the tenant name. Adds 5 new tenant env vars + Fleet-mode Header/Footer gating + form polish per architect spec (drop Card, restructure title, sign-up to bottom, OAuth env-gating with icons). |

Discovered + driven while standing up a stamped Fleet kit end-to-end against the Customer Fleet demo. Each visible state was verified live before moving on.

## Why

The Fleet kit posture is "every customer (current + future) gets the same generic auth shell; only their env-driven bindings differ — no per-customer code paths." But the existing auth pages had multiple structural problems blocking that promise:

1. **`process.env` reads in `'use client'` pages got inlined at build time** → tenant env (e.g. `REVEALUI_TENANT_NAME=an enterprise customer`) was ignored; pages defaulted to `'RevealUI'`. Root cause + fix: Server Component shell + Client Form split.

2. **No `SplitAuthLayout` primitive** existed — every customer would have re-implemented an inline split. Added as a proper primitive in `@revealui/presentation`.

3. **Field borders used alpha-translucent OKLCH tokens** that read as "glitchy silver" against the white form surface. Architect-spec'd unified solid-neutral borders + brand-tinted focus across all field primitives.

4. **OAuth row had hard-coded buttons with no env-gating** — kits without OAuth configured still rendered dead provider buttons. Now server-gated via `REVEALUI_OAUTH_PROVIDERS=github,google,...`.

5. **RevealUI-branded Header + Footer rendered on Fleet customer kits**, breaking whitelabel. Now gated on `REVEALUI_FLEET_MODE=true`.

6. **Card-on-white-on-color form arrangement** looked flat. Architect recommended dropping the Card; form renders directly on `--rvui-surface-1` for paper-meets-color architecture.

## New tenant env vars (consumed by `apps/admin`)

| Var | Default | Effect |
|---|---|---|
| `REVEALUI_TENANT_BRAND_ON` | `white` | Foreground color on brand-colored panel (customer must set a dark value if their brand color is light to maintain WCAG contrast — no automatic luminance calculation by design) |
| `REVEALUI_TENANT_HIDE_NAME` | (unset) | When `'true'`, hides the visible name heading (alt text on logo stays for screen readers). Useful when the logo itself contains the company wordmark. |
| `REVEALUI_TENANT_TAGLINE` | (unset) | Optional subline under the name on auth pages |
| `REVEALUI_TENANT_FONT` | (unset) | Optional font family. Must already be loaded as a stylesheet (built-in support: Inter / Mona Sans / Geist) |
| `REVEALUI_OAUTH_PROVIDERS` | (unset) | Comma-separated allowlist (`github,google,vercel,linkedin`). Unset = no OAuth row at all. |
| `REVEALUI_FLEET_MODE` | (unset; `'true'` in kits) | When `'true'`, suppresses the RevealUI Header + Footer + Built-with-RevealUI badge defaults |

## Behaviour change matrix

| Scenario | Before | After |
|---|---|---|
| Fleet kit with tenant env set | Shows `'RevealUI'` heading + powered-by badge | Shows actual tenant name + optional tagline + no powered-by |
| Fleet kit OAuth row | 4 hardcoded buttons regardless of config | Renders only configured providers; row hidden if none |
| Field borders | Alpha-translucent (silver-looking) | Solid `border-zinc-300/700` with brand-tinted focus |
| Card on white panel | Card barely visible (white-on-white) | Form renders directly on the panel surface |
| Page when env unset (revealui.com SaaS) | (unchanged) | (unchanged — defaults preserve revealui.com behavior) |

## Test plan

- [x] Verified end-to-end on a stamped Fleet kit (`~/acme-fleet/`) — login page renders with the first customer branding, no RevealUI artifacts, OAuth icons visible
- [x] All 6 field primitives use `border-zinc-300` in rendered HTML (verified via curl + grep)
- [x] `BrandedAuthLayout` reads `process.env.REVEALUI_TENANT_NAME` at server-render time (no client-bundle inlining)
- [x] Token bridge (`--tenant-brand` → `--primary`) preserved; revealui.com SaaS surface unaffected
- [ ] CI: existing presentation + admin test suites (this PR doesn't add new tests; recommend a follow-up to add visual snapshots for the new layout primitive)
- [ ] Manual: signup / reset-password / mfa / rotate-password / setup pages still use the old (broken) env-inlining pattern; this PR doesn't fix them — flagged as the next mechanical follow-up

## Follow-ups (separate PRs)

1. **Extend the server/client split to the other 5 auth pages** (`signup`, `reset-password`, `mfa`, `rotate-password`, `setup`) — they still show `'RevealUI'` + powered-by badge until split.
2. **Radio + Switch primitives** still use hardcoded `outline-blue-500` for focus — apply the same `var(--tenant-brand, var(--ring))` chain.
3. **New `--rvui-field-*` tokens** in `tokens.css` (additive — replace literal `zinc-300/700` classes with token references).
4. **Centralized `fieldClasses.ts` constants** to prevent future drift.
5. **Brand-variant icons** for revealui.com's own SaaS surface (multi-color G, etc.) — optional `variant="brand"` on each icon component.
6. **Visual regression baselines** for the new SplitAuthLayout primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
