### PR TITLE
feat(server): scaffold Fly worker deployment — fly.toml + Dockerfile + docs

### DIFF
--- a/apps/server/Dockerfile.worker
+++ b/apps/server/Dockerfile.worker
@@ -1,0 +1,66 @@
+# apps/server/Dockerfile.worker
+#
+# Builds the apps/server long-running worker for Fly deployment.
+# Entry: dist/worker.js (built via tsup; see apps/server/tsup.config.ts).
+# Companion: apps/server/fly.toml.
+#
+# Build context: MUST be the monorepo root (NOT apps/server) so
+# pnpm-workspace.yaml + packages/* are accessible for workspace
+# symlink resolution. flyctl auto-uses the monorepo root when
+# invoked from there:
+#   cd ~/revfleet/revealui
+#   flyctl deploy --config apps/server/fly.toml \
+#     --dockerfile apps/server/Dockerfile.worker
+#
+# Known gotcha (per memory feedback_pnpm_deploy_optional_peer_dangles):
+# pnpm deploy --legacy leaves @revealui/ai + @revealui/services
+# (optional peers per apps/server/package.json peerDependenciesMeta)
+# as dangling workspace symlinks. The Dockerfile takes the "include
+# the packages in the runtime image" path to avoid the dangle.
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 1: builder — pnpm install + tsup build
+# ─────────────────────────────────────────────────────────────────────
+FROM node:24-alpine AS builder
+
+# Native build deps for pg (libc6-compat for prebuilt binaries on alpine).
+RUN apk add --no-cache python3 make g++ libc6-compat
+
+WORKDIR /repo
+RUN corepack enable
+
+# Copy workspace plumbing first for layer caching on dep changes.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY .npmrc* tsconfig.base.json ./
+
+# Copy all workspace packages — needed for workspace:* symlink resolution.
+COPY packages ./packages
+COPY apps/server ./apps/server
+
+# Install + build only the server slice + its dependency closure.
+RUN pnpm install --frozen-lockfile --filter "server..."
+RUN pnpm --filter server build
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 2: runtime — minimal Node 24 alpine + built worker
+# ─────────────────────────────────────────────────────────────────────
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Copy the built worker + its node_modules tree + workspace packages
+# (symlinks resolve into ./packages from /app).
+COPY --from=builder /repo/apps/server/dist ./apps/server/dist
+COPY --from=builder /repo/apps/server/node_modules ./apps/server/node_modules
+COPY --from=builder /repo/apps/server/package.json ./apps/server/package.json
+COPY --from=builder /repo/packages ./packages
+COPY --from=builder /repo/node_modules ./node_modules
+COPY --from=builder /repo/package.json ./package.json
+COPY --from=builder /repo/pnpm-workspace.yaml ./pnpm-workspace.yaml
+
+ENV NODE_ENV=production
+ENV WORKER_PORT=8080
+EXPOSE 8080
+
+WORKDIR /app/apps/server
+CMD ["node", "dist/worker.js"]

--- a/apps/server/fly.toml
+++ b/apps/server/fly.toml
@@ -1,0 +1,71 @@
+# apps/server/fly.toml
+#
+# Fly.io configuration for the apps/server long-running worker.
+# Hosts: alerting, Yjs collab WS, agent-collab WS, terminal-ws
+# (Forge-gated), RVMarket executor (flag-gated). Built from
+# dist/worker.js (see apps/server/tsup.config.ts).
+#
+# Region: iad (Ashburn, VA — matches Neon prod region us-east-1 for
+# sub-ms latency on shape queries via the Hono app).
+#
+# Deploy: see docs/deployment/fly.md
+#
+# Dependency: requires apps/server/src/worker.ts (Phase 2 of the
+# infra-consolidation lane, currently in flight as a separate PR). The
+# Dockerfile builds dist/worker.js via tsup's worker entry. Until
+# Phase 2 lands on test, `flyctl deploy` will fail at the build step.
+
+app = 'revealui-worker'
+primary_region = 'iad'
+
+[build]
+  dockerfile = 'Dockerfile.worker'
+
+[env]
+  NODE_ENV = 'production'
+  WORKER_PORT = '8080'
+  # REVMARKET_EXECUTOR_ENABLED defaults to OFF. Flip to 'true' when
+  # the marketplace UI is ready to accept real customer task
+  # submissions. Set via `flyctl secrets set REVMARKET_EXECUTOR_ENABLED=true`
+  # (non-secret values can also live here in [env]; placed in
+  # secrets-style for owner-gated visibility).
+  REVMARKET_EXECUTOR_ENABLED = 'false'
+  # REVEALUI_FORGE defaults to OFF. The Forge stamp pipeline sets
+  # this to 'true' for self-hosted deployments where the harness
+  # daemon Unix socket exists at ~/.local/share/revealui/harness.sock.
+  REVEALUI_FORGE = 'false'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Worker has in-memory state (Yjs collab rooms, executor poll
+  # loop, alerting setInterval). auto_stop_machines = 'off' keeps the
+  # state alive; min_machines_running = 1 ensures always-on. Auto-
+  # start is irrelevant when auto-stop is off — there's nothing to
+  # auto-start FROM since the machine never stops.
+  auto_stop_machines = 'off'
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 250
+    soft_limit = 200
+
+  # Fly health check hits /api/health which is mounted by the Hono
+  # app at apps/server/src/routes/health.ts (worker.ts imports the
+  # full app so the route is available).
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/api/health'
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  # 512 MB is generous for a Node worker with WS rooms + poll loops.
+  # Bump to 1024 if collab room count grows or executor concurrency
+  # increases (config.maxConcurrent in revmarket-executor.ts:508).
+  memory_mb = 512

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -1,0 +1,148 @@
+---
+title: Fly.io Deployment — apps/server Worker
+description: Deploy + secrets workflow for the apps/server long-running worker on Fly.io.
+category: deployment
+audience: maintainer
+---
+
+# Fly Deployment — apps/server worker
+
+The apps/server long-running worker runs on Fly in region `iad`
+(Ashburn, VA — matched to Neon's prod region `us-east-1` for sub-ms
+latency on shape queries via the worker's Hono app surface).
+
+## Apps
+
+| Fly app | Purpose | Status |
+|---------|---------|--------|
+| `revealui-worker` | apps/server long-running subset (alerting, Yjs collab WS, agent-collab WS, terminal-ws Forge-gated, RVMarket executor flag-gated) | Phase 3 — scaffolded, first deploy pending |
+| `revealui-electric` | ElectricSQL sync service, replicates from Neon | Phase 5 — Electric cutover from Railway |
+
+## First deploy (one-time setup)
+
+Run from the monorepo root (`~/revfleet/revealui`) so flyctl uses
+the right build context for the pnpm workspace:
+
+```bash
+cd ~/revfleet/revealui
+
+# 1. Authenticate to Fly (one-time per machine)
+flyctl auth login
+
+# 2. Create the Fly app (one-time per environment)
+flyctl apps create revealui-worker --org revealui-studio
+
+# 3. Mirror prod secrets from revvault → Fly. The revvault-sync
+#    pipeline (Phase 4 of the lane) automates this; before that
+#    lands, set them manually:
+flyctl secrets set --app revealui-worker \
+  POSTGRES_URL="$(revvault --json get revealui/prod/db/postgres-url | jq -r .value)" \
+  REVEALUI_SECRET="$(revvault --json get revealui/prod/revealui-secret | jq -r .value)" \
+  STRIPE_SECRET_KEY="$(revvault --json get revealui/prod/stripe/secret-key | jq -r .value)" \
+  STRIPE_WEBHOOK_SECRET="$(revvault --json get revealui/prod/stripe/webhook-secret | jq -r .value)" \
+  SENTRY_DSN="$(revvault --json get revealui/prod/sentry/dsn | jq -r .value)" \
+  REVEALUI_LICENSE_PRIVATE_KEY="$(revvault --json get revealui/prod/license/private-key | jq -r .value)" \
+  REVEALUI_LICENSE_PUBLIC_KEY="$(revvault --json get revealui/prod/license/public-key | jq -r .value)" \
+  ELECTRIC_SERVICE_URL="$(revvault --json get revealui/prod/electric/service-url | jq -r .value)" \
+  ELECTRIC_SECRET="$(revvault --json get revealui/prod/electric/secret | jq -r .value)"
+
+# 4. Deploy
+flyctl deploy --config apps/server/fly.toml \
+  --dockerfile apps/server/Dockerfile.worker
+
+# 5. Verify
+flyctl status --app revealui-worker
+flyctl logs --app revealui-worker --tail
+# expect:
+#   - "Worker startup validation failed" → check secrets
+#   - "License tier: <tier>" → license validation passed
+#   - "Alerting system started (60s interval)" → initAlerting fired
+#   - "Worker running on http://localhost:8080" → serve() bound
+#   - Every 60s: alerting evaluating rules
+```
+
+## Regular deploys (post-bootstrap)
+
+Manual deploys from the monorepo root:
+
+```bash
+cd ~/revfleet/revealui
+flyctl deploy --config apps/server/fly.toml \
+  --dockerfile apps/server/Dockerfile.worker
+```
+
+Automated deploys via GitHub Actions land in a future phase
+(track via the lane plan).
+
+## Secrets
+
+All secrets live in revvault per [`docs/SECRETS.md`](../SECRETS.md).
+The mirror to Fly happens via `revvault-sync` (Phase 4 of the
+infra-consolidation lane) or manually via `flyctl secrets set` as
+shown above.
+
+**Never** paste secrets into `apps/server/fly.toml` — that file is
+committed to the public repo. The `[env]` block in `fly.toml` is for
+non-secret configuration only (NODE_ENV, port numbers, feature
+flags).
+
+## Env vars (non-secret, in `fly.toml`)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `NODE_ENV` | `production` | Required for worker boot path |
+| `WORKER_PORT` | `8080` | Fly maps this internally to public 80/443 via the `[http_service]` block |
+| `REVMARKET_EXECUTOR_ENABLED` | `false` | Flip to `true` when marketplace UI is ready to accept real customer task submissions |
+| `REVEALUI_FORGE` | `false` | Forge stamp pipeline sets `true` for self-hosted deployments (mounts terminal-ws WebSocket bridge) |
+
+## Health check
+
+Fly hits `/api/health` every 30s. That route is served by
+`apps/server/src/routes/health.ts` (mounted by the Hono `app` that
+worker.ts imports). The route returns 200 when:
+
+- DB is reachable
+- License validation has completed
+- No catastrophic startup errors
+
+If health checks fail repeatedly, Fly will mark the machine
+unhealthy. Investigate via `flyctl logs --app revealui-worker`.
+
+## Known gotchas
+
+1. **pnpm workspace Docker builds**: optional peers
+   (`@revealui/ai`, `@revealui/services` per
+   `apps/server/package.json` `peerDependenciesMeta.optional`) can
+   dangle as broken symlinks after `pnpm deploy --legacy`. The
+   `Dockerfile.worker` takes the "include the packages in the
+   runtime image" path to avoid this. See memory
+   `feedback_pnpm_deploy_optional_peer_dangles`.
+
+2. **Worker port vs API port**: worker binds `WORKER_PORT` (default
+   8080). The Vercel-deployed apps/server uses
+   `API_PORT||PORT||3004`. Different ports prevent local-dev
+   collision when running both.
+
+3. **Auto-stop is OFF**: `auto_stop_machines = 'off'` because the
+   worker has in-memory state (collab rooms, executor poll loop,
+   alerting interval). Stopping the machine drops the state.
+   `min_machines_running = 1` keeps it always-on.
+
+4. **Build context = monorepo root**: not `apps/server/`. flyctl
+   auto-uses the right context when invoked from `~/revfleet/revealui`.
+   If invoked from `apps/server/`, the build fails on missing
+   `pnpm-workspace.yaml`.
+
+5. **Dependency on `apps/server/src/worker.ts`** (Phase 2 of the
+   infra-consolidation lane). Until Phase 2 lands on `test`,
+   `flyctl deploy` will fail at the build step (no
+   `dist/worker.js` to ship).
+
+## Electric (Phase 5)
+
+ElectricSQL Fly setup lives in a separate `fly.electric.toml`
+(landing in Phase 5 of the infra-consolidation lane). Same region
+(iad), same Fly account. Connects to the same Neon `POSTGRES_URL`
+the worker uses. The cutover from Railway-hosted Electric to
+Fly-hosted Electric is the load-bearing piece of Phase 5 — see the
+lane plan for sequencing.


### PR DESCRIPTION
## Summary

Scaffolds the Fly.io deployment for the `apps/server` long-running worker (extracted in [#954](https://github.com/RevealUIStudio/revealui/pull/954)). Three new files, no deploy executed yet.

## Files

- **`apps/server/fly.toml`** — single-process Fly app `revealui-worker`, region `iad`, always-on (`auto_stop_machines = 'off'` + `min_machines_running = 1`) because the worker holds in-memory state (Yjs collab rooms, executor poll loop, alerting interval). Health check on `/api/health`. Env defaults for `REVMARKET_EXECUTOR_ENABLED` + `REVEALUI_FORGE` (both OFF).
- **`apps/server/Dockerfile.worker`** — multi-stage Node 24 alpine. Builder stage: `pnpm install --frozen-lockfile --filter "server..."` + `pnpm --filter server build`. Runtime stage: copies built dist + node_modules + workspace packages. Includes workspace packages in the runtime image to avoid `pnpm deploy --legacy` optional-peer-dangle (per memory).
- **`docs/deployment/fly.md`** — first-deploy bootstrap, regular-deploy workflow, revvault-to-flyctl secrets mirror commands, known gotchas, env-var reference, Electric (Phase 5) pointer.

## Region rationale

Neon prod is on AWS **us-east-1** (resolved via `revvault get revealui/prod/db/postgres-url` → hostname pattern `ep-*.c-3.us-east-1.aws.neon.tech`). Matching Fly region is **iad** (Ashburn, VA) — sub-ms latency on Postgres reads from the worker's Hono surface.

## Stacking + dependency

This PR is **based on `test`, NOT stacked on [#954](https://github.com/RevealUIStudio/revealui/pull/954)**. Reasoning: the files are infra config that reviews independently. But `Dockerfile.worker` builds `dist/worker.js`, which doesn't exist on `test` until [#954](https://github.com/RevealUIStudio/revealui/pull/954) merges. So **`flyctl deploy` against this branch will fail at the tsup build step until [#954](https://github.com/RevealUIStudio/revealui/pull/954) lands**. Acceptable for a config-scaffold PR.

## What this PR does NOT do

- No Fly account creation (manual `flyctl apps create` step documented in `docs/deployment/fly.md`).
- No actual `flyctl deploy` (post-merge action, gated on [#954](https://github.com/RevealUIStudio/revealui/pull/954) landing first).
- No revvault-to-Fly mirror automation (Phase 4 PR).
- No Electric Fly config (Phase 5 PR — alongside the Railway → Fly Electric cutover).
- No GitHub Actions workflow for automated deploys (future phase).

## Test plan

- [ ] CI passes (Biome ignores `.toml`/`.md`/`Dockerfile` so no formatter issues expected; Gitleaks scans body).
- [ ] No secrets accidentally committed in `fly.toml` (the `[env]` block carries only NODE_ENV + ports + boolean feature flags).
- [ ] `docs/deployment/fly.md` renders cleanly in GitHub markdown preview.
- [ ] **First-deploy follow-up** (post-#954 merge): `cd ~/revfleet/revealui && flyctl deploy --config apps/server/fly.toml --dockerfile apps/server/Dockerfile.worker` succeeds against a `revealui-worker-staging` Fly app; `/api/health` returns 200; logs show `Alerting system started (60s interval)`.

Phase 3 of an internal infra-consolidation lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
