### PR TITLE
chore(server): extend drizzle mock typing — variants + importOriginal (follow-up to #935)

### DIFF
--- a/apps/server/src/lib/__tests__/billing-status.test.ts
+++ b/apps/server/src/lib/__tests__/billing-status.test.ts
@@ -30,8 +30,8 @@ vi.mock('@revealui/db/schema', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: vi.fn((_col, _val) => `eq(${String(_col)},${String(_val)})`),
-  desc: vi.fn((_col) => `desc(${String(_col)})`),
+  eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
+  desc: vi.fn((_col: unknown) => `desc(${String(_col)})`),
   sql: Object.assign((_strings: TemplateStringsArray, ..._values: unknown[]) => 'sql-expression', {
     raw: (_s: string) => 'sql-raw',
   }),

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -33,7 +33,7 @@ vi.mock('@revealui/db/schema', () => ({
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
-  eq: vi.fn((_col, _val) => `eq(${String(_col)},${String(_val)})`),
+  eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
 }));
 
 import { entitlementMiddleware, getEntitlementsFromContext } from '../entitlements.js';

--- a/apps/server/src/middleware/__tests__/resource-limits.test.ts
+++ b/apps/server/src/middleware/__tests__/resource-limits.test.ts
@@ -13,7 +13,7 @@ vi.mock('@revealui/core/observability/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
-vi.mock('drizzle-orm', async (importOriginal) => {
+vi.mock('drizzle-orm', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return {
     ...actual,

--- a/apps/server/src/routes/__tests__/a2a-edge.test.ts
+++ b/apps/server/src/routes/__tests__/a2a-edge.test.ts
@@ -127,7 +127,7 @@ vi.mock('../../middleware/task-quota.js', () => ({
   requireTaskQuota: mockRequireTaskQuota,
 }));
 
-vi.mock('@revealui/contracts', async (importOriginal) => {
+vi.mock('@revealui/contracts', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('@revealui/contracts')>();
   return {
     ...actual,

--- a/apps/server/src/routes/__tests__/a2a.test.ts
+++ b/apps/server/src/routes/__tests__/a2a.test.ts
@@ -112,7 +112,7 @@ vi.mock('../../middleware/license.js', () => ({
 }));
 
 // Contracts  -  real Zod schemas replaced with pass-through mocks
-vi.mock('@revealui/contracts', async (importOriginal) => {
+vi.mock('@revealui/contracts', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('@revealui/contracts')>();
   return {
     ...actual,

--- a/apps/server/src/routes/__tests__/gdpr-stripe-erasure.test.ts
+++ b/apps/server/src/routes/__tests__/gdpr-stripe-erasure.test.ts
@@ -96,7 +96,7 @@ vi.mock('@revealui/db/schema', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: vi.fn((_c, _v) => 'eq'),
+  eq: vi.fn((_c: unknown, _v: unknown) => 'eq'),
 }));
 
 vi.mock('@revealui/db/queries/users', () => ({

--- a/apps/server/src/routes/__tests__/marketplace-payouts-idempotent.test.ts
+++ b/apps/server/src/routes/__tests__/marketplace-payouts-idempotent.test.ts
@@ -66,7 +66,7 @@ vi.mock('drizzle-orm', () => ({
   eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
   isNull: vi.fn((_col: unknown) => `isNull(${String(_col)})`),
-  inArray: vi.fn((_col, _vals) => `inArray(${String(_col)})`),
+  inArray: vi.fn((_col: unknown, _vals: unknown) => `inArray(${String(_col)})`),
   sql: Object.assign(
     vi.fn((s: TemplateStringsArray) => String(s)),
     { join: vi.fn() },

--- a/apps/server/src/routes/__tests__/marketplace-x402-kill.test.ts
+++ b/apps/server/src/routes/__tests__/marketplace-x402-kill.test.ts
@@ -84,7 +84,7 @@ vi.mock('@revealui/db/schema', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: vi.fn((_c, _v) => 'eq'),
+  eq: vi.fn((_c: unknown, _v: unknown) => 'eq'),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
   asc: vi.fn(() => 'asc'),
   sql: vi.fn(() => 'sql'),

--- a/apps/server/src/routes/__tests__/publish-scheduled-edge.test.ts
+++ b/apps/server/src/routes/__tests__/publish-scheduled-edge.test.ts
@@ -20,7 +20,7 @@ vi.mock('@revealui/db/client', () => ({
   getClient: vi.fn(),
 }));
 
-vi.mock('drizzle-orm', async (importOriginal) => {
+vi.mock('drizzle-orm', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return actual;
 });

--- a/apps/server/src/routes/__tests__/publish-scheduled.test.ts
+++ b/apps/server/src/routes/__tests__/publish-scheduled.test.ts
@@ -10,7 +10,7 @@ vi.mock('@revealui/db/client', () => ({
 }));
 
 // drizzle-orm operators are used directly in the route; stub them to pass-through
-vi.mock('drizzle-orm', async (importOriginal) => {
+vi.mock('drizzle-orm', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return actual;
 });

--- a/apps/server/src/routes/__tests__/revmarket.test.ts
+++ b/apps/server/src/routes/__tests__/revmarket.test.ts
@@ -74,7 +74,7 @@ vi.mock('../../middleware/x402.js', () => ({
   getAdvertisedCurrencyLabel: () => 'usdc-only',
 }));
 
-vi.mock('../../services/revmarket-executor.js', async (importOriginal) => {
+vi.mock('../../services/revmarket-executor.js', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('../../services/revmarket-executor.js')>();
   return {
     ...actual,

--- a/apps/server/src/routes/__tests__/webhook-livemode.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-livemode.test.ts
@@ -91,7 +91,7 @@ vi.mock('@revealui/db/schema', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: vi.fn((_c, _v) => `eq`),
+  eq: vi.fn((_c: unknown, _v: unknown) => `eq`),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
   desc: vi.fn(() => 'desc'),
   isNull: vi.fn(() => 'isNull'),

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -199,8 +199,8 @@ vi.mock('drizzle-orm', () => ({
       join: vi.fn((...args: unknown[]) => args),
     },
   ),
-  inArray: vi.fn((_col, _vals) => `inArray`),
-  notInArray: vi.fn((_col, _vals) => `notInArray`),
+  inArray: vi.fn((_col: unknown, _vals: unknown) => `inArray`),
+  notInArray: vi.fn((_col: unknown, _vals: unknown) => `notInArray`),
   count: vi.fn(() => 'count()'),
   countDistinct: vi.fn((_col: unknown) => `countDistinct(${String(_col)})`),
 }));


### PR DESCRIPTION
## Summary

Follow-up to [#935](https://github.com/RevealUIStudio/revealui/pull/935). Catches the implicit-any patterns the first sweep missed:

- **3 `__tests__` directories** beyond `routes/__tests__/`: `apps/server/src/lib/__tests__/`, `apps/server/src/middleware/__tests__/`.
- **Variable name variants** beyond `_col`/`_val`: `(_c, _v)`, `(_col, _vals)`.
- **`importOriginal`** callback param on `vi.mock(..., async (importOriginal) => ...)`.

13 files, 15 type annotations.

## Diff shape

```diff
-vi.fn((_c, _v) => 'eq'),
+vi.fn((_c: unknown, _v: unknown) => 'eq'),

-vi.fn((_col, _vals) => `inArray(${String(_col)})`),
+vi.fn((_col: unknown, _vals: unknown) => `inArray(${String(_col)})`),

-vi.mock('drizzle-orm', async (importOriginal) => {
+vi.mock('drizzle-orm', async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   ...
});
```

The `<T>() => Promise<T>` shape matches vitest's `MockFactory` second arg — preserves the polymorphic call-site behavior (`importOriginal<typeof import('drizzle-orm')>()` still typechecks because T is inferred at the call site).

## Verification

```
$ pnpm turbo typecheck --filter=server
 Tasks:    15 successful, 15 total
 Cached:   14 cached, 15 total
  Time:    32s
```

0 errors locally. Same caveats as #935:
- These were cosmetic Vercel-only `##[error]` annotations that don't fail `vercel build` (deploys went through unchanged).
- CI workflow on test has been green throughout.
- This PR is durable code-quality cleanup per the strict-mode rule, not gap-closing.

## Method

Literal-string replacement via one-shot `/tmp/fix-drizzle-mocks-v2.mjs` (not committed — same pattern as #935's `/tmp/fix-drizzle-mocks.mjs`). No regex authored, per fleet no-regex rule.

## Bucket #3 status after this PR

| Pattern | Count | Status |
|---|---|---|
| Drizzle mock callbacks (`_col`/`_val` — routes/__tests__/) | 105 | ✅ #935 |
| Drizzle mock callback variants (`_c`/`_v`/`_vals`) + 3 dirs | ~15 | **this PR** |
| `importOriginal` callback | ~6 | **this PR** |
| React `props` on Vite-app showcase files | ~86 | TBD (different fix per component — needs Recharts types) |
| Recharts `e` event handlers | ~16 | TBD |
| Hono `c` context | ~9 | TBD (easy: `c: Context`) |
| Other (`slug`, `m`, `tier`, `s`, `p`, `file`, `t`, `event`, `col`) | ~40 | long tail, varied fixes |
