### PR TITLE
feat(validate): CI gate for seed-script npm wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Empty-catch validation (hard fail)
         run: pnpm validate:empty-catch
 
+      - name: Seed script wiring validation (hard fail)
+        run: pnpm validate:seed-wiring
+
       - name: Changeset validation (hard fail)
         # Catches mixed ignored+non-ignored changeset frontmatter BEFORE
         # merge, instead of discovering the same rejection later inside

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",
     "validate:raw-sql": "tsx scripts/validate/raw-sql.ts",
+    "validate:seed-wiring": "tsx scripts/validate/seed-script-wiring.ts",
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
     "vercel:sync": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",

--- a/scripts/validate/seed-script-wiring.ts
+++ b/scripts/validate/seed-script-wiring.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed Script Wiring Validation
+ *
+ * Every file under scripts/setup/ whose name begins with "seed" MUST have a
+ * corresponding npm script in package.json that invokes it. Otherwise the
+ * script silently rots after a rename, never runs in any sweep, and the
+ * fleet picks up a "ghost" workflow surface — the same drift class as the
+ * unwired-validator pattern this gate's sibling rules address.
+ *
+ * Exit codes:
+ *   0  -  every seed script has at least one npm-scripts entry that
+ *         references its relative path.
+ *   1  -  one or more seed scripts are unwired.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const SEED_DIR_REL = 'scripts/setup';
+const SEED_DIR_ABS = join(REPO_ROOT, SEED_DIR_REL);
+
+interface SeedScript {
+  fileName: string;
+  relativePath: string;
+}
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+}
+
+function discoverSeedScripts(): SeedScript[] {
+  const entries = readdirSync(SEED_DIR_ABS, { withFileTypes: true });
+  const seeds: SeedScript[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.startsWith('seed')) continue;
+    if (!entry.name.endsWith('.ts')) continue;
+    seeds.push({
+      fileName: entry.name,
+      relativePath: `${SEED_DIR_REL}/${entry.name}`,
+    });
+  }
+  return seeds.sort((a, b) => a.fileName.localeCompare(b.fileName));
+}
+
+function loadPackageScripts(): Record<string, string> {
+  const pkgPath = join(REPO_ROOT, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as PackageJson;
+  return pkg.scripts ?? {};
+}
+
+function findReferencingScripts(seed: SeedScript, npmScripts: Record<string, string>): string[] {
+  const matches: string[] = [];
+  for (const [scriptName, scriptBody] of Object.entries(npmScripts)) {
+    if (scriptBody.includes(seed.relativePath)) {
+      matches.push(scriptName);
+    }
+  }
+  return matches.sort();
+}
+
+function validateSeedWiring(): boolean {
+  const Sep = '='.repeat(60);
+  console.log(`\n${Sep}`);
+  console.log('Seed Script Wiring Validation');
+  console.log(Sep);
+
+  const seeds = discoverSeedScripts();
+  if (seeds.length === 0) {
+    console.log('No seed scripts found under scripts/setup/');
+    console.log(`${Sep}\n`);
+    return true;
+  }
+
+  const npmScripts = loadPackageScripts();
+  let allWired = true;
+
+  for (const seed of seeds) {
+    const callers = findReferencingScripts(seed, npmScripts);
+    if (callers.length === 0) {
+      console.log(`  ✗ ${seed.relativePath}`);
+      console.log(`    No npm script in package.json invokes this file.`);
+      console.log(`    Add an entry like: "<name>": "tsx ${seed.relativePath}"`);
+      allWired = false;
+    } else {
+      console.log(`  ✓ ${seed.relativePath} ← ${callers.join(', ')}`);
+    }
+  }
+
+  console.log(`\n${Sep}`);
+  if (allWired) {
+    console.log('✓ Seed script wiring validation passed');
+  } else {
+    console.log('✗ Seed script wiring validation failed');
+  }
+  console.log(`${Sep}\n`);
+
+  return allWired;
+}
+
+function main(): void {
+  const ok = validateSeedWiring();
+  process.exit(ok ? 0 : 1);
+}
+
+main();
+
+export { validateSeedWiring };


### PR DESCRIPTION
## Summary

Adds a CI gate that fails the build if any `scripts/setup/seed*.ts` is not
wired to an npm script in `package.json`. Closes the same drift class
covered by the unwired-validator pattern other validators in the fleet
already guard.

## Why

Without this gate, a seed script can rot silently after a rename, and the
next sweep never catches it. The two existing seed files (seed-billing.ts +
seed-stripe.ts) are wired today; this just locks the invariant for the
next one.

## Files

- `scripts/validate/seed-script-wiring.ts` (new)
- `package.json` (adds `"validate:seed-wiring"` npm script)
- `.github/workflows/ci.yml` (adds gate after `validate:empty-catch`)

## Validator output (smoke test, current state)

```
============================================================
Seed Script Wiring Validation
============================================================
  ✓ scripts/setup/seed-billing.ts ← db:seed:billing
  ✓ scripts/setup/seed-stripe.ts ← stripe:seed
============================================================
✓ Seed script wiring validation passed
============================================================
```

## Approach

Pure node fs + JSON.parse, deterministic ordering. No regex per fleet
posture. Validator finds each seed file's relative path, then scans every
`pkg.scripts.*` value for a substring match. Exit 1 on first orphan.

## Test plan

- [ ] CI green (the gate runs against itself)
- [ ] Manual: rename one seed file, expect the gate to fail
