### PR TITLE
fix(setup): backfill tosAcceptedAt for pre-#458 bootstrap admins

### DIFF
--- a/packages/test/src/__tests__/backfill-tos-pre-458-bootstrap.test.ts
+++ b/packages/test/src/__tests__/backfill-tos-pre-458-bootstrap.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for scripts/setup/backfill-tos-pre-458-bootstrap.ts
+ *
+ * Uses an in-memory PGlite database so no real Postgres connection is needed.
+ * The backfill logic is mirrored here via Drizzle directly, keeping tests
+ * fast and deterministic without shelling out to the script.
+ *
+ * Covers: dry-run, apply, idempotency, and ineligible-row filtering.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { and, eq, isNull } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanTables, createTestDb, type TestDb } from '../utils/drizzle-test-db.js';
+
+// ---------------------------------------------------------------------------
+// Constants — match the script exactly
+// ---------------------------------------------------------------------------
+
+const TOS_VERSION = '2026-03-01';
+const AGENT_ID = 'setup:script:backfill-tos-pre-458-bootstrap';
+const EVENT_TYPE = 'setup:tos-backfill';
+
+interface BackfillPayload {
+  userId: string;
+  previousTosAcceptedAt: null;
+  previousTosVersion: null;
+  backfilledTosAcceptedAt: string;
+  backfilledTosVersion: string;
+  rationale: string;
+  issue: number;
+}
+
+// ---------------------------------------------------------------------------
+// Logic mirrors — exercise the same predicates as the script
+// ---------------------------------------------------------------------------
+
+async function findMatchedUsers(db: TestDb['drizzle']) {
+  const { users } = await import('@revealui/db/schema');
+  return db
+    .select({ id: users.id, createdAt: users.createdAt })
+    .from(users)
+    .where(
+      and(isNull(users.tosAcceptedAt), eq(users.role, 'owner'), eq(users.emailVerified, true)),
+    );
+}
+
+async function applyBackfill(db: TestDb['drizzle']): Promise<number> {
+  const { users, auditLog } = await import('@revealui/db/schema');
+  const matched = await findMatchedUsers(db);
+
+  if (matched.length === 0) return 0;
+
+  await db.transaction(async (tx) => {
+    for (const user of matched) {
+      await tx
+        .update(users)
+        .set({ tosAcceptedAt: user.createdAt, tosVersion: TOS_VERSION })
+        .where(and(eq(users.id, user.id), isNull(users.tosAcceptedAt)));
+
+      await tx.insert(auditLog).values({
+        id: randomUUID(),
+        eventType: EVENT_TYPE,
+        agentId: AGENT_ID,
+        severity: 'info',
+        payload: {
+          userId: user.id,
+          previousTosAcceptedAt: null,
+          previousTosVersion: null,
+          backfilledTosAcceptedAt: user.createdAt.toISOString(),
+          backfilledTosVersion: TOS_VERSION,
+          rationale: 'CR-8 backfill for pre-#458 bootstrap admin',
+          issue: 460,
+        },
+      });
+    }
+  });
+
+  return matched.length;
+}
+
+// ---------------------------------------------------------------------------
+// Seed helper
+// ---------------------------------------------------------------------------
+
+async function seedUser(
+  db: TestDb['drizzle'],
+  overrides: {
+    id?: string;
+    role?: string;
+    emailVerified?: boolean;
+    tosAcceptedAt?: Date | null;
+    tosVersion?: string | null;
+    createdAt?: Date;
+  } = {},
+): Promise<string> {
+  const { users } = await import('@revealui/db/schema');
+  const id = overrides.id ?? randomUUID();
+  const createdAt = overrides.createdAt ?? new Date('2026-01-15T10:00:00Z');
+
+  await db.insert(users).values({
+    id,
+    name: `User ${id.slice(0, 8)}`,
+    email: `${id.slice(0, 8)}@example.com`,
+    role: overrides.role ?? 'owner',
+    emailVerified: overrides.emailVerified ?? true,
+    tosAcceptedAt: overrides.tosAcceptedAt !== undefined ? overrides.tosAcceptedAt : null,
+    tosVersion: overrides.tosVersion !== undefined ? overrides.tosVersion : null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('backfill-tos-pre-458-bootstrap', () => {
+  let db: TestDb;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+  }, 60_000);
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await cleanTables(db.drizzle, ['audit_log', 'users']);
+  });
+
+  describe('dry-run behaviour (findMatchedUsers)', () => {
+    it('finds matching rows without mutating', async () => {
+      const { users } = await import('@revealui/db/schema');
+
+      const userId = await seedUser(db.drizzle);
+      const matched = await findMatchedUsers(db.drizzle);
+
+      expect(matched).toHaveLength(1);
+      expect(matched[0].id).toBe(userId);
+
+      const [row] = await db.drizzle
+        .select({ tosAcceptedAt: users.tosAcceptedAt })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      expect(row?.tosAcceptedAt).toBeNull();
+    });
+
+    it('returns empty array when no rows match', async () => {
+      const matched = await findMatchedUsers(db.drizzle);
+      expect(matched).toHaveLength(0);
+    });
+  });
+
+  describe('apply mode', () => {
+    it('sets tosAcceptedAt = createdAt and tosVersion for matching user', async () => {
+      const { users } = await import('@revealui/db/schema');
+      const createdAt = new Date('2026-02-01T08:00:00Z');
+
+      const userId = await seedUser(db.drizzle, { createdAt });
+      const count = await applyBackfill(db.drizzle);
+
+      expect(count).toBe(1);
+
+      const [row] = await db.drizzle
+        .select({ tosAcceptedAt: users.tosAcceptedAt, tosVersion: users.tosVersion })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      expect(row?.tosAcceptedAt).toEqual(createdAt);
+      expect(row?.tosVersion).toBe(TOS_VERSION);
+    });
+
+    it('writes one audit_log entry per backfilled user with correct shape', async () => {
+      const { auditLog } = await import('@revealui/db/schema');
+      const userId = await seedUser(db.drizzle);
+
+      await applyBackfill(db.drizzle);
+
+      const entries = await db.drizzle
+        .select()
+        .from(auditLog)
+        .where(eq(auditLog.eventType, EVENT_TYPE));
+
+      expect(entries).toHaveLength(1);
+
+      const entry = entries[0];
+      expect(entry.agentId).toBe(AGENT_ID);
+      expect(entry.severity).toBe('info');
+
+      const payload = entry.payload as BackfillPayload;
+      expect(payload.userId).toBe(userId);
+      expect(payload.previousTosAcceptedAt).toBeNull();
+      expect(payload.previousTosVersion).toBeNull();
+      expect(payload.backfilledTosVersion).toBe(TOS_VERSION);
+      expect(payload.rationale).toBe('CR-8 backfill for pre-#458 bootstrap admin');
+      expect(payload.issue).toBe(460);
+    });
+
+    it('backfills multiple matching users with one audit entry each', async () => {
+      const { auditLog } = await import('@revealui/db/schema');
+
+      await seedUser(db.drizzle, { id: 'u1' });
+      await seedUser(db.drizzle, { id: 'u2' });
+
+      const count = await applyBackfill(db.drizzle);
+      expect(count).toBe(2);
+
+      const entries = await db.drizzle
+        .select()
+        .from(auditLog)
+        .where(eq(auditLog.eventType, EVENT_TYPE));
+
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('second apply finds 0 rows after first apply', async () => {
+      await seedUser(db.drizzle);
+
+      const firstCount = await applyBackfill(db.drizzle);
+      expect(firstCount).toBe(1);
+
+      const secondCount = await applyBackfill(db.drizzle);
+      expect(secondCount).toBe(0);
+    });
+  });
+
+  describe('ineligible rows are not touched', () => {
+    it('skips users with tosAcceptedAt already set', async () => {
+      const { users } = await import('@revealui/db/schema');
+      const existingDate = new Date('2026-03-01T00:00:00Z');
+
+      const userId = await seedUser(db.drizzle, {
+        tosAcceptedAt: existingDate,
+        tosVersion: '2026-03-01',
+      });
+
+      const count = await applyBackfill(db.drizzle);
+      expect(count).toBe(0);
+
+      const [row] = await db.drizzle
+        .select({ tosAcceptedAt: users.tosAcceptedAt })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      expect(row?.tosAcceptedAt).toEqual(existingDate);
+    });
+
+    it('skips users with role != owner', async () => {
+      const { users } = await import('@revealui/db/schema');
+
+      const userId = await seedUser(db.drizzle, { role: 'viewer' });
+      const count = await applyBackfill(db.drizzle);
+
+      expect(count).toBe(0);
+
+      const [row] = await db.drizzle
+        .select({ tosAcceptedAt: users.tosAcceptedAt })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      expect(row?.tosAcceptedAt).toBeNull();
+    });
+
+    it('skips users with emailVerified = false', async () => {
+      const { users } = await import('@revealui/db/schema');
+
+      const userId = await seedUser(db.drizzle, { emailVerified: false });
+      const count = await applyBackfill(db.drizzle);
+
+      expect(count).toBe(0);
+
+      const [row] = await db.drizzle
+        .select({ tosAcceptedAt: users.tosAcceptedAt })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      expect(row?.tosAcceptedAt).toBeNull();
+    });
+  });
+});

--- a/scripts/setup/backfill-tos-pre-458-bootstrap.ts
+++ b/scripts/setup/backfill-tos-pre-458-bootstrap.ts
@@ -1,0 +1,156 @@
+/**
+ * Backfill tosAcceptedAt for pre-#458 bootstrap admins.
+ *
+ * Bootstrap admins created before PR #458 have tosAcceptedAt = NULL because
+ * the setup flow did not persist TOS acceptance at that time. This script
+ * finds those rows and backfills them so the legal record is defensible.
+ *
+ * Closes #460 (CR-8 audit gap).
+ *
+ * Dry-run is the default. Pass `--apply` to mutate.
+ *
+ * Idempotent: a second run finds 0 rows because the WHERE clause filters on
+ * tosAcceptedAt IS NULL, which will no longer match after backfill.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Pool } from 'pg';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const APPLY_FLAG = process.argv.includes('--apply');
+const DRY_RUN = !APPLY_FLAG;
+
+const TOS_VERSION = process.env.TOS_VERSION ?? '2026-03-01';
+
+function getPostgresUrl(): string {
+  const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    process.stderr.write('✗ POSTGRES_URL (or DATABASE_URL) not set\n');
+    process.exit(2);
+  }
+  return url;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MatchedUser {
+  id: string;
+  createdAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const pool = new Pool({
+    connectionString: getPostgresUrl(),
+    max: 1,
+    connectionTimeoutMillis: 10_000,
+  });
+
+  try {
+    const findResult = await pool.query<MatchedUser>(
+      `SELECT id, created_at AS "createdAt"
+       FROM users
+       WHERE tos_accepted_at IS NULL
+         AND role = 'owner'
+         AND email_verified = true`,
+    );
+
+    const matched = findResult.rows;
+
+    if (matched.length === 0) {
+      process.stdout.write('✓ No rows require backfill\n');
+      return;
+    }
+
+    if (DRY_RUN) {
+      process.stdout.write(
+        `[dry-run] Would backfill ${matched.length} user(s) with tosAcceptedAt = createdAt, tosVersion = '${TOS_VERSION}'\n`,
+      );
+      for (const user of matched) {
+        process.stdout.write(`  user.id=${user.id} createdAt=${user.createdAt.toISOString()}\n`);
+      }
+      process.stdout.write('[dry-run] Pass --apply to apply changes\n');
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      for (const user of matched) {
+        await client.query(
+          `UPDATE users
+           SET tos_accepted_at = $1,
+               tos_version     = $2
+           WHERE id = $3
+             AND tos_accepted_at IS NULL`,
+          [user.createdAt, TOS_VERSION, user.id],
+        );
+
+        await client.query(
+          `INSERT INTO audit_log
+             (id, event_type, agent_id, severity, payload)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [
+            randomUUID(),
+            'setup:tos-backfill',
+            'setup:script:backfill-tos-pre-458-bootstrap',
+            'info',
+            JSON.stringify({
+              userId: user.id,
+              previousTosAcceptedAt: null,
+              previousTosVersion: null,
+              backfilledTosAcceptedAt: user.createdAt.toISOString(),
+              backfilledTosVersion: TOS_VERSION,
+              rationale: 'CR-8 backfill for pre-#458 bootstrap admin',
+              issue: 460,
+            }),
+          ],
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    const verifyResult = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+       FROM users
+       WHERE tos_accepted_at IS NULL
+         AND role = 'owner'
+         AND email_verified = true`,
+    );
+    const remaining = Number(verifyResult.rows[0]?.count ?? '0');
+
+    if (remaining !== 0) {
+      process.stderr.write(
+        `✗ Post-apply drift: ${remaining} row(s) still have tosAcceptedAt = NULL\n`,
+      );
+      process.exit(1);
+    }
+
+    process.stdout.write(
+      `✓ Backfilled ${matched.length} user(s); 0 rows remain with tosAcceptedAt = NULL\n`,
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`✗ backfill-tos-pre-458-bootstrap failed: ${msg}\n`);
+  process.exit(2);
+});

--- a/scripts/validate/raw-sql-allowlist.json
+++ b/scripts/validate/raw-sql-allowlist.json
@@ -85,6 +85,12 @@
       "rules": ["direct-import"],
       "reason": "KEK rotation operational tool (GAP-126 Phase 2). One-off script that performs simple SELECT/UPDATE on the two KEK-encrypted columns (user_api_keys.encrypted_key + users.mfa_secret). Uses raw pg.Pool instead of @revealui/db/client to keep the rotation tool isolated from production DB-client lifecycle (singleton pools, retry policies, observability hooks). Operator-invoked; 2 surfaces, ~3 SQL ops total. Permanent.",
       "migrationPhase": null
+    },
+    {
+      "path": "scripts/setup/backfill-tos-pre-458-bootstrap.ts",
+      "rules": ["direct-import"],
+      "reason": "CR-8 one-shot TOS backfill script (closes #460). Uses pg.Pool directly — same rationale as rotate-kek.ts: operational script that must remain isolated from @revealui/db's singleton pool, retry, and observability lifecycle. The script runs once by the founder, not in the application request path. Permanent.",
+      "migrationPhase": null
     }
   ]
 }


### PR DESCRIPTION
Closes #460

## Summary

- Adds `scripts/setup/backfill-tos-pre-458-bootstrap.ts` -- idempotent one-shot script that backfills tosAcceptedAt and tosVersion for bootstrap admins created before PR #458
- Adds allowlist entry in `scripts/validate/raw-sql-allowlist.json` for the script (pg.Pool, same rationale as rotate-kek.ts)
- Test suite in `packages/test/src/__tests__/backfill-tos-pre-458-bootstrap.test.ts` -- 9 cases via PGlite

## Script behaviour

- Finds rows: users WHERE tosAcceptedAt IS NULL AND role = owner AND emailVerified = true
- Sets tosAcceptedAt = createdAt (closest defensible proxy to bootstrap completion), tosVersion = TOS_VERSION env var (default 2026-03-01, matches bootstrap default)
- Writes one audit_log row per backfilled user (eventType: setup:tos-backfill, agentId: setup:script:backfill-tos-pre-458-bootstrap)
- Single transaction in apply mode -- partial failure rolls back cleanly
- Dry-run by default; pass --apply to mutate
- Idempotent: re-run finds 0 rows

## Test plan

- [x] packages/test vitest: 9/9 passing (dry-run, apply, idempotency, ineligible-row filtering)
- [x] Pre-push gate: all 17 checks passing including raw-SQL validator
- [x] pnpm typecheck:all: 51/51 tasks passing
- [ ] Founder runs script locally against dev DB before applying to prod