### PR TITLE
chore(tests): type call param in .mock.calls callbacks (13 annotations)

### DIFF
--- a/apps/docs/__tests__/utils/file-discovery.test.ts
+++ b/apps/docs/__tests__/utils/file-discovery.test.ts
@@ -149,7 +149,7 @@ describe('discoverFiles', () => {
     // Second call onwards should use HEAD method
     const headCalls = vi
       .mocked(fetch)
-      .mock.calls.filter((call) => typeof call[1] === 'object' && call[1]?.method === 'HEAD');
+      .mock.calls.filter((call: Parameters<typeof fetch>) => call[1]?.method === 'HEAD');
     expect(headCalls.length).toBeGreaterThan(0);
   });
 });

--- a/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
+++ b/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
@@ -545,7 +545,7 @@ describe('Billing lifecycle integration', () => {
       expect(mockDb.update).toHaveBeenCalled();
       const updateCalls = mockDbUpdateChain.set.mock.calls;
       const hasActiveUpdate = updateCalls.some(
-        (call) => (call[0] as Record<string, unknown>).status === 'active',
+        (call: unknown[]) => (call[0] as Record<string, unknown>).status === 'active',
       );
       expect(hasActiveUpdate).toBe(true);
 
@@ -780,7 +780,7 @@ describe('Billing lifecycle integration', () => {
       // subscriptions.update is called once for license key metadata (from checkout flow),
       // but NOT called with pending_change metadata clearing
       const pendingChangeCalls = mockSubscriptionsUpdate.mock.calls.filter(
-        (call) =>
+        (call: unknown[]) =>
           (call[1] as Record<string, Record<string, string>>)?.metadata?.pending_change === '',
       );
       expect(pendingChangeCalls).toHaveLength(0);

--- a/apps/server/src/routes/__tests__/webhook-payment-action-required.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-payment-action-required.test.ts
@@ -461,7 +461,7 @@ describe('POST /stripe webhook  -  invoice.payment_action_required (3DS/SCA)', (
       // DrizzleAuditStore.append is called with a single object:
       //   { id, timestamp, eventType, severity, agentId, payload, policyViolations }
       expect(mockAuditAppend).toHaveBeenCalled();
-      const found = mockAuditAppend.mock.calls.some((call) => {
+      const found = mockAuditAppend.mock.calls.some((call: unknown[]) => {
         const entry = call[0] as { eventType?: string } | undefined;
         return entry?.eventType === 'payment.action_required';
       });
@@ -477,7 +477,7 @@ describe('POST /stripe webhook  -  invoice.payment_action_required (3DS/SCA)', (
       const app = createApp();
       await app.request(postStripe(event));
 
-      const found = mockAuditAppend.mock.calls.some((call) => {
+      const found = mockAuditAppend.mock.calls.some((call: unknown[]) => {
         const entry = call[0] as { payload?: Record<string, unknown> } | undefined;
         return entry?.payload?.hostedInvoiceUrl === 'https://invoice.stripe.com/i/abc123';
       });
@@ -545,7 +545,7 @@ describe('POST /stripe webhook  -  invoice.payment_action_required (3DS/SCA)', (
       const found = vi
         .mocked(loggerModule.logger)
         .info.mock.calls.some(
-          (call) =>
+          (call: unknown[]) =>
             typeof call[0] === 'string' &&
             (call[0].includes('3DS') ||
               call[0].includes('SCA') ||

--- a/apps/server/src/routes/__tests__/webhook-payment-intent-requires-action.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-payment-intent-requires-action.test.ts
@@ -424,7 +424,7 @@ describe('POST /stripe webhook  -  payment_intent.requires_action (3DS/SCA, one-
       await app.request(postStripe(event));
 
       expect(mockAuditAppend).toHaveBeenCalled();
-      const found = mockAuditAppend.mock.calls.some((call) => {
+      const found = mockAuditAppend.mock.calls.some((call: unknown[]) => {
         const entry = call[0] as { eventType?: string } | undefined;
         return entry?.eventType === 'payment_intent.action_required';
       });
@@ -442,7 +442,7 @@ describe('POST /stripe webhook  -  payment_intent.requires_action (3DS/SCA, one-
       const app = createApp();
       await app.request(postStripe(event));
 
-      const found = mockAuditAppend.mock.calls.some((call) => {
+      const found = mockAuditAppend.mock.calls.some((call: unknown[]) => {
         const entry = call[0] as { payload?: Record<string, unknown> } | undefined;
         return (
           entry?.payload?.paymentIntentId === 'pi_test_requires_action' &&
@@ -517,7 +517,7 @@ describe('POST /stripe webhook  -  payment_intent.requires_action (3DS/SCA, one-
       const found = vi
         .mocked(loggerModule.logger)
         .info.mock.calls.some(
-          (call) =>
+          (call: unknown[]) =>
             typeof call[0] === 'string' &&
             (call[0].includes('3DS') ||
               call[0].includes('SCA') ||

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -321,7 +321,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
 
     expect(mockDb.update).toHaveBeenCalled();
     const updateSetArg = mockDbUpdateChain.set.mock.calls.find(
-      (call) => (call[0] as Record<string, unknown>).status === 'revoked',
+      (call: unknown[]) => (call[0] as Record<string, unknown>).status === 'revoked',
     );
     expect(updateSetArg).toBeDefined();
   });
@@ -344,7 +344,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     const app = createApp();
     await app.request(postStripe(event));
 
-    const emailCall = mockSendEmail.mock.calls.find((call) => {
+    const emailCall = mockSendEmail.mock.calls.find((call: unknown[]) => {
       const opts = call[0] as Record<string, unknown>;
       return (
         opts.to === 'enterprise@example.com' &&
@@ -373,7 +373,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     await app.request(postStripe(event));
 
     const revokeCall = mockDbUpdateChain.set.mock.calls.find(
-      (call) => (call[0] as Record<string, unknown>).status === 'revoked',
+      (call: unknown[]) => (call[0] as Record<string, unknown>).status === 'revoked',
     );
     expect(revokeCall).toBeUndefined();
   });
@@ -398,7 +398,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     expect(res.status).toBe(200);
 
     const revokeCall = mockDbUpdateChain.set.mock.calls.find(
-      (call) => (call[0] as Record<string, unknown>).status === 'revoked',
+      (call: unknown[]) => (call[0] as Record<string, unknown>).status === 'revoked',
     );
     expect(revokeCall).toBeDefined();
   });


### PR DESCRIPTION
## Summary

Annotates 13 implicit-any `call` parameters in vitest `.mock.calls.<find|filter|some>()` introspection callbacks. 5 files / 13 annotations. Bucket #3b follow-up to [#935](https://github.com/RevealUIStudio/revealui/pull/935), [#938](https://github.com/RevealUIStudio/revealui/pull/938), [#939](https://github.com/RevealUIStudio/revealui/pull/939).

## Diff shape

**Server tests** (4 files) — bodies use `(call[N] as Type)` casts; `unknown[]` is compatible:

```diff
-mock.calls.find((call) => (call[0] as Record<string, unknown>).status === 'revoked'),
+mock.calls.find((call: unknown[]) => (call[0] as Record<string, unknown>).status === 'revoked'),
```

**apps/docs/file-discovery.test.ts** — uses `call[1]?.method` property access; needs the typed `Parameters` shape:

```diff
-.mock.calls.filter((call) => typeof call[1] === 'object' && call[1]?.method === 'HEAD');
+.mock.calls.filter((call: Parameters<typeof fetch>) => call[1]?.method === 'HEAD');
```

The `typeof call[1] === 'object'` runtime guard becomes redundant because `call[1]` is now typed as `RequestInit | undefined` — the optional chain `?.method` already covers undefined.

## Verification

```
$ pnpm turbo typecheck --filter=server --filter=docs
 Tasks:    18 successful, 18 total
 Cached:   17 cached, 18 total
  Time:    25s
```

0 errors. No behavior change in either pattern.

## Method

Script `/tmp/fix-mock-call-params.mjs` (literal-string replacement, no regex authored) handled the uniform `mock.calls.<method>((call) =>` shape across 4 server-test files (11 annotations). Two manual edits for patterns the script didn't cover:
- `billing-lifecycle.test.ts:548` — `updateCalls.some(...)` (variable-assigned, not `mock.calls.some` chain)
- `file-discovery.test.ts:152` — property-access pattern requiring `Parameters<typeof fetch>` instead of `unknown[]`

## Cumulative bucket #3 progress

| | PR | Annotations |
|---|---|---|
| Drizzle mocks routes | [#935](https://github.com/RevealUIStudio/revealui/pull/935) ✅ | 105 |
| Drizzle variants + importOriginal | [#938](https://github.com/RevealUIStudio/revealui/pull/938) ✅ | 15 |
| Showcase props | [#939](https://github.com/RevealUIStudio/revealui/pull/939) ⏳ | 86 |
| **Mock-call introspection** | **this PR** | **13** |
| **Total bucket #3 (when all land)** | | **219 / ~426** |

## Same posture

Cosmetic Vercel-only `##[error]` annotations that don't fail `vercel build`. CI workflow on test has been green throughout. Durable code-quality cleanup per strict-mode rule.
