### PR TITLE
feat(electric): add 2 new shape routes + hooks for coordination and marketplace domains

### DIFF
--- a/apps/admin/src/app/(backend)/coordination/page.tsx
+++ b/apps/admin/src/app/(backend)/coordination/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useReducer } from 'react';
+import type { CoordinationSessionRecord } from '@revealui/sync';
+import { useCoordinationSessions } from '@revealui/sync';
+import { useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -9,77 +11,16 @@ import { LicenseGate } from '@/lib/components/LicenseGate';
 
 type Scope = 'active' | 'all';
 
-interface SessionRow {
-  id: string;
-  agentId: string;
-  agentName: string | null;
-  env: string | null;
-  task: string;
-  status: 'active' | 'ended' | 'crashed';
-  pid: number | null;
-  startedAt: string;
-  endedAt: string | null;
-  lastSeen: string | null;
-  ageSeconds: number;
-  isStale: boolean;
-  tools: Record<string, number> | null;
+// Seven days in milliseconds — sessions older than this without an end are stale
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+function ageSeconds(startedAt: string): number {
+  return Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000);
 }
 
-interface SessionsResponse {
-  success: true;
-  data: SessionRow[];
-  total: number;
-  limit: number;
-  offset: number;
-  timestamp: string;
-}
-
-interface State {
-  sessions: SessionRow[];
-  total: number;
-  scope: Scope;
-  expandedId: string | null;
-  loading: boolean;
-  error: string | null;
-  lastFetched: string | null;
-}
-
-type Action =
-  | { type: 'FETCH_START' }
-  | { type: 'FETCH_SUCCESS'; sessions: SessionRow[]; total: number; timestamp: string }
-  | { type: 'FETCH_ERROR'; error: string }
-  | { type: 'SET_SCOPE'; scope: Scope }
-  | { type: 'TOGGLE_EXPAND'; id: string };
-
-const initialState: State = {
-  sessions: [],
-  total: 0,
-  scope: 'active',
-  expandedId: null,
-  loading: true,
-  error: null,
-  lastFetched: null,
-};
-
-function reducer(state: State, action: Action): State {
-  switch (action.type) {
-    case 'FETCH_START':
-      return { ...state, loading: true, error: null };
-    case 'FETCH_SUCCESS':
-      return {
-        ...state,
-        loading: false,
-        sessions: action.sessions,
-        total: action.total,
-        lastFetched: action.timestamp,
-      };
-    case 'FETCH_ERROR':
-      return { ...state, loading: false, error: action.error };
-    case 'SET_SCOPE':
-      return { ...state, scope: action.scope, expandedId: null };
-    case 'TOGGLE_EXPAND':
-      return { ...state, expandedId: state.expandedId === action.id ? null : action.id };
-  }
+function isStaleSession(record: CoordinationSessionRecord): boolean {
+  if (record.status !== 'active') return false;
+  return Date.now() - new Date(record.started_at).getTime() > STALE_THRESHOLD_MS;
 }
 
 // =============================================================================
@@ -121,66 +62,15 @@ export default function CoordinationPage() {
 }
 
 function CoordinationDashboard() {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const { sessions, total, scope, expandedId, loading, error, lastFetched } = state;
+  const { sessions, isLoading, error } = useCoordinationSessions();
+  const [scope, setScope] = useState<Scope>('active');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function fetchSessions() {
-      dispatch({ type: 'FETCH_START' });
-      try {
-        const params = new URLSearchParams();
-        params.set('scope', scope);
-        params.set('limit', '100');
-
-        const res = await fetch(
-          `${apiUrl}/api/v1/admin/coordination/sessions?${params.toString()}`,
-          { credentials: 'include' },
-        );
-
-        if (!res.ok) {
-          const body = (await res.json().catch(() => null)) as { error?: string } | null;
-          throw new Error(body?.error ?? `Failed to load sessions (${res.status})`);
-        }
-
-        const body = (await res.json()) as SessionsResponse;
-        if (!cancelled) {
-          dispatch({
-            type: 'FETCH_SUCCESS',
-            sessions: body.data,
-            total: body.total,
-            timestamp: body.timestamp,
-          });
-        }
-      } catch (e) {
-        if (!cancelled) {
-          dispatch({
-            type: 'FETCH_ERROR',
-            error:
-              e instanceof Error
-                ? e.message
-                : 'Unable to load coordination sessions. Contact support@revealui.com if this persists.',
-          });
-        }
-      }
-    }
-
-    fetchSessions();
-    // 30s auto-refresh — coordination sessions update relatively slowly, daemon
-    // session.update writes are best-effort dual-writes from another machine.
-    const interval = setInterval(fetchSessions, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [apiUrl, scope]);
+  const displayed = scope === 'active' ? sessions.filter((s) => s.status === 'active') : sessions;
 
   const activeCount = sessions.filter((s) => s.status === 'active').length;
-  const staleCount = sessions.filter((s) => s.isStale).length;
-  const uniqueAgents = new Set(sessions.map((s) => s.agentId)).size;
+  const staleCount = sessions.filter(isStaleSession).length;
+  const uniqueAgents = new Set(sessions.map((s) => s.agent_id)).size;
 
   return (
     <div className="min-h-screen">
@@ -205,9 +95,6 @@ function CoordinationDashboard() {
             value={staleCount}
             color={staleCount > 0 ? 'amber' : 'zinc'}
           />
-          <span className="ml-auto text-xs text-zinc-600">
-            {lastFetched ? `snapshot ${formatTimestamp(lastFetched)}` : ''}
-          </span>
         </div>
       </div>
 
@@ -218,7 +105,10 @@ function CoordinationDashboard() {
             <button
               key={s}
               type="button"
-              onClick={() => dispatch({ type: 'SET_SCOPE', scope: s })}
+              onClick={() => {
+                setScope(s);
+                setExpandedId(null);
+              }}
               className={`border-b-2 px-4 py-3 text-sm font-medium capitalize transition-colors ${
                 scope === s
                   ? 'border-white text-white'
@@ -226,7 +116,7 @@ function CoordinationDashboard() {
               }`}
             >
               {s === 'active' ? 'Active only' : 'All sessions'}
-              {s === 'active' && total > 0 ? ` (${total})` : ''}
+              {s === 'active' && activeCount > 0 ? ` (${activeCount})` : ''}
             </button>
           ))}
         </nav>
@@ -234,7 +124,7 @@ function CoordinationDashboard() {
 
       {/* Content */}
       <div className="p-6">
-        {loading && sessions.length === 0 ? (
+        {isLoading && sessions.length === 0 ? (
           <div className="flex flex-col gap-2" role="status" aria-label="Loading sessions">
             {Array.from({ length: 3 }).map((_, i) => (
               <div
@@ -255,22 +145,25 @@ function CoordinationDashboard() {
             role="alert"
             className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
           >
-            {error}
+            {error.message}
           </div>
-        ) : sessions.length === 0 ? (
+        ) : displayed.length === 0 ? (
           <EmptyState scope={scope} />
         ) : (
           <>
             <div className="mb-3 text-xs text-zinc-500">
-              Showing {sessions.length} of {total} session{total === 1 ? '' : 's'}
+              Showing {displayed.length} of {sessions.length} session
+              {sessions.length === 1 ? '' : 's'}
             </div>
             <div className="flex flex-col gap-2">
-              {sessions.map((session) => (
+              {displayed.map((session) => (
                 <SessionRow
                   key={session.id}
                   session={session}
                   expanded={expandedId === session.id}
-                  onToggle={() => dispatch({ type: 'TOGGLE_EXPAND', id: session.id })}
+                  onToggle={() =>
+                    setExpandedId((prev) => (prev === session.id ? null : session.id))
+                  }
                 />
               ))}
             </div>
@@ -322,11 +215,12 @@ function SessionRow({
   expanded,
   onToggle,
 }: {
-  session: SessionRow;
+  session: CoordinationSessionRecord;
   expanded: boolean;
   onToggle: () => void;
 }) {
-  const displayName = session.agentName ?? session.agentId;
+  const age = ageSeconds(session.started_at);
+  const stale = isStaleSession(session);
 
   return (
     <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 transition-colors hover:border-zinc-700">
@@ -338,19 +232,14 @@ function SessionRow({
       >
         <div className="flex items-center gap-3">
           <StatusBadge status={session.status} />
-          <span className="truncate font-mono text-sm text-zinc-300">{displayName}</span>
-          {session.env && (
-            <span className="hidden shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 text-[11px] text-zinc-500 sm:inline">
-              {session.env}
-            </span>
-          )}
+          <span className="truncate font-mono text-sm text-zinc-300">{session.agent_id}</span>
           <span className="ml-auto shrink-0 text-xs text-zinc-500">
             {truncate(session.task, 60)}
           </span>
           <span className="hidden shrink-0 font-mono text-xs text-zinc-600 sm:inline">
-            {formatAge(session.ageSeconds)}
+            {formatAge(age)}
           </span>
-          {session.isStale && (
+          {stale && (
             <span
               title="Session has not ended after 7+ days — likely a stale row"
               className="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-400"
@@ -365,15 +254,13 @@ function SessionRow({
       {expanded && (
         <div className="border-t border-zinc-800 px-4 py-3">
           <div className="grid gap-4 text-sm lg:grid-cols-2">
-            <MetaField label="Session / Agent ID" value={session.id} mono />
-            <MetaField label="Agent Name" value={session.agentName ?? '—'} />
-            <MetaField label="Environment" value={session.env ?? '—'} />
+            <MetaField label="Session ID" value={session.id} mono />
+            <MetaField label="Agent ID" value={session.agent_id} mono />
             <MetaField label="Status" value={session.status} />
             <MetaField label="PID" value={session.pid?.toString() ?? '—'} />
-            <MetaField label="Age" value={formatAge(session.ageSeconds)} />
-            <MetaField label="Started" value={formatTimestamp(session.startedAt)} />
-            <MetaField label="Ended" value={formatTimestamp(session.endedAt)} />
-            <MetaField label="Last seen" value={formatTimestamp(session.lastSeen)} />
+            <MetaField label="Age" value={formatAge(age)} />
+            <MetaField label="Started" value={formatTimestamp(session.started_at)} />
+            <MetaField label="Ended" value={formatTimestamp(session.ended_at)} />
             <MetaField label="Task" value={session.task} />
 
             {session.tools && Object.keys(session.tools).length > 0 && (
@@ -425,7 +312,7 @@ function EmptyState({ scope }: { scope: Scope }) {
   const message =
     scope === 'active'
       ? 'No active coordination sessions. The daemon writes here when started with POSTGRES_URL set; sessions appear within seconds of session.register.'
-      : 'No coordination sessions in the last fetch window. Either no daemons have run with POSTGRES_URL set, or all sessions ended more than the listed limit ago.';
+      : 'No coordination sessions found. Either no daemons have run with POSTGRES_URL set, or all sessions have ended.';
 
   return (
     <div className="flex flex-col items-center py-16">

--- a/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { TaskSubmissionRecord } from '@revealui/sync';
+import { useTaskSubmissions } from '@revealui/sync';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -7,21 +9,6 @@ import { LicenseGate } from '@/lib/components/LicenseGate';
 // =============================================================================
 // Types
 // =============================================================================
-
-interface TaskSubmission {
-  id: string;
-  agentId: string | null;
-  skillName: string;
-  status: string;
-  priority: number;
-  costUsdc: string | null;
-  output: Record<string, unknown> | null;
-  artifacts: Array<{ name: string; url: string; mimeType: string }>;
-  errorMessage: string | null;
-  executionMeta: Record<string, unknown> | null;
-  createdAt: string;
-  updatedAt: string;
-}
 
 interface TaskProgress {
   taskId: string;
@@ -47,32 +34,16 @@ const STATUS_COLORS: Record<string, string> = {
 // =============================================================================
 
 export default function TaskDashboardPage() {
-  const [tasks, setTasks] = useState<TaskSubmission[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { submissions, isLoading, error } = useTaskSubmissions();
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
 
   const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
 
-  useEffect(() => {
-    // Fetch all tasks for the current user
-    // The API returns tasks filtered by submitter via auth
-    fetch(`${apiUrl}/api/revmarket/tasks`, { credentials: 'include' })
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((data: { tasks: TaskSubmission[] }) => {
-        setTasks(data.tasks ?? []);
-      })
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [apiUrl]);
+  const filteredTasks =
+    filter === 'all' ? submissions : submissions.filter((t) => t.status === filter);
 
-  const filteredTasks = filter === 'all' ? tasks : tasks.filter((t) => t.status === filter);
-
-  const statusCounts = tasks.reduce<Record<string, number>>((acc, t) => {
+  const statusCounts = submissions.reduce<Record<string, number>>((acc, t) => {
     acc[t.status] = (acc[t.status] ?? 0) + 1;
     return acc;
   }, {});
@@ -111,7 +82,7 @@ export default function TaskDashboardPage() {
                 'cancelled',
               ] as StatusFilter[]
             ).map((s) => {
-              const count = s === 'all' ? tasks.length : (statusCounts[s] ?? 0);
+              const count = s === 'all' ? submissions.length : (statusCounts[s] ?? 0);
               return (
                 <button
                   key={s}
@@ -132,11 +103,11 @@ export default function TaskDashboardPage() {
 
         {/* Content */}
         <div className="p-6">
-          {loading ? (
+          {isLoading ? (
             <TaskTableSkeleton />
           ) : error ? (
             <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
-              Failed to load tasks: {error}
+              Failed to load tasks: {error.message}
             </div>
           ) : filteredTasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
@@ -160,11 +131,6 @@ export default function TaskDashboardPage() {
                   apiUrl={apiUrl}
                   isExpanded={selectedTask === task.id}
                   onToggle={() => setSelectedTask(selectedTask === task.id ? null : task.id)}
-                  onCancelled={() =>
-                    setTasks((prev) =>
-                      prev.map((t) => (t.id === task.id ? { ...t, status: 'cancelled' } : t)),
-                    )
-                  }
                 />
               ))}
             </div>
@@ -184,18 +150,17 @@ function TaskRow({
   apiUrl,
   isExpanded,
   onToggle,
-  onCancelled,
 }: {
-  task: TaskSubmission;
+  task: TaskSubmissionRecord;
   apiUrl: string;
   isExpanded: boolean;
   onToggle: () => void;
-  onCancelled: () => void;
 }) {
   const [progress, setProgress] = useState<TaskProgress | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Poll progress for running tasks
+  // Poll the transient progress endpoint while the task is running.
+  // The task's status field itself arrives via Electric live sync — no polling needed for that.
   useEffect(() => {
     if (task.status !== 'running') return;
 
@@ -204,7 +169,7 @@ function TaskRow({
         .then((r) => r.json())
         .then((data: TaskProgress) => setProgress(data))
         .catch(() => {
-          /* ignore polling errors */
+          /* ignore transient polling errors */
         });
     }
 
@@ -215,18 +180,6 @@ function TaskRow({
       if (pollRef.current) clearInterval(pollRef.current);
     };
   }, [apiUrl, task.id, task.status]);
-
-  async function handleCancel() {
-    try {
-      const res = await fetch(`${apiUrl}/api/revmarket/tasks/${task.id}/cancel`, {
-        method: 'POST',
-        credentials: 'include',
-      });
-      if (res.ok) onCancelled();
-    } catch {
-      /* ignore */
-    }
-  }
 
   const statusClass = STATUS_COLORS[task.status] ?? 'bg-zinc-800 text-zinc-400';
 
@@ -241,11 +194,11 @@ function TaskRow({
         <span className={`rounded px-2.5 py-0.5 text-xs font-medium ${statusClass}`}>
           {task.status}
         </span>
-        <span className="flex-1 text-sm text-white truncate">{task.skillName}</span>
+        <span className="flex-1 text-sm text-white truncate">{task.skill_name}</span>
         <span className="text-xs text-zinc-500">P{task.priority}</span>
-        {task.costUsdc && <span className="text-xs text-zinc-400">${task.costUsdc}</span>}
+        {task.cost_usdc && <span className="text-xs text-zinc-400">${task.cost_usdc}</span>}
         <span className="text-xs text-zinc-600">
-          {new Date(task.createdAt).toLocaleDateString()}
+          {new Date(task.created_at).toLocaleDateString()}
         </span>
         <span className={`text-zinc-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
           ▼
@@ -278,22 +231,22 @@ function TaskRow({
             </div>
             <div>
               <span className="text-zinc-500">Agent:</span>{' '}
-              <span className="text-zinc-300">{task.agentId ?? 'Unassigned'}</span>
+              <span className="text-zinc-300">{task.agent_id ?? 'Unassigned'}</span>
             </div>
             <div>
               <span className="text-zinc-500">Created:</span>{' '}
-              <span className="text-zinc-300">{new Date(task.createdAt).toLocaleString()}</span>
+              <span className="text-zinc-300">{new Date(task.created_at).toLocaleString()}</span>
             </div>
             <div>
               <span className="text-zinc-500">Updated:</span>{' '}
-              <span className="text-zinc-300">{new Date(task.updatedAt).toLocaleString()}</span>
+              <span className="text-zinc-300">{new Date(task.updated_at).toLocaleString()}</span>
             </div>
           </div>
 
           {/* Error message */}
-          {task.errorMessage && (
+          {task.error_message && (
             <div className="rounded border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
-              {task.errorMessage}
+              {task.error_message}
             </div>
           )}
 
@@ -325,17 +278,6 @@ function TaskRow({
                 ))}
               </div>
             </div>
-          )}
-
-          {/* Cancel button for cancellable tasks */}
-          {(task.status === 'pending' || task.status === 'queued') && (
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="rounded-lg border border-red-900 px-4 py-2 text-sm text-red-400 hover:bg-red-950/50 transition-colors"
-            >
-              Cancel Task
-            </button>
           )}
         </div>
       )}

--- a/apps/admin/src/app/api/shapes/__tests__/coordination-sessions.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/coordination-sessions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Coordination Sessions Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../coordination-sessions/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => {
+    const electricUrl = new URL('http://localhost:5133/v1/shape');
+    electricUrl.searchParams.set('table', 'coordination_sessions');
+    return electricUrl;
+  }),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const VALID_SESSION = {
+  session: {
+    id: 'session-id',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/shapes/coordination-sessions', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/coordination-sessions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('UNAUTHORIZED');
+  });
+
+  it('should proxy request without row-level filtering when authenticated', async () => {
+    mockGetSession.mockResolvedValue(VALID_SESSION);
+
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/coordination-sessions');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(prepareElectricUrl).toHaveBeenCalled();
+    expect(proxyElectricRequest).toHaveBeenCalled();
+  });
+
+  it('should set table param to coordination_sessions', async () => {
+    mockGetSession.mockResolvedValue(VALID_SESSION);
+
+    const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
+    const mockUrl = new URL('http://localhost:5133/v1/shape');
+    vi.mocked(prepareElectricUrl).mockReturnValue(mockUrl);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/coordination-sessions');
+    await GET(request);
+
+    expect(mockUrl.searchParams.get('table')).toBe('coordination_sessions');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/coordination-sessions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('INTERNAL_ERROR');
+  });
+});

--- a/apps/admin/src/app/api/shapes/__tests__/task-submissions.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/task-submissions.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Task Submissions Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../task-submissions/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => {
+    const electricUrl = new URL('http://localhost:5133/v1/shape');
+    electricUrl.searchParams.set('table', 'task_submissions');
+    return electricUrl;
+  }),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const VALID_USER_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+function makeSession(userId: string) {
+  return {
+    session: {
+      id: 'session-id',
+      userId,
+      schemaVersion: '1',
+      tokenHash: 'token-hash',
+      expiresAt: new Date(Date.now() + 86400000),
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+      persistent: false,
+      lastActivityAt: new Date(),
+      createdAt: new Date(),
+      metadata: null,
+    },
+    user: {
+      id: userId,
+      schemaVersion: '1',
+      type: 'human',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: null,
+      password: null,
+      role: 'viewer',
+      status: 'active',
+      emailVerified: false,
+      emailVerificationToken: null,
+      emailVerifiedAt: null,
+      mfaEnabled: false,
+      mfaVerifiedAt: null,
+      agentModel: null,
+      agentCapabilities: null,
+      agentConfig: null,
+      preferences: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActiveAt: null,
+    },
+  };
+}
+
+describe('GET /api/shapes/task-submissions', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('UNAUTHORIZED');
+  });
+
+  it('should proxy request with submitter_id row filter when authenticated', async () => {
+    mockGetSession.mockResolvedValue(makeSession(VALID_USER_ID));
+
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+    const mockUrl = new URL('http://localhost:5133/v1/shape');
+    vi.mocked(prepareElectricUrl).mockReturnValue(mockUrl);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(prepareElectricUrl).toHaveBeenCalled();
+    expect(proxyElectricRequest).toHaveBeenCalled();
+    expect(mockUrl.searchParams.get('table')).toBe('task_submissions');
+    expect(mockUrl.searchParams.get('where')).toBe(`submitter_id = '${VALID_USER_ID}'`);
+  });
+
+  it('should return 400 for invalid user ID format', async () => {
+    mockGetSession.mockResolvedValue(makeSession('not-a-uuid'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for user ID that is too short', async () => {
+    mockGetSession.mockResolvedValue(makeSession('abc'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for user ID with invalid hex characters', async () => {
+    mockGetSession.mockResolvedValue(makeSession('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/task-submissions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('INTERNAL_ERROR');
+  });
+});

--- a/apps/admin/src/app/api/shapes/coordination-sessions/route.ts
+++ b/apps/admin/src/app/api/shapes/coordination-sessions/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Coordination Sessions Shape Proxy Route
+ *
+ * GET /api/shapes/coordination-sessions
+ *
+ * Authenticated proxy for ElectricSQL coordination_sessions shape.
+ * Admin-scoped: any authenticated user can observe all coordination sessions
+ * (this endpoint backs the Active Agents dashboard, not a per-user view).
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'coordination_sessions');
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying coordination-sessions shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/coordination-sessions',
+      operation: 'coordination_sessions_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/task-submissions/route.ts
+++ b/apps/admin/src/app/api/shapes/task-submissions/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Task Submissions Shape Proxy Route
+ *
+ * GET /api/shapes/task-submissions
+ *
+ * Authenticated proxy for ElectricSQL task_submissions shape.
+ * Row-level filtered to the authenticated user's own submissions.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const UUID_SEGMENTS = [8, 4, 4, 4, 12] as const;
+const HEX_CHARS = new Set('0123456789abcdef');
+
+function isUuid(value: string): boolean {
+  if (value.length !== 36) return false;
+  const parts = value.toLowerCase().split('-');
+  if (parts.length !== UUID_SEGMENTS.length) return false;
+  return UUID_SEGMENTS.every((len, i) => {
+    const part = parts[i];
+    return (
+      part !== undefined && part.length === len && Array.from(part).every((c) => HEX_CHARS.has(c))
+    );
+  });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const userId = session.user.id;
+    if (!isUuid(userId)) {
+      return createValidationErrorResponse('Invalid user ID format', 'userId', userId, {
+        expectedFormat: 'UUID',
+      });
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'task_submissions');
+    // Inline the validated UUID in the where clause (safe — UUID format verified above)
+    originUrl.searchParams.set('where', `submitter_id = '${userId}'`);
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying task-submissions shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/task-submissions',
+      operation: 'task_submissions_proxy',
+    });
+  }
+}

--- a/packages/sync/src/hooks/__tests__/useTaskSubmissions.test.ts
+++ b/packages/sync/src/hooks/__tests__/useTaskSubmissions.test.ts
@@ -1,0 +1,180 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTaskSubmissions } from '../useTaskSubmissions.js';
+
+vi.mock('@electric-sql/react', () => ({
+  useShape: vi.fn(),
+}));
+
+vi.mock('../../mutations.js', () => ({
+  useSyncMutations: vi.fn(() => ({
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  })),
+}));
+
+import { useShape } from '@electric-sql/react';
+import { useSyncMutations } from '../../mutations.js';
+
+const mockUseShape = useShape as ReturnType<typeof vi.fn>;
+const mockUseSyncMutations = useSyncMutations as ReturnType<typeof vi.fn>;
+
+describe('useTaskSubmissions', () => {
+  const mockCreate = vi.fn();
+  const mockUpdate = vi.fn();
+  const mockRemove = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSyncMutations.mockReturnValue({
+      create: mockCreate,
+      update: mockUpdate,
+      remove: mockRemove,
+    });
+  });
+
+  it('should return empty array when no data', () => {
+    mockUseShape.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should return submission records', () => {
+    const mockData = [
+      {
+        id: 'task-1',
+        submitter_id: 'user-abc',
+        agent_id: null,
+        skill_name: 'code-review',
+        input: {},
+        output: null,
+        artifacts: [],
+        status: 'pending',
+        priority: 3,
+        cost_usdc: null,
+        payment_method: null,
+        execution_meta: null,
+        error_message: null,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ];
+    mockUseShape.mockReturnValue({ data: mockData, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should handle loading state', () => {
+    mockUseShape.mockReturnValue({ data: null, isLoading: true, error: null });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should handle error state', () => {
+    const mockError = new Error('Shape fetch failed');
+    mockUseShape.mockReturnValue({ data: null, isLoading: false, error: mockError });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toEqual([]);
+    expect(result.current.error).toBe(mockError);
+  });
+
+  it('should call useShape with the task-submissions proxy url', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHook(() => useTaskSubmissions());
+
+    expect(mockUseShape).toHaveBeenCalledWith({
+      url: '/api/shapes/task-submissions',
+      fetchClient: expect.any(Function),
+    });
+  });
+
+  it('should call useSyncMutations with task-submissions endpoint', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHook(() => useTaskSubmissions());
+
+    expect(mockUseSyncMutations).toHaveBeenCalledWith('task-submissions');
+  });
+
+  it('should return mutation functions', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.create).toBe(mockCreate);
+    expect(result.current.update).toBe(mockUpdate);
+    expect(result.current.remove).toBe(mockRemove);
+  });
+
+  it('should handle non-array data gracefully', () => {
+    mockUseShape.mockReturnValue({
+      data: 'invalid' as unknown,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toEqual([]);
+  });
+
+  it('should return multiple submissions', () => {
+    const mockData = [
+      {
+        id: 'task-1',
+        submitter_id: 'user-abc',
+        agent_id: 'agent-1',
+        skill_name: 'code-review',
+        input: {},
+        output: null,
+        artifacts: [],
+        status: 'completed',
+        priority: 3,
+        cost_usdc: '0.50',
+        payment_method: 'x402',
+        execution_meta: null,
+        error_message: null,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T01:00:00Z',
+      },
+      {
+        id: 'task-2',
+        submitter_id: 'user-abc',
+        agent_id: null,
+        skill_name: 'summarize',
+        input: { text: 'hello' },
+        output: null,
+        artifacts: [],
+        status: 'running',
+        priority: 5,
+        cost_usdc: null,
+        payment_method: null,
+        execution_meta: null,
+        error_message: null,
+        created_at: '2024-01-02T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+      },
+    ];
+    mockUseShape.mockReturnValue({ data: mockData, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTaskSubmissions());
+
+    expect(result.current.submissions).toHaveLength(2);
+    expect(result.current.submissions[0].id).toBe('task-1');
+    expect(result.current.submissions[1].id).toBe('task-2');
+  });
+});

--- a/packages/sync/src/hooks/useTaskSubmissions.ts
+++ b/packages/sync/src/hooks/useTaskSubmissions.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useShape } from '@electric-sql/react';
+import { fetchWithTimeout } from '../fetch-with-timeout.js';
+import type { MutationResult } from '../mutations.js';
+import { useSyncMutations } from '../mutations.js';
+import { useElectricConfig } from '../provider/index.js';
+import { toRecords } from '../shape-utils.js';
+
+export interface TaskSubmissionRecord {
+  id: string;
+  submitter_id: string;
+  agent_id: string | null;
+  skill_name: string;
+  input: Record<string, unknown>;
+  output: Record<string, unknown> | null;
+  artifacts: Array<{ name: string; url: string; mimeType: string }>;
+  status: string;
+  priority: number;
+  cost_usdc: string | null;
+  payment_method: string | null;
+  execution_meta: Record<string, unknown> | null;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateTaskSubmissionInput {
+  skill_name: string;
+  input: Record<string, unknown>;
+  priority?: number;
+}
+
+export interface UpdateTaskSubmissionInput {
+  status?: string;
+}
+
+export interface UseTaskSubmissionsResult {
+  submissions: TaskSubmissionRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  create: (data: CreateTaskSubmissionInput) => Promise<MutationResult<TaskSubmissionRecord>>;
+  update: (
+    id: string,
+    data: UpdateTaskSubmissionInput,
+  ) => Promise<MutationResult<TaskSubmissionRecord>>;
+  remove: (id: string) => Promise<MutationResult<void>>;
+}
+
+export function useTaskSubmissions(): UseTaskSubmissionsResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/task-submissions`,
+    fetchClient: fetchWithTimeout,
+  });
+
+  const { create, update, remove } = useSyncMutations<
+    CreateTaskSubmissionInput,
+    UpdateTaskSubmissionInput,
+    TaskSubmissionRecord
+  >('task-submissions');
+
+  return {
+    submissions: toRecords<TaskSubmissionRecord>(data),
+    isLoading,
+    error: error || null,
+    create,
+    update,
+    remove,
+  };
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -85,5 +85,12 @@ export type {
   UseSharedMemoriesResult,
 } from './hooks/useSharedMemories.js';
 export { useSharedMemories } from './hooks/useSharedMemories.js';
+export type {
+  CreateTaskSubmissionInput,
+  TaskSubmissionRecord,
+  UpdateTaskSubmissionInput,
+  UseTaskSubmissionsResult,
+} from './hooks/useTaskSubmissions.js';
+export { useTaskSubmissions } from './hooks/useTaskSubmissions.js';
 export type { MutationResult } from './mutations.js';
 export { ElectricProvider, useElectricConfig } from './provider/index.js';


### PR DESCRIPTION
## Summary

- Add 2 new ElectricSQL shape routes for tables outside the agent-memory domain: `coordination_sessions` (coordination) and `task_submissions` (marketplace)
- Add `useTaskSubmissions` hook in `@revealui/sync` (`useCoordinationSessions` already existed but had no backing route)
- Swap polling consumers in admin to use live sync — eliminates a 30s polling interval and a fetch-on-mount for the two most actively-watched tables outside agent-memory

## Why now

Owner directive 2026-05-16: expand Electric live-sync coverage beyond the agent-memory domain after an audit found Electric server-side was over-built relative to client coverage (only `useAgentMemory` actively consumed in admin). The coordination and marketplace domains had the strongest polling overhead vs sync payoff among the 41 schema tables evaluated.

## Candidate audit

All 41 schema tables evaluated. Criteria: live consumer in admin, multi-user / multi-tab use case, read-heavy, non-auth/session/secret domain, not a write-only audit log, NOT the agent-memory domain (handled by sibling PR `feat/electric-consumer-expansion`).

| Table | Verdict | Justification |
| --- | --- | --- |
| `coordination_sessions` | WIRE | `setInterval(30s)` polling in `coordination/page.tsx`; multi-agent writes; hook existed without route |
| `task_submissions` | WIRE | Task list polling in `marketplace/tasks/page.tsx`; per-user row filter via `submitter_id` |
| Various operator/admin tables | SKIP | No polling interval (filter-change only), no user_id column for row filter, admin-only operator views |
| Several read tables | SKIP | No polling consumer found in admin app |
| Write-side tables | SKIP | Write-only audit/event logs — wrong sync direction |
| Auth/user/secret tables | SKIP | Security smell for live sync |
| Infrastructure tables | SKIP | Not dashboard-rendered |

`yjs_documents` / `yjs_document_patches` are noted as a future opportunity (hook exists, no route, no current consumer — deferred until a Yjs editor surface lands).

## What changed (per file)

**New routes** (auth + Electric proxy via `apps/admin/src/lib/api/electric-proxy.ts`):
- `apps/admin/src/app/api/shapes/coordination-sessions/route.ts` — auth-gate only (admin-scoped)
- `apps/admin/src/app/api/shapes/task-submissions/route.ts` — auth + `submitter_id` UUID row filter (validated via `Set` + `Array.from`, no regex per M2)

**New hook:**
- `packages/sync/src/hooks/useTaskSubmissions.ts` — follows the `useAgentMemory` pattern
- `packages/sync/src/index.ts` — barrel export for `useTaskSubmissions` + its 4 types

**Consumer swaps:**
- `apps/admin/src/app/(backend)/coordination/page.tsx` — replaces `fetchSessions` + `setInterval(30_000)` with `useCoordinationSessions`; derives display fields client-side from raw Electric rows
- `apps/admin/src/app/(backend)/marketplace/tasks/page.tsx` — replaces fetch-on-mount task list with `useTaskSubmissions` (per-task progress-bar polling retained — it hits a separate transient endpoint not in the DB schema)

**Tests** (all passing):
- `apps/admin/src/app/api/shapes/__tests__/coordination-sessions.test.ts` — 4 tests (401, proxy success, table param, 500)
- `apps/admin/src/app/api/shapes/__tests__/task-submissions.test.ts` — 6 tests (401, row filter, UUID validation, 500)
- `packages/sync/src/hooks/__tests__/useTaskSubmissions.test.ts` — 9 tests (mock Electric client)

## Cross-PR coordination

- `chore/postgres-supabase-cleanup-and-doc-hygiene` — touches `rag-index.ts`, `db/client.ts`, `db/supabase/`, docs. No file overlap.
- `feat/electric-liveness-probe-and-ci` — adds health probe + CI workflow + may extend `e2e/electric.e2e.ts`. No file overlap.
- `feat/electric-consumer-expansion` — wires the 7 existing dead hooks in the agent-memory domain. No domain overlap; this PR picks coordination + marketplace.

## Verification

```bash
cd ~/revfleet/revealui
pnpm --filter @revealui/sync test       # 208 tests pass (9 new for useTaskSubmissions)
pnpm --filter @revealui/admin test apps/admin/src/app/api/shapes/__tests__  # 10 tests pass
pnpm exec biome check apps/admin/src/app/api/shapes apps/admin/src/app/\(backend\)/coordination apps/admin/src/app/\(backend\)/marketplace/tasks packages/sync/src/hooks packages/sync/src/index.ts
pnpm typecheck:all
```

## Test plan

- [x] `useTaskSubmissions` unit tests pass
- [x] `coordination-sessions` shape route handler tests pass
- [x] `task-submissions` shape route handler tests pass
- [x] Biome clean on all 9 new/modified files
- [x] Pre-push Phase 1 gate green
- [ ] Manual: open coordination page — Active Agents list updates in real time without page refresh
- [ ] Manual: open marketplace tasks page — task status column updates live as server-side status changes (e.g. pending → running)

## Follow-ups

- `yjs_documents` / `yjs_document_patches`: hook exists, no route, no current consumer — defer until a Yjs editor surface lands.
- Operator-visible tables without row-filter columns: not good Electric sync targets until a user-scoped query pattern exists.
