### PR TITLE
feat(marketing): rebuild /products as RevFleet family lineup

### DIFF
--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -1,18 +1,218 @@
-// Sourced from: app/routes/ProductsPage.tsx (Phase 1c extraction).
-// Phase 3 (2026-05-18) update: stats bar numbers now reference METRICS from
-// site.ts (single source per docs/MARKETING_METRICS.md §1). MCP count bumped
-// 12→13. "187+ Security tests" replaced with `${METRICS.testFiles}` (912 total
-// test files per validator) — the "187+" claim was unverifiable per plan §3.
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// RevFleet product family roster — the actual products RevealUI Studio ships.
+//
+// Sourced from per-product README audit (2026-05-18) cross-referenced against
+// docs/lanes/marketing-overhaul/plan.md §2.1 (canonical status table). Owner
+// directive 2026-05-18 redirected /products from "5 primitives deep-dive" to
+// "RevFleet product family lineup". RevealCoin omitted per
+// project_revealcoin_shelved_2026_05_15 memory. The legacy primitives data
+// (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
+// relocation to a /concepts or /platform page per lane owner's discretion.
+//
+// Status semantics:
+//   Beta         — production-ready code, limited paying users / dogfooded
+//   Alpha        — development-preview quality; works, ships, may break
+//   Active (MIT) — released, free-and-open library, no SLA
+//   Planned      — code-complete or scaffolded, not yet shipped to users
 
 import { METRICS, SITE } from './site';
 import type { Cta } from './types';
 
 export const PRODUCTS_PAGE_HERO = {
-  h1: 'Five primitives. One runtime.',
+  h1: 'The RevFleet product family',
   subtitle:
-    'Users, content, products, payments, and intelligence — pre-wired and exposed to your agents via MCP.',
+    'One foundation. Eight products. Each one ships today or ships soon — built and operated by RevealUI Studio.',
 } as const;
+
+export type ProductStatus = 'Beta' | 'Alpha' | 'Active (MIT)' | 'Planned';
+
+export interface ProductStatusStyle {
+  readonly bg: string;
+  readonly text: string;
+  readonly ring: string;
+}
+
+export const PRODUCT_STATUS_STYLES: Readonly<Record<ProductStatus, ProductStatusStyle>> = {
+  Beta: {
+    bg: 'bg-emerald-500/10',
+    text: 'text-emerald-700',
+    ring: 'ring-emerald-500/30',
+  },
+  Alpha: {
+    bg: 'bg-amber-500/10',
+    text: 'text-amber-700',
+    ring: 'ring-amber-500/30',
+  },
+  'Active (MIT)': {
+    bg: 'bg-blue-500/10',
+    text: 'text-blue-700',
+    ring: 'ring-blue-500/30',
+  },
+  Planned: {
+    bg: 'bg-slate-500/10',
+    text: 'text-slate-700',
+    ring: 'ring-slate-500/30',
+  },
+} as const;
+
+export interface FlagshipFact {
+  readonly stat: string;
+  readonly label: string;
+}
+
+export interface FlagshipProduct {
+  readonly slug: string;
+  readonly name: string;
+  readonly eyebrow: string;
+  readonly status: ProductStatus;
+  readonly version: string;
+  readonly tagline: string;
+  readonly body: string;
+  readonly iconPath: string;
+  readonly facts: readonly FlagshipFact[];
+  readonly ctas: {
+    readonly docs: Cta;
+    readonly pricing: Cta;
+    readonly repo: Cta;
+  };
+}
+
+// Flagship — featured full-width treatment with brand emerald accent.
+export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
+  slug: 'revealui',
+  name: 'RevealUI',
+  eyebrow: 'FLAGSHIP',
+  status: 'Beta',
+  version: 'v0.3.0',
+  tagline: 'The agentic business runtime',
+  body: 'Auth, content, products, payments, and intelligence — pre-wired and exposed to your agents via MCP. The runtime everything else in RevFleet plugs into.',
+  iconPath: 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5',
+  facts: [
+    { stat: String(METRICS.packages), label: 'packages' },
+    { stat: String(METRICS.dbTables), label: 'DB tables' },
+    { stat: String(METRICS.mcpServers), label: 'MCP servers' },
+    { stat: String(METRICS.testFiles), label: 'test files' },
+  ],
+  ctas: {
+    docs: { label: 'Read the docs', href: SITE.urls.docs },
+    pricing: { label: 'View pricing', href: '/pricing' },
+    repo: { label: 'GitHub →', href: SITE.urls.repo, external: true },
+  },
+} as const;
+
+export interface SisterProduct {
+  readonly slug: string;
+  readonly name: string;
+  readonly tagline: string;
+  readonly body: string;
+  readonly status: ProductStatus;
+  readonly version?: string;
+  readonly iconPath: string;
+  readonly primaryCta: Cta;
+}
+
+// Sister products — uniform card grid. Order is roughly stability-descending
+// (Beta first, then Alpha, then Active-library, then Planned) so the most
+// adoption-ready surfaces lead.
+export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
+  {
+    slug: 'revvault',
+    name: 'RevVault',
+    tagline: 'Age-encrypted secret vault',
+    body: 'Rust CLI plus Tauri desktop app. 100% compatible with passage; canonical secret store for every RevealUI install — no .env plaintext.',
+    status: 'Beta',
+    version: 'v0.2.0',
+    iconPath:
+      'M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revvault',
+      external: true,
+    },
+  },
+  {
+    slug: 'revforge',
+    name: 'RevForge',
+    tagline: 'White-label stamping tool',
+    body: 'Operator-side tool that generates branded RevealUI Fleet trial kits — domain-locked, multi-tenant self-hosted runtime instances (e.g. AlleviaFleet).',
+    status: 'Beta',
+    iconPath:
+      'M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766m-2.704 3.796-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revforge',
+      external: true,
+    },
+  },
+  {
+    slug: 'revdev',
+    name: 'RevDev',
+    tagline: 'Multi-agent IDE harness',
+    body: 'Native desktop Studio plus Console UI plus Node daemon. Coordinates AI agents across a multi-repo workspace; Studio is currently development-preview quality.',
+    status: 'Alpha',
+    version: 'v0.1.0',
+    iconPath: 'M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revdev',
+      external: true,
+    },
+  },
+  {
+    slug: 'revcon',
+    name: 'RevCon',
+    tagline: 'Editor config sync',
+    body: 'Centralized Zed / VS Code / Cursor configs symlinked into every project. Edit once, propagate instantly across the fleet.',
+    status: 'Alpha',
+    iconPath:
+      'M6 13.5V3.75m0 9.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 3.75V16.5m12-3V3.75m0 9.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 3.75V16.5m-6-9V3.75m0 3.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 9.75V10.5',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revcon',
+      external: true,
+    },
+  },
+  {
+    slug: 'revskills',
+    name: 'RevSkills',
+    tagline: 'Claude Code skills library',
+    body: 'Reusable agent skills for Next.js, Tailwind, Drizzle, ElectricSQL, MCP, and testing patterns. Free, open, importable.',
+    status: 'Active (MIT)',
+    iconPath:
+      'M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revskills',
+      external: true,
+    },
+  },
+  {
+    slug: 'revkit',
+    name: 'RevKit',
+    tagline: 'Portable WSL dev environment',
+    body: 'Profile-based WSL bootstrap with parameterized templates and tier-aware resource configs. Reproducible developer machines.',
+    status: 'Planned',
+    iconPath:
+      'M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z',
+    primaryCta: {
+      label: 'GitHub →',
+      href: 'https://github.com/RevealUIStudio/revkit',
+      external: true,
+    },
+  },
+  {
+    slug: 'revmarket',
+    name: 'RevMarket',
+    tagline: 'Agent tool marketplace',
+    body: `First-party catalog of ${METRICS.mcpServers} production MCP servers (code-validator, Stripe, Neon, Vercel, Next.js, and more). Third-party publishing is planned, not shipped.`,
+    status: 'Planned',
+    iconPath:
+      'M13.5 21v-7.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349M3.75 21V9.349m0 0a3.001 3.001 0 0 0 3.75-.615A2.993 2.993 0 0 0 9.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 0 0 2.25 1.016c.896 0 1.7-.393 2.25-1.015a3.001 3.001 0 0 0 3.75.614m-16.5 0a3.004 3.004 0 0 1-.621-4.72L4.318 3.44A1.5 1.5 0 0 1 5.378 3h13.243a1.5 1.5 0 0 1 1.06.44l1.19 1.189a3 3 0 0 1-.621 4.72m-13.5 8.65h3.75a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75H6.75a.75.75 0 0 0-.75.75v3.75c0 .415.336.75.75.75Z',
+    primaryCta: {
+      label: 'Browse the catalog',
+      href: '/marketplace',
+    },
+  },
+] as const;
 
 export interface StatItem {
   readonly stat: string;
@@ -24,15 +224,15 @@ export const PRODUCTS_STATS_SECTION = {
   body: 'Not a starter template. A complete runtime with tested, documented, and audited code.',
   items: [
     { stat: String(METRICS.packages), label: 'workspace packages' },
-    { stat: String(METRICS.dbTables), label: 'Database tables' },
+    { stat: String(METRICS.dbTables), label: 'database tables' },
     { stat: String(METRICS.testFiles), label: 'test files' },
     { stat: String(METRICS.mcpServers), label: 'first-party MCP servers' },
   ] as readonly StatItem[],
 } as const;
 
 export const PRODUCTS_CTA_SECTION = {
-  heading: 'Start building with all five primitives',
-  body: 'One command. Full source code. Users, content, products, payments, and intelligence - pre-wired and ready for your first deploy.',
+  heading: 'Start with the runtime',
+  body: 'Every other RevFleet product builds on RevealUI. One command, full source, everything pre-wired and ready for your first deploy.',
   cliSnippet: 'npx create-revealui my-app',
   cta: {
     docs: { label: 'Read the Docs', href: SITE.urls.docs } satisfies Cta,

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,16 +1,23 @@
 import { Footer } from '../components/Footer';
-import { PRODUCTS_PRIMITIVES } from '../content/primitives';
 import {
+  PRODUCT_STATUS_STYLES,
   PRODUCTS_CTA_SECTION,
+  PRODUCTS_FLAGSHIP,
   PRODUCTS_PAGE_HERO,
+  PRODUCTS_SISTERS,
   PRODUCTS_STATS_SECTION,
 } from '../content/products';
+
+const ALL_PRODUCT_ANCHORS = [
+  { slug: PRODUCTS_FLAGSHIP.slug, name: PRODUCTS_FLAGSHIP.name },
+  ...PRODUCTS_SISTERS.map((p) => ({ slug: p.slug, name: p.name })),
+] as const;
 
 export function ProductsPage() {
   return (
     <div className="min-h-screen bg-white">
       {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-indigo-50 via-white to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-emerald-50 via-white to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
             {PRODUCTS_PAGE_HERO.h1}
@@ -18,125 +25,195 @@ export function ProductsPage() {
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
             {PRODUCTS_PAGE_HERO.subtitle}
           </p>
-          <div className="mt-10 flex flex-wrap justify-center gap-3 text-sm font-medium">
-            {PRODUCTS_PRIMITIVES.map((p) => (
+          <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
+            {ALL_PRODUCT_ANCHORS.map((anchor) => (
               <a
-                key={p.name}
-                href={`#${p.name.toLowerCase()}`}
-                className={`rounded-full px-4 py-1.5 transition-colors ${p.bgColor} ${p.color} hover:opacity-80`}
+                key={anchor.slug}
+                href={`#${anchor.slug}`}
+                className="rounded-full bg-white px-4 py-1.5 text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-emerald-50 hover:text-emerald-700 hover:ring-emerald-300"
               >
-                {p.name}
+                {anchor.name}
               </a>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Primitives */}
-      {PRODUCTS_PRIMITIVES.map((primitive, i) => (
-        <section
-          key={primitive.name}
-          id={primitive.name.toLowerCase()}
-          className={`py-24 sm:py-32 ${i % 2 === 1 ? 'bg-gray-50' : ''}`}
-        >
-          <div className="mx-auto max-w-7xl px-6 lg:px-8">
-            {/* Section header */}
-            <div className="flex items-center gap-4 mb-12">
-              <div
-                className={`flex h-12 w-12 items-center justify-center rounded-xl ${primitive.bgColor} ring-1 ${primitive.ringColor}`}
-              >
-                <svg
-                  className={`h-6 w-6 ${primitive.color}`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                >
-                  <title>{primitive.name}</title>
-                  <path strokeLinecap="round" strokeLinejoin="round" d={primitive.icon} />
-                </svg>
-              </div>
-              <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-                {primitive.name}
-              </h2>
-            </div>
-
-            {/* Three-layer cards */}
-            <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-              {/* For You */}
-              <div className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200">
-                <div className="mb-4">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-blue-600">
-                    For You
+      {/* Flagship — RevealUI featured card */}
+      <section id={PRODUCTS_FLAGSHIP.slug} className="py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-700 to-emerald-900 p-10 shadow-2xl ring-1 ring-emerald-900/20 sm:p-14">
+            <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-emerald-400/20 blur-3xl" />
+            <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
+            <div className="relative">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 ring-1 ring-white/30 backdrop-blur">
+                    <svg
+                      className="h-7 w-7 text-white"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.75}
+                      stroke="currentColor"
+                    >
+                      <title>{PRODUCTS_FLAGSHIP.name}</title>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d={PRODUCTS_FLAGSHIP.iconPath}
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-100/90">
+                      {PRODUCTS_FLAGSHIP.eyebrow}
+                    </p>
+                    <h2 className="mt-1 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                      {PRODUCTS_FLAGSHIP.name}
+                    </h2>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-xs font-semibold">
+                  <span className="rounded-full bg-white/15 px-3 py-1 text-white ring-1 ring-white/30 backdrop-blur">
+                    {PRODUCTS_FLAGSHIP.status}
+                  </span>
+                  <span className="rounded-full bg-white/10 px-3 py-1 font-mono text-white/90 ring-1 ring-white/20">
+                    {PRODUCTS_FLAGSHIP.version}
                   </span>
                 </div>
-                <h3 className="text-lg font-bold tracking-tight text-gray-900">
-                  {primitive.forYou.headline}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-gray-600">
-                  {primitive.forYou.description}
-                </p>
               </div>
 
-              {/* For Your Agents */}
-              <div className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200">
-                <div className="mb-4">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
-                    For Your Agents
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-tight text-gray-900">
-                  {primitive.forAgents.headline}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-gray-600">
-                  {primitive.forAgents.description}
-                </p>
-              </div>
+              <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-emerald-50">
+                {PRODUCTS_FLAGSHIP.tagline}
+              </p>
+              <p className="mt-3 max-w-3xl text-base leading-7 text-emerald-100/90">
+                {PRODUCTS_FLAGSHIP.body}
+              </p>
 
-              {/* Together */}
-              <div className="rounded-2xl bg-gradient-to-br from-gray-900 to-gray-800 p-8 shadow-lg">
-                <div className="mb-4">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-indigo-400">
-                    Together
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-tight text-white">
-                  {primitive.together.headline}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-gray-400">
-                  {primitive.together.description}
-                </p>
-              </div>
-            </div>
-
-            {/* Feature list */}
-            <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-              {primitive.features.map((feature) => (
-                <div
-                  key={feature}
-                  className="flex items-start gap-2 rounded-lg bg-white px-3 py-2 text-sm text-gray-700 ring-1 ring-gray-100"
-                >
-                  <svg
-                    className={`mt-0.5 h-4 w-4 shrink-0 ${primitive.color}`}
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
+              <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+                {PRODUCTS_FLAGSHIP.facts.map((fact) => (
+                  <div
+                    key={fact.label}
+                    className="rounded-xl bg-white/10 px-4 py-3 ring-1 ring-white/20 backdrop-blur"
                   >
-                    <title>Included</title>
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  <span>{feature}</span>
-                </div>
-              ))}
+                    <dt className="text-xs uppercase tracking-wide text-emerald-100/80">
+                      {fact.label}
+                    </dt>
+                    <dd className="mt-1 text-2xl font-bold tracking-tight text-white">
+                      {fact.stat}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+
+              <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href={PRODUCTS_FLAGSHIP.ctas.docs.href}
+                  className="rounded-md bg-white px-6 py-3 text-sm font-semibold text-emerald-800 shadow-sm transition-colors hover:bg-emerald-50"
+                >
+                  {PRODUCTS_FLAGSHIP.ctas.docs.label}
+                </a>
+                <a
+                  href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
+                  className="rounded-md bg-emerald-900/40 px-6 py-3 text-sm font-semibold text-white ring-1 ring-white/30 transition-colors hover:bg-emerald-900/60"
+                >
+                  {PRODUCTS_FLAGSHIP.ctas.pricing.label}
+                </a>
+                <a
+                  href={PRODUCTS_FLAGSHIP.ctas.repo.href}
+                  className="rounded-md px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+                  {...(PRODUCTS_FLAGSHIP.ctas.repo.external
+                    ? { target: '_blank', rel: 'noreferrer' }
+                    : {})}
+                >
+                  {PRODUCTS_FLAGSHIP.ctas.repo.label}
+                </a>
+              </div>
             </div>
           </div>
-        </section>
-      ))}
+        </div>
+      </section>
 
-      {/* Stats */}
+      {/* Sister products — uniform card grid */}
+      <section className="bg-gray-50 py-20 sm:py-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-2xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              And the rest of the fleet
+            </h2>
+            <p className="mt-4 text-lg leading-7 text-gray-600">
+              Sister products that extend the runtime — secrets, dev tooling, white-labeling,
+              skills, and the agent tool catalog.
+            </p>
+          </div>
+
+          <ul className="mt-14 grid grid-cols-1 gap-6 md:grid-cols-2">
+            {PRODUCTS_SISTERS.map((product) => {
+              const status = PRODUCT_STATUS_STYLES[product.status];
+              return (
+                <li
+                  key={product.slug}
+                  id={product.slug}
+                  className="group relative flex flex-col rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200 transition-shadow hover:shadow-lg"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-4">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gray-50 ring-1 ring-gray-200">
+                        <svg
+                          className="h-6 w-6 text-gray-700"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth={1.5}
+                          stroke="currentColor"
+                        >
+                          <title>{product.name}</title>
+                          <path strokeLinecap="round" strokeLinejoin="round" d={product.iconPath} />
+                        </svg>
+                      </div>
+                      <div>
+                        <h3 className="text-xl font-bold tracking-tight text-gray-900">
+                          {product.name}
+                        </h3>
+                        <p className="mt-0.5 text-sm font-medium text-gray-600">
+                          {product.tagline}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-end gap-1.5 text-xs font-semibold">
+                      <span
+                        className={`rounded-full px-2.5 py-1 ring-1 ${status.bg} ${status.text} ${status.ring}`}
+                      >
+                        {product.status}
+                      </span>
+                      {product.version ? (
+                        <span className="font-mono text-[0.7rem] text-gray-500">
+                          {product.version}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <p className="mt-5 grow text-sm leading-6 text-gray-600">{product.body}</p>
+
+                  <div className="mt-6">
+                    <a
+                      href={product.primaryCta.href}
+                      className="inline-flex items-center text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
+                      {...(product.primaryCta.external
+                        ? { target: '_blank', rel: 'noreferrer' }
+                        : {})}
+                    >
+                      {product.primaryCta.label}
+                    </a>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+
+      {/* Stats — production credibility */}
       <section className="bg-gray-950 py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-16">
@@ -171,7 +248,7 @@ export function ProductsPage() {
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
               href={PRODUCTS_CTA_SECTION.cta.docs.href}
-              className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
+              className="rounded-md bg-emerald-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-emerald-500 transition-colors"
             >
               {PRODUCTS_CTA_SECTION.cta.docs.label}
             </a>


### PR DESCRIPTION
## Summary

Replaces the previous "five primitives deep-dive" `/products` page with a **RevFleet product family lineup**:

- **Flagship card** (full-width, brand-emerald): RevealUI v0.3.0 (Beta) with quick-facts grid (26 packages · 86 DB tables · 13 MCP servers · 912 test files) and three CTAs (docs · pricing · GitHub).
- **Sister-product grid** (uniform cards, 2-col desktop): RevVault · RevForge · RevDev · RevCon · RevSkills · RevKit · RevMarket. Each card carries an honest status badge (Beta / Alpha / Active (MIT) / Planned), a 1-line tagline, a short body, and a primary link.
- **Stats bar** preserved (production credibility), now with brand-emerald accents instead of indigo.
- **Hero + CTA** copy rewritten to lead with the family.

RevealCoin omitted entirely from the page — it's shelved per internal posture and should not appear in shipped marketing.

Status labels were drawn from a per-product README audit (revealui, revdev, revvault, revforge, revcon, revskills, revkit, revmarket) cross-referenced against the canonical internal status table. No claims exceed what the READMEs support.

All metric numbers continue to consume `METRICS` from `content/site.ts` — no new hardcoded counts. Claim-drift validator stays the single source of truth.

The legacy `PRODUCTS_PRIMITIVES` data is unchanged in `content/primitives.ts` (still exported) so it can be relocated to a future `/concepts` or `/platform` page in a separate PR without this one blocking that choice.

## Files

- `apps/marketing/app/content/products.ts` — adds `PRODUCTS_FLAGSHIP`, `PRODUCTS_SISTERS`, `PRODUCT_STATUS_STYLES` typed exports; refreshes `PRODUCTS_PAGE_HERO` + `PRODUCTS_CTA_SECTION` copy; keeps `PRODUCTS_STATS_SECTION` structure.
- `apps/marketing/app/routes/ProductsPage.tsx` — new layout consuming the rewritten content. No new dependencies, no new icon library (keeps the existing heroicons-style inline `<path>` pattern).

## Test plan

- [x] `pnpm --filter marketing build` clean (273 modules transformed, exit 0)
- [x] Marketing `routes.test.ts` still imports `ProductsPage` — symbol preserved
- [x] `vite preview` on the built output → `/products` renders: flagship card + all 8 anchor pills + 7 sister cards in correct order + status badges + facts row + stats bar + CTA; no console errors
- [ ] Visual review on Vercel preview deploy
- [ ] Mobile responsive check (1-col on mobile, 2-col on `md:`)
