### PR TITLE
feat(server): extract Fly worker entry — apps/server/src/worker.ts

### DIFF
--- a/apps/server/src/__tests__/index.startup.test.ts
+++ b/apps/server/src/__tests__/index.startup.test.ts
@@ -97,10 +97,9 @@ describe('apps/server/src/index.ts — post-Phase-2 invariants', () => {
     const devBlockBody = extractBranchBody(indexSource, DEV_GUARD, STARTUP_BRANCH_MARKER);
     const serveCount = indexSource.split('serve({ fetch: app.fetch, port }').length - 1;
     const devBlockServeCount = devBlockBody.split('serve({ fetch: app.fetch, port }').length - 1;
-    expect(
-      serveCount,
-      'All serve() calls in index.ts must live inside the dev guard',
-    ).toBe(devBlockServeCount);
+    expect(serveCount, 'All serve() calls in index.ts must live inside the dev guard').toBe(
+      devBlockServeCount,
+    );
   });
 
   it('still contains the dev guard with validateLicenseAtStartup (pnpm dev:api boot path)', () => {
@@ -122,10 +121,9 @@ describe('apps/server/src/index.ts — post-Phase-2 invariants', () => {
       indexSource,
       'index.ts must export terminalWs so worker.ts can call injectWebSocket',
     ).toContain('export const terminalWs = createTerminalRoute()');
-    expect(
-      indexSource,
-      'index.ts must export initAlerting so worker.ts can call it',
-    ).toContain('export function initAlerting');
+    expect(indexSource, 'index.ts must export initAlerting so worker.ts can call it').toContain(
+      'export function initAlerting',
+    );
   });
 });
 

--- a/apps/server/src/__tests__/index.startup.test.ts
+++ b/apps/server/src/__tests__/index.startup.test.ts
@@ -1,25 +1,26 @@
 /**
- * Regression test for the API startup hang.
+ * Regression tests for the API startup hang AND the 2026-05-18 Phase 2
+ * worker extraction.
  *
- * Background: between 2026-04 and 2026-05-10, `apps/server/src/index.ts`
- * carried two near-identical NODE_ENV branches — one for dev (and Fleet
- * docker compose runs) at the top of the module, and one for production
- * (Vercel) lower down. The production branch ran every initializer
- * (validateLicenseAtStartup, initAlerting, hydrateInferenceConfigs)
- * but lacked the `serve()` call that actually
- * binds the HTTP listener. Result: NODE_ENV=production containers came up,
- * passed liveness, but never answered traffic — a silent hang.
+ * Pre-2026-05-18 background: apps/server/src/index.ts carried two
+ * near-identical NODE_ENV branches — one for dev (Fleet docker compose
+ * runs) and one for production (Vercel). The production branch ran
+ * every initializer (validateLicenseAtStartup, initAlerting,
+ * hydrateInferenceConfigs) AND called serve() + injectWebSocket(). On
+ * Vercel cold-start that bound a useless port and leaked setIntervals
+ * on instance shutdown.
  *
- * Diagnosis: HANDOFF-2026-05-10-1245Z-strategy-arc-session-archive.md §"API
- * startup hang root cause identified" (apps/server/src/index.ts:1318-1342
- * was missing serve() relative to the dev branch at lines ~1300-1305).
+ * Post-Phase-2 (this file's invariants): the prod block is GONE from
+ * index.ts. Vercel cold-start now executes index.ts purely as a module
+ * — no top-level NODE_ENV=production side effects. The long-running
+ * boot logic lives in src/worker.ts (Fly entry).
  *
- * This test asserts the production branch contains the literal pieces that
- * make up a binding listener so the regression cannot recur. We do not
- * boot the server (importing `index.ts` runs initializers as a side
- * effect, which is wrong for a unit test) — instead we read the source
- * file and verify shape via string containment. No regex authored, per
- * `feedback_no_regex_ast_only`.
+ * The dev block in index.ts is preserved so `pnpm dev:api` continues
+ * to bind a listener under NODE_ENV=development.
+ *
+ * Tests read source files via fs (don't boot — importing index.ts
+ * triggers the dev guard which short-circuits in NODE_ENV=test). No
+ * regex authored, per `feedback_no_regex_ast_only`.
  */
 
 import { readFileSync } from 'node:fs';
@@ -27,12 +28,13 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const indexSource = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+const workerSource = readFileSync(resolve(__dirname, '..', 'worker.ts'), 'utf-8');
 
 const PROD_GUARD = "if (process.env.NODE_ENV === 'production') {";
 const DEV_GUARD = "if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {";
 
 // The startup branch is the one that runs license validation. Other
-// `process.env.NODE_ENV === 'production'` guards exist in the file
+// `process.env.NODE_ENV === 'production'` guards may exist in the file
 // (e.g. Sentry init); this marker disambiguates them.
 const STARTUP_BRANCH_MARKER = 'validateLicenseAtStartup';
 
@@ -72,60 +74,109 @@ function extractBranchBody(source: string, guard: string, marker?: string): stri
   return '';
 }
 
-describe('apps/server/src/index.ts startup branches', () => {
-  it('production startup branch exists (disambiguated by license-validation marker)', () => {
-    expect(indexSource).toContain(PROD_GUARD);
-    expect(indexSource).toContain(STARTUP_BRANCH_MARKER);
-    const body = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
-    expect(body, 'a production guard whose body validates the license must exist').toContain(
-      STARTUP_BRANCH_MARKER,
-    );
-  });
-
-  it('production startup branch binds the HTTP listener via serve()', () => {
-    const body = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
-    expect(body, 'production startup branch must call serve(...)').toContain(
-      'serve({ fetch: app.fetch, port }',
-    );
-  });
-
-  it('production startup branch injects the terminal WebSocket so /ws routes attach', () => {
+describe('apps/server/src/index.ts — post-Phase-2 invariants', () => {
+  it('does NOT contain a production guard that runs validateLicenseAtStartup (boot side-effect moved to worker.ts)', () => {
+    // Other `process.env.NODE_ENV === 'production'` guards may exist
+    // (e.g. Sentry init), but NONE may also contain validateLicenseAtStartup.
+    // That combination defined the legacy prod boot block which now
+    // lives in worker.ts exclusively. Re-introducing it would cause
+    // Vercel cold-start to bind a useless port + leak setIntervals.
     const body = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
     expect(
       body,
-      'production startup branch must call terminalWs.injectWebSocket(server)',
-    ).toContain('terminalWs.injectWebSocket(server)');
+      'index.ts must NOT contain a production guard with validateLicenseAtStartup — that block moved to worker.ts',
+    ).toBe('');
   });
 
-  it('production startup branch reads port from API_PORT or PORT with 3004 fallback', () => {
-    const body = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
-    expect(body).toContain('process.env.API_PORT || process.env.PORT');
-    expect(body).toContain('3004');
+  it('does NOT call serve() outside the dev guard (would bind a useless port on Vercel cold-start)', () => {
+    // A bare `serve({ fetch: app.fetch, port })` outside any guard fires
+    // unconditionally when api/index.js imports dist/index.js. The dev
+    // block's `serve()` is guarded by NODE_ENV !== 'production' so it
+    // short-circuits on Vercel — that's fine. This test asserts every
+    // serve() call in index.ts lives inside the dev guard.
+    const devBlockBody = extractBranchBody(indexSource, DEV_GUARD, STARTUP_BRANCH_MARKER);
+    const serveCount = indexSource.split('serve({ fetch: app.fetch, port }').length - 1;
+    const devBlockServeCount = devBlockBody.split('serve({ fetch: app.fetch, port }').length - 1;
+    expect(
+      serveCount,
+      'All serve() calls in index.ts must live inside the dev guard',
+    ).toBe(devBlockServeCount);
   });
 
-  it('production startup branch logs the running listener URL', () => {
-    const body = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
-    expect(body).toContain('API server running on http://localhost:');
+  it('still contains the dev guard with validateLicenseAtStartup (pnpm dev:api boot path)', () => {
+    const body = extractBranchBody(indexSource, DEV_GUARD, STARTUP_BRANCH_MARKER);
+    expect(
+      body,
+      'index.ts dev block must still validate license + bind serve() for `pnpm dev:api`',
+    ).toContain(STARTUP_BRANCH_MARKER);
+    expect(body).toContain('serve({ fetch: app.fetch, port }');
+    expect(body).toContain('terminalWs.injectWebSocket(server)');
   });
 
-  it('production and dev startup branches stay shape-equivalent on listener binding', () => {
-    // If someone changes one branch's listener shape, the other must follow.
-    // Asserts: every literal that appears in the dev branch's serve()/log
-    // section also appears in the production startup branch.
+  it('exports the symbols worker.ts imports', () => {
+    expect(
+      indexSource,
+      'index.ts must export default app for api/index.js (Vercel) AND worker.ts',
+    ).toContain('export default app;');
+    expect(
+      indexSource,
+      'index.ts must export terminalWs so worker.ts can call injectWebSocket',
+    ).toContain('export const terminalWs = createTerminalRoute()');
+    expect(
+      indexSource,
+      'index.ts must export initAlerting so worker.ts can call it',
+    ).toContain('export function initAlerting');
+  });
+});
+
+describe('apps/server/src/worker.ts — Fly entry invariants', () => {
+  it('binds the HTTP listener via serve()', () => {
+    expect(workerSource).toContain('serve({ fetch: app.fetch, port }');
+  });
+
+  it('reads port from WORKER_PORT or PORT with 8080 fallback (distinct from API_PORT)', () => {
+    expect(workerSource).toContain('process.env.WORKER_PORT || process.env.PORT');
+    expect(workerSource).toContain('8080');
+  });
+
+  it('runs the former prod-block initializers (validateLicenseAtStartup, initAlerting, hydrateInferenceConfigs)', () => {
+    expect(workerSource).toContain('validateLicenseAtStartup()');
+    expect(workerSource).toContain('initAlerting()');
+    expect(workerSource).toContain('hydrateInferenceConfigs()');
+  });
+
+  it('gates startExecutor on REVMARKET_EXECUTOR_ENABLED (default OFF — wired but dormant until marketplace ready)', () => {
+    expect(workerSource).toContain("process.env.REVMARKET_EXECUTOR_ENABLED === 'true'");
+    expect(workerSource).toContain('startExecutor()');
+  });
+
+  it('gates terminalWs.injectWebSocket on REVEALUI_FORGE (default OFF — daemon socket only exists in Forge)', () => {
+    expect(workerSource).toContain("process.env.REVEALUI_FORGE === 'true'");
+    expect(workerSource).toContain('terminalWs.injectWebSocket(server)');
+  });
+
+  it('logs the running listener URL', () => {
+    expect(workerSource).toContain('Worker running on http://localhost:');
+  });
+});
+
+describe('index.ts dev block <-> worker.ts shape-equivalence on listener binding', () => {
+  it('shared listener signals appear in both surfaces', () => {
+    // If someone changes one surface's listener shape, the other must follow.
+    // This prevents drift between the local-dev boot path and the Fly worker
+    // boot path.
     const dev = extractBranchBody(indexSource, DEV_GUARD, STARTUP_BRANCH_MARKER);
-    const prod = extractBranchBody(indexSource, PROD_GUARD, STARTUP_BRANCH_MARKER);
 
     const sharedSignals = [
       'serve({ fetch: app.fetch, port }',
       'terminalWs.injectWebSocket(server)',
-      'API server running on http://localhost:',
       'API documentation available at http://localhost:',
       'OpenAPI spec available at http://localhost:',
     ] as const;
 
     for (const signal of sharedSignals) {
-      expect(dev, `dev startup branch should contain ${signal}`).toContain(signal);
-      expect(prod, `production startup branch should contain ${signal}`).toContain(signal);
+      expect(dev, `dev block should contain ${signal}`).toContain(signal);
+      expect(workerSource, `worker.ts should contain ${signal}`).toContain(signal);
     }
   });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1181,7 +1181,7 @@ app.route('/api/console-auth', terminalAuthRoute);
 // Auth required: terminal sessions give PTY access to the server
 app.use('/api/terminal/*', writeProtected);
 app.use('/api/terminal/*', routeLimit('terminal-sessions'));
-const terminalWs = createTerminalRoute();
+export const terminalWs = createTerminalRoute();
 app.route('/api/terminal', terminalWs.app);
 
 app.route('', createCollabRoute());
@@ -1242,7 +1242,7 @@ export default app;
 // Runs in both dev and prod. Console channel always active.
 let monitoringInterval: NodeJS.Timeout | undefined;
 
-function initAlerting(): void {
+export function initAlerting(): void {
   alerting.addChannel(consoleChannel);
 
   alerting.registerRule(
@@ -1318,52 +1318,11 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
 // IPs / 'unknown' for everyone.
 configureClientIp({ trustedProxyCount: 1 });
 
-// Also validate in production before accepting traffic
-if (process.env.NODE_ENV === 'production') {
-  // Swap in persistent audit storage (replaces default InMemoryAuditStorage)
-  audit.setStorage(new PostgresAuditStorage());
-  validateStartup();
-  // Forge customer deployments (Docker stack from forge/stamp.sh) reach
-  // here in NODE_ENV=production with a studio-issued JWT in
-  // REVEALUI_LICENSE_KEY but no signing key. validateLicenseAtStartup
-  // throws on invalid/expired/missing license; process.exit(1) makes the
-  // container restart-loop instead of silently degrading to free tier.
-  //
-  // validateBillingCatalogAtStartup runs only in hosted mode with
-  // STRIPE_LIVE_MODE=true. It queries the billing_catalog table and fails
-  // boot if any expected plan is missing or has null stripe_price_id —
-  // preventing the failure mode where a customer checkout 500s
-  // mid-transaction because seed-billing.ts wasn't run after the live-key
-  // flip. Forge mode short-circuits (no Stripe); hosted test mode
-  // short-circuits (catalog can be partial pre-flip).
-  validateLicenseAtStartup()
-    .then(() => validateBillingCatalogAtStartup())
-    .then(() => initializeLicense())
-    .then((tier) => {
-      logger.info(`License tier: ${tier}`);
-    })
-    .catch((err: unknown) => {
-      logger.error(
-        'Startup validation failed; exiting',
-        err instanceof Error ? err : new Error(String(err)),
-      );
-      process.exit(1);
-    });
-  initAlerting();
-  hydrateInferenceConfigs();
-  // Bind the HTTP listener. Mirrors the dev branch shape above so a Fleet
-  // Docker container (NODE_ENV=production) actually starts answering
-  // requests instead of initializing-everything-but-never-listening.
-  // The previous shape ran every initializer (validateLicenseAtStartup,
-  // initAlerting, hydrateInferenceConfigs) but never
-  // called serve(), so containers came up, passed liveness, and silently
-  // hung pre-listen. Diagnosed in
-  // .jv/docs/HANDOFF-2026-05-10-1245Z-strategy-arc-session-archive.md
-  // §"API startup hang root cause identified".
-  const port = Number(process.env.API_PORT || process.env.PORT) || 3004;
-  const server = serve({ fetch: app.fetch, port });
-  terminalWs.injectWebSocket(server);
-  logger.info(`🚀 API server running on http://localhost:${port}`);
-  logger.info(`📚 API documentation available at http://localhost:${port}/docs`);
-  logger.info(`📄 OpenAPI spec available at http://localhost:${port}/openapi.json`);
-}
+// NODE_ENV === 'production' boot is handled by src/worker.ts (Fly entry).
+// This module is intentionally side-effect-free in production so the Vercel
+// serverless handler (api/index.js → dist/index.js) doesn't kick off
+// long-running side effects (serve(), injectWebSocket, initAlerting,
+// hydrateInferenceConfigs, startExecutor) on every cold start. The dev
+// block above still fires for `pnpm dev:api` because that runs with
+// NODE_ENV=development. See the internal infra-consolidation lane plan
+// (Phase 2) for the extraction history.

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -1,0 +1,116 @@
+// apps/server/src/worker.ts
+//
+// Fly entry point. Boots the long-running subset of the apps/server runtime —
+// alerting, terminal-ws (Forge-gated), Yjs collab WS, agent-collab WS,
+// RVMarket executor (flag-gated). Replaces the NODE_ENV === 'production'
+// boot block that used to live in apps/server/src/index.ts and ran as a
+// side effect of importing the Hono app from api/index.js on Vercel cold
+// start (bound a useless port, leaked setIntervals on instance shutdown,
+// attempted WS upgrades that can't function in serverless).
+//
+// Vercel cold-start now only executes apps/server/src/index.ts module-level
+// code (Hono app composition + middleware + routes + the dev block guard
+// that short-circuits when NODE_ENV === 'production'). No serve(), no
+// injectWebSocket, no setIntervals, no executor poll loop.
+//
+// Local-dev caveat: worker.ts assumes NODE_ENV === 'production'. Running it
+// with NODE_ENV === 'development' will trigger the dev block in index.ts
+// AND the worker boot here = double-init. For local worker testing, set
+// NODE_ENV=production explicitly: `NODE_ENV=production tsx src/worker.ts`.
+
+import * as Sentry from '@sentry/node';
+
+// Initialize Sentry before all other imports for proper instrumentation
+// (mirrors apps/server/src/index.ts:4-20). The Vercel entry initializes
+// its own Sentry instance; both honor the same SENTRY_DSN env.
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV ?? 'production',
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+    beforeSend(event) {
+      if (process.env.NODE_ENV !== 'production') return null;
+      if (event.request?.headers) {
+        const { cookie: _, authorization: __, ...safe } = event.request.headers;
+        event.request.headers = safe;
+      }
+      return event;
+    },
+  });
+}
+
+import { serve } from '@hono/node-server';
+import { initializeLicense } from '@revealui/core/license';
+import { logger } from '@revealui/core/observability/logger';
+import { audit } from '@revealui/core/security';
+import app, { initAlerting, terminalWs } from './index.js';
+import { hydrateInferenceConfigs } from './lib/hydrate-inference-configs.js';
+import { PostgresAuditStorage } from './lib/postgres-audit-storage.js';
+import {
+  validateBillingCatalogAtStartup,
+  validateLicenseAtStartup,
+  validateStartup,
+} from './lib/validate-startup.js';
+import { startExecutor } from './services/revmarket-executor.js';
+
+// Persistent audit storage (replaces default InMemoryAuditStorage).
+audit.setStorage(new PostgresAuditStorage());
+
+// Environment + license + billing catalog validation.
+// validateLicenseAtStartup throws on invalid/expired/missing license in Forge
+// mode; process.exit(1) makes the container restart-loop instead of silently
+// degrading to free tier. validateBillingCatalogAtStartup runs only with
+// STRIPE_LIVE_MODE=true and fails boot on missing billing_catalog rows
+// (prevents mid-customer-transaction 500s).
+validateStartup();
+validateLicenseAtStartup()
+  .then(() => validateBillingCatalogAtStartup())
+  .then(() => initializeLicense())
+  .then((tier) => {
+    logger.info(`License tier: ${tier}`);
+  })
+  .catch((err: unknown) => {
+    logger.error(
+      'Worker startup validation failed; exiting',
+      err instanceof Error ? err : new Error(String(err)),
+    );
+    process.exit(1);
+  });
+
+initAlerting();
+hydrateInferenceConfigs();
+
+// RVMarket executor — gated on REVMARKET_EXECUTOR_ENABLED, default OFF.
+// The executor's poll loop (configurable interval, default 60s) claims
+// queued tasks and forks child processes per task with a 60s exec budget.
+// Until the marketplace UI / pricing / payouts surface is ready for real
+// customer task submissions, the executor stays dormant. Flip the env to
+// 'true' when marketplace is ready to begin consuming tasks.
+if (process.env.REVMARKET_EXECUTOR_ENABLED === 'true') {
+  startExecutor();
+} else {
+  logger.info(
+    'RVMarket executor not started (set REVMARKET_EXECUTOR_ENABLED=true to enable)',
+  );
+}
+
+const port = Number(process.env.WORKER_PORT || process.env.PORT) || 8080;
+const server = serve({ fetch: app.fetch, port });
+
+// Terminal WebSocket bridge — gated on REVEALUI_FORGE, default OFF. The
+// bridge proxies to a local harness daemon Unix socket at
+// ~/.local/share/revealui/harness.sock; that daemon only exists in
+// self-hosted/Forge deployments. Mounting on hosted SaaS would expose a
+// WS endpoint with no working backend.
+if (process.env.REVEALUI_FORGE === 'true') {
+  terminalWs.injectWebSocket(server);
+  logger.info('Terminal WebSocket bridge mounted (REVEALUI_FORGE=true)');
+} else {
+  logger.info(
+    'Terminal WebSocket bridge not mounted (REVEALUI_FORGE != "true")',
+  );
+}
+
+logger.info(`🚀 Worker running on http://localhost:${port}`);
+logger.info(`📚 API documentation available at http://localhost:${port}/docs`);
+logger.info(`📄 OpenAPI spec available at http://localhost:${port}/openapi.json`);

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -89,9 +89,7 @@ hydrateInferenceConfigs();
 if (process.env.REVMARKET_EXECUTOR_ENABLED === 'true') {
   startExecutor();
 } else {
-  logger.info(
-    'RVMarket executor not started (set REVMARKET_EXECUTOR_ENABLED=true to enable)',
-  );
+  logger.info('RVMarket executor not started (set REVMARKET_EXECUTOR_ENABLED=true to enable)');
 }
 
 const port = Number(process.env.WORKER_PORT || process.env.PORT) || 8080;
@@ -106,9 +104,7 @@ if (process.env.REVEALUI_FORGE === 'true') {
   terminalWs.injectWebSocket(server);
   logger.info('Terminal WebSocket bridge mounted (REVEALUI_FORGE=true)');
 } else {
-  logger.info(
-    'Terminal WebSocket bridge not mounted (REVEALUI_FORGE != "true")',
-  );
+  logger.info('Terminal WebSocket bridge not mounted (REVEALUI_FORGE != "true")');
 }
 
 logger.info(`🚀 Worker running on http://localhost:${port}`);

--- a/apps/server/tsup.config.ts
+++ b/apps/server/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/worker.ts'],
   format: ['esm'],
   platform: 'node',
   bundle: true,


### PR DESCRIPTION
## Summary

Extract the Fly worker entry — `apps/server/src/worker.ts` — and remove the `NODE_ENV === 'production'` boot block from `index.ts`. Vercel cold-start becomes side-effect-free; the long-running boot logic lives in a dedicated module that the (forthcoming) Fly machine runs.

**Stacked on [#953](https://github.com/RevealUIStudio/revealui/pull/953) (Phase 1). Base retargets to `test` when #953 merges.**

## Why

Pre-this-PR, `apps/server/src/index.ts` had a `NODE_ENV === 'production'` boot block that ran every time Vercel cold-started a function instance:
- `serve({ fetch: app.fetch, port })` bound port 3004 inside the function's local network namespace (useless — Vercel routes requests via the exported handler, not the bound port)
- `terminalWs.injectWebSocket(server)` attached WS upgrade handlers to that orphan server (broken — Vercel functions can't service WS)
- `initAlerting()` started a 60s `setInterval` that leaked when Vercel scaled the instance down
- `hydrateInferenceConfigs()` kicked off a DB query

None of these effects were useful on Vercel; they were holdovers from when `apps/server` ran as a long-running Node process on Railway. With Railway being removed and replaced by Fly for the long-running subset, the prod block moves to the Fly entry.

## Architecture after this PR

```
apps/server/
├─ api/index.js          ← Vercel handler (handle(app))
├─ src/index.ts          ← Hono app composition + middleware + routes
│                          NO top-level production side effects
│                          Dev block (NODE_ENV=development) preserved
│                          for `pnpm dev:api`
└─ src/worker.ts         ← Fly entry (NEW)
                           Long-running services: alerting, collab WS,
                           agent-collab WS, terminal-ws (Forge-gated),
                           RVMarket executor (flag-gated)
```

## What this PR does

- **NEW** `apps/server/src/worker.ts` (116 lines):
  - Sentry init (mirrors index.ts)
  - `audit.setStorage` + `validateStartup` + license/billing validation
  - `initAlerting()` + `hydrateInferenceConfigs()`
  - **NEW** `startExecutor()` gated on `REVMARKET_EXECUTOR_ENABLED === 'true'` (default OFF until marketplace UI is ready)
  - `serve()` on `WORKER_PORT || PORT || 8080`
  - `terminalWs.injectWebSocket(server)` gated on `REVEALUI_FORGE === 'true'` (default OFF — daemon socket only exists in Forge deployments)
- **DELETE** the NODE_ENV === 'production' boot block in `apps/server/src/index.ts` (was the `if (process.env.NODE_ENV === 'production') { … }` at the end of the file).
- **ADD** `export` to `const terminalWs = createTerminalRoute()` and `function initAlerting(): void` so worker.ts can import them.
- **ADD** `src/worker.ts` to `apps/server/tsup.config.ts` entry array so the build emits `dist/worker.js` alongside `dist/index.js`.
- **REWRITE** `apps/server/src/__tests__/index.startup.test.ts`. Pre-Phase-2 it asserted the prod block contains `serve()` + `injectWebSocket()`; that block no longer exists. New invariants assert the inverse (no prod boot in index.ts) + the worker.ts equivalent (worker has the binding listener, gates on env flags, shares listener signals with dev block).

## What this PR does NOT do

- No Fly deploy yet (Phase 3).
- No revvault → Fly secrets mirror (Phase 4).
- No Electric cutover (Phase 5).
- No removal of `@revealui/services/revealcoin` price oracle module — it stays for `@revealui/engines/payments`.

## Behavior change matrix

| Surface | Before | After |
|---------|--------|-------|
| Vercel cold-start (`api/index.js` → `dist/index.js`) | Runs prod block: `serve()`, `injectWebSocket()`, `initAlerting()`, `hydrateInferenceConfigs()` as side effect on module import | No side effects. Hono app exported; handler routes requests. |
| `pnpm dev:api` (NODE_ENV=development) | Dev block fires: `serve()` on port 3004 + `injectWebSocket` + `initAlerting` | Unchanged. |
| `node dist/worker.js` (NEW, Fly target) | n/a | Boots: Sentry → audit + license validation → `initAlerting` → `hydrateInferenceConfigs` → `serve()` on port 8080 → `injectWebSocket` (if `REVEALUI_FORGE=true`) → `startExecutor()` (if `REVMARKET_EXECUTOR_ENABLED=true`) |

## Test plan

- [ ] CI gate passes (typecheck + tests + biome + build).
- [ ] `apps/server/src/__tests__/index.startup.test.ts` passes against post-extraction `index.ts` + `worker.ts`.
- [ ] `tsup` build emits BOTH `dist/index.js` and `dist/worker.js`.
- [ ] Vercel preview deploy of the api project shows no runtime regressions (HTTP routes work, /docs serves Swagger, /openapi.json serves spec).
- [ ] **Phase 3** acceptance: `node dist/worker.js` boots cleanly with valid env on a Fly machine; alerting logs every 60s; `REVMARKET_EXECUTOR_ENABLED=true` makes the executor claim queued tasks; `REVEALUI_FORGE=true` mounts terminal-ws.

Phase 2 of an internal infra-consolidation lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
