### PR TITLE
ci(dependabot): auto-fix catalog specifier drift in pnpm-lock.yaml

### DIFF
--- a/.github/workflows/dependabot-catalog-autofix.yml
+++ b/.github/workflows/dependabot-catalog-autofix.yml
@@ -1,0 +1,98 @@
+name: Dependabot Catalog Lockfile Auto-Fix
+
+# When Dependabot bumps a catalog-managed dependency, it sometimes replaces
+# `specifier: 'catalog:'` in the pnpm-lock.yaml importer block with the
+# resolved version (e.g. `specifier: 8.21.0`), even though
+# `pnpm-workspace.yaml`'s catalog was correctly bumped. The resulting
+# importer entry no longer matches the manifest, so
+# `pnpm install --frozen-lockfile` rejects it with
+# ERR_PNPM_OUTDATED_LOCKFILE — breaking every Quality / Security / CodeQL
+# job until a human checks out the branch and runs `pnpm install`.
+#
+# This workflow runs that one-line fix automatically:
+#   1. Triggers only on Dependabot PRs that touched pnpm-lock.yaml.
+#   2. Checks out the PR head branch.
+#   3. Runs `pnpm install --lockfile-only --ignore-scripts`, which
+#      regenerates importer specifiers back to 'catalog:' against the
+#      already-correct workspace catalog.
+#   4. If the lockfile drifted, commits the fix as github-actions[bot]
+#      and pushes to the PR head.
+#
+# Push-loop guard: the workflow only runs when `github.actor` is
+# dependabot[bot]. The auto-fix commit is authored by
+# github-actions[bot], so the resulting push event will re-trigger the
+# workflow but the actor check will short-circuit the job.
+#
+# Security: `pull_request_target` runs with the BASE branch's workflow
+# definition, so a PR can't modify this workflow to escalate privileges.
+# `pnpm install --ignore-scripts` skips lifecycle scripts so a malicious
+# package.json change can't execute arbitrary code.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: dependabot-catalog-autofix-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.28.2"
+
+jobs:
+  autofix:
+    if: github.actor == 'dependabot[bot]'
+    name: Restore catalog specifiers in lockfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Regenerate lockfile entries from manifests
+        run: pnpm install --lockfile-only --ignore-scripts
+
+      - name: Detect lockfile drift
+        id: drift
+        run: |
+          if git diff --quiet pnpm-lock.yaml; then
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Lockfile already matches manifests — no fix needed"
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Lockfile drift detected — committing fix"
+            git --no-pager diff --stat pnpm-lock.yaml
+          fi
+
+      - name: Commit + push catalog specifier fix
+        if: steps.drift.outputs.drifted == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git -c core.fileMode=false commit -m "fix(deps): restore catalog specifiers in pnpm-lock.yaml"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          echo "::notice::Pushed catalog-specifier fix to ${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-catalog-autofix.yml` to auto-fix a recurring Dependabot + pnpm-catalog interaction that breaks CI on roughly half of weekly group bumps.

The bug: Dependabot bumps a catalog-managed dependency in `pnpm-workspace.yaml`, then **also** mutates one importer's `pnpm-lock.yaml` entry — replacing `specifier: 'catalog:'` with the resolved hard-pin. `pnpm install --frozen-lockfile` rejects the mismatch with `ERR_PNPM_OUTDATED_LOCKFILE`, taking out `Quality`, `Security Gate`, and `CodeQL` jobs simultaneously.

Most recent occurrence: [#968](https://github.com/RevealUIStudio/revealui/pull/968) (production-server group, `pg 8.20.0 → 8.21.0`), fixed manually as `a0eb7a54b`.

## How it works

- Triggers on `pull_request_target` with `paths: pnpm-lock.yaml`
- Job-level guard: only runs when `github.actor == 'dependabot[bot]'`
- Runs `pnpm install --lockfile-only --ignore-scripts` against the PR head
- If `pnpm-lock.yaml` drifted, commits the diff as `github-actions[bot]` and pushes back to the PR head
- **Push-loop guard:** the auto-fix commit changes `github.actor` to `github-actions[bot]`, which fails the job-level `if` on the resulting re-trigger

## Why this approach over the alternative

Considered adding all ~27 catalog-managed packages to `dependabot.yml`'s `ignore:` list. Rejected per fleet's `durable-only` HARDLINE:

- **Loses Dependabot surveillance** for the entire impactful dependency set — `next`, `react`, `pg`, `drizzle-orm`, `zod`, `typescript`, `vite`, etc. — including security advisories that would otherwise auto-PR.
- **Requires hand-curation** of the ignore list every time a new catalog package is added. Silent-breakage risk: someone bumps the workspace catalog with a new package, forgets to update `dependabot.yml`, the bug recurs.
- This workflow is **zero-maintenance** and scales automatically to any future catalog growth.

Prior art for the write-back-to-PR-branch pattern exists in:
- `.github/workflows/regen-visual-snapshots.yml` (commits + pushes regenerated snapshots)
- `.github/workflows/release.yml` (pushes tags after publish)

This isn't a novel security surface for the repo.

## Validation

Replayed against [#968](https://github.com/RevealUIStudio/revealui/pull/968)'s broken commit `7fc311f3fe` in a side worktree:

```sh
git checkout 7fc311f3fe
pnpm install --lockfile-only --ignore-scripts
git diff pnpm-lock.yaml
```

produces the **identical** one-line fix that the manual cleanup commit `a0eb7a54b` shipped:

```diff
@@ -205,7 +205,7 @@ importers:
       pg:
-        specifier: 8.21.0
+        specifier: 'catalog:'
         version: 8.21.0
```

`pnpm-lock.yaml | 2 +-` — same byte count, same line, same fix.

## Safety analysis

- **Token scope:** uses the default `GITHUB_TOKEN` with `contents: write` + `pull-requests: read`. No PAT, no app token.
- **`pull_request_target` security:** workflow definition is read from the BASE branch (`test`), so a malicious PR cannot modify this workflow to escalate.
- **Script execution:** `--ignore-scripts` skips lifecycle hooks; a malicious `package.json` script change can't execute arbitrary code during the fix.
- **Actor check** is the single guard, but it's adequate — `dependabot[bot]` is a privileged identity that GitHub enforces.

## Test plan

- [ ] CI passes on this PR (no lockfile drift expected — only adds a new workflow file)
- [ ] After merge, next Dependabot group PR that touches a catalog dep either needs no fix or gets an auto-fix commit from `github-actions[bot]`
- [ ] Verify push-loop guard fires on the re-trigger (the second workflow run should skip the job at the `if:` level)
- [ ] If Dependabot ever pushes a non-catalog lockfile change that legitimately differs from `pnpm install --lockfile-only`, the auto-fix will commit a "correct" lockfile — review the PR before merging

## Locked posture

- Base: `test` (per fleet PR policy)
- No `--auto`, no `--no-verify`, no `--admin`
- Manual merge after green
