### PR TITLE
refactor(harnesses): finish protocol rename — drop unused aliases + split adapter-less profiles

### DIFF
--- a/.changeset/protocol-cleanup-0-5-0.md
+++ b/.changeset/protocol-cleanup-0-5-0.md
@@ -1,0 +1,17 @@
+---
+'@revealui/harnesses': minor
+---
+
+Finish the VAUGHN → Harness Protocol rename: drop transitional aliases (no external consumers found) and split adapter-less profiles into `ROADMAP_PROFILES` for structural visibility.
+
+0.4.0 left three transitional carry-overs to protect against a phantom daemon consumer — `vaughn.*` RPC method names, a `VAUGHN_AGENT_ID` env-var fallback with deprecation warning, and a `/tmp/vaughn-session-<ppid>.id` cache-file fallback. A post-publish audit (`grep` across the entire fleet, including revdev, hooks, shell configs, `.jv/`) confirmed **none had any external consumer**. The deprecation pattern was carrying weight for nothing. 0.5.0 removes the aliases for a clean final state.
+
+**Breaking — RPC method names:** `vaughn.capabilities` / `vaughn.dispatch` / `vaughn.events` / `vaughn.config.sync` → `protocol.*` (same handlers, new wire names).
+
+**Breaking — env var:** `VAUGHN_AGENT_ID` is no longer read. Use `PROTOCOL_AGENT_ID`.
+
+**Breaking — session cache file:** `/tmp/vaughn-session-<ppid>.id` is no longer read. New path `/tmp/protocol-session-<ppid>.id` is used exclusively.
+
+**Breaking — `TOOL_PROFILES` shape:** previously contained four entries (claude-code, codex, cursor, revealui-agent). Now contains only `revealui-agent` (the only tool with a working adapter). The three adapter-less entries moved to a new `ROADMAP_PROFILES` export from `@revealui/harnesses/protocol`. A merged view `ALL_KNOWN_PROFILES` is also exported for callers that want capability data for any known tool ID. `HarnessCoordinator.dispatchTask` consults explicit registered capabilities first, then `TOOL_PROFILES`, then `ROADMAP_PROFILES`, so dispatch behavior is preserved for callers that register stub adapters for unimplemented tools.
+
+**Migration:** rename `vaughn.*` RPC calls to `protocol.*`; rename `VAUGHN_AGENT_ID` env var to `PROTOCOL_AGENT_ID`; import unimplemented-tool profiles from `ROADMAP_PROFILES` (or `ALL_KNOWN_PROFILES`) instead of `TOOL_PROFILES`.

--- a/docs/HARNESS_PROTOCOL.md
+++ b/docs/HARNESS_PROTOCOL.md
@@ -8,10 +8,10 @@ audience: developer
 # Harness Protocol
 
 > **Version:** 0.1.0  (Active — Phase 1 + 2 shipped; multi-tool adapters and full coordinator surface remain on the roadmap.)
-> **Package:** [`@revealui/harnesses`](../packages/harnesses) at v0.4.0+
+> **Package:** [`@revealui/harnesses`](../packages/harnesses) at v0.5.0+
 > **Renamed:** 2026-05-18, from the original "VAUGHN" backronym. See [§Why "Harness Protocol"](#why-harness-protocol) at the end.
 
-A protocol for normalizing agent capabilities, lifecycle events, and configuration across AI coding tools, so a single coordinator can dispatch work to whichever adapter is available. Ships today with **one working adapter** (the RevealUI Agent) plus static capability profiles and degradation-strategy data for Claude Code / Codex / Cursor; adapters for those three tools are roadmap items.
+A protocol for normalizing agent capabilities, lifecycle events, and configuration across AI coding tools, so a single coordinator can dispatch work to whichever adapter is available. Ships today with **one working adapter** (the RevealUI Agent — in `TOOL_PROFILES`) plus declared-but-unimplemented profiles for Claude Code / Codex / Cursor (in `ROADMAP_PROFILES`); adapters for those three tools are roadmap items.
 
 This doc describes what's in the package today. Items in the [Roadmap](#roadmap) section are deferred work, not current behavior.
 
@@ -22,7 +22,8 @@ This doc describes what's in the package today. Items in the [Roadmap](#roadmap)
 | Surface | Status | Location |
 |---|---|---|
 | Protocol type foundation | ✓ | [packages/harnesses/src/protocol/](../packages/harnesses/src/protocol) |
-| Capability profiles (4 tools, static data) | ✓ | [protocol/capabilities.ts](../packages/harnesses/src/protocol/capabilities.ts) |
+| Capability profiles for shipped adapters (`TOOL_PROFILES`) | ✓ — revealui-agent only | [protocol/capabilities.ts](../packages/harnesses/src/protocol/capabilities.ts) |
+| Capability profiles for unimplemented tools (`ROADMAP_PROFILES`) | ✓ — claude-code, codex, cursor | [protocol/roadmap-profiles.ts](../packages/harnesses/src/protocol/roadmap-profiles.ts) |
 | 10 canonical lifecycle events + Zod schemas | ✓ | [protocol/event-envelope.ts](../packages/harnesses/src/protocol/event-envelope.ts) |
 | Event normalization (HarnessEvent → ProtocolEventEnvelope) | ✓ partial — 5 of 10 events have emit paths today | [protocol/event-normalizer.ts](../packages/harnesses/src/protocol/event-normalizer.ts) |
 | Degradation strategy lookup | ✓ | [protocol/degradation-strategies.ts](../packages/harnesses/src/protocol/degradation-strategies.ts) |
@@ -31,7 +32,7 @@ This doc describes what's in the package today. Items in the [Roadmap](#roadmap)
 | Config normalization: `AGENTS.md` (write-only) | ✓ | same |
 | Config normalization: `.claude/rules/*.md` (per-rule, write-only) | ✓ | same |
 | Coordinator: start / stop / registerAdapter / dispatchTask / healthCheck | ✓ | [coordinator.ts](../packages/harnesses/src/coordinator.ts) |
-| JSON-RPC server with `vaughn.*` methods | ✓ (historical wire-format names) | [server/rpc-server.ts](../packages/harnesses/src/server/rpc-server.ts) |
+| JSON-RPC server with `protocol.*` methods | ✓ | [server/rpc-server.ts](../packages/harnesses/src/server/rpc-server.ts) |
 | HTTP gateway (optional, off by default) | ✓ existence; security audit pending | [server/http-gateway.ts](../packages/harnesses/src/server/http-gateway.ts) |
 | **RevealUI Agent adapter** | ✓ working | [adapters/revealui-agent-adapter.ts](../packages/harnesses/src/adapters/revealui-agent-adapter.ts) |
 | Workboard manager + PGlite daemon store | ✓ | [workboard/](../packages/harnesses/src/workboard), [storage/](../packages/harnesses/src/storage) |
@@ -72,9 +73,15 @@ export interface ProtocolAdapter {
 
 ### Capability profiles
 
-[`TOOL_PROFILES`](../packages/harnesses/src/protocol/capabilities.ts) is static reference data describing what each tool *would* support if an adapter wrapped it. Only `revealui-agent` has a working adapter today; the other three profiles inform the degradation table and future adapter work.
+Capability data is split across two named exports to make the spec-vs-shipped gap structurally visible:
 
-| Capability | Claude Code | Codex CLI | Cursor | **RevealUI Agent (shipped)** |
+- [`TOOL_PROFILES`](../packages/harnesses/src/protocol/capabilities.ts) — profiles for tools that have working adapters in this package. **One entry today: `revealui-agent`.**
+- [`ROADMAP_PROFILES`](../packages/harnesses/src/protocol/roadmap-profiles.ts) — declared profiles for tools the spec targets but where no adapter is implemented yet. **Three entries today: `claude-code`, `codex`, `cursor`.**
+- [`ALL_KNOWN_PROFILES`](../packages/harnesses/src/protocol/roadmap-profiles.ts) — merged view for callers that want capability data for any known tool ID. Shipped entries take precedence on key collision.
+
+`HarnessCoordinator.dispatchTask` consults explicit registered capabilities first, then `TOOL_PROFILES`, then `ROADMAP_PROFILES` — so coordinators that register stub adapters for spec'd-but-unimplemented tools still get capability data for dispatch decisions.
+
+| Capability | Claude Code _(roadmap)_ | Codex CLI _(roadmap)_ | Cursor _(roadmap)_ | **RevealUI Agent (shipped)** |
 |---|---|---|---|---|
 | dispatch.generateCode / analyzeCode / applyEdit / executeCommand | false × 4 | false × 4 | false × 4 | **true × 4** |
 | readWorkboard / writeWorkboard | true / true | true / true | false / false | **true / true** |
@@ -170,16 +177,16 @@ All adapters can coordinate through `.claude/workboard.md` directly. No daemon r
 
 ### JSON-RPC transport (Unix domain socket)
 
-`@revealui/harnesses` ships a JSON-RPC 2.0 server. Method names use the historical `vaughn.*` namespace — the protocol was renamed 2026-05-18; method names are preserved for wire-format stability with existing consumers (notably the [revdev daemon](https://github.com/RevealUIStudio/revdev) which talks to this socket).
+`@revealui/harnesses` ships a JSON-RPC 2.0 server.
 
 | Method | Returns | Purpose |
 |---|---|---|
-| `vaughn.capabilities` | `Array<{ id, capabilities: ProtocolCapabilities }>` | List registered adapters + capability profiles |
-| `vaughn.dispatch` | `{ adapterId: string \| null }` | Pick best adapter for capability requirements |
-| `vaughn.events` | `ProtocolEventEnvelope[]` | Last 100 events from the queue |
-| `vaughn.config.sync` | `{ files: Record<string, string> }` | Generate all configs from a `ProtocolConfig` |
+| `protocol.capabilities` | `Array<{ id, capabilities: ProtocolCapabilities }>` | List registered adapters + capability profiles (shipped only — `TOOL_PROFILES`) |
+| `protocol.dispatch` | `{ adapterId: string \| null }` | Pick best adapter for capability requirements |
+| `protocol.events` | `ProtocolEventEnvelope[]` | Last 100 events from the queue |
+| `protocol.config.sync` | `{ files: Record<string, string> }` | Generate all configs from a `ProtocolConfig` |
 
-Renaming these methods to `protocol.*` is tracked as a coordinated migration with the daemon consumer; see [Roadmap](#roadmap).
+> 0.5.0 renamed these methods from the historical `vaughn.*` namespace. A pre-publish audit confirmed no external consumers (the revdev daemon was never wired into these methods), so the rename is a clean break with no backward-compat alias.
 
 ### HTTP transport (optional, off by default)
 
@@ -191,7 +198,7 @@ Renaming these methods to `protocol.*` is tracked as a coordinated migration wit
 
 Session type detection in [`workboard/session-identity.ts`](../packages/harnesses/src/workboard/session-identity.ts) resolves to one of `'claude' | 'codex' | 'zed' | 'cursor' | 'terminal'` via this cascade:
 
-1. Explicit `PROTOCOL_AGENT_ID` env var (legacy fallback: `VAUGHN_AGENT_ID`)
+1. Explicit `PROTOCOL_AGENT_ID` env var
 2. Tool-specific env var (`CLAUDE_AGENT_ROLE`)
 3. Session cache (`/tmp/protocol-session-<ppid>.id`)
 4. Process tree walk
@@ -215,7 +222,6 @@ Items defined in the original spec but not implemented today:
 - **7-tier identity cascade** with structured identity formats.
 - **MCP tool reservation** (concurrency control across adapters calling the same MCP tool).
 - **HTTP transport security:** bearer-token auth enforcement, TLS, rate limiting, sandbox-mode-aware dispatch — audit before non-localhost exposure.
-- **RPC method rename** from `vaughn.*` to `protocol.*` (coordinated with the daemon consumer).
 - **Cross-machine coordination** (distributed lock for HTTP transport).
 
 These are tracked in [docs/MASTER_PLAN.md](./MASTER_PLAN.md) under harness-related lanes.
@@ -231,10 +237,8 @@ This protocol was originally named VAUGHN — a backronym (Versioned Agent Unifi
 
 Renamed 2026-05-18 to **Harness Protocol** — descriptive, matching the existing `@revealui/harnesses` package name and the existing `HarnessAdapter` / `HarnessCoordinator` types. The protocol describes how an adapter wraps a tool ("harnesses" it) and how the coordinator orchestrates work across registered adapters.
 
-The previous name survives in three places, intentionally:
+0.4.0 (the rename release) left three transitional carry-overs in place — `vaughn.*` RPC method aliases, a `VAUGHN_AGENT_ID` env-var fallback with deprecation warning, and a `/tmp/vaughn-session-<ppid>.id` cache-file fallback. A 0.5.0 audit confirmed none of those had any external consumer (no shell config, hook, script, or repo in the fleet referenced them), so the deprecation pattern was protecting phantoms. 0.5.0 removed the aliases and fallbacks for a clean final state.
 
-- **RPC method namespace** (`vaughn.capabilities`, etc.) — kept for wire-format stability with the daemon consumer
-- **`CHANGELOG.md` entries** — history is history
-- **Legacy env var alias** (`VAUGHN_AGENT_ID` still read as a fallback after `PROTOCOL_AGENT_ID`)
+The previous name now survives only in `CHANGELOG.md` entries — history is history.
 
 The principles, not the name, do the work.

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @revealui/harnesses
 
+## 0.5.0
+
+### Minor Changes
+
+- Finish the VAUGHN → Harness Protocol rename: drop transitional aliases (no external consumers) and split adapter-less profiles into `ROADMAP_PROFILES` for structural visibility.
+
+  **Audit finding behind this release:** 0.4.0 (the rename release) left three transitional carry-overs in place to protect against a phantom daemon consumer — `vaughn.*` RPC method names, a `VAUGHN_AGENT_ID` env-var fallback with deprecation warning, and a `/tmp/vaughn-session-<ppid>.id` cache-file fallback. A post-publish audit (`grep` across the entire fleet, including revdev, hooks, shell configs, `.jv/`) confirmed **none of those had any external consumer**. The deprecation pattern was carrying weight for nothing. 0.5.0 removes the aliases for a clean final state.
+
+  **Breaking — RPC method names** (`@revealui/harnesses/server/rpc-server`):
+
+  - `vaughn.capabilities` → `protocol.capabilities`
+  - `vaughn.dispatch` → `protocol.dispatch`
+  - `vaughn.events` → `protocol.events`
+  - `vaughn.config.sync` → `protocol.config.sync`
+
+  **Breaking — env var:** `VAUGHN_AGENT_ID` is no longer read. Use `PROTOCOL_AGENT_ID`.
+
+  **Breaking — session cache file:** `/tmp/vaughn-session-<ppid>.id` is no longer read. The new path `/tmp/protocol-session-<ppid>.id` is used exclusively.
+
+  **Breaking — `TOOL_PROFILES` shape:** previously contained four entries (`claude-code`, `codex`, `cursor`, `revealui-agent`). Now contains only `revealui-agent` — the only tool with a working adapter in this package. The three adapter-less entries moved to a new export `ROADMAP_PROFILES` from `@revealui/harnesses/protocol`. A merged view `ALL_KNOWN_PROFILES` is also exported for callers that want capability data for any known tool ID regardless of adapter status.
+
+  - `TOOL_PROFILES` → shipped adapters only (revealui-agent)
+  - `ROADMAP_PROFILES` → declared but unimplemented (claude-code, codex, cursor)
+  - `ALL_KNOWN_PROFILES` → merged view (shipped entries take precedence on key collision)
+
+  `HarnessCoordinator.dispatchTask` consults explicit registered capabilities first, then `TOOL_PROFILES`, then `ROADMAP_PROFILES` — so coordinators that register stub adapters for spec'd-but-unimplemented tools still get capability data for dispatch decisions.
+
+  **Migration:**
+
+  - If you call the harnesses RPC server: rename your method strings from `vaughn.*` to `protocol.*`.
+  - If you set `VAUGHN_AGENT_ID` in any environment: rename to `PROTOCOL_AGENT_ID`.
+  - If you import `TOOL_PROFILES['claude-code']` / `['codex']` / `['cursor']`: import `ROADMAP_PROFILES` (or `ALL_KNOWN_PROFILES`) from `@revealui/harnesses/protocol` instead.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI harness integration — adapters, daemon, workboard coordination, JSON-RPC server.",
   "repository": {
     "type": "git",

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ALL_KNOWN_PROFILES,
   createDefaultCapabilities,
   createEventEnvelope,
   getDegradationStrategy,
@@ -7,6 +8,7 @@ import {
   PROTOCOL_VERSION,
   protocolEventEnvelopeSchema,
   protocolEventSchema,
+  ROADMAP_PROFILES,
   TOOL_PROFILES,
 } from '../protocol/index.js';
 
@@ -30,40 +32,82 @@ describe('protocol capabilities', () => {
     expect(caps.maxContextTokens).toBe(0);
     expect(caps.lifecycleEvents).toEqual([]);
   });
+});
 
-  it('TOOL_PROFILES has entries for all known tools', () => {
-    expect(TOOL_PROFILES['claude-code']).toBeDefined();
-    expect(TOOL_PROFILES.codex).toBeDefined();
-    expect(TOOL_PROFILES.cursor).toBeDefined();
-    expect(TOOL_PROFILES['revealui-agent']).toBeDefined();
+describe('TOOL_PROFILES (shipped adapters)', () => {
+  it('contains revealui-agent only', () => {
+    expect(Object.keys(TOOL_PROFILES)).toEqual(['revealui-agent']);
   });
 
   it('revealui-agent has full dispatch capabilities', () => {
     const caps = TOOL_PROFILES['revealui-agent'];
+    expect(caps).toBeDefined();
     expect(caps.dispatch.generateCode).toBe(true);
     expect(caps.dispatch.analyzeCode).toBe(true);
     expect(caps.dispatch.applyEdit).toBe(true);
     expect(caps.dispatch.executeCommand).toBe(true);
   });
 
-  it('claude-code does not have dispatch capabilities', () => {
-    const caps = TOOL_PROFILES['claude-code'];
+  it('revealui-agent supports all 10 canonical lifecycle events', () => {
+    const caps = TOOL_PROFILES['revealui-agent'];
+    expect(caps.lifecycleEvents).toHaveLength(10);
+  });
+
+  it('does not contain entries for tools without adapters', () => {
+    expect(TOOL_PROFILES['claude-code']).toBeUndefined();
+    expect(TOOL_PROFILES.codex).toBeUndefined();
+    expect(TOOL_PROFILES.cursor).toBeUndefined();
+  });
+});
+
+describe('ROADMAP_PROFILES (declared, no adapter)', () => {
+  it('contains the three spec-declared tools', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'cursor']);
+  });
+
+  it('claude-code has no dispatch capabilities (interactive tool)', () => {
+    const caps = ROADMAP_PROFILES['claude-code'];
     expect(caps.dispatch.generateCode).toBe(false);
     expect(caps.dispatch.analyzeCode).toBe(false);
   });
 
   it('codex has sandbox support', () => {
-    const caps = TOOL_PROFILES.codex;
+    const caps = ROADMAP_PROFILES.codex;
     expect(caps.sandbox.supported).toBe(true);
     expect(caps.sandbox.modes).toContain('read-only');
   });
 
   it('cursor has minimal capabilities', () => {
-    const caps = TOOL_PROFILES.cursor;
+    const caps = ROADMAP_PROFILES.cursor;
     expect(caps.headless).toBe(false);
     expect(caps.hooks.supported).toBe(false);
     expect(caps.readWorkboard).toBe(false);
     expect(caps.lifecycleEvents).toEqual([]);
+  });
+
+  it('does not overlap with TOOL_PROFILES', () => {
+    for (const id of Object.keys(ROADMAP_PROFILES)) {
+      expect(TOOL_PROFILES[id]).toBeUndefined();
+    }
+  });
+});
+
+describe('ALL_KNOWN_PROFILES (merged view)', () => {
+  it('contains all four declared tools', () => {
+    expect(Object.keys(ALL_KNOWN_PROFILES).sort()).toEqual([
+      'claude-code',
+      'codex',
+      'cursor',
+      'revealui-agent',
+    ]);
+  });
+
+  it('shipped entries take precedence over roadmap entries on key collision', () => {
+    // No collision today (the four IDs are disjoint), but the spread order
+    // (...ROADMAP_PROFILES first, then ...TOOL_PROFILES) guarantees that
+    // a future shipped adapter overrides any roadmap declaration with the
+    // same ID. Verify the shape of revealui-agent matches TOOL_PROFILES.
+    expect(ALL_KNOWN_PROFILES['revealui-agent']).toEqual(TOOL_PROFILES['revealui-agent']);
   });
 });
 

--- a/packages/harnesses/src/__tests__/rpc-server.test.ts
+++ b/packages/harnesses/src/__tests__/rpc-server.test.ts
@@ -184,51 +184,48 @@ describe('RpcServer (harnesses)', () => {
 
   // -----------------------------------------------------------------------
   // Harness Protocol methods
-  // (Wire-format method names use the historical `vaughn.*` namespace
-  // for backward compatibility with existing consumers — see
-  // docs/HARNESS_PROTOCOL.md §Transports.)
   // -----------------------------------------------------------------------
-  it('vaughn.capabilities returns empty array when no adapters registered', async () => {
-    const res = (await sendRequest(socket, 'vaughn.capabilities')) as {
+  it('protocol.capabilities returns empty array when no adapters registered', async () => {
+    const res = (await sendRequest(socket, 'protocol.capabilities')) as {
       result: unknown[];
     };
     expect(Array.isArray(res.result)).toBe(true);
     expect(res.result).toHaveLength(0);
   });
 
-  it('vaughn.dispatch returns error when dispatch not configured', async () => {
-    const res = (await sendRequest(socket, 'vaughn.dispatch', {
+  it('protocol.dispatch returns error when dispatch not configured', async () => {
+    const res = (await sendRequest(socket, 'protocol.dispatch', {
       description: 'test task',
     })) as { error: { code: number } };
     expect(res.error?.code).toBe(-32603);
   });
 
-  it('vaughn.dispatch returns error when description missing', async () => {
+  it('protocol.dispatch returns error when description missing', async () => {
     server.setProtocolDispatch(() => null);
-    const res = (await sendRequest(socket, 'vaughn.dispatch', {})) as {
+    const res = (await sendRequest(socket, 'protocol.dispatch', {})) as {
       error: { code: number };
     };
     expect(res.error?.code).toBe(-32602);
   });
 
-  it('vaughn.dispatch returns adapterId when configured', async () => {
+  it('protocol.dispatch returns adapterId when configured', async () => {
     server.setProtocolDispatch((_req, _desc) => 'claude-code');
-    const res = (await sendRequest(socket, 'vaughn.dispatch', {
+    const res = (await sendRequest(socket, 'protocol.dispatch', {
       description: 'run tests',
       requirements: { headless: true },
     })) as { result: { adapterId: string } };
     expect(res.result?.adapterId).toBe('claude-code');
   });
 
-  it('vaughn.events returns empty array initially', async () => {
-    const res = (await sendRequest(socket, 'vaughn.events')) as {
+  it('protocol.events returns empty array initially', async () => {
+    const res = (await sendRequest(socket, 'protocol.events')) as {
       result: unknown[];
     };
     expect(Array.isArray(res.result)).toBe(true);
     expect(res.result).toHaveLength(0);
   });
 
-  it('vaughn.events returns pushed events', async () => {
+  it('protocol.events returns pushed events', async () => {
     server.pushProtocolEvent({
       version: '0.1.0',
       event: 'session.start',
@@ -238,14 +235,14 @@ describe('RpcServer (harnesses)', () => {
       sessionId: 'sess-1',
       payload: {},
     });
-    const res = (await sendRequest(socket, 'vaughn.events')) as {
+    const res = (await sendRequest(socket, 'protocol.events')) as {
       result: Array<{ event: string }>;
     };
     expect(res.result).toHaveLength(1);
     expect(res.result[0].event).toBe('session.start');
   });
 
-  it('vaughn.events respects limit parameter', async () => {
+  it('protocol.events respects limit parameter', async () => {
     for (let i = 0; i < 5; i++) {
       server.pushProtocolEvent({
         version: '0.1.0',
@@ -257,20 +254,20 @@ describe('RpcServer (harnesses)', () => {
         payload: { index: i },
       });
     }
-    const res = (await sendRequest(socket, 'vaughn.events', { limit: 2 })) as {
+    const res = (await sendRequest(socket, 'protocol.events', { limit: 2 })) as {
       result: unknown[];
     };
     expect(res.result.length).toBeLessThanOrEqual(2);
   });
 
-  it('vaughn.config.sync returns error when config missing', async () => {
-    const res = (await sendRequest(socket, 'vaughn.config.sync', {})) as {
+  it('protocol.config.sync returns error when config missing', async () => {
+    const res = (await sendRequest(socket, 'protocol.config.sync', {})) as {
       error: { code: number };
     };
     expect(res.error?.code).toBe(-32602);
   });
 
-  it('vaughn.config.sync generates all config files', async () => {
+  it('protocol.config.sync generates all config files', async () => {
     const config = {
       identity: { name: 'Test', email: 'test@test.com' },
       permissions: { autoApprove: [], deny: [] },
@@ -279,7 +276,7 @@ describe('RpcServer (harnesses)', () => {
       skills: [],
       commands: [],
     };
-    const res = (await sendRequest(socket, 'vaughn.config.sync', { config })) as {
+    const res = (await sendRequest(socket, 'protocol.config.sync', { config })) as {
       result: { files: Record<string, string> };
     };
     expect(res.result?.files).toBeDefined();

--- a/packages/harnesses/src/coordinator.ts
+++ b/packages/harnesses/src/coordinator.ts
@@ -13,6 +13,7 @@ import type { HarnessAdapter } from './types/adapter.js';
 import type { HealthCheckResult } from './types/core.js';
 import type { ProtocolCapabilities } from './protocol/capabilities.js';
 import { TOOL_PROFILES } from './protocol/capabilities.js';
+import { ROADMAP_PROFILES } from './protocol/roadmap-profiles.js';
 import { deriveSessionId, detectSessionType } from './workboard/session-identity.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
@@ -207,7 +208,12 @@ export class HarnessCoordinator {
     const candidates: Array<{ id: string; caps: ProtocolCapabilities }> = [];
 
     for (const id of this.registry.listAll()) {
-      const caps = this.protocolCapabilities.get(id) ?? TOOL_PROFILES[id];
+      // Lookup order: explicit registration > shipped adapter profile > roadmap profile.
+      // The ROADMAP_PROFILES fallback lets coordinators that register stub adapters
+      // for spec'd-but-unimplemented tools (claude-code, codex, cursor) still get
+      // capability data for dispatch decisions.
+      const caps =
+        this.protocolCapabilities.get(id) ?? TOOL_PROFILES[id] ?? ROADMAP_PROFILES[id];
       if (!caps) continue;
       if (this.matchesRequirements(caps, requirements)) {
         candidates.push({ id, caps });

--- a/packages/harnesses/src/protocol/capabilities.ts
+++ b/packages/harnesses/src/protocol/capabilities.ts
@@ -101,103 +101,18 @@ export function createDefaultCapabilities(): ProtocolCapabilities {
 }
 
 /**
- * Known capability profiles for supported tools.
- * These are reference profiles; actual adapters may override.
+ * Capability profiles for tools that have working adapters in this package.
  *
- * Note: only 'revealui-agent' has a working adapter today. The other three
- * entries describe what those tools support natively, for use by future
- * adapters and the degradation table.
+ * Only `revealui-agent` ships an adapter today. Profile data for tools
+ * that are spec'd but have no adapter implementation lives in
+ * `./roadmap-profiles.ts` to make the spec-vs-shipped gap structurally
+ * visible.
+ *
+ * If you're looking for the previous full set (claude-code, codex,
+ * cursor, revealui-agent), import `ALL_KNOWN_PROFILES` from
+ * `./roadmap-profiles.ts` which merges both.
  */
 export const TOOL_PROFILES: Record<string, ProtocolCapabilities> = {
-  'claude-code': {
-    dispatch: {
-      generateCode: false,
-      analyzeCode: false,
-      applyEdit: false,
-      executeCommand: false,
-    },
-    readWorkboard: true,
-    writeWorkboard: true,
-    claimTasks: true,
-    reportConflicts: true,
-    headless: true,
-    resumable: false,
-    forkable: false,
-    backgroundable: true,
-    hooks: { supported: true, granularity: 'all-tools', canBlock: true },
-    sandbox: { supported: false, modes: [] },
-    supportsWorktrees: true,
-    supportsSkills: true,
-    supportsMcp: true,
-    memory: { supported: false, backend: 'none' },
-    maxContextTokens: 200_000,
-    lifecycleEvents: [
-      'session.start',
-      'session.stop',
-      'prompt.submit',
-      'tool.before',
-      'tool.after',
-      'tool.blocked',
-    ],
-  },
-
-  codex: {
-    dispatch: {
-      generateCode: false,
-      analyzeCode: false,
-      applyEdit: false,
-      executeCommand: false,
-    },
-    readWorkboard: true,
-    writeWorkboard: true,
-    claimTasks: true,
-    reportConflicts: false,
-    headless: true,
-    resumable: true,
-    forkable: true,
-    backgroundable: true,
-    hooks: { supported: true, granularity: 'bash-only', canBlock: true },
-    sandbox: { supported: true, modes: ['read-only', 'workspace-write', 'full-access'] },
-    supportsWorktrees: false,
-    supportsSkills: true,
-    supportsMcp: true,
-    memory: { supported: true, backend: 'sqlite' },
-    maxContextTokens: 200_000,
-    lifecycleEvents: [
-      'session.start',
-      'session.stop',
-      'prompt.submit',
-      'tool.before',
-      'tool.after',
-      'tool.blocked',
-    ],
-  },
-
-  cursor: {
-    dispatch: {
-      generateCode: false,
-      analyzeCode: false,
-      applyEdit: false,
-      executeCommand: false,
-    },
-    readWorkboard: false,
-    writeWorkboard: false,
-    claimTasks: false,
-    reportConflicts: false,
-    headless: false,
-    resumable: false,
-    forkable: false,
-    backgroundable: false,
-    hooks: { supported: false, granularity: 'none', canBlock: false },
-    sandbox: { supported: false, modes: [] },
-    supportsWorktrees: false,
-    supportsSkills: false,
-    supportsMcp: false,
-    memory: { supported: false, backend: 'none' },
-    maxContextTokens: 128_000,
-    lifecycleEvents: [],
-  },
-
   'revealui-agent': {
     dispatch: {
       generateCode: true,

--- a/packages/harnesses/src/protocol/index.ts
+++ b/packages/harnesses/src/protocol/index.ts
@@ -4,8 +4,7 @@
  * Re-exports all protocol types, schemas, factories, and utilities.
  *
  * Historical note: this protocol was originally named VAUGHN. Renamed
- * 2026-05-18; see docs/HARNESS_PROTOCOL.md for context. RPC method
- * names (`vaughn.*`) are preserved for wire-format stability.
+ * 2026-05-18; see docs/HARNESS_PROTOCOL.md for context.
  */
 
 // Adapter
@@ -22,7 +21,7 @@ export type {
   ProtocolRule,
   ProtocolSkill,
 } from './adapter.js';
-// Capabilities
+// Capabilities (shipped adapters only)
 export type {
   HookGranularity,
   MemoryBackend,
@@ -30,6 +29,8 @@ export type {
   SandboxMode,
 } from './capabilities.js';
 export { createDefaultCapabilities, TOOL_PROFILES } from './capabilities.js';
+// Roadmap profiles (declared but not implemented)
+export { ALL_KNOWN_PROFILES, ROADMAP_PROFILES } from './roadmap-profiles.js';
 // Config normalization
 export type { ClaudeCodeSettings, ConfigGenerationResult } from './config-normalizer.js';
 export {

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -1,0 +1,126 @@
+/**
+ * Roadmap Capability Profiles
+ *
+ * Declared profiles for AI coding tools that the Harness Protocol spec
+ * targets but which DO NOT have a working adapter in this package today.
+ *
+ * These entries describe what those tools support natively, useful for:
+ *  - The degradation table in `./degradation-strategies.ts` (which knows
+ *    how to fall back when a tool can't emit a canonical event).
+ *  - Future adapter implementations — when an adapter is wired up for one
+ *    of these tools, its profile graduates to `./capabilities.ts`
+ *    `TOOL_PROFILES` and the entry is removed from this file.
+ *  - Documentation / planning surfaces that want to enumerate "what we've
+ *    declared profiles for" vs "what we actually ship."
+ *
+ * The separation from `TOOL_PROFILES` is structural: it surfaces the
+ * spec-vs-shipped gap as a code-level distinction instead of a comment.
+ * `HarnessCoordinator.dispatchTask` consults both — registered capabilities
+ * win, then `TOOL_PROFILES` (shipped), then `ROADMAP_PROFILES` (declared).
+ */
+
+import type { ProtocolCapabilities } from './capabilities.js';
+import { TOOL_PROFILES } from './capabilities.js';
+
+export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
+  'claude-code': {
+    dispatch: {
+      generateCode: false,
+      analyzeCode: false,
+      applyEdit: false,
+      executeCommand: false,
+    },
+    readWorkboard: true,
+    writeWorkboard: true,
+    claimTasks: true,
+    reportConflicts: true,
+    headless: true,
+    resumable: false,
+    forkable: false,
+    backgroundable: true,
+    hooks: { supported: true, granularity: 'all-tools', canBlock: true },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: true,
+    supportsSkills: true,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 200_000,
+    lifecycleEvents: [
+      'session.start',
+      'session.stop',
+      'prompt.submit',
+      'tool.before',
+      'tool.after',
+      'tool.blocked',
+    ],
+  },
+
+  codex: {
+    dispatch: {
+      generateCode: false,
+      analyzeCode: false,
+      applyEdit: false,
+      executeCommand: false,
+    },
+    readWorkboard: true,
+    writeWorkboard: true,
+    claimTasks: true,
+    reportConflicts: false,
+    headless: true,
+    resumable: true,
+    forkable: true,
+    backgroundable: true,
+    hooks: { supported: true, granularity: 'bash-only', canBlock: true },
+    sandbox: { supported: true, modes: ['read-only', 'workspace-write', 'full-access'] },
+    supportsWorktrees: false,
+    supportsSkills: true,
+    supportsMcp: true,
+    memory: { supported: true, backend: 'sqlite' },
+    maxContextTokens: 200_000,
+    lifecycleEvents: [
+      'session.start',
+      'session.stop',
+      'prompt.submit',
+      'tool.before',
+      'tool.after',
+      'tool.blocked',
+    ],
+  },
+
+  cursor: {
+    dispatch: {
+      generateCode: false,
+      analyzeCode: false,
+      applyEdit: false,
+      executeCommand: false,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: false,
+    resumable: false,
+    forkable: false,
+    backgroundable: false,
+    hooks: { supported: false, granularity: 'none', canBlock: false },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: false,
+    supportsSkills: false,
+    supportsMcp: false,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 128_000,
+    lifecycleEvents: [],
+  },
+} as const;
+
+/**
+ * Merged view of shipped + roadmap profiles. Use when you want capability
+ * data for any known tool ID regardless of adapter-implementation status.
+ *
+ * Consumers that need to distinguish shipped from roadmap should import
+ * `TOOL_PROFILES` and `ROADMAP_PROFILES` separately.
+ */
+export const ALL_KNOWN_PROFILES: Record<string, ProtocolCapabilities> = {
+  ...ROADMAP_PROFILES,
+  ...TOOL_PROFILES,
+} as const;

--- a/packages/harnesses/src/server/rpc-server.ts
+++ b/packages/harnesses/src/server/rpc-server.ts
@@ -89,10 +89,10 @@ const ERR_INTERNAL = -32603;
  *   merge.resolve             → MergeResult
  *   merge.list                → MergeRequest[]
  *   ci.report                 → CIFeedbackResult
- *   vaughn.capabilities       → ProtocolAdapterInfo[]   (Harness Protocol; wire name kept for compat)
- *   vaughn.dispatch           → { adapterId: string | null }
- *   vaughn.events             → ProtocolEventEnvelope[]
- *   vaughn.config.sync        → { files: Record<string, string> }
+ *   protocol.capabilities     → Array<{ id, capabilities: ProtocolCapabilities }>
+ *   protocol.dispatch         → { adapterId: string | null }
+ *   protocol.events           → ProtocolEventEnvelope[]
+ *   protocol.config.sync      → { files: Record<string, string> }
  *   shared.facts.publish      → SharedFact
  *   shared.memory.store       → SharedMemory
  *   shared.scratchpad.patch   → YjsPatch
@@ -744,11 +744,9 @@ export class RpcServer {
       }
 
       // -----------------------------------------------------------------------
-      // Harness Protocol  (wire-format method names use the historical
-      // `vaughn.*` namespace for backward compatibility with existing
-      // consumers — see docs/HARNESS_PROTOCOL.md §Transports.)
+      // Harness Protocol
       // -----------------------------------------------------------------------
-      case 'vaughn.capabilities': {
+      case 'protocol.capabilities': {
         const result: Array<{ id: string; capabilities: ProtocolCapabilities }> = [];
         for (const adapterId of this.registry.listAll()) {
           const caps = TOOL_PROFILES[adapterId];
@@ -757,7 +755,7 @@ export class RpcServer {
         return { jsonrpc: '2.0', id, result };
       }
 
-      case 'vaughn.dispatch': {
+      case 'protocol.dispatch': {
         if (!this.protocolDispatchFn) return this.noService(id, 'protocol-dispatch');
         const description = p.description as string | undefined;
         if (!description) return this.missingParam(id, 'description');
@@ -766,13 +764,13 @@ export class RpcServer {
         return { jsonrpc: '2.0', id, result: { adapterId } };
       }
 
-      case 'vaughn.events': {
+      case 'protocol.events': {
         const limit = (p.limit as number | undefined) ?? 50;
         const events = this.protocolEventQueue.slice(-limit);
         return { jsonrpc: '2.0', id, result: events };
       }
 
-      case 'vaughn.config.sync': {
+      case 'protocol.config.sync': {
         const config = p.config as ProtocolConfig | undefined;
         if (!config) return this.missingParam(id, 'config');
         const generated = generateAllConfigs(config);

--- a/packages/harnesses/src/workboard/session-identity.ts
+++ b/packages/harnesses/src/workboard/session-identity.ts
@@ -1,7 +1,5 @@
 import { readFileSync } from 'node:fs';
 
-let _legacyEnvWarningEmitted = false;
-
 /**
  * Type of session detected from the runtime environment.
  *
@@ -15,26 +13,17 @@ export type SessionType = 'claude' | 'codex' | 'zed' | 'cursor' | 'terminal';
  *
  * | Priority | Source                                                          |
  * |----------|-----------------------------------------------------------------|
- * | 1        | PROTOCOL_AGENT_ID env var (legacy fallback: VAUGHN_AGENT_ID)    |
+ * | 1        | PROTOCOL_AGENT_ID env var (explicit override)                   |
  * | 2        | CLAUDE_AGENT_ROLE env var (tool-specific)                       |
- * | 3        | Session cache (/tmp/protocol-session-<ppid>.id, legacy fallback /tmp/vaughn-session-<ppid>.id) |
+ * | 3        | Session cache (/tmp/protocol-session-<ppid>.id)                 |
  * | 4        | Process tree walk (/proc for tool binaries)                     |
  * | 5        | IDE detection (Zed, Cursor)                                     |
  * | 6        | TERM_PROGRAM env var                                            |
  * | 7        | Generic 'terminal' fallback                                     |
  */
 export function detectSessionType(): SessionType {
-  // Tier 1: Explicit PROTOCOL_AGENT_ID override (legacy VAUGHN_AGENT_ID still
-  // read for migration; remove the fallback once consumers have migrated).
-  const protocolAgentId = process.env.PROTOCOL_AGENT_ID;
-  const legacyAgentId = process.env.VAUGHN_AGENT_ID;
-  if (legacyAgentId && !protocolAgentId && !_legacyEnvWarningEmitted) {
-    _legacyEnvWarningEmitted = true;
-    process.stderr.write(
-      '[harnesses] VAUGHN_AGENT_ID is deprecated; rename to PROTOCOL_AGENT_ID. See @revealui/harnesses CHANGELOG 0.4.0.\n',
-    );
-  }
-  const agentId = protocolAgentId ?? legacyAgentId;
+  // Tier 1: Explicit PROTOCOL_AGENT_ID override
+  const agentId = process.env.PROTOCOL_AGENT_ID;
   if (agentId) {
     const tool = agentId.split('-')[0]?.toLowerCase();
     if (tool === 'claude') return 'claude';
@@ -47,20 +36,15 @@ export function detectSessionType(): SessionType {
   // Tier 2: Tool-specific env vars
   if (process.env.CLAUDE_AGENT_ROLE) return 'claude';
 
-  // Tier 3: Session cache (reuse previous detection). Prefer the protocol path;
-  // fall back to the legacy vaughn path during migration.
-  for (const cachePath of [
-    `/tmp/protocol-session-${process.ppid}.id`,
-    `/tmp/vaughn-session-${process.ppid}.id`,
-  ]) {
-    try {
-      const cached = readFileSync(cachePath, 'utf8').trim();
-      if (cached === 'claude' || cached === 'codex' || cached === 'zed' || cached === 'cursor') {
-        return cached;
-      }
-    } catch {
-      // Cache miss or not available.
+  // Tier 3: Session cache (reuse previous detection)
+  try {
+    const cachePath = `/tmp/protocol-session-${process.ppid}.id`;
+    const cached = readFileSync(cachePath, 'utf8').trim();
+    if (cached === 'claude' || cached === 'codex' || cached === 'zed' || cached === 'cursor') {
+      return cached;
     }
+  } catch {
+    // Cache miss or not available.
   }
 
   // Tier 4+5: Process tree walk (tool binaries and IDE detection)


### PR DESCRIPTION
## Summary

Finishes the VAUGHN → Harness Protocol rename. **Stacked on #982** (`chore/vaughn-trim-rename`), which is itself stacked on #980. Retarget this PR's base as each parent merges (`#982` first, then `test`).

Bumps `@revealui/harnesses` to **0.5.0** (pre-1.0 minor for breaking changes, per `versioning.md`).

## What this PR does

PR #982 (the rename) left three transitional carry-overs to protect against a daemon consumer that I assumed existed:

1. `vaughn.*` RPC method names kept as the wire-format spelling
2. `VAUGHN_AGENT_ID` env-var fallback with a one-time stderr deprecation warning
3. `/tmp/vaughn-session-<ppid>.id` cache-file fallback

A post-publish audit (`grep` across the entire fleet — `revfleet/`, `revdev/`, `~/.claude/hooks/`, `~/.claude/coordination/`, shell configs, internal docs/`) confirmed **none of those have any external consumer**. The deprecation pattern was protecting phantoms. This PR removes the aliases for a clean final state, and also splits the `TOOL_PROFILES` constant to make the spec-vs-shipped gap structurally visible.

## Breaking changes

**RPC method names** (no consumer found in the fleet):

| Old | New |
|---|---|
| `vaughn.capabilities` | `protocol.capabilities` |
| `vaughn.dispatch` | `protocol.dispatch` |
| `vaughn.events` | `protocol.events` |
| `vaughn.config.sync` | `protocol.config.sync` |

**Env var:** `VAUGHN_AGENT_ID` is no longer read. Use `PROTOCOL_AGENT_ID`. The one-time stderr deprecation warning is removed (no remaining callers to warn about).

**Session cache file:** `/tmp/vaughn-session-<ppid>.id` is no longer read. New path `/tmp/protocol-session-<ppid>.id` is used exclusively.

**`TOOL_PROFILES` shape:**

| Export | Before | After |
|---|---|---|
| `TOOL_PROFILES` | 4 entries (claude-code, codex, cursor, revealui-agent) | **1 entry** (revealui-agent — the only shipped adapter) |
| `ROADMAP_PROFILES` | _(new)_ | claude-code, codex, cursor (declared, no adapter) |
| `ALL_KNOWN_PROFILES` | _(new)_ | merged view; shipped wins on key collision |

`HarnessCoordinator.dispatchTask` consults explicit registered capabilities first, then `TOOL_PROFILES`, then `ROADMAP_PROFILES` — so callers that register stub adapters for spec'd-but-unimplemented tools still get capability data for dispatch decisions. **Dispatch behavior preserved.**

## Why both changes in one PR

Both are post-audit cleanup of the same situation: #982's audit found the over-claim ("coordination across heterogeneous AI tools") AND the audit-prompted patterns from #982 turned out to be over-engineered too (deprecation aliases protecting nobody; capability-profile blob mixing shipped + roadmap). One coherent cleanup PR instead of three fragmented ones.

## Migration

- **RPC callers:** rename method strings from `vaughn.*` to `protocol.*`.
- **Env consumers:** rename `VAUGHN_AGENT_ID` to `PROTOCOL_AGENT_ID` in any shell config / process environment.
- **Code reading TOOL_PROFILES['claude-code'/'codex'/'cursor']:** import `ROADMAP_PROFILES` (or `ALL_KNOWN_PROFILES`) from `@revealui/harnesses/protocol` instead.

## Test plan

- [ ] CI: quality + typecheck + tests + build pass
- [ ] `pnpm --filter @revealui/harnesses test` passes (tests rewritten to assert TOOL_PROFILES has only revealui-agent; ROADMAP_PROFILES has the other 3; merged view has all 4)
- [ ] `grep -r "vaughn\|VAUGHN"` returns only intentional residuals: CHANGELOG entries (history), HARNESS_PROTOCOL.md "Why" footnote (historical context), MASTER_PLAN.md historical Phase 2 records (annotated), blog author bylines, glossary "Rev Vaughn" example, slug-manifest `vaughn` legacy alias

## Closes the original PR #982 follow-up list

All three follow-ups from PR #982's body are addressed in this one PR (each turned out to be smaller than projected once the audit confirmed no external consumers):

- ~~Coordinate `vaughn.*` → `protocol.*` rename with daemon~~ → no daemon consumer; clean rename
- ~~Remove legacy env-var + cache fallbacks after deprecation window~~ → no consumer; removed now
- ~~Decide on TOOL_PROFILES split~~ → split into TOOL_PROFILES + ROADMAP_PROFILES + ALL_KNOWN_PROFILES
