### PR TITLE
fix(a11y): admin /login WCAG contrast on SplitAuthLayout + BuiltWithRevealUI

### DIFF
--- a/packages/presentation/src/components/BuiltWithRevealUI.tsx
+++ b/packages/presentation/src/components/BuiltWithRevealUI.tsx
@@ -15,8 +15,11 @@ const badgeStyles = cva(
         inline: '',
       },
       colorScheme: {
-        light: 'border-gray-200 bg-white/90 text-gray-500 opacity-75 backdrop-blur-sm',
-        dark: 'border-gray-700 bg-gray-800/80 text-gray-300 opacity-90',
+        // Text + bg opacity raised to clear WCAG 2 AA 4.5:1 for small (10/12px) text.
+        // Previous values (text-gray-300/opacity-90 on bg-gray-800/80) measured 4.41:1.
+        // `transition-opacity hover:opacity-100` on the base still un-dims on interaction.
+        light: 'border-gray-300 bg-white/95 text-gray-700 backdrop-blur-sm',
+        dark: 'border-gray-700 bg-gray-800/95 text-gray-100',
       },
     },
     defaultVariants: {

--- a/packages/presentation/src/components/split-auth-layout.tsx
+++ b/packages/presentation/src/components/split-auth-layout.tsx
@@ -58,7 +58,12 @@ export function SplitAuthLayout({
         className={cn(
           'flex flex-col items-center justify-center gap-6 px-6 py-12 lg:w-1/2 lg:gap-8 lg:py-16',
           brandBgClass,
-          'text-[var(--tenant-brand-on,white)]',
+          // Foreground falls back to the surface-paired text token (`--rvui-text-0`)
+          // so the no-tenant default keeps WCAG contrast in both light + dark modes
+          // (white-on-surface-3 was 1.18:1 in light mode — failed AA). Customers
+          // should override `--tenant-brand-on` to a value that contrasts with
+          // their `--tenant-brand` — see header docstring.
+          'text-[var(--tenant-brand-on,var(--rvui-text-0))]',
         )}
       >
         {brand}


### PR DESCRIPTION
## Summary

Fixes the two WCAG 2 AA contrast violations that are blocking #915 (test→main promotion). Both flagged as **serious** by axe-core in the `Admin basic render › Admin root has no critical accessibility violations` smoke test (chromium + mobile-chrome + tablet).

## Bug 1 — SplitAuthLayout brand panel: white h1 on light-gray surface

**Measured:** 1.18:1 (h1, white `#ffffff` on light gray `#e8eced`, 30px). **WCAG AA requires 3:1** for large text.

**Root cause:** `text-[var(--tenant-brand-on,white)]` fell through to white when no tenant env var was set, while the background fallback resolved to `--rvui-surface-3` which is `oklch(0.94 0.005 218)` (~#e8eced) in light mode.

**Fix:** swap the foreground fallback from `white` to `var(--rvui-text-0)`. That token is the canonical surface-paired text — `oklch(0.15 …)` in light mode, `oklch(0.95 …)` in dark mode — so the no-tenant default clears AA in both modes. No runtime contrast computation needed; the docstring's "set both vars or accept the default pair" contract is preserved.

Customer override path is unchanged: setting `--tenant-brand-on` still wins.

## Bug 2 — BuiltWithRevealUI badge: gray-300 + opacity-90 on gray-800/80

**Measured:** 4.41:1 (light gray `#d3d7dd` on darker gray `#57606b`, 10/12px small text). **WCAG AA requires 4.5:1** for small text.

**Root cause:** the `dark` colorScheme combined `text-gray-300 opacity-90` on `bg-gray-800/80`. Opacity on the text dropped the effective foreground luminance below the AA floor.

**Fix:** bump `dark` colorScheme to `text-gray-100` (no opacity reduction) on `bg-gray-800/95`. Symmetrically tighten `light` colorScheme to `text-gray-700` on `bg-white/95` with `border-gray-300` (was 4.62:1 — passing today, but right at the edge with the previous opacity-75 modifier).

The `transition-opacity hover:opacity-100` on the base remains — it now un-dims on hover from a starting state that already clears AA, which is what was intended.

## Files

- `packages/presentation/src/components/split-auth-layout.tsx` (foreground fallback token + clarifying comment)
- `packages/presentation/src/components/BuiltWithRevealUI.tsx` (both colorScheme variants + clarifying comment)

## Verification

- ✓ Inspected against axe-core's failure output — foreground/background colors quoted in the run match the source elements.
- ✗ Local browser preview of admin app requires NeonDB connection + many `REVEALUI_*` env vars — not exercised here.
- ⏳ **Real verification path: this PR's own CI E2E smoke run.** Same test that's failing on #915; if my fix is right, CI green.

## Why this unblocks #915

#915 (test→main, 8-PR train) currently fails on 3 E2E checks: `E2E Smoke`, `Accessibility (E2E)`, `Visual Regression (E2E)`. All three trace to the same axe-core color-contrast violation on `/admin` root. Landing this PR on `test` and re-running #915's CI should clear all three.

## Test plan

- [ ] Quality + Typecheck + Unit Tests green
- [ ] E2E Smoke green (the canary — was failing on #915)
- [ ] Accessibility (E2E) green
- [ ] Visual Regression (E2E) — may show pixel diffs from the color shift; review snapshot updates carefully
- [ ] After merge: re-trigger #915 CI; expect 3 failures → 0
