### PR TITLE
feat(admin): emit admin.bootstrap.completed audit event on web setup (#459)

### DIFF
--- a/apps/admin/src/app/api/setup/route.ts
+++ b/apps/admin/src/app/api/setup/route.ts
@@ -70,6 +70,28 @@ export async function POST(request: Request): Promise<NextResponse<BootstrapResu
     seed: parsed.data.seed ?? true,
   });
 
+  if (result.status === 'created') {
+    try {
+      const { hostname } = await import('node:os');
+      const { getClient } = await import('@revealui/db/client');
+      const { auditLog } = await import('@revealui/db/schema');
+      const db = getClient('rest');
+      await db.insert(auditLog).values({
+        event: 'admin.bootstrap.completed',
+        actor: 'web',
+        severity: 'info',
+        meta: {
+          email: parsed.data.email,
+          source: 'web',
+          hostname: hostname(),
+          seeded: parsed.data.seed ?? true,
+        },
+      } as never);
+    } catch {
+      // Non-fatal — audit log may not be available in all environments
+    }
+  }
+
   const statusCode = result.status === 'created' ? 201 : result.status === 'locked' ? 403 : 500;
 
   return NextResponse.json(result, { status: statusCode });


### PR DESCRIPTION
## Summary

- Wires the web call site for the `admin.bootstrap.completed` audit event, mirroring the CLI pattern at `scripts/admin/bootstrap.ts:175`.
- Fires only on `result.status === 'created'` (matches CLI semantics — CLI exits early on `error`/`locked`).
- Best-effort try/catch around the DB insert (matches CLI — non-fatal if audit table unavailable).

## Why

Per [#459](https://github.com/RevealUIStudio/revealui/issues/459) and today's status comment: CLI half was shipped; web call site at `apps/admin/src/app/api/setup/route.ts` was the remaining gap.

## Meta divergence from CLI

| Field | CLI | Web | Reason |
| --- | --- | --- | --- |
| `actor` | `'cli'` | `'web'` | distinct call-site identifier |
| `source` | `'revvault'` | `'web'` | CLI reads creds from revvault; web takes them from request body |
| `hostname` | server hostname | server hostname | same |
| `env` | resolved from `--env`/`REVEALUI_ENV`/`NODE_ENV` | omitted | web doesn't resolve env from revvault paths |
| `forceRotate` | from revvault, default `true` | omitted | web flow doesn't set `mustRotatePassword` |
| `seeded` | `result.seeded ?? false` | `parsed.data.seed ?? true` | mirrors each route's input default |

## Test plan

- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter admin test src/__tests__/api/setup-routes.test.ts` — 10/10 pass (including "creates admin user and returns 201" which now exercises the new branch; DB import fails inside the try/catch in test env, silent — verifies the safety net)
- [ ] Integration-verified end-to-end against a real Neon DB (not run; covered by existing audit pipelines)

Closes #459
