### PR TITLE
chore(docs): full per-file audit cleanup — 7 batches (counts/Supabase/RevealCoin/LOGGING/archive)

### DIFF
--- a/apps/docs/scripts/copy-docs.sh
+++ b/apps/docs/scripts/copy-docs.sh
@@ -21,13 +21,8 @@ echo "   Target: $TARGET_DOCS"
 # IMPORTANT: Keep in sync with INTERNAL_DOC_FILES in vite.config.ts
 INTERNAL_FILES=(
   "MASTER_PLAN.md"
-  "GOVERNANCE.md"
   "AI-AGENT-RULES.md"
   "AUTOMATION.md"
-  "CI_ENVIRONMENT.md"
-  "PRICE_COLLECTION.md"
-  "PRODUCT_COLLECTION.md"
-  "SECRETS-MANAGEMENT.md"
   "STANDARDS.md"
 )
 

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -23,13 +23,8 @@ const DEBUG = /\b(docs-copy|\*)\b/.test(process.env.DEBUG ?? '');
 // IMPORTANT: Keep in sync with INTERNAL_FILES in scripts/copy-docs.sh
 const INTERNAL_DOC_FILES = new Set([
   'MASTER_PLAN.md',
-  'GOVERNANCE.md',
   'AI-AGENT-RULES.md',
   'AUTOMATION.md',
-  'CI_ENVIRONMENT.md',
-  'PRICE_COLLECTION.md',
-  'PRODUCT_COLLECTION.md',
-  'SECRETS-MANAGEMENT.md',
   'STANDARDS.md',
 ]);
 

--- a/docs/COMMERCIAL_READINESS.md
+++ b/docs/COMMERCIAL_READINESS.md
@@ -44,7 +44,7 @@ UX, plaintext secrets). All three must hold.
       "our team" in marketing copy if it's one person. Buyers who would reject a solo-founder SaaS
       will reject it louder after they discover it post-purchase.
 - [ ] **Subprocessor list** on a public page (`/legal/subprocessors`). Include: Vercel, NeonDB,
-      Supabase, Stripe, the current LLM inference providers, email provider, blob storage.
+      ~~Supabase~~ (Legacy — retiring per ADR `2026-05-01-supabase-removal.md`; remove from list once phase-out completes), Stripe, the current LLM inference providers, email provider, blob storage.
       Update-on-change with a dated changelog. Required for any enterprise sale and enforced by
       most DPAs.
 
@@ -79,7 +79,7 @@ for a lawyer review when you begin collecting payment.
 ### Data handling transparency
 
 - [ ] **Customer data map** — internal document naming every place customer data flows: Neon
-      region, Supabase region, Stripe, inference providers (including whether prompts leave the
+      region, ~~Supabase region~~ (Legacy — retiring per ADR `2026-05-01-supabase-removal.md`), Stripe, inference providers (including whether prompts leave the
       account boundary), blob storage, logs. Surface the externally-relevant parts on the
       Privacy Policy.
 - [ ] **Training-data promise** — explicit public statement of whether customer content is used
@@ -112,7 +112,7 @@ MASTER_PLAN § Current Reality). The remaining work is operational.
       OAuth client secrets, and database credentials in staging end-to-end, timed. Document the
       exact command sequence. If you can't rotate in under an hour today, a compromise
       tomorrow will take days.
-- [ ] **Backup restoration drill** — restore NeonDB and Supabase from backup into a clean
+- [ ] **Backup restoration drill** — restore NeonDB and ~~Supabase~~ (Legacy — retiring per ADR `2026-05-01-supabase-removal.md`) from backup into a clean
       environment. Verify RPO (how much data loss is acceptable) and RTO (how long to restore)
       against what's promised in the SLA / Privacy Policy. Unrestored backups are fiction.
 - [ ] **Separate staging environment** with production-equivalent config but non-production
@@ -121,7 +121,7 @@ MASTER_PLAN § Current Reality). The remaining work is operational.
 
 ### Account + access hygiene
 
-- [ ] **MFA enforced on every critical external account**: Stripe, Vercel, NeonDB, Supabase,
+- [ ] **MFA enforced on every critical external account**: Stripe, Vercel, NeonDB, ~~Supabase~~ (Legacy — retiring per ADR `2026-05-01-supabase-removal.md`),
       GitHub, npm, domain registrar, email provider. Check each one; they each have a separate
       MFA setting.
 - [ ] **Privilege separation** — deploy/CI credentials (read-only push, narrow scope) distinct

--- a/docs/CREDENTIAL-ROTATION-RUNBOOK.md
+++ b/docs/CREDENTIAL-ROTATION-RUNBOOK.md
@@ -125,7 +125,9 @@ revvault set revealui/env/admin REVEALUI_ADMIN_API_KEY "$NEW_KEY"
 
 **Risk:** Brief downtime if stale connection pools exist. Use rolling deploy.
 
-#### SUPABASE_DATABASE_URI
+#### SUPABASE_DATABASE_URI — Legacy
+
+> **Legacy — retired per ADR `2026-05-01-supabase-removal.md`. Current stack: Neon (primary) + ElectricSQL (sync).** Steps below are preserved for any legacy install that has not yet completed migration.
 
 1. Supabase Dashboard > Project Settings > Database > Reset password
 2. Update connection URI in RevVault
@@ -236,7 +238,7 @@ All secrets are managed through RevVault. Namespace mapping:
 | `revealui/env/core` | REVEALUI_SECRET, REVEALUI_KEK, VERCEL_API_KEY, NEON_API_KEY, BLOB_READ_WRITE_TOKEN |
 | `revealui/env/license` | REVEALUI_LICENSE_PRIVATE_KEY, REVEALUI_LICENSE_PUBLIC_KEY, REVEALUI_LICENSE_ENCRYPTION_KEY |
 | `revealui/env/stripe` | STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PUBLISHABLE_KEY, price IDs |
-| `revealui/env/supabase` | SUPABASE_DATABASE_URI, SUPABASE_SERVICE_ROLE_KEY, anon key |
+| `revealui/env/supabase` | SUPABASE_DATABASE_URI, SUPABASE_SERVICE_ROLE_KEY, anon key — **Legacy** (retired per ADR `2026-05-01-supabase-removal.md`) |
 | `revealui/env/services` | ANTHROPIC_API_KEY, OPENAI_API_KEY, RESEND_API_KEY, Google/GitHub OAuth |
 | `revealui/env/cron` | REVEALUI_CRON_SECRET |
 | `revealui/env/admin` | REVEALUI_ADMIN_API_KEY, REVEALUI_ADMIN_EMAIL |

--- a/docs/DEPLOYMENT-RUNBOOK.md
+++ b/docs/DEPLOYMENT-RUNBOOK.md
@@ -204,7 +204,7 @@ See [Section 5](#5-database-migration-steps) for details.
 ### Architecture
 
 - **Primary database**: NeonDB (PostgreSQL, Drizzle ORM)
-- **Secondary database**: Supabase (vectors, auth)
+- **Secondary database**: ~~Supabase~~ **Legacy — retired per ADR `2026-05-01-supabase-removal.md`. Current stack: Neon (primary) + ElectricSQL (sync).**
 - **Schema definitions**: `packages/db/src/schema/` (86 tables)
 - **Migration files**: `packages/db/migrations/`
 - **ORM config**: `packages/db/drizzle.config.ts`
@@ -418,7 +418,7 @@ For security incidents, data breaches, or critical production failures, follow t
 
 1. Check Vercel deployment status and function logs.
 2. If a bad deploy caused the issue, roll back immediately (see [Section 4](#4-rollback-procedures)).
-3. If the issue is database-related, check NeonDB and Supabase dashboards.
+3. If the issue is database-related, check NeonDB dashboard. (Supabase dashboard: Legacy — retired per ADR `2026-05-01-supabase-removal.md`.)
 4. If the issue is a security incident, escalate per the Incident Response Plan.
 5. Contact: security@revealui.com (security), founder@revealui.com (general).
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -193,7 +193,7 @@ For high-volume logs, sample only a percentage at the call site — there is
 no bundled helper; use a small guard to keep it explicit:
 
 ```typescript
-import { logger } from '@revealui/core/observability/logger'
+import { logger } from '@revealui/core/utils/logger'
 
 // Log only 10% of messages
 if (Math.random() < 0.1) {
@@ -305,22 +305,24 @@ This makes logs searchable and parseable by log aggregation tools like:
    authLogger.info('Login attempt') // Includes module: 'auth'
    ```
 
-## ESLint Configuration
+## Biome Configuration
 
-Add this rule to prevent `console.*` usage:
+The `noConsole` rule is enforced in `biome.json` and blocks all `console.*` calls (errors at lint time). This is wired in the root Biome config under `linter.rules.suspicious.noConsole: "error"`, with file-level overrides set to `"off"` for scripts and test helpers that legitimately write to stdout.
 
-```javascript
-// eslint.config.js
-export default [
-  {
-    rules: {
-      'no-console': ['error', {
-        allow: [] // No console methods allowed
-      }]
+```jsonc
+// biome.json (already configured — shown for reference)
+{
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noConsole": "error"
+      }
     }
   }
-]
+}
 ```
+
+Run `pnpm lint` or `pnpm exec biome check .` to catch any `console.*` calls in your working tree.
 
 ## Testing
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -98,9 +98,10 @@ RevealUI is part of a four-project ecosystem. Each project has features distribu
 | RevVault rotation engine | | Yes | Yes | Yes |
 | RevKit agent coordination protocol | Yes | Yes | Yes | Yes |
 | RevKit environment provisioning | | | Yes | Yes |
-| RevealCoin x402 agent payments | | | | Yes |
 
-The MIT-licensed components (RevVault CLI, RevKit agent coordination) are free forever. Commercial features (desktop app, rotation engine, provisioning, x402 payments) require the corresponding tier.
+> **Deferred — SHELVED 2026-05-15:** RevealCoin x402 agent payments are not on the current roadmap. Mainnet is indefinitely postponed pending revenue + legal review. The `X402_ENABLED=false` flag preserves the code for future resumption.
+
+The MIT-licensed components (RevVault CLI, RevKit agent coordination) are free forever. Commercial features (desktop app, rotation engine, provisioning) require the corresponding tier.
 
 ## Licensing (Fair Source + MIT)
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -38,7 +38,7 @@ Each of the eight products in RevFleet ships in its own repo. The table below or
 | **RevDev** | [revdev](https://github.com/RevealUIStudio/revdev) | Native developer tools: Studio (Tauri 2 desktop AI editor + agent dashboard) and Console (Go SSH TUI). Both talk to a shared harness daemon that coordinates agents and routes tools to the RevealUI API. | per-product LICENSE |
 | **RevVault** | [revvault](https://github.com/RevealUIStudio/revvault) | Age-encrypted secret vault. CLI + Tauri 2 desktop app. 100% passage-compatible. Source of truth for every secret in RevFleet per the fleet-wide secrets rule. | per-product LICENSE |
 | **RevCon** | [revcon](https://github.com/RevealUIStudio/revcon) | Centralized editor configs (Zed, VS Code, Cursor) + agent-rule sync. Symlinked into target projects via `link.sh`; edits propagate instantly. Not gated by the RevealUI Pro license. | per-product LICENSE |
-| **RevealCoin** | [revealcoin](https://github.com/RevealUIStudio/revealcoin) | Hybrid utility/governance/reward token on Solana Token-2022. Customer-facing ticker: `RVC` (6 decimals, 58.906B supply, freeze authority renounced). Devnet preview; mainnet pending 2026-Q4 per charge-readiness audit. | per-product LICENSE |
+| **RevealCoin** | [revealcoin](https://github.com/RevealUIStudio/revealcoin) | Hybrid utility/governance/reward token on Solana Token-2022. Customer-facing ticker: `RVC` (6 decimals, 58.906B supply, freeze authority renounced). Devnet preview. **SHELVED 2026-05-15 — mainnet indefinitely postponed pending revenue + legal review. Code lives in `RevealUIStudio/revealcoin` repo for resumption.** | per-product LICENSE |
 | **RevSkills** | [revskills](https://github.com/RevealUIStudio/revskills) | Curated Agent Skills (`SKILL.md` format) for modern web development. Compatible with Claude Code, Cursor, and any tool supporting the Agent Skills standard. | per-product LICENSE |
 | **RevKit** | [revkit](https://github.com/RevealUIStudio/revkit) | Portable WSL development environment toolkit. Profile presets, bootstrap scripts, shell config, boot optimization, RevStation PowerShell module. | per-product LICENSE |
 
@@ -74,7 +74,7 @@ RevCon is not gated by Pro. Any contributor can run `./link.sh --target ~/revfle
 
 ### RevealCoin (RVC)
 
-`RVC` is the customer-facing on-chain ticker; `$RVUI` is the internal codename used in code constants and route paths. Public-facing copy always uses `RVC`. Devnet preview; mainnet public distribution gated until 2026-Q4.
+`RVC` is the customer-facing on-chain ticker; `$RVUI` is the internal codename used in code constants and route paths. Public-facing copy always uses `RVC`. Devnet preview. **SHELVED 2026-05-15 — mainnet indefinitely postponed pending revenue + legal review. Code lives in `RevealUIStudio/revealcoin` repo for resumption.**
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,7 +47,7 @@ Alpha = functional, not deployed/published. Planned = design or schema only.
 - **Billing stack**  -  Stripe checkout, subscriptions, webhooks, license keys, billing portal, tier enforcement (free/pro/max/enterprise)
 - **UI components**  -  57 native React 19 components (Tailwind v4, zero external UI deps)
 - **Real-time sync**  -  ElectricSQL integration for editor/client/agent sync _(experimental  -  basic shape subscriptions, no offline-first)_
-- **Database**  -  86 tables via Drizzle ORM, dual-DB architecture (NeonDB + Supabase)
+- **Database**  -  86 tables via Drizzle ORM. Neon (primary) + ElectricSQL (sync). Supabase retired per ADR `2026-05-01-supabase-removal.md`.
 - **CLI**  -  `npx create-revealui my-app` scaffolds a full project from npm
 - **AI agents**  -  A2A protocol, CRDT memory, open-model inference, streaming, tool execution
 - **MCP servers**  -  12 first-party servers under `packages/mcp/src/servers/` (Stripe, Neon, Supabase, Vercel, Playwright, Code Validator, Next.js DevTools, RevealUI Content / Email / Memory / Stripe, plus the adapter base class)

--- a/docs/SCRIPT_MANAGEMENT.md
+++ b/docs/SCRIPT_MANAGEMENT.md
@@ -1,6 +1,17 @@
 # Script Management System
 
-Complete guide to the RevealUI Script Management Enhancement System - infrastructure for managing 222+ TypeScript scripts with visibility, type safety, verification, and rollback capabilities.
+Complete guide to the RevealUI Script Management Enhancement System - infrastructure for managing 203 TypeScript scripts with visibility, type safety, verification, and rollback capabilities.
+
+## Status
+
+| Feature | State |
+|---------|-------|
+| Script count (203 `.ts` files under `scripts/`) | SHIPPED |
+| Zod-based runtime validation on script inputs | SHIPPED |
+| `EnhancedCLI` base class | PROPOSED — not yet implemented |
+| PGlite-backed execution catalog | PROPOSED — not yet implemented |
+| `pnpm scripts:list` / `health:check` / `version:list` commands | PROPOSED — not yet implemented |
+| Phase-level profiling + usage analytics | PROPOSED — not yet implemented |
 
 ## Table of Contents
 
@@ -30,7 +41,7 @@ Complete guide to the RevealUI Script Management Enhancement System - infrastruc
 
 The Script Management System provides comprehensive tooling for managing TypeScript scripts across the RevealUI monorepo. It offers:
 
-- **Automatic Discovery**: Scans and catalogs 222+ scripts with metadata
+- **Automatic Discovery**: Scans and catalogs 203 scripts with metadata
 - **Type Safety**: Zod-based runtime validation for all inputs
 - **Audit Trail**: Complete execution history in PGlite database
 - **Performance Insights**: Phase-level profiling with bottleneck detection
@@ -50,7 +61,7 @@ The Script Management System provides comprehensive tooling for managing TypeScr
 
 ### System Statistics
 
-- **Scripts Cataloged**: 222 TypeScript scripts
+- **Scripts Cataloged**: 203 TypeScript scripts
 - **CLI Commands**: 50+ commands across 7 categories
 - **Database Tables**: 6 tables for persistence
 - **Test Coverage**: 19 integration tests

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -97,11 +97,11 @@ Honest list of things that are not done, not deployed, or not verified.
 | Metric | Value | Verified |
 |--------|-------|----------|
 | Workspaces (apps + packages) | 30 | Yes |
-| Apps | 5 (`admin`, `api`, `docs`, `marketing`, `revealcoin`) | Yes |
+| Apps | 4 (`admin`, `server`, `docs`, `marketing`) | Yes |
 | OSS packages (MIT) | 22 | Yes |
 | Pro packages (FSL-1.1-MIT) | 3 (`ai`, `harnesses`, `engines`) | Yes |
 | UI components 58 | Yes |
-| Database tables | 85 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
+| Database tables | 86 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
 | MCP servers (`packages/mcp/src/servers/`) | 13 | Yes |
 | Test cases | run `pnpm test` for current count | Reproducible |
 | Test files | run `find . -name "*.test.ts*" -not -path "*/node_modules/*"` | Reproducible |

--- a/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
+++ b/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
@@ -3,6 +3,8 @@ title: "Documentation Assessment"
 description: "Audit of documentation completeness and accuracy across all packages"
 category: internal
 audience: maintainer
+archived: 2026-05-18
+archive-reason: "Self-acknowledged stale snapshot; superseded by WHAT_WORKS_TODAY.md and pnpm validate:claims gate"
 ---
 
 # Documentation vs Reality Assessment

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,3 @@
+# docs/archive/
+
+Frozen historical documentation. Files here are NOT published to docs.revealui.com (apps/docs/scripts/copy-docs.sh skips the archive/ subdir). See git history for full provenance.

--- a/docs/decisions/licensing-platform-evaluation.md
+++ b/docs/decisions/licensing-platform-evaluation.md
@@ -3,7 +3,9 @@
 > **SUPERSEDED 2026-05-04 by [`docs/specs/cr8-p0-01-api-ed25519-migration.md`](../specs/cr8-p0-01-api-ed25519-migration.md) (private repo).** The platform-evaluation decision recorded below selected RS256 at the time of writing. The 2026-05-04 charge-readiness re-audit surfaced an issuer/daemon-verifier format mismatch that required revisiting the algorithm choice; Owner approved migration to Ed25519 (Option α — preserve rich JWT payload, swap algorithm). The original decision-record is preserved verbatim below for SOC2-audit decision lineage.
 
 **Date:** 2026-03-31
-**Status:** Decided  -  keep current implementation
+**Status:** Superseded
+**Superseded-date:** 2026-05-04
+**Superseded-by:** private repo spec `docs/specs/cr8-p0-01-api-ed25519-migration.md` (Ed25519 migration)
 **Phase:** 5 (Agent-First Infrastructure)
 
 ## Context


### PR DESCRIPTION
## Summary

Full per-file audit of `docs/` (~115 .md across root + 14 subdirs) against current code reality. Applies seven themed commits cleaning up drift identified in the audit. Source of truth for these claims is the audit findings (Phase 2/3 verification log lives in the internal handoff; this PR ships only the code-aligned fixes).

## What changed

**Counts** (`81d03e549`)
- `SCRIPT_MANAGEMENT.md`: "222+ scripts" → "203 scripts" (verified via `find scripts -type f -name '*.ts' | wc -l`); added Status section distinguishing SHIPPED vs PROPOSED features in the script-management framework.
- `WHAT_WORKS_TODAY.md`: app list 5 → 4 (admin, **server**, docs, marketing — `apps/server/` not `apps/api/`; `apps/revealcoin/` removed in [#936](https://github.com/RevealUIStudio/revealui/pull/936)). Table count aligned to verified 86.

**Supabase legacy markers** (`1ce4a3edf`) — per ADR [`docs/decisions/2026-05-01-supabase-removal.md`](docs/decisions/2026-05-01-supabase-removal.md) + [#913](https://github.com/RevealUIStudio/revealui/pull/913)
- `DEPLOYMENT-RUNBOOK.md` — Supabase secondary-DB sections marked Legacy.
- `CREDENTIAL-ROTATION-RUNBOOK.md` — `revealui/env/supabase` namespace section gets Legacy callout.
- `COMMERCIAL_READINESS.md` — subprocessor list line marked Legacy.
- `ROADMAP.md` — "dual-DB (NeonDB + Supabase)" → "Neon (primary) + ElectricSQL (sync). Supabase retired per ADR 2026-05-01."

Sections preserved (not deleted) so anyone with a legacy install still finds rotation/migration info.

**RevealCoin shelved** (`e314d4662`) — per the 2026-05-15 owner ruling (mainnet indefinitely postponed pending revenue + legal review)
- `REVFLEET.md`: "mainnet pending 2026-Q4" → "SHELVED 2026-05-15 — code lives in an internal repo for resumption".
- `PRO.md`: removed "RevealCoin x402 agent payments" from Enterprise tier features table.

x402 code itself stays dormant (`X402_ENABLED=false` flag preserved); this is a docs-only realignment.

**LOGGING.md fixes** (`8d11b34f7`)
- ESLint config block → Biome equivalent (codebase uses Biome).
- Standardized logger import paths to canonical export from `@revealui/core`.

**Cleanup** (3 commits):
- `81292753e` — Dropped 5 ghost entries (`GOVERNANCE.md`, `CI_ENVIRONMENT.md`, `PRICE_COLLECTION.md`, `PRODUCT_COLLECTION.md`, `SECRETS-MANAGEMENT.md`) from `apps/docs/scripts/copy-docs.sh` `INTERNAL_FILES` and `apps/docs/vite.config.ts` `INTERNAL_DOC_FILES`. No source files exist; they were no-ops at build time and misleading as "we exclude X" signal.
- `a4e820f6b` — Archived self-acknowledged-stale `DOCUMENTATION_ASSESSMENT.md` (2026-03-28 snapshot, banner already told readers to use `WHAT_WORKS_TODAY.md` instead). Moved to `docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md` with new `archived` / `archive-reason` frontmatter; established `docs/archive/` convention with README pointer. `copy-docs.sh` already excludes `archive/` so it doesn't ship to docs.revealui.com.
- `d0fef2f4d` — `decisions/licensing-platform-evaluation.md`: aligned body-vs-frontmatter status drift (body said "Superseded 2026-05-04 by private repo spec (Ed25519 migration)" while inline status field still claimed "Decided").

## Files touched (13)

```
apps/docs/scripts/copy-docs.sh
apps/docs/vite.config.ts
docs/COMMERCIAL_READINESS.md
docs/CREDENTIAL-ROTATION-RUNBOOK.md
docs/DEPLOYMENT-RUNBOOK.md
docs/LOGGING.md
docs/PRO.md
docs/REVFLEET.md
docs/ROADMAP.md
docs/SCRIPT_MANAGEMENT.md
docs/WHAT_WORKS_TODAY.md
docs/decisions/licensing-platform-evaluation.md
docs/{ → archive/2026-03-28-}DOCUMENTATION_ASSESSMENT.md
+ docs/archive/README.md (new)
```

## Audit scope NOT included

These were surfaced by the audit but deferred — owner can pick up or close as not-worth-fixing:

- **Component-count discrepancy** (`INDEX.md` + `QUICK_START.md` claim 59 vs `COMPONENT_CATALOG.md` claims 80 = 59 presentation + 21 admin/richtext core). Audit verified presentation = 59 but "21 core components" depends on definition (raw .tsx file count is 23 but many are hooks/plugins/layouts, not user-facing components). Skipped — needs owner judgment on definition before any change.
- **Timestamp refreshes** across 5+ files (cosmetic; would create churn).
- **THIRD_PARTY_LICENSES.md** — 74 days stale; would require re-running license audit (out of scope for docs cleanup PR).
- **JOSHUA.md "22 OSS packages"** — needs verification against current package count + license map.
- **B.3 SECRETS.md** prescribed by audit was a no-op — file has zero Supabase references; the namespace lives in `CREDENTIAL-ROTATION-RUNBOOK.md` only (correctly fixed in batch B).
- **`apps/docs/public/blog-drafts/`** local orphan — gitignored, won't ship via CI build. Leaving alone.

## Test plan

- [x] `bash -n apps/docs/scripts/copy-docs.sh` — syntax OK
- [x] `bash apps/docs/scripts/copy-docs.sh` standalone — runs cleanly, copies 115 .md, excludes 4 real internal files (no more ghost-entry warnings)
- [x] `docs/archive/` not copied to `apps/docs/public/` — verified
- [x] DOCUMENTATION_ASSESSMENT.md no longer ships publicly — verified (public/.md count 44→43)
- [ ] CI: Quality + Typecheck + Build pass (let CI run)
- [ ] CI: docs app Vite build succeeds (path-filtered; should re-run since `apps/docs/` files changed)
- [ ] Owner spot-check on Supabase legacy phrasing in `DEPLOYMENT-RUNBOOK.md` / `CREDENTIAL-ROTATION-RUNBOOK.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
