### PR TITLE
chore(docs): refresh React patch version 19.2.4 -> 19.2.5 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Key postures — full definitions in `docs/methodology.md`.
 - All workspaces build and typecheck clean (run `pnpm build` and `pnpm typecheck:all`)
 - Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
 - Pinned overrides enforce minimum safe versions for transitive deps (see `pnpm.overrides` block in root `package.json`)
-- React 19.2.14 (CVE-2025-55182 React2Shell patched)
+- React 19.2.5 (CVE-2025-55182 React2Shell patched)
 - GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; future triage trackers land in the private `revealui-jv` repo per the issue-redaction convention
 - AST-based code-pattern analyzer: execSync injection, TOCTOU, ReDoS (ret parser + contracts schemas)
 - Pre-push gate runs affected tests on protected branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Key postures — full definitions in `docs/methodology.md`.
 - All workspaces build and typecheck clean (run `pnpm build` and `pnpm typecheck:all`)
 - Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
 - Pinned overrides enforce minimum safe versions for transitive deps (see `pnpm.overrides` block in root `package.json`)
-- React 19.2.4 (CVE-2025-55182 React2Shell patched)
+- React 19.2.14 (CVE-2025-55182 React2Shell patched)
 - GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; future triage trackers land in the private `revealui-jv` repo per the issue-redaction convention
 - AST-based code-pattern analyzer: execSync injection, TOCTOU, ReDoS (ret parser + contracts schemas)
 - Pre-push gate runs affected tests on protected branches

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -31,7 +31,7 @@ note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (
 - **Codebase:** ~270,000 lines of TypeScript/Rust/Go across apps + packages
 - **History:** 2,400+ commits (Dec 30, 2025 – May 2026), solo developer
 - **Apps:** 4 (server, admin, docs, marketing) — `apps/api` was renamed to `apps/server` in CHIP-4 (revealui#649, 2026-04-28); `marketing` migrated from Next.js to Vite (2026-04-28); the agency site (revealuistudio.com) extracted into a separate repo (2026-04-29); the revealcoin dashboard relocated to RevealUIStudio/revealcoin `apps/dashboard/` (2026-05-17)
-- **Packages:** 27 packages + 4 apps = 31 workspaces
+- **Packages:** 26 packages + 4 apps = 30 workspaces
 - **Tests:** extensive test suite across unit, integration, and E2E layers; all workspaces build and typecheck (run `pnpm test` for current count)
 - **Database:** 86 tables (Drizzle ORM on **Neon** — primary). Supabase phase-out is in flight: GAP-129 PR-A/B/D shipped (2026-05-01); PR-C (dual-DB client collapse) is the remaining work. RAG tables (`ragDocuments`, `ragChunks`) and the legacy Supabase MCP server adapter remain in-tree during the transition. 61 CHECK constraints enforced (migration 0001 applied 2026-04-15).
 - **UI Components:** 59 native components (Tailwind v4, zero external UI deps)

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -31,7 +31,7 @@ note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (
 - **Codebase:** ~270,000 lines of TypeScript/Rust/Go across apps + packages
 - **History:** 2,400+ commits (Dec 30, 2025 – May 2026), solo developer
 - **Apps:** 4 (server, admin, docs, marketing) — `apps/api` was renamed to `apps/server` in CHIP-4 (revealui#649, 2026-04-28); `marketing` migrated from Next.js to Vite (2026-04-28); the agency site (revealuistudio.com) extracted into a separate repo (2026-04-29); the revealcoin dashboard relocated to RevealUIStudio/revealcoin `apps/dashboard/` (2026-05-17)
-- **Packages:** 26 packages + 4 apps = 30 workspaces
+- **Packages:** 27 packages + 4 apps = 31 workspaces
 - **Tests:** extensive test suite across unit, integration, and E2E layers; all workspaces build and typecheck (run `pnpm test` for current count)
 - **Database:** 86 tables (Drizzle ORM on **Neon** — primary). Supabase phase-out is in flight: GAP-129 PR-A/B/D shipped (2026-05-01); PR-C (dual-DB client collapse) is the remaining work. RAG tables (`ragDocuments`, `ragChunks`) and the legacy Supabase MCP server adapter remain in-tree during the transition. 61 CHECK constraints enforced (migration 0001 applied 2026-04-15).
 - **UI Components:** 59 native components (Tailwind v4, zero external UI deps)


### PR DESCRIPTION
## Summary

One-line refresh after an internal doc/config-drift audit (2026-05-18):

- **`CLAUDE.md` line 195** — React version claim `19.2.4` → `19.2.5`. Matches `pnpm-lock.yaml` `react@19.2.5:` block. Same CVE-2025-55182 patch status; the doc was off by one patch level.

(Initial commit on this branch also touched `docs/MASTER_PLAN.md` line 34 with a workspace-count edit. That edit was based on a sloppy recount and has been reverted by a follow-up corrective commit — the original `26 packages + 4 apps = 30 workspaces` claim is correct. `ls -1 packages/` returned 27 only because of the `PACKAGE-CONVENTIONS.md` doc file; true package-directory count is 26. PR #949 verified the same count.)

## Test plan

- [ ] CI green (no semantic change — doc-only edit)
- [ ] Visual review of net diff vs `origin/test` (1 line in `CLAUDE.md`)
