### PR TITLE
chore(marketing): Phase 1 — centralize copy into app/content/ (overhaul lane)

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -1,4 +1,6 @@
 import { BuiltWithRevealUI } from '@revealui/presentation';
+import { FOOTER_COLUMNS, FOOTER_LEGAL, FOOTER_LEGAL_LINKS, FOOTER_TAGLINE } from '../content/nav';
+import { SITE } from '../content/site';
 import { NewsletterSignup } from './NewsletterSignup';
 
 export function Footer() {
@@ -8,11 +10,8 @@ export function Footer() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
           <div className="lg:col-span-2">
-            <div className="text-2xl font-bold tracking-tight text-white mb-4">RevealUI</div>
-            <p className="text-gray-400 text-sm leading-6 max-w-sm">
-              Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open
-              source, and ready to deploy.
-            </p>
+            <div className="text-2xl font-bold tracking-tight text-white mb-4">{SITE.brand}</div>
+            <p className="text-gray-400 text-sm leading-6 max-w-sm">{FOOTER_TAGLINE}</p>
             <div className="mt-6">
               <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
                 Stay in the loop
@@ -24,7 +23,7 @@ export function Footer() {
             </div>
             <div className="mt-6 flex gap-4">
               <a
-                href="https://github.com/RevealUIStudio/revealui"
+                href={SITE.urls.repo}
                 className="text-gray-400 hover:text-white transition-colors"
                 aria-label="GitHub"
               >
@@ -38,7 +37,7 @@ export function Footer() {
                 </svg>
               </a>
               <a
-                href="https://x.com/revealui"
+                href={SITE.urls.x}
                 className="text-gray-400 hover:text-white transition-colors"
                 aria-label="RevealUI on X"
               >
@@ -48,7 +47,7 @@ export function Footer() {
                 </svg>
               </a>
               <a
-                href="https://www.linkedin.com/company/revealui"
+                href={SITE.urls.linkedin}
                 className="text-gray-400 hover:text-white transition-colors"
                 aria-label="RevealUI on LinkedIn"
               >
@@ -59,124 +58,49 @@ export function Footer() {
               </a>
             </div>
           </div>
-          <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">
-              Product
-            </h3>
-            <ul className="space-y-3 text-sm text-gray-400">
-              <li>
-                <a href="/products" className="hover:text-white transition-colors">
-                  Products
-                </a>
-              </li>
-              <li>
-                <a href="/marketplace" className="hover:text-white transition-colors">
-                  Marketplace
-                </a>
-              </li>
-              <li>
-                <a href="/pricing" className="hover:text-white transition-colors">
-                  Pricing
-                </a>
-              </li>
-              <li>
-                <a href="https://docs.revealui.com" className="hover:text-white transition-colors">
-                  Documentation
-                </a>
-              </li>
-              <li>
-                <a href="/blog" className="hover:text-white transition-colors">
-                  Blog
-                </a>
-              </li>
-              <li>
-                <a href="/coming-soon" className="hover:text-white transition-colors">
-                  Roadmap
-                </a>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">
-              Community
-            </h3>
-            <ul className="space-y-3 text-sm text-gray-400">
-              <li>
-                <a
-                  href="https://github.com/RevealUIStudio/revealui"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-white transition-colors"
-                >
-                  GitHub
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://github.com/RevealUIStudio/revealui/discussions"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-white transition-colors"
-                >
-                  Discussions
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://revnation.discourse.group"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-white transition-colors"
-                >
-                  Forum
-                </a>
-              </li>
-              <li>
-                <a href="/sponsor" className="hover:text-white transition-colors">
-                  Sponsor
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://revealuistudio.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-white transition-colors"
-                >
-                  RevealUI Studio (agency) →
-                </a>
-              </li>
-              <li>
-                <a href="/contact" className="hover:text-white transition-colors">
-                  Contact
-                </a>
-              </li>
-            </ul>
-          </div>
+          {FOOTER_COLUMNS.map((col) => (
+            <div key={col.heading}>
+              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">
+                {col.heading}
+              </h3>
+              <ul className="space-y-3 text-sm text-gray-400">
+                {col.links.map(({ label, href, external }) => (
+                  <li key={label}>
+                    <a
+                      href={href}
+                      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                      className="hover:text-white transition-colors"
+                    >
+                      {label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
         <div className="mt-12 pt-8 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-4 text-gray-400 text-sm">
           <div className="flex items-center gap-4">
             <p>
               &copy; {currentYear} RevealUI is operated by{' '}
               <a
-                href="https://revealuistudio.com"
+                href={FOOTER_LEGAL.operatorHref}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:text-white transition-colors underline-offset-4 hover:underline"
               >
-                REVEALUI STUDIO L.L.C.
+                {FOOTER_LEGAL.operator}
               </a>{' '}
-              (Tennessee). All rights reserved.
+              ({FOOTER_LEGAL.jurisdiction}). All rights reserved.
             </p>
             <BuiltWithRevealUI size="sm" colorScheme="dark" />
           </div>
           <div className="flex gap-6">
-            <a href="/privacy" className="hover:text-white transition-colors">
-              Privacy Policy
-            </a>
-            <a href="/terms" className="hover:text-white transition-colors">
-              Terms of Service
-            </a>
+            {FOOTER_LEGAL_LINKS.map(({ label, href }) => (
+              <a key={label} href={href} className="hover:text-white transition-colors">
+                {label}
+              </a>
+            ))}
           </div>
         </div>
       </div>

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -1,4 +1,5 @@
 import { ButtonCVA } from '@revealui/presentation';
+import { HOME_GET_STARTED } from '../content/home';
 import { NewsletterSignup } from './NewsletterSignup';
 
 export function GetStarted() {
@@ -7,15 +8,12 @@ export function GetStarted() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-            Ready to build?
+            {HOME_GET_STARTED.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-400">
-            Users, content, products, payments, and AI, pre-wired. Start building locally in
-            minutes; flip to live mode when you are ready.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-400">{HOME_GET_STARTED.body}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">
-              <a href="https://admin.revealui.com/signup">Get started free</a>
+              <a href={HOME_GET_STARTED.cta.primary.href}>{HOME_GET_STARTED.cta.primary.label}</a>
             </ButtonCVA>
             <ButtonCVA
               asChild
@@ -23,8 +21,8 @@ export function GetStarted() {
               size="lg"
               className="border-gray-700 text-gray-300 hover:text-white hover:border-gray-500"
             >
-              <a href="https://docs.revealui.com">
-                Read the docs
+              <a href={HOME_GET_STARTED.cta.secondary.href}>
+                {HOME_GET_STARTED.cta.secondary.label}
                 <svg
                   className="h-4 w-4 ml-1.5"
                   fill="none"
@@ -46,7 +44,7 @@ export function GetStarted() {
           {/* Newsletter */}
           <div className="mt-16 pt-10 border-t border-gray-800">
             <p className="text-sm font-medium text-gray-400 mb-4">
-              Not ready to start? Get product updates and engineering insights.
+              {HOME_GET_STARTED.newsletter.label}
             </p>
             <NewsletterSignup variant="stacked" />
           </div>

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,13 +1,6 @@
 import { LinkButton } from '@revealui/presentation';
 import { useState } from 'react';
-
-const navLinks = [
-  { label: 'Products', href: '/products' },
-  { label: 'Marketplace', href: '/marketplace' },
-  { label: 'Pricing', href: '/pricing' },
-  { label: 'Docs', href: 'https://docs.revealui.com' },
-  { label: 'Blog', href: '/blog' },
-];
+import { NAV_AUTH, NAV_LINKS } from '../content/nav';
 
 export function NavBar() {
   const [open, setOpen] = useState(false);
@@ -21,7 +14,7 @@ export function NavBar() {
 
         {/* Desktop links */}
         <div className="hidden sm:flex items-center gap-8 text-sm font-medium text-gray-600">
-          {navLinks.map(({ label, href }) => (
+          {NAV_LINKS.map(({ label, href }) => (
             <a key={label} href={href} className="hover:text-gray-900 transition-colors">
               {label}
             </a>
@@ -46,12 +39,12 @@ export function NavBar() {
 
         <div className="flex items-center gap-3">
           <a
-            href="https://admin.revealui.com/login"
+            href={NAV_AUTH.login.href}
             className="hidden sm:inline-flex text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
           >
-            Log in
+            {NAV_AUTH.login.label}
           </a>
-          <LinkButton href="https://admin.revealui.com/signup">Get started free</LinkButton>
+          <LinkButton href={NAV_AUTH.signup.href}>{NAV_AUTH.signup.label}</LinkButton>
 
           {/* Hamburger - mobile only */}
           <button
@@ -96,7 +89,7 @@ export function NavBar() {
       {open && (
         <div className="sm:hidden border-t border-gray-100 bg-white px-6 py-4">
           <div className="flex flex-col gap-1">
-            {navLinks.map(({ label, href }) => (
+            {NAV_LINKS.map(({ label, href }) => (
               <a
                 key={label}
                 href={href}
@@ -118,18 +111,18 @@ export function NavBar() {
           </div>
           <div className="mt-4 flex flex-col gap-2 border-t border-gray-100 pt-4">
             <a
-              href="https://admin.revealui.com/login"
+              href={NAV_AUTH.login.href}
               className="rounded-md px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-colors"
               onClick={() => setOpen(false)}
             >
-              Log in
+              {NAV_AUTH.login.label}
             </a>
             <LinkButton
-              href="https://admin.revealui.com/signup"
+              href={NAV_AUTH.signup.href}
               onClick={() => setOpen(false)}
               className="w-full"
             >
-              Get started free
+              {NAV_AUTH.signup.label}
             </LinkButton>
           </div>
         </div>

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -1,22 +1,5 @@
+import { HOME_DEMO } from '../../content/home';
 import { ProductMockup } from '../ProductMockup';
-
-const beats = [
-  {
-    n: '01',
-    title: 'Spin up a stack.',
-    body: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
-  },
-  {
-    n: '02',
-    title: 'Customer flow, end to end.',
-    body: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
-  },
-  {
-    n: '03',
-    title: 'Agent-native, by default.',
-    body: 'Every primitive ships with a matching MCP server. Wire an LLM provider and your agents read customers, refund subscriptions, and write content through the same APIs your app uses.',
-  },
-];
 
 export function Demo() {
   return (
@@ -24,14 +7,12 @@ export function Demo() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            Watch it work
+            {HOME_DEMO.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            From CLI to a working stack in 90 seconds.
+            {HOME_DEMO.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_DEMO.body}</p>
         </div>
 
         <div className="mx-auto mt-16 max-w-5xl">
@@ -41,16 +22,16 @@ export function Demo() {
             </div>
           </div>
           <p className="mt-3 text-center text-xs text-gray-500">
-            Local screenshot from a fresh{' '}
+            {HOME_DEMO.mockupCaption.prefix}{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700">
-              npx create-revealui
+              {HOME_DEMO.mockupCaption.code}
             </code>
-            . The three beats below describe the steps.
+            {HOME_DEMO.mockupCaption.suffix}
           </p>
         </div>
 
         <div className="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3">
-          {beats.map((b) => (
+          {HOME_DEMO.beats.map((b) => (
             <div key={b.n} className="rounded-2xl bg-white p-8 ring-1 ring-gray-950/5">
               <div className="font-mono text-xs font-semibold uppercase tracking-widest text-emerald-700">
                 {b.n}

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -1,54 +1,24 @@
-const faqs = [
-  {
-    q: 'How is this different from Supabase, Convex, Clerk, or Trigger?',
-    a: 'Convex gives you real-time DB + functions. Supabase gives you Postgres + auth. Clerk gives you sessions. Trigger runs background jobs. Each one is a slice. RevealUI is the whole runtime — auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel and Cloudflare are deploy targets, not competitors — RevealUI runs on both.)',
-  },
-  {
-    q: 'Can I self-host?',
-    a: 'Yes. 24 of 26 packages are MIT and stay MIT — forever. The 2 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infra at any tier — no vendor-specific edge runtimes, no proprietary database.',
-  },
-  {
-    q: 'What does "agent-native" actually mean in code?',
-    a: 'Every collection is an MCP tool AND a REST endpoint AND a typed SDK call — gated by the same RBAC + ABAC policy. Agents are first-class principals: scope one to a collection, give it a budget, watch every action sign into the audit chain, revoke when done. The runtime is the contract, not a glue layer.',
-  },
-  {
-    q: "What's the lock-in story?",
-    a: 'Open standards, end-to-end. OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Postgres for data. Deploy anywhere Next.js and Hono run — Vercel, Cloudflare, Railway, Hetzner, your own metal. Your data, your code, your infra. RevealUI is the runtime, not the prison.',
-  },
-  {
-    q: 'Production-ready?',
-    a: 'Behind a 3-phase CI gate: Biome lint, Vitest unit + integration, Playwright E2E, CodeQL, Gitleaks, claim-drift validator. Every PR runs the gate before it can land. The marketing site you are reading runs on @revealui/router and @revealui/presentation; the agency site at revealuistudio.com runs on the same packages. View the source on GitHub.',
-  },
-  {
-    q: "What's the rest of RevFleet?",
-    a: 'RevFleet is the umbrella. RevealUI is the runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness (multi-agent coordination across Claude / Cursor / Copilot). RevCon syncs editor configs. RevSkills is the skills library. RevForge is the operator-side stamping tool that produces white-label trial kits. RevealCoin is x402-compatible payments — deployed on Solana mainnet but pre-launch (see RevealCoin README for blockers). RevKit is the portable WSL dev environment. Use RevealUI standalone, or compose what you need.',
-  },
-  {
-    q: 'How does AI inference work?',
-    a: 'Bring your own model. Default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ollama or Ubuntu Inference Snaps — your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
-  },
-  {
-    q: 'How do agent payments work?',
-    a: "x402-native. RevealUI implements the HTTP 402 payment protocol — compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare's x402 Foundation. Agents pay agents over standard HTTP. RevealCoin is one optional Solana implementation; the protocol is what is load-bearing. RevealCoin itself is pre-launch — see the RevealCoin README for the open prerequisites.",
-  },
-];
+import { HOME_FAQ } from '../../content/home';
 
 export function Faq() {
   return (
     <section className="bg-white py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">FAQ</p>
+          <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            {HOME_FAQ.eyebrow}
+          </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Common questions.
+            {HOME_FAQ.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl divide-y divide-gray-200">
-          {faqs.map((item) => (
-            <details key={item.q} className="group py-6">
+          {HOME_FAQ.items.map((item) => (
+            <details key={item.question} className="group py-6">
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3 className="text-lg font-semibold leading-7 text-gray-950">{item.q}</h3>
+                <h3 className="text-lg font-semibold leading-7 text-gray-950">{item.question}</h3>
+
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
                   <svg
                     className="h-4 w-4"
@@ -62,7 +32,7 @@ export function Faq() {
                   </svg>
                 </span>
               </summary>
-              <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{item.a}</div>
+              <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{item.answer}</div>
             </details>
           ))}
         </div>

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -1,4 +1,6 @@
 import { ButtonCVA } from '@revealui/presentation';
+import { HOME_HERO } from '../../content/home';
+import { SITE } from '../../content/site';
 
 const backgroundPrimitives = [
   {
@@ -73,37 +75,35 @@ export function Hero() {
         <div className="mx-auto max-w-3xl text-center">
           <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 mb-6">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle mr-2 animate-pulse" />
-            Open-source. Self-hostable. Audit-grade.
+            {HOME_HERO.eyebrow}
           </p>
 
           <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
-            The open runtime for AI-native businesses.
+            {HOME_HERO.h1}
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            <strong className="text-gray-900">Yours to install. Ours to build for you.</strong>{' '}
-            Auth, content, products, payments, and intelligence &mdash; five primitives, one policy
-            plane, one hash-chained audit log. For founders shipping AI products who need audit
-            trails and unified governance from day one &mdash; whether you build with{' '}
+            <strong className="text-gray-900">{HOME_HERO.subtitle.strong}</strong>{' '}
+            {HOME_HERO.subtitle.body} &mdash;{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-base text-gray-900">
-              npx create-revealui
+              {SITE.cli.create}
             </code>{' '}
-            or hire{' '}
+            {HOME_HERO.subtitle.cliSuffix}{' '}
             <a
-              href="https://revealuistudio.com"
+              href={HOME_HERO.subtitle.agencyHref}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-emerald-700 hover:underline"
             >
-              RevealUI Studio
+              {HOME_HERO.subtitle.agencyLabel}
             </a>{' '}
-            to build it for you.
+            {HOME_HERO.subtitle.agencySuffix}
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="w-full sm:w-auto gap-2">
-              <a href="https://admin.revealui.com/signup">
-                Start free
+              <a href={HOME_HERO.cta.primary.href}>
+                {HOME_HERO.cta.primary.label}
                 <svg
                   className="h-4 w-4"
                   fill="none"
@@ -122,29 +122,25 @@ export function Hero() {
               </a>
             </ButtonCVA>
             <ButtonCVA asChild variant="outline" size="lg" className="w-full sm:w-auto gap-2">
-              <a
-                href="https://github.com/RevealUIStudio/revealui"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href={HOME_HERO.cta.secondary.href} target="_blank" rel="noopener noreferrer">
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <title>GitHub</title>
                   <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
                 </svg>
-                See it on GitHub
+                {HOME_HERO.cta.secondary.label}
               </a>
             </ButtonCVA>
           </div>
 
           <p className="mt-6 text-sm text-gray-600">
-            Want it built for you?{' '}
+            {HOME_HERO.agencyCta.prefix}{' '}
             <a
-              href="https://revealuistudio.com"
+              href={HOME_HERO.agencyCta.href}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-emerald-700 hover:underline"
             >
-              RevealUI Studio builds AI businesses on RevealUI &rarr;
+              {HOME_HERO.agencyCta.label}
             </a>
           </p>
 
@@ -155,45 +151,14 @@ export function Hero() {
             <span className="text-blue-300">my-app</span>
           </div>
 
-          <p className="mt-4 text-sm text-gray-500">
-            Local dev stack in 60 seconds. No credit card.
-          </p>
+          <p className="mt-4 text-sm text-gray-500">{HOME_HERO.cliCaption}</p>
 
           <div className="mt-16 border-t border-gray-100 pt-10">
             <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-600 mb-6">
-              What ships today
+              {HOME_HERO.shipsToday.heading}
             </h2>
             <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
-              {[
-                {
-                  metric: '26 packages',
-                  detail:
-                    '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private workspace packages. Source at packages/.',
-                },
-                {
-                  metric: '86 database tables',
-                  detail:
-                    'Drizzle ORM over NeonDB across 5 schemas. Source at packages/db/src/schema/.',
-                },
-                {
-                  metric: '13 first-party MCP servers',
-                  detail: 'Every one stdio-launchable. Source at packages/mcp/src/servers/.',
-                },
-                {
-                  metric: 'EdDSA-signed Pro license JWTs',
-                  detail:
-                    'Verified every 5 minutes against the license server. Source at packages/core/src/license.ts.',
-                },
-                {
-                  metric: 'FSL-1.1-MIT on 5 Fair Source packages',
-                  detail:
-                    'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
-                },
-                {
-                  metric: 'Vite + Hono + ElectricSQL browser sync',
-                  detail: 'No Next.js, no community router, no Supabase in the production path.',
-                },
-              ].map((item) => (
+              {HOME_HERO.shipsToday.items.map((item) => (
                 <li key={item.metric} className="flex gap-3">
                   <svg
                     className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500"

--- a/apps/marketing/app/components/landing/Persona.tsx
+++ b/apps/marketing/app/components/landing/Persona.tsx
@@ -1,10 +1,4 @@
-const checklist = [
-  'Hash-chained audit log of every action by every human and every agent — provable, not just observable',
-  'One RBAC + ABAC policy plane covering humans, agents, and service accounts',
-  'GDPR consent + deletion + anonymization scaffolded into the data model',
-  'Stripe webhook reconciliation that catches the events most apps lose silently',
-  'Source-visible Pro packages on Fair Source — auditable for procurement and security review',
-];
+import { PERSONA_CARD, PERSONA_SECTION } from '../../content/persona';
 
 export function Persona() {
   return (
@@ -12,26 +6,22 @@ export function Persona() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            Who it&apos;s for
+            {PERSONA_SECTION.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Founders shipping AI products who need governance from day one.
+            {PERSONA_SECTION.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl">
           <div className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
             <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
-              What this team needs before they can charge customers
+              {PERSONA_CARD.label}
             </p>
-            <p className="mt-4 text-xl leading-8 italic text-gray-700">
-              You have a working agent demo. Now your first procurement review wants audit trails,
-              identity gates, and a story for who can revoke an agent at 3am &mdash; without
-              rebuilding the runtime to get there.
-            </p>
+            <p className="mt-4 text-xl leading-8 italic text-gray-700">{PERSONA_CARD.quote}</p>
 
             <ul className="mt-10 space-y-4">
-              {checklist.map((item) => (
+              {PERSONA_CARD.checklist.map((item) => (
                 <li key={item} className="flex items-start gap-3 text-base text-gray-700">
                   <svg
                     className="mt-1 h-5 w-5 flex-shrink-0 text-emerald-500"
@@ -52,13 +42,11 @@ export function Persona() {
           </div>
 
           <p className="mt-8 text-center text-sm text-gray-500">
-            Also a fit for{' '}
-            <span className="font-medium text-gray-700">
-              teams escaping backend-platform sprawl
-            </span>{' '}
-            (Convex + Supabase + Clerk + Trigger), and{' '}
-            <span className="font-medium text-gray-700">studios + consultancies</span>{' '}
-            white-labeling one runtime across N customers without re-licensing N SaaS stacks.
+            {PERSONA_CARD.footer.prefix}{' '}
+            <span className="font-medium text-gray-700">{PERSONA_CARD.footer.sprawl}</span>{' '}
+            {PERSONA_CARD.footer.sprawlNote}{' '}
+            <span className="font-medium text-gray-700">{PERSONA_CARD.footer.studios}</span>{' '}
+            {PERSONA_CARD.footer.studiosNote}
           </p>
         </div>
       </div>

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -1,6 +1,11 @@
 import type { LicenseTierId, PricingResponse } from '@revealui/contracts/pricing';
 import { Button, ButtonCVA } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
+import {
+  PRICING_TEASER_FOOTER,
+  PRICING_TEASER_SECTION,
+  PRICING_TEASER_TIERS,
+} from '../../content/pricing-teaser';
 
 // Fallback used when /api/pricing is unreachable. Mirrors HARDCODED_SUBSCRIPTION_PRICES
 // in apps/server/src/routes/pricing.ts. The billing-readiness cron drift-checks the API
@@ -16,66 +21,6 @@ const TEASER_FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: str
 const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
-
-interface TeaserTier {
-  id: LicenseTierId;
-  name: string;
-  description: string;
-  features: string[];
-  cta: string;
-  href: string;
-  highlight: boolean;
-}
-
-// Tier copy lives here (curated for the teaser context); pricing comes from the API.
-// The teaser shows three tiers — Free, Pro, Enterprise — instead of the four on /pricing.
-// Max is omitted; the "See full pricing" link surfaces it.
-const TEASER_TIERS: TeaserTier[] = [
-  {
-    id: 'free',
-    name: 'Free',
-    description:
-      '24 of 26 packages MIT — forever. The 2 Pro packages are Fair Source (FSL) and convert to MIT after two years. No telemetry.',
-    features: [
-      'Full primitive stack',
-      'Admin dashboard + API',
-      'Self-host on any infra',
-      'Bring your own model (open-weight default)',
-    ],
-    cta: 'Get started free',
-    href: 'https://admin.revealui.com/signup',
-    highlight: false,
-  },
-  {
-    id: 'pro',
-    name: 'Pro',
-    description: 'Pro AI primitives, agent task allowance, and priority support.',
-    features: [
-      'Everything in Free',
-      '10,000 agent tasks / month included',
-      'Pro AI features (agents, MCP, memory) — beta in production',
-      'Priority support',
-    ],
-    cta: 'See Pro pricing',
-    href: '/pricing',
-    highlight: true,
-  },
-  {
-    id: 'enterprise',
-    name: 'Enterprise',
-    description:
-      'Audit logs, multi-tenant architecture, and a named contact. Custom plans for high volume; SSO and on-prem on the roadmap.',
-    features: [
-      'Everything in Pro',
-      'Audit logs + compliance reports',
-      'Multi-tenant architecture',
-      'Roadmap: SSO, SCIM, on-prem deploy',
-    ],
-    cta: 'Talk to us',
-    href: '/contact',
-    highlight: false,
-  },
-];
 
 export function PricingTeaser() {
   const [prices, setPrices] = useState(TEASER_FALLBACK_PRICE);
@@ -109,18 +54,17 @@ export function PricingTeaser() {
     <section className="bg-gray-50 py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">Pricing</p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Start free. Pay when you scale.
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Self-host the open-source stack at no cost. Pay for the AI primitives and priority
-            support when your business needs them.
+          <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            {PRICING_TEASER_SECTION.eyebrow}
           </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            {PRICING_TEASER_SECTION.heading}
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{PRICING_TEASER_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
-          {TEASER_TIERS.map((t) => {
+          {PRICING_TEASER_TIERS.map((t) => {
             const { price, period } = prices[t.id];
             return (
               <div
@@ -201,15 +145,15 @@ export function PricingTeaser() {
         </div>
 
         <div className="mt-12 text-center">
-          <Button plain href="/pricing" className="text-sm font-medium">
-            See full pricing &rarr;
+          <Button plain href={PRICING_TEASER_FOOTER.moreHref} className="text-sm font-medium">
+            {PRICING_TEASER_FOOTER.moreLabel}
           </Button>
           <p className="mt-6 text-xs leading-5 text-gray-500">
-            Deploys to Vercel, Cloudflare, Railway, Hetzner, or self-host.{' '}
+            {PRICING_TEASER_FOOTER.caption.prefix}{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700">
-              pnpm build
+              {PRICING_TEASER_FOOTER.caption.code}
             </code>{' '}
-            produces a standard Node bundle &mdash; no vendor-specific edge runtimes.
+            {PRICING_TEASER_FOOTER.caption.suffix}
           </p>
         </div>
       </div>

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -1,42 +1,5 @@
 import { Button } from '@revealui/presentation';
-
-const primitives = [
-  {
-    label: 'Users',
-    body: 'Auth, sessions, RBAC + ABAC. Same policy governs human and agent access.',
-    color: 'emerald',
-    iconPath:
-      'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
-  },
-  {
-    label: 'Content',
-    body: 'Headless CMS, rich text, media. Auto-exposed as MCP tools.',
-    color: 'blue',
-    iconPath:
-      'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
-  },
-  {
-    label: 'Products',
-    body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
-    color: 'amber',
-    iconPath:
-      'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
-  },
-  {
-    label: 'Payments',
-    body: 'Stripe billing, subscriptions, webhook reconciliation. x402-native agent payments.',
-    color: 'cyan',
-    iconPath:
-      'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
-  },
-  {
-    label: 'Intelligence',
-    body: 'Agents, MCP servers, CRDT memory. Bring-your-own-model; open-weight default.',
-    color: 'violet',
-    iconPath:
-      'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',
-  },
-];
+import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 
 const accentBg: Record<string, string> = {
   emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
@@ -52,19 +15,16 @@ export function Primitives() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            Five primitives. One audit log. One policy plane.
+            {HOME_PRIMITIVES_SECTION.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Everything a business needs. Nothing you don&apos;t.
+            {HOME_PRIMITIVES_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Auth, content, products, payments, and intelligence &mdash; every action by every human
-            and agent is RBAC-gated, ABAC-checked, and signed into a tamper-evident audit chain.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_PRIMITIVES_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
-          {primitives.map((p) => (
+          {HOME_PRIMITIVES.map((p) => (
             <div
               key={p.label}
               className="flex flex-col items-start rounded-2xl bg-white p-6 ring-1 ring-gray-950/5 transition hover:ring-gray-950/10"
@@ -90,8 +50,12 @@ export function Primitives() {
         </div>
 
         <div className="mt-12 text-center">
-          <Button plain href="https://docs.revealui.com" className="text-sm font-medium">
-            See the primitive reference &rarr;
+          <Button
+            plain
+            href={HOME_PRIMITIVES_SECTION.docsLink.href}
+            className="text-sm font-medium"
+          >
+            {HOME_PRIMITIVES_SECTION.docsLink.label}
           </Button>
         </div>
       </div>

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -1,48 +1,4 @@
-interface Row {
-  capability: string;
-  sprawl: string;
-  agentOnly: string;
-  revealui: string;
-}
-
-const rows: Row[] = [
-  {
-    capability: 'Auth + RBAC + sessions',
-    sprawl: 'Clerk Pro ($25/seat)',
-    agentOnly: 'Bring your own',
-    revealui: 'Built in',
-  },
-  {
-    capability: 'CMS + admin UI',
-    sprawl: 'Payload + your team',
-    agentOnly: 'Bring your own',
-    revealui: 'Built in',
-  },
-  {
-    capability: 'Stripe billing + webhooks',
-    sprawl: 'Stripe + your code',
-    agentOnly: 'Bring your own',
-    revealui: 'Built in (with reconciliation)',
-  },
-  {
-    capability: 'MCP tools for every API',
-    sprawl: 'Per-collection plugin',
-    agentOnly: 'Tool registry only',
-    revealui: 'Auto-exposed, RBAC-governed',
-  },
-  {
-    capability: 'Tamper-evident audit log',
-    sprawl: 'Datadog + custom hashing',
-    agentOnly: 'Logs only',
-    revealui: 'Hash-chained, in DB',
-  },
-  {
-    capability: 'Cost (5 devs, mid-startup)',
-    sprawl: '~$1,200 / mo',
-    agentOnly: '~$300 / mo + infra',
-    revealui: '$49 / mo + infra',
-  },
-];
+import { HOME_PROBLEM } from '../../content/home';
 
 export function Problem() {
   return (
@@ -50,47 +6,43 @@ export function Problem() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            The problem
+            {HOME_PROBLEM.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Vendor sprawl, or framework-only. Pick neither.
+            {HOME_PROBLEM.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Most AI teams glue together a half-dozen SaaS backends. Some pick a thin agent framework
-            and rebuild auth, billing, and content from scratch. RevealUI is the third option:
-            everything wired in, governed by one policy, owned by you.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_PROBLEM.body}</p>
         </div>
 
         <div className="mx-auto mt-16 max-w-6xl overflow-hidden rounded-2xl ring-1 ring-gray-950/10 shadow-sm">
           <section
             // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable comparison table — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally on narrow viewports
             tabIndex={0}
-            aria-label="Vendor sprawl vs agent-framework vs RevealUI comparison"
+            aria-label={HOME_PROBLEM.tableAriaLabel}
             className="overflow-x-auto"
           >
             <table className="w-full text-left text-sm">
               <thead>
                 <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-widest text-gray-500">
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                    Capability
+                    {HOME_PROBLEM.columns.capability}
                   </th>
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                    Vendor sprawl
+                    {HOME_PROBLEM.columns.sprawl}
                   </th>
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                    Agent framework only
+                    {HOME_PROBLEM.columns.agentOnly}
                   </th>
                   <th
                     scope="col"
                     className="bg-emerald-50 px-4 py-3 text-emerald-800 sm:px-6 sm:py-4"
                   >
-                    RevealUI
+                    {HOME_PROBLEM.columns.revealui}
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 bg-white">
-                {rows.map((r) => (
+                {HOME_PROBLEM.rows.map((r) => (
                   <tr key={r.capability} className="hover:bg-gray-50/60 transition">
                     <td className="px-4 py-4 font-medium text-gray-950 sm:px-6">{r.capability}</td>
                     <td className="px-4 py-4 text-gray-600 sm:px-6">{r.sprawl}</td>
@@ -106,9 +58,7 @@ export function Problem() {
         </div>
 
         <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-gray-500">
-          Sprawl prices reflect typical mid-startup invoices. RevealUI Pro is $49/mo + your own
-          infrastructure. Vercel and Cloudflare are deploy targets, not competitors &mdash; RevealUI
-          runs on both.
+          {HOME_PROBLEM.footnote}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,25 +1,12 @@
 import { Button } from '@revealui/presentation';
-
-const stack = [
-  { label: 'Vite', kind: 'Marketing + docs frontends' },
-  { label: 'Next.js 16', kind: 'Admin frontend' },
-  { label: 'React 19', kind: 'UI runtime' },
-  { label: 'PostgreSQL', kind: 'Database' },
-  { label: 'Drizzle', kind: 'ORM' },
-  { label: 'Stripe', kind: 'Payments' },
-  { label: 'Hono', kind: 'API + edge' },
-  { label: 'MCP', kind: 'Agent protocol' },
-  { label: 'Tailwind', kind: 'Design system' },
-];
-
-const ciSignals = [
-  'Biome lint + format',
-  'Vitest unit + integration',
-  'Playwright E2E',
-  'CodeQL + Gitleaks',
-  'TypeScript strict, repo-wide',
-  'Affected-only PR gate',
-];
+import {
+  PROOF_CI_SIGNALS,
+  PROOF_REPO_SIGNALS,
+  PROOF_SECTION,
+  PROOF_STACK,
+  PROOF_STACK_PANEL,
+  PROOF_TRUST,
+} from '../../content/proof';
 
 export function Proof() {
   return (
@@ -27,27 +14,26 @@ export function Proof() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            The stack so far
+            {PROOF_SECTION.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            Built in the open. Verifiable in the repo.
+            {PROOF_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Every package, every PR, every test. Inspect the code before you commit a single line of
-            your own.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{PROOF_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Repo signals */}
           <div className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-950/5">
             <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
-              On GitHub
+              {PROOF_REPO_SIGNALS.eyebrow}
             </p>
-            <h3 className="mt-2 text-xl font-semibold text-gray-950">Live signals</h3>
+            <h3 className="mt-2 text-xl font-semibold text-gray-950">
+              {PROOF_REPO_SIGNALS.heading}
+            </h3>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <a
-                href="https://github.com/RevealUIStudio/revealui"
+                href={PROOF_REPO_SIGNALS.repoHref}
                 className="inline-flex items-center gap-2 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:ring-gray-400 transition"
               >
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
@@ -57,7 +43,7 @@ export function Proof() {
                 {/* biome-ignore lint/performance/noImgElement: dynamic shields.io SVG badge, no image optimizer in Vite SPA */}
                 <img
                   alt="GitHub stars"
-                  src="https://img.shields.io/github/stars/RevealUIStudio/revealui?style=flat&label=Stars&color=10b981"
+                  src={`https://img.shields.io/github/stars/RevealUIStudio/revealui?style=flat&label=Stars&color=10b981`}
                   className="h-5"
                 />
               </a>
@@ -83,10 +69,10 @@ export function Proof() {
 
             <div className="mt-6 border-t border-gray-200 pt-6">
               <p className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">
-                Quality gates that block every PR
+                {PROOF_REPO_SIGNALS.ciLabel}
               </p>
               <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                {ciSignals.map((s) => (
+                {PROOF_CI_SIGNALS.map((s) => (
                   <li key={s} className="flex items-center gap-2 text-sm text-gray-700">
                     <svg
                       className="h-4 w-4 flex-shrink-0 text-emerald-500"
@@ -110,16 +96,13 @@ export function Proof() {
           {/* Stack standards */}
           <div className="rounded-2xl bg-gray-950 p-8 text-white">
             <p className="text-xs font-semibold uppercase tracking-widest text-emerald-400">
-              No proprietary lock-in
+              {PROOF_STACK_PANEL.eyebrow}
             </p>
-            <h3 className="mt-2 text-xl font-semibold">Standards your team already knows</h3>
-            <p className="mt-3 text-sm leading-6 text-gray-300">
-              No proprietary runtime, no vendor-specific edge functions. Deploys to Vercel,
-              Cloudflare, Railway, Hetzner, or your own infra. Take your data with you.
-            </p>
+            <h3 className="mt-2 text-xl font-semibold">{PROOF_STACK_PANEL.heading}</h3>
+            <p className="mt-3 text-sm leading-6 text-gray-300">{PROOF_STACK_PANEL.body}</p>
 
             <ul className="mt-6 grid grid-cols-2 gap-3">
-              {stack.map((s) => (
+              {PROOF_STACK.map((s) => (
                 <li
                   key={s.label}
                   className="rounded-lg bg-white/5 px-3 py-2.5 ring-1 ring-white/10"
@@ -135,119 +118,111 @@ export function Proof() {
         {/* Trust: verifiable in three places */}
         <div className="mx-auto mt-16 max-w-5xl">
           <div className="text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">Trust</p>
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              {PROOF_TRUST.eyebrow}
+            </p>
             <h3 className="mt-3 text-2xl font-bold tracking-tight text-gray-950 sm:text-3xl">
-              Verifiable in three places.
+              {PROOF_TRUST.heading}
             </h3>
           </div>
 
           <div className="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-3">
             <div className="rounded-2xl bg-emerald-50/40 p-6 ring-1 ring-emerald-200">
               <p className="text-xs font-semibold uppercase tracking-widest text-emerald-800">
-                In the repo
+                {PROOF_TRUST.cards[0].eyebrow}
               </p>
               <h4 className="mt-3 text-base font-semibold text-gray-950">
-                21 of 26 packages MIT &mdash; forever.
+                {PROOF_TRUST.cards[0].heading}
               </h4>
               <p className="mt-2 text-sm leading-6 text-gray-700">
-                The 5 Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two
-                years after each release. View the{' '}
+                {PROOF_TRUST.cards[0].body.prefix}{' '}
                 <a
-                  href="https://github.com/RevealUIStudio/revealui/blob/main/LICENSE"
+                  href={PROOF_TRUST.cards[0].body.licenseHref}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
                 >
-                  LICENSE
+                  {PROOF_TRUST.cards[0].body.licenseLabel}
                 </a>{' '}
-                or the{' '}
+                {PROOF_TRUST.cards[0].body.middle}{' '}
                 <a
-                  href="/fair-source"
+                  href={PROOF_TRUST.cards[0].body.explainerHref}
                   className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
                 >
-                  Fair Source explainer
+                  {PROOF_TRUST.cards[0].body.explainerLabel}
                 </a>
-                .
+                {PROOF_TRUST.cards[0].body.suffix}
               </p>
             </div>
 
             <div className="rounded-2xl bg-gray-950 p-6 ring-1 ring-gray-950/10 text-white">
               <p className="text-xs font-semibold uppercase tracking-widest text-emerald-400">
-                In the schema
+                {PROOF_TRUST.cards[1].eyebrow}
               </p>
-              <h4 className="mt-3 text-base font-semibold">
-                Every mutation signs into a hash chain.
-              </h4>
+              <h4 className="mt-3 text-base font-semibold">{PROOF_TRUST.cards[1].heading}</h4>
               <pre
                 // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable code region — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally
                 tabIndex={0}
                 className="mt-3 overflow-x-auto rounded-lg bg-black/40 px-3 py-2 font-mono text-[11px] leading-5 text-gray-300 ring-1 ring-white/10"
               >
-                {`signature:        text('signature').notNull(),
-previousSignature: text('previous_signature'),
-hashAlgorithm:    text('hash_algorithm')
-  .notNull().default('sha256-hmac'),`}
+                {PROOF_TRUST.cards[1].codeSnippet}
               </pre>
               <p className="mt-3 text-xs leading-5 text-gray-400">
                 <a
-                  href="https://github.com/RevealUIStudio/revealui/blob/main/packages/db/src/schema/audit-log.ts"
+                  href={PROOF_TRUST.cards[1].fileHref}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-emerald-400 underline decoration-emerald-700 underline-offset-4 hover:text-emerald-300"
                 >
-                  packages/db/src/schema/audit-log.ts
+                  {PROOF_TRUST.cards[1].fileLabel}
                 </a>{' '}
-                &mdash; tampering breaks the chain.
+                {PROOF_TRUST.cards[1].caption}
               </p>
             </div>
 
             <div className="rounded-2xl bg-emerald-50/40 p-6 ring-1 ring-emerald-200">
               <p className="text-xs font-semibold uppercase tracking-widest text-emerald-800">
-                In production
+                {PROOF_TRUST.cards[2].eyebrow}
               </p>
               <h4 className="mt-3 text-base font-semibold text-gray-950">
-                This site runs on RevealUI.
+                {PROOF_TRUST.cards[2].heading}
               </h4>
               <p className="mt-2 text-sm leading-6 text-gray-700">
-                The marketing site you are reading and the agency site at{' '}
+                {PROOF_TRUST.cards[2].body.prefix}{' '}
                 <a
-                  href="https://revealuistudio.com"
+                  href={PROOF_TRUST.cards[2].body.agencyHref}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
                 >
-                  revealuistudio.com
+                  {PROOF_TRUST.cards[2].body.agencyLabel}
                 </a>{' '}
-                both run on{' '}
+                {PROOF_TRUST.cards[2].body.middle}{' '}
                 <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-gray-900 ring-1 ring-emerald-200">
-                  @revealui/router
+                  {PROOF_TRUST.cards[2].body.pkg1}
                 </code>{' '}
-                +{' '}
+                {PROOF_TRUST.cards[2].body.plus}{' '}
                 <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-gray-900 ring-1 ring-emerald-200">
-                  @revealui/presentation
+                  {PROOF_TRUST.cards[2].body.pkg2}
                 </code>
-                . View the{' '}
+                {PROOF_TRUST.cards[2].body.suffix}{' '}
                 <a
-                  href="https://github.com/RevealUIStudio/revealui/tree/main/apps/marketing"
+                  href={PROOF_TRUST.cards[2].body.sourceHref}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
                 >
-                  marketing app source
+                  {PROOF_TRUST.cards[2].body.sourceLabel}
                 </a>
-                .
+                {PROOF_TRUST.cards[2].body.end}
               </p>
             </div>
           </div>
         </div>
 
         <div className="mt-12 text-center">
-          <Button
-            plain
-            href="https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md"
-            className="text-sm font-medium"
-          >
-            See what shipped this month &rarr;
+          <Button plain href={PROOF_TRUST.changelogCta.href} className="text-sm font-medium">
+            {PROOF_TRUST.changelogCta.label}
           </Button>
         </div>
       </div>

--- a/apps/marketing/app/components/landing/WhatsShipped.tsx
+++ b/apps/marketing/app/components/landing/WhatsShipped.tsx
@@ -1,69 +1,4 @@
-interface Capability {
-  title: string;
-  body: string;
-  path: string;
-  href: string;
-}
-
-const REPO_ROOT = 'https://github.com/RevealUIStudio/revealui/blob/main';
-const REPO_TREE = 'https://github.com/RevealUIStudio/revealui/tree/main';
-
-const capabilities: Capability[] = [
-  {
-    title: 'Tamper-evident audit chain',
-    body: 'Every mutation across every primitive — by humans or agents — signs into an HMAC-SHA256 hash chain. Tampering breaks the chain.',
-    path: 'packages/db/src/schema/audit-log.ts',
-    href: `${REPO_ROOT}/packages/db/src/schema/audit-log.ts`,
-  },
-  {
-    title: 'Unified RBAC + ABAC policy engine',
-    body: 'One policy plane covering humans, agents, and service accounts. Role checks, attribute checks, and action attribution all in one engine.',
-    path: 'packages/security/src/authorization.ts',
-    href: `${REPO_ROOT}/packages/security/src/authorization.ts`,
-  },
-  {
-    title: 'Stripe webhook reconciliation',
-    body: 'Most apps lose webhooks silently. This schema stores every event, retries failed handlers, and surfaces drift between Stripe and the local DB.',
-    path: 'packages/db/src/schema/webhook-reconciliation.ts',
-    href: `${REPO_ROOT}/packages/db/src/schema/webhook-reconciliation.ts`,
-  },
-  {
-    title: 'CRDT operation replay',
-    body: 'Most platforms snapshot-merge. RevealUI replays operations — collaborative editing across humans and agents stays correct after concurrent edits.',
-    path: 'packages/db/src/schema/crdt-operations.ts',
-    href: `${REPO_ROOT}/packages/db/src/schema/crdt-operations.ts`,
-  },
-  {
-    title: 'Circuit breakers + retry + bulkhead',
-    body: 'Production-grade resilience patterns wired into the runtime — adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
-    path: 'packages/resilience/src/circuit-breaker.ts',
-    href: `${REPO_ROOT}/packages/resilience/src/circuit-breaker.ts`,
-  },
-  {
-    title: 'Multi-agent harness',
-    body: 'Claude, Cursor, and Copilot coordinate on the same project through a shared workboard — its own product category, ships in the runtime.',
-    path: 'packages/harnesses',
-    href: `${REPO_TREE}/packages/harnesses`,
-  },
-  {
-    title: 'MCP hypervisor + introspection',
-    body: 'One process supervises all MCP servers, surfaces their tool registries, and gates calls through the same RBAC + ABAC plane the rest of the runtime uses.',
-    path: 'packages/mcp/src/hypervisor.ts',
-    href: `${REPO_ROOT}/packages/mcp/src/hypervisor.ts`,
-  },
-  {
-    title: 'Envelope encryption + key rotation',
-    body: 'Sensitive fields wrapped in per-record DEKs encrypted by a KEK. Rotation is online — no downtime, no re-encrypt-the-world batch job.',
-    path: 'packages/security/src/encryption.ts',
-    href: `${REPO_ROOT}/packages/security/src/encryption.ts`,
-  },
-  {
-    title: 'Code provenance tracking',
-    body: 'Every commit attributed to human, agent, or model. A real supply-chain primitive baked into the data model — not bolted on after the fact.',
-    path: 'packages/db/src/schema/code-provenance.ts',
-    href: `${REPO_ROOT}/packages/db/src/schema/code-provenance.ts`,
-  },
-];
+import { CAPABILITIES, CAPABILITIES_SECTION } from '../../content/capabilities';
 
 export function WhatsShipped() {
   return (
@@ -71,19 +6,16 @@ export function WhatsShipped() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-            Capabilities, file by file
+            {CAPABILITIES_SECTION.eyebrow}
           </p>
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-            What&apos;s actually shipped.
+            {CAPABILITIES_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Nine load-bearing primitives most platforms ship as separate products &mdash; or never
-            ship at all. Each card links to the actual file.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{CAPABILITIES_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {capabilities.map((c) => (
+          {CAPABILITIES.map((c) => (
             <a
               key={c.path}
               href={c.href}
@@ -103,8 +35,7 @@ export function WhatsShipped() {
         </div>
 
         <p className="mx-auto mt-10 max-w-2xl text-center text-xs text-gray-500">
-          Trust through specificity. Buyers comparing to Convex, Supabase, or Payload see depth
-          competitors don&apos;t ship.
+          {CAPABILITIES_SECTION.footnote}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/content/capabilities.ts
+++ b/apps/marketing/app/content/capabilities.ts
@@ -1,0 +1,79 @@
+// Sourced from: app/components/landing/WhatsShipped.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+
+export interface Capability {
+  readonly title: string;
+  readonly body: string;
+  readonly path: string;
+  readonly href: string;
+}
+
+const REPO_ROOT = `${SITE.urls.repo}/blob/main`;
+const REPO_TREE = `${SITE.urls.repo}/tree/main`;
+
+export const CAPABILITIES_SECTION = {
+  eyebrow: 'Capabilities, file by file',
+  heading: "What's actually shipped.",
+  body: 'Nine load-bearing primitives most platforms ship as separate products — or never ship at all. Each card links to the actual file.',
+  footnote:
+    "Trust through specificity. Buyers comparing to Convex, Supabase, or Payload see depth competitors don't ship.",
+} as const;
+
+export const CAPABILITIES: readonly Capability[] = [
+  {
+    title: 'Tamper-evident audit chain',
+    body: 'Every mutation across every primitive — by humans or agents — signs into an HMAC-SHA256 hash chain. Tampering breaks the chain.',
+    path: 'packages/db/src/schema/audit-log.ts',
+    href: `${REPO_ROOT}/packages/db/src/schema/audit-log.ts`,
+  },
+  {
+    title: 'Unified RBAC + ABAC policy engine',
+    body: 'One policy plane covering humans, agents, and service accounts. Role checks, attribute checks, and action attribution all in one engine.',
+    path: 'packages/security/src/authorization.ts',
+    href: `${REPO_ROOT}/packages/security/src/authorization.ts`,
+  },
+  {
+    title: 'Stripe webhook reconciliation',
+    body: 'Most apps lose webhooks silently. This schema stores every event, retries failed handlers, and surfaces drift between Stripe and the local DB.',
+    path: 'packages/db/src/schema/webhook-reconciliation.ts',
+    href: `${REPO_ROOT}/packages/db/src/schema/webhook-reconciliation.ts`,
+  },
+  {
+    title: 'CRDT operation replay',
+    body: 'Most platforms snapshot-merge. RevealUI replays operations — collaborative editing across humans and agents stays correct after concurrent edits.',
+    path: 'packages/db/src/schema/crdt-operations.ts',
+    href: `${REPO_ROOT}/packages/db/src/schema/crdt-operations.ts`,
+  },
+  {
+    title: 'Circuit breakers + retry + bulkhead',
+    body: 'Production-grade resilience patterns wired into the runtime — adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
+    path: 'packages/resilience/src/circuit-breaker.ts',
+    href: `${REPO_ROOT}/packages/resilience/src/circuit-breaker.ts`,
+  },
+  {
+    title: 'Multi-agent harness',
+    body: 'Claude, Cursor, and Copilot coordinate on the same project through a shared workboard — its own product category, ships in the runtime.',
+    path: 'packages/harnesses',
+    href: `${REPO_TREE}/packages/harnesses`,
+  },
+  {
+    title: 'MCP hypervisor + introspection',
+    body: 'One process supervises all MCP servers, surfaces their tool registries, and gates calls through the same RBAC + ABAC plane the rest of the runtime uses.',
+    path: 'packages/mcp/src/hypervisor.ts',
+    href: `${REPO_ROOT}/packages/mcp/src/hypervisor.ts`,
+  },
+  {
+    title: 'Envelope encryption + key rotation',
+    body: 'Sensitive fields wrapped in per-record DEKs encrypted by a KEK. Rotation is online — no downtime, no re-encrypt-the-world batch job.',
+    path: 'packages/security/src/encryption.ts',
+    href: `${REPO_ROOT}/packages/security/src/encryption.ts`,
+  },
+  {
+    title: 'Code provenance tracking',
+    body: 'Every commit attributed to human, agent, or model. A real supply-chain primitive baked into the data model — not bolted on after the fact.',
+    path: 'packages/db/src/schema/code-provenance.ts',
+    href: `${REPO_ROOT}/packages/db/src/schema/code-provenance.ts`,
+  },
+] as const;

--- a/apps/marketing/app/content/contact.ts
+++ b/apps/marketing/app/content/contact.ts
@@ -1,0 +1,42 @@
+// Sourced from: app/routes/ContactPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+
+export interface ContactMethod {
+  readonly title: string;
+  readonly body: string;
+  readonly linkLabel: string;
+  readonly href: string;
+  readonly external?: boolean;
+  readonly isEmail?: boolean;
+}
+
+export const CONTACT_HERO = {
+  title: 'Get in touch',
+  subtitle:
+    'Questions about RevealUI? Interested in Enterprise or custom pricing? We would love to hear from you.',
+} as const;
+
+export const CONTACT_METHODS: readonly ContactMethod[] = [
+  {
+    title: 'Community',
+    body: 'Join the conversation on',
+    linkLabel: 'GitHub Discussions',
+    href: SITE.urls.repoDiscussions,
+    external: true,
+  },
+  {
+    title: 'Support',
+    body: '',
+    linkLabel: SITE.emails.support,
+    href: `mailto:${SITE.emails.support}`,
+    isEmail: true,
+  },
+  {
+    title: 'Bug Reports',
+    body: '',
+    linkLabel: 'GitHub Issues',
+    href: SITE.urls.repoIssues,
+    external: true,
+  },
+] as const;

--- a/apps/marketing/app/content/fair-source.ts
+++ b/apps/marketing/app/content/fair-source.ts
@@ -1,0 +1,211 @@
+// Sourced from: app/routes/FairSourcePage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { FaqItem } from './types';
+
+export interface ContractCard {
+  readonly kind: 'yes' | 'no';
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FslPackage {
+  readonly name: string;
+  readonly purpose: string;
+  readonly license: string;
+  readonly repo: string;
+  readonly npm: string;
+}
+
+export interface LicensePeer {
+  readonly name: string;
+  readonly note: string;
+  readonly url: string;
+}
+
+export const FAIR_SOURCE_PAGE_TITLE = 'Fair Source — RevealUI';
+
+export const FAIR_SOURCE_HERO = {
+  eyebrow: 'License contract for the Pro packages',
+  headline: '21 of 26 MIT.',
+  headlineHighlight: 'Forever.',
+  subhead: 'The 5 commercial packages convert to MIT after 2 years.',
+  body: {
+    prefix:
+      'Twenty-one RevealUI packages ship under plain MIT and stay that way. Five packages ship under',
+    fslLabel: 'FSL-1.1-MIT',
+    fslHref: SITE.urls.fslSoftware,
+    suffix:
+      '— source-visible, commercially usable, and each release auto-converts to plain MIT two years after publish. Same license model used by Sentry, GitButler, and Keygen.',
+  },
+  ogTitle: 'Fair Source',
+  ogSubtitle: 'Source-visible. Commercially usable. MIT in two years.',
+} as const;
+
+export const FAIR_SOURCE_CONTRACT_SECTION = {
+  eyebrow: 'The contract, in plain English',
+  heading: 'Three yeses and one no.',
+} as const;
+
+export const FAIR_SOURCE_CONTRACT_CARDS: readonly ContractCard[] = [
+  {
+    kind: 'yes',
+    title: 'Use it commercially',
+    body: 'Ship Fair Source code in your product, charge customers, run it in production. No royalties, no per-seat fees, no usage caps.',
+  },
+  {
+    kind: 'yes',
+    title: 'Read and modify the source',
+    body: 'Every line is on GitHub. Fork it, patch it, audit it for security. The source is the source of truth — there is no closed binary hiding behind it.',
+  },
+  {
+    kind: 'yes',
+    title: 'Self-host on your own infra',
+    body: 'Run it in your VPC, on bare metal, or air-gapped. RevealUI does not phone home and does not depend on a vendor service to function.',
+  },
+  {
+    kind: 'no',
+    title: 'Build a competing developer platform',
+    body: 'You cannot ship a substantially similar developer platform that competes with RevealUI on top of these packages. This is the only restriction. After two years, even this restriction lifts and the release becomes plain MIT.',
+  },
+];
+
+export const FAIR_SOURCE_PACKAGES_SECTION = {
+  eyebrow: 'Scope',
+  heading: 'Which RevealUI packages are Fair Source.',
+  body: {
+    prefix:
+      'Five packages carry FSL-1.1-MIT — the four published to npm are listed below, plus the private',
+    privatePackage: '@revealui/engines',
+    suffix:
+      'workspace package. Every other RevealUI package is plain MIT — no non-compete, no time limit, fully open source.',
+  },
+  footer: {
+    prefix: "Looking for a specific package's license? Run",
+    command: 'npm view @revealui/<name> license',
+    suffix: '— npm always tells the truth.',
+  },
+} as const;
+
+export const FAIR_SOURCE_PACKAGES: readonly FslPackage[] = [
+  {
+    name: '@revealui/ai',
+    purpose: 'AI agents, CRDT memory, LLM provider abstractions, orchestration',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/ai',
+    npm: 'https://www.npmjs.com/package/@revealui/ai',
+  },
+  {
+    name: '@revealui/harnesses',
+    purpose: 'AI harness adapters, workboard coordination, JSON-RPC primitives',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses',
+    npm: 'https://www.npmjs.com/package/@revealui/harnesses',
+  },
+  {
+    name: '@revealui/mcp',
+    purpose: 'MCP framework — server hypervisor, adapter pattern, tool discovery',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp',
+    npm: 'https://www.npmjs.com/package/@revealui/mcp',
+  },
+  {
+    name: '@revealui/services',
+    purpose: 'External service integrations — Stripe, Solana (RVC), Vercel',
+    license: 'FSL-1.1-MIT',
+    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/services',
+    npm: 'https://www.npmjs.com/package/@revealui/services',
+  },
+];
+
+export const FAIR_SOURCE_CLOCK_SECTION = {
+  eyebrow: 'The two-year clock',
+  heading: 'Every release auto-converts to MIT.',
+  body: "The 2-year timer starts on each release's publish date. Older releases reach MIT first; newer releases start their own clock from their own publish date. The clause does not require any action from RevealUI Studio — it is in the license text and self-executing.",
+  steps: [
+    {
+      title: 'Release publishes under FSL-1.1-MIT',
+      body: 'Source on GitHub. Installable from npm. The 2-year clock starts ticking the moment the version tag lands.',
+      color: 'emerald' as const,
+    },
+    {
+      title: 'Year one and year two',
+      body: 'All freedoms apply (use commercially, modify, self-host) except the non-compete clause. You build on it, you ship products with it, you charge customers for those products.',
+      color: 'amber' as const,
+    },
+    {
+      title: 'Two years later: plain MIT',
+      body: 'That specific release auto-converts to plain MIT. The non-compete clause lifts; the license becomes OSI-approved open source.',
+      color: 'emerald' as const,
+    },
+  ],
+} as const;
+
+export const FAIR_SOURCE_PEERS_SECTION = {
+  eyebrow: 'In good company',
+  heading: 'The same license model used by serious infrastructure projects.',
+} as const;
+
+export const FAIR_SOURCE_PEERS: readonly LicensePeer[] = [
+  {
+    name: 'Sentry',
+    note: 'Application monitoring; flagship FSL adopter (license they originally co-authored with FOSSA).',
+    url: 'https://blog.sentry.io/introducing-the-functional-source-license-freedom-without-free-riding/',
+  },
+  {
+    name: 'GitButler',
+    note: 'Git client for branch management. FSL across the stack.',
+    url: 'https://gitbutler.com/blog/fair-source',
+  },
+  {
+    name: 'Keygen',
+    note: 'License management infrastructure; FSL on their core engine.',
+    url: 'https://keygen.sh/blog/fair-source/',
+  },
+];
+
+export const FAIR_SOURCE_FAQ_SECTION = {
+  eyebrow: 'Common questions',
+  heading: 'Detailed answers, not lawyer-speak.',
+} as const;
+
+export const FAIR_SOURCE_FAQS: readonly FaqItem[] = [
+  {
+    question: 'Is Fair Source open source?',
+    answer:
+      'Not in the OSI-approved sense — the non-compete clause means it is "source-available" rather than "open source." But for almost every practical purpose (read, modify, deploy, charge for products built on top), the freedoms match what most builders need from open source. After two years per release, the clause lifts and the code becomes plain MIT, which IS OSI open source.',
+  },
+  {
+    question: 'What counts as a "competing developer platform"?',
+    answer: `The license uses the standard FSL definition: a software product with substantially the same functionality as RevealUI that is offered to the same audience as a developer platform. Building a SaaS app for end users that happens to use @revealui/ai under the hood is fine. Building a marketplace for AI-agent tooling on top of @revealui/harnesses and selling it to developers is the case the clause addresses. If you are unsure, email ${SITE.emails.founder} — we would rather you ship than worry.`,
+  },
+  {
+    question: 'When exactly does each release convert to MIT?',
+    answer:
+      "Two years after the publish date of that specific release. So today's 0.4.0 release of @revealui/ai becomes MIT on its 2-year anniversary; a future 0.5.0 starts its own clock from its own publish date. Older releases reach MIT first; this is intentional.",
+  },
+  {
+    question: 'Why not just use plain MIT for everything?',
+    answer:
+      'The Pro packages represent meaningful R&D investment in agent runtimes and harness coordination. Plain MIT lets a competitor fork the entire stack on day one and undercut the project on price, leaving the studio with no path to sustain the work. Fair Source closes that specific risk while keeping every other freedom you need. It is a deliberate middle path between "everything free, no business model" and "closed proprietary."',
+  },
+  {
+    question: 'How is the Pro tier enforced if the source is visible?',
+    answer:
+      'License enforcement is at runtime in the hosted product, not baked into the npm packages. The hosted RevealUI API checks Ed25519-signed license JWTs and gates Pro API routes; the packages themselves ship ungated, so self-hosters run them freely. FSL is the legal protection — the source is visible and you can run it, but shipping a competing developer platform on top of it is exactly what the non-compete clause prohibits, with civil remedies available. Two years after each release, that release becomes plain MIT.',
+  },
+  {
+    question: 'What about the rest of the RevealUI packages?',
+    answer:
+      'Every other RevealUI package is plain MIT — no non-compete clause, no time limit, fully open source. That is the OSS substrate (auth, content, billing primitives, admin UI, presentation system, router, etc.). Fair Source applies to five packages: @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, and @revealui/services.',
+  },
+];
+
+export const FAIR_SOURCE_CTA = {
+  heading: 'Read the spec yourself.',
+  body: 'FSL-1.1-MIT is short, plain English, and authored by the FOSSA legal team. Two pages. Read it before you ship.',
+  primaryLabel: 'FSL-1.1-MIT spec text',
+  primaryHref: SITE.urls.fslSpecText,
+  secondaryLabel: 'Email a license question',
+  secondaryHref: `mailto:${SITE.emails.founder}?subject=Fair%20Source%20question`,
+} as const;

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -1,0 +1,234 @@
+// Sourced from: app/components/landing/Hero.tsx, app/components/landing/Problem.tsx,
+//   app/components/landing/Demo.tsx, app/components/landing/Faq.tsx,
+//   app/components/GetStarted.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { Cta, FaqItem } from './types';
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+
+export const HOME_HERO = {
+  eyebrow: 'Open-source. Self-hostable. Audit-grade.',
+  h1: 'The open runtime for AI-native businesses.',
+  subtitle: {
+    strong: 'Yours to install. Ours to build for you.',
+    body: 'Auth, content, products, payments, and intelligence — five primitives, one policy plane, one hash-chained audit log. For founders shipping AI products who need audit trails and unified governance from day one — whether you build with',
+    cliSuffix: 'or hire',
+    agencyLabel: 'RevealUI Studio',
+    agencyHref: SITE.urls.agency,
+    agencySuffix: 'to build it for you.',
+  },
+  cta: {
+    primary: { label: 'Start free', href: SITE.urls.signup } satisfies Cta,
+    secondary: { label: 'See it on GitHub', href: SITE.urls.repo, external: true } satisfies Cta,
+  },
+  agencyCta: {
+    prefix: 'Want it built for you?',
+    label: 'RevealUI Studio builds AI businesses on RevealUI →',
+    href: SITE.urls.agency,
+  },
+  cliCaption: 'Local dev stack in 60 seconds. No credit card.',
+  shipsToday: {
+    heading: 'What ships today',
+    items: [
+      {
+        metric: '26 packages',
+        detail:
+          '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private workspace packages. Source at packages/.',
+      },
+      {
+        metric: '86 database tables',
+        detail: 'Drizzle ORM over NeonDB across 5 schemas. Source at packages/db/src/schema/.',
+      },
+      {
+        metric: '13 first-party MCP servers',
+        detail: 'Every one stdio-launchable. Source at packages/mcp/src/servers/.',
+      },
+      {
+        metric: 'EdDSA-signed Pro license JWTs',
+        detail:
+          'Verified every 5 minutes against the license server. Source at packages/core/src/license.ts.',
+      },
+      {
+        metric: 'FSL-1.1-MIT on 5 Fair Source packages',
+        detail: 'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
+      },
+      {
+        metric: 'Vite + Hono + ElectricSQL browser sync',
+        detail: 'No Next.js, no community router, no Supabase in the production path.',
+      },
+    ],
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Problem (comparison table)
+// ---------------------------------------------------------------------------
+
+export interface ProblemRow {
+  readonly capability: string;
+  readonly sprawl: string;
+  readonly agentOnly: string;
+  readonly revealui: string;
+}
+
+export const HOME_PROBLEM = {
+  eyebrow: 'The problem',
+  heading: 'Vendor sprawl, or framework-only. Pick neither.',
+  body: 'Most AI teams glue together a half-dozen SaaS backends. Some pick a thin agent framework and rebuild auth, billing, and content from scratch. RevealUI is the third option: everything wired in, governed by one policy, owned by you.',
+  tableAriaLabel: 'Vendor sprawl vs agent-framework vs RevealUI comparison',
+  columns: {
+    capability: 'Capability',
+    sprawl: 'Vendor sprawl',
+    agentOnly: 'Agent framework only',
+    revealui: 'RevealUI',
+  },
+  rows: [
+    {
+      capability: 'Auth + RBAC + sessions',
+      sprawl: 'Clerk Pro ($25/seat)',
+      agentOnly: 'Bring your own',
+      revealui: 'Built in',
+    },
+    {
+      capability: 'CMS + admin UI',
+      sprawl: 'Payload + your team',
+      agentOnly: 'Bring your own',
+      revealui: 'Built in',
+    },
+    {
+      capability: 'Stripe billing + webhooks',
+      sprawl: 'Stripe + your code',
+      agentOnly: 'Bring your own',
+      revealui: 'Built in (with reconciliation)',
+    },
+    {
+      capability: 'MCP tools for every API',
+      sprawl: 'Per-collection plugin',
+      agentOnly: 'Tool registry only',
+      revealui: 'Auto-exposed, RBAC-governed',
+    },
+    {
+      capability: 'Tamper-evident audit log',
+      sprawl: 'Datadog + custom hashing',
+      agentOnly: 'Logs only',
+      revealui: 'Hash-chained, in DB',
+    },
+    {
+      capability: 'Cost (5 devs, mid-startup)',
+      sprawl: '~$1,200 / mo',
+      agentOnly: '~$300 / mo + infra',
+      revealui: '$49 / mo + infra',
+    },
+  ] as readonly ProblemRow[],
+  footnote:
+    'Sprawl prices reflect typical mid-startup invoices. RevealUI Pro is $49/mo + your own infrastructure. Vercel and Cloudflare are deploy targets, not competitors — RevealUI runs on both.',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Demo
+// ---------------------------------------------------------------------------
+
+export interface DemoBeat {
+  readonly n: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export const HOME_DEMO = {
+  eyebrow: 'Watch it work',
+  heading: 'From CLI to a working stack in 90 seconds.',
+  body: 'Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP.',
+  mockupCaption: {
+    prefix: 'Local screenshot from a fresh',
+    code: 'npx create-revealui',
+    suffix: '. The three beats below describe the steps.',
+  },
+  beats: [
+    {
+      n: '01',
+      title: 'Spin up a stack.',
+      body: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
+    },
+    {
+      n: '02',
+      title: 'Customer flow, end to end.',
+      body: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+    },
+    {
+      n: '03',
+      title: 'Agent-native, by default.',
+      body: 'Every primitive ships with a matching MCP server. Wire an LLM provider and your agents read customers, refund subscriptions, and write content through the same APIs your app uses.',
+    },
+  ] as readonly DemoBeat[],
+} as const;
+
+// ---------------------------------------------------------------------------
+// FAQ
+// ---------------------------------------------------------------------------
+
+export const HOME_FAQ = {
+  eyebrow: 'FAQ',
+  heading: 'Common questions.',
+  items: [
+    {
+      question: 'How is this different from Supabase, Convex, Clerk, or Trigger?',
+      answer:
+        'Convex gives you real-time DB + functions. Supabase gives you Postgres + auth. Clerk gives you sessions. Trigger runs background jobs. Each one is a slice. RevealUI is the whole runtime — auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel and Cloudflare are deploy targets, not competitors — RevealUI runs on both.)',
+    },
+    {
+      question: 'Can I self-host?',
+      answer:
+        'Yes. 24 of 26 packages are MIT and stay MIT — forever. The 2 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infra at any tier — no vendor-specific edge runtimes, no proprietary database.',
+    },
+    {
+      question: 'What does "agent-native" actually mean in code?',
+      answer:
+        'Every collection is an MCP tool AND a REST endpoint AND a typed SDK call — gated by the same RBAC + ABAC policy. Agents are first-class principals: scope one to a collection, give it a budget, watch every action sign into the audit chain, revoke when done. The runtime is the contract, not a glue layer.',
+    },
+    {
+      question: "What's the lock-in story?",
+      answer:
+        'Open standards, end-to-end. OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Postgres for data. Deploy anywhere Next.js and Hono run — Vercel, Cloudflare, Railway, Hetzner, your own metal. Your data, your code, your infra. RevealUI is the runtime, not the prison.',
+    },
+    {
+      question: 'Production-ready?',
+      answer:
+        'Behind a 3-phase CI gate: Biome lint, Vitest unit + integration, Playwright E2E, CodeQL, Gitleaks, claim-drift validator. Every PR runs the gate before it can land. The marketing site you are reading runs on @revealui/router and @revealui/presentation; the agency site at revealuistudio.com runs on the same packages. View the source on GitHub.',
+    },
+    {
+      question: "What's the rest of RevFleet?",
+      answer:
+        'RevFleet is the umbrella. RevealUI is the runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness (multi-agent coordination across Claude / Cursor / Copilot). RevCon syncs editor configs. RevSkills is the skills library. RevForge is the operator-side stamping tool that produces white-label trial kits. RevealCoin is x402-compatible payments — deployed on Solana mainnet but pre-launch (see RevealCoin README for blockers). RevKit is the portable WSL dev environment. Use RevealUI standalone, or compose what you need.',
+    },
+    {
+      question: 'How does AI inference work?',
+      answer:
+        'Bring your own model. Default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ollama or Ubuntu Inference Snaps — your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
+    },
+    {
+      question: 'How do agent payments work?',
+      answer:
+        "x402-native. RevealUI implements the HTTP 402 payment protocol — compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare's x402 Foundation. Agents pay agents over standard HTTP. RevealCoin is one optional Solana implementation; the protocol is what is load-bearing. RevealCoin itself is pre-launch — see the RevealCoin README for the open prerequisites.",
+    },
+  ] as readonly FaqItem[],
+} as const;
+
+// ---------------------------------------------------------------------------
+// GetStarted CTA
+// ---------------------------------------------------------------------------
+
+export const HOME_GET_STARTED = {
+  heading: 'Ready to build?',
+  body: 'Users, content, products, payments, and AI, pre-wired. Start building locally in minutes; flip to live mode when you are ready.',
+  cta: {
+    primary: { label: 'Get started free', href: SITE.urls.signup } satisfies Cta,
+    secondary: { label: 'Read the docs', href: SITE.urls.docs } satisfies Cta,
+  },
+  newsletter: {
+    label: 'Not ready to start? Get product updates and engineering insights.',
+  },
+} as const;

--- a/apps/marketing/app/content/legal/privacy.ts
+++ b/apps/marketing/app/content/legal/privacy.ts
@@ -1,0 +1,164 @@
+// Sourced from: app/routes/PrivacyPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from '../site';
+
+export interface LegalSection {
+  readonly heading: string;
+  readonly subsections?: readonly LegalSubsection[];
+  readonly listPreamble?: string;
+  readonly paragraphs?: readonly string[];
+  readonly listItems?: readonly string[];
+  readonly thirdParties?: readonly ThirdParty[];
+  readonly contactEmail?: string;
+}
+
+export interface LegalSubsection {
+  readonly heading: string;
+  readonly paragraph?: string;
+  readonly listItems?: readonly string[];
+}
+
+export interface ThirdParty {
+  readonly name: string;
+  readonly description: string;
+  readonly policyLabel: string;
+  readonly policyUrl: string;
+  readonly extra?: string;
+}
+
+export const PRIVACY_META = {
+  title: 'Privacy Policy',
+  lastUpdated: 'April 22, 2026',
+  intro:
+    'The RevealUI platform (revealui.com, admin.revealui.com, api.revealui.com, and docs.revealui.com — the "Service") is operated by REVEALUI STUDIO L.L.C., a Tennessee limited liability company ("we", "us", "our"). This Privacy Policy describes how we collect, use, and protect your personal information.',
+} as const;
+
+export const PRIVACY_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Information We Collect',
+    subsections: [
+      {
+        heading: 'Account Information',
+        paragraph:
+          'When you create an account, we collect your email address, name, and password (stored as a bcrypt hash). If you sign up via OAuth (Google, GitHub), we receive your provider profile information.',
+      },
+      {
+        heading: 'Payment Information',
+        paragraph:
+          'Payment processing is handled entirely by Stripe. We never store credit card numbers. We store your Stripe customer ID to link your account to your subscription.',
+      },
+      {
+        heading: 'Usage Data',
+        paragraph:
+          'We collect server logs (IP address, request path, user agent) for security monitoring and debugging. See §4 below for retention windows.',
+      },
+      {
+        heading: 'Content Data',
+        paragraph:
+          'Any content you create through the admin (posts, pages, media) is stored in your database. For hosted plans, this data is stored in NeonDB (PostgreSQL).',
+      },
+    ],
+  },
+  {
+    heading: '2. How We Use Your Information',
+    listItems: [
+      'To provide and maintain the Service',
+      'To process payments and manage subscriptions',
+      'To send transactional emails (password resets, billing notifications, license delivery)',
+      'To detect and prevent fraud, abuse, and security incidents',
+      'To diagnose application errors using error telemetry (Sentry). When an error occurs, a partial session recording of the moments preceding the crash may be captured to aid debugging. No proactive or continuous session recording is performed.',
+      'To respond to support requests',
+    ],
+    paragraphs: [
+      'We do not sell your personal information. We do not use your data for advertising.',
+    ],
+  },
+  {
+    heading: '3. Data Sharing',
+    listPreamble: 'We share data only with:',
+    thirdParties: [
+      {
+        name: 'Stripe',
+        description: 'for payment processing',
+        policyLabel: 'Stripe Privacy Policy',
+        policyUrl: 'https://stripe.com/privacy',
+      },
+      {
+        name: 'NeonDB',
+        description: 'database hosting',
+        policyLabel: 'Neon Privacy Policy',
+        policyUrl: 'https://neon.tech/privacy',
+      },
+      {
+        name: 'Vercel',
+        description: 'application hosting',
+        policyLabel: 'Vercel Privacy Policy',
+        policyUrl: 'https://vercel.com/legal/privacy-policy',
+      },
+      {
+        name: 'Google Workspace',
+        description: 'transactional email delivery via Gmail API',
+        policyLabel: 'Google Privacy Policy',
+        policyUrl: 'https://policies.google.com/privacy',
+      },
+      {
+        name: 'Sentry',
+        description: 'application error tracking and crash-replay diagnostics',
+        policyLabel: 'Sentry Privacy Policy',
+        policyUrl: 'https://sentry.io/privacy/',
+        extra:
+          'Error data may include browser context, page URL, and a partial session recording captured at the time of an error. No continuous session recording is performed.',
+      },
+    ],
+  },
+  {
+    heading: '4. Data Retention',
+    paragraphs: [
+      'Account data is retained while your account is active. After account deletion, we permanently remove your personal data within 30 days. Application logs and error events are retained for 90 days. Agent activity audit logs are retained indefinitely for security and compliance purposes. Infrastructure server logs (IP address, request path, user agent) are retained by our hosting provider per their policy. Billing records are retained as required by tax law (typically 7 years).',
+    ],
+  },
+  {
+    heading: '5. Your Rights (GDPR / CCPA)',
+    listItems: [
+      'Access your personal data, available via your account settings or by contacting us',
+      'Export your data: use the GDPR export endpoint in the admin',
+      'Delete your account and all associated data: use the account deletion feature or contact us',
+      'Correct inaccurate data: update your profile in the admin dashboard',
+      'Object to processing: contact us at the email below',
+    ],
+    paragraphs: [
+      'California residents: Under the CCPA, you have the right to know what personal information we collect and to request its deletion. We do not sell personal information.',
+    ],
+  },
+  {
+    heading: '6. Security',
+    paragraphs: [
+      'We protect your data using: bcrypt password hashing, session-based authentication with secure cookies, rate limiting and brute-force protection, HTTPS/TLS encryption in transit, and encrypted database connections.',
+    ],
+  },
+  {
+    heading: '7. Cookies',
+    paragraphs: [
+      'We use essential cookies only: a session cookie for authentication. We do not use tracking cookies, analytics cookies, or advertising cookies.',
+    ],
+  },
+  {
+    heading: '8. Children',
+    paragraphs: [
+      'The Service is not intended for children under 13. We do not knowingly collect personal information from children under 13.',
+    ],
+  },
+  {
+    heading: '9. Changes',
+    paragraphs: [
+      'We may update this Privacy Policy from time to time. We will notify registered users of material changes via email.',
+    ],
+  },
+  {
+    heading: '10. Contact',
+    paragraphs: [
+      `For privacy-related questions or to exercise your data rights, contact us at ${SITE.emails.support}.`,
+    ],
+    contactEmail: SITE.emails.support,
+  },
+];

--- a/apps/marketing/app/content/legal/terms.ts
+++ b/apps/marketing/app/content/legal/terms.ts
@@ -1,0 +1,121 @@
+// Sourced from: app/routes/TermsPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from '../site';
+import type { LegalSection } from './privacy';
+
+export const TERMS_META = {
+  title: 'Terms of Service',
+  lastUpdated: 'March 4, 2026',
+  intro:
+    'These Terms of Service ("Terms") govern your use of the RevealUI platform provided by REVEALUI STUDIO L.L.C., a Tennessee limited liability company ("we", "us", "our"). By creating an account or using the Service, you agree to these Terms.',
+} as const;
+
+export const TERMS_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Service Description',
+    paragraphs: [
+      'RevealUI is an open-source agentic business runtime for software companies. It includes a content engine, authentication, billing integration, AI agents, and UI components. The Service is available in four tiers: Free (OSS), Pro, Max, and Enterprise.',
+    ],
+  },
+  {
+    heading: '2. Accounts',
+    listItems: [
+      'You must provide accurate information when creating an account.',
+      'You are responsible for maintaining the security of your account credentials.',
+      'You must be at least 13 years old to use the Service.',
+      'One person or organization may not maintain more than one free account.',
+    ],
+  },
+  {
+    heading: '3. Free Tier (OSS)',
+    paragraphs: [
+      'The Free tier is licensed under the MIT License. You may use, modify, and distribute the open-source code freely, subject to the MIT License terms. The Free tier includes limited features (1 site, 3 users, community support).',
+    ],
+  },
+  {
+    heading: '4. Paid Tiers (Pro, Max & Enterprise)',
+    subsections: [
+      {
+        heading: 'Billing',
+        listItems: [
+          'Pro: $49/month, billed monthly. Includes a 7-day free trial.',
+          'Max: $149/month, billed monthly. Includes a 7-day free trial.',
+          'Enterprise: $299/month, billed monthly. Contact sales for annual pricing.',
+          'All prices are in USD and exclude applicable taxes.',
+          "Payment is processed by Stripe. You agree to Stripe's terms of service.",
+        ],
+      },
+      {
+        heading: 'Trial',
+        paragraph:
+          'The Pro tier includes a 7-day free trial. You will not be charged during the trial period. If you do not cancel before the trial ends, your subscription will automatically begin and you will be charged the applicable monthly rate.',
+      },
+      {
+        heading: 'Cancellation',
+        paragraph:
+          'You may cancel your subscription at any time through the Stripe billing portal or by contacting us. Cancellation takes effect at the end of your current billing period. You retain access to paid features until then.',
+      },
+      {
+        heading: 'Refunds',
+        paragraph: `We offer a full refund if requested within 14 days of your first paid charge (not including the trial period). After 14 days, no refunds are issued for partial billing periods. Contact ${SITE.emails.support} for refund requests.`,
+      },
+    ],
+  },
+  {
+    heading: '5. Commercial License',
+    paragraphs: [
+      'Pro packages (@revealui/ai and @revealui/harnesses) are commercially licensed. The license is granted per-subscription and is non-transferable. See LICENSE.commercial in the repository for full terms.',
+    ],
+  },
+  {
+    heading: '6. Acceptable Use',
+    listPreamble: 'You agree not to:',
+    listItems: [
+      'Use the Service for any unlawful purpose',
+      'Attempt to gain unauthorized access to the Service or its infrastructure',
+      'Distribute malware, spam, or harmful content through the Service',
+      'Exceed reasonable usage limits or abuse API rate limits',
+      'Resell Pro/Max/Enterprise features without a valid license',
+      'Reverse-engineer, decompile, or circumvent license key validation',
+    ],
+    paragraphs: ['We reserve the right to suspend or terminate accounts that violate these terms.'],
+  },
+  {
+    heading: '7. Data and Content',
+    listItems: [
+      'You retain ownership of all content you create using the Service.',
+      'We do not claim any intellectual property rights over your content.',
+      'You are responsible for maintaining backups of your data. While we use reliable hosting providers, we do not guarantee against data loss.',
+      'For self-hosted deployments, you are responsible for your own data security and compliance.',
+    ],
+  },
+  {
+    heading: '8. Service Availability',
+    paragraphs: [
+      'We strive for high availability but do not guarantee uninterrupted service. The Service is provided "as is" without warranty of any kind, express or implied. We are not liable for any downtime, data loss, or damages resulting from use of the Service.',
+    ],
+  },
+  {
+    heading: '9. Limitation of Liability',
+    paragraphs: [
+      'To the maximum extent permitted by law, REVEALUI STUDIO L.L.C. shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to loss of profits, data, or business opportunities. Our total liability under these Terms shall not exceed the amount paid by you to us in the 12 months preceding the claim.',
+    ],
+  },
+  {
+    heading: '10. Changes to Terms',
+    paragraphs: [
+      'We may update these Terms from time to time. We will notify registered users of material changes via email at least 30 days before they take effect. Continued use of the Service after changes take effect constitutes acceptance of the new Terms.',
+    ],
+  },
+  {
+    heading: '11. Governing Law',
+    paragraphs: [
+      'These Terms are governed by the laws of the State of Tennessee, United States, without regard to its conflict-of-laws provisions. Any disputes shall be resolved in the state or federal courts located in Tennessee.',
+    ],
+  },
+  {
+    heading: '12. Contact',
+    paragraphs: [`For questions about these Terms, contact us at ${SITE.emails.support}.`],
+    contactEmail: SITE.emails.support,
+  },
+];

--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -1,0 +1,150 @@
+// Sourced from: app/routes/MarketplacePage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { Cta, SectionHeading } from './types';
+
+export interface McpServer {
+  readonly name: string;
+  readonly description: string;
+  readonly category: string;
+}
+
+export interface DiscoveryStep {
+  readonly step: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+export const MARKETPLACE_HERO: SectionHeading = {
+  title: 'MCP server catalog',
+  subtitle:
+    '12 first-party MCP servers, RBAC-scoped and audit-logged. Agents discover tools via MCP. RevealUI implements MCP natively.',
+};
+
+export const MARKETPLACE_HERO_NAV_ANCHORS = [
+  { label: 'MCP Servers', href: '#mcp-servers' },
+  { label: 'How agents discover tools', href: '#discovery' },
+] as const;
+
+export const MARKETPLACE_DISCOVERY_SECTION: SectionHeading = {
+  title: 'How agents discover and use tools',
+  subtitle:
+    'MCP (Model Context Protocol) is the open standard for connecting AI agents to tools and data sources. RevealUI implements MCP natively.',
+};
+
+export const MARKETPLACE_DISCOVERY_STEPS: readonly DiscoveryStep[] = [
+  {
+    step: '1',
+    title: 'Discover',
+    description:
+      'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities and required permissions.',
+  },
+  {
+    step: '2',
+    title: 'Authenticate',
+    description:
+      'The agent authenticates using the same RBAC system that governs human users. Permissions are scoped per tenant and per role.',
+  },
+  {
+    step: '3',
+    title: 'Execute',
+    description:
+      'The agent calls the tool through a standardized JSON-RPC interface. Results are typed, validated, and logged for audit.',
+  },
+];
+
+export const MARKETPLACE_SERVERS_SECTION = {
+  eyebrow: 'Open Source',
+  heading: '12 First-Party MCP Servers',
+  body: 'MCP servers included with RevealUI. Each server is rate-limited, audited, and governed by RBAC.',
+} as const;
+
+export const MARKETPLACE_MCP_SERVERS: readonly McpServer[] = [
+  {
+    name: 'Stripe',
+    description: 'Manage products, prices, subscriptions, and payment intents through MCP.',
+    category: 'Payments',
+  },
+  {
+    name: 'RevealUI Stripe',
+    description:
+      'RevealUI-specific Stripe operations: billing portal, webhook management, tier enforcement.',
+    category: 'Payments',
+  },
+  {
+    name: 'Neon',
+    description: 'Query and manage Neon PostgreSQL databases: branches, roles, and SQL execution.',
+    category: 'Database',
+  },
+  {
+    name: 'Supabase',
+    description: 'Interact with Supabase for vector storage, auth, and real-time subscriptions.',
+    category: 'Database',
+  },
+  {
+    name: 'Vercel',
+    description: 'Deploy, manage environment variables, inspect deployments, and view logs.',
+    category: 'Infrastructure',
+  },
+  {
+    name: 'Playwright',
+    description: 'Run browser automation, take screenshots, and execute end-to-end test flows.',
+    category: 'Testing',
+  },
+  {
+    name: 'Next.js DevTools',
+    description: 'Inspect routes, middleware, server components, and build output in development.',
+    category: 'Development',
+  },
+  {
+    name: 'RevealUI Content',
+    description: 'Create, query, and manage collections and documents through the content API.',
+    category: 'Content',
+  },
+  {
+    name: 'RevealUI Email',
+    description: 'Send transactional emails, manage templates, and track delivery status.',
+    category: 'Communication',
+  },
+  {
+    name: 'Code Validator',
+    description: 'Validate TypeScript, lint with Biome, and run type checks on code snippets.',
+    category: 'Development',
+  },
+  {
+    name: 'RevealUI Memory',
+    description:
+      'Read and write the agent memory store (episodic, semantic, and procedural layers).',
+    category: 'Content',
+  },
+  {
+    name: 'Contracts',
+    description: 'Validate pricing contracts, check OpenAPI mirror drift, and inspect schema.',
+    category: 'Development',
+  },
+];
+
+export const MARKETPLACE_COMING_SOON = {
+  badge: 'Coming after marketplace v1',
+  heading: 'Publishing and monetization',
+  body: {
+    prefix:
+      'Third-party MCP server publishing, developer earnings, and marketplace discovery are planned for a future release. See the',
+    linkLabel: 'public roadmap',
+    linkHref: SITE.urls.repoRoadmap,
+    suffix: 'for current status — listed under "Agent Marketplace" in the Mid-Term section.',
+  },
+} as const;
+
+export const MARKETPLACE_CTA = {
+  heading: 'Start with the MCP server catalog',
+  body: '12 first-party servers ship with every RevealUI install. Read the MCP docs to wire your agents.',
+  primary: {
+    label: 'MCP Documentation',
+    href: SITE.urls.docsMcp,
+  } satisfies Cta,
+  secondary: {
+    label: 'View All Products',
+    href: '/products',
+  } satisfies Cta,
+} as const;

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -1,0 +1,62 @@
+// Sourced from: app/components/NavBar.tsx, app/components/Footer.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { NavLink } from './types';
+
+export const NAV_LINKS: readonly NavLink[] = [
+  { label: 'Products', href: '/products' },
+  { label: 'Marketplace', href: '/marketplace' },
+  { label: 'Pricing', href: '/pricing' },
+  { label: 'Docs', href: SITE.urls.docs },
+  { label: 'Blog', href: '/blog' },
+] as const;
+
+export const NAV_AUTH = {
+  login: { label: 'Log in', href: SITE.urls.adminLogin },
+  signup: { label: 'Get started free', href: SITE.urls.signup },
+} as const;
+
+export interface FooterColumn {
+  readonly heading: string;
+  readonly links: readonly NavLink[];
+}
+
+export const FOOTER_COLUMNS: readonly FooterColumn[] = [
+  {
+    heading: 'Product',
+    links: [
+      { label: 'Products', href: '/products' },
+      { label: 'Marketplace', href: '/marketplace' },
+      { label: 'Pricing', href: '/pricing' },
+      { label: 'Documentation', href: SITE.urls.docs },
+      { label: 'Blog', href: '/blog' },
+      { label: 'Roadmap', href: '/coming-soon' },
+    ],
+  },
+  {
+    heading: 'Community',
+    links: [
+      { label: 'GitHub', href: SITE.urls.repo, external: true },
+      { label: 'Discussions', href: SITE.urls.repoDiscussions, external: true },
+      { label: 'Forum', href: SITE.urls.forum, external: true },
+      { label: 'Sponsor', href: '/sponsor' },
+      { label: 'RevealUI Studio (agency) →', href: SITE.urls.agency, external: true },
+      { label: 'Contact', href: '/contact' },
+    ],
+  },
+] as const;
+
+export const FOOTER_TAGLINE =
+  'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and ready to deploy.' as const;
+
+export const FOOTER_LEGAL = {
+  operator: 'REVEALUI STUDIO L.L.C.',
+  operatorHref: SITE.urls.agency,
+  jurisdiction: 'Tennessee',
+} as const;
+
+export const FOOTER_LEGAL_LINKS: readonly NavLink[] = [
+  { label: 'Privacy Policy', href: '/privacy' },
+  { label: 'Terms of Service', href: '/terms' },
+] as const;

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -1,0 +1,28 @@
+// Sourced from: app/components/landing/Persona.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+export const PERSONA_SECTION = {
+  eyebrow: "Who it's for",
+  heading: 'Founders shipping AI products who need governance from day one.',
+} as const;
+
+export const PERSONA_CARD = {
+  label: 'What this team needs before they can charge customers',
+  quote:
+    'You have a working agent demo. Now your first procurement review wants audit trails, identity gates, and a story for who can revoke an agent at 3am — without rebuilding the runtime to get there.',
+  checklist: [
+    'Hash-chained audit log of every action by every human and every agent — provable, not just observable',
+    'One RBAC + ABAC policy plane covering humans, agents, and service accounts',
+    'GDPR consent + deletion + anonymization scaffolded into the data model',
+    'Stripe webhook reconciliation that catches the events most apps lose silently',
+    'Source-visible Pro packages on Fair Source — auditable for procurement and security review',
+  ],
+  footer: {
+    prefix: 'Also a fit for',
+    sprawl: 'teams escaping backend-platform sprawl',
+    sprawlNote: '(Convex + Supabase + Clerk + Trigger), and',
+    studios: 'studios + consultancies',
+    studiosNote:
+      'white-labeling one runtime across N customers without re-licensing N SaaS stacks.',
+  },
+} as const;

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -1,0 +1,58 @@
+// Sourced from: app/routes/PricingPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { FaqItem } from './types';
+
+export const PRICING_FAQ_SECTION = {
+  heading: 'Frequently Asked Questions',
+} as const;
+
+export const PRICING_FAQS: readonly FaqItem[] = [
+  {
+    question: 'Can I use the Free tier for commercial projects?',
+    answer:
+      'Yes! The Free tier is fully open-source (MIT) and can be used for commercial projects. You get full source code access and can deploy it anywhere you like.',
+  },
+  {
+    question: 'What happens after the free trial ends?',
+    answer:
+      "Pro and Max tiers include a 7-day free trial. After the trial ends, you'll be charged the monthly rate. You can cancel anytime during the trial without being charged.",
+  },
+  {
+    question: 'How does agent task billing work?',
+    answer:
+      'Every paid subscription includes generous task allowances. Agent task usage billing is coming soon — for now, all tiers include unlimited agent tasks during early access.',
+  },
+  {
+    question: 'What are perpetual licenses?',
+    answer:
+      'A perpetual license is a one-time purchase that gives you a license key for the corresponding tier, forever, with no monthly subscription required. Support and updates are included for 1 year; after that, renew your support contract or keep using the version you have.',
+  },
+  {
+    question: 'Can I upgrade or downgrade my plan?',
+    answer: `Yes, you can upgrade your plan at any time. You'll be charged the prorated amount immediately. To downgrade, visit your billing portal or contact ${SITE.emails.support}.`,
+  },
+  {
+    question: 'How does AI inference work?',
+    answer:
+      'Bring your own model. The default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ollama or Ubuntu Inference Snaps from Canonical (canonical default — Studio lifecycle pending) — your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
+  },
+  {
+    question: 'What does "full source code access" mean?',
+    answer:
+      'You get the complete RevealUI source code — every app and package is published in the public monorepo. Infrastructure packages (@revealui/core, auth, db, contracts, security, utils, config, cache, resilience, openapi, sync, mcp) are MIT-licensed. The two Pro packages (@revealui/ai, @revealui/harnesses) ship under Fair Source (FSL-1.1-MIT): source is visible, commercial use is permitted except for building a directly competing developer platform, and each release automatically converts to plain MIT two years after publication. All paid tiers add runtime entitlements (license validation, feature gates, priority updates) on top of that source access — nothing is hidden behind a closed binary.',
+  },
+  {
+    question: 'What is Fair Source (FSL-1.1-MIT)?',
+    answer: `Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. Source-available under FSL: free for everyone except SaaS competitors. Pro plan = hosted infra + support, not npm-level enforcement. Full explainer at /fair-source.`,
+  },
+  {
+    question: 'Do you offer custom pricing for large teams?',
+    answer: `Yes! If you need more than what the Enterprise tier offers, contact us at ${SITE.emails.support} to discuss custom pricing and SLAs.`,
+  },
+  {
+    question: 'What is RevFleet?',
+    answer:
+      'RevFleet is the RevealUI Studio product family — eight products that compose around the RevealUI runtime. RevealUI is the agentic business runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness for multi-agent coordination across Claude, Cursor, and Copilot (Studio + Console MIT, Daemon Fair Source). RevCon syncs editor configs (MIT). RevSkills is the Claude Code skills library (MIT). RevForge is the operator-side stamping tool that produces white-label trial kits (operator-only). RevKit is the portable WSL dev environment toolkit (Pro). RevealCoin is x402-compatible agent payments — deployed on Solana mainnet but pre-launch (multisig migration + on-chain vesting gating; see RevealCoin README for the open prerequisites). Use RevealUI standalone, or compose what you need.',
+  },
+];

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -1,0 +1,79 @@
+// Sourced from: app/components/landing/PricingTeaser.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Tier copy lives here; runtime pricing (prices/periods) fetched from /api/pricing in the component.
+
+import type { LicenseTierId } from '@revealui/contracts/pricing';
+import { SITE } from './site';
+
+export interface TeaserTier {
+  readonly id: LicenseTierId;
+  readonly name: string;
+  readonly description: string;
+  readonly features: readonly string[];
+  readonly cta: string;
+  readonly href: string;
+  readonly highlight: boolean;
+}
+
+export const PRICING_TEASER_SECTION = {
+  eyebrow: 'Pricing',
+  heading: 'Start free. Pay when you scale.',
+  body: 'Self-host the open-source stack at no cost. Pay for the AI primitives and priority support when your business needs them.',
+} as const;
+
+export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    description:
+      '24 of 26 packages MIT — forever. The 2 Pro packages are Fair Source (FSL) and convert to MIT after two years. No telemetry.',
+    features: [
+      'Full primitive stack',
+      'Admin dashboard + API',
+      'Self-host on any infra',
+      'Bring your own model (open-weight default)',
+    ],
+    cta: 'Get started free',
+    href: SITE.urls.signup,
+    highlight: false,
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    description: 'Pro AI primitives, agent task allowance, and priority support.',
+    features: [
+      'Everything in Free',
+      '10,000 agent tasks / month included',
+      'Pro AI features (agents, MCP, memory) — beta in production',
+      'Priority support',
+    ],
+    cta: 'See Pro pricing',
+    href: '/pricing',
+    highlight: true,
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    description:
+      'Audit logs, multi-tenant architecture, and a named contact. Custom plans for high volume; SSO and on-prem on the roadmap.',
+    features: [
+      'Everything in Pro',
+      'Audit logs + compliance reports',
+      'Multi-tenant architecture',
+      'Roadmap: SSO, SCIM, on-prem deploy',
+    ],
+    cta: 'Talk to us',
+    href: '/contact',
+    highlight: false,
+  },
+] as const;
+
+export const PRICING_TEASER_FOOTER = {
+  moreLabel: 'See full pricing →',
+  moreHref: '/pricing',
+  caption: {
+    prefix: 'Deploys to Vercel, Cloudflare, Railway, Hetzner, or self-host.',
+    code: 'pnpm build',
+    suffix: 'produces a standard Node bundle — no vendor-specific edge runtimes.',
+  },
+} as const;

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -1,0 +1,148 @@
+// Sourced from: app/routes/PricingPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Canonical pricing numbers re-exported from @revealui/contracts/pricing for component convenience.
+
+export {
+  PERPETUAL_TIERS,
+  SUBSCRIPTION_TIERS,
+  type PricingResponse,
+} from '@revealui/contracts/pricing';
+
+import { SITE } from './site';
+import type { Cta, SectionHeading } from './types';
+
+export interface CfoLineItem {
+  readonly label: string;
+  readonly amount: string;
+}
+
+export interface AgentFeatureCard {
+  readonly heading: string;
+  readonly body: string;
+}
+
+export const PRICING_HERO: SectionHeading = {
+  title: 'Two ways to use RevealUI',
+  subtitle: 'Subscribe monthly or buy a perpetual license. Start free. Upgrade when you need to.',
+};
+
+export const PRICING_HERO_SUBTEXT = {
+  prefix:
+    'All plans run as self-hosted installations under your license — managed deployment available as a service add-on. Want to deploy a branded version for your own customers? See',
+  linkLabel: 'Agency Perpetual',
+  linkHref: '#track-c',
+  suffix: 'for RevealUI Fleet licensing.',
+} as const;
+
+export const PRICING_HERO_NAV_ANCHORS = [
+  { label: 'Track A: Subscriptions', href: '#track-a' },
+  { label: 'Track C: Perpetual Licenses', href: '#track-c' },
+] as const;
+
+export const PRICING_TRACK_A_SECTION = {
+  eyebrow: 'Track A',
+  heading: 'Subscription Plans',
+  body: 'Monthly subscriptions with a task allowance included. 7-day free trial on Pro and Max.',
+} as const;
+
+export const PRICING_CFO_PANEL = {
+  eyebrow: 'Replacing what?',
+  heading: 'A typical 5-dev startup pays $800–1,000/mo for the backend layer alone.',
+  lineItems: [
+    { label: 'Convex Team:', amount: '$125/mo (5 × $25)' },
+    { label: 'Supabase Team:', amount: '$599/mo' },
+    { label: 'Trigger.dev Pro:', amount: '$50/mo' },
+    { label: 'Clerk Pro:', amount: '$25/mo' },
+    { label: 'Stripe + observability:', amount: '~$50/mo+' },
+  ] as readonly CfoLineItem[],
+  totalLine: 'Total backend-platform spend: ~$800–1,000 / mo + per-event API costs.',
+  bottomLine: 'RevealUI Pro is $49/mo + your own infrastructure. You own the runtime.',
+  footnote:
+    'Deploy targets like Vercel, Cloudflare, Railway, and Hetzner are unchanged — RevealUI runs on all of them. We replace the backend platforms, not where you ship.',
+} as const;
+
+export const PRICING_HIGHLIGHTED_BADGE = 'Most Popular' as const;
+
+export const PRICING_TRACK_C_SECTION = {
+  eyebrow: 'Track C',
+  heading: 'Perpetual Licenses',
+  body: 'Pay once, use forever. No subscription required. Support renewals are optional.',
+} as const;
+
+export const PRICING_AGENTS_SECTION = {
+  eyebrow: 'Agent-Native',
+  heading: 'RevealUI for AI Agents',
+  subhead: 'Agents discover, authenticate, and pay without human intervention.',
+  badge: 'Coming soon',
+} as const;
+
+export const PRICING_AGENT_A2A = {
+  heading: 'A2A Discovery',
+  body: {
+    prefix: 'Agents find RevealUI via a standard Agent Card at',
+    linkLabel: '/.well-known/agent.json',
+    linkHref: SITE.urls.apiAgent,
+    suffix: '. Capabilities, skills, and pricing all machine-readable.',
+  },
+} as const;
+
+export const PRICING_AGENT_X402 = {
+  heading: 'x402-Native Payments',
+  body: 'RevealUI implements the HTTP 402 payment protocol. Compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare’s x402 Foundation. Agents pay agents over standard HTTP — no accounts, no subscriptions.',
+  footnote: {
+    prefix:
+      'RevealCoin is one optional Solana implementation — deployed on mainnet but pre-launch (see',
+    linkLabel: 'RevealCoin README',
+    linkHref: SITE.urls.revealcoinReadme,
+    suffix: 'for the open prerequisites).',
+  },
+} as const;
+
+export const PRICING_AGENT_MCP = {
+  heading: 'MCP Servers',
+  // COUNT: mcp-servers = 13 (verified at packages/mcp/src/servers/, excluding _-prefixed helpers)
+  body: '13 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright, Next.js DevTools, content management, and email. Marketplace discovery coming soon.',
+  docsLink: {
+    label: 'MCP docs →',
+    href: SITE.urls.docsMcp,
+  } satisfies Cta,
+} as const;
+
+export const PRICING_AGENT_CTA_LINKS = {
+  openapi: {
+    label: 'OpenAPI spec',
+    href: SITE.urls.apiOpenapi,
+    external: true,
+  } satisfies Cta,
+  apiDocs: {
+    label: 'API docs',
+    href: SITE.urls.apiDocs,
+  } satisfies Cta,
+} as const;
+
+export const PRICING_AGENCY_SECTION = {
+  heading: 'Need help adopting RevealUI?',
+  body: 'Architecture reviews, migrations, and launch support are offered separately by RevealUI Studio (the agency). Engagements are scoped per-project.',
+  cta: {
+    label: 'Visit revealuistudio.com →',
+    href: SITE.urls.agency,
+    external: true,
+  } satisfies Cta,
+} as const;
+
+export const PRICING_FINAL_CTA: SectionHeading = {
+  title: 'Ready to get started?',
+  subtitle: 'Start free with full source code access. Upgrade when your business needs it.',
+};
+
+export const PRICING_FINAL_CTA_LINKS = {
+  getStarted: {
+    label: 'Get Started Free',
+    href: SITE.urls.signup,
+  } satisfies Cta,
+  contactSales: {
+    label: 'Contact Sales',
+    href: '/contact',
+  } satisfies Cta,
+} as const;
+
+export const PRICING_NEWSLETTER_LABEL = 'Not ready yet? Stay in the loop.' as const;

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -3,8 +3,8 @@
 
 export {
   PERPETUAL_TIERS,
-  SUBSCRIPTION_TIERS,
   type PricingResponse,
+  SUBSCRIPTION_TIERS,
 } from '@revealui/contracts/pricing';
 
 import { SITE } from './site';

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -87,7 +87,7 @@ export const PRICING_AGENT_A2A = {
 
 export const PRICING_AGENT_X402 = {
   heading: 'x402-Native Payments',
-  body: 'RevealUI implements the HTTP 402 payment protocol. Compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare’s x402 Foundation. Agents pay agents over standard HTTP — no accounts, no subscriptions.',
+  body: "RevealUI implements the HTTP 402 payment protocol. Compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare's x402 Foundation. Agents pay agents over standard HTTP — no accounts, no subscriptions.",
   footnote: {
     prefix:
       'RevealCoin is one optional Solana implementation — deployed on mainnet but pre-launch (see',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -1,0 +1,236 @@
+// Sourced from: app/components/landing/Primitives.tsx, app/routes/ProductsPage.tsx
+//   (Phase 1c, no copy changes). The two sources have different data shapes:
+//   - HomePrimitive: label + body only (used by landing Primitives.tsx)
+//   - ProductsPrimitive: full forYou/forAgents/together/features deep-dive (used by ProductsPage.tsx)
+//   Both are canonical here. Phase 4 reconciles any copy redundancy.
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+
+// ---------------------------------------------------------------------------
+// Landing (Home) primitives — compact card data
+// ---------------------------------------------------------------------------
+
+export interface HomePrimitive {
+  readonly label: string;
+  readonly body: string;
+  readonly color: string;
+  readonly iconPath: string;
+}
+
+export const HOME_PRIMITIVES_SECTION = {
+  eyebrow: 'Five primitives. One audit log. One policy plane.',
+  heading: "Everything a business needs. Nothing you don't.",
+  body: 'Auth, content, products, payments, and intelligence — every action by every human and agent is RBAC-gated, ABAC-checked, and signed into a tamper-evident audit chain.',
+  docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
+} as const;
+
+export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
+  {
+    label: 'Users',
+    body: 'Auth, sessions, RBAC + ABAC. Same policy governs human and agent access.',
+    color: 'emerald',
+    iconPath:
+      'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
+  },
+  {
+    label: 'Content',
+    body: 'Headless CMS, rich text, media. Auto-exposed as MCP tools.',
+    color: 'blue',
+    iconPath:
+      'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
+  },
+  {
+    label: 'Products',
+    body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
+    color: 'amber',
+    iconPath:
+      'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
+  },
+  {
+    label: 'Payments',
+    body: 'Stripe billing, subscriptions, webhook reconciliation. x402-native agent payments.',
+    color: 'cyan',
+    iconPath:
+      'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
+  },
+  {
+    label: 'Intelligence',
+    body: 'Agents, MCP servers, CRDT memory. Bring-your-own-model; open-weight default.',
+    color: 'violet',
+    iconPath:
+      'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Products page primitives — full deep-dive
+// ---------------------------------------------------------------------------
+
+export interface PrimitiveTriplet {
+  readonly headline: string;
+  readonly description: string;
+}
+
+export interface ProductsPrimitive {
+  readonly name: string;
+  readonly icon: string;
+  readonly color: string;
+  readonly bgColor: string;
+  readonly ringColor: string;
+  readonly forYou: PrimitiveTriplet;
+  readonly forAgents: PrimitiveTriplet;
+  readonly together: PrimitiveTriplet;
+  readonly features: readonly string[];
+}
+
+export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
+  {
+    name: 'Users',
+    icon: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
+    color: 'text-blue-600',
+    bgColor: 'bg-blue-500/10',
+    ringColor: 'ring-blue-500/20',
+    forYou: {
+      headline: 'Auth, roles, and compliance, handled',
+      description:
+        'Session-based auth, RBAC with 58 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
+    },
+    forAgents: {
+      headline: 'RBAC governs agent access per tenant',
+      description:
+        'Every agent action is scoped by the same role and permission system that governs human users. Audit logs track every agent operation with full attribution.',
+    },
+    together: {
+      headline: 'Set permissions once. Agents respect them automatically.',
+      description:
+        'Define your access control rules for humans. Agents inherit the same boundaries. Every action, human or machine, is attributable and auditable.',
+    },
+    features: [
+      'Session-based auth (httpOnly, secure, sameSite)',
+      'RBAC + ABAC policy engine',
+      'Rate limiting and brute-force protection',
+      'GDPR compliance framework',
+      'Audit logging with agent attribution',
+      'Multi-tenant user isolation',
+    ],
+  },
+  {
+    name: 'Content',
+    icon: 'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
+    color: 'text-emerald-600',
+    bgColor: 'bg-emerald-500/10',
+    ringColor: 'ring-emerald-500/20',
+    forYou: {
+      headline: 'Define collections in TypeScript, get an API and admin UI',
+      description:
+        'Rich text editing with Lexical, media management, draft/live publishing, and a full REST API with OpenAPI spec. Define your data model once and the admin dashboard and API generate automatically.',
+    },
+    forAgents: {
+      headline: 'Collections become discoverable tools via MCP',
+      description:
+        'Every collection you define is automatically exposed as an MCP tool. Agents create, query, and update content through the same API humans use. No separate integration layer.',
+    },
+    together: {
+      headline: 'Define your data model. Agents immediately operate on it.',
+      description:
+        'Add a collection. The admin UI, REST API, and MCP tool all appear simultaneously. No integration step between what humans see and what agents can do.',
+    },
+    features: [
+      'Schema-first collection definitions',
+      'Rich text editor with custom blocks',
+      'REST API with OpenAPI spec',
+      'Draft/live publishing workflow',
+      'Media management and CDN delivery',
+      'Real-time sync across sessions',
+    ],
+  },
+  {
+    name: 'Products',
+    icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
+    color: 'text-purple-600',
+    bgColor: 'bg-purple-500/10',
+    ringColor: 'ring-purple-500/20',
+    forYou: {
+      headline: 'Product catalog, pricing tiers, and usage tracking',
+      description:
+        'Define products, pricing tiers, and feature gates in one place. License enforcement and upgrade prompts are built in. Subscription billing via Stripe with perpetual license support.',
+    },
+    forAgents: {
+      headline: 'Feature gates control which agent capabilities unlock per tier',
+      description:
+        'Agent capabilities are gated by the same tier system that governs human features. When a customer upgrades, their agents automatically gain access to more tools and higher task limits.',
+    },
+    together: {
+      headline: 'Revenue model governs both humans and agents.',
+      description:
+        'Upgrade a customer and their agents get smarter. One product catalog, one billing system, one set of feature gates, applied consistently to every user and every agent.',
+    },
+    features: [
+      'Two pricing tracks (subscription, services). Perpetual licenses coming soon.',
+      'Feature gating with tier enforcement',
+      'Usage tracking and limit enforcement',
+      'License key management',
+      'Upgrade prompts and billing portal',
+      'Agent task billing in development — unlimited during early access',
+    ],
+  },
+  {
+    name: 'Payments',
+    icon: 'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
+    color: 'text-amber-600',
+    bgColor: 'bg-amber-500/10',
+    ringColor: 'ring-amber-500/20',
+    forYou: {
+      headline: 'Stripe checkout, subscriptions, and billing, pre-configured',
+      description:
+        'Stripe checkout, subscription management, webhooks, and a customer billing portal. Products, prices, and webhooks are wired up. You configure your Stripe keys and start charging.',
+    },
+    forAgents: {
+      headline: 'x402 protocol design — coming with RevealCoin mainnet',
+      description:
+        'The x402 design routes agent payments via HTTP 402 using RevealCoin on Solana. This is in development and gated on RevealCoin mainnet launch. See the roadmap for current status.',
+    },
+    together: {
+      headline: 'Humans monetize. Agents transact. One billing infrastructure.',
+      description:
+        'Human customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
+    },
+    features: [
+      'Stripe checkout and subscriptions',
+      'Webhook handling and event processing',
+      'Customer billing portal',
+      'x402 agent payments (in development)',
+      'RevealCoin on Solana (pre-launch)',
+    ],
+  },
+  {
+    name: 'Intelligence',
+    icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z',
+    color: 'text-violet-600',
+    bgColor: 'bg-violet-500/10',
+    ringColor: 'ring-violet-500/20',
+    forYou: {
+      headline: 'AI agents that work on your business, no proprietary API keys',
+      description:
+        'AI agents manage content, process tasks, and coordinate workflows. Runs on open models only (Apache 2.0) via Ubuntu Inference Snaps or Ollama. No vendor lock-in, no API bills.',
+    },
+    forAgents: {
+      headline: 'A2A protocol, CRDT memory, and MCP servers',
+      description:
+        'Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and 12 production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.',
+    },
+    together: {
+      headline: 'Build one business. Agents extend it. Neither locked to any vendor.',
+      description:
+        'You build on open standards. Your agents operate through the same open standards. Switch models, swap providers, self-host everything. The intelligence layer belongs to you.',
+    },
+    features: [
+      'Open-model inference (Snaps, Ollama)',
+      'CRDT-based agent memory (working + episodic + vector)',
+      '12 production MCP servers',
+      'A2A agent-to-agent protocol',
+      'Multi-agent coordination and orchestration',
+    ],
+  },
+] as const;

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -1,0 +1,39 @@
+// Sourced from: app/routes/ProductsPage.tsx (Phase 1c, no copy changes).
+// ProductsPage-specific content: hero, stats bar, CTA section.
+// The 5 primitives data lives in ./primitives.ts (shared with landing).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { Cta } from './types';
+
+export const PRODUCTS_PAGE_HERO = {
+  h1: 'Five primitives. One runtime.',
+  subtitle:
+    'Users, content, products, payments, and intelligence — pre-wired and exposed to your agents via MCP.',
+} as const;
+
+export interface StatItem {
+  readonly stat: string;
+  readonly label: string;
+}
+
+export const PRODUCTS_STATS_SECTION = {
+  heading: 'Built to production standards',
+  body: 'Not a starter template. A complete runtime with tested, documented, and audited code.',
+  items: [
+    { stat: '26', label: 'workspace packages' },
+    { stat: '86', label: 'Database tables' },
+    { stat: '187+', label: 'Security tests' },
+    { stat: '12', label: 'first-party MCP servers' },
+  ] as readonly StatItem[],
+} as const;
+
+export const PRODUCTS_CTA_SECTION = {
+  heading: 'Start building with all five primitives',
+  body: 'One command. Full source code. Users, content, products, payments, and intelligence - pre-wired and ready for your first deploy.',
+  cliSnippet: 'npx create-revealui my-app',
+  cta: {
+    docs: { label: 'Read the Docs', href: SITE.urls.docs } satisfies Cta,
+    pricing: { label: 'View Pricing', href: '/pricing' } satisfies Cta,
+  },
+} as const;

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -1,0 +1,102 @@
+// Sourced from: app/components/landing/Proof.tsx (Phase 1c, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+
+export interface StackItem {
+  readonly label: string;
+  readonly kind: string;
+}
+
+export const PROOF_SECTION = {
+  eyebrow: 'The stack so far',
+  heading: 'Built in the open. Verifiable in the repo.',
+  body: 'Every package, every PR, every test. Inspect the code before you commit a single line of your own.',
+} as const;
+
+export const PROOF_REPO_SIGNALS = {
+  eyebrow: 'On GitHub',
+  heading: 'Live signals',
+  repoHref: SITE.urls.repo,
+  ciLabel: 'Quality gates that block every PR',
+} as const;
+
+export const PROOF_CI_SIGNALS: readonly string[] = [
+  'Biome lint + format',
+  'Vitest unit + integration',
+  'Playwright E2E',
+  'CodeQL + Gitleaks',
+  'TypeScript strict, repo-wide',
+  'Affected-only PR gate',
+] as const;
+
+export const PROOF_STACK: readonly StackItem[] = [
+  { label: 'Vite', kind: 'Marketing + docs frontends' },
+  { label: 'Next.js 16', kind: 'Admin frontend' },
+  { label: 'React 19', kind: 'UI runtime' },
+  { label: 'PostgreSQL', kind: 'Database' },
+  { label: 'Drizzle', kind: 'ORM' },
+  { label: 'Stripe', kind: 'Payments' },
+  { label: 'Hono', kind: 'API + edge' },
+  { label: 'MCP', kind: 'Agent protocol' },
+  { label: 'Tailwind', kind: 'Design system' },
+] as const;
+
+export const PROOF_STACK_PANEL = {
+  eyebrow: 'No proprietary lock-in',
+  heading: 'Standards your team already knows',
+  body: 'No proprietary runtime, no vendor-specific edge functions. Deploys to Vercel, Cloudflare, Railway, Hetzner, or your own infra. Take your data with you.',
+} as const;
+
+export const PROOF_TRUST = {
+  eyebrow: 'Trust',
+  heading: 'Verifiable in three places.',
+  cards: [
+    {
+      eyebrow: 'In the repo',
+      heading: '21 of 26 packages MIT — forever.',
+      body: {
+        prefix:
+          'The 5 Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. View the',
+        licenseLabel: 'LICENSE',
+        licenseHref: SITE.urls.repoLicense,
+        middle: 'or the',
+        explainerLabel: 'Fair Source explainer',
+        explainerHref: '/fair-source',
+        suffix: '.',
+      },
+    },
+    {
+      eyebrow: 'In the schema',
+      heading: 'Every mutation signs into a hash chain.',
+      codeSnippet: `signature:        text('signature').notNull(),
+previousSignature: text('previous_signature'),
+hashAlgorithm:    text('hash_algorithm')
+  .notNull().default('sha256-hmac'),`,
+      fileLabel: 'packages/db/src/schema/audit-log.ts',
+      fileHref: `${SITE.urls.repo}/blob/main/packages/db/src/schema/audit-log.ts`,
+      caption: '— tampering breaks the chain.',
+    },
+    {
+      eyebrow: 'In production',
+      heading: 'This site runs on RevealUI.',
+      body: {
+        prefix: 'The marketing site you are reading and the agency site at',
+        agencyLabel: 'revealuistudio.com',
+        agencyHref: SITE.urls.agency,
+        middle: 'both run on',
+        pkg1: '@revealui/router',
+        plus: '+',
+        pkg2: '@revealui/presentation',
+        suffix: '. View the',
+        sourceLabel: 'marketing app source',
+        sourceHref: `${SITE.urls.repo}/tree/main/apps/marketing`,
+        end: '.',
+      },
+    },
+  ],
+  changelogCta: {
+    label: 'See what shipped this month →',
+    href: SITE.urls.repoChangelog,
+  },
+} as const;

--- a/apps/marketing/app/content/roadmap.ts
+++ b/apps/marketing/app/content/roadmap.ts
@@ -1,0 +1,115 @@
+// Sourced from: app/routes/ComingSoonPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// File named roadmap.ts per Phase 4 /roadmap rename plan; route stays ComingSoonPage.tsx for now.
+
+import { SITE } from './site';
+import type { Cta, SectionHeading } from './types';
+
+export interface RoadmapItem {
+  readonly name: string;
+  readonly description: string;
+  readonly status: string;
+  readonly category: string;
+}
+
+export const ROADMAP_HERO: SectionHeading = {
+  title: 'Product Roadmap',
+  subtitle: 'What we have shipped and what we are building next.',
+};
+
+export const ROADMAP_HERO_LINK = {
+  label: 'public roadmap',
+  href: SITE.urls.repoRoadmap,
+} as const;
+
+export const ROADMAP_SHIPPED_SECTION: SectionHeading = {
+  title: 'Recently shipped',
+};
+
+export const ROADMAP_SHIPPED: readonly RoadmapItem[] = [
+  {
+    name: 'Dashboard Agent Chat',
+    description:
+      'Interact with an AI agent directly from the admin dashboard. Create content, query data, manage collections, and automate workflows through natural language, with streaming responses, tool visibility, and conversation history.',
+    status: 'Shipped',
+    category: 'AI',
+  },
+  {
+    name: 'Documentation Site',
+    description:
+      'Documentation site live at docs.revealui.com with quick-start guides, API reference, architecture docs, and package reference. Video walkthroughs and collection cookbook coming soon.',
+    status: 'Shipped',
+    category: 'Docs',
+  },
+];
+
+export const ROADMAP_UPCOMING_SECTION: SectionHeading = {
+  title: 'Coming next',
+};
+
+export const ROADMAP_UPCOMING: readonly RoadmapItem[] = [
+  {
+    name: 'RevealCoin + x402 Agent Payments',
+    description:
+      'Native cryptocurrency micropayments powered by RevealCoin on the Solana blockchain. Agents discover, authenticate, and pay per task via the HTTP 402 payment protocol. No accounts, no subscriptions.',
+    status: 'In development',
+    category: 'Payments',
+  },
+  {
+    name: 'Perpetual Licenses (Track C)',
+    description:
+      'One-time purchase for lifetime access to Pro, Max, or Enterprise tier features. No subscription required. Includes 1 year of priority support and updates.',
+    status: 'Coming soon',
+    category: 'Billing',
+  },
+  {
+    name: 'MCP Marketplace',
+    description:
+      'A registry where developers publish and discover MCP servers and AI agent capabilities. Revenue share model for developers. Discoverable via Smithery, mcpt, and the RevealUI registry.',
+    status: 'Planned — in design',
+    category: 'AI',
+  },
+  {
+    name: 'Self-Hosted Docker Images (RevealUI Fleet)',
+    description:
+      'Official Docker images published to GitHub Container Registry for fully self-hosted deployment. Domain-locked licensing, air-gap capable.',
+    status: 'Planned — designed, not built',
+    category: 'Infrastructure',
+  },
+  {
+    name: 'Visual Builder',
+    description:
+      'A no-code visual builder for creating RevealUI sites. Drag-and-drop page building, component customization, and one-click deployment.',
+    status: 'Planned — backlog',
+    category: 'Product',
+  },
+  {
+    name: 'Enterprise SSO / SAML',
+    description:
+      'Single sign-on via SAML for enterprise customers. Advanced audit logging, custom RBAC policy editor, and multi-region deployment support.',
+    status: 'Planned — designed, not built',
+    category: 'Enterprise',
+  },
+];
+
+export const ROADMAP_CTA: SectionHeading = {
+  title: 'Want to influence what ships next?',
+  subtitle: 'We prioritize based on customer impact, product readiness, and community demand.',
+};
+
+export const ROADMAP_CTA_LINKS = {
+  requestFeature: {
+    label: 'Request a feature',
+    href: SITE.urls.repoIssues,
+    external: true,
+  } satisfies Cta,
+  joinDiscussion: {
+    label: 'Join the discussion',
+    href: SITE.urls.repoDiscussions,
+    external: true,
+  } satisfies Cta,
+} as const;
+
+export const ROADMAP_CTA_PRODUCTS_LINK = {
+  label: 'Products',
+  href: '/products',
+} as const;

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -4,6 +4,7 @@
 //   app/components/landing/Hero.tsx, app/routes/*.tsx
 // Per docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
 // Phase 1b additions: repoRoadmap, apiDocs, revealcoinReadme.
+// Phase 1c additions: adminLogin, x, linkedin, forum, repoChangelog, repoLicense.
 
 export const SITE = {
   brand: 'RevealUI',
@@ -26,6 +27,12 @@ export const SITE = {
     revealcoinReadme: 'https://github.com/RevealUIStudio/revealcoin#pre-launch-risk-disclosure',
     fslSoftware: 'https://fsl.software/',
     fslSpecText: 'https://fsl.software/FSL-1.1-MIT.template.md',
+    adminLogin: 'https://admin.revealui.com/login',
+    x: 'https://x.com/revealui',
+    linkedin: 'https://www.linkedin.com/company/revealui',
+    forum: 'https://revnation.discourse.group',
+    repoChangelog: 'https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md',
+    repoLicense: 'https://github.com/RevealUIStudio/revealui/blob/main/LICENSE',
   },
   emails: {
     support: 'support@revealui.com',

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -1,0 +1,35 @@
+// Site-wide constants: URLs, contact, social, repo links, brand strings.
+// Sourced from extraction of inline JSX content in:
+//   app/components/Footer.tsx, app/components/GetStarted.tsx,
+//   app/components/landing/Hero.tsx, app/routes/*.tsx
+// Per docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
+
+export const SITE = {
+  brand: 'RevealUI',
+  brandTagline: 'The open runtime for AI-native businesses.',
+  urls: {
+    signup: 'https://admin.revealui.com/signup',
+    admin: 'https://admin.revealui.com',
+    docs: 'https://docs.revealui.com',
+    docsMcp: 'https://docs.revealui.com/mcp',
+    repo: 'https://github.com/RevealUIStudio/revealui',
+    repoDiscussions: 'https://github.com/RevealUIStudio/revealui/discussions',
+    repoIssues: 'https://github.com/RevealUIStudio/revealui/issues',
+    sponsors: 'https://github.com/sponsors/RevealUIStudio',
+    agency: 'https://revealuistudio.com',
+    api: 'https://api.revealui.com',
+    apiAgent: 'https://api.revealui.com/.well-known/agent.json',
+    apiOpenapi: 'https://api.revealui.com/openapi.json',
+    fslSoftware: 'https://fsl.software/',
+    fslSpecText: 'https://fsl.software/FSL-1.1-MIT.template.md',
+  },
+  emails: {
+    support: 'support@revealui.com',
+    founder: 'founder@revealui.com',
+  },
+  cli: {
+    create: 'npx create-revealui@latest my-app',
+  },
+} as const;
+
+export type SiteConfig = typeof SITE;

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -3,6 +3,7 @@
 //   app/components/Footer.tsx, app/components/GetStarted.tsx,
 //   app/components/landing/Hero.tsx, app/routes/*.tsx
 // Per docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
+// Phase 1b additions: repoRoadmap, apiDocs, revealcoinReadme.
 
 export const SITE = {
   brand: 'RevealUI',
@@ -13,6 +14,7 @@ export const SITE = {
     docs: 'https://docs.revealui.com',
     docsMcp: 'https://docs.revealui.com/mcp',
     repo: 'https://github.com/RevealUIStudio/revealui',
+    repoRoadmap: 'https://github.com/RevealUIStudio/revealui/blob/main/docs/ROADMAP.md',
     repoDiscussions: 'https://github.com/RevealUIStudio/revealui/discussions',
     repoIssues: 'https://github.com/RevealUIStudio/revealui/issues',
     sponsors: 'https://github.com/sponsors/RevealUIStudio',
@@ -20,6 +22,8 @@ export const SITE = {
     api: 'https://api.revealui.com',
     apiAgent: 'https://api.revealui.com/.well-known/agent.json',
     apiOpenapi: 'https://api.revealui.com/openapi.json',
+    apiDocs: 'https://docs.revealui.com/api',
+    revealcoinReadme: 'https://github.com/RevealUIStudio/revealcoin#pre-launch-risk-disclosure',
     fslSoftware: 'https://fsl.software/',
     fslSpecText: 'https://fsl.software/FSL-1.1-MIT.template.md',
   },

--- a/apps/marketing/app/content/sponsor.ts
+++ b/apps/marketing/app/content/sponsor.ts
@@ -1,0 +1,123 @@
+// Sponsor page content.
+// Sourced from extraction of app/routes/SponsorPage.tsx (Phase 1, no copy changes).
+// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+
+import { SITE } from './site';
+import type { Cta } from './types';
+
+export interface SponsorTier {
+  readonly name: string;
+  readonly price: string;
+  readonly period: string;
+  readonly emoji: string;
+  readonly description: string;
+  readonly benefits: readonly string[];
+}
+
+export interface SupportArea {
+  readonly title: string;
+  readonly description: string;
+  readonly iconKey: 'development' | 'documentation' | 'community';
+}
+
+export const SPONSOR_HERO = {
+  brand: 'Sponsor',
+  brandHighlight: 'RevealUI',
+  subhead:
+    'RevealUI is open source and free to use. Your sponsorship helps fund development, documentation, and community support.',
+  cta: {
+    label: 'Sponsor on GitHub',
+    href: SITE.urls.sponsors,
+    external: true,
+  } satisfies Cta,
+} as const;
+
+export const SPONSOR_TIERS_SECTION = {
+  heading: {
+    title: 'Sponsorship Tiers',
+    subtitle: 'Every contribution matters. Choose the tier that works for you.',
+  },
+  ctaBottom: {
+    label: 'Become a Sponsor',
+    href: SITE.urls.sponsors,
+    external: true,
+  } satisfies Cta,
+} as const;
+
+export const SPONSOR_TIERS: readonly SponsorTier[] = [
+  {
+    name: 'Supporter',
+    price: '$5',
+    period: '/month',
+    emoji: '☕',
+    description: 'Buy the maintainers a coffee.',
+    benefits: ['Sponsor badge on GitHub profile', 'Shoutout in release notes'],
+  },
+  {
+    name: 'Backer',
+    price: '$25',
+    period: '/month',
+    emoji: '⭐',
+    description: 'Support ongoing development.',
+    benefits: [
+      'All Supporter benefits',
+      'Name listed on sponsors page',
+      'Early access to roadmap updates',
+      'Priority issue responses',
+    ],
+  },
+  {
+    name: 'Gold Sponsor',
+    price: '$100',
+    period: '/month',
+    emoji: '\u{1F3C6}',
+    description: 'Fund a major feature every quarter.',
+    benefits: [
+      'All Backer benefits',
+      'Logo on README and docs site',
+      'Monthly office hours call',
+      'Vote on roadmap priorities',
+    ],
+  },
+  {
+    name: 'Platinum Sponsor',
+    price: '$500',
+    period: '/month',
+    emoji: '\u{1F48E}',
+    description: 'Shape the future of RevealUI.',
+    benefits: [
+      'All Gold Sponsor benefits',
+      'Logo with link on landing page',
+      'Dedicated Discourse channel',
+      'Direct line to the founder for prioritized feature requests — implementation scoped separately via RevealUI Studio engagements',
+    ],
+  },
+] as const;
+
+export const SPONSOR_SUPPORT_AREAS: readonly SupportArea[] = [
+  {
+    title: 'Development',
+    description: 'New features, bug fixes, and performance improvements.',
+    iconKey: 'development',
+  },
+  {
+    title: 'Documentation',
+    description: 'Guides, tutorials, API references, and examples.',
+    iconKey: 'documentation',
+  },
+  {
+    title: 'Community',
+    description: 'Discourse forums, issue triage, code reviews, and mentorship.',
+    iconKey: 'community',
+  },
+];
+
+export const SPONSOR_SUPPORT_HEADING = 'Where Your Support Goes';
+
+export const SPONSOR_FOOTER_NOTE = {
+  prefix: 'Looking for the product? See ',
+  productsLink: { label: 'Products', href: '/products' } satisfies Cta,
+  separator: ' or ',
+  docsLink: { label: 'read the docs', href: SITE.urls.docs, external: true } satisfies Cta,
+  suffix: '.',
+} as const;

--- a/apps/marketing/app/content/types.ts
+++ b/apps/marketing/app/content/types.ts
@@ -1,0 +1,26 @@
+// Shared content types for marketing/app/content/*
+// Sourced from extraction of inline JSX content per
+// docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
+
+export interface Cta {
+  readonly label: string;
+  readonly href: string;
+  readonly external?: boolean;
+}
+
+export interface FaqItem {
+  readonly question: string;
+  readonly answer: string;
+}
+
+export interface NavLink {
+  readonly label: string;
+  readonly href: string;
+  readonly external?: boolean;
+}
+
+export interface SectionHeading {
+  readonly eyebrow?: string;
+  readonly title: string;
+  readonly subtitle?: string;
+}

--- a/apps/marketing/app/routes/ComingSoonPage.tsx
+++ b/apps/marketing/app/routes/ComingSoonPage.tsx
@@ -1,73 +1,16 @@
 import { Footer } from '../components/Footer';
-
-interface Feature {
-  name: string;
-  description: string;
-  status: string;
-  category: string;
-}
-
-const shipped: Feature[] = [
-  {
-    name: 'Dashboard Agent Chat',
-    description:
-      'Interact with an AI agent directly from the admin dashboard. Create content, query data, manage collections, and automate workflows through natural language, with streaming responses, tool visibility, and conversation history.',
-    status: 'Shipped',
-    category: 'AI',
-  },
-  {
-    name: 'Documentation Site',
-    description:
-      'Documentation site live at docs.revealui.com with quick-start guides, API reference, architecture docs, and package reference. Video walkthroughs and collection cookbook coming soon.',
-    status: 'Shipped',
-    category: 'Docs',
-  },
-];
-
-const upcoming: Feature[] = [
-  {
-    name: 'RevealCoin + x402 Agent Payments',
-    description:
-      'Native cryptocurrency micropayments powered by RevealCoin on the Solana blockchain. Agents discover, authenticate, and pay per task via the HTTP 402 payment protocol. No accounts, no subscriptions.',
-    status: 'In development',
-    category: 'Payments',
-  },
-  {
-    name: 'Perpetual Licenses (Track C)',
-    description:
-      'One-time purchase for lifetime access to Pro, Max, or Enterprise tier features. No subscription required. Includes 1 year of priority support and updates.',
-    status: 'Coming soon',
-    category: 'Billing',
-  },
-  {
-    name: 'MCP Marketplace',
-    description:
-      'A registry where developers publish and discover MCP servers and AI agent capabilities. Revenue share model for developers. Discoverable via Smithery, mcpt, and the RevealUI registry.',
-    status: 'Planned — in design',
-    category: 'AI',
-  },
-  {
-    name: 'Self-Hosted Docker Images (RevealUI Fleet)',
-    description:
-      'Official Docker images published to GitHub Container Registry for fully self-hosted deployment. Domain-locked licensing, air-gap capable.',
-    status: 'Planned — designed, not built',
-    category: 'Infrastructure',
-  },
-  {
-    name: 'Visual Builder',
-    description:
-      'A no-code visual builder for creating RevealUI sites. Drag-and-drop page building, component customization, and one-click deployment.',
-    status: 'Planned — backlog',
-    category: 'Product',
-  },
-  {
-    name: 'Enterprise SSO / SAML',
-    description:
-      'Single sign-on via SAML for enterprise customers. Advanced audit logging, custom RBAC policy editor, and multi-region deployment support.',
-    status: 'Planned — designed, not built',
-    category: 'Enterprise',
-  },
-];
+import {
+  ROADMAP_CTA,
+  ROADMAP_CTA_LINKS,
+  ROADMAP_CTA_PRODUCTS_LINK,
+  ROADMAP_HERO,
+  ROADMAP_HERO_LINK,
+  ROADMAP_SHIPPED,
+  ROADMAP_SHIPPED_SECTION,
+  ROADMAP_UPCOMING,
+  ROADMAP_UPCOMING_SECTION,
+  type RoadmapItem,
+} from '../content/roadmap';
 
 const categoryColors: Record<string, string> = {
   payments: 'bg-amber-100 text-amber-700',
@@ -86,7 +29,7 @@ function statusBadgeClass(status: string): string {
   return 'text-amber-700 bg-amber-50 ring-amber-200';
 }
 
-function FeatureCard({ feature }: { feature: Feature }) {
+function FeatureCard({ feature }: { feature: RoadmapItem }) {
   return (
     <div className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200">
       <div className="flex items-center gap-3 mb-4">
@@ -120,14 +63,14 @@ export function ComingSoonPage() {
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            What we have shipped and what we are building next. See our{' '}
+            {ROADMAP_HERO.subtitle} See our{' '}
             <a
-              href="https://github.com/RevealUIStudio/revealui/blob/main/docs/ROADMAP.md"
+              href={ROADMAP_HERO_LINK.href}
               target="_blank"
               rel="noopener noreferrer"
               className="text-amber-700 underline hover:text-amber-600"
             >
-              public roadmap
+              {ROADMAP_HERO_LINK.label}
             </a>{' '}
             for the full timeline.
           </p>
@@ -138,10 +81,10 @@ export function ComingSoonPage() {
       <section className="py-16 sm:py-20 bg-gray-50">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl mb-8">
-            Recently shipped
+            {ROADMAP_SHIPPED_SECTION.title}
           </h2>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {shipped.map((feature) => (
+            {ROADMAP_SHIPPED.map((feature) => (
               <FeatureCard key={feature.name} feature={feature} />
             ))}
           </div>
@@ -152,10 +95,10 @@ export function ComingSoonPage() {
       <section className="py-16 sm:py-20">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl mb-8">
-            Coming next
+            {ROADMAP_UPCOMING_SECTION.title}
           </h2>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {upcoming.map((feature) => (
+            {ROADMAP_UPCOMING.map((feature) => (
               <FeatureCard key={feature.name} feature={feature} />
             ))}
           </div>
@@ -166,36 +109,34 @@ export function ComingSoonPage() {
       <section className="bg-gray-50 py-16">
         <div className="mx-auto max-w-4xl px-6 text-center lg:px-8">
           <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-            Want to influence what ships next?
+            {ROADMAP_CTA.title}
           </h2>
-          <p className="mt-4 text-lg text-gray-600">
-            We prioritize based on customer impact, product readiness, and community demand.
-          </p>
+          <p className="mt-4 text-lg text-gray-600">{ROADMAP_CTA.subtitle}</p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href="https://github.com/RevealUIStudio/revealui/issues"
+              href={ROADMAP_CTA_LINKS.requestFeature.href}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md bg-gray-900 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
             >
-              Request a feature
+              {ROADMAP_CTA_LINKS.requestFeature.label}
             </a>
             <a
-              href="https://github.com/RevealUIStudio/revealui/discussions"
+              href={ROADMAP_CTA_LINKS.joinDiscussion.href}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md bg-white px-6 py-3 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-gray-300 hover:bg-gray-50 transition-colors"
             >
-              Join the discussion
+              {ROADMAP_CTA_LINKS.joinDiscussion.label}
             </a>
           </div>
           <p className="mt-8 text-sm text-gray-500">
             See what's shipped today &rarr;{' '}
             <a
-              href="/products"
+              href={ROADMAP_CTA_PRODUCTS_LINK.href}
               className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
             >
-              Products
+              {ROADMAP_CTA_PRODUCTS_LINK.label}
             </a>
           </p>
         </div>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -1,5 +1,6 @@
 import { ContactForm } from '../components/ContactForm';
 import { Footer } from '../components/Footer';
+import { CONTACT_HERO, CONTACT_METHODS } from '../content/contact';
 
 export function ContactPage() {
   return (
@@ -8,55 +9,30 @@ export function ContactPage() {
         <div className="mx-auto max-w-2xl">
           <div className="text-center mb-12">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-              Get in touch
+              {CONTACT_HERO.title}
             </h1>
-            <p className="mt-6 text-lg leading-8 text-gray-600">
-              Questions about RevealUI? Interested in Enterprise or custom pricing? We would love to
-              hear from you.
-            </p>
+            <p className="mt-6 text-lg leading-8 text-gray-600">{CONTACT_HERO.subtitle}</p>
           </div>
 
           <ContactForm />
 
           <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-3 text-center">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">Community</h3>
-              <p className="mt-2 text-sm text-gray-600">
-                Join the conversation on{' '}
-                <a
-                  href="https://github.com/RevealUIStudio/revealui/discussions"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:text-blue-500 underline"
-                >
-                  GitHub Discussions
-                </a>
-              </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">Support</h3>
-              <p className="mt-2 text-sm text-gray-600">
-                <a
-                  href="mailto:support@revealui.com"
-                  className="text-blue-600 hover:text-blue-500 underline"
-                >
-                  support@revealui.com
-                </a>
-              </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">Bug Reports</h3>
-              <p className="mt-2 text-sm text-gray-600">
-                <a
-                  href="https://github.com/RevealUIStudio/revealui/issues"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:text-blue-500 underline"
-                >
-                  GitHub Issues
-                </a>
-              </p>
-            </div>
+            {CONTACT_METHODS.map((method) => (
+              <div key={method.title}>
+                <h3 className="text-sm font-semibold text-gray-900">{method.title}</h3>
+                <p className="mt-2 text-sm text-gray-600">
+                  {method.body ? <>{method.body} </> : null}
+                  <a
+                    href={method.href}
+                    target={method.external ? '_blank' : undefined}
+                    rel={method.external ? 'noopener noreferrer' : undefined}
+                    className="text-blue-600 hover:text-blue-500 underline"
+                  >
+                    {method.linkLabel}
+                  </a>
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -1,108 +1,21 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { useEffect } from 'react';
 import { Footer } from '../components/Footer';
+import {
+  FAIR_SOURCE_CONTRACT_CARDS,
+  FAIR_SOURCE_CONTRACT_SECTION,
+  FAIR_SOURCE_CTA,
+  FAIR_SOURCE_CLOCK_SECTION,
+  FAIR_SOURCE_FAQ_SECTION,
+  FAIR_SOURCE_FAQS,
+  FAIR_SOURCE_HERO,
+  FAIR_SOURCE_PACKAGES,
+  FAIR_SOURCE_PACKAGES_SECTION,
+  FAIR_SOURCE_PAGE_TITLE,
+  FAIR_SOURCE_PEERS,
+  FAIR_SOURCE_PEERS_SECTION,
+} from '../content/fair-source';
 import { buildOgUrl } from '../lib/og';
-
-const PAGE_TITLE = 'Fair Source — RevealUI';
-
-const contractCards = [
-  {
-    kind: 'yes' as const,
-    title: 'Use it commercially',
-    body: 'Ship Fair Source code in your product, charge customers, run it in production. No royalties, no per-seat fees, no usage caps.',
-  },
-  {
-    kind: 'yes' as const,
-    title: 'Read and modify the source',
-    body: 'Every line is on GitHub. Fork it, patch it, audit it for security. The source is the source of truth — there is no closed binary hiding behind it.',
-  },
-  {
-    kind: 'yes' as const,
-    title: 'Self-host on your own infra',
-    body: 'Run it in your VPC, on bare metal, or air-gapped. RevealUI does not phone home and does not depend on a vendor service to function.',
-  },
-  {
-    kind: 'no' as const,
-    title: 'Build a competing developer platform',
-    body: 'You cannot ship a substantially similar developer platform that competes with RevealUI on top of these packages. This is the only restriction. After two years, even this restriction lifts and the release becomes plain MIT.',
-  },
-];
-
-const packages = [
-  {
-    name: '@revealui/ai',
-    purpose: 'AI agents, CRDT memory, LLM provider abstractions, orchestration',
-    license: 'FSL-1.1-MIT',
-    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/ai',
-    npm: 'https://www.npmjs.com/package/@revealui/ai',
-  },
-  {
-    name: '@revealui/harnesses',
-    purpose: 'AI harness adapters, workboard coordination, JSON-RPC primitives',
-    license: 'FSL-1.1-MIT',
-    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses',
-    npm: 'https://www.npmjs.com/package/@revealui/harnesses',
-  },
-  {
-    name: '@revealui/mcp',
-    purpose: 'MCP framework — server hypervisor, adapter pattern, tool discovery',
-    license: 'FSL-1.1-MIT',
-    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp',
-    npm: 'https://www.npmjs.com/package/@revealui/mcp',
-  },
-  {
-    name: '@revealui/services',
-    purpose: 'External service integrations — Stripe, Solana (RVC), Vercel',
-    license: 'FSL-1.1-MIT',
-    repo: 'https://github.com/RevealUIStudio/revealui/tree/main/packages/services',
-    npm: 'https://www.npmjs.com/package/@revealui/services',
-  },
-];
-
-const peers = [
-  {
-    name: 'Sentry',
-    note: 'Application monitoring; flagship FSL adopter (license they originally co-authored with FOSSA).',
-    url: 'https://blog.sentry.io/introducing-the-functional-source-license-freedom-without-free-riding/',
-  },
-  {
-    name: 'GitButler',
-    note: 'Git client for branch management. FSL across the stack.',
-    url: 'https://gitbutler.com/blog/fair-source',
-  },
-  {
-    name: 'Keygen',
-    note: 'License management infrastructure; FSL on their core engine.',
-    url: 'https://keygen.sh/blog/fair-source/',
-  },
-];
-
-const faqs = [
-  {
-    q: 'Is Fair Source open source?',
-    a: 'Not in the OSI-approved sense — the non-compete clause means it is "source-available" rather than "open source." But for almost every practical purpose (read, modify, deploy, charge for products built on top), the freedoms match what most builders need from open source. After two years per release, the clause lifts and the code becomes plain MIT, which IS OSI open source.',
-  },
-  {
-    q: 'What counts as a "competing developer platform"?',
-    a: 'The license uses the standard FSL definition: a software product with substantially the same functionality as RevealUI that is offered to the same audience as a developer platform. Building a SaaS app for end users that happens to use @revealui/ai under the hood is fine. Building a marketplace for AI-agent tooling on top of @revealui/harnesses and selling it to developers is the case the clause addresses. If you are unsure, email founder@revealui.com — we would rather you ship than worry.',
-  },
-  {
-    q: 'When exactly does each release convert to MIT?',
-    a: "Two years after the publish date of that specific release. So today's 0.4.0 release of @revealui/ai becomes MIT on its 2-year anniversary; a future 0.5.0 starts its own clock from its own publish date. Older releases reach MIT first; this is intentional.",
-  },
-  {
-    q: 'Why not just use plain MIT for everything?',
-    a: 'The Pro packages represent meaningful R&D investment in agent runtimes and harness coordination. Plain MIT lets a competitor fork the entire stack on day one and undercut the project on price, leaving the studio with no path to sustain the work. Fair Source closes that specific risk while keeping every other freedom you need. It is a deliberate middle path between "everything free, no business model" and "closed proprietary."',
-  },
-  {
-    q: 'How is the Pro tier enforced if the source is visible?',
-    a: 'License enforcement is at runtime in the hosted product, not baked into the npm packages. The hosted RevealUI API checks Ed25519-signed license JWTs and gates Pro API routes; the packages themselves ship ungated, so self-hosters run them freely. FSL is the legal protection — the source is visible and you can run it, but shipping a competing developer platform on top of it is exactly what the non-compete clause prohibits, with civil remedies available. Two years after each release, that release becomes plain MIT.',
-  },
-  {
-    q: 'What about the rest of the RevealUI packages?',
-    a: 'Every other RevealUI package is plain MIT — no non-compete clause, no time limit, fully open source. That is the OSS substrate (auth, content, billing primitives, admin UI, presentation system, router, etc.). Fair Source applies to five packages: @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, and @revealui/services.',
-  },
-];
 
 export function FairSourcePage() {
   // Per-page OG tag override. Vite SPAs can update <head> at runtime; the
@@ -110,11 +23,8 @@ export function FairSourcePage() {
   // (Twitterbot, Slackbot, Discordbot, LinkedIn, OpenGraph spec consumers)
   // execute JavaScript and pick up the dynamic OG image.
   useEffect(() => {
-    document.title = PAGE_TITLE;
-    const ogImage = buildOgUrl(
-      'Fair Source',
-      'Source-visible. Commercially usable. MIT in two years.',
-    );
+    document.title = FAIR_SOURCE_PAGE_TITLE;
+    const ogImage = buildOgUrl(FAIR_SOURCE_HERO.ogTitle, FAIR_SOURCE_HERO.ogSubtitle);
     setMetaContent('og:image', ogImage);
     setMetaContent('twitter:image', ogImage);
   }, []);
@@ -135,27 +45,25 @@ export function FairSourcePage() {
         <div className="relative mx-auto max-w-3xl text-center">
           <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 mb-6">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle mr-2" />
-            License contract for the Pro packages
+            {FAIR_SOURCE_HERO.eyebrow}
           </p>
           <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
-            21 of 26 MIT.
-            <span className="block text-emerald-700">Forever.</span>
+            {FAIR_SOURCE_HERO.headline}
+            <span className="block text-emerald-700">{FAIR_SOURCE_HERO.headlineHighlight}</span>
           </h1>
           <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-gray-600 sm:text-2xl">
-            The 5 commercial packages convert to MIT after 2 years.
+            {FAIR_SOURCE_HERO.subhead}
           </p>
           <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-gray-600">
             {/* COUNT: packages-fsl = 5, packages-mit = 21 (of 26 total — see /packages/ in repo) */}
-            Twenty-one RevealUI packages ship under plain MIT and stay that way. Five packages ship
-            under{' '}
+            {FAIR_SOURCE_HERO.body.prefix}{' '}
             <a
-              href="https://fsl.software/"
+              href={FAIR_SOURCE_HERO.body.fslHref}
               className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
             >
-              FSL-1.1-MIT
+              {FAIR_SOURCE_HERO.body.fslLabel}
             </a>{' '}
-            &mdash; source-visible, commercially usable, and each release auto-converts to plain MIT
-            two years after publish. Same license model used by Sentry, GitButler, and Keygen.
+            &mdash; {FAIR_SOURCE_HERO.body.suffix}
           </p>
         </div>
       </section>
@@ -165,15 +73,15 @@ export function FairSourcePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-              The contract, in plain English
+              {FAIR_SOURCE_CONTRACT_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-              Three yeses and one no.
+              {FAIR_SOURCE_CONTRACT_SECTION.heading}
             </h2>
           </div>
 
           <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
-            {contractCards.map((c) => (
+            {FAIR_SOURCE_CONTRACT_CARDS.map((c) => (
               <div
                 key={c.title}
                 className={`rounded-2xl p-6 ring-1 transition ${
@@ -227,18 +135,18 @@ export function FairSourcePage() {
       <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">Scope</p>
+            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+              {FAIR_SOURCE_PACKAGES_SECTION.eyebrow}
+            </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-              Which RevealUI packages are Fair Source.
+              {FAIR_SOURCE_PACKAGES_SECTION.heading}
             </h2>
             <p className="mt-6 text-base leading-7 text-gray-600">
-              Five packages carry FSL-1.1-MIT — the four published to npm are listed below, plus the
-              private{' '}
+              {FAIR_SOURCE_PACKAGES_SECTION.body.prefix}{' '}
               <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-sm text-gray-900">
-                @revealui/engines
+                {FAIR_SOURCE_PACKAGES_SECTION.body.privatePackage}
               </code>{' '}
-              workspace package. Every other RevealUI package is plain MIT — no non-compete, no time
-              limit, fully open source.
+              {FAIR_SOURCE_PACKAGES_SECTION.body.suffix}
             </p>
           </div>
 
@@ -253,7 +161,7 @@ export function FairSourcePage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
-                {packages.map((p) => (
+                {FAIR_SOURCE_PACKAGES.map((p) => (
                   <tr key={p.name}>
                     <td className="px-6 py-4 font-mono text-sm font-semibold text-gray-950">
                       {p.name}
@@ -289,11 +197,11 @@ export function FairSourcePage() {
             </table>
           </div>
           <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-gray-500">
-            Looking for a specific package&rsquo;s license? Run{' '}
+            {FAIR_SOURCE_PACKAGES_SECTION.footer.prefix}{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
-              npm view @revealui/&lt;name&gt; license
+              {FAIR_SOURCE_PACKAGES_SECTION.footer.command}
             </code>{' '}
-            — npm always tells the truth.
+            {FAIR_SOURCE_PACKAGES_SECTION.footer.suffix}
           </p>
         </div>
       </section>
@@ -303,52 +211,31 @@ export function FairSourcePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-              The two-year clock
+              {FAIR_SOURCE_CLOCK_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-              Every release auto-converts to MIT.
+              {FAIR_SOURCE_CLOCK_SECTION.heading}
             </h2>
             <p className="mt-6 text-base leading-7 text-gray-600">
-              The 2-year timer starts on each release&rsquo;s publish date. Older releases reach MIT
-              first; newer releases start their own clock from their own publish date. The clause
-              does not require any action from RevealUI Studio — it is in the license text and
-              self-executing.
+              {FAIR_SOURCE_CLOCK_SECTION.body}
             </p>
           </div>
 
           <div className="mx-auto mt-12 max-w-3xl">
             <ol className="relative border-l-2 border-emerald-200 pl-8">
-              <li className="mb-8 last:mb-0">
-                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-600 ring-4 ring-white">
-                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
-                </span>
-                <h3 className="font-semibold text-gray-950">Release publishes under FSL-1.1-MIT</h3>
-                <p className="mt-1 text-sm text-gray-600">
-                  Source on GitHub. Installable from npm. The 2-year clock starts ticking the moment
-                  the version tag lands.
-                </p>
-              </li>
-              <li className="mb-8 last:mb-0">
-                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-amber-600 ring-4 ring-white">
-                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
-                </span>
-                <h3 className="font-semibold text-gray-950">Year one and year two</h3>
-                <p className="mt-1 text-sm text-gray-600">
-                  All freedoms apply (use commercially, modify, self-host) except the non-compete
-                  clause. You build on it, you ship products with it, you charge customers for those
-                  products.
-                </p>
-              </li>
-              <li>
-                <span className="absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-600 ring-4 ring-white">
-                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
-                </span>
-                <h3 className="font-semibold text-gray-950">Two years later: plain MIT</h3>
-                <p className="mt-1 text-sm text-gray-600">
-                  That specific release auto-converts to plain MIT. The non-compete clause lifts;
-                  the license becomes OSI-approved open source.
-                </p>
-              </li>
+              {FAIR_SOURCE_CLOCK_SECTION.steps.map((step) => (
+                <li key={step.title} className="mb-8 last:mb-0">
+                  <span
+                    className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-white ${
+                      step.color === 'emerald' ? 'bg-emerald-600' : 'bg-amber-600'
+                    }`}
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                  </span>
+                  <h3 className="font-semibold text-gray-950">{step.title}</h3>
+                  <p className="mt-1 text-sm text-gray-600">{step.body}</p>
+                </li>
+              ))}
             </ol>
           </div>
         </div>
@@ -359,15 +246,15 @@ export function FairSourcePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-              In good company
+              {FAIR_SOURCE_PEERS_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-              The same license model used by serious infrastructure projects.
+              {FAIR_SOURCE_PEERS_SECTION.heading}
             </h2>
           </div>
 
           <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
-            {peers.map((p) => (
+            {FAIR_SOURCE_PEERS.map((p) => (
               <a
                 key={p.name}
                 href={p.url}
@@ -389,18 +276,18 @@ export function FairSourcePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
-              Common questions
+              {FAIR_SOURCE_FAQ_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
-              Detailed answers, not lawyer-speak.
+              {FAIR_SOURCE_FAQ_SECTION.heading}
             </h2>
           </div>
 
           <div className="mx-auto mt-12 max-w-3xl divide-y divide-gray-200">
-            {faqs.map((f) => (
-              <details key={f.q} className="group py-6">
+            {FAIR_SOURCE_FAQS.map((f) => (
+              <details key={f.question} className="group py-6">
                 <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                  <h3 className="text-lg font-semibold leading-7 text-gray-950">{f.q}</h3>
+                  <h3 className="text-lg font-semibold leading-7 text-gray-950">{f.question}</h3>
                   <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
                     <svg
                       className="h-4 w-4"
@@ -419,7 +306,7 @@ export function FairSourcePage() {
                     </svg>
                   </span>
                 </summary>
-                <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{f.a}</div>
+                <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{f.answer}</div>
               </details>
             ))}
           </div>
@@ -430,15 +317,12 @@ export function FairSourcePage() {
       <section className="bg-gray-950 py-16 sm:py-24">
         <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-            Read the spec yourself.
+            {FAIR_SOURCE_CTA.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-400">
-            FSL-1.1-MIT is short, plain English, and authored by the FOSSA legal team. Two pages.
-            Read it before you ship.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-400">{FAIR_SOURCE_CTA.body}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">
-              <a href="https://fsl.software/FSL-1.1-MIT.template.md">FSL-1.1-MIT spec text</a>
+              <a href={FAIR_SOURCE_CTA.primaryHref}>{FAIR_SOURCE_CTA.primaryLabel}</a>
             </ButtonCVA>
             <ButtonCVA
               asChild
@@ -446,9 +330,7 @@ export function FairSourcePage() {
               size="lg"
               className="border-gray-700 text-gray-300 hover:text-white hover:border-gray-500"
             >
-              <a href="mailto:founder@revealui.com?subject=Fair%20Source%20question">
-                Email a license question
-              </a>
+              <a href={FAIR_SOURCE_CTA.secondaryHref}>{FAIR_SOURCE_CTA.secondaryLabel}</a>
             </ButtonCVA>
           </div>
         </div>

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -2,10 +2,10 @@ import { ButtonCVA } from '@revealui/presentation';
 import { useEffect } from 'react';
 import { Footer } from '../components/Footer';
 import {
+  FAIR_SOURCE_CLOCK_SECTION,
   FAIR_SOURCE_CONTRACT_CARDS,
   FAIR_SOURCE_CONTRACT_SECTION,
   FAIR_SOURCE_CTA,
-  FAIR_SOURCE_CLOCK_SECTION,
   FAIR_SOURCE_FAQ_SECTION,
   FAIR_SOURCE_FAQS,
   FAIR_SOURCE_HERO,

--- a/apps/marketing/app/routes/MarketplacePage.tsx
+++ b/apps/marketing/app/routes/MarketplacePage.tsx
@@ -1,75 +1,14 @@
 import { Footer } from '../components/Footer';
-
-interface McpServer {
-  name: string;
-  description: string;
-  category: string;
-}
-
-const mcpServers: McpServer[] = [
-  {
-    name: 'Stripe',
-    description: 'Manage products, prices, subscriptions, and payment intents through MCP.',
-    category: 'Payments',
-  },
-  {
-    name: 'RevealUI Stripe',
-    description:
-      'RevealUI-specific Stripe operations: billing portal, webhook management, tier enforcement.',
-    category: 'Payments',
-  },
-  {
-    name: 'Neon',
-    description: 'Query and manage Neon PostgreSQL databases: branches, roles, and SQL execution.',
-    category: 'Database',
-  },
-  {
-    name: 'Supabase',
-    description: 'Interact with Supabase for vector storage, auth, and real-time subscriptions.',
-    category: 'Database',
-  },
-  {
-    name: 'Vercel',
-    description: 'Deploy, manage environment variables, inspect deployments, and view logs.',
-    category: 'Infrastructure',
-  },
-  {
-    name: 'Playwright',
-    description: 'Run browser automation, take screenshots, and execute end-to-end test flows.',
-    category: 'Testing',
-  },
-  {
-    name: 'Next.js DevTools',
-    description: 'Inspect routes, middleware, server components, and build output in development.',
-    category: 'Development',
-  },
-  {
-    name: 'RevealUI Content',
-    description: 'Create, query, and manage collections and documents through the content API.',
-    category: 'Content',
-  },
-  {
-    name: 'RevealUI Email',
-    description: 'Send transactional emails, manage templates, and track delivery status.',
-    category: 'Communication',
-  },
-  {
-    name: 'Code Validator',
-    description: 'Validate TypeScript, lint with Biome, and run type checks on code snippets.',
-    category: 'Development',
-  },
-  {
-    name: 'RevealUI Memory',
-    description:
-      'Read and write the agent memory store (episodic, semantic, and procedural layers).',
-    category: 'Content',
-  },
-  {
-    name: 'Contracts',
-    description: 'Validate pricing contracts, check OpenAPI mirror drift, and inspect schema.',
-    category: 'Development',
-  },
-];
+import {
+  MARKETPLACE_COMING_SOON,
+  MARKETPLACE_CTA,
+  MARKETPLACE_DISCOVERY_SECTION,
+  MARKETPLACE_DISCOVERY_STEPS,
+  MARKETPLACE_HERO,
+  MARKETPLACE_HERO_NAV_ANCHORS,
+  MARKETPLACE_MCP_SERVERS,
+  MARKETPLACE_SERVERS_SECTION,
+} from '../content/marketplace';
 
 const categoryColors: Record<string, string> = {
   Payments: 'bg-amber-100 text-amber-700',
@@ -95,21 +34,20 @@ export function MarketplacePage() {
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            12 first-party MCP servers, RBAC-scoped and audit-logged. Agents discover tools via MCP.
-            RevealUI implements MCP natively.
+            {MARKETPLACE_HERO.subtitle}
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-3">
             <a
-              href="#mcp-servers"
+              href={MARKETPLACE_HERO_NAV_ANCHORS[0].href}
               className="rounded-full bg-violet-100 px-4 py-1.5 text-sm font-medium text-violet-700 hover:bg-violet-200 transition-colors"
             >
-              MCP Servers
+              {MARKETPLACE_HERO_NAV_ANCHORS[0].label}
             </a>
             <a
-              href="#discovery"
+              href={MARKETPLACE_HERO_NAV_ANCHORS[1].href}
               className="rounded-full bg-purple-100 px-4 py-1.5 text-sm font-medium text-purple-700 hover:bg-purple-200 transition-colors"
             >
-              How agents discover tools
+              {MARKETPLACE_HERO_NAV_ANCHORS[1].label}
             </a>
           </div>
         </div>
@@ -120,34 +58,12 @@ export function MarketplacePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-3xl text-center mb-16">
             <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              How agents discover and use tools
+              {MARKETPLACE_DISCOVERY_SECTION.title}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
-              MCP (Model Context Protocol) is the open standard for connecting AI agents to tools
-              and data sources. RevealUI implements MCP natively.
-            </p>
+            <p className="mt-4 text-lg text-gray-600">{MARKETPLACE_DISCOVERY_SECTION.subtitle}</p>
           </div>
           <div className="mx-auto max-w-4xl grid grid-cols-1 gap-8 sm:grid-cols-3">
-            {[
-              {
-                step: '1',
-                title: 'Discover',
-                description:
-                  'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities and required permissions.',
-              },
-              {
-                step: '2',
-                title: 'Authenticate',
-                description:
-                  'The agent authenticates using the same RBAC system that governs human users. Permissions are scoped per tenant and per role.',
-              },
-              {
-                step: '3',
-                title: 'Execute',
-                description:
-                  'The agent calls the tool through a standardized JSON-RPC interface. Results are typed, validated, and logged for audit.',
-              },
-            ].map((item) => (
+            {MARKETPLACE_DISCOVERY_STEPS.map((item) => (
               <div key={item.step} className="text-center">
                 <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-violet-100 text-lg font-bold text-violet-700">
                   {item.step}
@@ -165,18 +81,15 @@ export function MarketplacePage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-12">
             <span className="text-sm font-semibold tracking-wide text-violet-600 uppercase">
-              Open Source
+              {MARKETPLACE_SERVERS_SECTION.eyebrow}
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              12 First-Party MCP Servers
+              {MARKETPLACE_SERVERS_SECTION.heading}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
-              MCP servers included with RevealUI. Each server is rate-limited, audited, and governed
-              by RBAC.
-            </p>
+            <p className="mt-4 text-lg text-gray-600">{MARKETPLACE_SERVERS_SECTION.body}</p>
           </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {mcpServers.map((server) => (
+            {MARKETPLACE_MCP_SERVERS.map((server) => (
               <div
                 key={server.name}
                 className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-200"
@@ -207,23 +120,22 @@ export function MarketplacePage() {
         <div className="mx-auto max-w-3xl px-6 lg:px-8">
           <div className="rounded-2xl bg-violet-50 ring-1 ring-violet-200 p-10 text-center">
             <span className="inline-block text-xs font-semibold text-violet-700 bg-violet-100 px-3 py-1 rounded-full ring-1 ring-violet-200 mb-4">
-              Coming after marketplace v1
+              {MARKETPLACE_COMING_SOON.badge}
             </span>
             <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-              Publishing and monetization
+              {MARKETPLACE_COMING_SOON.heading}
             </h2>
             <p className="mt-4 text-base text-gray-600">
-              Third-party MCP server publishing, developer earnings, and marketplace discovery are
-              planned for a future release. See the{' '}
+              {MARKETPLACE_COMING_SOON.body.prefix}{' '}
               <a
-                href="https://github.com/RevealUIStudio/revealui/blob/main/docs/ROADMAP.md"
+                href={MARKETPLACE_COMING_SOON.body.linkHref}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-violet-700 underline hover:text-violet-600"
               >
-                public roadmap
+                {MARKETPLACE_COMING_SOON.body.linkLabel}
               </a>{' '}
-              for current status — listed under "Agent Marketplace" in the Mid-Term section.
+              {MARKETPLACE_COMING_SOON.body.suffix}
             </p>
           </div>
         </div>
@@ -233,24 +145,21 @@ export function MarketplacePage() {
       <section className="bg-gray-50 py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
           <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-            Start with the MCP server catalog
+            {MARKETPLACE_CTA.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            12 first-party servers ship with every RevealUI install. Read the MCP docs to wire your
-            agents.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{MARKETPLACE_CTA.body}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href="https://docs.revealui.com/mcp"
+              href={MARKETPLACE_CTA.primary.href}
               className="rounded-md bg-violet-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-violet-500 transition-colors"
             >
-              MCP Documentation
+              {MARKETPLACE_CTA.primary.label}
             </a>
             <a
-              href="/products"
+              href={MARKETPLACE_CTA.secondary.href}
               className="rounded-md bg-gray-100 px-8 py-4 text-base font-semibold text-gray-900 hover:bg-gray-200 transition-colors"
             >
-              View All Products
+              {MARKETPLACE_CTA.secondary.label}
             </a>
           </div>
         </div>

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -19,8 +19,8 @@ import {
   PRICING_NEWSLETTER_LABEL,
   PRICING_TRACK_A_SECTION,
   PRICING_TRACK_C_SECTION,
-  SUBSCRIPTION_TIERS,
   type PricingResponse,
+  SUBSCRIPTION_TIERS,
 } from '../content/pricing';
 import { PRICING_FAQ_SECTION, PRICING_FAQS } from '../content/pricing-faq';
 

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -1,69 +1,33 @@
-import {
-  PERPETUAL_TIERS,
-  type PricingResponse,
-  SUBSCRIPTION_TIERS,
-} from '@revealui/contracts/pricing';
 import { useEffect, useState } from 'react';
 import { Footer } from '../components/Footer';
 import { NewsletterSignup } from '../components/NewsletterSignup';
+import {
+  PERPETUAL_TIERS,
+  PRICING_AGENCY_SECTION,
+  PRICING_AGENT_A2A,
+  PRICING_AGENT_CTA_LINKS,
+  PRICING_AGENT_MCP,
+  PRICING_AGENT_X402,
+  PRICING_AGENTS_SECTION,
+  PRICING_CFO_PANEL,
+  PRICING_FINAL_CTA,
+  PRICING_FINAL_CTA_LINKS,
+  PRICING_HERO,
+  PRICING_HERO_NAV_ANCHORS,
+  PRICING_HERO_SUBTEXT,
+  PRICING_HIGHLIGHTED_BADGE,
+  PRICING_NEWSLETTER_LABEL,
+  PRICING_TRACK_A_SECTION,
+  PRICING_TRACK_C_SECTION,
+  SUBSCRIPTION_TIERS,
+  type PricingResponse,
+} from '../content/pricing';
+import { PRICING_FAQ_SECTION, PRICING_FAQS } from '../content/pricing-faq';
 
 const ADMIN_URL = import.meta.env.VITE_ADMIN_URL ?? 'https://admin.revealui.com';
 const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
-
-const faqs = [
-  {
-    question: 'Can I use the Free tier for commercial projects?',
-    answer:
-      'Yes! The Free tier is fully open-source (MIT) and can be used for commercial projects. You get full source code access and can deploy it anywhere you like.',
-  },
-  {
-    question: 'What happens after the free trial ends?',
-    answer:
-      "Pro and Max tiers include a 7-day free trial. After the trial ends, you'll be charged the monthly rate. You can cancel anytime during the trial without being charged.",
-  },
-  {
-    question: 'How does agent task billing work?',
-    answer:
-      'Every paid subscription includes generous task allowances. Agent task usage billing is coming soon — for now, all tiers include unlimited agent tasks during early access.',
-  },
-  {
-    question: 'What are perpetual licenses?',
-    answer:
-      'A perpetual license is a one-time purchase that gives you a license key for the corresponding tier, forever, with no monthly subscription required. Support and updates are included for 1 year; after that, renew your support contract or keep using the version you have.',
-  },
-  {
-    question: 'Can I upgrade or downgrade my plan?',
-    answer:
-      "Yes, you can upgrade your plan at any time. You'll be charged the prorated amount immediately. To downgrade, visit your billing portal or contact support@revealui.com.",
-  },
-  {
-    question: 'How does AI inference work?',
-    answer:
-      'Bring your own model. The default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ollama or Ubuntu Inference Snaps from Canonical (canonical default — Studio lifecycle pending) — your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
-  },
-  {
-    question: 'What does "full source code access" mean?',
-    answer:
-      'You get the complete RevealUI source code — every app and package is published in the public monorepo. Infrastructure packages (@revealui/core, auth, db, contracts, security, utils, config, cache, resilience, openapi, sync, mcp) are MIT-licensed. The two Pro packages (@revealui/ai, @revealui/harnesses) ship under Fair Source (FSL-1.1-MIT): source is visible, commercial use is permitted except for building a directly competing developer platform, and each release automatically converts to plain MIT two years after publication. All paid tiers add runtime entitlements (license validation, feature gates, priority updates) on top of that source access — nothing is hidden behind a closed binary.',
-  },
-  {
-    question: 'What is Fair Source (FSL-1.1-MIT)?',
-    answer:
-      "Fair Source is a middle path between closed commercial and plain open-source. Our Pro packages (@revealui/ai and @revealui/harnesses) are source-visible on GitHub, installable from npm, and legally usable in commercial products — with one non-compete clause: you can't ship a substantially similar developer platform that competes with RevealUI on top of them. Two years after each release, that release automatically converts to MIT. Same license model used by Sentry, GitButler, and Keygen. Source-available under FSL: free for everyone except SaaS competitors. Pro plan = hosted infra + support, not npm-level enforcement. Full explainer at /fair-source.",
-  },
-  {
-    question: 'Do you offer custom pricing for large teams?',
-    answer:
-      'Yes! If you need more than what the Enterprise tier offers, contact us at support@revealui.com to discuss custom pricing and SLAs.',
-  },
-  {
-    question: 'What is RevFleet?',
-    answer:
-      'RevFleet is the RevealUI Studio product family — eight products that compose around the RevealUI runtime. RevealUI is the agentic business runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness for multi-agent coordination across Claude, Cursor, and Copilot (Studio + Console MIT, Daemon Fair Source). RevCon syncs editor configs (MIT). RevSkills is the Claude Code skills library (MIT). RevForge is the operator-side stamping tool that produces white-label trial kits (operator-only). RevKit is the portable WSL dev environment toolkit (Pro). RevealCoin is x402-compatible agent payments — deployed on Solana mainnet but pre-launch (multisig migration + on-chain vesting gating; see RevealCoin README for the open prerequisites). Use RevealUI standalone, or compose what you need.',
-  },
-];
 
 export function PricingPage() {
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
@@ -101,32 +65,30 @@ export function PricingPage() {
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Subscribe monthly or buy a perpetual license. Start free. Upgrade when you need to.
+            {PRICING_HERO.subtitle}
           </p>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-gray-500">
-            All plans run as self-hosted installations under your license — managed deployment
-            available as a service add-on. Want to deploy a branded version for your own customers?
-            See{' '}
+            {PRICING_HERO_SUBTEXT.prefix}{' '}
             <a
-              href="#track-c"
+              href={PRICING_HERO_SUBTEXT.linkHref}
               className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
             >
-              Agency Perpetual
+              {PRICING_HERO_SUBTEXT.linkLabel}
             </a>{' '}
-            for RevealUI Fleet licensing.
+            {PRICING_HERO_SUBTEXT.suffix}
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium">
             <a
-              href="#track-a"
+              href={PRICING_HERO_NAV_ANCHORS[0].href}
               className="rounded-full bg-blue-100 px-4 py-1.5 text-blue-700 hover:bg-blue-200 transition-colors"
             >
-              Track A: Subscriptions
+              {PRICING_HERO_NAV_ANCHORS[0].label}
             </a>
             <a
-              href="#track-c"
+              href={PRICING_HERO_NAV_ANCHORS[1].href}
               className="rounded-full bg-emerald-100 px-4 py-1.5 text-emerald-700 hover:bg-emerald-200 transition-colors"
             >
-              Track C: Perpetual Licenses
+              {PRICING_HERO_NAV_ANCHORS[1].label}
             </a>
           </div>
         </div>
@@ -137,75 +99,45 @@ export function PricingPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-12">
             <span className="text-sm font-semibold tracking-wide text-blue-600 uppercase">
-              Track A
+              {PRICING_TRACK_A_SECTION.eyebrow}
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              Subscription Plans
+              {PRICING_TRACK_A_SECTION.heading}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
-              Monthly subscriptions with a task allowance included. 7-day free trial on Pro and Max.
-            </p>
+            <p className="mt-4 text-lg text-gray-600">{PRICING_TRACK_A_SECTION.body}</p>
           </div>
 
           {/* CFO comparison panel — replacing-what reframe */}
           <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-blue-50 to-indigo-50 p-8 ring-1 ring-blue-200">
             <p className="text-sm font-semibold uppercase tracking-widest text-blue-700">
-              Replacing what?
+              {PRICING_CFO_PANEL.eyebrow}
             </p>
             <h3 className="mt-3 text-2xl font-bold tracking-tight text-gray-950">
-              A typical 5-dev startup pays $800&ndash;$1,000/mo for the backend layer alone.
+              {PRICING_CFO_PANEL.heading}
             </h3>
             <ul className="mt-6 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
-              <li className="flex items-baseline gap-2">
-                <span className="text-gray-500">&bull;</span>
-                <span>
-                  <span className="font-semibold text-gray-900">Convex Team:</span> $125/mo (5 ×
-                  $25)
-                </span>
-              </li>
-              <li className="flex items-baseline gap-2">
-                <span className="text-gray-500">&bull;</span>
-                <span>
-                  <span className="font-semibold text-gray-900">Supabase Team:</span> $599/mo
-                </span>
-              </li>
-              <li className="flex items-baseline gap-2">
-                <span className="text-gray-500">&bull;</span>
-                <span>
-                  <span className="font-semibold text-gray-900">Trigger.dev Pro:</span> $50/mo
-                </span>
-              </li>
-              <li className="flex items-baseline gap-2">
-                <span className="text-gray-500">&bull;</span>
-                <span>
-                  <span className="font-semibold text-gray-900">Clerk Pro:</span> $25/mo
-                </span>
-              </li>
-              <li className="flex items-baseline gap-2 sm:col-span-2">
-                <span className="text-gray-500">&bull;</span>
-                <span>
-                  <span className="font-semibold text-gray-900">Stripe + observability:</span>{' '}
-                  ~$50/mo+
-                </span>
-              </li>
+              {PRICING_CFO_PANEL.lineItems.map((item, i) => (
+                <li
+                  key={item.label}
+                  className={`flex items-baseline gap-2${i === PRICING_CFO_PANEL.lineItems.length - 1 ? ' sm:col-span-2' : ''}`}
+                >
+                  <span className="text-gray-500">&bull;</span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{item.label}</span> {item.amount}
+                  </span>
+                </li>
+              ))}
             </ul>
 
             <div className="mt-6 rounded-xl bg-white p-5 ring-1 ring-blue-200">
-              <p className="text-sm leading-6 text-gray-700">
-                Total backend-platform spend:{' '}
-                <span className="font-semibold">~$800&ndash;$1,000 / mo</span> + per-event API
-                costs.
-              </p>
+              <p className="text-sm leading-6 text-gray-700">{PRICING_CFO_PANEL.totalLine}</p>
               <p className="mt-3 text-base font-semibold text-emerald-800">
-                RevealUI Pro is $49/mo + your own infrastructure. You own the runtime.
+                {PRICING_CFO_PANEL.bottomLine}
               </p>
             </div>
 
             <p className="mt-4 text-xs leading-5 text-gray-600">
-              <em>
-                Deploy targets like Vercel, Cloudflare, Railway, and Hetzner are unchanged &mdash;
-                RevealUI runs on all of them. We replace the backend platforms, not where you ship.
-              </em>
+              <em>{PRICING_CFO_PANEL.footnote}</em>
             </p>
           </div>
 
@@ -219,7 +151,7 @@ export function PricingPage() {
               >
                 {tier.highlighted && (
                   <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-3 py-1.5 text-sm font-semibold text-white text-center shadow-lg">
-                    Most Popular
+                    {PRICING_HIGHLIGHTED_BADGE}
                   </div>
                 )}
                 <div className="mb-8">
@@ -274,14 +206,12 @@ export function PricingPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-12">
             <span className="text-sm font-semibold tracking-wide text-emerald-700 uppercase">
-              Track C
+              {PRICING_TRACK_C_SECTION.eyebrow}
             </span>
             <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              Perpetual Licenses
+              {PRICING_TRACK_C_SECTION.heading}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
-              Pay once, use forever. No subscription required. Support renewals are optional.
-            </p>
+            <p className="mt-4 text-lg text-gray-600">{PRICING_TRACK_C_SECTION.body}</p>
           </div>
           <div className="mx-auto max-w-5xl grid grid-cols-1 gap-6 sm:grid-cols-3">
             {perpetualTiers.map((tier) => (
@@ -340,16 +270,14 @@ export function PricingPage() {
           <div className="mx-auto max-w-4xl">
             <div className="text-center mb-12">
               <span className="text-sm font-semibold tracking-wide text-emerald-400 uppercase">
-                Agent-Native
+                {PRICING_AGENTS_SECTION.eyebrow}
               </span>
               <h2 className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                RevealUI for AI Agents
+                {PRICING_AGENTS_SECTION.heading}
               </h2>
-              <p className="mt-4 text-lg text-gray-400">
-                Agents discover, authenticate, and pay without human intervention.
-              </p>
+              <p className="mt-4 text-lg text-gray-400">{PRICING_AGENTS_SECTION.subhead}</p>
               <span className="mt-3 inline-block text-xs font-semibold text-amber-300 bg-amber-400/10 px-3 py-1 rounded-full ring-1 ring-amber-400/20">
-                Coming soon
+                {PRICING_AGENTS_SECTION.badge}
               </span>
             </div>
 
@@ -371,18 +299,18 @@ export function PricingPage() {
                     />
                   </svg>
                 </div>
-                <h3 className="text-base font-semibold text-white">A2A Discovery</h3>
+                <h3 className="text-base font-semibold text-white">{PRICING_AGENT_A2A.heading}</h3>
                 <p className="mt-2 text-sm text-gray-400">
-                  Agents find RevealUI via a standard Agent Card at{' '}
+                  {PRICING_AGENT_A2A.body.prefix}{' '}
                   <a
-                    href="https://api.revealui.com/.well-known/agent.json"
+                    href={PRICING_AGENT_A2A.body.linkHref}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-emerald-400 hover:text-emerald-300 underline break-all"
                   >
-                    /.well-known/agent.json
+                    {PRICING_AGENT_A2A.body.linkLabel}
                   </a>
-                  . Capabilities, skills, and pricing all machine-readable.
+                  {PRICING_AGENT_A2A.body.suffix}
                 </p>
               </div>
 
@@ -403,24 +331,19 @@ export function PricingPage() {
                     />
                   </svg>
                 </div>
-                <h3 className="text-base font-semibold text-white">x402-Native Payments</h3>
-                <p className="mt-2 text-sm text-gray-400">
-                  RevealUI implements the HTTP 402 payment protocol. Compatible with Amazon Bedrock
-                  AgentCore Payments, Coinbase, and Cloudflare&rsquo;s x402 Foundation. Agents pay
-                  agents over standard HTTP &mdash; no accounts, no subscriptions.
-                </p>
+                <h3 className="text-base font-semibold text-white">{PRICING_AGENT_X402.heading}</h3>
+                <p className="mt-2 text-sm text-gray-400">{PRICING_AGENT_X402.body}</p>
                 <p className="mt-3 text-xs text-gray-400">
-                  RevealCoin is one optional Solana implementation &mdash; deployed on mainnet but
-                  pre-launch (see{' '}
+                  {PRICING_AGENT_X402.footnote.prefix}{' '}
                   <a
-                    href="https://github.com/RevealUIStudio/revealcoin#pre-launch-risk-disclosure"
+                    href={PRICING_AGENT_X402.footnote.linkHref}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 underline"
                   >
-                    RevealCoin README
+                    {PRICING_AGENT_X402.footnote.linkLabel}
                   </a>{' '}
-                  for the open prerequisites).
+                  {PRICING_AGENT_X402.footnote.suffix}
                 </p>
               </div>
 
@@ -441,25 +364,20 @@ export function PricingPage() {
                     />
                   </svg>
                 </div>
-                <h3 className="text-base font-semibold text-white">MCP Servers</h3>
-                <p className="mt-2 text-sm text-gray-400">
-                  {/* COUNT: mcp-servers = 13 (verified at packages/mcp/src/servers/, excluding _-prefixed helpers) */}
-                  13 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright,
-                  Next.js DevTools, content management, and email. Marketplace discovery coming
-                  soon.
-                </p>
+                <h3 className="text-base font-semibold text-white">{PRICING_AGENT_MCP.heading}</h3>
+                <p className="mt-2 text-sm text-gray-400">{PRICING_AGENT_MCP.body}</p>
                 <a
-                  href="https://docs.revealui.com/mcp"
+                  href={PRICING_AGENT_MCP.docsLink.href}
                   className="mt-3 inline-block text-xs font-semibold text-purple-400 hover:text-purple-300"
                 >
-                  MCP docs →
+                  {PRICING_AGENT_MCP.docsLink.label}
                 </a>
               </div>
             </div>
 
             <div className="mt-10 text-center">
               <a
-                href="https://api.revealui.com/openapi.json"
+                href={PRICING_AGENT_CTA_LINKS.openapi.href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-lg bg-white/5 px-4 py-2 text-sm font-medium text-gray-300 ring-1 ring-white/10 hover:bg-white/10 transition-colors"
@@ -478,13 +396,13 @@ export function PricingPage() {
                     d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
                   />
                 </svg>
-                OpenAPI spec
+                {PRICING_AGENT_CTA_LINKS.openapi.label}
               </a>
               <a
-                href="https://docs.revealui.com/api"
+                href={PRICING_AGENT_CTA_LINKS.apiDocs.href}
                 className="ml-4 inline-flex items-center gap-2 rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-600 transition-colors"
               >
-                API docs
+                {PRICING_AGENT_CTA_LINKS.apiDocs.label}
               </a>
             </div>
           </div>
@@ -495,20 +413,17 @@ export function PricingPage() {
       <section className="bg-amber-50/50 py-16 sm:py-20">
         <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
           <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-            Need help adopting RevealUI?
+            {PRICING_AGENCY_SECTION.heading}
           </h2>
-          <p className="mt-4 text-base text-gray-600">
-            Architecture reviews, migrations, and launch support are offered separately by RevealUI
-            Studio (the agency). Engagements are scoped per-project.
-          </p>
+          <p className="mt-4 text-base text-gray-600">{PRICING_AGENCY_SECTION.body}</p>
           <div className="mt-8">
             <a
-              href="https://revealuistudio.com"
+              href={PRICING_AGENCY_SECTION.cta.href}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center rounded-md bg-amber-700 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-600 transition-colors"
             >
-              Visit revealuistudio.com →
+              {PRICING_AGENCY_SECTION.cta.label}
             </a>
           </div>
         </div>
@@ -519,10 +434,10 @@ export function PricingPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-4xl">
             <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl text-center mb-12">
-              Frequently Asked Questions
+              {PRICING_FAQ_SECTION.heading}
             </h2>
             <dl className="space-y-8">
-              {faqs.map((faq) => (
+              {PRICING_FAQS.map((faq) => (
                 <div key={faq.question} className="bg-white rounded-lg p-6 shadow-sm">
                   <dt className="text-lg font-semibold text-gray-900 mb-2">{faq.question}</dt>
                   <dd className="text-base text-gray-600">{faq.answer}</dd>
@@ -537,29 +452,25 @@ export function PricingPage() {
       <section className="bg-gray-950 py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-            Ready to get started?
+            {PRICING_FINAL_CTA.title}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-400">
-            Start free with full source code access. Upgrade when your business needs it.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-400">{PRICING_FINAL_CTA.subtitle}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href={`${ADMIN_URL}/signup`}
+              href={`${ADMIN_URL}${PRICING_FINAL_CTA_LINKS.getStarted.href}`}
               className="rounded-md bg-white px-8 py-4 text-base font-semibold text-gray-950 shadow-sm hover:bg-gray-100 transition-colors"
             >
-              Get Started Free
+              {PRICING_FINAL_CTA_LINKS.getStarted.label}
             </a>
             <a
-              href="/contact"
+              href={PRICING_FINAL_CTA_LINKS.contactSales.href}
               className="rounded-md border border-gray-700 px-8 py-4 text-base font-semibold text-gray-300 hover:text-white hover:border-gray-500 transition-colors"
             >
-              Contact Sales
+              {PRICING_FINAL_CTA_LINKS.contactSales.label}
             </a>
           </div>
           <div className="mt-16 pt-10 border-t border-gray-800">
-            <p className="text-sm font-medium text-gray-400 mb-4">
-              Not ready yet? Stay in the loop.
-            </p>
+            <p className="text-sm font-medium text-gray-400 mb-4">{PRICING_NEWSLETTER_LABEL}</p>
             <NewsletterSignup variant="stacked" />
           </div>
         </div>

--- a/apps/marketing/app/routes/PrivacyPage.tsx
+++ b/apps/marketing/app/routes/PrivacyPage.tsx
@@ -1,153 +1,66 @@
 import { Footer } from '../components/Footer';
+import { PRIVACY_META, PRIVACY_SECTIONS } from '../content/legal/privacy';
 
 export function PrivacyPage() {
-  const lastUpdated = 'April 22, 2026';
   return (
     <div className="min-h-screen bg-white">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
-        <h1>Privacy Policy</h1>
-        <p className="text-sm text-gray-500">Last updated: {lastUpdated}</p>
+        <h1>{PRIVACY_META.title}</h1>
+        <p className="text-sm text-gray-500">Last updated: {PRIVACY_META.lastUpdated}</p>
 
-        <p>
-          The RevealUI platform (revealui.com, admin.revealui.com, api.revealui.com, and
-          docs.revealui.com — the &quot;Service&quot;) is operated by REVEALUI STUDIO L.L.C., a
-          Tennessee limited liability company (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;).
-          This Privacy Policy describes how we collect, use, and protect your personal information.
-        </p>
+        <p>{PRIVACY_META.intro}</p>
 
-        <h2>1. Information We Collect</h2>
-        <h3>Account Information</h3>
-        <p>
-          When you create an account, we collect your email address, name, and password (stored as a
-          bcrypt hash). If you sign up via OAuth (Google, GitHub), we receive your provider profile
-          information.
-        </p>
-        <h3>Payment Information</h3>
-        <p>
-          Payment processing is handled entirely by Stripe. We never store credit card numbers. We
-          store your Stripe customer ID to link your account to your subscription.
-        </p>
-        <h3>Usage Data</h3>
-        <p>
-          We collect server logs (IP address, request path, user agent) for security monitoring and
-          debugging. See §4 below for retention windows.
-        </p>
-        <h3>Content Data</h3>
-        <p>
-          Any content you create through the admin (posts, pages, media) is stored in your database.
-          For hosted plans, this data is stored in NeonDB (PostgreSQL).
-        </p>
+        {PRIVACY_SECTIONS.map((section) => (
+          <div key={section.heading}>
+            <h2>{section.heading}</h2>
 
-        <h2>2. How We Use Your Information</h2>
-        <ul>
-          <li>To provide and maintain the Service</li>
-          <li>To process payments and manage subscriptions</li>
-          <li>
-            To send transactional emails (password resets, billing notifications, license delivery)
-          </li>
-          <li>To detect and prevent fraud, abuse, and security incidents</li>
-          <li>
-            To diagnose application errors using error telemetry (Sentry). When an error occurs, a
-            partial session recording of the moments preceding the crash may be captured to aid
-            debugging. No proactive or continuous session recording is performed.
-          </li>
-          <li>To respond to support requests</li>
-        </ul>
-        <p>We do not sell your personal information. We do not use your data for advertising.</p>
+            {section.subsections?.map((sub) => (
+              <div key={sub.heading}>
+                <h3>{sub.heading}</h3>
+                {sub.paragraph && <p>{sub.paragraph}</p>}
+                {sub.listItems && (
+                  <ul>
+                    {sub.listItems.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
 
-        <h2>3. Data Sharing</h2>
-        <p>We share data only with:</p>
-        <ul>
-          <li>
-            <strong>Stripe</strong>: for payment processing (
-            <a href="https://stripe.com/privacy">Stripe Privacy Policy</a>)
-          </li>
-          <li>
-            <strong>NeonDB</strong>: database hosting (
-            <a href="https://neon.tech/privacy">Neon Privacy Policy</a>)
-          </li>
-          <li>
-            <strong>Vercel</strong>: application hosting (
-            <a href="https://vercel.com/legal/privacy-policy">Vercel Privacy Policy</a>)
-          </li>
-          <li>
-            <strong>Google Workspace</strong>: transactional email delivery via Gmail API (
-            <a href="https://policies.google.com/privacy">Google Privacy Policy</a>)
-          </li>
-          <li>
-            <strong>Sentry</strong>: application error tracking and crash-replay diagnostics (
-            <a href="https://sentry.io/privacy/">Sentry Privacy Policy</a>). Error data may include
-            browser context, page URL, and a partial session recording captured at the time of an
-            error. No continuous session recording is performed.
-          </li>
-        </ul>
+            {section.listPreamble && <p>{section.listPreamble}</p>}
 
-        <h2>4. Data Retention</h2>
-        <p>
-          Account data is retained while your account is active. After account deletion, we
-          permanently remove your personal data within 30 days. Application logs and error events
-          are retained for 90 days. Agent activity audit logs are retained indefinitely for security
-          and compliance purposes. Infrastructure server logs (IP address, request path, user agent)
-          are retained by our hosting provider per their policy. Billing records are retained as
-          required by tax law (typically 7 years).
-        </p>
+            {section.listItems && (
+              <ul>
+                {section.listItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
 
-        <h2>5. Your Rights (GDPR / CCPA)</h2>
-        <p>You have the right to:</p>
-        <ul>
-          <li>
-            <strong>Access</strong> your personal data, available via your account settings or by
-            contacting us
-          </li>
-          <li>
-            <strong>Export</strong> your data: use the GDPR export endpoint in the admin
-          </li>
-          <li>
-            <strong>Delete</strong> your account and all associated data: use the account deletion
-            feature or contact us
-          </li>
-          <li>
-            <strong>Correct</strong> inaccurate data: update your profile in the admin dashboard
-          </li>
-          <li>
-            <strong>Object</strong> to processing: contact us at the email below
-          </li>
-        </ul>
-        <p>
-          California residents: Under the CCPA, you have the right to know what personal information
-          we collect and to request its deletion. We do not sell personal information.
-        </p>
+            {section.thirdParties && (
+              <ul>
+                {section.thirdParties.map((tp) => (
+                  <li key={tp.name}>
+                    <strong>{tp.name}</strong>: {tp.description} (
+                    <a href={tp.policyUrl}>{tp.policyLabel}</a>){tp.extra ? ` ${tp.extra}` : ''}
+                  </li>
+                ))}
+              </ul>
+            )}
 
-        <h2>6. Security</h2>
-        <p>
-          We protect your data using: bcrypt password hashing, session-based authentication with
-          secure cookies, rate limiting and brute-force protection, HTTPS/TLS encryption in transit,
-          and encrypted database connections.
-        </p>
-
-        <h2>7. Cookies</h2>
-        <p>
-          We use essential cookies only: a session cookie for authentication. We do not use tracking
-          cookies, analytics cookies, or advertising cookies.
-        </p>
-
-        <h2>8. Children</h2>
-        <p>
-          The Service is not intended for children under 13. We do not knowingly collect personal
-          information from children under 13.
-        </p>
-
-        <h2>9. Changes</h2>
-        <p>
-          We may update this Privacy Policy from time to time. We will notify registered users of
-          material changes via email.
-        </p>
-
-        <h2>10. Contact</h2>
-        <p>
-          For privacy-related questions or to exercise your data rights, contact us at{' '}
-          <a href="mailto:support@revealui.com">support@revealui.com</a>.
-        </p>
+            {section.paragraphs?.map((para) =>
+              section.contactEmail ? (
+                <p key={para}>
+                  For privacy-related questions or to exercise your data rights, contact us at{' '}
+                  <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
+                </p>
+              ) : (
+                <p key={para}>{para}</p>
+              ),
+            )}
+          </div>
+        ))}
       </article>
       <Footer />
     </div>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,176 +1,10 @@
+import {
+  PRODUCTS_CTA_SECTION,
+  PRODUCTS_PAGE_HERO,
+  PRODUCTS_STATS_SECTION,
+} from '../content/products';
+import { PRODUCTS_PRIMITIVES } from '../content/primitives';
 import { Footer } from '../components/Footer';
-
-interface Primitive {
-  name: string;
-  icon: string;
-  color: string;
-  bgColor: string;
-  ringColor: string;
-  forYou: {
-    headline: string;
-    description: string;
-  };
-  forAgents: {
-    headline: string;
-    description: string;
-  };
-  together: {
-    headline: string;
-    description: string;
-  };
-  features: string[];
-}
-
-const primitives: Primitive[] = [
-  {
-    name: 'Users',
-    icon: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
-    color: 'text-blue-600',
-    bgColor: 'bg-blue-500/10',
-    ringColor: 'ring-blue-500/20',
-    forYou: {
-      headline: 'Auth, roles, and compliance, handled',
-      description:
-        'Session-based auth, RBAC with 58 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
-    },
-    forAgents: {
-      headline: 'RBAC governs agent access per tenant',
-      description:
-        'Every agent action is scoped by the same role and permission system that governs human users. Audit logs track every agent operation with full attribution.',
-    },
-    together: {
-      headline: 'Set permissions once. Agents respect them automatically.',
-      description:
-        'Define your access control rules for humans. Agents inherit the same boundaries. Every action, human or machine, is attributable and auditable.',
-    },
-    features: [
-      'Session-based auth (httpOnly, secure, sameSite)',
-      'RBAC + ABAC policy engine',
-      'Rate limiting and brute-force protection',
-      'GDPR compliance framework',
-      'Audit logging with agent attribution',
-      'Multi-tenant user isolation',
-    ],
-  },
-  {
-    name: 'Content',
-    icon: 'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
-    color: 'text-emerald-600',
-    bgColor: 'bg-emerald-500/10',
-    ringColor: 'ring-emerald-500/20',
-    forYou: {
-      headline: 'Define collections in TypeScript, get an API and admin UI',
-      description:
-        'Rich text editing with Lexical, media management, draft/live publishing, and a full REST API with OpenAPI spec. Define your data model once and the admin dashboard and API generate automatically.',
-    },
-    forAgents: {
-      headline: 'Collections become discoverable tools via MCP',
-      description:
-        'Every collection you define is automatically exposed as an MCP tool. Agents create, query, and update content through the same API humans use. No separate integration layer.',
-    },
-    together: {
-      headline: 'Define your data model. Agents immediately operate on it.',
-      description:
-        'Add a collection. The admin UI, REST API, and MCP tool all appear simultaneously. No integration step between what humans see and what agents can do.',
-    },
-    features: [
-      'Schema-first collection definitions',
-      'Rich text editor with custom blocks',
-      'REST API with OpenAPI spec',
-      'Draft/live publishing workflow',
-      'Media management and CDN delivery',
-      'Real-time sync across sessions',
-    ],
-  },
-  {
-    name: 'Products',
-    icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
-    color: 'text-purple-600',
-    bgColor: 'bg-purple-500/10',
-    ringColor: 'ring-purple-500/20',
-    forYou: {
-      headline: 'Product catalog, pricing tiers, and usage tracking',
-      description:
-        'Define products, pricing tiers, and feature gates in one place. License enforcement and upgrade prompts are built in. Subscription billing via Stripe with perpetual license support.',
-    },
-    forAgents: {
-      headline: 'Feature gates control which agent capabilities unlock per tier',
-      description:
-        'Agent capabilities are gated by the same tier system that governs human features. When a customer upgrades, their agents automatically gain access to more tools and higher task limits.',
-    },
-    together: {
-      headline: 'Revenue model governs both humans and agents.',
-      description:
-        'Upgrade a customer and their agents get smarter. One product catalog, one billing system, one set of feature gates, applied consistently to every user and every agent.',
-    },
-    features: [
-      'Two pricing tracks (subscription, services). Perpetual licenses coming soon.',
-      'Feature gating with tier enforcement',
-      'Usage tracking and limit enforcement',
-      'License key management',
-      'Upgrade prompts and billing portal',
-      'Agent task billing in development — unlimited during early access',
-    ],
-  },
-  {
-    name: 'Payments',
-    icon: 'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
-    color: 'text-amber-600',
-    bgColor: 'bg-amber-500/10',
-    ringColor: 'ring-amber-500/20',
-    forYou: {
-      headline: 'Stripe checkout, subscriptions, and billing, pre-configured',
-      description:
-        'Stripe checkout, subscription management, webhooks, and a customer billing portal. Products, prices, and webhooks are wired up. You configure your Stripe keys and start charging.',
-    },
-    forAgents: {
-      headline: 'x402 protocol design — coming with RevealCoin mainnet',
-      description:
-        'The x402 design routes agent payments via HTTP 402 using RevealCoin on Solana. This is in development and gated on RevealCoin mainnet launch. See the roadmap for current status.',
-    },
-    together: {
-      headline: 'Humans monetize. Agents transact. One billing infrastructure.',
-      description:
-        'Human customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
-    },
-    features: [
-      'Stripe checkout and subscriptions',
-      'Webhook handling and event processing',
-      'Customer billing portal',
-      'x402 agent payments (in development)',
-      'RevealCoin on Solana (pre-launch)',
-    ],
-  },
-  {
-    name: 'Intelligence',
-    icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z',
-    color: 'text-violet-600',
-    bgColor: 'bg-violet-500/10',
-    ringColor: 'ring-violet-500/20',
-    forYou: {
-      headline: 'AI agents that work on your business, no proprietary API keys',
-      description:
-        'AI agents manage content, process tasks, and coordinate workflows. Runs on open models only (Apache 2.0) via Ubuntu Inference Snaps or Ollama. No vendor lock-in, no API bills.',
-    },
-    forAgents: {
-      headline: 'A2A protocol, CRDT memory, and MCP servers',
-      description:
-        'Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and 12 production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.',
-    },
-    together: {
-      headline: 'Build one business. Agents extend it. Neither locked to any vendor.',
-      description:
-        'You build on open standards. Your agents operate through the same open standards. Switch models, swap providers, self-host everything. The intelligence layer belongs to you.',
-    },
-    features: [
-      'Open-model inference (Snaps, Ollama)',
-      'CRDT-based agent memory (working + episodic + vector)',
-      '12 production MCP servers',
-      'A2A agent-to-agent protocol',
-      'Multi-agent coordination and orchestration',
-    ],
-  },
-];
 
 export function ProductsPage() {
   return (
@@ -179,14 +13,13 @@ export function ProductsPage() {
       <section className="relative overflow-hidden bg-gradient-to-br from-indigo-50 via-white to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
-            Five primitives. One runtime.
+            {PRODUCTS_PAGE_HERO.h1}
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            Users, content, products, payments, and intelligence — pre-wired and exposed to your
-            agents via MCP.
+            {PRODUCTS_PAGE_HERO.subtitle}
           </p>
           <div className="mt-10 flex flex-wrap justify-center gap-3 text-sm font-medium">
-            {primitives.map((p) => (
+            {PRODUCTS_PRIMITIVES.map((p) => (
               <a
                 key={p.name}
                 href={`#${p.name.toLowerCase()}`}
@@ -200,7 +33,7 @@ export function ProductsPage() {
       </section>
 
       {/* Primitives */}
-      {primitives.map((primitive, i) => (
+      {PRODUCTS_PRIMITIVES.map((primitive, i) => (
         <section
           key={primitive.name}
           id={primitive.name.toLowerCase()}
@@ -308,19 +141,12 @@ export function ProductsPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-              Built to production standards
+              {PRODUCTS_STATS_SECTION.heading}
             </h2>
-            <p className="mt-4 text-lg text-gray-400">
-              Not a starter template. A complete runtime with tested, documented, and audited code.
-            </p>
+            <p className="mt-4 text-lg text-gray-400">{PRODUCTS_STATS_SECTION.body}</p>
           </div>
           <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
-            {[
-              { stat: '26', label: 'workspace packages' },
-              { stat: '86', label: 'Database tables' },
-              { stat: '187+', label: 'Security tests' },
-              { stat: '12', label: 'first-party MCP servers' },
-            ].map((item) => (
+            {PRODUCTS_STATS_SECTION.items.map((item) => (
               <div key={item.label} className="text-center">
                 <p className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
                   {item.stat}
@@ -336,27 +162,24 @@ export function ProductsPage() {
       <section className="py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
           <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-            Start building with all five primitives
+            {PRODUCTS_CTA_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            One command. Full source code. Users, content, products, payments, and intelligence -
-            pre-wired and ready for your first deploy.
-          </p>
+          <p className="mt-6 text-lg leading-8 text-gray-600">{PRODUCTS_CTA_SECTION.body}</p>
           <div className="mt-8 rounded-lg bg-gray-950 px-6 py-4 text-left font-mono text-sm text-gray-300">
-            <span className="text-gray-500">$</span> npx create-revealui my-app
+            <span className="text-gray-500">$</span> {PRODUCTS_CTA_SECTION.cliSnippet}
           </div>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href="https://docs.revealui.com"
+              href={PRODUCTS_CTA_SECTION.cta.docs.href}
               className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
             >
-              Read the Docs
+              {PRODUCTS_CTA_SECTION.cta.docs.label}
             </a>
             <a
-              href="/pricing"
+              href={PRODUCTS_CTA_SECTION.cta.pricing.href}
               className="rounded-md bg-gray-100 px-8 py-4 text-base font-semibold text-gray-900 hover:bg-gray-200 transition-colors"
             >
-              View Pricing
+              {PRODUCTS_CTA_SECTION.cta.pricing.label}
             </a>
           </div>
         </div>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,10 +1,10 @@
+import { Footer } from '../components/Footer';
+import { PRODUCTS_PRIMITIVES } from '../content/primitives';
 import {
   PRODUCTS_CTA_SECTION,
   PRODUCTS_PAGE_HERO,
   PRODUCTS_STATS_SECTION,
 } from '../content/products';
-import { PRODUCTS_PRIMITIVES } from '../content/primitives';
-import { Footer } from '../components/Footer';
 
 export function ProductsPage() {
   return (

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -1,54 +1,68 @@
 import { Footer } from '../components/Footer';
+import {
+  SPONSOR_FOOTER_NOTE,
+  SPONSOR_HERO,
+  SPONSOR_SUPPORT_AREAS,
+  SPONSOR_SUPPORT_HEADING,
+  SPONSOR_TIERS,
+  SPONSOR_TIERS_SECTION,
+  type SupportArea,
+} from '../content/sponsor';
 
-const tiers = [
-  {
-    name: 'Supporter',
-    price: '$5',
-    period: '/month',
-    emoji: '☕',
-    description: 'Buy the maintainers a coffee.',
-    benefits: ['Sponsor badge on GitHub profile', 'Shoutout in release notes'],
-  },
-  {
-    name: 'Backer',
-    price: '$25',
-    period: '/month',
-    emoji: '⭐',
-    description: 'Support ongoing development.',
-    benefits: [
-      'All Supporter benefits',
-      'Name listed on sponsors page',
-      'Early access to roadmap updates',
-      'Priority issue responses',
-    ],
-  },
-  {
-    name: 'Gold Sponsor',
-    price: '$100',
-    period: '/month',
-    emoji: '\u{1F3C6}',
-    description: 'Fund a major feature every quarter.',
-    benefits: [
-      'All Backer benefits',
-      'Logo on README and docs site',
-      'Monthly office hours call',
-      'Vote on roadmap priorities',
-    ],
-  },
-  {
-    name: 'Platinum Sponsor',
-    price: '$500',
-    period: '/month',
-    emoji: '\u{1F48E}',
-    description: 'Shape the future of RevealUI.',
-    benefits: [
-      'All Gold Sponsor benefits',
-      'Logo with link on landing page',
-      'Dedicated Discourse channel',
-      'Direct line to the founder for prioritized feature requests — implementation scoped separately via RevealUI Studio engagements',
-    ],
-  },
-];
+function SupportIcon({ iconKey }: { iconKey: SupportArea['iconKey'] }) {
+  if (iconKey === 'development') {
+    return (
+      <svg
+        className="h-8 w-8 text-blue-600"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+      >
+        <title>Development</title>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+        />
+      </svg>
+    );
+  }
+  if (iconKey === 'documentation') {
+    return (
+      <svg
+        className="h-8 w-8 text-blue-600"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+      >
+        <title>Documentation</title>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className="h-8 w-8 text-blue-600"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <title>Community</title>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+      />
+    </svg>
+  );
+}
 
 export function SponsorPage() {
   return (
@@ -57,23 +71,22 @@ export function SponsorPage() {
       <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
-            Sponsor
+            {SPONSOR_HERO.brand}
             <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-              RevealUI
+              {SPONSOR_HERO.brandHighlight}
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            RevealUI is open source and free to use. Your sponsorship helps fund development,
-            documentation, and community support.
+            {SPONSOR_HERO.subhead}
           </p>
           <div className="mt-10 flex items-center justify-center gap-x-6">
             <a
-              href="https://github.com/sponsors/RevealUIStudio"
+              href={SPONSOR_HERO.cta.href}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
             >
-              Sponsor on GitHub
+              {SPONSOR_HERO.cta.label}
             </a>
           </div>
         </div>
@@ -84,14 +97,12 @@ export function SponsorPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center mb-16">
             <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-              Sponsorship Tiers
+              {SPONSOR_TIERS_SECTION.heading.title}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
-              Every contribution matters. Choose the tier that works for you.
-            </p>
+            <p className="mt-4 text-lg text-gray-600">{SPONSOR_TIERS_SECTION.heading.subtitle}</p>
           </div>
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-            {tiers.map((tier) => (
+            {SPONSOR_TIERS.map((tier) => (
               <div
                 key={tier.name}
                 className="relative rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200 hover:ring-blue-300 transition-all"
@@ -129,12 +140,12 @@ export function SponsorPage() {
           </div>
           <div className="mt-16 text-center">
             <a
-              href="https://github.com/sponsors/RevealUIStudio"
+              href={SPONSOR_TIERS_SECTION.ctaBottom.href}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
             >
-              Become a Sponsor
+              {SPONSOR_TIERS_SECTION.ctaBottom.label}
             </a>
           </div>
         </div>
@@ -145,96 +156,39 @@ export function SponsorPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-3xl">
             <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl text-center mb-12">
-              Where Your Support Goes
+              {SPONSOR_SUPPORT_HEADING}
             </h2>
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-3">
-              <div className="text-center">
-                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
-                  <svg
-                    className="h-8 w-8 text-blue-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                  >
-                    <title>Development</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-                    />
-                  </svg>
+              {SPONSOR_SUPPORT_AREAS.map((area) => (
+                <div key={area.title} className="text-center">
+                  <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
+                    <SupportIcon iconKey={area.iconKey} />
+                  </div>
+                  <h3 className="mt-4 text-lg font-semibold text-gray-900">{area.title}</h3>
+                  <p className="mt-2 text-sm text-gray-600">{area.description}</p>
                 </div>
-                <h3 className="mt-4 text-lg font-semibold text-gray-900">Development</h3>
-                <p className="mt-2 text-sm text-gray-600">
-                  New features, bug fixes, and performance improvements.
-                </p>
-              </div>
-              <div className="text-center">
-                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
-                  <svg
-                    className="h-8 w-8 text-blue-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                  >
-                    <title>Documentation</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
-                    />
-                  </svg>
-                </div>
-                <h3 className="mt-4 text-lg font-semibold text-gray-900">Documentation</h3>
-                <p className="mt-2 text-sm text-gray-600">
-                  Guides, tutorials, API references, and examples.
-                </p>
-              </div>
-              <div className="text-center">
-                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
-                  <svg
-                    className="h-8 w-8 text-blue-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                  >
-                    <title>Community</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
-                    />
-                  </svg>
-                </div>
-                <h3 className="mt-4 text-lg font-semibold text-gray-900">Community</h3>
-                <p className="mt-2 text-sm text-gray-600">
-                  Discourse forums, issue triage, code reviews, and mentorship.
-                </p>
-              </div>
+              ))}
             </div>
           </div>
         </div>
       </section>
 
       <div className="py-8 text-center text-sm text-gray-500">
-        Looking for the product? See{' '}
+        {SPONSOR_FOOTER_NOTE.prefix}
         <a
-          href="/products"
+          href={SPONSOR_FOOTER_NOTE.productsLink.href}
           className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
         >
-          Products
-        </a>{' '}
-        or{' '}
-        <a
-          href="https://docs.revealui.com"
-          className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
-        >
-          read the docs
+          {SPONSOR_FOOTER_NOTE.productsLink.label}
         </a>
-        .
+        {SPONSOR_FOOTER_NOTE.separator}
+        <a
+          href={SPONSOR_FOOTER_NOTE.docsLink.href}
+          className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
+        >
+          {SPONSOR_FOOTER_NOTE.docsLink.label}
+        </a>
+        {SPONSOR_FOOTER_NOTE.suffix}
       </div>
 
       <Footer />

--- a/apps/marketing/app/routes/TermsPage.tsx
+++ b/apps/marketing/app/routes/TermsPage.tsx
@@ -1,138 +1,55 @@
 import { Footer } from '../components/Footer';
+import { TERMS_META, TERMS_SECTIONS } from '../content/legal/terms';
 
 export function TermsPage() {
-  const lastUpdated = 'March 4, 2026';
   return (
     <div className="min-h-screen bg-white">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
-        <h1>Terms of Service</h1>
-        <p className="text-sm text-gray-500">Last updated: {lastUpdated}</p>
+        <h1>{TERMS_META.title}</h1>
+        <p className="text-sm text-gray-500">Last updated: {TERMS_META.lastUpdated}</p>
 
-        <p>
-          These Terms of Service (&quot;Terms&quot;) govern your use of the RevealUI platform
-          provided by REVEALUI STUDIO L.L.C., a Tennessee limited liability company (&quot;we&quot;,
-          &quot;us&quot;, &quot;our&quot;). By creating an account or using the Service, you agree
-          to these Terms.
-        </p>
+        <p>{TERMS_META.intro}</p>
 
-        <h2>1. Service Description</h2>
-        <p>
-          RevealUI is an open-source agentic business runtime for software companies. It includes a
-          content engine, authentication, billing integration, AI agents, and UI components. The
-          Service is available in four tiers: Free (OSS), Pro, Max, and Enterprise.
-        </p>
+        {TERMS_SECTIONS.map((section) => (
+          <div key={section.heading}>
+            <h2>{section.heading}</h2>
 
-        <h2>2. Accounts</h2>
-        <ul>
-          <li>You must provide accurate information when creating an account.</li>
-          <li>You are responsible for maintaining the security of your account credentials.</li>
-          <li>You must be at least 13 years old to use the Service.</li>
-          <li>One person or organization may not maintain more than one free account.</li>
-        </ul>
+            {section.subsections?.map((sub) => (
+              <div key={sub.heading}>
+                <h3>{sub.heading}</h3>
+                {sub.paragraph && <p>{sub.paragraph}</p>}
+                {sub.listItems && (
+                  <ul>
+                    {sub.listItems.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
 
-        <h2>3. Free Tier (OSS)</h2>
-        <p>
-          The Free tier is licensed under the MIT License. You may use, modify, and distribute the
-          open-source code freely, subject to the MIT License terms. The Free tier includes limited
-          features (1 site, 3 users, community support).
-        </p>
+            {section.listPreamble && <p>{section.listPreamble}</p>}
 
-        <h2>4. Paid Tiers (Pro, Max &amp; Enterprise)</h2>
-        <h3>Billing</h3>
-        <ul>
-          <li>Pro: $49/month, billed monthly. Includes a 7-day free trial.</li>
-          <li>Max: $149/month, billed monthly. Includes a 7-day free trial.</li>
-          <li>Enterprise: $299/month, billed monthly. Contact sales for annual pricing.</li>
-          <li>All prices are in USD and exclude applicable taxes.</li>
-          <li>Payment is processed by Stripe. You agree to Stripe&apos;s terms of service.</li>
-        </ul>
-        <h3>Trial</h3>
-        <p>
-          The Pro tier includes a 7-day free trial. You will not be charged during the trial period.
-          If you do not cancel before the trial ends, your subscription will automatically begin and
-          you will be charged the applicable monthly rate.
-        </p>
-        <h3>Cancellation</h3>
-        <p>
-          You may cancel your subscription at any time through the Stripe billing portal or by
-          contacting us. Cancellation takes effect at the end of your current billing period. You
-          retain access to paid features until then.
-        </p>
-        <h3>Refunds</h3>
-        <p>
-          We offer a full refund if requested within 14 days of your first paid charge (not
-          including the trial period). After 14 days, no refunds are issued for partial billing
-          periods. Contact support@revealui.com for refund requests.
-        </p>
+            {section.listItems && (
+              <ul>
+                {section.listItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
 
-        <h2>5. Commercial License</h2>
-        <p>
-          Pro packages (@revealui/ai and @revealui/harnesses) are commercially licensed. The license
-          is granted per-subscription and is non-transferable. See LICENSE.commercial in the
-          repository for full terms.
-        </p>
-
-        <h2>6. Acceptable Use</h2>
-        <p>You agree not to:</p>
-        <ul>
-          <li>Use the Service for any unlawful purpose</li>
-          <li>Attempt to gain unauthorized access to the Service or its infrastructure</li>
-          <li>Distribute malware, spam, or harmful content through the Service</li>
-          <li>Exceed reasonable usage limits or abuse API rate limits</li>
-          <li>Resell Pro/Max/Enterprise features without a valid license</li>
-          <li>Reverse-engineer, decompile, or circumvent license key validation</li>
-        </ul>
-        <p>We reserve the right to suspend or terminate accounts that violate these terms.</p>
-
-        <h2>7. Data and Content</h2>
-        <ul>
-          <li>You retain ownership of all content you create using the Service.</li>
-          <li>We do not claim any intellectual property rights over your content.</li>
-          <li>
-            You are responsible for maintaining backups of your data. While we use reliable hosting
-            providers, we do not guarantee against data loss.
-          </li>
-          <li>
-            For self-hosted deployments, you are responsible for your own data security and
-            compliance.
-          </li>
-        </ul>
-
-        <h2>8. Service Availability</h2>
-        <p>
-          We strive for high availability but do not guarantee uninterrupted service. The Service is
-          provided &quot;as is&quot; without warranty of any kind, express or implied. We are not
-          liable for any downtime, data loss, or damages resulting from use of the Service.
-        </p>
-
-        <h2>9. Limitation of Liability</h2>
-        <p>
-          To the maximum extent permitted by law, REVEALUI STUDIO L.L.C. shall not be liable for any
-          indirect, incidental, special, consequential, or punitive damages, including but not
-          limited to loss of profits, data, or business opportunities. Our total liability under
-          these Terms shall not exceed the amount paid by you to us in the 12 months preceding the
-          claim.
-        </p>
-
-        <h2>10. Changes to Terms</h2>
-        <p>
-          We may update these Terms from time to time. We will notify registered users of material
-          changes via email at least 30 days before they take effect. Continued use of the Service
-          after changes take effect constitutes acceptance of the new Terms.
-        </p>
-
-        <h2>11. Governing Law</h2>
-        <p>
-          These Terms are governed by the laws of the State of Tennessee, United States, without
-          regard to its conflict-of-laws provisions. Any disputes shall be resolved in the state or
-          federal courts located in Tennessee.
-        </p>
-
-        <h2>12. Contact</h2>
-        <p>
-          For questions about these Terms, contact us at{' '}
-          <a href="mailto:support@revealui.com">support@revealui.com</a>.
-        </p>
+            {section.paragraphs?.map((para) =>
+              section.contactEmail ? (
+                <p key={para}>
+                  For questions about these Terms, contact us at{' '}
+                  <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
+                </p>
+              ) : (
+                <p key={para}>{para}</p>
+              ),
+            )}
+          </div>
+        ))}
       </article>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary

**Phase 1 of the marketing-overhaul lane** — centralize all inline JSX copy across the marketing app into typed `apps/marketing/app/content/*.ts` files. Components become pure renderers.

**ZERO copy changes.** Every string is verbatim. Drift items (12 vs 13 MCP servers, "live payments today", RVC framing, etc.) stay shipped as-is and get fixed in follow-up Phase 3 + 5 PRs against the same lane.

This is the prerequisite for the rest of the overhaul: doc-revalidation, separation-of-concerns rework, and copy overhaul all become single-file edits once content is centralized.

### Scope

19 content files (~2,063 LOC) added at `apps/marketing/app/content/`:

| Topic | File | LOC |
|---|---|---|
| Shared types | `types.ts` | 26 |
| Site-wide URLs/emails | `site.ts` | 46 |
| Navigation | `nav.ts` | 62 |
| Homepage sections | `home.ts` | 234 |
| 5 primitives (shared Home + Products) | `primitives.ts` | 236 |
| "What's shipped" capabilities | `capabilities.ts` | 79 |
| Persona section | `persona.ts` | 28 |
| Proof: stack + CI + trust | `proof.ts` | 102 |
| Home pricing teaser | `pricing-teaser.ts` | 79 |
| Pricing page UI adornments | `pricing.ts` | 148 |
| Pricing FAQ | `pricing-faq.ts` | 58 |
| Products page (stats, hero, CTA) | `products.ts` | 39 |
| Marketplace MCP catalog | `marketplace.ts` | 150 |
| Roadmap (coming-soon) | `roadmap.ts` | 115 |
| Fair Source license | `fair-source.ts` | 211 |
| Sponsor tiers | `sponsor.ts` | 123 |
| Contact methods | `contact.ts` | 42 |
| Privacy policy | `legal/privacy.ts` | 164 |
| Terms of service | `legal/terms.ts` | 121 |

Components refactored: 11 routes + 9 landing components + 3 shared (Footer/NavBar/GetStarted) = 23 files. Net LOC reduction across components/routes: ~1,600 lines moved into content.

### What's intentionally untouched

Per Phase 1 rule "content moves; runtime stays":
- Pricing data-fetch logic (`useEffect` + `useState` + `ADMIN_URL`/`API_URL` env vars) stays in `PricingPage.tsx`.
- `TEASER_FALLBACK_PRICE` stays in `PricingTeaser.tsx` (runtime fallback for failed API fetch).
- Decorative SVG path data + CSS class lookup maps stay in their components.
- `ContactForm.tsx`, `NewsletterSignup.tsx`, `ProductMockup.tsx` — no marketing copy; left alone.

### Provenance

Every content file has a header comment citing its source extraction:

```
// Sourced from: app/routes/<Page>.tsx (Phase 1, no copy changes).
// Per internal lane plan §4.4.
```

### Owner answers locked in lane plan §6

| Q | Answer |
|---|---|
| Q1 Positioning | shifts.md framing ("agents as first-class users") |
| Q2 RVC | Option A — one roadmap-line ("pre-launch (legal + multisig gates)"); stripped elsewhere |
| Q3 Status vocab | 3-state: `Shipped` / `In flight` / `Planned` |
| Q4 Blog rendering | Deferred to follow-up lane |

### Drift items inventoried (NOT fixed here — Phase 3 + 5)

- MCP server count: Hero + Pricing say "13", Marketplace + Products say "12". Verified count is **12** — Hero/Pricing collapse in Phase 3.
- "21 published + 5 private = 26" math in Hero conflicts with content-file count (engines is private, counted twice). Re-pin in Phase 2 via `pnpm tsx scripts/validate/claim-drift.ts`.
- RVC sections on Marketplace + agent-payment quotes — Phase 4 strips, Phase 5 reframes per Q2 lock-in.
- "Live payments today" implications — Phase 5 rewrites per `voice-and-headline-rules.md`.
- `HOME_FAQ` "Next.js + Hono" deploy framing — stale; Phase 5 truth pass.
- `PRICING_TEASER` "24 of 26 MIT" vs Hero "21 published" math conflict.
- Cross-page primitive descriptions drift slightly between Home `Primitives.tsx` and `ProductsPage.tsx` (extracted as `HomePrimitives` + `ProductsPrimitives` for Phase 4 reconciliation).
- Footer "Studio (agency) →" — should be "RevealUI Studio (agency)" per `brand-naming.md`. Phase 5.
- `pricing-faq.ts` Q7 says "2 Pro packages" vs fair-source page's 5 FSL packages. Phase 3.

Full drift inventory in internal lane plan §3.

## Verification

- `pnpm --filter marketing typecheck` — pass
- `pnpm --filter marketing test` — 2/2 pass
- `pnpm --filter marketing build` — pass (chunk-size warning unchanged, pre-existing)
- `biome check apps/marketing/{content,routes,components}` — 0 errors
- `vite preview` production-build visual verification: 5 spot-checked pages (`/`, `/pricing`, `/products`, `/marketplace`, `/fair-source`) — all render correctly with extracted content; H1/H2/H3 counts match expectations; "Three yeses and one no" appears on /fair-source; 12 MCP servers render on /marketplace.

Pre-existing dev-server (`vite dev`) limitation noted: `@revealui/security/dist/index.js:227` imports `crypto.createHmac` at top level which fails in the browser ("Module 'crypto' has been externalized"). Present on `origin/test` too; out of scope for this lane. Production build (`vite build` + `vite preview`) tree-shakes the path so the deployed site is unaffected.

## Test plan

- [ ] CI green on push (Phase 1 + Phase 3 build/typecheck/test gates; CodeQL; gitleaks; etc.)
- [ ] Reviewer spot-checks 2-3 content files for verbatim extraction (no copy changes)
- [ ] Reviewer spot-checks 2-3 routes for clean refactor (imports + JSX consuming content; no dead inline data)
- [ ] Vercel preview deploy renders all 13 routes correctly (auto-deploys when CI passes)
- [ ] Merge to `test`, watch for any auto-deploy regression
- [ ] After merge: open Phase 2 PR (`feat/marketing-doc-revalidation`) — gated on PR #949 (docs-audit peer) merging first

_(PR body redacted 2026-05-18T12:11Z by coordinator session — replaced private repo-path references with "internal lane plan" per leak-scan failure on run 26032401793; body-only edit + label removal per standing playbook, no commit pushed.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
