### PR TITLE
chore(scripts): align license docstrings to Ed25519 (was stale RS256)

### DIFF
--- a/scripts/setup/issue-revforge-license.ts
+++ b/scripts/setup/issue-revforge-license.ts
@@ -3,12 +3,12 @@
  * Issue a per-customer RevForge license JWT.
  *
  * Thin CLI wrapper around `@revealui/core/revforge-license`. Reads the studio's
- * RSA keypair from REVEALUI_LICENSE_PRIVATE_KEY / REVEALUI_LICENSE_PUBLIC_KEY,
+ * Ed25519 keypair from REVEALUI_LICENSE_PRIVATE_KEY / REVEALUI_LICENSE_PUBLIC_KEY,
  * parses argv, prints the signed JWT (or full JSON metadata with --json).
  *
  * Required env (source from revvault):
- *   REVEALUI_LICENSE_PRIVATE_KEY   RS256 PEM
- *   REVEALUI_LICENSE_PUBLIC_KEY    RS256 PEM
+ *   REVEALUI_LICENSE_PRIVATE_KEY   Ed25519 PEM
+ *   REVEALUI_LICENSE_PUBLIC_KEY    Ed25519 PEM
  *
  * Usage:
  *   revvault export-env -- pnpm tsx scripts/setup/issue-revforge-license.ts \
@@ -121,8 +121,8 @@ Options:
   -h, --help                Show this help.
 
 Required env (source from revvault):
-  REVEALUI_LICENSE_PRIVATE_KEY  RS256 private key (PEM, may be \\n-encoded).
-  REVEALUI_LICENSE_PUBLIC_KEY   RS256 public key (PEM, may be \\n-encoded).
+  REVEALUI_LICENSE_PRIVATE_KEY  Ed25519 private key (PEM, may be \\n-encoded).
+  REVEALUI_LICENSE_PUBLIC_KEY   Ed25519 public key (PEM, may be \\n-encoded).
 
 Examples:
   # 30-day trial license for Allevia


### PR DESCRIPTION
## Summary

Comment-only cleanup. `scripts/setup/issue-revforge-license.ts` describes
its required env vars as `RS256 PEM` in JSDoc + `--help`, but the actual
implementation calls `jose.importPKCS8(..., 'EdDSA')` to consume an Ed25519
key. Three of the four issuer-side touchpoints were aligned to Ed25519 in
the `revforge` repo migration; this finishes the cleanup on the revealui
side.

## Files

- `scripts/setup/issue-revforge-license.ts` — 5 docstring lines (6, 10, 11, 124, 125)

## Why

Reduces operator confusion when generating + restoring keys from revvault.
The previous text would have made anyone try to mint an RSA key for the
slot, which the runtime would have rejected at JWT verify time.

## Test plan

- [ ] CI green
- [ ] Visual diff confirms only comment lines changed
