### PR TITLE
chore(stripe): move env cache out of ~/.revealui namespace collision

### DIFF
--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -124,11 +124,11 @@ pnpm stripe:seed -- --dry-run
 # Seed Stripe products/prices and cache the resolved local price IDs
 pnpm stripe:seed -- --skip-webhook
 
-# Sync billing_catalog from env vars or the local .revealui/stripe-env.json cache
+# Sync billing_catalog from env vars or the local node_modules/.cache/revealui-stripe-env.json cache
 pnpm billing:catalog:sync
 ```
 
-`pnpm stripe:seed` now writes resolved price IDs to `.revealui/stripe-env.json` for local development.
+`pnpm stripe:seed` now writes resolved price IDs to `node_modules/.cache/revealui-stripe-env.json` for local development.
 That lets `billing:catalog:sync` populate `billing_catalog` even before you manually copy new price IDs into `.env` files.
 
 ### Dual Database Configuration

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -23,12 +23,13 @@
 import { execFileSync } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { config } from 'dotenv';
 import type Stripe from 'stripe';
 // Relative TS import resolves via tsx at script runtime; avoids adding
 // @revealui/contracts as a root-level dep. Script only; not bundled.
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '../../packages/contracts/src/stripe-webhook-events.js';
+import { LOCAL_STRIPE_ENV_CACHE_PATH } from './stripe-env-cache-path.js';
 
 // Load env from root .env
 config({ path: resolve(import.meta.dirname, '../../.env') });
@@ -41,8 +42,6 @@ config({ path: resolve(import.meta.dirname, '../../.env') });
 const require = createRequire(resolve(import.meta.dirname, '../../packages/services/'));
 const stripeModule = require('stripe') as { default?: typeof Stripe } & typeof Stripe;
 const StripeConstructor = (stripeModule.default ?? stripeModule) as typeof Stripe;
-const rootDir = resolve(import.meta.dirname, '../..');
-const LOCAL_STRIPE_ENV_CACHE_PATH = resolve(rootDir, '.revealui/stripe-env.json');
 
 // ─── Product Catalog ────────────────────────────────────────────────────────
 
@@ -901,7 +900,7 @@ async function writeLocalStripeEnvCache(
     return;
   }
 
-  await mkdir(resolve(rootDir, '.revealui'), { recursive: true });
+  await mkdir(dirname(LOCAL_STRIPE_ENV_CACHE_PATH), { recursive: true });
   await writeFile(
     LOCAL_STRIPE_ENV_CACHE_PATH,
     JSON.stringify(

--- a/scripts/setup/stripe-env-cache-path.ts
+++ b/scripts/setup/stripe-env-cache-path.ts
@@ -1,0 +1,8 @@
+import { resolve } from 'node:path';
+
+const rootDir = resolve(import.meta.dirname, '../..');
+
+export const LOCAL_STRIPE_ENV_CACHE_PATH = resolve(
+  rootDir,
+  'node_modules/.cache/revealui-stripe-env.json',
+);

--- a/scripts/setup/sync-billing-catalog.ts
+++ b/scripts/setup/sync-billing-catalog.ts
@@ -18,8 +18,9 @@ interface CatalogSeed {
   source: 'env' | 'local-cache';
 }
 
+import { LOCAL_STRIPE_ENV_CACHE_PATH as localStripeEnvCachePath } from './stripe-env-cache-path.js';
+
 const rootDir = resolve(import.meta.dirname, '../..');
-const localStripeEnvCachePath = resolve(rootDir, '.revealui/stripe-env.json');
 for (const envFile of [
   '.env',
   '.env.development.local',

--- a/scripts/setup/sync-stripe-env.sh
+++ b/scripts/setup/sync-stripe-env.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # sync-stripe-env.sh — Push Stripe price IDs to RevVault + Vercel
 #
-# Reads .revealui/stripe-env.json (written by pnpm stripe:seed), merges the
-# price IDs into the RevVault stripe vault, and pushes any missing vars to
-# Vercel production.
+# Reads node_modules/.cache/revealui-stripe-env.json (written by pnpm
+# stripe:seed), merges the price IDs into the RevVault stripe vault, and
+# pushes any missing vars to Vercel production.
 #
 # Usage:
 #   pnpm stripe:sync-env                # RevVault + Vercel
@@ -12,7 +12,7 @@
 #   pnpm stripe:sync-env --dry-run      # Preview what would be synced
 #
 # Prerequisites:
-#   - .revealui/stripe-env.json exists (run pnpm stripe:seed first)
+#   - node_modules/.cache/revealui-stripe-env.json exists (run pnpm stripe:seed first)
 #   - revvault binary at ~/.local/bin/revvault
 #   - vercel CLI authenticated (for Vercel sync)
 #   - jq installed
@@ -20,7 +20,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-CACHE_FILE="$ROOT_DIR/.revealui/stripe-env.json"
+# CACHE_FILE path MUST match scripts/setup/stripe-env-cache-path.ts.
+CACHE_FILE="$ROOT_DIR/node_modules/.cache/revealui-stripe-env.json"
 REVVAULT="$HOME/.local/bin/revvault"
 VAULT_PATH="revealui/env/stripe"
 


### PR DESCRIPTION
## Summary

Move the local Stripe env cache out of the `.revealui/` namespace that
collides with `~/.revealui/passage-store/` (revvault's encrypted secret
store). A clean-shell `find ~/.revealui -delete` would otherwise nuke both.

New path: `node_modules/.cache/revealui-stripe-env.json` — standard build
cache convention, already gitignored, auto-cleaned on deps reinstall.

## Drift cleanup (bonus)

The path constant was defined separately in 3 places — `seed-stripe.ts`,
`sync-billing-catalog.ts`, and `sync-stripe-env.sh`. The two TypeScript
files now import from a new tiny module (`scripts/setup/stripe-env-cache-path.ts`).
The shell script can't import across runtime boundaries, so it has a
comment noting it must match the TS module.

## Files

- `scripts/setup/stripe-env-cache-path.ts` (new, 8 lines)
- `scripts/setup/seed-stripe.ts` (import + remove unused `rootDir` + use `dirname(LOCAL_STRIPE_ENV_CACHE_PATH)` in mkdir)
- `scripts/setup/sync-billing-catalog.ts` (import)
- `scripts/setup/sync-stripe-env.sh` (path + doc + comment)
- `scripts/setup/README.md` (doc lines 127, 131)

## Follow-on PR (separate repo)

`revdev/apps/studio/src-tauri/src/commands/deploy/stripe.rs:36` reads the
old path. Will be updated in a paired PR against `revdev` immediately
after this lands. Until both ship, Studio's "deploy to Vercel" command
will fail to find the cache file on local dev — no production impact.

## Test plan

- [ ] CI green (Quality + Typecheck + Unit Tests + Build)
- [ ] `node_modules/.cache/` exists after `pnpm install` (always does)
- [ ] Visual diff: only the 5 listed files
