### PR TITLE
feat(mcp): extend runtime Zod validation to content/email/memory tool args

### DIFF
--- a/packages/mcp/src/__tests__/revealui-content-validation.test.ts
+++ b/packages/mcp/src/__tests__/revealui-content-validation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for runtime Zod validation in the revealui-content MCP server factory.
+ *
+ * Coverage targets:
+ *   - Per-tool: valid args pass through; missing required fields, wrong types,
+ *     extra fields are rejected.
+ *   - Fully-optional tools accept empty args {}.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GetContentArgsSchema,
+  ListContentArgsSchema,
+  ListSitesArgsSchema,
+  ListUsersArgsSchema,
+  SiteStatsArgsSchema,
+} from '../servers/factories/revealui-content.js';
+import { validateToolArgs } from '../validate-tool-args.js';
+
+describe('revealui_list_sites args', () => {
+  it('accepts empty args (all optional)', () => {
+    const r = validateToolArgs(ListSitesArgsSchema, {}, 'revealui_list_sites');
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts valid limit and page', () => {
+    const r = validateToolArgs(ListSitesArgsSchema, { limit: 10, page: 2 }, 'revealui_list_sites');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(ListSitesArgsSchema, { bogus: true }, 'revealui_list_sites');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.isError).toBe(true);
+  });
+
+  it('rejects wrong type for limit', () => {
+    const r = validateToolArgs(ListSitesArgsSchema, { limit: 'twenty' }, 'revealui_list_sites');
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('revealui_list_content args', () => {
+  it('accepts required collection only', () => {
+    const r = validateToolArgs(
+      ListContentArgsSchema,
+      { collection: 'posts' },
+      'revealui_list_content',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts all optional fields alongside collection', () => {
+    const r = validateToolArgs(
+      ListContentArgsSchema,
+      { collection: 'pages', site_id: 'site-1', limit: 5, page: 1, status: 'published' },
+      'revealui_list_content',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing collection', () => {
+    const r = validateToolArgs(ListContentArgsSchema, {}, 'revealui_list_content');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('revealui_list_content');
+  });
+
+  it('rejects empty string collection', () => {
+    const r = validateToolArgs(ListContentArgsSchema, { collection: '' }, 'revealui_list_content');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(
+      ListContentArgsSchema,
+      { collection: 'posts', extra: 'oops' },
+      'revealui_list_content',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('revealui_get_content args', () => {
+  it('accepts valid collection and id', () => {
+    const r = validateToolArgs(
+      GetContentArgsSchema,
+      { collection: 'posts', id: 'abc123' },
+      'revealui_get_content',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing id', () => {
+    const r = validateToolArgs(
+      GetContentArgsSchema,
+      { collection: 'posts' },
+      'revealui_get_content',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('revealui_get_content');
+  });
+
+  it('rejects missing collection', () => {
+    const r = validateToolArgs(GetContentArgsSchema, { id: 'abc123' }, 'revealui_get_content');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects empty string id', () => {
+    const r = validateToolArgs(
+      GetContentArgsSchema,
+      { collection: 'posts', id: '' },
+      'revealui_get_content',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('revealui_list_users args', () => {
+  it('accepts empty args (all optional)', () => {
+    const r = validateToolArgs(ListUsersArgsSchema, {}, 'revealui_list_users');
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts site_id with pagination', () => {
+    const r = validateToolArgs(
+      ListUsersArgsSchema,
+      { site_id: 'site-abc', limit: 50, page: 3 },
+      'revealui_list_users',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(ListUsersArgsSchema, { filter: 'admin' }, 'revealui_list_users');
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('revealui_site_stats args', () => {
+  it('accepts empty args (all optional)', () => {
+    const r = validateToolArgs(SiteStatsArgsSchema, {}, 'revealui_site_stats');
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts site_id', () => {
+    const r = validateToolArgs(SiteStatsArgsSchema, { site_id: 'site-xyz' }, 'revealui_site_stats');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects null args', () => {
+    const r = validateToolArgs(SiteStatsArgsSchema, null, 'revealui_site_stats');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(SiteStatsArgsSchema, { region: 'us-east' }, 'revealui_site_stats');
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/mcp/src/__tests__/revealui-email-validation.test.ts
+++ b/packages/mcp/src/__tests__/revealui-email-validation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for runtime Zod validation in the revealui-email MCP server.
+ *
+ * Coverage targets:
+ *   - email_send: string and array recipient; missing required; body-less pass-through.
+ *   - email_send_batch: valid batch; batch over 100; missing required item fields.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EmailSendArgsSchema, EmailSendBatchArgsSchema } from '../servers/revealui-email.js';
+import { validateToolArgs } from '../validate-tool-args.js';
+
+describe('email_send args', () => {
+  it('accepts string recipient', () => {
+    const r = validateToolArgs(
+      EmailSendArgsSchema,
+      { to: 'user@example.com', subject: 'Hello' },
+      'email_send',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts array of recipients', () => {
+    const r = validateToolArgs(
+      EmailSendArgsSchema,
+      { to: ['a@example.com', 'b@example.com'], subject: 'Batch hello' },
+      'email_send',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts all optional fields', () => {
+    const r = validateToolArgs(
+      EmailSendArgsSchema,
+      {
+        to: 'user@example.com',
+        subject: 'Hi',
+        html: '<p>Hello</p>',
+        text: 'Hello',
+        from: 'noreply@revealui.com',
+        reply_to: 'support@revealui.com',
+      },
+      'email_send',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing to', () => {
+    const r = validateToolArgs(EmailSendArgsSchema, { subject: 'No recipient' }, 'email_send');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('email_send');
+  });
+
+  it('rejects missing subject', () => {
+    const r = validateToolArgs(EmailSendArgsSchema, { to: 'user@example.com' }, 'email_send');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-string non-array to', () => {
+    const r = validateToolArgs(
+      EmailSendArgsSchema,
+      { to: 42, subject: 'Bad to field' },
+      'email_send',
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(
+      EmailSendArgsSchema,
+      { to: 'user@example.com', subject: 'Hi', priority: 'high' },
+      'email_send',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('email_send_batch args', () => {
+  it('accepts valid batch of one', () => {
+    const r = validateToolArgs(
+      EmailSendBatchArgsSchema,
+      { emails: [{ to: 'a@b.com', subject: 'Test' }] },
+      'email_send_batch',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts batch with optional fields on items', () => {
+    const r = validateToolArgs(
+      EmailSendBatchArgsSchema,
+      {
+        emails: [
+          { to: 'a@b.com', subject: 'S1', html: '<p>Hi</p>', text: 'Hi' },
+          { to: 'b@b.com', subject: 'S2', from: 'no-reply@foo.com' },
+        ],
+      },
+      'email_send_batch',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects batch over 100 items', () => {
+    const emails = Array.from({ length: 101 }, (_, i) => ({
+      to: `user${i}@example.com`,
+      subject: `msg ${i}`,
+    }));
+    const r = validateToolArgs(EmailSendBatchArgsSchema, { emails }, 'email_send_batch');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('email_send_batch');
+  });
+
+  it('rejects item missing to', () => {
+    const r = validateToolArgs(
+      EmailSendBatchArgsSchema,
+      { emails: [{ subject: 'No recipient' }] },
+      'email_send_batch',
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects item missing subject', () => {
+    const r = validateToolArgs(
+      EmailSendBatchArgsSchema,
+      { emails: [{ to: 'a@b.com' }] },
+      'email_send_batch',
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects missing emails array', () => {
+    const r = validateToolArgs(EmailSendBatchArgsSchema, {}, 'email_send_batch');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects item unknown field', () => {
+    const r = validateToolArgs(
+      EmailSendBatchArgsSchema,
+      { emails: [{ to: 'a@b.com', subject: 'Hi', priority: 'urgent' }] },
+      'email_send_batch',
+    );
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/mcp/src/__tests__/revealui-memory-validation.test.ts
+++ b/packages/mcp/src/__tests__/revealui-memory-validation.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for runtime Zod validation in the revealui-memory MCP server.
+ *
+ * Coverage targets:
+ *   - Per-tool: valid args pass through; missing required fields, wrong types,
+ *     enum out-of-range, and extra fields are rejected.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  CreateScratchpadArgsSchema,
+  ListFactsArgsSchema,
+  ListSharedArgsSchema,
+  PatchScratchpadArgsSchema,
+  PublishFactArgsSchema,
+  ReadScratchpadArgsSchema,
+  ReconcileArgsSchema,
+  ShareMemoryArgsSchema,
+} from '../servers/revealui-memory.js';
+import { validateToolArgs } from '../validate-tool-args.js';
+
+describe('memory_publish_fact args', () => {
+  it('accepts valid required fields', () => {
+    const r = validateToolArgs(
+      PublishFactArgsSchema,
+      {
+        session_id: 'sess-1',
+        agent_id: 'agent-a',
+        content: 'Found a bug',
+        fact_type: 'bug',
+      },
+      'memory_publish_fact',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts all optional fields', () => {
+    const r = validateToolArgs(
+      PublishFactArgsSchema,
+      {
+        session_id: 'sess-1',
+        agent_id: 'agent-a',
+        content: 'Decision made',
+        fact_type: 'decision',
+        confidence: 0.9,
+        tags: ['arch', 'phase-3'],
+        source_ref: { file: 'src/foo.ts', line: 42 },
+      },
+      'memory_publish_fact',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects invalid fact_type enum', () => {
+    const r = validateToolArgs(
+      PublishFactArgsSchema,
+      { session_id: 'sess-1', agent_id: 'a', content: 'x', fact_type: 'opinion' },
+      'memory_publish_fact',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('memory_publish_fact');
+  });
+
+  it('rejects missing fact_type', () => {
+    const r = validateToolArgs(
+      PublishFactArgsSchema,
+      { session_id: 'sess-1', agent_id: 'a', content: 'x' },
+      'memory_publish_fact',
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(
+      PublishFactArgsSchema,
+      {
+        session_id: 'sess-1',
+        agent_id: 'a',
+        content: 'x',
+        fact_type: 'discovery',
+        extra: true,
+      },
+      'memory_publish_fact',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_list_facts args', () => {
+  it('accepts valid session_id', () => {
+    const r = validateToolArgs(
+      ListFactsArgsSchema,
+      { session_id: 'sess-abc' },
+      'memory_list_facts',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing session_id', () => {
+    const r = validateToolArgs(ListFactsArgsSchema, {}, 'memory_list_facts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('memory_list_facts');
+  });
+});
+
+describe('memory_create_scratchpad args', () => {
+  it('accepts required fields only', () => {
+    const r = validateToolArgs(
+      CreateScratchpadArgsSchema,
+      { document_id: 'doc-1', agent_id: 'agent-b' },
+      'memory_create_scratchpad',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts optional title', () => {
+    const r = validateToolArgs(
+      CreateScratchpadArgsSchema,
+      { document_id: 'doc-1', agent_id: 'agent-b', title: 'My Plan' },
+      'memory_create_scratchpad',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing document_id', () => {
+    const r = validateToolArgs(
+      CreateScratchpadArgsSchema,
+      { agent_id: 'agent-b' },
+      'memory_create_scratchpad',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_patch_scratchpad args', () => {
+  it('accepts valid patch', () => {
+    const r = validateToolArgs(
+      PatchScratchpadArgsSchema,
+      {
+        document_id: 'doc-1',
+        agent_id: 'agent-a',
+        patch_type: 'append_section',
+        path: 'findings',
+        content: 'New finding',
+      },
+      'memory_patch_scratchpad',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects invalid patch_type enum', () => {
+    const r = validateToolArgs(
+      PatchScratchpadArgsSchema,
+      {
+        document_id: 'doc-1',
+        agent_id: 'agent-a',
+        patch_type: 'delete_all',
+        path: 'findings',
+        content: 'x',
+      },
+      'memory_patch_scratchpad',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('memory_patch_scratchpad');
+  });
+
+  it('rejects missing content', () => {
+    const r = validateToolArgs(
+      PatchScratchpadArgsSchema,
+      {
+        document_id: 'doc-1',
+        agent_id: 'agent-a',
+        patch_type: 'set_key',
+        path: 'title',
+      },
+      'memory_patch_scratchpad',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_read_scratchpad args', () => {
+  it('accepts valid document_id', () => {
+    const r = validateToolArgs(
+      ReadScratchpadArgsSchema,
+      { document_id: 'doc-42' },
+      'memory_read_scratchpad',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing document_id', () => {
+    const r = validateToolArgs(ReadScratchpadArgsSchema, {}, 'memory_read_scratchpad');
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_share args', () => {
+  it('accepts valid required fields', () => {
+    const r = validateToolArgs(
+      ShareMemoryArgsSchema,
+      {
+        session_scope: 'scope-1',
+        agent_id: 'agent-a',
+        site_id: 'site-xyz',
+        content: 'Remember this',
+        type: 'fact',
+        source: { tool: 'grep', file: 'src/foo.ts' },
+      },
+      'memory_share',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects invalid type enum', () => {
+    const r = validateToolArgs(
+      ShareMemoryArgsSchema,
+      {
+        session_scope: 'scope-1',
+        agent_id: 'a',
+        site_id: 'site-1',
+        content: 'x',
+        type: 'thought',
+        source: {},
+      },
+      'memory_share',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('memory_share');
+  });
+
+  it('rejects missing source', () => {
+    const r = validateToolArgs(
+      ShareMemoryArgsSchema,
+      {
+        session_scope: 'scope-1',
+        agent_id: 'a',
+        site_id: 'site-1',
+        content: 'x',
+        type: 'preference',
+      },
+      'memory_share',
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_list_shared args', () => {
+  it('accepts valid session_scope', () => {
+    const r = validateToolArgs(
+      ListSharedArgsSchema,
+      { session_scope: 'scope-abc' },
+      'memory_list_shared',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing session_scope', () => {
+    const r = validateToolArgs(ListSharedArgsSchema, {}, 'memory_list_shared');
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('memory_reconcile args', () => {
+  it('accepts valid session_id and site_id', () => {
+    const r = validateToolArgs(
+      ReconcileArgsSchema,
+      { session_id: 'sess-1', site_id: 'site-1' },
+      'memory_reconcile',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing site_id', () => {
+    const r = validateToolArgs(ReconcileArgsSchema, { session_id: 'sess-1' }, 'memory_reconcile');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.content[0].text).toContain('memory_reconcile');
+  });
+
+  it('rejects unknown field', () => {
+    const r = validateToolArgs(
+      ReconcileArgsSchema,
+      { session_id: 'sess-1', site_id: 'site-1', force: true },
+      'memory_reconcile',
+    );
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -43,6 +43,8 @@ import {
   type Resource,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod/v4';
+import { validateToolArgs } from '../../validate-tool-args.js';
 
 // ---------------------------------------------------------------------------
 // Credential overrides (set by hypervisor / HTTP launcher)
@@ -107,6 +109,48 @@ async function apiGet(
   }
   return body;
 }
+
+// ---------------------------------------------------------------------------
+// Tool argument schemas (Zod 4)
+// ---------------------------------------------------------------------------
+
+export const ListSitesArgsSchema = z
+  .object({
+    limit: z.number().optional(),
+    page: z.number().optional(),
+  })
+  .strict();
+
+export const ListContentArgsSchema = z
+  .object({
+    site_id: z.string().optional(),
+    collection: z.string().min(1),
+    limit: z.number().optional(),
+    page: z.number().optional(),
+    status: z.string().optional(),
+  })
+  .strict();
+
+export const GetContentArgsSchema = z
+  .object({
+    collection: z.string().min(1),
+    id: z.string().min(1),
+  })
+  .strict();
+
+export const ListUsersArgsSchema = z
+  .object({
+    site_id: z.string().optional(),
+    limit: z.number().optional(),
+    page: z.number().optional(),
+  })
+  .strict();
+
+export const SiteStatsArgsSchema = z
+  .object({
+    site_id: z.string().optional(),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Tool definitions
@@ -487,10 +531,9 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
 
       switch (toolName) {
         case 'revealui_list_sites': {
-          const { limit = 20, page = 1 } = request.params.arguments as {
-            limit?: number;
-            page?: number;
-          };
+          const parsed = validateToolArgs(ListSitesArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error;
+          const { limit = 20, page = 1 } = parsed.value;
           data = await apiGet(apiUrl, apiKey, '/api/sites', {
             limit: String(limit),
             page: String(page),
@@ -499,19 +542,13 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_list_content': {
-          const {
-            site_id,
-            collection,
-            limit = 20,
-            page = 1,
-            status,
-          } = request.params.arguments as {
-            site_id?: string;
-            collection: string;
-            limit?: number;
-            page?: number;
-            status?: string;
-          };
+          const parsed = validateToolArgs(
+            ListContentArgsSchema,
+            request.params.arguments,
+            toolName,
+          );
+          if (!parsed.ok) return parsed.error;
+          const { site_id, collection, limit = 20, page = 1, status } = parsed.value;
           const params: Record<string, string> = {
             limit: String(limit),
             page: String(page),
@@ -524,24 +561,17 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_get_content': {
-          const { collection, id } = request.params.arguments as {
-            collection: string;
-            id: string;
-          };
+          const parsed = validateToolArgs(GetContentArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error;
+          const { collection, id } = parsed.value;
           data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
           break;
         }
 
         case 'revealui_list_users': {
-          const {
-            site_id,
-            limit = 20,
-            page = 1,
-          } = request.params.arguments as {
-            site_id?: string;
-            limit?: number;
-            page?: number;
-          };
+          const parsed = validateToolArgs(ListUsersArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error;
+          const { site_id, limit = 20, page = 1 } = parsed.value;
           const params: Record<string, string> = {
             limit: String(limit),
             page: String(page),
@@ -553,7 +583,9 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_site_stats': {
-          const { site_id } = request.params.arguments as { site_id?: string };
+          const parsed = validateToolArgs(SiteStatsArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error;
+          const { site_id } = parsed.value;
           const params: Record<string, string> = {};
           if (site_id) params.siteId = site_id;
 

--- a/packages/mcp/src/servers/revealui-email.ts
+++ b/packages/mcp/src/servers/revealui-email.ts
@@ -29,6 +29,8 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '@revealui/core/observability/logger';
+import { z } from 'zod/v4';
+import { validateToolArgs } from '../validate-tool-args.js';
 import { type EmailPayload, sendEmail, sendEmailBatch } from './_email-provider.js';
 
 // ---------------------------------------------------------------------------
@@ -44,6 +46,37 @@ let _credentialOverrides: Record<string, string> = {};
 export function setCredentials(creds: Record<string, string>): void {
   _credentialOverrides = creds;
 }
+
+// ---------------------------------------------------------------------------
+// Tool argument schemas (Zod 4)
+// ---------------------------------------------------------------------------
+
+export const EmailSendArgsSchema = z
+  .object({
+    to: z.union([z.string(), z.array(z.string())]),
+    subject: z.string(),
+    html: z.string().optional(),
+    text: z.string().optional(),
+    from: z.string().optional(),
+    reply_to: z.string().optional(),
+  })
+  .strict();
+
+const EmailItemSchema = z
+  .object({
+    to: z.string(),
+    subject: z.string(),
+    html: z.string().optional(),
+    text: z.string().optional(),
+    from: z.string().optional(),
+  })
+  .strict();
+
+export const EmailSendBatchArgsSchema = z
+  .object({
+    emails: z.array(EmailItemSchema).max(100),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Server
@@ -135,21 +168,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
     switch (toolName) {
       case 'email_send': {
-        const {
-          to,
-          subject,
-          html,
-          text,
-          from = fromAddress,
-          reply_to,
-        } = request.params.arguments as {
-          to: string | string[];
-          subject: string;
-          html?: string;
-          text?: string;
-          from?: string;
-          reply_to?: string;
-        };
+        const parsed = validateToolArgs(EmailSendArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        const { to, subject, html, text, from = fromAddress, reply_to } = parsed.value;
 
         if (!(html ?? text)) {
           return {
@@ -169,22 +190,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       }
 
       case 'email_send_batch': {
-        const { emails } = request.params.arguments as {
-          emails: Array<{
-            to: string;
-            subject: string;
-            html?: string;
-            text?: string;
-            from?: string;
-          }>;
-        };
-
-        if (emails.length > 100) {
-          return {
-            content: [{ type: 'text', text: 'Error: Batch size cannot exceed 100 emails' }],
-            isError: true,
-          };
-        }
+        const parsed = validateToolArgs(
+          EmailSendBatchArgsSchema,
+          request.params.arguments,
+          toolName,
+        );
+        if (!parsed.ok) return parsed.error;
+        const { emails } = parsed.value;
 
         const payloads: EmailPayload[] = emails.map((e) => {
           const payload: EmailPayload = {

--- a/packages/mcp/src/servers/revealui-memory.ts
+++ b/packages/mcp/src/servers/revealui-memory.ts
@@ -31,6 +31,8 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '@revealui/core/observability/logger';
+import { z } from 'zod/v4';
+import { validateToolArgs } from '../validate-tool-args.js';
 
 // ---------------------------------------------------------------------------
 // Credential overrides (set by Hypervisor before tool invocations)
@@ -90,6 +92,85 @@ async function apiGet(path: string, params?: Record<string, string>): Promise<un
   }
   return data;
 }
+
+// ---------------------------------------------------------------------------
+// Tool argument schemas (Zod 4)
+// ---------------------------------------------------------------------------
+
+export const PublishFactArgsSchema = z
+  .object({
+    session_id: z.string(),
+    agent_id: z.string(),
+    content: z.string(),
+    fact_type: z.enum(['discovery', 'bug', 'decision', 'warning', 'question', 'answer']),
+    confidence: z.number().optional(),
+    tags: z.array(z.string()).optional(),
+    source_ref: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const ListFactsArgsSchema = z
+  .object({
+    session_id: z.string(),
+  })
+  .strict();
+
+export const CreateScratchpadArgsSchema = z
+  .object({
+    document_id: z.string(),
+    agent_id: z.string(),
+    title: z.string().optional(),
+  })
+  .strict();
+
+export const PatchScratchpadArgsSchema = z
+  .object({
+    document_id: z.string(),
+    agent_id: z.string(),
+    patch_type: z.enum(['append_section', 'append_item', 'replace_section', 'set_key']),
+    path: z.string(),
+    content: z.string(),
+  })
+  .strict();
+
+export const ReadScratchpadArgsSchema = z
+  .object({
+    document_id: z.string(),
+  })
+  .strict();
+
+export const ShareMemoryArgsSchema = z
+  .object({
+    session_scope: z.string(),
+    agent_id: z.string(),
+    site_id: z.string(),
+    content: z.string(),
+    type: z.enum([
+      'fact',
+      'preference',
+      'decision',
+      'feedback',
+      'example',
+      'correction',
+      'skill',
+      'warning',
+    ]),
+    source: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const ListSharedArgsSchema = z
+  .object({
+    session_scope: z.string(),
+  })
+  .strict();
+
+export const ReconcileArgsSchema = z
+  .object({
+    session_id: z.string(),
+    site_id: z.string(),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Server
@@ -276,32 +357,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
     switch (toolName) {
       // Layer 1
       case 'memory_publish_fact': {
-        const args = request.params.arguments as {
-          session_id: string;
-          agent_id: string;
-          content: string;
-          fact_type: string;
-          confidence?: number;
-          tags?: string[];
-          source_ref?: Record<string, unknown>;
-        };
-        data = await apiPost('/api/sync/shared-facts', args);
+        const parsed = validateToolArgs(PublishFactArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        data = await apiPost('/api/sync/shared-facts', parsed.value);
         break;
       }
 
       case 'memory_list_facts': {
-        const { session_id } = request.params.arguments as { session_id: string };
-        data = await apiGet('/api/shapes/shared-facts', { session_id });
+        const parsed = validateToolArgs(ListFactsArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        data = await apiGet('/api/shapes/shared-facts', { session_id: parsed.value.session_id });
         break;
       }
 
       // Layer 2
       case 'memory_create_scratchpad': {
-        const { document_id, agent_id, title } = request.params.arguments as {
-          document_id: string;
-          agent_id: string;
-          title?: string;
-        };
+        const parsed = validateToolArgs(
+          CreateScratchpadArgsSchema,
+          request.params.arguments,
+          toolName,
+        );
+        if (!parsed.ok) return parsed.error;
+        const { document_id, agent_id, title } = parsed.value;
         data = await apiPost('/api/sync/yjs-document-patches', {
           document_id,
           agent_id,
@@ -313,49 +390,48 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       }
 
       case 'memory_patch_scratchpad': {
-        const args = request.params.arguments as {
-          document_id: string;
-          agent_id: string;
-          patch_type: string;
-          path: string;
-          content: string;
-        };
-        data = await apiPost('/api/sync/yjs-document-patches', args);
+        const parsed = validateToolArgs(
+          PatchScratchpadArgsSchema,
+          request.params.arguments,
+          toolName,
+        );
+        if (!parsed.ok) return parsed.error;
+        data = await apiPost('/api/sync/yjs-document-patches', parsed.value);
         break;
       }
 
       case 'memory_read_scratchpad': {
-        const { document_id } = request.params.arguments as { document_id: string };
-        data = await apiGet('/api/shapes/yjs-documents', { document_id });
+        const parsed = validateToolArgs(
+          ReadScratchpadArgsSchema,
+          request.params.arguments,
+          toolName,
+        );
+        if (!parsed.ok) return parsed.error;
+        data = await apiGet('/api/shapes/yjs-documents', { document_id: parsed.value.document_id });
         break;
       }
 
       // Layer 3
       case 'memory_share': {
-        const args = request.params.arguments as {
-          session_scope: string;
-          agent_id: string;
-          site_id: string;
-          content: string;
-          type: string;
-          source: Record<string, unknown>;
-        };
-        data = await apiPost('/api/sync/shared-memories', args);
+        const parsed = validateToolArgs(ShareMemoryArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        data = await apiPost('/api/sync/shared-memories', parsed.value);
         break;
       }
 
       case 'memory_list_shared': {
-        const { session_scope } = request.params.arguments as { session_scope: string };
-        data = await apiGet('/api/shapes/shared-memories', { session_scope });
+        const parsed = validateToolArgs(ListSharedArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        data = await apiGet('/api/shapes/shared-memories', {
+          session_scope: parsed.value.session_scope,
+        });
         break;
       }
 
       case 'memory_reconcile': {
-        const args = request.params.arguments as {
-          session_id: string;
-          site_id: string;
-        };
-        data = await apiPost('/api/sync/reconcile', args);
+        const parsed = validateToolArgs(ReconcileArgsSchema, request.params.arguments, toolName);
+        if (!parsed.ok) return parsed.error;
+        data = await apiPost('/api/sync/reconcile', parsed.value);
         break;
       }
 


### PR DESCRIPTION
## Summary

Follow-on to #902. Extends `validateToolArgs()` runtime Zod validation to the three remaining first-party MCP servers: `revealui-content`, `revealui-email`, and `revealui-memory`.

**Why:** 4 of 5 first-party MCP servers advertised `inputSchema` as JSON Schema but cast `request.params.arguments as { ... }` at dispatch — no runtime validation. An LLM sending malformed args could crash the handler or silently produce wrong output. This PR makes all servers honest about their contracts.

**Scope (internal lane: 2026-05-16 schemas + validation fleet audit, §P1-3 sibling-server follow-on):**

- `packages/mcp/src/servers/factories/revealui-content.ts` — 5 tools converted. Schemas exported for testability. Fully-optional tools accept `{}`.
- `packages/mcp/src/servers/revealui-email.ts` — 2 tools converted. `to` maps to `z.union([z.string(), z.array(z.string())])`. Batch cap enforced via `z.array(...).max(100)`, removing the now-redundant manual guard.
- `packages/mcp/src/servers/revealui-memory.ts` — 8 tools converted across 3 layers. Enums enforced for `fact_type`, `patch_type`, and memory `type`. Opaque metadata fields typed as `z.record(z.string(), z.unknown())`.

**Test files added (57 new tests total):**
- `src/__tests__/revealui-content-validation.test.ts` — 20 tests
- `src/__tests__/revealui-email-validation.test.ts` — 14 tests
- `src/__tests__/revealui-memory-validation.test.ts` — 23 tests

**No new authored regex.** The pre-existing `parseResourceUri` regex in the content factory is untouched. Zero regex authored in schemas or handlers.

**With this PR, audit §P1-3 is fully closed** — all five first-party MCP servers (`contracts`, `revealui-stripe`, `revealui-content`, `revealui-email`, `revealui-memory`) now validate tool args at runtime.

## Verification

All three ran clean locally:
- `pnpm --filter @revealui/mcp typecheck` — clean
- `pnpm --filter @revealui/mcp test` — 378 pass, 5 skipped (pre-existing skips)
- `pnpm exec biome check packages/mcp` — 2 pre-existing warnings in `contracts.ts`, 0 errors introduced

## Test plan

- [ ] CI gate passes on this PR
- [ ] Manual merge (`gh pr merge --squash --delete-branch`) once CI green
