### PR TITLE
chore(admin): type onChange e param in 6 auth Form components

### DIFF
--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -14,7 +14,7 @@ import {
 } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, useState } from 'react';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 
 export type OAuthProvider = 'github' | 'google' | 'vercel' | 'linkedin';
@@ -134,7 +134,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
             id="email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             disabled={anyLoading}
             autoComplete="email"
             required
@@ -150,7 +150,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
               id="password"
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               disabled={anyLoading}
               autoComplete="current-password"
               className="pr-10"

--- a/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { type FormEvent, useState } from 'react';
+import { type ChangeEvent, type FormEvent, useState } from 'react';
 
 function filterDigits(value: string): string {
   return [...value].filter((c) => c >= '0' && c <= '9').join('');
@@ -74,7 +74,7 @@ export function MFAForm() {
               id="backup-code"
               type="text"
               value={code}
-              onChange={(e) => setCode(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setCode(e.target.value)}
               disabled={isLoading}
               autoComplete="one-time-code"
               autoFocus
@@ -95,7 +95,7 @@ export function MFAForm() {
               pattern="[0-9]*"
               maxLength={6}
               value={code}
-              onChange={(e) => setCode(filterDigits(e.target.value))}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setCode(filterDigits(e.target.value))}
               disabled={isLoading}
               autoComplete="one-time-code"
               autoFocus

--- a/apps/admin/src/app/(frontend)/reset-password/ResetPasswordForm.tsx
+++ b/apps/admin/src/app/(frontend)/reset-password/ResetPasswordForm.tsx
@@ -8,7 +8,7 @@ import {
 } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, useState } from 'react';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 
 function ResetPasswordSkeleton() {
@@ -118,7 +118,7 @@ function RequestResetForm() {
             id="email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             disabled={isLoading}
             autoComplete="email"
             required
@@ -213,7 +213,7 @@ function ResetWithTokenForm({ tokenId, token }: { tokenId: string; token: string
               id="password"
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               disabled={isLoading}
               autoComplete="new-password"
               className="pr-10"

--- a/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
+++ b/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
@@ -7,7 +7,7 @@ import {
   InputCVA as Input,
 } from '@revealui/presentation/server';
 import { useRouter } from 'next/navigation';
-import { type FormEvent, useState } from 'react';
+import { type ChangeEvent, type FormEvent, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -94,7 +94,7 @@ export function RotatePasswordForm() {
               id="current-password"
               type={showCurrentPassword ? 'text' : 'password'}
               value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setCurrentPassword(e.target.value)}
               autoComplete="current-password"
               required
               className="pr-10"
@@ -111,7 +111,7 @@ export function RotatePasswordForm() {
               id="new-password"
               type={showNewPassword ? 'text' : 'password'}
               value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setNewPassword(e.target.value)}
               autoComplete="new-password"
               required
               className="pr-10"
@@ -131,7 +131,7 @@ export function RotatePasswordForm() {
               id="confirm-password"
               type={showConfirmPassword ? 'text' : 'password'}
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
               autoComplete="new-password"
               required
               className="pr-10"

--- a/apps/admin/src/app/(frontend)/setup/SetupForm.tsx
+++ b/apps/admin/src/app/(frontend)/setup/SetupForm.tsx
@@ -7,7 +7,7 @@ import {
   InputCVA as Input,
 } from '@revealui/presentation/server';
 import { useRouter } from 'next/navigation';
-import type { FormEvent } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
 import { useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 
@@ -99,7 +99,7 @@ export function SetupForm({ siteName }: SetupFormProps) {
             type="text"
             placeholder="Admin"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
             autoComplete="name"
           />
         </div>
@@ -113,7 +113,7 @@ export function SetupForm({ siteName }: SetupFormProps) {
             type="email"
             placeholder="admin@example.com"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             required
             autoComplete="email"
           />
@@ -128,7 +128,7 @@ export function SetupForm({ siteName }: SetupFormProps) {
               id="setup-password"
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               required
               minLength={12}
               autoComplete="new-password"

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -10,7 +10,7 @@ import {
 } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, useState } from 'react';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 
 interface SignupFormProps {
@@ -188,7 +188,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
             id="name"
             type="text"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
             disabled={anyLoading}
             autoComplete="name"
             required
@@ -203,7 +203,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
             id="email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             disabled={anyLoading}
             autoComplete="email"
             required
@@ -219,7 +219,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
               id="password"
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
               disabled={anyLoading}
               autoComplete="new-password"
               className="pr-10"
@@ -238,7 +238,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
             id="tos"
             type="checkbox"
             checked={tosAccepted}
-            onChange={(e) => setTosAccepted(e.target.checked)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setTosAccepted(e.target.checked)}
             disabled={anyLoading}
             required
             className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-[var(--tenant-brand,#2563eb)] accent-[var(--tenant-brand,#2563eb)]"


### PR DESCRIPTION
## Summary

Annotates 16 implicit-any `e` parameters in `onChange={(e) => ...}` handlers across **all 6 auth Form components**, plus adds the `ChangeEvent` named import to each file. 6 files, 22 line changes (16 handler annotations + 6 import additions).

Bucket #3b — concentrated cluster in admin auth surfaces.

## Files

| Component | Handlers typed |
|---|---|
| [SignupForm.tsx](apps/admin/src/app/(frontend)/signup/SignupForm.tsx) | 4 |
| [SetupForm.tsx](apps/admin/src/app/(frontend)/setup/SetupForm.tsx) | 3 |
| [RotatePasswordForm.tsx](apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx) | 3 |
| [LoginForm.tsx](apps/admin/src/app/(frontend)/login/LoginForm.tsx) | 2 |
| [MFAForm.tsx](apps/admin/src/app/(frontend)/mfa/MFAForm.tsx) | 2 |
| [ResetPasswordForm.tsx](apps/admin/src/app/(frontend)/reset-password/ResetPasswordForm.tsx) | 2 |

## Diff shape

```diff
-import { type FormEvent, Suspense, useState } from 'react';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 ...
-onChange={(e) => setEmail(e.target.value)}
+onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
```

All annotated handlers target `<Input>` text/email/password fields or native checkbox `<input>` — both are `HTMLInputElement`. `e.target.value` / `.checked` access unchanged. No runtime behavior delta.

## Why now (despite admin being migration-bound)

Owner directive 2026-05-17: "our rewrite will go better if we have working code to refactor". Per GAP-194 ADR (Phase 2 of admin → RevealUI-native via Vite + @revealui/router), the migration is a **port** rather than a rewrite — so clean source code (no implicit-any) reduces port friction. These 6 Forms are exactly the shape that'll move to the apps/admin-vite parallel build.

## Verification

```
$ pnpm turbo typecheck --filter=admin
 Tasks:    18 successful, 18 total
 Cached:   17 cached, 18 total
  Time:    19.6s
```

0 errors. Biome auto-formatted on commit (no changes — already conformed).

## Method

Script `/tmp/fix-auth-form-onchange.mjs` (literal-string replacement, no regex authored, not committed). Three import-line variants handled (with/without `Suspense`, split `import type` form). Single handler pattern: `onChange={(e) =>` → `onChange={(e: ChangeEvent<HTMLInputElement>) =>`.

## Cumulative bucket #3 progress

| | PR | Annotations |
|---|---|---|
| Drizzle mocks routes | [#935](https://github.com/RevealUIStudio/revealui/pull/935) ✅ | 105 |
| Drizzle variants + importOriginal | [#938](https://github.com/RevealUIStudio/revealui/pull/938) ✅ | 15 |
| Showcase props | [#939](https://github.com/RevealUIStudio/revealui/pull/939) ✅ | 86 |
| Mock-call params | [#940](https://github.com/RevealUIStudio/revealui/pull/940) ✅ | 13 |
| **Auth Form onChange** | **this PR** | **16** (+ 6 imports) |
| **Total** | | **235 / ~426 (~55%)** |

## Same posture

Cosmetic Vercel-only `##[error]` annotations that don't fail `vercel build`. CI workflow on test has been green throughout. Durable code-quality cleanup per strict-mode rule, with migration-port benefit per owner directive.
