### PR TITLE
chore(ci): remove stale revealcoin references from deploy workflows

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           INPUT_APPS: ${{ inputs.apps }}
         run: |
-          ALL_APPS="api admin marketing docs revealcoin"
+          ALL_APPS="api admin marketing docs"
 
           if [ "$INPUT_APPS" = "all" ] || [ -z "$INPUT_APPS" ]; then
             AFFECTED="$ALL_APPS"
@@ -79,7 +79,6 @@ jobs:
               admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
               marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
               docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;
               *) echo "::warning::Unknown app: $app"; continue ;;
             esac
             if [ "$FIRST" = true ]; then FIRST=false; else MATRIX="$MATRIX,"; fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,7 +221,7 @@ jobs:
         run: |
           echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
-          ALL_APPS="api admin marketing docs revealcoin"
+          ALL_APPS="api admin marketing docs"
 
           # Manual override: deploy specific apps or all
           if [ -n "$INPUT_APPS" ] && [ "$INPUT_APPS" != "auto" ]; then
@@ -285,7 +285,6 @@ jobs:
               admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
               marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
               docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;
               *) echo "::warning::Unknown app: $app"; continue ;;
             esac
             if [ "$FIRST" = true ]; then FIRST=false; else MATRIX="$MATRIX,"; fi
@@ -450,7 +449,6 @@ jobs:
               admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
               marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
               docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;
               *) continue ;;
             esac
 


### PR DESCRIPTION
Closes N/A — sibling cleanup to #936 and #946.

## Summary

Removes stale `revealcoin` references from the two deploy workflow files. PR #936 removed `apps/revealcoin/` from the monorepo (merged 2026-05-17); PR #946 cleaned up the `.changeset/config.json` reference. This PR completes the CI-layer cleanup.

Surfaced 2026-05-17 by a sub-agent investigating Release Canary failures. Not currently breaking anything because deploys aren't auto-firing on test pushes, but will fail the next time deploy runs.

## Changes per file

**`.github/workflows/deploy.yml`**
- Line 224 — removed `revealcoin` from `ALL_APPS` string (detect job)
- Line 288 — removed `revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;` case entry (detect job matrix builder)
- Line 453 — removed `revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;` case entry (rollback job)

**`.github/workflows/deploy-test.yml`**
- Line 56 — removed `revealcoin` from `ALL_APPS` string (detect job)
- Line 82 — removed `revealcoin) PID="prj_XDiPXngciRytGA8j0vNIDz7hENRM" ;;` case entry (detect job matrix builder)

No comments or URL strings were involved — all five hits were pure workspace references.

## Test plan

- [ ] CI lint passes (Biome, yaml syntax — these are shell-in-yaml, no structural change)
- [ ] Workflow logic is unchanged for the 4 remaining apps: `api`, `admin`, `marketing`, `docs`
- [ ] Manually triggering `deploy-test.yml` with `apps: all` would produce a 4-app matrix (not 5)
- [ ] Manually triggering `deploy.yml` rollback path would not attempt to roll back a non-existent revealcoin Vercel project
