### PR TITLE
feat(electric): add liveness probe + wire e2e to CI

### DIFF
--- a/.github/workflows/electric-e2e.yml
+++ b/.github/workflows/electric-e2e.yml
@@ -1,0 +1,91 @@
+name: Electric E2E
+
+# Runs against the deployed production admin when relevant paths change.
+# Requires live services (Electric on Railway + NeonDB) — uses production
+# env vars injected as GitHub Actions secrets.
+#
+# NOT a required check until it accumulates ~10 green runs.
+# See: PR feat/electric-liveness-probe-and-ci for context.
+
+on:
+  push:
+    branches: [main, test]
+    paths:
+      - 'apps/admin/src/app/api/shapes/**'
+      - 'apps/admin/src/app/api/health/electric/**'
+      - 'packages/sync/**'
+      - 'e2e/electric.e2e.ts'
+  pull_request:
+    branches: [main, test]
+    paths:
+      - 'apps/admin/src/app/api/shapes/**'
+      - 'apps/admin/src/app/api/health/electric/**'
+      - 'packages/sync/**'
+      - 'e2e/electric.e2e.ts'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: electric-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.28.2"
+
+jobs:
+  electric-e2e:
+    name: Electric E2E (production)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Only run when the repo variable is opted in.
+    # Secrets cannot be used in job-level if: expressions; the health-probe
+    # step below will exit 1 with a clear message if ELECTRIC_E2E_ADMIN_URL
+    # is absent, which skips the run without a confusing auth failure.
+    if: vars.ELECTRIC_E2E_ENABLED == 'true'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Probe Electric health before running E2E
+        run: |
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+            "${{ secrets.ELECTRIC_E2E_ADMIN_URL }}/api/health/electric" || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Electric health probe returned HTTP $STATUS — skipping E2E to avoid false failures"
+            exit 1
+          fi
+          echo "Electric health probe: HTTP $STATUS — proceeding"
+
+      - name: Run Electric E2E tests
+        run: pnpm test:e2e -- --project=chromium e2e/electric.e2e.ts
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: ${{ secrets.ELECTRIC_E2E_ADMIN_URL }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: electric-e2e-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/apps/admin/src/app/api/health/electric/__tests__/electric-health.test.ts
+++ b/apps/admin/src/app/api/health/electric/__tests__/electric-health.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+vi.mock('next/server', () => {
+  class MockNextResponse {
+    body: unknown;
+    status: number;
+    constructor(body: unknown, init?: { status?: number }) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+    static json(data: unknown, init?: { status?: number }) {
+      return new MockNextResponse(data, init);
+    }
+  }
+  return { NextResponse: MockNextResponse };
+});
+
+describe('GET /api/health/electric', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ELECTRIC_SERVICE_URL = 'http://electric.test';
+    delete process.env.ELECTRIC_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.ELECTRIC_SERVICE_URL;
+    delete process.env.ELECTRIC_URL;
+    delete process.env.ELECTRIC_SECRET;
+  });
+
+  async function loadRoute() {
+    const mod = await import('../route.js');
+    return mod.GET;
+  }
+
+  it('returns ok:true with latencyMs on 200 from Electric', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', version: '1.2.3' }),
+    });
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(200);
+    const body = (
+      res as unknown as { body: { ok: boolean; latencyMs: number; electricVersion: string } }
+    ).body;
+    expect(body.ok).toBe(true);
+    expect(typeof body.latencyMs).toBe('number');
+    expect(body.electricVersion).toBe('1.2.3');
+  });
+
+  it('returns ok:true without electricVersion when body has no version field', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok' }),
+    });
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(200);
+    const body = (res as unknown as { body: { ok: boolean; electricVersion?: string } }).body;
+    expect(body.ok).toBe(true);
+    expect(body.electricVersion).toBeUndefined();
+  });
+
+  it('returns ok:false with 503 when Electric responds non-200', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => ({}),
+    });
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(503);
+    const body = (res as unknown as { body: { ok: boolean; error: string; latencyMs: number } })
+      .body;
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('502');
+    expect(typeof body.latencyMs).toBe('number');
+  });
+
+  it('returns ok:false with 503 on AbortError (timeout)', async () => {
+    const abortError = Object.assign(
+      new DOMException('The operation was aborted.', 'TimeoutError'),
+    );
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(503);
+    const body = (res as unknown as { body: { ok: boolean; error: string } }).body;
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('timed out');
+  });
+
+  it('returns ok:false with 503 on network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(503);
+    const body = (res as unknown as { body: { ok: boolean; error: string } }).body;
+    expect(body.ok).toBe(false);
+  });
+
+  it('returns ok:false with 503 when ELECTRIC_SERVICE_URL is not set', async () => {
+    delete process.env.ELECTRIC_SERVICE_URL;
+    delete process.env.ELECTRIC_URL;
+
+    const GET = await loadRoute();
+    const res = await GET();
+
+    expect((res as { status: number }).status).toBe(503);
+    const body = (res as unknown as { body: { ok: boolean; error: string } }).body;
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('not configured');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends Authorization header when ELECTRIC_SECRET is set', async () => {
+    process.env.ELECTRIC_SECRET = 'super-secret';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    const GET = await loadRoute();
+    await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://electric.test/v1/health',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer super-secret' },
+      }),
+    );
+  });
+
+  it('omits Authorization header when ELECTRIC_SECRET is not set', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    const GET = await loadRoute();
+    await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://electric.test/v1/health',
+      expect.objectContaining({
+        headers: {},
+      }),
+    );
+  });
+});

--- a/apps/admin/src/app/api/health/electric/route.ts
+++ b/apps/admin/src/app/api/health/electric/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface ElectricHealthOk {
+  ok: true;
+  latencyMs: number;
+  electricVersion?: string;
+}
+
+interface ElectricHealthFail {
+  ok: false;
+  error: string;
+  latencyMs?: number;
+}
+
+function getElectricServiceUrl(): string {
+  const url = process.env.ELECTRIC_SERVICE_URL || process.env.ELECTRIC_URL;
+  if (!url) {
+    throw new Error('ELECTRIC_SERVICE_URL is not set');
+  }
+  return url;
+}
+
+export async function GET(): Promise<NextResponse<ElectricHealthOk | ElectricHealthFail>> {
+  const start = Date.now();
+
+  let electricUrl: string;
+  try {
+    electricUrl = getElectricServiceUrl();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Electric service URL not configured' },
+      { status: 503 },
+    );
+  }
+
+  const healthUrl = `${electricUrl}/v1/health`;
+
+  try {
+    const response = await fetch(healthUrl, {
+      signal: AbortSignal.timeout(5_000),
+      headers: process.env.ELECTRIC_SECRET
+        ? { Authorization: `Bearer ${process.env.ELECTRIC_SECRET}` }
+        : {},
+    });
+
+    const latencyMs = Date.now() - start;
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { ok: false, error: `Electric health check returned HTTP ${response.status}`, latencyMs },
+        { status: 503 },
+      );
+    }
+
+    let electricVersion: string | undefined;
+    try {
+      const body = (await response.json()) as Record<string, unknown>;
+      if (typeof body.version === 'string') {
+        electricVersion = body.version;
+      }
+    } catch {
+      // JSON parse failure is non-fatal — Electric responded 200, that's what matters
+    }
+
+    return NextResponse.json({ ok: true, latencyMs, electricVersion }, { status: 200 });
+  } catch (error) {
+    const latencyMs = Date.now() - start;
+    const isDomTimeout = error instanceof DOMException && error.name === 'TimeoutError';
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isDomTimeout || isAbort) {
+      return NextResponse.json(
+        { ok: false, error: 'Electric health check timed out (5s)', latencyMs },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: 'Electric health check failed', latencyMs },
+      { status: 503 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/health/electric` — a liveness probe for the ElectricSQL service with latency measurement
- Adds `.github/workflows/electric-e2e.yml` — wires the previously-dead `e2e/electric.e2e.ts` into CI with a path-filtered trigger

## What changed

### Probe endpoint — `apps/admin/src/app/api/health/electric/route.ts`

Calls Electric's own `/v1/health` endpoint with a 5-second timeout. Returns:
- `200 { ok: true, latencyMs: number, electricVersion?: string }` on success
- `503 { ok: false, error: string, latencyMs?: number }` on non-200, timeout, or network failure

Sends `Authorization: Bearer $ELECTRIC_SECRET` when the env var is set (matching the proxy's auth pattern). No secret values in response bodies. Extends the existing `/api/health/live` and `/api/health/ready` hierarchy — same package, same pattern.

Unit tests (`apps/admin/src/app/api/health/electric/__tests__/electric-health.test.ts`): 8 cases via `vi.fn()` mocked fetch covering the ok path, missing version field, non-200 upstream, DOMException timeout, network error, missing env var, and both Authorization header states.

### CI workflow — `.github/workflows/electric-e2e.yml`

Triggers on push/PR to `main` or `test` when any of these paths change:
- `apps/admin/src/app/api/shapes/**`
- `apps/admin/src/app/api/health/electric/**`
- `packages/sync/**`
- `e2e/electric.e2e.ts`

Probes the new health endpoint before running Playwright — if Electric is transiently down the job fails fast with a clear error rather than producing misleading Playwright failures.

Guarded by `vars.ELECTRIC_E2E_ENABLED == 'true'` and `secrets.ELECTRIC_E2E_ADMIN_URL` so forks and external PRs skip cleanly rather than failing on missing credentials.

**Not a required check** until it accumulates ~10 green runs.

## Why now

An audit found two gaps in the stability pillar: no visibility into Electric service health, and a test file (`e2e/electric.e2e.ts`) that existed but was unreferenced by any workflow. Both are now fixed durably.

## Verification

```bash
# Probe (requires live Electric on Railway)
curl -s https://admin.revealui.com/api/health/electric | jq .

# Unit tests
cd ~/revfleet/revealui/apps/admin
pnpm exec vitest run src/app/api/health/electric/__tests__/electric-health.test.ts
# → 8 passed
```

## Test plan

- [ ] Unit tests pass locally (8/8 verified above)
- [ ] `pnpm --filter admin typecheck` clean
- [ ] `pnpm exec biome check apps/admin/src/app/api/health/electric/` clean
- [ ] CI workflow appears in Actions tab on push
- [ ] Set `vars.ELECTRIC_E2E_ENABLED = true` and `secrets.ELECTRIC_E2E_ADMIN_URL = https://admin.revealui.com` in repo settings to enable the E2E job

## Follow-ups

- No uptime/alerting monitor wired yet — no existing monitoring config was found in the repo. Recommend adding an external uptime check (e.g., Railway health check or a cron workflow hitting `/api/health/electric`) once Electric has been stable for a few weeks.
- Add `ELECTRIC_E2E_ENABLED` and `ELECTRIC_E2E_ADMIN_URL` to repo vars/secrets to activate the workflow.
- Promote to required check after ~10 green runs.
