### PR TITLE
fix(marketing): raise <th> text contrast to clear WCAG AA 4.5:1

### DIFF
--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -23,7 +23,7 @@ export function Problem() {
           >
             <table className="w-full text-left text-sm">
               <thead>
-                <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-widest text-gray-500">
+                <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-widest text-gray-600">
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
                     {HOME_PROBLEM.columns.capability}
                   </th>


### PR DESCRIPTION
## Summary

- **Root cause:** `apps/marketing/app/components/landing/Problem.tsx` table header row (`<tr>`) uses `text-gray-500` on `bg-gray-50`. With the Cobalt v5 palette remap in `index.css`, these resolve to `#6a7683` on `#f9fafc` — a contrast ratio of **4.45:1**, below the 4.5:1 WCAG 2 AA minimum for bold 12px uppercase text.
- **Fix:** Changed the `<tr className="... text-gray-500">` to `text-gray-600` on the table header row only. `text-gray-600` (#4a5765) on `bg-gray-50` (#f9fafc) = **7.11:1** — passes both AA and AAA.
- **Scope:** One class name change in one component. Palette token left unchanged — `gray-500` is also used on dark (`bg-gray-950`) backgrounds where it is already marginal; darkening the token would worsen those ratios.

## Contrast math (verified)

| Element | Before | After |
|---|---|---|
| Foreground | `text-gray-500` → `#6a7683` | `text-gray-600` → `#4a5765` |
| Background | `bg-gray-50` → `#f9fafc` | `bg-gray-50` → `#f9fafc` |
| Ratio | 4.45:1 (FAIL) | 7.11:1 (PASS AA + AAA) |

## Test

The fix was verified via OKLCH→sRGB→WCAG contrast ratio computation against the actual remapped palette values. I did not run the Playwright E2E suite locally (sandboxed environment). CI will run `smoke.e2e.ts:138 Marketing homepage has no critical accessibility violations` as part of the PR gate.

Unblocks test→main promotion PR #992.
