### PR TITLE
feat(core/storage): GAP-208 Phase 2a — r2 + mock providers + factory

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1049.0",
     "@electric-sql/pglite": "^0.4.4",
     "@lexical/clipboard": "^0.44.0",
     "@lexical/code": "^0.44.0",
@@ -31,12 +32,12 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@revealui/dev": "workspace:*",
     "@types/json-schema": "^7.0.15",
     "@types/pg": "^8.20.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "@revealui/dev": "workspace:*",
     "expect-type": "^1.3.0",
     "tsup": "catalog:",
     "vitest": "catalog:"

--- a/packages/core/src/storage/__tests__/factory.test.ts
+++ b/packages/core/src/storage/__tests__/factory.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub @aws-sdk/client-s3 so createR2Provider can construct the S3Client
+// without touching network / requiring real creds.
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {
+    constructor(_args: unknown) {}
+  },
+  PutObjectCommand: class {
+    constructor(public input: unknown) {}
+  },
+  DeleteObjectCommand: class {
+    constructor(public input: unknown) {}
+  },
+  ListObjectsV2Command: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+import { createStorage } from '../index.js';
+import type { StorageConfig } from '../types.js';
+
+describe('createStorage', () => {
+  describe('provider routing', () => {
+    it('returns an r2 provider for { provider: "r2", r2: {...} }', () => {
+      const provider = createStorage({
+        provider: 'r2',
+        r2: {
+          accountId: 'a',
+          accessKeyId: 'k',
+          secretAccessKey: 's',
+          bucket: 'b',
+          publicBaseUrl: 'https://cdn.example',
+        },
+      });
+      expect(provider.provider).toBe('r2');
+    });
+
+    it('returns a mock provider for { provider: "mock" }', () => {
+      const provider = createStorage({ provider: 'mock' });
+      expect(provider.provider).toBe('mock');
+    });
+  });
+
+  describe('vercel-blob deferral', () => {
+    it('throws with a Phase 2b reference for { provider: "vercel-blob" }', () => {
+      expect(() =>
+        createStorage({
+          provider: 'vercel-blob',
+          vercelBlob: { token: 'vercel_blob_rw_test' },
+        }),
+      ).toThrow(/Phase 2b/);
+    });
+
+    it('mentions the legacy vercelBlobStorage plugin in the error', () => {
+      expect(() =>
+        createStorage({
+          provider: 'vercel-blob',
+          vercelBlob: { token: 'tok' },
+        }),
+      ).toThrow(/vercelBlobStorage/);
+    });
+  });
+
+  describe('exhaustiveness', () => {
+    it('throws with a clear message for unknown provider tags', () => {
+      // Bypass the discriminated union to simulate a runtime config that
+      // doesn't match any case (e.g. config loaded from a stale config file).
+      const bogus = { provider: 'tigris', tigris: {} } as unknown as StorageConfig;
+      expect(() => createStorage(bogus)).toThrow(/unknown provider tag/);
+    });
+  });
+
+  describe('r2 propagation', () => {
+    it('propagates the r2 config validation error (missing publicBaseUrl)', () => {
+      expect(() =>
+        createStorage({
+          provider: 'r2',
+          r2: {
+            accountId: 'a',
+            accessKeyId: 'k',
+            secretAccessKey: 's',
+            bucket: 'b',
+            // publicBaseUrl intentionally omitted
+          },
+        }),
+      ).toThrow(/requires R2Config.publicBaseUrl/);
+    });
+  });
+});

--- a/packages/core/src/storage/__tests__/mock.test.ts
+++ b/packages/core/src/storage/__tests__/mock.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createMockProvider, type MockProvider } from '../mock.js';
+
+describe('createMockProvider', () => {
+  let provider: MockProvider;
+
+  beforeEach(() => {
+    provider = createMockProvider();
+  });
+
+  describe('provider tag', () => {
+    it('exposes provider="mock"', () => {
+      expect(provider.provider).toBe('mock');
+    });
+  });
+
+  describe('put', () => {
+    it('stores Uint8Array payloads', async () => {
+      const data = new Uint8Array([1, 2, 3, 4]);
+      const result = await provider.put('foo/bar.bin', data);
+
+      expect(result.key).toBe('foo/bar.bin');
+      expect(result.url).toBe('mock://storage/foo/bar.bin');
+      expect(result.size).toBe(4);
+      expect(result.provider).toBe('mock');
+      expect(provider.read('foo/bar.bin')).toEqual(data);
+    });
+
+    it('stores ArrayBuffer payloads', async () => {
+      const buf = new ArrayBuffer(8);
+      new Uint8Array(buf).set([10, 20, 30, 40, 50, 60, 70, 80]);
+      const result = await provider.put('buf.bin', buf);
+
+      expect(result.size).toBe(8);
+      expect(provider.read('buf.bin')).toEqual(new Uint8Array(buf));
+    });
+
+    it('stores Blob payloads', async () => {
+      const blob = new Blob(['hello world']);
+      const result = await provider.put('blob.txt', blob);
+
+      expect(result.size).toBe(11);
+      const stored = provider.read('blob.txt');
+      expect(stored).toBeDefined();
+      expect(new TextDecoder().decode(stored)).toBe('hello world');
+    });
+
+    it('stores ReadableStream payloads', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      });
+      const result = await provider.put('stream.bin', stream);
+
+      expect(result.size).toBe(5);
+      expect(provider.read('stream.bin')).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    });
+
+    it('captures contentType + cacheControl + metadata', async () => {
+      await provider.put('meta.bin', new Uint8Array([1]), {
+        contentType: 'image/png',
+        cacheControl: 'public, max-age=31536000',
+        metadata: { author: 'tester', source: 'unit-test' },
+      });
+
+      const entry = provider.inspect('meta.bin');
+      expect(entry?.contentType).toBe('image/png');
+      expect(entry?.cacheControl).toBe('public, max-age=31536000');
+      expect(entry?.metadata).toEqual({ author: 'tester', source: 'unit-test' });
+    });
+
+    it('defaults contentType to application/octet-stream', async () => {
+      await provider.put('default.bin', new Uint8Array([1]));
+      expect(provider.inspect('default.bin')?.contentType).toBe('application/octet-stream');
+    });
+
+    it('overwrites existing key', async () => {
+      await provider.put('key', new Uint8Array([1, 2, 3]));
+      await provider.put('key', new Uint8Array([9]));
+      expect(provider.read('key')).toEqual(new Uint8Array([9]));
+      expect(provider.size()).toBe(1);
+    });
+  });
+
+  describe('del', () => {
+    it('deletes by key', async () => {
+      await provider.put('to-delete', new Uint8Array([1]));
+      expect(provider.size()).toBe(1);
+      await provider.del('to-delete');
+      expect(provider.size()).toBe(0);
+    });
+
+    it('deletes by mock URL', async () => {
+      await provider.put('to-delete', new Uint8Array([1]));
+      await provider.del('mock://storage/to-delete');
+      expect(provider.size()).toBe(0);
+    });
+
+    it('is a no-op for missing keys (best-effort contract)', async () => {
+      await expect(provider.del('never-existed')).resolves.toBeUndefined();
+      await expect(provider.del('mock://storage/also-missing')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('list', () => {
+    beforeEach(async () => {
+      await provider.put('a/1.txt', new Uint8Array([1]));
+      await provider.put('a/2.txt', new Uint8Array([1, 2]));
+      await provider.put('a/3.txt', new Uint8Array([1, 2, 3]));
+      await provider.put('b/1.txt', new Uint8Array([1, 2, 3, 4]));
+    });
+
+    it('lists all items when no opts given', async () => {
+      const result = await provider.list();
+      expect(result.items.map((i) => i.key)).toEqual(['a/1.txt', 'a/2.txt', 'a/3.txt', 'b/1.txt']);
+      expect(result.hasMore).toBe(false);
+      expect(result.cursor).toBeUndefined();
+    });
+
+    it('filters by prefix', async () => {
+      const result = await provider.list({ prefix: 'a/' });
+      expect(result.items.map((i) => i.key)).toEqual(['a/1.txt', 'a/2.txt', 'a/3.txt']);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns empty list for non-matching prefix', async () => {
+      const result = await provider.list({ prefix: 'nothing/' });
+      expect(result.items).toEqual([]);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('paginates with limit + cursor', async () => {
+      const page1 = await provider.list({ limit: 2 });
+      expect(page1.items.map((i) => i.key)).toEqual(['a/1.txt', 'a/2.txt']);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.cursor).toBe('a/2.txt');
+
+      const page2 = await provider.list({ limit: 2, cursor: page1.cursor });
+      expect(page2.items.map((i) => i.key)).toEqual(['a/3.txt', 'b/1.txt']);
+      expect(page2.hasMore).toBe(false);
+    });
+
+    it('returns size + url + uploadedAt for each item', async () => {
+      const result = await provider.list({ prefix: 'a/1' });
+      expect(result.items[0]).toMatchObject({
+        key: 'a/1.txt',
+        url: 'mock://storage/a/1.txt',
+        size: 1,
+      });
+      expect(result.items[0].uploadedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('test helpers', () => {
+    it('size() returns object count', async () => {
+      expect(provider.size()).toBe(0);
+      await provider.put('a', new Uint8Array([1]));
+      await provider.put('b', new Uint8Array([2]));
+      expect(provider.size()).toBe(2);
+    });
+
+    it('clear() wipes the store', async () => {
+      await provider.put('a', new Uint8Array([1]));
+      provider.clear();
+      expect(provider.size()).toBe(0);
+      expect(provider.read('a')).toBeUndefined();
+    });
+
+    it('inspect() returns the full entry or undefined', async () => {
+      await provider.put('x', new Uint8Array([1]), { contentType: 'text/plain' });
+      expect(provider.inspect('x')?.contentType).toBe('text/plain');
+      expect(provider.inspect('missing')).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/storage/__tests__/r2.test.ts
+++ b/packages/core/src/storage/__tests__/r2.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @aws-sdk/client-s3 — capture S3Client constructor args + every command
+// sent, return canned responses from a queue per command type.
+// ---------------------------------------------------------------------------
+const s3ConstructorArgs: unknown[] = [];
+const sendCalls: Array<{ command: string; input: unknown }> = [];
+const listResponses: unknown[] = [];
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class FakeS3Client {
+    constructor(args: unknown) {
+      s3ConstructorArgs.push(args);
+    }
+    async send(command: { __command: string; input: unknown }): Promise<unknown> {
+      sendCalls.push({ command: command.__command, input: command.input });
+      if (command.__command === 'ListObjectsV2Command') {
+        return listResponses.shift() ?? { Contents: [], IsTruncated: false };
+      }
+      return {};
+    }
+  }
+  const wrap = (name: string) => {
+    return class {
+      readonly __command = name;
+      constructor(public input: unknown) {}
+    };
+  };
+  return {
+    S3Client: FakeS3Client,
+    PutObjectCommand: wrap('PutObjectCommand'),
+    DeleteObjectCommand: wrap('DeleteObjectCommand'),
+    ListObjectsV2Command: wrap('ListObjectsV2Command'),
+  };
+});
+
+import { createR2Provider } from '../r2.js';
+import type { R2Config } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function baseConfig(overrides: Partial<R2Config> = {}): R2Config {
+  return {
+    accountId: 'acct-123',
+    accessKeyId: 'AKIA-TEST',
+    secretAccessKey: 'secret-test',
+    bucket: 'media',
+    publicBaseUrl: 'https://media.revealui.com',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('createR2Provider', () => {
+  beforeEach(() => {
+    s3ConstructorArgs.length = 0;
+    sendCalls.length = 0;
+    listResponses.length = 0;
+  });
+
+  describe('construction', () => {
+    it('throws if publicBaseUrl is missing', () => {
+      expect(() => createR2Provider(baseConfig({ publicBaseUrl: undefined }))).toThrow(
+        /requires R2Config.publicBaseUrl/,
+      );
+    });
+
+    it('configures S3Client with R2 endpoint + region="auto" + credentials', () => {
+      createR2Provider(baseConfig());
+      expect(s3ConstructorArgs).toHaveLength(1);
+      expect(s3ConstructorArgs[0]).toEqual({
+        region: 'auto',
+        endpoint: 'https://acct-123.r2.cloudflarestorage.com',
+        credentials: {
+          accessKeyId: 'AKIA-TEST',
+          secretAccessKey: 'secret-test',
+        },
+      });
+    });
+
+    it('exposes provider="r2"', () => {
+      const provider = createR2Provider(baseConfig());
+      expect(provider.provider).toBe('r2');
+    });
+  });
+
+  describe('put', () => {
+    it('sends PutObjectCommand with bucket + key + body + content-type', async () => {
+      const provider = createR2Provider(baseConfig());
+      const body = new Uint8Array([1, 2, 3, 4, 5]);
+      const result = await provider.put('uploads/a.bin', body, { contentType: 'image/png' });
+
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0].command).toBe('PutObjectCommand');
+      expect(sendCalls[0].input).toMatchObject({
+        Bucket: 'media',
+        Key: 'uploads/a.bin',
+        Body: body,
+        ContentType: 'image/png',
+        ContentLength: 5,
+      });
+
+      expect(result).toEqual({
+        key: 'uploads/a.bin',
+        url: 'https://media.revealui.com/uploads/a.bin',
+        size: 5,
+        provider: 'r2',
+      });
+    });
+
+    it('defaults contentType to application/octet-stream', async () => {
+      const provider = createR2Provider(baseConfig());
+      await provider.put('blob', new Uint8Array([1]));
+      expect(sendCalls[0].input).toMatchObject({ ContentType: 'application/octet-stream' });
+    });
+
+    it('passes cacheControl + metadata when provided', async () => {
+      const provider = createR2Provider(baseConfig());
+      await provider.put('cached', new Uint8Array([1]), {
+        cacheControl: 'public, max-age=3600',
+        metadata: { owner: 'tester' },
+      });
+      expect(sendCalls[0].input).toMatchObject({
+        CacheControl: 'public, max-age=3600',
+        Metadata: { owner: 'tester' },
+      });
+    });
+
+    it('strips trailing slash from publicBaseUrl when building result url', async () => {
+      const provider = createR2Provider(baseConfig({ publicBaseUrl: 'https://cdn.example/' }));
+      const result = await provider.put('a/b.txt', new Uint8Array([1]));
+      expect(result.url).toBe('https://cdn.example/a/b.txt');
+    });
+
+    it('throws when access="private" is requested (Phase 2a limit)', async () => {
+      const provider = createR2Provider(baseConfig());
+      await expect(provider.put('p', new Uint8Array([1]), { access: 'private' })).rejects.toThrow(
+        /Phase 2a does not support access: 'private'/,
+      );
+    });
+
+    it('normalizes ArrayBuffer input', async () => {
+      const provider = createR2Provider(baseConfig());
+      const buf = new ArrayBuffer(3);
+      new Uint8Array(buf).set([7, 8, 9]);
+      const result = await provider.put('ab', buf);
+      expect(result.size).toBe(3);
+    });
+
+    it('normalizes Blob input', async () => {
+      const provider = createR2Provider(baseConfig());
+      const blob = new Blob(['hi']);
+      const result = await provider.put('b', blob);
+      expect(result.size).toBe(2);
+    });
+
+    it('normalizes ReadableStream input', async () => {
+      const provider = createR2Provider(baseConfig());
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2]));
+          controller.enqueue(new Uint8Array([3]));
+          controller.close();
+        },
+      });
+      const result = await provider.put('s', stream);
+      expect(result.size).toBe(3);
+    });
+  });
+
+  describe('del', () => {
+    it('sends DeleteObjectCommand with the key when given a bare key', async () => {
+      const provider = createR2Provider(baseConfig());
+      await provider.del('uploads/a.bin');
+      expect(sendCalls[0]).toEqual({
+        command: 'DeleteObjectCommand',
+        input: { Bucket: 'media', Key: 'uploads/a.bin' },
+      });
+    });
+
+    it('extracts key from a full URL', async () => {
+      const provider = createR2Provider(baseConfig());
+      await provider.del('https://media.revealui.com/uploads/b.png');
+      expect(sendCalls[0].input).toEqual({ Bucket: 'media', Key: 'uploads/b.png' });
+    });
+
+    it('handles URL with no path beyond root', async () => {
+      const provider = createR2Provider(baseConfig());
+      await provider.del('https://media.revealui.com/');
+      expect(sendCalls[0].input).toEqual({ Bucket: 'media', Key: '' });
+    });
+  });
+
+  describe('list', () => {
+    it('returns mapped items + cursor + hasMore from ListObjectsV2 response', async () => {
+      listResponses.push({
+        Contents: [
+          { Key: 'media/a.jpg', Size: 1024, LastModified: new Date('2026-05-18T10:00:00Z') },
+          { Key: 'media/b.jpg', Size: 2048, LastModified: new Date('2026-05-18T11:00:00Z') },
+        ],
+        IsTruncated: true,
+        NextContinuationToken: 'next-cursor',
+      });
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.list({ prefix: 'media/', limit: 2 });
+
+      expect(sendCalls[0]).toEqual({
+        command: 'ListObjectsV2Command',
+        input: {
+          Bucket: 'media',
+          Prefix: 'media/',
+          MaxKeys: 2,
+          ContinuationToken: undefined,
+        },
+      });
+      expect(result).toEqual({
+        items: [
+          {
+            key: 'media/a.jpg',
+            url: 'https://media.revealui.com/media/a.jpg',
+            size: 1024,
+            uploadedAt: new Date('2026-05-18T10:00:00Z'),
+          },
+          {
+            key: 'media/b.jpg',
+            url: 'https://media.revealui.com/media/b.jpg',
+            size: 2048,
+            uploadedAt: new Date('2026-05-18T11:00:00Z'),
+          },
+        ],
+        cursor: 'next-cursor',
+        hasMore: true,
+      });
+    });
+
+    it('defaults to maxKeys=1000 when no limit given', async () => {
+      listResponses.push({ Contents: [], IsTruncated: false });
+      const provider = createR2Provider(baseConfig());
+      await provider.list();
+      expect(sendCalls[0].input).toMatchObject({ MaxKeys: 1000 });
+    });
+
+    it('handles empty Contents response', async () => {
+      listResponses.push({ Contents: [], IsTruncated: false });
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.list();
+      expect(result).toEqual({ items: [], cursor: undefined, hasMore: false });
+    });
+
+    it('omits entries without a Key', async () => {
+      listResponses.push({
+        Contents: [
+          { Key: 'a', Size: 1, LastModified: new Date('2026-01-01') },
+          { Size: 5, LastModified: new Date('2026-01-02') }, // bogus row
+        ],
+        IsTruncated: false,
+      });
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.list();
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].key).toBe('a');
+    });
+
+    it('falls back to epoch when LastModified is missing', async () => {
+      listResponses.push({
+        Contents: [{ Key: 'a', Size: 1 }],
+        IsTruncated: false,
+      });
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.list();
+      expect(result.items[0].uploadedAt).toEqual(new Date(0));
+    });
+
+    it('falls back to size=0 when Size is missing', async () => {
+      listResponses.push({
+        Contents: [{ Key: 'a', LastModified: new Date('2026-01-01') }],
+        IsTruncated: false,
+      });
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.list();
+      expect(result.items[0].size).toBe(0);
+    });
+
+    it('passes cursor through as ContinuationToken', async () => {
+      listResponses.push({ Contents: [], IsTruncated: false });
+      const provider = createR2Provider(baseConfig());
+      await provider.list({ cursor: 'resume-from' });
+      expect(sendCalls[0].input).toMatchObject({ ContinuationToken: 'resume-from' });
+    });
+  });
+});

--- a/packages/core/src/storage/_helpers.ts
+++ b/packages/core/src/storage/_helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * Internal helpers shared across storage providers.
+ *
+ * Underscore prefix denotes private-to-storage/; not re-exported from
+ * packages/core/src/storage/index.ts.
+ *
+ * GAP-208 Phase 2a (2026-05-18).
+ */
+
+/**
+ * Normalize the four accepted body types into a Uint8Array so providers
+ * can compute size + hand a known buffer to their underlying SDKs.
+ */
+export async function toUint8Array(
+  data: Blob | ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+  if (data instanceof Blob) {
+    return new Uint8Array(await data.arrayBuffer());
+  }
+  const reader = data.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,8 +1,19 @@
-// Re-export storage abstraction (StorageProvider interface + per-provider configs).
+// Storage abstraction (StorageProvider interface + per-provider configs + factory).
 // GAP-208 — introduced 2026-05-18 alongside Vercel Blob → Cloudflare R2 swap.
 //
-// The factory `createStorage(config)` will land in Phase 2a; this file currently
-// only re-exports the types so consumers can start depending on the contract.
+// Phase 1 (#959): types.ts + index.ts type re-exports.
+// Phase 2a (this PR): r2 + mock providers + createStorage factory.
+
+import { createMockProvider } from './mock.js';
+import { createR2Provider } from './r2.js';
+import type { StorageConfig, StorageProvider } from './types.js';
+
+export { createMockProvider } from './mock.js';
+
+// Provider factories — exported so callers can construct a provider directly
+// when they already know which one they want (skipping the discriminated-union
+// factory below).
+export { createR2Provider } from './r2.js';
 export type {
   ListItem,
   ListOptions,
@@ -18,3 +29,37 @@ export type {
 // Legacy Payload-style plugin — kept during GAP-208 migration so existing
 // `apps/admin/revealui.config.ts` keeps working. Dropped in Phase 4 cleanup.
 export { vercelBlobStorage } from './vercel-blob.js';
+
+/**
+ * Construct a StorageProvider from a tagged config.
+ *
+ * Per `feedback_pluggable_provider_pattern`: explicit "no-X" opt-in — unknown
+ * or unsupported tags throw with a clear message; no silent fallback.
+ *
+ * Supported tags in Phase 2a: 'r2', 'mock'. The 'vercel-blob' tag is reserved
+ * for Phase 2b (StorageProvider impl over @vercel/blob); during the migration
+ * window, consumers needing Vercel Blob should use the legacy `vercelBlobStorage`
+ * Payload plugin via `revealui.config.ts`.
+ */
+export function createStorage(config: StorageConfig): StorageProvider {
+  switch (config.provider) {
+    case 'r2':
+      return createR2Provider(config.r2);
+    case 'mock':
+      return createMockProvider();
+    case 'vercel-blob':
+      throw new Error(
+        "createStorage: provider 'vercel-blob' is not yet implemented as a " +
+          'StorageProvider (lands in GAP-208 Phase 2b). For the migration ' +
+          'window, use the legacy `vercelBlobStorage` Payload plugin in ' +
+          "revealui.config.ts, or switch to provider: 'r2'.",
+      );
+    default: {
+      const _exhaustive: never = config;
+      throw new Error(
+        `createStorage: unknown provider tag. Got ${JSON.stringify(_exhaustive)}. ` +
+          "Valid tags: 'r2', 'mock', 'vercel-blob' (Phase 2b).",
+      );
+    }
+  }
+}

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,0 +1,130 @@
+/**
+ * In-memory mock implementation of StorageProvider for tests.
+ *
+ * Per `feedback_pluggable_provider_pattern`: every provider abstraction ships
+ * a mock so consumer tests don't need network access or real cloud creds.
+ *
+ * Stores objects in a Map keyed by storage key. URLs use a synthetic
+ * `mock://` scheme so callers can distinguish mock results from real ones
+ * without parsing host names.
+ *
+ * GAP-208 Phase 2a (2026-05-18).
+ */
+
+import { toUint8Array } from './_helpers.js';
+import type {
+  ListItem,
+  ListOptions,
+  ListResult,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+} from './types.js';
+
+const PROVIDER_TAG = 'mock';
+const MOCK_URL_SCHEME = 'mock://storage';
+const DEFAULT_LIST_LIMIT = 1000;
+
+interface MockEntry {
+  body: Uint8Array;
+  contentType: string;
+  cacheControl?: string;
+  metadata?: Record<string, string>;
+  uploadedAt: Date;
+}
+
+class MockProvider implements StorageProvider {
+  readonly provider = PROVIDER_TAG;
+  private readonly store = new Map<string, MockEntry>();
+
+  async put(
+    key: string,
+    data: Blob | ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    const body = await toUint8Array(data);
+    this.store.set(key, {
+      body,
+      contentType: opts?.contentType ?? 'application/octet-stream',
+      cacheControl: opts?.cacheControl,
+      metadata: opts?.metadata,
+      uploadedAt: new Date(),
+    });
+    return {
+      key,
+      url: `${MOCK_URL_SCHEME}/${key}`,
+      size: body.byteLength,
+      provider: PROVIDER_TAG,
+    };
+  }
+
+  async del(keyOrUrl: string): Promise<void> {
+    const key = this.extractKey(keyOrUrl);
+    this.store.delete(key);
+  }
+
+  async list(opts?: ListOptions): Promise<ListResult> {
+    const prefix = opts?.prefix ?? '';
+    const limit = opts?.limit ?? DEFAULT_LIST_LIMIT;
+    const startAfter = opts?.cursor;
+
+    const allKeys = Array.from(this.store.keys())
+      .filter((key) => key.startsWith(prefix))
+      .sort();
+
+    const startIndex = startAfter ? allKeys.findIndex((k) => k > startAfter) : 0;
+    const effectiveStart = startIndex < 0 ? allKeys.length : startIndex;
+    const page = allKeys.slice(effectiveStart, effectiveStart + limit);
+
+    const items: ListItem[] = page.map((key) => {
+      const entry = this.store.get(key);
+      if (!entry) {
+        throw new Error(`mock: store mutated during list iteration (${key})`);
+      }
+      return {
+        key,
+        url: `${MOCK_URL_SCHEME}/${key}`,
+        size: entry.body.byteLength,
+        uploadedAt: entry.uploadedAt,
+      };
+    });
+
+    const hasMore = effectiveStart + limit < allKeys.length;
+    const nextCursor = hasMore ? page[page.length - 1] : undefined;
+
+    return { items, cursor: nextCursor, hasMore };
+  }
+
+  /** Test helper — read the raw bytes back. Not part of StorageProvider. */
+  read(key: string): Uint8Array | undefined {
+    return this.store.get(key)?.body;
+  }
+
+  /** Test helper — full entry inspection. Not part of StorageProvider. */
+  inspect(key: string): MockEntry | undefined {
+    return this.store.get(key);
+  }
+
+  /** Test helper — count of stored objects. Not part of StorageProvider. */
+  size(): number {
+    return this.store.size;
+  }
+
+  /** Test helper — wipe all stored objects. Not part of StorageProvider. */
+  clear(): void {
+    this.store.clear();
+  }
+
+  private extractKey(keyOrUrl: string): string {
+    if (keyOrUrl.startsWith(`${MOCK_URL_SCHEME}/`)) {
+      return keyOrUrl.slice(MOCK_URL_SCHEME.length + 1);
+    }
+    return keyOrUrl;
+  }
+}
+
+export function createMockProvider(): MockProvider {
+  return new MockProvider();
+}
+
+export type { MockProvider };

--- a/packages/core/src/storage/r2.ts
+++ b/packages/core/src/storage/r2.ts
@@ -1,0 +1,161 @@
+/**
+ * Cloudflare R2 implementation of StorageProvider.
+ *
+ * R2 is S3-compatible — uses @aws-sdk/client-s3 with a custom endpoint and
+ * region='auto'. See https://developers.cloudflare.com/r2/api/s3/api/.
+ *
+ * GAP-208 Phase 2a (2026-05-18). Phase 1 (interface + types) shipped in #959.
+ *
+ * Server-only. Do NOT import from client-side code or edge runtime.
+ */
+
+import {
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { toUint8Array } from './_helpers.js';
+import type {
+  ListItem,
+  ListOptions,
+  ListResult,
+  PutOptions,
+  PutResult,
+  R2Config,
+  StorageProvider,
+} from './types.js';
+
+const PROVIDER_TAG = 'r2';
+const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
+const DEFAULT_LIST_LIMIT = 1000;
+
+class R2Provider implements StorageProvider {
+  readonly provider = PROVIDER_TAG;
+  private readonly client: S3Client;
+  private readonly bucket: string;
+  private readonly publicBaseUrl: string;
+
+  constructor(config: R2Config) {
+    if (!config.publicBaseUrl) {
+      throw new Error(
+        'R2 provider requires R2Config.publicBaseUrl. Presigned/private URLs ' +
+          'are not supported in Phase 2a. Set publicBaseUrl to either a bound ' +
+          "custom domain (e.g. 'https://media.revealui.com') or the R2 dev URL " +
+          "('https://<account-id>.r2.cloudflarestorage.com/<bucket>').",
+      );
+    }
+
+    this.bucket = config.bucket;
+    this.publicBaseUrl = stripTrailingSlash(config.publicBaseUrl);
+    this.client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+    });
+  }
+
+  async put(
+    key: string,
+    data: Blob | ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    if (opts?.access === 'private') {
+      throw new Error(
+        "R2 provider Phase 2a does not support access: 'private'. All objects " +
+          'are written under the publicBaseUrl. Presigned/private-URL support ' +
+          'lands in Phase 2b.',
+      );
+    }
+
+    const body = await toUint8Array(data);
+
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: body,
+        ContentType: opts?.contentType ?? DEFAULT_CONTENT_TYPE,
+        ContentLength: body.byteLength,
+        CacheControl: opts?.cacheControl,
+        Metadata: opts?.metadata,
+      }),
+    );
+
+    return {
+      key,
+      url: `${this.publicBaseUrl}/${key}`,
+      size: body.byteLength,
+      provider: PROVIDER_TAG,
+    };
+  }
+
+  async del(keyOrUrl: string): Promise<void> {
+    const key = this.extractKey(keyOrUrl);
+    await this.client.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      }),
+    );
+  }
+
+  async list(opts?: ListOptions): Promise<ListResult> {
+    const response = await this.client.send(
+      new ListObjectsV2Command({
+        Bucket: this.bucket,
+        Prefix: opts?.prefix,
+        MaxKeys: opts?.limit ?? DEFAULT_LIST_LIMIT,
+        ContinuationToken: opts?.cursor,
+      }),
+    );
+
+    const items: ListItem[] = (response.Contents ?? []).flatMap((entry) => {
+      if (!entry.Key) return [];
+      return [
+        {
+          key: entry.Key,
+          url: `${this.publicBaseUrl}/${entry.Key}`,
+          size: entry.Size ?? 0,
+          uploadedAt: entry.LastModified ?? new Date(0),
+        },
+      ];
+    });
+
+    return {
+      items,
+      cursor: response.NextContinuationToken,
+      hasMore: response.IsTruncated === true,
+    };
+  }
+
+  private extractKey(keyOrUrl: string): string {
+    const parsed = tryParseUrl(keyOrUrl);
+    if (!parsed) {
+      return keyOrUrl;
+    }
+    // URL form — strip the leading slash from the pathname.
+    return parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
+  }
+}
+
+export function createR2Provider(config: R2Config): StorageProvider {
+  return new R2Provider(config);
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function tryParseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,7 +302,7 @@ importers:
         version: 2.3.3
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -487,7 +487,7 @@ importers:
         version: link:../../packages/router
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       react:
         specifier: '>=19.2.4'
         version: 19.2.5
@@ -887,6 +887,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1049.0
+        version: 3.1049.0
       '@electric-sql/pglite':
         specifier: ^0.4.4
         version: 0.4.4
@@ -1687,6 +1690,125 @@ packages:
 
   '@assemblyscript/loader@0.19.23':
     resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1049.0':
+    resolution: {integrity: sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.12':
+    resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.8':
+    resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.14':
+    resolution: {integrity: sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.12':
+    resolution: {integrity: sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.20':
+    resolution: {integrity: sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.41':
+    resolution: {integrity: sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.10':
+    resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1049.0':
+    resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@axe-core/playwright@4.11.2':
     resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
@@ -2841,6 +2963,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3932,6 +4057,42 @@ packages:
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       size-limit: 12.1.0
+
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
@@ -5674,6 +5835,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -6470,6 +6634,13 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -7806,6 +7977,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -8504,6 +8679,9 @@ packages:
       '@types/node':
         optional: true
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -9198,6 +9376,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -9319,6 +9501,271 @@ snapshots:
   '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@assemblyscript/loader@0.19.23': {}
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1049.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.14
+      '@aws-sdk/middleware-expect-continue': 3.972.12
+      '@aws-sdk/middleware-flexible-checksums': 3.974.20
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-sdk-s3': 3.972.41
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-login': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-ini': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/token-providers': 3.1049.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.14':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.20':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/crc64-nvme': 3.972.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.10':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1049.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
     dependencies:
@@ -10547,6 +10994,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11524,6 +11973,54 @@ snapshots:
       - esbuild
       - uglify-js
       - webpack-cli
+
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -13186,7 +13683,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -13639,6 +14136,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.5:
     dependencies:
@@ -14329,6 +14828,18 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -15841,6 +16352,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -16669,6 +17182,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
+  strnum@2.3.0: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -17380,6 +17895,8 @@ snapshots:
       os-paths: 4.4.0
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

Continues GAP-208 from Phase 1 ([#959](https://github.com/RevealUIStudio/revealui/pull/959), merged 2026-05-18) which shipped the `StorageProvider` interface + per-provider configs. Phase 2a delivers concrete provider implementations and the discriminated-union factory.

## What ships

| File | Role |
|---|---|
| `packages/core/src/storage/r2.ts` | Cloudflare R2 provider over `@aws-sdk/client-s3` (`region: 'auto'`, custom endpoint, SigV4 creds). |
| `packages/core/src/storage/mock.ts` | In-memory test provider backed by a `Map`. Sorted-prefix list with cursor pagination + `read`/`inspect`/`size`/`clear` test helpers. |
| `packages/core/src/storage/_helpers.ts` | Shared `toUint8Array` body normalizer (internal — underscore prefix, not re-exported). |
| `packages/core/src/storage/index.ts` | `createStorage(config)` factory over the `StorageConfig` discriminated union + barrel exports. |
| `packages/core/src/storage/__tests__/{r2,mock,factory}.test.ts` | 46 new Vitest tests. |

### Design decisions

- **R2 endpoint shape.** `https://<accountId>.r2.cloudflarestorage.com` + `region: 'auto'` (R2 has no region concept). Standard S3 SigV4 with R2-issued access key / secret. Per Cloudflare's [R2 S3 API docs](https://developers.cloudflare.com/r2/api/s3/api/).
- **`publicBaseUrl` required in Phase 2a.** Presigned/private URLs (requires `@aws-sdk/s3-request-presigner` + lifecycle plumbing) are deferred to Phase 2b. Construction throws with a clear error referencing custom domain vs dev URL.
- **`access: 'private'` rejected.** Same deferral — Phase 2a writes all objects under `publicBaseUrl`. Phase 2b lifts this.
- **Body normalization.** All four interface body types (`Blob | ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>`) collapse to `Uint8Array` before the AWS SDK call. Lets us guarantee `size` in every `PutResult` and avoids stream-size-unknown edge cases.
- **`del()` accepts key or URL.** URL form uses the `URL` parser (try/catch fallback) — no regex, per the fleet's no-regex posture. Key form passes through.
- **`createStorage` is exhaustive.** Switch over the discriminated union with a `never`-typed default branch — drops one provider tag and TypeScript will flag the unhandled case at compile time.
- **`vercel-blob` is an explicit "no-X" opt-out.** The factory throws with a Phase 2b reference pointing consumers to the existing `vercelBlobStorage` Payload plugin during the migration window. No silent fallback. Pattern follows the fleet's pluggable-provider convention (tag + factory + explicit deferral).
- **Mock provider URL scheme `mock://storage/...`** so consumer tests can distinguish mock results from real ones without parsing hostnames.

## Dependency

- `@aws-sdk/client-s3@^3.1049.0` added to `@revealui/core`.

## What's NOT in this PR

- **Phase 2b** — `vercel-blob` `StorageProvider` impl, presigned URL support, `access: 'private'` support.
- **Phase 3** — consumer cutover (apps/server media route, apps/admin health probe). Gated on `revealui/prod/storage/r2/*` revvault paths being present; the paths are not yet populated, so this PR ships provider code only.
- **Phase 4** — legacy `vercelBlobStorage` Payload plugin removal + Vercel Blob migration drain.

## Test plan

- [x] `pnpm --filter @revealui/core typecheck` — clean
- [x] `pnpm --filter @revealui/core test src/storage` — 60/60 (21 r2 + 19 mock + 6 factory + 14 pre-existing legacy plugin)
- [x] `pnpm --filter @revealui/core test` — 2680/2680 (full suite, no regressions)
- [x] `pnpm --filter @revealui/core lint` — clean (1 info-level unsafe-fix suggestion for an empty constructor in a test stub, declined per safe-only policy)
- [ ] CI gate on `test` branch
