### PR TITLE
test(e2e): split visual snapshots by auth so routes capture distinct renders

### DIFF
--- a/e2e/visual-snapshots.e2e.ts
+++ b/e2e/visual-snapshots.e2e.ts
@@ -5,7 +5,14 @@
  * These tests ensure visual consistency across changes and detect unintended
  * visual regressions.
  *
- * Updated to target actual admin routes that exist in the application.
+ * Unauthenticated tests (login page, error states) run without storageState.
+ * Authenticated tests (collections, globals, responsive, theme, cross-browser)
+ * use the storageState written by global-setup.ts (e2e/.auth/user.json) so
+ * each route renders its actual content rather than the /login redirect.
+ *
+ * If ADMIN_EMAIL/ADMIN_PASSWORD were not set during setup, e2e/.auth/user.json
+ * will contain an empty cookie list and the authenticated tests will redirect
+ * to /login — run global-setup again with credentials to populate the state.
  *
  * Usage:
  * - Run tests: pnpm test:e2e:visual
@@ -16,58 +23,16 @@
 import { expect, test } from '@playwright/test';
 import { waitForNetworkIdle } from './utils/test-helpers';
 
+const AUTH_STATE = 'e2e/.auth/user.json';
+
 test.describe('Visual Snapshots - Admin Application', () => {
-  test.describe('Admin Panel', () => {
-    test('admin login page should match snapshot', async ({ page }) => {
+  test.describe('Unauthenticated States', () => {
+    test('login page should match snapshot', async ({ page }) => {
       await page.goto('/login');
       await waitForNetworkIdle(page);
       await page.waitForLoadState('networkidle');
 
       await expect(page).toHaveScreenshot('admin-login-page.png', {
-        fullPage: true,
-      });
-    });
-
-    test('admin collections page should match snapshot', async ({ page }) => {
-      await page.goto('/collections');
-      await waitForNetworkIdle(page);
-      await page.waitForLoadState('networkidle');
-
-      await expect(page).toHaveScreenshot('admin-collections.png', {
-        fullPage: true,
-      });
-    });
-
-    test('admin globals page should match snapshot', async ({ page }) => {
-      await page.goto('/globals');
-      await waitForNetworkIdle(page);
-      await page.waitForLoadState('networkidle');
-
-      await expect(page).toHaveScreenshot('admin-globals.png', {
-        fullPage: true,
-      });
-    });
-  });
-
-  test.describe('Responsive Snapshots', () => {
-    test('admin login on mobile viewport should match snapshot', async ({ page }) => {
-      await page.setViewportSize({ width: 375, height: 667 });
-      await page.goto('/login');
-      await waitForNetworkIdle(page);
-
-      await expect(page).toHaveScreenshot('admin-login-mobile.png', {
-        fullPage: true,
-      });
-    });
-  });
-
-  test.describe('Theme Snapshots', () => {
-    test('admin login with dark color scheme should match snapshot', async ({ page }) => {
-      await page.emulateMedia({ colorScheme: 'dark' });
-      await page.goto('/login');
-      await waitForNetworkIdle(page);
-
-      await expect(page).toHaveScreenshot('admin-login-dark-mode.png', {
         fullPage: true,
       });
     });
@@ -84,12 +49,66 @@ test.describe('Visual Snapshots - Admin Application', () => {
     });
   });
 
-  test.describe('Cross-Browser Consistency', () => {
-    test('admin login should be visually consistent across browsers', async ({ page }) => {
-      await page.goto('/login');
+  test.describe('Authenticated Admin Pages', () => {
+    test.use({ storageState: AUTH_STATE });
+
+    test('collections page should match snapshot', async ({ page }) => {
+      await page.goto('/collections');
+      await waitForNetworkIdle(page);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page).toHaveScreenshot('admin-collections.png', {
+        fullPage: true,
+      });
+    });
+
+    test('globals page should match snapshot', async ({ page }) => {
+      await page.goto('/globals');
+      await waitForNetworkIdle(page);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page).toHaveScreenshot('admin-globals.png', {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe('Responsive Snapshots', () => {
+    test.use({ storageState: AUTH_STATE });
+
+    test('collections page on mobile viewport should match snapshot', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto('/collections');
       await waitForNetworkIdle(page);
 
-      await expect(page).toHaveScreenshot('cross-browser-admin-login.png', {
+      await expect(page).toHaveScreenshot('admin-collections-mobile.png', {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe('Theme Snapshots', () => {
+    test.use({ storageState: AUTH_STATE });
+
+    test('collections page with dark color scheme should match snapshot', async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto('/collections');
+      await waitForNetworkIdle(page);
+
+      await expect(page).toHaveScreenshot('admin-collections-dark-mode.png', {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe('Cross-Browser Consistency', () => {
+    test.use({ storageState: AUTH_STATE });
+
+    test('collections page should be visually consistent across browsers', async ({ page }) => {
+      await page.goto('/collections');
+      await waitForNetworkIdle(page);
+
+      await expect(page).toHaveScreenshot('cross-browser-admin-collections.png', {
         fullPage: true,
       });
     });


### PR DESCRIPTION
## Summary

- Restructured `e2e/visual-snapshots.e2e.ts` so each test captures the route it claims to test. Previously, the suite ran every test unauthenticated, so navigation to `/collections`, `/globals`, `/login`, and the 404 path all redirected to `/login` and produced five PNGs that hashed identically.
- Wrapped the four authenticated blocks (Admin Pages / Responsive / Theme / Cross-Browser) with `test.use({ storageState: 'e2e/.auth/user.json' })` so they pick up the session written by `e2e/global-setup.ts` when `ADMIN_EMAIL` + `ADMIN_PASSWORD` are set.
- Kept the unauthenticated cases minimal: one login-page test (the legitimate unauth render) and one 404 test.

## Why now

PR #921 noted the duplicate-baseline situation as a deferred follow-up. This is the deferral.

## Baseline behavior

Baseline PNGs are intentionally **not** touched in this PR. The new test names will trip snapshot mismatches on first run; that's expected and is the cue for a separate baseline-regeneration PR.

Orphan baselines now on disk under `e2e/__snapshots__/visual-snapshots.e2e.ts/`:

```
admin-login-mobile-chromium.png
admin-login-mobile-mobile-chrome.png
admin-login-mobile-tablet.png
admin-login-dark-mode-chromium.png
admin-login-dark-mode-mobile-chrome.png
admin-login-dark-mode-tablet.png
cross-browser-admin-login-chromium.png
cross-browser-admin-login-mobile-chrome.png
cross-browser-admin-login-tablet.png
```

Plus the existing `admin-collections-*` / `admin-globals-*` baselines, which currently capture the login-redirect render rather than real content — they'll need regeneration in the follow-up.

## Notes on `global-setup.ts`

The setup has a deliberate preserve-on-failure path — if sign-in fails it keeps existing cookies rather than overwriting with an empty state. So if `ADMIN_EMAIL` / `ADMIN_PASSWORD` aren't set on a particular run but `e2e/.auth/user.json` already holds valid cookies, the authenticated tests can still pass against those cookies. The new file comment calls this out so reviewers understand the conditional.

## Test plan

- [ ] Local: `pnpm exec tsc --noEmit` clean (verified)
- [ ] Local: `pnpm exec biome check e2e/visual-snapshots.e2e.ts` clean (verified)
- [ ] CI: full gate green
- [ ] Reviewer to decide whether the orphan-baseline cleanup happens in this PR's follow-up or merged in alongside baseline regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
