### PR TITLE
docs(claude): drop React patch version from CLAUDE.md status line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Key postures — full definitions in `docs/methodology.md`.
 - All workspaces build and typecheck clean (run `pnpm build` and `pnpm typecheck:all`)
 - Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
 - Pinned overrides enforce minimum safe versions for transitive deps (see `pnpm.overrides` block in root `package.json`)
-- React 19.2.5 (CVE-2025-55182 React2Shell patched)
+- React 19 (resolved patch tracked via `pnpm-lock.yaml`; minimum-safe range pinned per `pnpm.overrides`; CVE-2025-55182 React2Shell mitigated)
 - GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; future triage trackers land in the private `revealui-jv` repo per the issue-redaction convention
 - AST-based code-pattern analyzer: execSync injection, TOCTOU, ReDoS (ret parser + contracts schemas)
 - Pre-push gate runs affected tests on protected branches


### PR DESCRIPTION
## Summary

`CLAUDE.md` `## Build & Security Status` line 195 quoted a specific React patch version (`React 19.2.5`). Patch numbers in this doc drift every time pnpm resolves a new patch — `package.json` semver ranges target `^19.2.6` and Dependabot/manual bumps land regularly, so the literal number desyncs from `pnpm-lock.yaml` within days.

Replace the patch reference with durable wording pointing at the authoritative sources (`pnpm-lock.yaml` for the resolved version, `pnpm.overrides` for the minimum-safe pin). CVE-2025-55182 React2Shell mitigation reference preserved — it's the load-bearing claim the line was added to make.

## Before / After

```diff
-- React 19.2.5 (CVE-2025-55182 React2Shell patched)
+- React 19 (resolved patch tracked via `pnpm-lock.yaml`; minimum-safe range pinned per `pnpm.overrides`; CVE-2025-55182 React2Shell mitigated)
```

## Test plan

- [x] `grep "React 19" CLAUDE.md` — returns the new line
- [ ] CI gate on `test` branch (markdown-only change, no code-affecting paths)
