### PR TITLE
docs(fleet): remove status banner — GHCR images publicly pullable

### DIFF
--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -7,8 +7,6 @@ audience: enterprise
 
 # RevealUI Fleet — Self-Hosted Deployment
 
-> **Status (as of 2026-05-16): build + publish pipeline shipped, public access pending.** The `docker/` stack, stamp scripts, source tree, and licensing flow are production-ready. The images this guide references (`ghcr.io/revealuistudio/revealui-api`, `ghcr.io/revealuistudio/revealui-admin`) are built via [`.github/workflows/docker.yml`](../.github/workflows/docker.yml) and pushed to GHCR on every `workflow_dispatch` run. Image visibility is currently **PRIVATE** — anonymous `docker pull` will fail with `401 UNAUTHORIZED` until package visibility is flipped to public in [GitHub Packages settings](https://github.com/orgs/RevealUIStudio/packages). Self-hosters using a license-authenticated pull flow will work today; anonymous Fleet trial pulls require the visibility flip.
-
 Customers buy the Enterprise tier of RevealUI; the Fleet kit (produced by RevForge) is what they deploy. Instead of running on `revealui.com`, you deploy the entire stack on your own infrastructure with full domain lock and unlimited users.
 
 RevealUI Fleet is a deployment-level commercial product, distinct from the hosted account-level subscription and metered usage model used for SaaS.


### PR DESCRIPTION
## Summary

Removes the `> **Status (as of 2026-05-16)...** ` banner from `docs/FLEET.md`. The banner was added in #907 to reflect that GHCR Docker images were built+published but visibility was still private. **GHCR visibility has now been flipped to public** — anonymous registry verification confirms both `ghcr.io/revealuistudio/revealui-api` and `revealui-admin` return HTTP 200 for tag listing + manifest fetch via the standard token-dance (which `docker pull` executes automatically).

## Why

The softened banner from #907 said "public access pending" and pointed at the visibility-flip action. That action has been completed by the owner. The banner is no longer accurate and the deployment guide body text speaks for itself — no banner needed.

## Verification

```
$ curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:revealuistudio/revealui-api:pull" | jq -r .token
<got 68-char token>

$ curl -s -H "Authorization: Bearer $TOKEN" \
       https://ghcr.io/v2/revealuistudio/revealui-api/tags/list
{"name":"revealuistudio/revealui-api","tags":["latest","sha-f550078","sha-ffa1d26"]}

$ curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" \
       -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
       https://ghcr.io/v2/revealuistudio/revealui-api/manifests/latest
200
```

Both packages confirmed publicly pullable.

## Test plan

- [ ] Confirm banner removed from FLEET.md
- [ ] No other content changes (single 1-line removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
