### PR TITLE
chore(admin): type onChange e param in 13 admin pages (40 handlers)

### DIFF
--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -3,7 +3,7 @@
 import type { A2AAgentCard } from '@revealui/contracts';
 import { Breadcrumb } from '@revealui/presentation/client';
 import { useRouter } from 'next/navigation';
-import { use, useEffect, useState } from 'react';
+import { type ChangeEvent, use, useEffect, useState } from 'react';
 import { AgentContexts } from '@/lib/components/agents/agent-contexts';
 import { AgentMemory } from '@/lib/components/agents/agent-memory';
 import { TaskHistory } from '@/lib/components/agents/task-history';
@@ -197,7 +197,11 @@ export default function AgentDetailPage({ params }: PageProps) {
                           id="edit-name"
                           type="text"
                           value={editName}
-                          onChange={(e) => setEditName(e.target.value)}
+                          onChange={(
+                            e: ChangeEvent<
+                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                            >,
+                          ) => setEditName(e.target.value)}
                           className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
                         />
                       </div>
@@ -212,7 +216,11 @@ export default function AgentDetailPage({ params }: PageProps) {
                           id="edit-description"
                           type="text"
                           value={editDescription}
-                          onChange={(e) => setEditDescription(e.target.value)}
+                          onChange={(
+                            e: ChangeEvent<
+                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                            >,
+                          ) => setEditDescription(e.target.value)}
                           className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
                         />
                       </div>
@@ -227,7 +235,11 @@ export default function AgentDetailPage({ params }: PageProps) {
                           id="edit-system-prompt"
                           rows={7}
                           value={editSystemPrompt}
-                          onChange={(e) => setEditSystemPrompt(e.target.value)}
+                          onChange={(
+                            e: ChangeEvent<
+                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                            >,
+                          ) => setEditSystemPrompt(e.target.value)}
                           className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none resize-none"
                         />
                       </div>

--- a/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
@@ -16,7 +16,7 @@
 
 import { Breadcrumb } from '@revealui/presentation/client';
 import Link from 'next/link';
-import { use, useState } from 'react';
+import { type ChangeEvent, use, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { ElicitationForm, type ElicitationSchema } from '@/lib/components/mcp/elicitation-form';
 import { type AgentStreamChunk, useAgentStream } from '@/lib/hooks/useAgentStream';
@@ -75,7 +75,9 @@ export default function AgentRunPage({ params }: PageProps) {
           <textarea
             id="instruction"
             value={instruction}
-            onChange={(e) => setInstruction(e.target.value)}
+            onChange={(
+              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+            ) => setInstruction(e.target.value)}
             disabled={stream.isStreaming}
             rows={4}
             placeholder="What would you like the agent to do?"
@@ -86,7 +88,9 @@ export default function AgentRunPage({ params }: PageProps) {
               <span>Mode</span>
               <select
                 value={mode}
-                onChange={(e) => setMode(e.target.value as 'admin' | 'coding')}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) => setMode(e.target.value as 'admin' | 'coding')}
                 disabled={stream.isStreaming}
                 className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-60"
               >

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -3,7 +3,7 @@
 import { Breadcrumb } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useReducer } from 'react';
+import { type ChangeEvent, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -303,7 +303,9 @@ export default function NewAgentPage() {
                     type="text"
                     required
                     value={name}
-                    onChange={(e) => handleNameChange(e.target.value)}
+                    onChange={(
+                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                    ) => handleNameChange(e.target.value)}
                     placeholder={`e.g. ${tpl?.label ?? 'My Agent'}`}
                     className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
                   />
@@ -333,7 +335,9 @@ export default function NewAgentPage() {
                     id="agent-desc"
                     type="text"
                     value={description}
-                    onChange={(e) => dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })}
+                    onChange={(
+                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                    ) => dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })}
                     placeholder={tpl?.description ?? 'What does this agent do?'}
                     className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
                   />
@@ -351,7 +355,9 @@ export default function NewAgentPage() {
                     id="agent-prompt"
                     rows={6}
                     value={systemPrompt}
-                    onChange={(e) => dispatch({ type: 'SET_SYSTEM_PROMPT', value: e.target.value })}
+                    onChange={(
+                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                    ) => dispatch({ type: 'SET_SYSTEM_PROMPT', value: e.target.value })}
                     placeholder="Describe the agent's role, personality, and constraints..."
                     className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none resize-none"
                   />

--- a/apps/admin/src/app/(backend)/jobs/page.tsx
+++ b/apps/admin/src/app/(backend)/jobs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useReducer } from 'react';
+import { type ChangeEvent, useEffect, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -277,7 +277,9 @@ function JobsDashboard() {
             <select
               id="name-filter"
               value={nameFilter}
-              onChange={(e) => dispatch({ type: 'SET_NAME_FILTER', filter: e.target.value })}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => dispatch({ type: 'SET_NAME_FILTER', filter: e.target.value })}
               className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-300 focus:border-zinc-500 focus:outline-none"
             >
               <option value="">All handlers</option>

--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { type ChangeEvent, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -324,7 +324,9 @@ function ReviewsPanel({
               Comment (optional)
               <textarea
                 value={comment}
-                onChange={(e) => setComment(e.target.value)}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) => setComment(e.target.value)}
                 rows={3}
                 className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
                 placeholder="Share your experience..."
@@ -461,7 +463,9 @@ function SubmitTaskPanel({
           ) : (
             <select
               value={selectedSkill}
-              onChange={(e) => setSelectedSkill(e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => setSelectedSkill(e.target.value)}
               className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
             >
               {skills.map((skill) => (
@@ -480,7 +484,9 @@ function SubmitTaskPanel({
           Input (JSON)
           <textarea
             value={inputJson}
-            onChange={(e) => setInputJson(e.target.value)}
+            onChange={(
+              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+            ) => setInputJson(e.target.value)}
             rows={8}
             className="mt-1 w-full font-mono rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
             placeholder='{"key": "value"}'
@@ -497,7 +503,9 @@ function SubmitTaskPanel({
             min={1}
             max={5}
             value={priority}
-            onChange={(e) => setPriority(Number(e.target.value))}
+            onChange={(
+              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+            ) => setPriority(Number(e.target.value))}
             className="mt-1 w-full"
           />
         </label>

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { type ChangeEvent, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -117,14 +117,18 @@ export default function MarketplacePage() {
               type="text"
               placeholder="Search agents..."
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => setSearch(e.target.value)}
               className="flex-1 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
             />
 
             {/* Category filter */}
             <select
               value={category}
-              onChange={(e) => setCategory(e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => setCategory(e.target.value)}
               className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
             >
               {CATEGORIES.map((cat) => (
@@ -137,7 +141,9 @@ export default function MarketplacePage() {
             {/* Sort */}
             <select
               value={sort}
-              onChange={(e) => setSort(e.target.value as SortOption)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => setSort(e.target.value as SortOption)}
               className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
             >
               <option value="rating">Highest Rated</option>

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { type ChangeEvent, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -355,7 +355,9 @@ function StepBasicInfo({
         <input
           type="text"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setName(e.target.value)
+          }
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
           placeholder="Code Reviewer Pro"
         />
@@ -366,7 +368,9 @@ function StepBasicInfo({
         <span className="text-sm text-zinc-400">Description</span>
         <textarea
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setDescription(e.target.value)
+          }
           rows={3}
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
           placeholder="An AI agent that reviews code for best practices, security issues, and performance..."
@@ -380,7 +384,9 @@ function StepBasicInfo({
         <span className="text-sm text-zinc-400">Category</span>
         <select
           value={category}
-          onChange={(e) => setCategory(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setCategory(e.target.value)
+          }
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
         >
           {CATEGORIES.map((cat) => (
@@ -396,7 +402,9 @@ function StepBasicInfo({
         <input
           type="text"
           value={tags}
-          onChange={(e) => setTags(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setTags(e.target.value)
+          }
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
           placeholder="typescript, react, code-review"
         />
@@ -461,7 +469,9 @@ function StepConfiguration({
                 name="pricingModel"
                 value={pm.value}
                 checked={pricingModel === pm.value}
-                onChange={(e) => setPricingModel(e.target.value)}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) => setPricingModel(e.target.value)}
                 className="accent-blue-500"
               />
               <span className="text-sm text-zinc-300">{pm.label}</span>
@@ -475,7 +485,9 @@ function StepConfiguration({
         <input
           type="text"
           value={basePriceUsdc}
-          onChange={(e) => setBasePriceUsdc(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setBasePriceUsdc(e.target.value)
+          }
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
           placeholder="0.10"
         />
@@ -489,7 +501,9 @@ function StepConfiguration({
         <input
           type="number"
           value={maxExecutionSecs}
-          onChange={(e) => setMaxExecutionSecs(Number(e.target.value))}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setMaxExecutionSecs(Number(e.target.value))
+          }
           min={10}
           max={3600}
           className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
@@ -500,7 +514,9 @@ function StepConfiguration({
         <span className="text-sm text-zinc-400">Agent Definition (JSON)</span>
         <textarea
           value={definitionJson}
-          onChange={(e) => setDefinitionJson(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+            setDefinitionJson(e.target.value)
+          }
           rows={8}
           className="mt-1 w-full font-mono rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
         />
@@ -589,7 +605,9 @@ function StepSkills({
             <input
               type="text"
               value={skill.name}
-              onChange={(e) => updateSkill(i, 'name', e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => updateSkill(i, 'name', e.target.value)}
               className="mt-1 w-full rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-sm text-white focus:border-zinc-500 focus:outline-none"
               placeholder="code-review"
             />
@@ -603,7 +621,9 @@ function StepSkills({
             <input
               type="text"
               value={skill.description}
-              onChange={(e) => updateSkill(i, 'description', e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => updateSkill(i, 'description', e.target.value)}
               className="mt-1 w-full rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-sm text-white focus:border-zinc-500 focus:outline-none"
               placeholder="Reviews code for bugs, security issues, and best practices"
             />
@@ -616,7 +636,9 @@ function StepSkills({
             <span className="text-xs text-zinc-500">Input Schema (JSON)</span>
             <textarea
               value={skill.inputSchema}
-              onChange={(e) => updateSkill(i, 'inputSchema', e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => updateSkill(i, 'inputSchema', e.target.value)}
               rows={3}
               className="mt-1 w-full font-mono rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-white focus:border-zinc-500 focus:outline-none"
             />
@@ -629,7 +651,9 @@ function StepSkills({
             <span className="text-xs text-zinc-500">Output Schema (JSON)</span>
             <textarea
               value={skill.outputSchema}
-              onChange={(e) => updateSkill(i, 'outputSchema', e.target.value)}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => updateSkill(i, 'outputSchema', e.target.value)}
               rows={3}
               className="mt-1 w-full font-mono rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-white focus:border-zinc-500 focus:outline-none"
             />

--- a/apps/admin/src/app/(backend)/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/page.tsx
@@ -13,7 +13,7 @@
 
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
 import { UsageDashboard } from '@/lib/components/mcp/usage-dashboard';
 import type { CollectionMcpSummary } from '@/lib/mcp/collections';
@@ -203,7 +203,9 @@ export default function McpCatalogPage() {
                   name="tenant"
                   type="text"
                   value={tenant}
-                  onChange={(e) => setTenant(e.target.value)}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => setTenant(e.target.value)}
                   pattern="[A-Za-z0-9_-]{1,64}"
                   placeholder="acme"
                   className="w-64 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { type ChangeEvent, useCallback, useRef, useState } from 'react';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -155,7 +155,7 @@ function DropZone({
         accept="image/jpeg,image/png,image/webp,image/gif"
         multiple
         className="hidden"
-        onChange={(e) => {
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
           if (e.target.files && e.target.files.length > 0) {
             onFiles(e.target.files);
             e.target.value = '';
@@ -402,7 +402,9 @@ export default function MediaLibraryPage() {
         <div className="flex items-center gap-3">
           <select
             value={filter}
-            onChange={(e) => handleFilterChange(e.target.value)}
+            onChange={(
+              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+            ) => handleFilterChange(e.target.value)}
             className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-white"
           >
             <option value="">All types</option>

--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useReducer } from 'react';
+import { type ChangeEvent, useEffect, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -324,7 +324,9 @@ function RefundsDashboard() {
                 id="refund-identifier"
                 type="text"
                 value={identifier}
-                onChange={(e) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
                 placeholder="pi_abc123 or ch_abc123"
                 required
                 className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
@@ -346,7 +348,9 @@ function RefundsDashboard() {
                 id="refund-amount"
                 type="number"
                 value={amountInput}
-                onChange={(e) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
                 placeholder="Leave empty for full refund"
                 min="0.01"
                 step="0.01"
@@ -366,7 +370,9 @@ function RefundsDashboard() {
               <select
                 id="refund-reason"
                 value={reason}
-                onChange={(e) =>
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                ) =>
                   dispatch({
                     type: 'SET_REASON',
                     value: e.target.value as State['reason'],

--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -2,7 +2,7 @@
 
 const SAVED_FEEDBACK_MS = 2_000;
 
-import { useEffect, useState } from 'react';
+import { type ChangeEvent, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -151,7 +151,9 @@ export default function ApiKeysPage() {
                 <select
                   id="provider-select"
                   value={provider}
-                  onChange={(e) => setProvider(e.target.value as Provider)}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => setProvider(e.target.value as Provider)}
                   className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-zinc-500 focus:outline-none"
                 >
                   {PROVIDERS.map((p) => (
@@ -185,7 +187,9 @@ export default function ApiKeysPage() {
                     id="api-key-input"
                     type={showKey ? 'text' : 'password'}
                     value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
+                    onChange={(
+                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                    ) => setApiKey(e.target.value)}
                     placeholder={activeProviderInfo?.placeholder ?? ''}
                     className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 pr-16 text-sm text-zinc-100 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none font-mono"
                   />

--- a/apps/admin/src/app/(backend)/settings/security/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/security/page.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from '@revealui/presentation/client';
 import { QRCodeSVG } from 'qrcode.react';
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
@@ -524,7 +524,11 @@ function SecuritySettingsContent() {
                         autoComplete="one-time-code"
                         maxLength={6}
                         value={verifyCode}
-                        onChange={(e) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
+                        onChange={(
+                          e: ChangeEvent<
+                            HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                          >,
+                        ) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
                         placeholder="000000"
                         className="w-32 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
                       />
@@ -578,7 +582,11 @@ function SecuritySettingsContent() {
                               id="mfa-disable-password"
                               type="password"
                               value={disablePassword}
-                              onChange={(e) => setDisablePassword(e.target.value)}
+                              onChange={(
+                                e: ChangeEvent<
+                                  HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                                >,
+                              ) => setDisablePassword(e.target.value)}
                               placeholder="Password"
                               className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none sm:w-48"
                             />
@@ -696,7 +704,11 @@ function SecuritySettingsContent() {
                               <input
                                 type="text"
                                 value={renameValue}
-                                onChange={(e) => setRenameValue(e.target.value)}
+                                onChange={(
+                                  e: ChangeEvent<
+                                    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+                                  >,
+                                ) => setRenameValue(e.target.value)}
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter') void submitRename(passkey.id);
                                   if (e.key === 'Escape') cancelRename();

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 interface SubscriptionData {
@@ -333,7 +333,9 @@ export default function LicensePage() {
                     type="text"
                     placeholder="your-github-handle"
                     value={githubUsername}
-                    onChange={(e) => setGithubUsername(e.target.value)}
+                    onChange={(
+                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                    ) => setGithubUsername(e.target.value)}
                     className="rounded-md border px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
                   />
                   <span className="text-xs text-zinc-600">


### PR DESCRIPTION
## Summary

Annotates 40 implicit-any `onChange={(e) => ...}` handlers across 13 admin pages (12 backend + 1 license page in frontend). Adds `type ChangeEvent` to the react import in each file. Sibling to [#941](https://github.com/RevealUIStudio/revealui/pull/941) (auth Forms).

## Files (13)

**(backend) pages** (12):
- `agents/{[agentId],[agentId]/run,new}/page.tsx`
- `jobs/page.tsx`, `mcp/page.tsx`, `refunds/page.tsx`, `media/page.tsx`
- `marketplace/{page,publish/page,[agentId]/page}.tsx`
- `settings/{api-keys,security}/page.tsx`

**(frontend) consumer** (1):
- `account/license/page.tsx`

## Pattern

Pre-confirmed no `(backend)` file uses `e.target.checked` (all use `.target.value`), so union `ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>` is sound for inputs / textareas / selects:

```diff
-onChange={(e) => setX(e.target.value)}
+onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+  setX(e.target.value)}
```

**Special case:** [`media/page.tsx`](apps/admin/src/app/(backend)/media/page.tsx) file-upload uses `e.target.files` (only `HTMLInputElement` has it). Annotated specifically as `ChangeEvent<HTMLInputElement>`.

## Verification

```
$ pnpm turbo typecheck --filter=admin
 Tasks:    18 successful, 18 total
 Cached:   17 cached, 18 total
  Time:    5.8s
```

0 errors. Biome auto-formatted on commit (multi-line break of the long union annotation, no semantic change). Insertion count is 143 vs 53 deletions due to Biome's line-breaking — pure formatting delta.

## Method

`/tmp/fix-admin-onchange-v2.mjs` (literal-string replacement, no regex). v1 had a bug where import-detection ran AFTER handler replacement and always saw `ChangeEvent` in the just-inserted annotation; v2 checks for `ChangeEvent` specifically in import statements before patching. One manual edit for the `media/page.tsx` file-input case after typecheck surfaced it.

## Why now (admin migration-bound)

Owner directive 2026-05-17 — "our rewrite will go better if we have working code to refactor." Per GAP-194 Phase 2 (admin → RevealUI-native via Vite + @revealui/router), the migration is a port — clean source code (no implicit-any) reduces port friction. Form pages are exactly the shape that moves to the apps/admin-vite parallel build.

## Cumulative bucket #3 progress

| | PR | Annotations | Surface |
|---|---|---|---|
| Drizzle mocks routes | [#935](https://github.com/RevealUIStudio/revealui/pull/935) ✅ | 105 | server |
| Drizzle variants + importOriginal | [#938](https://github.com/RevealUIStudio/revealui/pull/938) ✅ | 15 | server |
| Showcase props | [#939](https://github.com/RevealUIStudio/revealui/pull/939) ✅ | 86 | docs |
| Mock-call params | [#940](https://github.com/RevealUIStudio/revealui/pull/940) ✅ | 13 | server + docs |
| Auth Form onChange | [#941](https://github.com/RevealUIStudio/revealui/pull/941) ⏳ | 16 | admin (port-prep) |
| **Backend admin onChange** | **this PR** | **40** | admin (port-prep) |
| **Total** | | **275 / ~426 (~65%)** |

## Same posture

Cosmetic Vercel-only `##[error]` annotations that don't fail `vercel build`. CI workflow on test has been green throughout. Durable code-quality cleanup per strict-mode rule, port-friction reduction per owner directive.
