### PR TITLE
chore: finish getVectorClient script migration after #913

### DIFF
--- a/scripts/dev-tools/verify-test-setup.ts
+++ b/scripts/dev-tools/verify-test-setup.ts
@@ -14,7 +14,7 @@
  *
  * @dependencies
  * - scripts/lib/errors.ts - ErrorCode enum for exit codes
- * - @revealui/db - Database clients (getRestClient, getVectorClient, resetClient)
+ * - @revealui/db - Database clients (getRestClient, resetClient)
  * - drizzle-orm - SQL query builder (sql)
  *
  * @requires
@@ -23,7 +23,7 @@
  * - Environment: OPENAI_API_KEY (OpenAI API for embeddings)
  */
 
-import { getRestClient, getVectorClient, resetClient } from '@revealui/db';
+import { getRestClient, resetClient } from '@revealui/db';
 import { ErrorCode } from '@revealui/scripts/errors.js';
 import { sql } from 'drizzle-orm';
 
@@ -143,7 +143,7 @@ async function verifyDatabaseConnections() {
   // Test Vector database connection
   try {
     resetClient();
-    const vectorDb = getVectorClient();
+    const vectorDb = getRestClient();
     await vectorDb.execute(sql`SELECT 1 as test`);
     addResult({
       name: 'Vector Database Connection',
@@ -166,7 +166,7 @@ async function verifySupabaseSchema() {
 
   try {
     resetClient();
-    const vectorDb = getVectorClient();
+    const vectorDb = getRestClient();
 
     // Check if agent_memories table exists
     const tableCheck = await vectorDb.execute(
@@ -252,7 +252,7 @@ async function verifyPgVectorExtension() {
 
   try {
     resetClient();
-    const vectorDb = getVectorClient();
+    const vectorDb = getRestClient();
 
     const extensionCheck = await vectorDb.execute(
       sql`SELECT EXISTS (
@@ -311,7 +311,7 @@ async function verifyIndexes() {
 
   try {
     resetClient();
-    const vectorDb = getVectorClient();
+    const vectorDb = getRestClient();
 
     const indexCheck = await vectorDb.execute(
       sql`SELECT indexname, indexdef 

--- a/scripts/setup/setup-dual-database.ts
+++ b/scripts/setup/setup-dual-database.ts
@@ -15,7 +15,7 @@
  *
  * @dependencies
  * - scripts/lib/errors.ts - ErrorCode and ScriptError for validation
- * - @revealui/db - Database clients (getRestClient, getVectorClient, resetClient)
+ * - @revealui/db - Database clients (getRestClient, resetClient)
  * - node:fs - File system operations (readFileSync)
  * - node:path - Path manipulation utilities
  * - node:url - URL utilities for ES modules
@@ -36,7 +36,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getRestClient, getVectorClient, resetClient } from '@revealui/db';
+import { getRestClient, resetClient } from '@revealui/db';
 import { ErrorCode, ScriptError } from '@revealui/scripts/errors.js';
 import { sql } from 'drizzle-orm';
 
@@ -191,7 +191,7 @@ async function setupVectorDatabase(): Promise<boolean> {
 
   try {
     resetClient();
-    const db = getVectorClient();
+    const db = getRestClient();
 
     // Check current state
     const extensionExists = await checkExtension(db, 'vector');

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -81,12 +81,6 @@
       "migrationPhase": null
     },
     {
-      "path": "packages/db/src/supabase/setup-vector-extension.sql",
-      "rules": ["sql-file-outside-migrations"],
-      "reason": "Supabase-side pgvector extension bootstrap (CREATE EXTENSION IF NOT EXISTS vector). Applied by scripts/setup/setup-dual-database.ts against getVectorClient(). drizzle-kit currently only tracks the Neon side of the dual-DB architecture; Supabase-side DDL lives outside drizzle-kit by necessity. Phase 7 (drizzle-consolidation-spec) evaluates standing up a second drizzle-kit pipeline for Supabase; until then, this file + setup-dual-database.ts are the canonical Supabase-side applier. See packages/db/src/supabase/README.md for the architectural rationale.",
-      "migrationPhase": 7
-    },
-    {
       "path": "scripts/security/rotate-kek.ts",
       "rules": ["direct-import"],
       "reason": "KEK rotation operational tool (GAP-126 Phase 2). One-off script that performs simple SELECT/UPDATE on the two KEK-encrypted columns (user_api_keys.encrypted_key + users.mfa_secret). Uses raw pg.Pool instead of @revealui/db/client to keep the rotation tool isolated from production DB-client lifecycle (singleton pools, retry policies, observability hooks). Operator-invoked; 2 surfaces, ~3 SQL ops total. Permanent.",


### PR DESCRIPTION
## Summary

Finishes PR #913's incomplete caller migration. #913 deleted `getVectorClient()` from `packages/db` but left two runtime scripts and one validator-allowlist entry still referencing it. These slipped past the gate because the root `scripts/` tree isn't on `pnpm typecheck:all` (turbo runs typecheck per-workspace and these scripts aren't in a workspace) — but they would fail the moment anyone ran them.

## Changes

- `scripts/dev-tools/verify-test-setup.ts` — drop `getVectorClient` from imports; swap 4 call-sites to `getRestClient()`. Variable names + log messages unchanged (still semantically "vector" operations against pgvector on NeonDB).
- `scripts/setup/setup-dual-database.ts` — drop `getVectorClient` from imports; swap `setupVectorDatabase()` call-site to `getRestClient()`.
- `scripts/validate/raw-sql-allowlist.json` — remove the stale allowlist entry for `packages/db/src/supabase/setup-vector-extension.sql` (file deleted in #913; reason text still cited `getVectorClient()` and a `packages/db/src/supabase/README.md` that's also gone).

## Flagged for follow-up (separate PRs, deeper script restructuring)

- `scripts/setup/setup-dual-database.ts:209` still reads from the deleted path `packages/db/src/supabase/setup-vector-extension.sql` — the `setupVectorDatabase()` function will fail at `executeSQLFile()` the moment it runs against a fresh database. Per `scripts/setup/README.md`, pgvector setup now flows through `pnpm db:migrate`, so the entire `setupVectorDatabase()` function is obsolete and should be deleted or rewritten as a thin wrapper around the standard migration path.
- `scripts/setup/database.ts` + `scripts/setup/reset-database.ts` still detect Supabase as a separate provider and reference `SUPABASE_DATABASE_URI`.
- `scripts/__tests__/unit/validation.test.ts` asserts Supabase URL detection that no longer applies.
- `packages/test/package.json` `test:db:setup` script points to `packages/test/scripts/setup-dual-database.ts` — a path that doesn't exist (file moved to `scripts/setup/`).

## Test plan

- [x] Pre-push gate passed (Biome, audits, structure, boundary, version policy, docs-import-drift, claim drift, raw-SQL hard-fail, etc.)
- [x] `node --check` parses both modified scripts cleanly
- [x] `jq` validates the modified allowlist JSON

Refs: docs/decisions/2026-05-01-supabase-removal.md
