### PR TITLE
chore(docs): annotate showcase props param (Record<string, unknown>) — 86 annotations

### DIFF
--- a/apps/docs/app/showcase/accordion.showcase.tsx
+++ b/apps/docs/app/showcase/accordion.showcase.tsx
@@ -19,7 +19,7 @@ const story: ShowcaseStory = {
     defaultOpen: { type: 'boolean', default: false },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const count = props.items as number;
     const defaultOpen = props.defaultOpen as boolean;
     const items = Array.from({ length: count }, (_, i) => ({
@@ -79,7 +79,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const open = props.defaultOpen ? ' defaultOpen' : '';
     return `<Accordion>
   <AccordionItem title="Section 1"${open}>

--- a/apps/docs/app/showcase/alert.showcase.tsx
+++ b/apps/docs/app/showcase/alert.showcase.tsx
@@ -54,7 +54,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => <AlertDemo size={props.size as string} />,
+  render: (props: Record<string, unknown>) => <AlertDemo size={props.size as string} />,
 
   examples: [
     {
@@ -86,7 +86,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Alert open={open} onClose={() => setOpen(false)}${props.size !== 'md' ? ` size="${props.size}"` : ''}>
   <AlertTitle>Confirm Action</AlertTitle>
   <AlertDescription>Are you sure?</AlertDescription>

--- a/apps/docs/app/showcase/animations.showcase.tsx
+++ b/apps/docs/app/showcase/animations.showcase.tsx
@@ -143,7 +143,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const demo = props.demo as string;
 
     if (demo === 'presence') return <PresenceDemo />;
@@ -216,7 +216,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     if (props.demo === 'presence') {
       return `const { mounted, present, ref } = usePresence(show, 300);
 

--- a/apps/docs/app/showcase/avatar-group.showcase.tsx
+++ b/apps/docs/app/showcase/avatar-group.showcase.tsx
@@ -33,7 +33,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <AvatarGroup
       items={teamMembers}
       max={props.max as number}
@@ -59,7 +59,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = ['items={users}'];
     if (props.max !== 5) attrs.push(`max={${props.max}}`);
     if (props.size !== 'md') attrs.push(`size="${props.size}"`);

--- a/apps/docs/app/showcase/avatar.showcase.tsx
+++ b/apps/docs/app/showcase/avatar.showcase.tsx
@@ -14,7 +14,7 @@ const story: ShowcaseStory = {
     alt: { type: 'text', default: 'User avatar' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Avatar
       initials={props.initials as string}
       square={props.square as boolean}
@@ -58,7 +58,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.initials) attrs.push(`initials="${props.initials}"`);
     if (props.square) attrs.push('square');

--- a/apps/docs/app/showcase/badge.showcase.tsx
+++ b/apps/docs/app/showcase/badge.showcase.tsx
@@ -33,7 +33,9 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'Badge' },
   },
 
-  render: (props) => <Badge color={props.color as 'zinc'}>{props.children as string}</Badge>,
+  render: (props: Record<string, unknown>) => (
+    <Badge color={props.color as 'zinc'}>{props.children as string}</Badge>
+  ),
 
   variantGrid: {
     color: badgeColors,
@@ -65,7 +67,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const colorAttr = props.color !== 'zinc' ? ` color="${props.color}"` : '';
     return `<Badge${colorAttr}>${props.children}</Badge>`;
   },

--- a/apps/docs/app/showcase/breadcrumb.showcase.tsx
+++ b/apps/docs/app/showcase/breadcrumb.showcase.tsx
@@ -17,7 +17,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const depth = props.depth as number;
     const allItems = [
       { label: 'Home', href: '#' },
@@ -60,7 +60,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const depth = props.depth as number;
     const items = [
       '{ label: "Home", href: "/" }',

--- a/apps/docs/app/showcase/button.showcase.tsx
+++ b/apps/docs/app/showcase/button.showcase.tsx
@@ -24,7 +24,7 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'Click me' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Button
       variant={props.variant as 'default'}
       size={props.size as 'default'}
@@ -71,7 +71,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.variant !== 'default') attrs.push(`variant="${props.variant}"`);
     if (props.size !== 'default') attrs.push(`size="${props.size}"`);

--- a/apps/docs/app/showcase/callout.showcase.tsx
+++ b/apps/docs/app/showcase/callout.showcase.tsx
@@ -18,7 +18,7 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'This is important information you should know about.' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Callout variant={props.variant as 'info'} title={props.title as string}>
       {props.children as string}
     </Callout>
@@ -59,7 +59,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.variant !== 'info') attrs.push(`variant="${props.variant}"`);
     if (props.title) attrs.push(`title="${props.title}"`);

--- a/apps/docs/app/showcase/card.showcase.tsx
+++ b/apps/docs/app/showcase/card.showcase.tsx
@@ -26,7 +26,7 @@ const story: ShowcaseStory = {
     showFooter: { type: 'boolean', default: true },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Card className="w-[350px]">
       <CardHeader>
         <CardTitle>{props.title as string}</CardTitle>
@@ -84,7 +84,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const lines = [
       '<Card>',
       '  <CardHeader>',

--- a/apps/docs/app/showcase/checkbox.showcase.tsx
+++ b/apps/docs/app/showcase/checkbox.showcase.tsx
@@ -13,7 +13,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     // biome-ignore lint/a11y/noLabelWithoutControl: Checkbox uses role="checkbox" (ARIA)
     <label className="flex items-center gap-3">
       <Checkbox checked={props.checked as boolean} disabled={props.disabled as boolean} />
@@ -67,7 +67,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.checked) attrs.push('checked');
     if (props.disabled) attrs.push('disabled');

--- a/apps/docs/app/showcase/code-block.showcase.tsx
+++ b/apps/docs/app/showcase/code-block.showcase.tsx
@@ -13,7 +13,7 @@ const story: ShowcaseStory = {
     showCopy: { type: 'boolean', default: true },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <CodeBlock
       code={`import { Button } from '@revealui/presentation/server';
 
@@ -47,7 +47,7 @@ export function App() {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<CodeBlock
   code="const x = 1;"
   language="${props.language}"${props.filename ? `\n  filename="${props.filename}"` : ''}${!props.showCopy ? '\n  showCopy={false}' : ''}

--- a/apps/docs/app/showcase/combobox.showcase.tsx
+++ b/apps/docs/app/showcase/combobox.showcase.tsx
@@ -23,7 +23,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-72">
       <Combobox
         options={frameworks}
@@ -62,7 +62,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Combobox
   options={items}
   displayValue={(item) => item.name}

--- a/apps/docs/app/showcase/dialog.showcase.tsx
+++ b/apps/docs/app/showcase/dialog.showcase.tsx
@@ -58,7 +58,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => <DialogDemo {...props} />,
+  render: (props: Record<string, unknown>) => <DialogDemo {...props} />,
 
   examples: [
     {
@@ -93,7 +93,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const sizeAttr = props.size !== 'lg' ? ` size="${props.size}"` : '';
     return [
       `<Dialog open={open} onClose={() => setOpen(false)}${sizeAttr}>`,

--- a/apps/docs/app/showcase/divider.showcase.tsx
+++ b/apps/docs/app/showcase/divider.showcase.tsx
@@ -11,7 +11,7 @@ const story: ShowcaseStory = {
     soft: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-80 space-y-4">
       <p className="text-sm text-(--rvui-color-text)">Content above</p>
       <Divider soft={props.soft as boolean} />
@@ -34,7 +34,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => `<Divider${props.soft ? ' soft' : ''} />`,
+  code: (props: Record<string, unknown>) => `<Divider${props.soft ? ' soft' : ''} />`,
 };
 
 export default story;

--- a/apps/docs/app/showcase/drawer.showcase.tsx
+++ b/apps/docs/app/showcase/drawer.showcase.tsx
@@ -46,7 +46,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => <DrawerDemo {...props} />,
+  render: (props: Record<string, unknown>) => <DrawerDemo {...props} />,
 
   examples: [
     {
@@ -81,7 +81,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const side = props.side !== 'right' ? ` side="${props.side}"` : '';
     return `<Drawer open={open} onClose={() => setOpen(false)}${side}>
   <DrawerHeader onClose={() => setOpen(false)}>Title</DrawerHeader>

--- a/apps/docs/app/showcase/dropdown.showcase.tsx
+++ b/apps/docs/app/showcase/dropdown.showcase.tsx
@@ -23,7 +23,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Dropdown>
       <DropdownButton as={Button}>Actions</DropdownButton>
       <DropdownMenu anchor={props.anchor as 'bottom' | 'top'}>
@@ -64,7 +64,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Dropdown>
   <DropdownButton as={Button}>Actions</DropdownButton>
   <DropdownMenu anchor="${props.anchor}">

--- a/apps/docs/app/showcase/empty-state.showcase.tsx
+++ b/apps/docs/app/showcase/empty-state.showcase.tsx
@@ -21,7 +21,7 @@ const story: ShowcaseStory = {
     showIcon: { type: 'boolean', default: true },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <EmptyState
       icon={props.showIcon ? <IconSearch size="lg" /> : undefined}
       title={props.title as string}
@@ -68,7 +68,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.showIcon) attrs.push('icon={<IconSearch size="lg" />}');
     attrs.push(`title="${props.title}"`);

--- a/apps/docs/app/showcase/fieldset.showcase.tsx
+++ b/apps/docs/app/showcase/fieldset.showcase.tsx
@@ -21,7 +21,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Fieldset disabled={props.disabled as boolean}>
       <Legend>Account Details</Legend>
       <FieldGroup>
@@ -56,7 +56,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Fieldset${props.disabled ? ' disabled' : ''}>
   <Legend>Account Details</Legend>
   <FieldGroup>

--- a/apps/docs/app/showcase/heading.showcase.tsx
+++ b/apps/docs/app/showcase/heading.showcase.tsx
@@ -16,7 +16,7 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'Page Title' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div>
       <Heading level={Number(props.level) as 1 | 2 | 3 | 4 | 5 | 6}>
         {props.children as string}
@@ -47,7 +47,8 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => `<Heading level={${props.level}}>${props.children}</Heading>`,
+  code: (props: Record<string, unknown>) =>
+    `<Heading level={${props.level}}>${props.children}</Heading>`,
 };
 
 export default story;

--- a/apps/docs/app/showcase/icons.showcase.tsx
+++ b/apps/docs/app/showcase/icons.showcase.tsx
@@ -114,7 +114,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const size = props.size as (typeof sizes)[number];
     const group = props.group as string;
     const filtered = group === 'All' ? allIcons : allIcons.filter((i) => i.group === group);
@@ -186,7 +186,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `import { IconStar } from '@revealui/presentation/server';
 
 <IconStar size="${props.size}"${props.size === 'md' ? '' : ''} />`,

--- a/apps/docs/app/showcase/input.showcase.tsx
+++ b/apps/docs/app/showcase/input.showcase.tsx
@@ -17,7 +17,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Input
       type={props.type as string}
       placeholder={props.placeholder as string}
@@ -45,7 +45,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.type !== 'text') attrs.push(`type="${props.type}"`);
     if (props.placeholder) attrs.push(`placeholder="${props.placeholder}"`);

--- a/apps/docs/app/showcase/kbd.showcase.tsx
+++ b/apps/docs/app/showcase/kbd.showcase.tsx
@@ -11,7 +11,7 @@ const story: ShowcaseStory = {
     separator: { type: 'text', default: '+' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <KbdShortcut keys={['Ctrl', 'Shift', 'P']} separator={props.separator as string} />
   ),
 
@@ -48,7 +48,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<KbdShortcut keys={['Ctrl', 'Shift', 'P']}${props.separator !== '+' ? ` separator="${props.separator}"` : ''} />`,
 };
 

--- a/apps/docs/app/showcase/link.showcase.tsx
+++ b/apps/docs/app/showcase/link.showcase.tsx
@@ -13,7 +13,9 @@ const story: ShowcaseStory = {
     href: { type: 'text', default: '#' },
   },
 
-  render: (props) => <Link href={props.href as string}>{props.children as string}</Link>,
+  render: (props: Record<string, unknown>) => (
+    <Link href={props.href as string}>{props.children as string}</Link>
+  ),
 
   examples: [
     {
@@ -27,7 +29,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => `<Link href="${props.href}">${props.children}</Link>`,
+  code: (props: Record<string, unknown>) => `<Link href="${props.href}">${props.children}</Link>`,
 };
 
 export default story;

--- a/apps/docs/app/showcase/linkbutton.showcase.tsx
+++ b/apps/docs/app/showcase/linkbutton.showcase.tsx
@@ -26,7 +26,7 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'Book a call' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <LinkButton
       href={props.href as string}
       external={props.external as boolean}
@@ -91,7 +91,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [`href="${props.href}"`];
     if (props.external) attrs.push('external');
     if (props.variant !== 'default') attrs.push(`variant="${props.variant}"`);

--- a/apps/docs/app/showcase/listbox.showcase.tsx
+++ b/apps/docs/app/showcase/listbox.showcase.tsx
@@ -20,7 +20,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-64">
       <Listbox
         placeholder={props.placeholder as string}
@@ -67,7 +67,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Listbox placeholder="${props.placeholder}"${props.disabled ? ' disabled' : ''}>
   <ListboxOption value="active">
     <ListboxLabel>Active</ListboxLabel>

--- a/apps/docs/app/showcase/navbar.showcase.tsx
+++ b/apps/docs/app/showcase/navbar.showcase.tsx
@@ -22,7 +22,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const active = props.activeItem as string;
 
     return (

--- a/apps/docs/app/showcase/pagination.showcase.tsx
+++ b/apps/docs/app/showcase/pagination.showcase.tsx
@@ -25,7 +25,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const active = props.activePage as number;
 
     return (

--- a/apps/docs/app/showcase/progress.showcase.tsx
+++ b/apps/docs/app/showcase/progress.showcase.tsx
@@ -30,7 +30,7 @@ const story: ShowcaseStory = {
     showValue: { type: 'boolean', default: true },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-full max-w-md">
       <Progress
         value={props.value as number}
@@ -78,7 +78,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [`value={${props.value}}`];
     if (props.color !== 'blue') attrs.push(`color="${props.color}"`);
     if (props.size !== 'md') attrs.push(`size="${props.size}"`);

--- a/apps/docs/app/showcase/radio.showcase.tsx
+++ b/apps/docs/app/showcase/radio.showcase.tsx
@@ -28,7 +28,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <RadioGroup defaultValue="option-1" disabled={props.disabled as boolean}>
       {['Option 1', 'Option 2', 'Option 3'].map((label, i) => (
         <RadioField key={label}>
@@ -89,7 +89,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<RadioGroup defaultValue="option-1"${props.disabled ? ' disabled' : ''}>
   <RadioField>
     <Radio color="${props.color}" value="option-1" />

--- a/apps/docs/app/showcase/rating.showcase.tsx
+++ b/apps/docs/app/showcase/rating.showcase.tsx
@@ -23,7 +23,7 @@ const story: ShowcaseStory = {
     readOnly: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Rating
       defaultValue={3}
       max={props.max as number}
@@ -55,7 +55,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = ['defaultValue={3}'];
     if (props.max !== 5) attrs.push(`max={${props.max}}`);
     if (props.size !== 'md') attrs.push(`size="${props.size}"`);

--- a/apps/docs/app/showcase/select.showcase.tsx
+++ b/apps/docs/app/showcase/select.showcase.tsx
@@ -18,7 +18,7 @@ const story: ShowcaseStory = {
     placeholder: { type: 'text', default: 'Choose a fruit...' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Select>
       <SelectTrigger className="w-64">
         <SelectValue placeholder={props.placeholder as string} />
@@ -51,7 +51,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Select>
   <SelectTrigger>
     <SelectValue placeholder="${props.placeholder}" />

--- a/apps/docs/app/showcase/sidebar.showcase.tsx
+++ b/apps/docs/app/showcase/sidebar.showcase.tsx
@@ -25,7 +25,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const active = props.activeItem as string;
 
     return (

--- a/apps/docs/app/showcase/skeleton.showcase.tsx
+++ b/apps/docs/app/showcase/skeleton.showcase.tsx
@@ -23,7 +23,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const variant = props.variant as string;
 
     if (variant === 'text') {
@@ -69,7 +69,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     if (props.variant === 'text') return `<SkeletonText lines={${props.lines}} />`;
     if (props.variant === 'card') return `<SkeletonCard />`;
     return `<Skeleton className="h-4 w-full rounded" />`;

--- a/apps/docs/app/showcase/slider.showcase.tsx
+++ b/apps/docs/app/showcase/slider.showcase.tsx
@@ -15,7 +15,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-72">
       <Slider
         defaultValue={50}
@@ -48,7 +48,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = ['defaultValue={50}'];
     if (props.min !== 0) attrs.push(`min={${props.min}}`);
     if (props.max !== 100) attrs.push(`max={${props.max}}`);

--- a/apps/docs/app/showcase/stat.showcase.tsx
+++ b/apps/docs/app/showcase/stat.showcase.tsx
@@ -16,7 +16,7 @@ const story: ShowcaseStory = {
     description: { type: 'text', default: 'from last month' },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Stat
       label={props.label as string}
       value={props.value as string}
@@ -62,7 +62,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs = [`label="${props.label}"`, `value="${props.value}"`];
     if (props.change) attrs.push(`change="${props.change}"`);
     if (props.trend !== 'up') attrs.push(`trend="${props.trend}"`);

--- a/apps/docs/app/showcase/stepper.showcase.tsx
+++ b/apps/docs/app/showcase/stepper.showcase.tsx
@@ -23,7 +23,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const current = props.currentStep as number;
     const steps = [
       { label: 'Account', description: 'Create your account' },
@@ -58,7 +58,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `<Stepper
   orientation="${props.orientation}"
   steps={[

--- a/apps/docs/app/showcase/switch.showcase.tsx
+++ b/apps/docs/app/showcase/switch.showcase.tsx
@@ -40,7 +40,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Switch
       color={props.color as (typeof COLORS)[number]}
       defaultChecked={props.defaultChecked as boolean}
@@ -91,7 +91,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.color !== 'dark/zinc') attrs.push(`color="${props.color}"`);
     if (props.defaultChecked) attrs.push('defaultChecked');

--- a/apps/docs/app/showcase/table.showcase.tsx
+++ b/apps/docs/app/showcase/table.showcase.tsx
@@ -30,7 +30,7 @@ const story: ShowcaseStory = {
     striped: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <Table
       bleed={props.bleed as boolean}
       dense={props.dense as boolean}
@@ -119,7 +119,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     if (props.bleed) attrs.push('bleed');
     if (props.dense) attrs.push('dense');

--- a/apps/docs/app/showcase/tabs.showcase.tsx
+++ b/apps/docs/app/showcase/tabs.showcase.tsx
@@ -18,7 +18,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const count = props.tabCount as number;
     const tabs = Array.from({ length: count }, (_, i) => ({
       id: `tab-${i + 1}`,

--- a/apps/docs/app/showcase/text.showcase.tsx
+++ b/apps/docs/app/showcase/text.showcase.tsx
@@ -16,7 +16,7 @@ const story: ShowcaseStory = {
     children: { type: 'text', default: 'The quick brown fox jumps over the lazy dog.' },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const variant = props.variant as string;
     const content = props.children as string;
 
@@ -71,7 +71,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const variant = props.variant as string;
     const content = props.children as string;
     if (variant === 'strong') return `<Text><Strong>${content}</Strong></Text>`;

--- a/apps/docs/app/showcase/textarea.showcase.tsx
+++ b/apps/docs/app/showcase/textarea.showcase.tsx
@@ -13,7 +13,7 @@ const story: ShowcaseStory = {
     disabled: { type: 'boolean', default: false },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="w-80">
       <Textarea
         placeholder={props.placeholder as string}
@@ -48,7 +48,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [];
     attrs.push(`placeholder="${props.placeholder}"`);
     if (props.rows !== 4) attrs.push(`rows={${props.rows}}`);

--- a/apps/docs/app/showcase/theme.showcase.tsx
+++ b/apps/docs/app/showcase/theme.showcase.tsx
@@ -102,7 +102,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) =>
+  code: (props: Record<string, unknown>) =>
     `const { theme, resolvedTheme, setTheme } = useTheme();
 
 // Current: theme="${props.mode}", resolved to the active mode

--- a/apps/docs/app/showcase/timeline.showcase.tsx
+++ b/apps/docs/app/showcase/timeline.showcase.tsx
@@ -17,7 +17,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => {
+  render: (props: Record<string, unknown>) => {
     const count = props.items as number;
     const events = [
       { title: 'Project created', date: 'Jan 1', description: 'Initial repository setup' },

--- a/apps/docs/app/showcase/toast.showcase.tsx
+++ b/apps/docs/app/showcase/toast.showcase.tsx
@@ -90,7 +90,7 @@ const story: ShowcaseStory = {
     description: { type: 'text', default: 'Your settings have been updated.' },
   },
 
-  render: (props) => <ToastDemoWrapper {...props} />,
+  render: (props: Record<string, unknown>) => <ToastDemoWrapper {...props} />,
 
   examples: [
     {
@@ -103,7 +103,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [`title: '${props.title}'`];
     if (props.description) attrs.push(`description: '${props.description}'`);
     if (props.variant !== 'default') attrs.push(`variant: '${props.variant}'`);

--- a/apps/docs/app/showcase/tooltip.showcase.tsx
+++ b/apps/docs/app/showcase/tooltip.showcase.tsx
@@ -25,7 +25,7 @@ const story: ShowcaseStory = {
     },
   },
 
-  render: (props) => (
+  render: (props: Record<string, unknown>) => (
     <div className="flex items-center justify-center py-12">
       <Tooltip
         content={props.content as string}
@@ -69,7 +69,7 @@ const story: ShowcaseStory = {
     },
   ],
 
-  code: (props) => {
+  code: (props: Record<string, unknown>) => {
     const attrs: string[] = [`content="${props.content}"`];
     if (props.side !== 'top') attrs.push(`side="${props.side}"`);
     if (props.delay !== 200) attrs.push(`delay={${props.delay}}`);


### PR DESCRIPTION
## Summary

Annotates the `props` parameter in 46 [showcase files](apps/docs/app/showcase/) — 86 total type annotations on `render` and `code` callbacks. Closes the largest remaining cluster from the post-#915 audit's TS7006 bucket.

## Diff shape

```diff
-render: (props) => (
+render: (props: Record<string, unknown>) => (
   <Tooltip
     content={props.content as string}
     side={props.side as 'top' | 'bottom' | 'left' | 'right'}
   />
 ),

-code: (props) => {
+code: (props: Record<string, unknown>) => {
   const attrs: string[] = [`content="${props.content}"`];
   ...
 },
```

## Why explicit annotation (not contextual typing)

The [`ShowcaseStory`](apps/docs/app/components/showcase/types.ts:50) type already declares:

```ts
render: (props: Record<string, unknown>) => React.ReactNode;
code?:  (props: Record<string, unknown>) => string;
```

In healthy TS, contextual typing on a property-assignment inside a `ShowcaseStory`-annotated object literal would infer the param type — and **does locally** (`pnpm turbo typecheck --filter=docs` → 0 errors before this change). In CI's Vercel cold-cache `vercel build` env, the contextual typing fails. Explicit annotation at the call site matches the declared type and silences the errors deterministically regardless of inference depth.

No runtime behavior change — bodies already do `as` casts on the indexed access.

## Verification

```
$ pnpm turbo typecheck --filter=docs
 Tasks:    12 successful, 12 total
 Cached:   11 cached, 12 total
  Time:    6.5s
```

0 errors. Pre-commit Biome formatter ran (slight insertion delta: 91 inserts / 86 deletes = 5 lines of formatting normalization).

## Method

Literal-string replacement via one-shot `/tmp/fix-showcase-props.mjs` (not committed). No regex authored, per fleet no-regex rule. Two patterns: `render: (props) =>` and `code: (props) =>`.

## Cumulative bucket #3 progress

| | PR | Annotations |
|---|---|---|
| Drizzle mocks routes/__tests__ | [#935](https://github.com/RevealUIStudio/revealui/pull/935) | 105 |
| Drizzle mocks variants + 3 dirs + importOriginal | [#938](https://github.com/RevealUIStudio/revealui/pull/938) | 15 |
| **Showcase `props` (46 files)** | **this PR** | **86** |
| **Bucket #3a + 3b cumulative** | | **206 / ~426** |

Remaining: ~220 errors split across (per architect's audit) Recharts `e` event handlers (~16), Hono `c` heterogeneous (~9), `slug`/`m`/`tier`/etc. long tail (~40), `_label` drizzle alias (~4), `importOriginal` in non-`drizzle-orm` mocks if any, and the React `props` handful outside showcase files. Each remaining bucket needs per-pattern judgment and is sub-10-error scope — diminishing returns on mechanical sweeps from here.

## Same posture as #935/#938

These were cosmetic Vercel-only `##[error]` annotations that don't fail `vercel build`. CI workflow on test has been green throughout. Durable code-quality cleanup per strict-mode rule.
