### PR TITLE
fix(audit): require non-empty HMAC secret for audit log signing

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -127,6 +127,16 @@ WS_BASE_URL=ws://localhost:3004
 # REVEALUI_CRON_SECRET=your-cron-secret-min-32-chars
 
 # -----------------------------------------------------------------------------
+# Audit log HMAC signing (optional override)
+# -----------------------------------------------------------------------------
+# Used by apps/server/src/lib/postgres-audit-storage.ts to chain-sign audit
+# entries with HMAC-SHA256. When unset, falls back to REVEALUI_SECRET (which is
+# required at 32+ chars by the @revealui/config schema). With both unset, the
+# audit-storage layer refuses to write (defense-in-depth fail-loud, no silent
+# hash-chain degradation).
+# REVEALUI_AUDIT_HMAC_SECRET=your-audit-hmac-secret-min-32-chars
+
+# -----------------------------------------------------------------------------
 # Logging
 # -----------------------------------------------------------------------------
 LOG_LEVEL=debug

--- a/apps/server/src/lib/postgres-audit-storage.ts
+++ b/apps/server/src/lib/postgres-audit-storage.ts
@@ -26,7 +26,18 @@ import { and, count, desc, eq, gte, lte, sql } from 'drizzle-orm';
 let lastSignature: string | null = null;
 
 function getAuditSecret(): string {
-  return process.env.REVEALUI_AUDIT_HMAC_SECRET ?? process.env.REVEALUI_SECRET ?? '';
+  const secret = process.env.REVEALUI_AUDIT_HMAC_SECRET ?? process.env.REVEALUI_SECRET;
+  if (!secret) {
+    throw new Error(
+      'Audit HMAC signing requires REVEALUI_AUDIT_HMAC_SECRET (or REVEALUI_SECRET fallback) ' +
+        'to be set. Audit log integrity is non-optional; missing key fails loud rather than ' +
+        'silently degrading the hash chain. The @revealui/config schema validates REVEALUI_SECRET ' +
+        'at 32+ chars in any environment that boots, so this throw is a defense-in-depth signal ' +
+        'for impossible states (env tampering mid-run, sub-process spawning without env). ' +
+        'See docs/SECRETS.md and packages/config/src/modules/reveal.ts (auditHmacSecret field).',
+    );
+  }
+  return secret;
 }
 
 /**

--- a/packages/config/src/__tests__/modules.test.ts
+++ b/packages/config/src/__tests__/modules.test.ts
@@ -174,6 +174,23 @@ describe('config modules', () => {
       );
       expect(config.whitelistOrigins).toEqual(['https://old.com', 'https://legacy.com']);
     });
+
+    it('falls back to REVEALUI_SECRET for auditHmacSecret when override not set', () => {
+      const config = getRevealConfig(
+        makeEnv({ REVEALUI_SECRET: 'fallback-secret-that-is-at-least-32chars!' }),
+      );
+      expect(config.auditHmacSecret).toBe('fallback-secret-that-is-at-least-32chars!');
+    });
+
+    it('uses REVEALUI_AUDIT_HMAC_SECRET when set, ignoring REVEALUI_SECRET', () => {
+      const config = getRevealConfig(
+        makeEnv({
+          REVEALUI_SECRET: 'main-secret-that-is-at-least-32-chars',
+          REVEALUI_AUDIT_HMAC_SECRET: 'dedicated-audit-key-min-32-chars-here',
+        }),
+      );
+      expect(config.auditHmacSecret).toBe('dedicated-audit-key-min-32-chars-here');
+    });
   });
 
   describe('getStorageConfig', () => {

--- a/packages/config/src/modules/reveal.ts
+++ b/packages/config/src/modules/reveal.ts
@@ -6,6 +6,7 @@ import type { EnvConfig } from '../schema.js';
 
 export interface RevealConfig {
   secret: string;
+  auditHmacSecret: string;
   serverURL: string;
   publicServerURL: string;
   adminEmail?: string;
@@ -25,6 +26,7 @@ export function getRevealConfig(env: EnvConfig): RevealConfig {
 
   const config: RevealConfig = {
     secret: env.REVEALUI_SECRET,
+    auditHmacSecret: env.REVEALUI_AUDIT_HMAC_SECRET || env.REVEALUI_SECRET,
     serverURL: env.NEXT_PUBLIC_SERVER_URL ?? '',
     publicServerURL: env.REVEALUI_PUBLIC_SERVER_URL ?? '',
     corsOrigins: corsOrigins || [],

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -72,6 +72,14 @@ const optionalSchema = z.object({
   // Cron endpoint authentication
   REVEALUI_CRON_SECRET: secretSchema.optional(),
 
+  // Audit log HMAC signing key (M-2 paired meta-fix for the audit-storage
+  // silent-empty fallback in apps/server/src/lib/postgres-audit-storage.ts).
+  // When set, audit entries chain-sign with HMAC-SHA256 using this key.
+  // When unset, the audit-storage module falls back to REVEALUI_SECRET
+  // (which is schema-required at 32+ chars), so the chain is always signed
+  // in any environment that boots successfully.
+  REVEALUI_AUDIT_HMAC_SECRET: secretSchema.optional(),
+
   // Log retention window for app_logs + error_events (days). Default 90.
   // Privacy policy commits to a concrete window; see docs/security/.
   REVEALUI_LOG_RETENTION_DAYS: z.coerce


### PR DESCRIPTION
## Summary

Closes the silent-empty fallback in `PostgresAuditStorage`'s hash-chain signing. When the HMAC key was missing, the audit log persisted with `signature=null`, the chain never formed, and tampering with any entry would go undetected. SOC 2 posture depends on this chain being non-forgeable.

The fix has two layers:

1. **Schema-level enforcement (M-2 paired meta-fix).** Adds optional `REVEALUI_AUDIT_HMAC_SECRET` (validated min 32 chars when present) to the typed `@revealui/config` env schema, and a `auditHmacSecret` field to `RevealConfig` populated via `REVEALUI_AUDIT_HMAC_SECRET → REVEALUI_SECRET` fallback. `REVEALUI_SECRET` is already schema-required at 32+ chars, so any environment that boots is guaranteed to have a valid signing key.
2. **Runtime defense-in-depth.** `getAuditSecret()` in `apps/server/src/lib/postgres-audit-storage.ts` now throws on empty instead of returning `''`. Audit writes refuse to persist when integrity can't be guaranteed.

## Audit reference

Net-new finding from the 2026-05-16 fleet non-durable signal audit, filed internally at internal docs §"First concrete patch" (private repo, an internal repo). Same M-2 enforcement pattern as the in-flight fleet-security-hardening lane T0-9 (env-bypassing-schema).

## Files touched (49 LOC)

- `packages/config/src/schema.ts` — add `REVEALUI_AUDIT_HMAC_SECRET: secretSchema.optional()` after `REVEALUI_CRON_SECRET`.
- `packages/config/src/modules/reveal.ts` — add `auditHmacSecret: string` to `RevealConfig` + populate in `getRevealConfig`.
- `packages/config/src/__tests__/modules.test.ts` — 2 new tests covering the fallback + the override.
- `apps/server/src/lib/postgres-audit-storage.ts` — `getAuditSecret()` throws with descriptive error on empty.
- `apps/server/.env.example` — document the new optional override.

## Behavioral impact

Before:
- Missing HMAC key → silent empty signature, chain not formed, tampering undetectable.

After:
- Missing HMAC key → fast-fail boot (schema validation rejects missing `REVEALUI_SECRET`) OR audit write throws with descriptive error.
- Sets `REVEALUI_AUDIT_HMAC_SECRET` separately when the operator wants the audit chain keyed independently from the application secret (rotation hygiene, scope separation).
- No behavior change in any environment with a valid `REVEALUI_SECRET` already set (the documented production case).

## Test plan

- [x] `pnpm --filter @revealui/config typecheck` — clean.
- [x] `pnpm --filter @revealui/config test` — 132/132 pass, including the 2 new fallback tests.
- [x] No literal `RevealConfig` constructors outside the getter (verified via grep) — interface field addition is non-breaking.
- [ ] CI gate validates the full tree (`apps/server` typecheck reads pre-existing tree-cold failures in `webhooks.ts` + `revmarket-executor.ts` in this worktree before the build step runs; turbo-ordered CI builds deps first so this passes there).

## Posture / discipline

- Audit-first SDLC: linked to the an internal repo audit doc which preceded this fix.
- Worktree isolation off `origin/test` (peer has the main clone dirty with unrelated work).
- Explicit pathspec on commit (5 named files; no `git add -A`).
- Commit message via `-F /tmp/cmsg-*.txt` (no special-char trap).
- No `--no-verify`, no `--auto`. Manual merge on green per standing fleet policy.
- No regex authored.
- No `.env` secrets touched.

## Follow-ups (deferred from this PR)

1. Integrate `postgres-audit-storage` consumer-side with `@revealui/config` Proxy singleton (bootstrap-time question; schema slot delivers the M-2 enforcement on its own).
2. Update `docs/SECRETS.md` with the new env var (peer has the file dirty in main clone with NeonDB/Supabase consolidation — defer to avoid merge conflict).
3. Triage of fleet-security-hardening lane Tier-1 backlog should include the audit's remaining P0 #6 (CMS Bearer) and P0 #7 (Groq/HF keys), which share the same M-2 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
