### PR TITLE
chore(marketing): Phase 2 — pin canonical metrics + drift fix + blog honesty (overhaul lane)

### DIFF
--- a/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pricing Marketing Drift Tests (marketing-overhaul Phase 2.6)
+ *
+ * Canonical price map lives in `docs/MARKETING_METRICS.md` §2 — this test
+ * asserts the server-side fallback prices in `apps/server/src/routes/pricing.ts`
+ * match it exactly. When a price changes, ALL of these must update in lockstep:
+ *
+ *   1. `apps/server/src/routes/pricing.ts` HARDCODED_*_PRICES
+ *   2. `apps/marketing/app/content/pricing.ts` + dependent content
+ *   3. `apps/marketing/app/components/landing/PricingTeaser.tsx` TEASER_FALLBACK_PRICE
+ *   4. `docs/MARKETING_METRICS.md` §2 (the canonical doc)
+ *   5. Stripe live data (via `pnpm stripe:seed` post-update)
+ *   6. This file
+ *
+ * If this test fails, the lockstep was broken. Don't update the test in
+ * isolation — update all six together so the canonical truth stays canonical.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock Stripe to be unavailable so the fallback path runs.
+const { mockProductsList } = vi.hoisted(() => ({ mockProductsList: vi.fn() }));
+vi.mock('stripe', () => ({
+  default: class MockStripe {
+    products = { list: mockProductsList };
+  },
+}));
+vi.mock('@revealui/services', () => ({
+  protectedStripe: { products: { list: mockProductsList } },
+}));
+
+// Always trip the circuit-breaker so the fallback fires deterministically.
+vi.mock('@revealui/core/error-handling', () => ({
+  CircuitBreaker: class {
+    async execute<T>(_fn: () => Promise<T>): Promise<T> {
+      throw new CircuitBreakerOpenErrorStub();
+    }
+  },
+  CircuitBreakerOpenError: class CircuitBreakerOpenErrorStub extends Error {},
+}));
+class CircuitBreakerOpenErrorStub extends Error {}
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import app from '../pricing.js';
+
+// ---------------------------------------------------------------------------
+// Canonical price map — sourced from docs/MARKETING_METRICS.md §2 (2026-05-18).
+// When this map changes, update all six surfaces listed in the file header.
+// ---------------------------------------------------------------------------
+
+const CANONICAL_SUBSCRIPTION_PRICES = {
+  free: { price: '$0', period: undefined },
+  pro: { price: '$49', period: '/month' },
+  max: { price: '$149', period: '/month' },
+  enterprise: { price: '$299', period: '/month' },
+} as const;
+
+const CANONICAL_CREDIT_PRICES = {
+  Starter: { price: '$10', priceNote: 'one-time', costPer: '$0.001/task' },
+  Standard: { price: '$50', priceNote: 'one-time', costPer: '$0.00083/task' },
+  Scale: { price: '$250', priceNote: 'one-time', costPer: '$0.00071/task' },
+} as const;
+
+const CANONICAL_PERPETUAL_PRICES = {
+  'Pro Perpetual': {
+    price: '$299',
+    priceNote: 'one-time',
+    renewal: '$99/yr for continued support',
+  },
+  'Agency Perpetual': {
+    price: '$799',
+    priceNote: 'one-time',
+    renewal: '$199/yr for continued support',
+  },
+  'Enterprise Perpetual': {
+    price: '$1,999',
+    priceNote: 'one-time',
+    renewal: '$499/yr for continued support',
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Pricing Marketing Drift — fallback prices match docs/MARKETING_METRICS.md §2', () => {
+  beforeEach(() => {
+    mockProductsList.mockReset();
+    mockProductsList.mockResolvedValue({ data: [] });
+  });
+
+  it('subscription fallback prices match canonical map exactly', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.subscriptions).toBeDefined();
+    expect(Array.isArray(body.subscriptions)).toBe(true);
+    expect(body.subscriptions.length).toBe(Object.keys(CANONICAL_SUBSCRIPTION_PRICES).length);
+
+    for (const tier of body.subscriptions) {
+      const canonical =
+        CANONICAL_SUBSCRIPTION_PRICES[tier.id as keyof typeof CANONICAL_SUBSCRIPTION_PRICES];
+      expect(
+        canonical,
+        `Subscription tier ${tier.id} not present in canonical map; add or remove the tier and update docs/MARKETING_METRICS.md §2`,
+      ).toBeDefined();
+      expect(tier.price, `Subscription tier ${tier.id} price drift`).toBe(canonical.price);
+      if (canonical.period === undefined) {
+        // Free tier — period may be absent OR present as a falsy string. Both OK.
+        expect(tier.period ?? null, `Free tier should have no period`).toBeFalsy();
+      } else {
+        expect(tier.period, `Subscription tier ${tier.id} period drift`).toBe(canonical.period);
+      }
+    }
+  });
+
+  it('credit-bundle fallback prices match canonical map exactly', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.credits).toBeDefined();
+    expect(Array.isArray(body.credits)).toBe(true);
+    expect(body.credits.length).toBe(Object.keys(CANONICAL_CREDIT_PRICES).length);
+
+    for (const credit of body.credits) {
+      const canonical =
+        CANONICAL_CREDIT_PRICES[credit.name as keyof typeof CANONICAL_CREDIT_PRICES];
+      expect(
+        canonical,
+        `Credit bundle ${credit.name} not present in canonical map; add or remove the bundle and update docs/MARKETING_METRICS.md §2`,
+      ).toBeDefined();
+      expect(credit.price, `Credit bundle ${credit.name} price drift`).toBe(canonical.price);
+      expect(credit.priceNote, `Credit bundle ${credit.name} priceNote drift`).toBe(
+        canonical.priceNote,
+      );
+      expect(credit.costPer, `Credit bundle ${credit.name} costPer drift`).toBe(canonical.costPer);
+    }
+  });
+
+  it('perpetual-tier fallback prices match canonical map exactly', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.perpetual).toBeDefined();
+    expect(Array.isArray(body.perpetual)).toBe(true);
+    expect(body.perpetual.length).toBe(Object.keys(CANONICAL_PERPETUAL_PRICES).length);
+
+    for (const tier of body.perpetual) {
+      const canonical =
+        CANONICAL_PERPETUAL_PRICES[tier.name as keyof typeof CANONICAL_PERPETUAL_PRICES];
+      expect(
+        canonical,
+        `Perpetual tier ${tier.name} not present in canonical map; add or remove the tier and update docs/MARKETING_METRICS.md §2`,
+      ).toBeDefined();
+      expect(tier.price, `Perpetual tier ${tier.name} price drift`).toBe(canonical.price);
+      expect(tier.priceNote, `Perpetual tier ${tier.name} priceNote drift`).toBe(
+        canonical.priceNote,
+      );
+      expect(tier.renewal, `Perpetual tier ${tier.name} renewal drift`).toBe(canonical.renewal);
+    }
+  });
+});

--- a/apps/server/src/routes/pricing.ts
+++ b/apps/server/src/routes/pricing.ts
@@ -74,7 +74,12 @@ const HARDCODED_PERPETUAL_PRICES: Record<
     priceNote: 'one-time',
     renewal: '$199/yr for continued support',
   },
-  'Forge Perpetual': {
+  // 'Enterprise Perpetual' is the post-rename canonical name per
+  // brand-naming ADR (2026-05-03-revfleet-rename.md). The contracts file
+  // ships this name; the server fallback now matches. marketing-overhaul
+  // Phase 2.6 (2026-05-18) closed the pre-rename "Forge Perpetual" drift
+  // surfaced by pricing-marketing-drift.test.ts.
+  'Enterprise Perpetual': {
     price: '$1,999',
     priceNote: 'one-time',
     renewal: '$499/yr for continued support',

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -1,0 +1,182 @@
+---
+title: "Marketing Metrics — Pinned Truth"
+description: "Single source of truth for every metric, count, and status claim used in the marketing app and public-facing copy. Updated when the code changes; validated by claim-drift CI gate."
+category: internal
+audience: maintainer
+last-verified: 2026-05-18
+verified-via: pnpm tsx scripts/validate/claim-drift.ts
+---
+
+# Marketing Metrics — Pinned Truth
+
+This doc is the **single source of truth** for every metric, count, package name, license string, and status label that appears in the marketing app (`apps/marketing/`) and in customer-facing copy (`README.md`, `docs/PRO.md`, `packages/mcp/README.md`).
+
+If a number appears in marketing copy, it MUST match the value below. If a value below is wrong, update **here first**, then run `pnpm tsx scripts/validate/claim-drift.ts` to verify the CI gate still passes, then propagate the new value into marketing content in a follow-up commit on the same branch.
+
+**Why this doc exists.** Without it, every page invents its own count (witness the pre-Phase-1 state: Hero said "13 first-party MCP servers", Marketplace said "12", Pricing said "13", blog post 07 said "12 including the adapter base class"). Phase 2 of the marketing-overhaul lane pinned the canonical numbers here so Phase 3 can mechanically propagate them.
+
+---
+
+## 1. Codebase metrics (validated by claim-drift CI gate)
+
+Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-05-18 (commit `b0c6bbc81`).
+
+| Metric | Canonical value | Source of truth (script ref) | Notes |
+|---|---|---|---|
+| Packages in `packages/` | **26** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
+| Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (revealcoin removed per PR #936 + #946 + #947). |
+| Workspaces (monorepo total) | **30** | `countWorkspaces()` (= 26 packages + 4 apps) | |
+| Test files | **912** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| UI components in `packages/presentation/` | **59** | `countUIComponents()` | Marketing copy says "59 native React components" or similar. |
+| **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
+| DB tables (Drizzle pgTable) | **86** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | |
+| License: MIT packages | **20** | `licenseSplit.mit` | |
+| License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
+| License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |
+
+**Marketing copy rule:** when a number appears, quote it as the canonical value. When a phrase says "more than N" or "N+", use the validated number as N. Don't round, don't approximate, don't add bonus framing like "(plus the adapter)" — the validator enforces the bare integer.
+
+## 2. Pricing canonical source
+
+Canonical: `packages/contracts/src/pricing.ts`.
+Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50-82`. Phase 2.6 adds a vitest that asserts both stay in sync.
+
+### Track A — Subscriptions (monthly)
+
+| Tier | Price | Sites | Users | Agent tasks/mo | API rate (req/min) |
+|---|---|---|---|---|---|
+| Free | $0 | 1 | 3 | 1,000 | 200 |
+| Pro | $49 | 5 | 25 | 10,000 | 300 |
+| Max | $149 | 15 | 100 | 50,000 | 600 |
+| Enterprise | $299 | unlimited | unlimited | unlimited | 1,000 |
+
+### Track B — Agent task credits (one-time)
+
+| Tier | Tasks | Price | Cost per task |
+|---|---|---|---|
+| Starter | 10,000 | $10 one-time | $0.001/task |
+| Standard | 60,000 | $50 one-time | $0.00083/task (17% off Starter) |
+| Scale | 350,000 | $250 one-time | $0.00071/task (29% off Starter) |
+
+### Track C — Perpetual licenses (one-time + support)
+
+| Tier | Price | Annual support renewal |
+|---|---|---|
+| Pro Perpetual | $299 | $99/yr |
+| Agency Perpetual | $799 | $199/yr |
+| Enterprise Perpetual | $1,999 | $499/yr |
+
+**Status:** marked `comingSoon: true` in `packages/contracts/src/pricing.ts`. Marketing must label Track C "Coming soon" at H2 weight (no corner badges).
+
+### Track D — Professional Services
+
+| Service | Price | Notes |
+|---|---|---|
+| Architecture Review | $3,500 | one-engagement |
+| Launch Package | $7,500 | one-engagement |
+| Migration Assist | $300/hr | hourly |
+| Consulting Hour | $300/hr | hourly |
+
+**Status:** sold through agency, not self-serve. Marketing copy on `/pricing` says "Talk to founder" / contact link, not "Buy now."
+
+## 3. Status claims (per locked owner answer Q3 — 3-state vocabulary)
+
+| Surface | Allowed labels |
+|---|---|
+| Marketing site (every page) | `Shipped` / `In flight` / `Planned` |
+| Per-product READMEs | Maturity terms OK (`Alpha` / `Beta` / `GA`) — separate axis from shipping status |
+
+### Status of marketing-relevant systems (2026-05-18)
+
+| Feature | Status | Notes |
+|---|---|---|
+| Stripe live payments | **In flight** | 3 of 5 pre-flip gates remain (Cat C heal + stripe:seed re-run + owner flip directive). Marketing copy may NOT claim "live payments today" / "accept payments immediately" — only "Stripe billing wired; live keys in flight." |
+| Dashboard Agent Chat | **Shipped** | Live at admin.revealui.com. |
+| Documentation Site | **Shipped** | docs.revealui.com. |
+| RevealCoin (RVC) | **Pre-launch** (special label) | SHELVED 2026-05-15 per memory + plan. Per locked Q2: roadmap-only single line ("RVC: pre-launch — legal + multisig gates open. See revealcoin/README."). Stripped from all other surfaces. |
+| x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant. "Designed; gated on Stripe live + RevealCoin unshelve." |
+| MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (13 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
+| Perpetual Licenses (Track C) | **Planned** | `comingSoon: true` in contracts. |
+| Self-Hosted Docker Images (RevealUI Fleet) | **Planned** | Designed, not built. |
+| Visual Builder | **Planned** | Backlog. |
+| Enterprise SSO / SAML | **Planned** | Designed, not built. |
+| Cloudflare adoption | **Planned** | Deferred post-launch per memory. |
+
+## 4. Brand
+
+| Surface | Value |
+|---|---|
+| Primary brand color (`--rvui-brand`) | `oklch(0.723 0.177 163.22)` (emerald, dark mode default) |
+| Light mode brand | `oklch(0.55 0.2 163.22)` |
+| Source-of-truth file | `packages/presentation/src/tokens.css:102-104` (dark) + `:180-183` (light) |
+| Memory | `project_fleet_brand_emerald_convergence` |
+
+Marketing copy may say "emerald" descriptively but the token name is `--rvui-brand`. Do NOT introduce new color variables in marketing CSS — consume the token via Tailwind config + `@revealui/presentation` import.
+
+## 5. Fleet product roster (per locked Q3 vocabulary)
+
+| Product | Marketing-site label | Per-product maturity (READMEs) | Notes for marketing |
+|---|---|---|---|
+| RevealUI | Shipped | Beta — no paying users yet | The core runtime |
+| RevDev | Shipped (Studio + Console + Daemon all shipping) | Alpha | Dev harness; dogfooded via studio-dogfood lane |
+| RevVault | Shipped | Beta (MIT CLI + Pro desktop app) | Secret management |
+| RevForge | Shipped | Beta (operator-only stamping tool) | Produces customer brands like AlleviaFleet |
+| RevCon | Shipped | Alpha (MIT) | Editor config sync |
+| RevSkills | Shipped | Active (MIT) | Claude Code skills library |
+| RevKit | Planned | Pro (planned) | Portable WSL dev env |
+| RevMarket | Planned | Code-complete, dormant | MCP marketplace; X402_ENABLED=false |
+| RevealCoin | **Pre-launch** (only on /roadmap) | Mainnet deployed but pre-launch | Shelved 2026-05-15; legal + multisig gates open |
+
+**AlleviaFleet** is NOT a fleet product — it's a customer brand stamped via RevForge. Memory `project_alleviafleet_is_stamped_revforge`.
+
+## 6. Open-weight inference defaults (per memory)
+
+Canonical defaults (when "open-model AI" is mentioned in marketing): Gemma 4, Phi-4-mini (via Ollama), DeepSeek-R1, Qwen-VL, Nemotron-3-nano, Nemotron-3-omni (via Ubuntu Inference Snaps).
+
+**Hard rule per memory `project_suite_roadmap`:** Anthropic SDK is NEVER imported by RevealUI runtime code. Marketing copy may say "Claude / Anthropic" as one of the supported model providers (the Claude API integration runs out-of-band) but never as the default. Default is open-weight.
+
+## 7. Brand language guardrails (per `brand-naming.md` + locked Q1)
+
+- **RevealUI** = the framework/runtime (customer-facing).
+- **RevFleet** = the umbrella product family (8 active products + RVC pre-launch).
+- **`RVC`** = the on-chain Token-2022 symbol (NOT `$RVUI`).
+- **`$RVUI`** = INTERNAL codename only; NEVER customer-facing.
+- **`RevForge`** = the stamping tool (NOT bare `Forge`).
+- **"Studio"** alone is ambiguous (collides with RevDev Studio app + RevealUI Studio agency); always qualify as "RevealUI Studio" or "RevDev Studio."
+- **Positioning (Q1 lock-in):** `shifts.md` primary + secondary —
+  - "The OSS business runtime where your agents are first-class users."
+  - "Auth, billing, content, and AI primitives — governed by one policy, audited by hash-chained logs, owned by you. From `npx create-revealui` to first paying customer in a weekend."
+
+## 8. Voice rules (per `.jv/docs/lanes/_closed/messaging-funnel-audit/voice-and-headline-rules.md`)
+
+Five testable rules — Phase 5 audits every page against these:
+
+1. **Lead with what ships today.** Every page's first sentence under H1 names a capability with a verifiable artifact.
+2. **Specifics over adjectives.** "Fast" → "13 first-party MCP servers." "Secure" → "Ed25519-signed license JWTs."
+3. **Identify the reader by their stack, not job title.**
+4. **Surface the trade-off, don't bury it.** "Three yeses and one no" pattern.
+5. **No marketing-speak, no emojis, no exclamation points.** Banned adjective table in `voice-and-headline-rules.md` §1.
+
+## 9. How to update this doc
+
+1. Make the underlying code change (add a package, ship an MCP server, etc.).
+2. Run `pnpm tsx scripts/validate/claim-drift.ts` — confirm the new actual values.
+3. Update this doc with the new canonical numbers.
+4. Run the validator again — confirm `Claims scanned: N, Mismatches: 0`.
+5. If marketing copy needs updating, do so in a follow-up commit on the same PR (mechanical find-and-replace).
+6. Update `last-verified` field in frontmatter.
+
+## 10. Drift report convention
+
+When this doc disagrees with marketing copy, file a `gh issue` titled `marketing-drift: <metric> says <X> on <surface>, MARKETING_METRICS.md says <Y>`. Tag with `area:marketing` + `kind:drift`. Phase 6 of the marketing-overhaul lane wires the claim-drift CI gate to also cover `apps/marketing/app/content/*.ts` so this drift is caught automatically.
+
+---
+
+**Related references:**
+- Lane plan: `.jv/docs/lanes/marketing-overhaul/plan.md`
+- Voice rules: `.jv/docs/lanes/_closed/messaging-funnel-audit/voice-and-headline-rules.md`
+- Positioning shifts: `.jv/docs/lanes/_closed/messaging-funnel-audit/shifts.md`
+- Brand naming: `.jv/docs/brand-naming.md`
+- Validator source: `scripts/validate/claim-drift.ts`
+- Pricing canonical: `packages/contracts/src/pricing.ts`
+- Brand tokens: `packages/presentation/src/tokens.css`

--- a/docs/blog/02-http-402-payments.md
+++ b/docs/blog/02-http-402-payments.md
@@ -4,6 +4,10 @@ _By Joshua Vaughn  -  RevealUI Studio_
 
 ---
 
+> **Status note (updated 2026-05-18):** The x402 integration in RevealUI is **designed and code-complete but dormant** today. The feature flag `X402_ENABLED=false` is the default; the endpoints exist but won't transact. Live agent payments are gated on (a) the Stripe live-keys flip (3 of 5 pre-flip gates remain open) and (b) the RevealCoin (RVC) unshelve decision (RVC is on mainnet but pre-launch — see `docs/MARKETING_METRICS.md` §3 for current shipping status). This post explains the design and how to wire it; it does not claim x402 payments are currently transactable through RevealUI in production.
+
+---
+
 HTTP 402 is the status code that was never used.
 
 It's been in the spec since 1996. The RFC says it's "reserved for future use" and the intended use was always some form of payment. For 30 years, practically nobody sent it. The web settled on subscription models and API keys  -  you authenticate with a token, and billing happens out-of-band via Stripe.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -1,5 +1,9 @@
 # The Five Primitives of Business Software
 
+> **Status note (updated 2026-05-18):** Two forward-looking systems mentioned in this post are not transactable in production today: **x402 agent-to-agent payments** (designed and code-complete behind `X402_ENABLED=false`) and **RevealCoin (RVC)** (on mainnet but pre-launch — legal and multisig gates open). Everything else described — auth, content, Stripe billing, MCP wiring, agent primitives — runs today. See `docs/MARKETING_METRICS.md` §3 for the current per-feature shipping status.
+
+---
+
 Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell products, a way to collect payments, and increasingly, a way to run AI. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
 
 RevealUI is an agentic business runtime. Its thesis is simple: these five primitives should be pre-wired, open source, and ready to deploy. You bring your business logic. We bring the infrastructure.

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -4,6 +4,8 @@ RevealUI is open source today; the commercial side is pre-launch. Before we talk
 
 This is a solo-founder project. I don't have a VC board to answer to or a growth team optimizing conversion funnels. I have a business model I believe in, and I'd rather explain it plainly than have you discover the trade-offs later.
 
+> **Status note (updated 2026-05-18):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **agent payments via x402 + RVC** — are **planned, not shipped**. The first-party MCP catalog (13 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. RevC (RVC) is on mainnet but pre-launch (legal and multisig gates open). x402 is code-complete behind `X402_ENABLED=false`. See `docs/MARKETING_METRICS.md` §3 for current shipping status of every commercial surface.
+
 ---
 
 ## The MIT Commitment

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -4,6 +4,10 @@
 
 ---
 
+> **Status note (updated 2026-05-18):** This post discusses the **agent-first future** RevealUI is building toward. Specifically: x402 micropayments (USDC on Base) and the per-call MCP server marketplace are **designed but not transactable today**. The x402 endpoints are code-complete behind `X402_ENABLED=false`; the marketplace ships its first-party catalog (13 MCP servers) but third-party publishing, payment proxying, and per-call billing are unbuilt. RevealCoin (RVC) is on mainnet but pre-launch (legal and multisig gates open). The Agent Card endpoint (`/.well-known/agent.json`) ships today; `payment-methods.json` ships with an `X402_ENABLED=false` empty-payments shape. See `docs/MARKETING_METRICS.md` §3 for current shipping status of every system mentioned below.
+
+---
+
 I have been building RevealUI for the past year as an agentic business runtime -- the kind of thing where you get users, content, products, payments, and AI pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
 
 But somewhere around the third month of building, I realized something that changed the architecture fundamentally: **the next wave of customers for software platforms are not human.**

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1086,6 +1086,11 @@ const RVUI_LEAK_ALLOWLIST = new Set<string>([
   // (customer-facing ticker) boundary; it must mention both to fulfil
   // its purpose as the cross-cutting vocabulary source of truth.
   'docs/glossary.md',
+  // MARKETING_METRICS.md is the marketing-overhaul lane's pinned-truth
+  // doc; it documents the `$RVUI` (internal) vs `RVC` (customer-facing)
+  // boundary in §7 so marketing copy stays aligned. Added 2026-05-18 via
+  // marketing-overhaul Phase 2.
+  'docs/MARKETING_METRICS.md',
 ]);
 
 function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {


### PR DESCRIPTION
## Summary

**Phase 2 of the marketing-overhaul lane** — pin canonical metrics + add drift-prevention infrastructure for the marketing surface, on top of merged peer PR #949 (docs-audit canonical-truth).

This is the doc-revalidation + truth-pinning + drift-prevention layer. Phase 3 will regenerate `apps/marketing/app/content/*.ts` from `docs/MARKETING_METRICS.md` (Phase 1's content extraction + this PR's pinned truth = mechanical Phase 3 work).

### Adds

- **`docs/MARKETING_METRICS.md`** — single source of truth for every metric, count, package name, license string, status label, brand token, and pricing tier used in marketing copy. Sections cover: codebase metrics (validator-pinned), pricing (4 tracks), shipping-status vocabulary (per locked owner Q3), brand color + naming guardrails, open-weight inference defaults, fleet product roster, voice rules. Phase 3 mechanically uses this doc to align `apps/marketing/app/content/*`.

- **`apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts`** — vitest that asserts the `/api/pricing` fallback response (subscription + credit + perpetual prices) matches a canonical price map sourced from `MARKETING_METRICS.md §2`. 3/3 tests pass. Catches future drift between server fallback ↔ canonical doc.

### Fixes (surfaced + closed in this PR)

- **`apps/server/src/routes/pricing.ts:77`** — `HARDCODED_PERPETUAL_PRICES` had the 3rd tier keyed as `'Forge Perpetual'` (pre-rename name), but `packages/contracts/src/pricing.ts` ships `'Enterprise Perpetual'` (per brand-naming ADR 2026-05-03). When Stripe was unreachable, the fallback lookup missed and Enterprise Perpetual rendered with **no price**. Caught by the new drift test; rename applied.

### Updates

- **`scripts/validate/claim-drift.ts`** — added `docs/MARKETING_METRICS.md` to `RVUI_LEAK_ALLOWLIST` (the doc explains the `$RVUI`-vs-`RVC` boundary in §7 and must mention both; same pattern as `docs/glossary.md`).

- **`docs/blog/02-http-402-payments.md`**, **`05-five-primitives.md`**, **`06-open-source-and-pro.md`**, **`07-agent-first-future.md`** — added a visible "Status note (updated 2026-05-18)" disclosure block at the top of each. Discloses that x402 (`X402_ENABLED=false`), the MCP marketplace third-party publishing, and RevealCoin (RVC) are **designed but not transactable today**. Body content preserved verbatim — engineering depth retained, shipping status honest.

### Lane plan updates (separate internal docs commit on an internal repo:main`)

- **`plan.md §2.3 MCP servers` — CORRECTED direction**: canonical count is **13** (validator + `packages/mcp/README.md` + `CHANGELOG.md` documents the 12→13 bump). Original audit-Explore-agent miscounted by excluding `adapter.ts`; post-merge validator confirms 13. Phase 3 will bump `marketplace.ts` + `primitives.ts` 12→13 (not 13→12 as originally planned).
- **`plan.md §3 added D21`**: 'Forge Perpetual' → 'Enterprise Perpetual' perpetual-tier rename caught by new drift test (Phase 2.6 FIXED).

### Memory update (separate, in user global memory)

`reference_npm_account_topology.md` clarified — the "36 packages" claim is npm-registry slots owned by `revealui-org` (22 active + 15 reserved squat-protection), NOT the same number as "26 packages in repo" (validator count). Added a disambiguation table. Marketing copy uses **26** (in-repo count).

## Verification

- `pnpm tsx scripts/validate/claim-drift.ts` — **pass** (68 claims scanned, 0 mismatches, 0 RVUI leaks, 0 phantom packages, 0 future-tense unlinked markers, 0 license-membership mismatches)
- `pnpm --filter server typecheck` — pass
- `pnpm --filter marketing typecheck` — pass
- `pnpm --filter marketing test` — 2/2 pass
- `pnpm vitest pricing-marketing-drift` (standalone) — 3/3 pass
- `biome check` on touched files — pass
- Push CI gate (`secrets:scan` + `lint-staged` + `Validating code standards`) — pass

## Test plan

- [ ] CI green on push (Phase 1 + Phase 3 build/typecheck/test gates; CodeQL; gitleaks)
- [ ] Reviewer reads `docs/MARKETING_METRICS.md` end-to-end (the high-leverage doc — Phase 3+ all key off this)
- [ ] Reviewer confirms Forge→Enterprise Perpetual rename is the right direction (it matches the contracts file + brand-naming ADR — fixing pre-rename drift, not introducing it)
- [ ] Reviewer spot-checks one blog status banner for tone (banners must be honest but not undercut the technical content)
- [ ] Merge to `test`, watch for any auto-deploy regression
- [ ] Phase 3 PR (`chore/marketing-content-regenerate`) opens after this merges — mechanical content/* updates using `MARKETING_METRICS.md` as source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
