### PR TITLE
docs(fleet): drop deleted Sync-AllRepos ref from revkit doc

### DIFF
--- a/apps/docs/public/fleet/revkit.md
+++ b/apps/docs/public/fleet/revkit.md
@@ -44,7 +44,7 @@ echo 'for f in ~/.revealui/wsl/bashrc.d/*.sh; do source "$f"; done' >> ~/.bashrc
 - **Shell config fragments** — sourced from `~/.revealui/wsl/bashrc.d/*.sh`
 - **Boot optimization** — `setup-wsl-boot.sh` masks 23 hardware/desktop services, disables Docker/snap auto-start (sockets preserved); cuts cold-boot time materially
 - **Editor configs** — portable Zed settings (and integrates with RevCon for the rest)
-- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Sync-AllRepos`, `Mount-WSLDev`, etc.)
+- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Mount-WSLDev`, `Sync-RevealUIToWindows`, `Compact-VHDx`, etc.)
 - **Sandbox drive support** — optional ext4 USB mount at `/mnt/sandbox` for offloading Docker data, models, databases, caches off the C: drive (renamed from "Forge drive" via revkit#13 MERGED 2026-05-02)
 
 ## How it composes with RevealUI

--- a/docs/fleet/revkit.md
+++ b/docs/fleet/revkit.md
@@ -44,7 +44,7 @@ echo 'for f in ~/.revealui/wsl/bashrc.d/*.sh; do source "$f"; done' >> ~/.bashrc
 - **Shell config fragments** — sourced from `~/.revealui/wsl/bashrc.d/*.sh`
 - **Boot optimization** — `setup-wsl-boot.sh` masks 23 hardware/desktop services, disables Docker/snap auto-start (sockets preserved); cuts cold-boot time materially
 - **Editor configs** — portable Zed settings (and integrates with RevCon for the rest)
-- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Sync-AllRepos`, `Mount-WSLDev`, etc.)
+- **PowerShell module** — `RevealUI.RevStation` for Windows-side helpers (`Mount-WSLDev`, `Sync-RevealUIToWindows`, `Compact-VHDx`, etc.)
 - **Sandbox drive support** — optional ext4 USB mount at `/mnt/sandbox` for offloading Docker data, models, databases, caches off the C: drive (renamed from "Forge drive" via revkit#13 MERGED 2026-05-02)
 
 ## How it composes with RevealUI


### PR DESCRIPTION
## Summary

Cross-repo follow-up to [revkit#30](https://github.com/RevealUIStudio/revkit/pull/30) (merged 2026-05-18). That PR deleted the `Sync-AllRepos`, `Register-SyncTask`, and `Unregister-SyncTask` cmdlets from the `RevealUI.RevStation` PowerShell module — they were dead code from the 2026-05-08 Windows-mirror sync retirement. This PR drops the stale `Sync-AllRepos` reference from the fleet `revkit.md` doc that still pointed at it.

## Changes

- `docs/fleet/revkit.md` (canonical source) — replace `Sync-AllRepos, Mount-WSLDev` example list with current cmdlet names (`Mount-WSLDev`, `Sync-RevealUIToWindows`, `Compact-VHDx`).
- `apps/docs/public/fleet/revkit.md` (generated mirror of `docs/`, also tracked in git) — same change to keep the docs-app served copy in sync ahead of next `copy-docs.sh` run.

## Verification

```
$ git grep -nE "Sync-AllRepos|Register-SyncTask|Unregister-SyncTask" -- '*.md' '*.mdx' '*.ts' '*.tsx'
(no matches)
```

## Test plan

- [x] Grep confirms no remaining references to the deleted cmdlets across `*.md`, `*.mdx`, `*.ts`, `*.tsx`.
- [x] Both `docs/fleet/revkit.md` and `apps/docs/public/fleet/revkit.md` updated identically.
- [ ] CI green on `test` base.
