### PR TITLE
fix(changesets): drop stale revealcoin entry from ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,13 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "server",
-    "admin",
-    "docs",
-    "marketing",
-    "test",
-    "@revealui/scripts",
-    "@revealui/dev"
-  ]
+  "ignore": ["server", "admin", "docs", "marketing", "test", "@revealui/scripts", "@revealui/dev"]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
     "docs",
     "marketing",
     "test",
-    "revealcoin",
     "@revealui/scripts",
     "@revealui/dev"
   ]


### PR DESCRIPTION
## Summary

Drops the stale `"revealcoin"` entry from `.changeset/config.json`'s `ignore` list. PR #936 removed `apps/revealcoin/` on 2026-05-17 but missed this companion edit, breaking the **Release Canary** workflow on every push to `test` since.

## Root cause

`@changesets/cli` validates the `ignore` list against the actual pnpm workspace at startup. When a referenced name is missing it throws:

```
ValidationError: The package or glob expression "revealcoin" is specified
in the `ignore` option but it is not found in the project.
```

That validation fires before `--snapshot canary` does anything, so the **"Apply snapshot versions"** step in `.github/workflows/release-canary.yml` aborts on the very first command (`pnpm changeset version --snapshot canary`).

## Evidence

- First failing run: `26003166631` (head SHA `f9e2014`) and 7 prior on `test` between 14:32Z and 21:26Z 2026-05-17 — every push since PR #936 merged.
- First failing run's parent: PR #936 merge (`Merge pull request #936 from RevealUIStudio/chore/remove-revealcoin-app`, 14:24:59Z).
- Failure output:
  ```
  ValidationError: Some errors occurred when validating the changesets config:
  The package or glob expression "revealcoin" is specified in the `ignore`
  option but it is not found in the project.
  ```
- Local repro on `origin/test` worktree: `pnpm changeset version --snapshot canary` fails the same way without this patch, succeeds with it.

## Out of scope (follow-up)

`.github/workflows/deploy.yml` (lines 224, 288, 453) and `.github/workflows/deploy-test.yml` (lines 56, 82) still reference `revealcoin` in their `ALL_APPS` arrays and project-id case branches. They don't auto-fire on push, so they're not currently breaking anything, but PR #936's sweep missed them. Worth a small follow-up PR.

## Test plan

- [ ] CI Release Canary run on this PR's merge to `test` succeeds at the **Apply snapshot versions** step (currently 8/8 failing in a row)
- [ ] Locally verified: `pnpm changeset version --snapshot canary` from `origin/test` + this patch produces "All files have been updated"
