### PR TITLE
chore(marketing): Phase 3 — regenerate content/* from MARKETING_METRICS.md (overhaul lane)

### DIFF
--- a/apps/marketing/app/content/fair-source.ts
+++ b/apps/marketing/app/content/fair-source.ts
@@ -1,6 +1,12 @@
-// Sourced from: app/routes/FairSourcePage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/FairSourcePage.tsx (Phase 1 extraction).
+// Phase 3 (2026-05-18) update: hero headline + body math now reference METRICS
+// license split (validator: 20 MIT + 5 FSL + 1 internal = 26). Original "21 of 26
+// MIT" was off-by-one — pre-Phase-3 audit counted create-revealui (MIT, separate
+// workspace) into the 21 but didn't account for the internal-only `test` workspace.
+// New phrasing: "20 of 26 MIT" + explicit accounting in the body prose.
+// Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 import type { FaqItem } from './types';
 
 export interface ContractCard {
@@ -27,16 +33,14 @@ export const FAIR_SOURCE_PAGE_TITLE = 'Fair Source — RevealUI';
 
 export const FAIR_SOURCE_HERO = {
   eyebrow: 'License contract for the Pro packages',
-  headline: '21 of 26 MIT.',
+  headline: `${METRICS.licenseSplit.mit} of ${METRICS.packages} MIT.`,
   headlineHighlight: 'Forever.',
-  subhead: 'The 5 commercial packages convert to MIT after 2 years.',
+  subhead: `The ${METRICS.licenseSplit.fsl} commercial packages convert to MIT after 2 years.`,
   body: {
-    prefix:
-      'Twenty-one RevealUI packages ship under plain MIT and stay that way. Five packages ship under',
+    prefix: `${METRICS.licenseSplit.mit} RevealUI packages ship under plain MIT and stay that way. ${METRICS.licenseSplit.fsl} packages ship under`,
     fslLabel: 'FSL-1.1-MIT',
     fslHref: SITE.urls.fslSoftware,
-    suffix:
-      '— source-visible, commercially usable, and each release auto-converts to plain MIT two years after publish. Same license model used by Sentry, GitButler, and Keygen.',
+    suffix: `— source-visible, commercially usable, and each release auto-converts to plain MIT two years after publish. Same license model used by Sentry, GitButler, and Keygen. (The remaining ${METRICS.licenseSplit.internal} workspace package is an internal-only test harness, not customer-facing.)`,
   },
   ogTitle: 'Fair Source',
   ogSubtitle: 'Source-visible. Commercially usable. MIT in two years.',

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -1,9 +1,14 @@
 // Sourced from: app/components/landing/Hero.tsx, app/components/landing/Problem.tsx,
 //   app/components/landing/Demo.tsx, app/components/landing/Faq.tsx,
-//   app/components/GetStarted.tsx (Phase 1c, no copy changes).
+//   app/components/GetStarted.tsx (Phase 1c extraction).
+// Phase 3 (2026-05-18) update: Hero "What ships today" metrics now reference
+// METRICS from site.ts (single source per docs/MARKETING_METRICS.md §1).
+// FSL package detail rewritten: now states 20 MIT + 5 FSL + 1 internal = 26 total
+// (matches validator licenseSplit; original copy's "21 published + 5 private" math
+// counted 26 by including create-revealui in the 21 — drift caught Phase 3.4).
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 import type { Cta, FaqItem } from './types';
 
 // ---------------------------------------------------------------------------
@@ -35,16 +40,15 @@ export const HOME_HERO = {
     heading: 'What ships today',
     items: [
       {
-        metric: '26 packages',
-        detail:
-          '21 published on npm (20 under @revealui/* plus create-revealui — browse npmjs.com/org/revealui) + 5 private workspace packages. Source at packages/.',
+        metric: `${METRICS.packages} packages`,
+        detail: `${METRICS.licenseSplit.mit} MIT-licensed forever + ${METRICS.licenseSplit.fsl} Fair Source (FSL-1.1-MIT, convert to MIT after 2 years) + ${METRICS.licenseSplit.internal} internal-only test workspace. Source at packages/.`,
       },
       {
-        metric: '86 database tables',
+        metric: `${METRICS.dbTables} database tables`,
         detail: 'Drizzle ORM over NeonDB across 5 schemas. Source at packages/db/src/schema/.',
       },
       {
-        metric: '13 first-party MCP servers',
+        metric: `${METRICS.mcpServers} first-party MCP servers`,
         detail: 'Every one stdio-launchable. Source at packages/mcp/src/servers/.',
       },
       {
@@ -53,7 +57,7 @@ export const HOME_HERO = {
           'Verified every 5 minutes against the license server. Source at packages/core/src/license.ts.',
       },
       {
-        metric: 'FSL-1.1-MIT on 5 Fair Source packages',
+        metric: `FSL-1.1-MIT on ${METRICS.licenseSplit.fsl} Fair Source packages`,
         detail: 'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
       },
       {

--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -1,6 +1,11 @@
-// Sourced from: app/routes/MarketplacePage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/MarketplacePage.tsx (Phase 1 extraction).
+// Phase 3 (2026-05-18) updates: bumped MCP server count to canonical 13 per
+// docs/MARKETING_METRICS.md §1 (was 12 — pre-merge audit miscount; validator
+// + packages/mcp/README.md + CHANGELOG 12→13 bump confirm 13). Added the
+// 13th catalog entry (MCP Adapter base class + Vercel/Stripe/Neon concrete
+// adapter subclasses). All numeric references now import from SITE.METRICS.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 import type { Cta, SectionHeading } from './types';
 
 export interface McpServer {
@@ -17,8 +22,7 @@ export interface DiscoveryStep {
 
 export const MARKETPLACE_HERO: SectionHeading = {
   title: 'MCP server catalog',
-  subtitle:
-    '12 first-party MCP servers, RBAC-scoped and audit-logged. Agents discover tools via MCP. RevealUI implements MCP natively.',
+  subtitle: `${METRICS.mcpServers} first-party MCP servers, RBAC-scoped and audit-logged. Agents discover tools via MCP. RevealUI implements MCP natively.`,
 };
 
 export const MARKETPLACE_HERO_NAV_ANCHORS = [
@@ -55,7 +59,7 @@ export const MARKETPLACE_DISCOVERY_STEPS: readonly DiscoveryStep[] = [
 
 export const MARKETPLACE_SERVERS_SECTION = {
   eyebrow: 'Open Source',
-  heading: '12 First-Party MCP Servers',
+  heading: `${METRICS.mcpServers} First-Party MCP Servers`,
   body: 'MCP servers included with RevealUI. Each server is rate-limited, audited, and governed by RBAC.',
 } as const;
 
@@ -122,6 +126,12 @@ export const MARKETPLACE_MCP_SERVERS: readonly McpServer[] = [
     description: 'Validate pricing contracts, check OpenAPI mirror drift, and inspect schema.',
     category: 'Development',
   },
+  {
+    name: 'MCP Adapter',
+    description:
+      'Base class plus concrete Vercel/Stripe/Neon adapters. Standardizes the MCP server contract — error handling, idempotency, observability — across every first-party server above. Source: packages/mcp/src/servers/adapter.ts.',
+    category: 'Framework',
+  },
 ];
 
 export const MARKETPLACE_COMING_SOON = {
@@ -138,7 +148,7 @@ export const MARKETPLACE_COMING_SOON = {
 
 export const MARKETPLACE_CTA = {
   heading: 'Start with the MCP server catalog',
-  body: '12 first-party servers ship with every RevealUI install. Read the MCP docs to wire your agents.',
+  body: `${METRICS.mcpServers} first-party servers ship with every RevealUI install. Read the MCP docs to wire your agents.`,
   primary: {
     label: 'MCP Documentation',
     href: SITE.urls.docsMcp,

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -1,4 +1,6 @@
-// Sourced from: app/routes/PricingPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/PricingPage.tsx (Phase 1 extraction).
+// Phase 3 (2026-05-18) update: agent-section MCP count now references
+// METRICS.mcpServers (canonical 13 per docs/MARKETING_METRICS.md §1).
 // Canonical pricing numbers re-exported from @revealui/contracts/pricing for component convenience.
 
 export {
@@ -7,7 +9,7 @@ export {
   SUBSCRIPTION_TIERS,
 } from '@revealui/contracts/pricing';
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 import type { Cta, SectionHeading } from './types';
 
 export interface CfoLineItem {
@@ -99,8 +101,8 @@ export const PRICING_AGENT_X402 = {
 
 export const PRICING_AGENT_MCP = {
   heading: 'MCP Servers',
-  // COUNT: mcp-servers = 13 (verified at packages/mcp/src/servers/, excluding _-prefixed helpers)
-  body: '13 production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright, Next.js DevTools, content management, and email. Marketplace discovery coming soon.',
+  // Count sourced from METRICS.mcpServers (canonical per docs/MARKETING_METRICS.md §1).
+  body: `${METRICS.mcpServers} production MCP servers including Stripe, Neon, Supabase, Vercel, Playwright, Next.js DevTools, content management, and email. Marketplace discovery coming soon.`,
   docsLink: {
     label: 'MCP docs →',
     href: SITE.urls.docsMcp,

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -4,8 +4,10 @@
 //   - ProductsPrimitive: full forYou/forAgents/together/features deep-dive (used by ProductsPage.tsx)
 //   Both are canonical here. Phase 4 reconciles any copy redundancy.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Phase 3 (2026-05-18) update: Intelligence primitive MCP count 12→13 per
+// docs/MARKETING_METRICS.md §1. Now uses METRICS.mcpServers.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 
 // ---------------------------------------------------------------------------
 // Landing (Home) primitives — compact card data
@@ -217,8 +219,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     },
     forAgents: {
       headline: 'A2A protocol, CRDT memory, and MCP servers',
-      description:
-        'Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and 12 production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.',
+      description: `Agent-to-agent communication, persistent memory with working, episodic, and vector layers, and ${METRICS.mcpServers} production MCP servers. Agents discover capabilities, remember context, and coordinate autonomously.`,
     },
     together: {
       headline: 'Build one business. Agents extend it. Neither locked to any vendor.',
@@ -228,7 +229,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     features: [
       'Open-model inference (Snaps, Ollama)',
       'CRDT-based agent memory (working + episodic + vector)',
-      '12 production MCP servers',
+      `${METRICS.mcpServers} production MCP servers`,
       'A2A agent-to-agent protocol',
       'Multi-agent coordination and orchestration',
     ],

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -1,9 +1,11 @@
-// Sourced from: app/routes/ProductsPage.tsx (Phase 1c, no copy changes).
-// ProductsPage-specific content: hero, stats bar, CTA section.
-// The 5 primitives data lives in ./primitives.ts (shared with landing).
+// Sourced from: app/routes/ProductsPage.tsx (Phase 1c extraction).
+// Phase 3 (2026-05-18) update: stats bar numbers now reference METRICS from
+// site.ts (single source per docs/MARKETING_METRICS.md §1). MCP count bumped
+// 12→13. "187+ Security tests" replaced with `${METRICS.testFiles}` (912 total
+// test files per validator) — the "187+" claim was unverifiable per plan §3.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 import type { Cta } from './types';
 
 export const PRODUCTS_PAGE_HERO = {
@@ -21,10 +23,10 @@ export const PRODUCTS_STATS_SECTION = {
   heading: 'Built to production standards',
   body: 'Not a starter template. A complete runtime with tested, documented, and audited code.',
   items: [
-    { stat: '26', label: 'workspace packages' },
-    { stat: '86', label: 'Database tables' },
-    { stat: '187+', label: 'Security tests' },
-    { stat: '12', label: 'first-party MCP servers' },
+    { stat: String(METRICS.packages), label: 'workspace packages' },
+    { stat: String(METRICS.dbTables), label: 'Database tables' },
+    { stat: String(METRICS.testFiles), label: 'test files' },
+    { stat: String(METRICS.mcpServers), label: 'first-party MCP servers' },
   ] as readonly StatItem[],
 } as const;
 

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -1,7 +1,9 @@
-// Sourced from: app/components/landing/Proof.tsx (Phase 1c, no copy changes).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/components/landing/Proof.tsx (Phase 1c extraction).
+// Phase 3 (2026-05-18) update: "21 of 26 packages MIT" trust card heading now
+// uses METRICS license split (20 MIT). Pre-Phase-3 audit had off-by-one count.
+// Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 
 export interface StackItem {
   readonly label: string;
@@ -54,10 +56,9 @@ export const PROOF_TRUST = {
   cards: [
     {
       eyebrow: 'In the repo',
-      heading: '21 of 26 packages MIT — forever.',
+      heading: `${METRICS.licenseSplit.mit} of ${METRICS.packages} packages MIT — forever.`,
       body: {
-        prefix:
-          'The 5 Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. View the',
+        prefix: `The ${METRICS.licenseSplit.fsl} Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. View the`,
         licenseLabel: 'LICENSE',
         licenseHref: SITE.urls.repoLicense,
         middle: 'or the',

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -1,10 +1,55 @@
-// Site-wide constants: URLs, contact, social, repo links, brand strings.
+// Site-wide constants: URLs, contact, social, repo links, brand strings, METRICS.
 // Sourced from extraction of inline JSX content in:
 //   app/components/Footer.tsx, app/components/GetStarted.tsx,
 //   app/components/landing/Hero.tsx, app/routes/*.tsx
 // Per docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
 // Phase 1b additions: repoRoadmap, apiDocs, revealcoinReadme.
 // Phase 1c additions: adminLogin, x, linkedin, forum, repoChangelog, repoLicense.
+// Phase 3 addition: METRICS export — canonical numbers from docs/MARKETING_METRICS.md §1
+//   (validated by `pnpm tsx scripts/validate/claim-drift.ts`). All content/* files
+//   that reference a count import METRICS rather than hardcoding the integer.
+//   When the underlying code changes (new package, new MCP server, etc.):
+//     1. Update docs/MARKETING_METRICS.md §1
+//     2. Update METRICS below to match
+//     3. Run claim-drift validator to confirm
+//     4. marketing content automatically reflects the new number — no copy edit needed
+
+/**
+ * Canonical marketing metrics — pinned-truth, sourced from
+ * docs/MARKETING_METRICS.md §1. Do NOT hardcode these integers anywhere
+ * else in apps/marketing/app/content/*.
+ */
+export const METRICS = {
+  /** Packages in `packages/` directories. Source: claim-drift countPackages. */
+  packages: 26,
+  /** Apps in `apps/`. Source: claim-drift countApps. */
+  apps: 4,
+  /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
+  workspaces: 30,
+  /** Test files across the monorepo. Source: claim-drift countTestFiles. */
+  testFiles: 912,
+  /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
+  uiComponents: 59,
+  /**
+   * MCP servers in `packages/mcp/src/servers/*.ts` (excluding underscore-prefixed
+   * utilities). Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon concrete
+   * adapter subclasses). Source: claim-drift countMCPServers.
+   */
+  mcpServers: 13,
+  /** Drizzle pgTable declarations across packages/db/src/schema/. Source: claim-drift countDbTables. */
+  dbTables: 86,
+  /** License split. Source: claim-drift licenseSplit. */
+  licenseSplit: {
+    /** MIT-licensed packages. */
+    mit: 20,
+    /** Fair Source (FSL-1.1-MIT) packages — @revealui/ai, engines, harnesses, mcp, services. */
+    fsl: 5,
+    /** Internal/none — `test` workspace package (private, no public license). */
+    internal: 1,
+  },
+} as const;
+
+export type Metrics = typeof METRICS;
 
 export const SITE = {
   brand: 'RevealUI',


### PR DESCRIPTION
## Summary

**Phase 3 of the marketing-overhaul lane** — regenerate `apps/marketing/app/content/*.ts` numbers from the pinned-truth doc landed in Phase 2 (`docs/MARKETING_METRICS.md`). All metric integers are now hoisted to `SITE.METRICS` in `content/site.ts`; content files import and interpolate, no more inline numbers.

Closes 7 of the 21 plan §3 drift items (D1-D6, D21 already fixed Phase 2.6, +D3 license-math).

### Adds

- **`content/site.ts` `METRICS` export** — canonical numbers (packages: 26, MCP: 13, db tables: 86, UI components: 59, test files: 912, license split: 20 MIT + 5 FSL + 1 internal). Mirrors `docs/MARKETING_METRICS.md §1`. The 4-step update protocol is documented in the file header — when code changes, update `MARKETING_METRICS.md` → update `METRICS` → run claim-drift → marketing automatically reflects the new value.

- **`marketplace.ts` 13th catalog entry**: "MCP Adapter" — explicitly explains the base class + Vercel/Stripe/Neon concrete subclasses pattern. Aligns the on-page count (12 named servers + adapter framework = 13) with the validator's count.

### Fixes per drift item

| Item | Surface | Before | After |
|---|---|---|---|
| **D1** | `marketplace.ts` hero/section/CTA | "12 first-party MCP servers" | `${METRICS.mcpServers}` (13) |
| **D2** | `primitives.ts` Intelligence | "12 production MCP servers" (2 spots) | `${METRICS.mcpServers}` (13) |
| **D2** | `pricing.ts` agent section | "13 production MCP servers" inline | `${METRICS.mcpServers}` (still 13, now sourced) |
| **D3** | `home.ts` Hero "What ships today" | "21 published + 5 private = 26" math | "20 MIT + 5 Fair Source + 1 internal = 26" (matches validator licenseSplit) |
| **D4** | `products.ts` stats bar | "187+ Security tests" (unverifiable) | `METRICS.testFiles` (912, validator-pinned) |
| **D5** | `products.ts` stats bar | "26 packages" / "86 tables" / "12 MCP" inline | `METRICS.*` references |
| **MIT-math** | `fair-source.ts` Hero | "21 of 26 MIT" | `${METRICS.licenseSplit.mit} of ${METRICS.packages}` (20 / 26) + explicit accounting of the 1 internal |
| **MIT-math** | `proof.ts` Trust card | "21 of 26 packages MIT" | `${METRICS.licenseSplit.mit} of ${METRICS.packages}` |

### Provenance

Every modified content file now leads with a comment block citing:
1. The Phase 1 extraction source (where this content came from)
2. The Phase 3 update reason (what changed + why)
3. The link to `docs/MARKETING_METRICS.md §1` (where to look when updating numbers)

### What's NOT in this PR (still pending Phases 4-6)

- Page separation-of-concerns rework + `/coming-soon` → `/roadmap` rename + redundancy elimination (Phase 4)
- Copy overhaul applying voice-and-headline-rules.md (Phase 5)
- Extended claim-drift validator + content/* contract tests + CI gate (Phase 6)

## Verification

- `pnpm --filter marketing typecheck` — pass
- `pnpm --filter marketing test` — 2/2 pass
- `pnpm --filter marketing build` — pass (chunk-size warning pre-existing, unchanged)
- `pnpm tsx scripts/validate/claim-drift.ts` — clean (all claims match codebase reality)
- `biome check apps/marketing/app/content/` — clean (1 auto-format applied to primitives.ts)
- Pre-push CI gate (secrets:scan + lint-staged + code standards) — PASS in 30s

## Test plan

- [ ] CI green on push
- [ ] Reviewer spot-checks `content/site.ts` `METRICS` block — confirms canonical numbers match `docs/MARKETING_METRICS.md §1`
- [ ] Reviewer confirms `marketplace.ts` 13th adapter entry makes sense as a customer-facing catalog item (it's explicitly framed as "Framework" category to distinguish from named service adapters)
- [ ] Vercel preview renders all pages with the new numbers
- [ ] Merge to test, watch for any auto-deploy regression
- [ ] Phase 4 (page separation + rename) opens once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
