### PR TITLE
chore(revealcoin): rewrite site copy for shelved state (N1)

### DIFF
--- a/apps/revealcoin/app/components/HeroSection.tsx
+++ b/apps/revealcoin/app/components/HeroSection.tsx
@@ -46,14 +46,11 @@ export function HeroSection() {
           </div>
         </div>
 
-        <Badge
-          color="violet"
-          className="mb-6 gap-2 rounded-full px-4 py-1.5 ring-1 ring-violet-200/80"
-        >
-          <span className="h-1.5 w-1.5 rounded-full bg-violet-500" />
+        <Badge color="zinc" className="mb-6 gap-2 rounded-full px-4 py-1.5 ring-1 ring-zinc-300/80">
+          <span className="h-1.5 w-1.5 rounded-full bg-zinc-500" />
           {ACTIVE_NETWORK === 'mainnet-beta'
-            ? 'Deployed on Solana Mainnet · Pre-launch'
-            : 'Devnet preview · Mainnet not yet deployed'}
+            ? 'Deployed on Solana Mainnet · Shelved'
+            : 'Devnet preview · Shelved'}
         </Badge>
 
         <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl hero-stagger">
@@ -71,17 +68,15 @@ export function HeroSection() {
           ecosystem rewards — including across the RevealUI platform.
         </p>
 
-        {/* Pre-launch disclaimer — devnet preview only */}
-        <div className="mx-auto mt-6 max-w-2xl rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-left text-sm text-amber-900">
+        {/* Shelved-state banner — see revealcoin/docs/decisions/2026-05-15-shelved-pending-revenue.md */}
+        <div className="mx-auto mt-6 max-w-2xl rounded-lg border border-zinc-300 bg-zinc-50 px-4 py-3 text-left text-sm text-zinc-900">
           <p className="font-semibold">
-            {ACTIVE_NETWORK === 'mainnet-beta'
-              ? 'Public trading is not yet live.'
-              : 'Devnet preview only — no public trading, no real value.'}
+            RVC is a deployed engineering artifact, not a tradable token.
           </p>
           <p className="mt-1 leading-relaxed">
-            {ACTIVE_NETWORK === 'mainnet-beta'
-              ? 'The token is deployed on mainnet, but distribution and Raydium liquidity are gated behind two pre-launch commitments: on-chain vesting migration (replacing the current custodial vesting model) and multi-sig on the mint authority. Watch the roadmap below for progress on both.'
-              : 'The token has not yet been deployed to Solana mainnet. The address shown below is the devnet preview deployment used for development and demo. Mainnet deploy is gated on on-chain vesting migration (replacing the current custodial vesting model), multi-sig on the mint authority, a third-party audit, and securities-counsel sign-off. Watch the roadmap below for progress.'}
+            No public sale is planned. RevealUI Studio will not seed a Raydium pool. No vesting
+            claims have been executed. Any $RVC pool, sale, or distribution event you encounter is
+            not affiliated with RevealUI Studio.
           </p>
         </div>
 

--- a/apps/revealcoin/app/components/RoadmapSection.tsx
+++ b/apps/revealcoin/app/components/RoadmapSection.tsx
@@ -1,4 +1,4 @@
-type MilestoneStatus = 'current' | 'upcoming' | 'complete';
+type MilestoneStatus = 'complete' | 'shelved';
 
 interface Milestone {
   phase: string;
@@ -10,58 +10,33 @@ interface Milestone {
 const milestones: Milestone[] = [
   {
     phase: 'Phase 0',
-    title: 'Foundation',
-    status: 'current',
+    title: 'On-chain artifact (deployed)',
+    status: 'complete',
     items: [
-      'Token-2022 mint deployed',
-      'Allocations defined + custody-enforced vesting',
-      'Metadata on Arweave',
-      'On-chain vesting migration (in design)',
-      'Multi-sig on mint authority (pending)',
+      'Token-2022 mint deployed on Solana mainnet-beta',
+      'Allocations distributed to custody accounts (no claims executed)',
+      'Metadata pinned on Arweave',
+      'Freeze authority permanently renounced',
     ],
   },
   {
-    phase: 'Phase 1',
-    title: 'Public Distribution',
-    status: 'upcoming',
+    phase: 'Phase 1+',
+    title: 'All further phases — shelved',
+    status: 'shelved',
     items: [
-      'Gated on: on-chain vesting + multi-sig complete',
-      'Initial liquidity seeding',
-      'Community channels + public communication',
-    ],
-  },
-  {
-    phase: 'Phase 2',
-    title: 'Liquidity & Trading',
-    status: 'upcoming',
-    items: ['Raydium CPMM pool creation', 'Jupiter aggregator listing', 'Price oracle (TWAP)'],
-  },
-  {
-    phase: 'Phase 3',
-    title: 'Marketplace Integration',
-    status: 'upcoming',
-    items: [
-      'RVC payments in RevealUI marketplace',
-      'x402 micropayment protocol',
-      'Creator earnings in RVC',
-    ],
-  },
-  {
-    phase: 'Phase 4',
-    title: 'Governance',
-    status: 'upcoming',
-    items: [
-      'Proposal creation & voting',
-      'Treasury spend visibility',
-      'Multi-sig authority transfer',
+      'Multi-sig migration: scripted but not executed; deferred until revenue allows hardware-wallet operational security',
+      'Public distribution: not planned by RevealUI Studio',
+      'Raydium pool seeding / DEX listing: not planned by RevealUI Studio',
+      'Marketplace RVC payments: not planned in the current scope',
+      'Governance / treasury votes: not planned in the current scope',
+      'Re-activation of any item above requires explicit owner approval, revenue runway, and legal review',
     ],
   },
 ];
 
 const statusStyles = {
   complete: 'bg-emerald-500',
-  current: 'bg-violet-500 animate-pulse',
-  upcoming: 'bg-gray-300',
+  shelved: 'bg-zinc-400',
 };
 
 export function RoadmapSection() {
@@ -69,9 +44,9 @@ export function RoadmapSection() {
     <section className="bg-white py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-violet-600">Roadmap</p>
+          <p className="text-sm font-semibold uppercase tracking-widest text-zinc-600">Status</p>
           <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Building in the open
+            What's deployed, what's shelved
           </h2>
         </div>
 

--- a/apps/revealcoin/public/whitepaper.md
+++ b/apps/revealcoin/public/whitepaper.md
@@ -5,6 +5,10 @@
 
 ---
 
+> **Document status (2026-05-15): shelved engineering reference.** RVC is deployed on Solana mainnet-beta as an on-chain artifact, but RevealUI Studio is not pursuing the launch, distribution, or trading plans described in this paper. No public sale, no Raydium pool seeding, no vesting claims have been or will be executed by RevealUI Studio. Re-activation of any of the sections that describe forward-looking plans requires explicit owner approval, revenue runway, and legal review — see the [README's shelved-state notice](https://github.com/RevealUIStudio/revealcoin#status-shelved-engineering-artifact-read-first) and the [2026-05-15 shelved-pending-revenue ADR](https://github.com/RevealUIStudio/revealcoin/blob/main/docs/decisions/2026-05-15-shelved-pending-revenue.md). The technical sections (token spec, on-chain artifact references, supply arithmetic) remain accurate as published.
+
+---
+
 ## Abstract
 
 RevealCoin (RVC) is a Solana-based digital token built on the Token-2022 (Token Extensions) program, designed to serve as the native economic layer of the RevealUI ecosystem. RevealUI is a complete business infrastructure platform for software companies  -  providing users, content, products, payments, and AI as composable primitives. RVC unifies three functions within this ecosystem: **utility** (payment for platform services), **governance** (community-driven decision-making), and **rewards** (incentives for contributors and early adopters).
@@ -686,29 +690,11 @@ All allocation wallets are publicly verifiable on Solana Explorer. Balances matc
 | Liquidity Provision | `DzV9wrMaLwWX2bqEuiU9io8btwkSkVY4N8izqt3xBBjv` | 6-mo lockup + 12-mo gradual |
 | Ecosystem Rewards | `9sAQqmaCta7nfwiXHPFQZi5iq1PHQskaf6YwAxp8gHmb` | Front-loaded over 5 years |
 
-### E. Liquidity Pool Plan
+### E. Liquidity Pool — shelved
 
-| Parameter | Value |
-|-----------|-------|
-| DEX | Raydium CPMM |
-| Pool pair | RVC / SOL |
-| Pool seed (RVC) | 589,060,000 RVC (10% of Liquidity Provision allocation) |
-| Pool seed (SOL) | ~1.77 SOL |
-| Initial price | 0.000000003 SOL/RVC (~$0.000000405 USD) |
-| FDV at launch | ~$23,900 USD |
-| Remaining liquidity | 5,301,540,000 RVC (locked in vesting custody) |
+RevealUI Studio has not seeded any liquidity pool for RVC and does not plan to. The Liquidity Provision allocation remains in its custody account (`DzV9wrMaLwWX2bqEuiU9io8btwkSkVY4N8izqt3xBBjv`) with no claims executed. Any $RVC pool, sale, or distribution event on any DEX is not affiliated with RevealUI Studio.
 
-#### Pricing Rationale
-
-The initial price was chosen to balance affordability, credibility, and accessibility:
-
-- **Founder-affordable**: ~$240 USD in SOL required for the pool's SOL side
-- **Credible micro-cap FDV**: ~$24K signals genuine early-stage, not an abandoned token
-- **Early supporter friendly**: 0.1 SOL (~$13.50) buys ~33M RVC  -  a meaningful position
-- **Room for organic price discovery**: low starting point lets the market find fair value as RevealUI launches
-- **Manageable slippage**: a 0.1 SOL trade moves price ~6%, acceptable for initial liquidity depth
-
-The remaining 90% of the Liquidity Provision allocation stays locked in vesting custody (6-month lockup + 12-month gradual release) and can be used to deepen liquidity over time.
+Re-activation of any pool-seeding step requires explicit owner approval and is gated on revenue + legal review per the [2026-05-15 shelved-pending-revenue ADR](https://github.com/RevealUIStudio/revealcoin/blob/main/docs/decisions/2026-05-15-shelved-pending-revenue.md).
 
 ### F. Supply Arithmetic
 


### PR DESCRIPTION
## Summary

Rewrites `apps/revealcoin/` site copy to reflect the shelved state per
the 2026-05-15 shelved-pending-revenue ADR + PLAN-2026-05-15 §N1-spec.
Companion to the revealcoin-side N2 PR.

## Files

- `apps/revealcoin/app/components/HeroSection.tsx` — status pill "Pre-launch" → "Shelved" (zinc-toned, not promotional); replace gating-status disclaimer with shelved-state banner ("RVC is a deployed engineering artifact, not a tradable token. …")
- `apps/revealcoin/app/components/RoadmapSection.tsx` — drop Phase 1-4 (Public Distribution / Liquidity & Trading / Marketplace / Governance); reframe as Phase 0 (deployed) + single "Phase 1+ — shelved" block enumerating what's deferred with explicit "not planned by RevealUI Studio" framing; section heading "Building in the open" → "What's deployed, what's shelved"
- `apps/revealcoin/public/whitepaper.md` — top banner warning that forward-looking sections describe plans that are no longer active (with links to README + ADR); §E "Liquidity Pool Plan" pricing table (Pool seed / Initial price / FDV at launch) + "Pricing Rationale" subsection → replaced with "Liquidity Pool — shelved" paragraph (no pricing, no FDV)

## Verification

```
grep -rn -iE "public trading|FDV at launch|initial price|will launch|coming soon|pre.?launch" apps/revealcoin/app apps/revealcoin/public
# (no matches — confirmed)

grep -rn -iE "raydium|pool seed" apps/revealcoin/app apps/revealcoin/public
# Remaining matches are negation context ("will not seed a Raydium pool",
# "Raydium pool seeding: not planned"), plus deep-body whitepaper sections
# §5.6 + Phase 1 checklist — out of N1 scope, deferred to N4 mainline
# cleanup audit per PLAN.
```

## Out of scope (intentional, deferred to N4)

- Whitepaper §5.6 Liquidity Provision narrative (Raydium/Orca pairs)
- Whitepaper §Phase 1 Ecosystem Bootstrap checklist (Liquidity provision line)
- Both belong to the comprehensive mainline cleanup pass per PLAN §N4.

## Companion PR

an internal repo — paired README rewrite.

## Test plan

- [ ] CI green (Quality + Typecheck + Build)
- [ ] Vercel preview: visual check that hero + roadmap render shelved framing
- [ ] Whitepaper banner appears at top of `/whitepaper` route
