### PR TITLE
fix(seed-stripe): use Stripe.API_VERSION for webhook endpoint creation

### DIFF
--- a/scripts/setup/__tests__/seed-stripe-apiversion.test.ts
+++ b/scripts/setup/__tests__/seed-stripe-apiversion.test.ts
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Drift guard: seed-stripe.ts MUST use StripeConstructor.API_VERSION
+ * for every apiVersion / api_version slot, never a hardcoded date literal.
+ *
+ * History: PR #637 consolidated apiVersion references across the codebase
+ * to use Stripe.API_VERSION so SDK upgrades auto-track the API version in
+ * lockstep. That consolidation missed the webhook-endpoint create call at
+ * line 708 (snake_case `api_version:` vs camelCase `apiVersion:` grep miss),
+ * leaving a stale `2026-01-28.clover` literal while the runtime SDK was
+ * pinned to `2026-04-22.dahlia`. Result: first live `pnpm stripe:seed`
+ * would create the webhook at the clover shape; the runtime handler reads
+ * the dahlia shape (`invoice.parent?.subscription_details?.subscription`),
+ * which is `undefined` on clover payloads, silently no-op'ing the
+ * post-refund subscription-cancel cascade.
+ *
+ * This test fails the build if any future change reintroduces a hardcoded
+ * apiVersion date string in seed-stripe.ts. Uses string-method predicates
+ * (no regex) per the fleet no-regex hardline.
+ */
+describe('seed-stripe.ts apiVersion drift guard', () => {
+  it('uses StripeConstructor.API_VERSION exclusively (no hardcoded date strings)', async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const seedStripePath = resolve(here, '..', 'seed-stripe.ts');
+    const content = await readFile(seedStripePath, 'utf8');
+
+    const lines = content.split('\n');
+    const violations: Array<{ lineNum: number; text: string }> = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lower = line.toLowerCase();
+
+      // Find either snake_case or camelCase apiVersion keyword.
+      const snakeIdx = lower.indexOf('api_version:');
+      const camelIdx = lower.indexOf('apiversion:');
+      const keyIdx = snakeIdx !== -1 ? snakeIdx : camelIdx;
+      if (keyIdx === -1) continue;
+
+      // Look at what follows the colon for a quoted Stripe date literal:
+      // either '20XX-... or "20XX-... (Stripe API versions are date-shaped).
+      const after = line.slice(keyIdx);
+      const hasQuotedDateLiteral = after.includes("'20") || after.includes('"20');
+
+      if (hasQuotedDateLiteral) {
+        violations.push({ lineNum: i + 1, text: line.trim() });
+      }
+    }
+
+    expect(
+      violations,
+      `seed-stripe.ts must use StripeConstructor.API_VERSION, not hardcoded apiVersion date literals. ` +
+        `Found ${violations.length} violation(s): ${JSON.stringify(violations, null, 2)}`,
+    ).toEqual([]);
+  });
+});

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -705,7 +705,7 @@ async function setupWebhookEndpoint(
   const endpoint = await stripe.webhookEndpoints.create({
     url,
     enabled_events: WEBHOOK_EVENTS,
-    api_version: '2026-01-28.clover',
+    api_version: StripeConstructor.API_VERSION,
   });
 
   log.success(`Created webhook endpoint: ${endpoint.id}`);


### PR DESCRIPTION
## Summary

`scripts/setup/seed-stripe.ts:708` hardcoded `api_version: '2026-01-28.clover'` when creating the Stripe webhook endpoint, while the runtime Stripe SDK is pinned to `2026-04-22.dahlia`. PR #637 consolidated apiVersion references across the codebase to use `Stripe.API_VERSION` but missed this site (snake_case `api_version:` vs camelCase `apiVersion:` grep miss).

On the first live `pnpm stripe:seed` run, this would create the webhook endpoint at `clover` shape. The runtime handler at `apps/server/src/routes/webhooks.ts:3288` reads `invoice.parent?.subscription_details?.subscription` (the dahlia-shape field — same migration as line 2451). On clover payloads that field is `undefined`, so the post-refund subscription-cancel cascade silently no-ops → customers with refunds keep getting charged.

## Changes

- **1-line:** `scripts/setup/seed-stripe.ts:708` — `'2026-01-28.clover'` → `StripeConstructor.API_VERSION`
- **New test:** `scripts/setup/__tests__/seed-stripe-apiversion.test.ts` — fails CI if any future change reintroduces a hardcoded apiVersion date literal in seed-stripe.ts. Uses string-method predicates (no regex) per fleet no-regex hardline.

## Test plan

- [x] New test reads file content and asserts no hardcoded apiVersion date literals exist
- [x] Pre-push gate ✓ — all 17 phase-1 checks pass (biome, claim-drift, raw-sql, empty-catch, stripe-client consolidation, OpenAPI mirror drift, security audit, etc.)
- [x] `pnpm --filter @revealui/openapi check:contracts` ✓ (no mirror drift)
- [ ] CI green on this PR

## Follow-up (separate PR)

Boot-time integrity check in `apps/server` startup that fetches the deployed webhook endpoint's actual `api_version` from Stripe and refuses to boot in prod on mismatch with `Stripe.API_VERSION`. Would catch this class of drift even if `seed-stripe` is correct but someone manually mutates the endpoint in the Stripe Dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
