### PR TITLE
docs(fleet): update FLEET.md status banner to reflect current GHCR state

### DIFF
--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -7,7 +7,7 @@ audience: enterprise
 
 # RevealUI Fleet — Self-Hosted Deployment
 
-> **Preview status — Fleet Docker images are not yet published to GHCR.** The `docker/` stack, stamp scripts, source tree, and licensing flow are production-ready, but the images this guide references (`ghcr.io/revealuistudio/revealui-api`, `ghcr.io/revealuistudio/revealui-admin`) have not been published yet. The `docker pull` commands below will fail with `manifest unknown` until images publish. Until then, build from source at the [revealui repo](https://github.com/RevealUIStudio/revealui) or use the [RevForge kit's source tree](https://github.com/RevealUIStudio/revforge). License-key issuance and welcome emails go live when Stripe billing-readiness sign-off lands.
+> **Status (as of 2026-05-16): build + publish pipeline shipped, public access pending.** The `docker/` stack, stamp scripts, source tree, and licensing flow are production-ready. The images this guide references (`ghcr.io/revealuistudio/revealui-api`, `ghcr.io/revealuistudio/revealui-admin`) are built via [`.github/workflows/docker.yml`](../.github/workflows/docker.yml) and pushed to GHCR on every `workflow_dispatch` run. Image visibility is currently **PRIVATE** — anonymous `docker pull` will fail with `401 UNAUTHORIZED` until package visibility is flipped to public in [GitHub Packages settings](https://github.com/orgs/RevealUIStudio/packages). Self-hosters using a license-authenticated pull flow will work today; anonymous Fleet trial pulls require the visibility flip.
 
 Customers buy the Enterprise tier of RevealUI; the Fleet kit (produced by RevForge) is what they deploy. Instead of running on `revealui.com`, you deploy the entire stack on your own infrastructure with full domain lock and unlimited users.
 


### PR DESCRIPTION
## Summary

Updates the FLEET.md "Preview status" banner in `docs/FLEET.md` to reflect actual current state: build + publish pipeline shipped, images published to GHCR, awaiting owner visibility flip for anonymous pulls.

(`apps/docs/public/FLEET.md` carries the same content but is listed in `apps/docs/.gitignore` — not tracked by git.)

## Why

The "Preview status — Fleet Docker images are not yet published to GHCR" wording is no longer accurate — images ARE published (workflow `.github/workflows/docker.yml` ran successfully 2026-05-16T19:01:38Z). What's missing is the public-visibility flip in [GitHub Packages settings](https://github.com/orgs/RevealUIStudio/packages), without which `docker pull` returns 401 to anonymous users.

This PR softens the banner to be honest about the gap:
- "not yet published" → removed (they are published)
- "manifest unknown" error → corrected to "401 UNAUTHORIZED"
- Adds note that license-authenticated pulls work today
- Identifies the exact missing step (visibility flip in GitHub Packages UI)

Once visibility is flipped to public, the banner can be removed entirely in a one-line follow-up edit.

## What's NOT in this PR

- The visibility flip itself (owner-only — requires GitHub Packages UI access)
- Full banner removal (deferred until after visibility flip)
- Any code changes — docs only

## Files changed

- `docs/FLEET.md` — banner updated at line 10

## Test plan

- [ ] Review new banner wording for accuracy + tone
- [ ] Confirm no broken links (`.github/workflows/docker.yml` link points to the workflow file; GitHub Packages settings link is correct)
- [ ] After owner flips package visibility to public: remove banner entirely in a follow-up one-liner

## Note for reviewer

Draft PR — awaiting owner review of wording. Banner can be removed in a follow-up once the visibility flip is confirmed. No merge until owner approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
