### PR TITLE
chore: anonymize customer references across docs, tests, scripts

### DIFF
--- a/apps/admin/src/lib/components/BrandedAuthLayout.tsx
+++ b/apps/admin/src/lib/components/BrandedAuthLayout.tsx
@@ -12,7 +12,7 @@ import type React from 'react';
  * Env vars consumed:
  * - `REVEALUI_TENANT_NAME` (or legacy `REVEALUI_BRAND_NAME`) — heading + logo alt text
  * - `REVEALUI_TENANT_HIDE_NAME` — `'true'` hides the visible heading text (useful when
- *   the logo already contains the company wordmark, e.g. "alleviatechnology"); alt
+ *   the logo already contains the company wordmark, e.g. "acmeinc"); alt
  *   text on the logo stays for screen-reader accessibility regardless
  * - `REVEALUI_TENANT_TAGLINE` — optional subline; suppressed if unset
  * - `REVEALUI_BRAND_LOGO_URL` — logo src; defaults to `/logo.webp` (kit-mountable)

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -133,7 +133,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
     slug: 'revforge',
     name: 'RevForge',
     tagline: 'White-label stamping tool',
-    body: 'Operator-side tool that generates branded RevealUI Fleet trial kits — domain-locked, multi-tenant self-hosted runtime instances (e.g. AlleviaFleet).',
+    body: 'Operator-side tool that generates branded RevealUI Fleet trial kits — domain-locked, multi-tenant self-hosted runtime instances.',
     status: 'Beta',
     iconPath:
       'M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766m-2.704 3.796-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z',

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -399,7 +399,7 @@ describe('validateLicenseAtStartup', () => {
 
   it('throws when the JWT was signed with a different key', async () => {
     const jwt = await generateLicenseKey(
-      { tier: 'enterprise', customerId: 'allevia' },
+      { tier: 'enterprise', customerId: 'acme' },
       testPrivateKey,
       30 * 24 * 60 * 60,
       testPublicKey,
@@ -432,7 +432,7 @@ describe('validateLicenseAtStartup', () => {
 
   it('passes for a valid Forge license JWT', async () => {
     const jwt = await generateLicenseKey(
-      { tier: 'enterprise', customerId: 'allevia' },
+      { tier: 'enterprise', customerId: 'acme' },
       testPrivateKey,
       30 * 24 * 60 * 60,
       testPublicKey,

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -120,14 +120,14 @@ Marketing copy may say "cobalt" (or "Electric Verdigris") descriptively but the 
 | RevealUI | Shipped | Beta — no paying users yet | The core runtime |
 | RevDev | Shipped (Studio + Console + Daemon all shipping) | Alpha | Dev harness; dogfooded via studio-dogfood lane |
 | RevVault | Shipped | Beta (MIT CLI + Pro desktop app) | Secret management |
-| RevForge | Shipped | Beta (operator-only stamping tool) | Produces customer brands like AlleviaFleet |
+| RevForge | Shipped | Beta (operator-only stamping tool) | Produces customer-stamped Fleet kits |
 | RevCon | Shipped | Alpha (MIT) | Editor config sync |
 | RevSkills | Shipped | Active (MIT) | Claude Code skills library |
 | RevKit | Planned | Pro (planned) | Portable WSL dev env |
 | RevMarket | Planned | Code-complete, dormant | MCP marketplace; X402_ENABLED=false |
 | RevealCoin | **Pre-launch** (only on /roadmap) | Mainnet deployed but pre-launch | Shelved 2026-05-15; legal + multisig gates open |
 
-**AlleviaFleet** is NOT a fleet product — it's a customer brand stamped via RevForge. Memory `project_alleviafleet_is_stamped_revforge`.
+Customer-stamped Fleet kits are NOT fleet products — they are per-customer brand instances produced via RevForge.
 
 ## 6. Open-weight inference defaults (per memory)
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -711,7 +711,7 @@ Phase D  -  Agent publisher tools (agent):
 
 ### Phase 7: Crucible  -  Business Bundle Generator (post-Phase 5, new product)
 
-**Origin:** Extracted from the Allevia Technology pitch kit workflow. Building the Allevia trial kit
+**Origin:** Extracted from the first enterprise pitch-kit workflow. Building the trial kit
 revealed a repeatable pattern worth productizing.
 
 **What it is:** A workflow and pipeline engine that takes a product/prototype and outputs a
@@ -728,15 +728,15 @@ structured "boardroom-ready business bundle"  -  a complete sales deliverable pa
 **Positioning:** "Your boardroom super pack  -  generated." For agencies, consultants, and SaaS
 companies pitching to enterprise or mid-market clients.
 
-**Seed artifact:** `~/projects/allevia-pitch-kit/`  -  the Allevia trial kit hand-assembled for
-RevealUI's first Forge prospect. The workflow to build it is the proto-Crucible pipeline.
+**Seed artifact:** an enterprise pitch kit hand-assembled for RevealUI's first Forge prospect.
+The workflow to build it is the proto-Crucible pipeline.
 
 **When to start:** After Phase 5 ships and RevealUI has recurring revenue. Crucible is a separate
 product, not an extension of RevealUI.
 
 - [ ] Define Crucible product spec (target customer, bundle types, delivery formats)
 - [ ] Bootstrap as new project (`~/revfleet/crucible`)
-- [ ] Extract Allevia kit workflow into repeatable pipeline steps
+- [ ] Extract first-customer kit workflow into repeatable pipeline steps
 - [ ] Build template library (pitch deck, SOW, install guide, pricing sheet)
 - [ ] Build bundle assembly CLI / UI
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -20,8 +20,7 @@ audience: developer
 | 3 | **RevForge** | Operator-side stamping tool (`RevealUIStudio/revforge`). Produces branded RevealUI Fleet kits per customer. | RevealUI Studio operators |
 | 4 | **RevealUI Fleet** | Customer-facing self-hosted runtime kit — white-label, multi-tenant, domain-locked, produced by RevForge. | Enterprise customers self-hosting |
 | 5 | **Enterprise** | SaaS billing tier label ($299/mo). Hosted alternative to self-hosting a Fleet kit. | Customers on the hosted Enterprise tier |
-| 6 | **AlleviaFleet** | First customer-stamped Fleet instance (Allevia Technology). | Allevia (first customer) |
-| 7 | (future stamps) | Customer-stamped Fleet instances per the Tier 4 model. | Future enterprise customers |
+| 6 | (customer stamps) | Customer-stamped Fleet instances per the Tier 4 model. | Enterprise customers |
 
 **Naming drift to avoid:** "Suite", "RevealUI Studio Fleet", bare "Fleet" → use **RevFleet**. Bare "Forge" is ambiguous — use RevForge (the tool), RevealUI Fleet (the kit), or Enterprise (the tier) per context.
 
@@ -56,7 +55,7 @@ Status: pre-launch (Docker images not yet on GHCR — stack runs from source tod
 
 ### RevealUI Fleet (the self-hosted kit)
 
-A Fleet kit is what an enterprise customer deploys on their own infrastructure. It is produced by RevForge, locked to the customer's domain, and supports unlimited users. AlleviaFleet is the first such instance.
+A Fleet kit is what an enterprise customer deploys on their own infrastructure. It is produced by RevForge, locked to the customer's domain, and supports unlimited users.
 
 The full Fleet deployment guide is at [`docs/FLEET.md`](./FLEET.md).
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,10 +16,6 @@ Synonyms in older copy: *AI assistant*, *model*, *task runner*, *bot*. Use **age
 
 The protocol agents use to discover and call each other. RevealUI's marketplace exposes A2A discovery alongside MCP tool invocation; the two together let an agent find the right specialist agent AND the right tools in one place. See [`docs/AI`](./AI.md).
 
-## AlleviaFleet
-
-The customer-stamped instance of [RevealUI Fleet](#revealui-fleet) deployed for Allevia Technology. Produced by the [RevForge](#revforge) stamping tool. Formerly *AlleviaForge* per ADR [`2026-05-03-revfleet-rename.md`](./decisions/2026-05-03-revfleet-rename.md) Tier 6 (supersedes 2026-05-01-forge-naming Phase 3).
-
 ## Customer
 
 External party who deploys a RevealUI runtime — either via the hosted service at `revealui.com` (SaaS tier) or via a self-hosted [RevealUI Fleet](#revealui-fleet) instance (Enterprise tier). Distinct from a *user* (who logs in to a deployed instance) and an *operator* (who runs the deployment).
@@ -89,7 +85,7 @@ A RevealUI agent's permanent named identity, formatted as **`Rev [Surname]`** (e
 
 ## RevealUI Fleet
 
-The white-label self-hosted runtime kit — Docker Compose stack + domain lock + unlimited users. Customers on the [Enterprise](#enterprise-tier) tier typically deploy a RevealUI Fleet instance on their own infrastructure. Produced by the [RevForge](#revforge) stamping tool, which yields per-customer instances (e.g., [AlleviaFleet](#alleviafleet) for Allevia Technology). Formerly *RevealUI Forge* per ADR [`2026-05-03-revfleet-rename.md`](./decisions/2026-05-03-revfleet-rename.md) Tier 4. **Status:** preview — Docker images not yet on GHCR; stack runs from source today. See [`./FORGE`](./FORGE.md) (page name preserved as redirect; content reflects "RevealUI Fleet" terminology).
+The white-label self-hosted runtime kit — Docker Compose stack + domain lock + unlimited users. Customers on the [Enterprise](#enterprise-tier) tier typically deploy a RevealUI Fleet instance on their own infrastructure. Produced by the [RevForge](#revforge) stamping tool, which yields per-customer instances. Formerly *RevealUI Forge* per ADR [`2026-05-03-revfleet-rename.md`](./decisions/2026-05-03-revfleet-rename.md) Tier 4. **Status:** preview — Docker images not yet on GHCR; stack runs from source today. See [`./FORGE`](./FORGE.md) (page name preserved as redirect; content reflects "RevealUI Fleet" terminology).
 
 ## RevForge
 

--- a/packages/core/src/__tests__/revforge-license.test.ts
+++ b/packages/core/src/__tests__/revforge-license.test.ts
@@ -138,17 +138,11 @@ describe('issueRevForgeLicense', () => {
 
   it('rejects non-positive maxSites / maxUsers', async () => {
     await expect(
-      issueRevForgeLicense(
-        { slug: 'acme', tier: 'pro', maxSites: 0 },
-        { privateKey, publicKey },
-      ),
+      issueRevForgeLicense({ slug: 'acme', tier: 'pro', maxSites: 0 }, { privateKey, publicKey }),
     ).rejects.toThrow(/--max-sites/);
 
     await expect(
-      issueRevForgeLicense(
-        { slug: 'acme', tier: 'pro', maxUsers: -5 },
-        { privateKey, publicKey },
-      ),
+      issueRevForgeLicense({ slug: 'acme', tier: 'pro', maxUsers: -5 }, { privateKey, publicKey }),
     ).rejects.toThrow(/--max-users/);
   });
 

--- a/packages/core/src/__tests__/revforge-license.test.ts
+++ b/packages/core/src/__tests__/revforge-license.test.ts
@@ -18,17 +18,17 @@ beforeAll(() => {
 describe('issueRevForgeLicense', () => {
   it('issues a JWT with the expected shape and metadata', async () => {
     const result = await issueRevForgeLicense(
-      { slug: 'allevia', tier: 'pro' },
+      { slug: 'acme', tier: 'pro' },
       { privateKey, publicKey },
     );
 
     expect(result.licenseKey).toMatch(/^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\..+/);
-    expect(result.customerId).toBe('allevia');
+    expect(result.customerId).toBe('acme');
     expect(result.tier).toBe('pro');
     expect(result.perpetual).toBe(false);
     expect(result.expiresAt).not.toBeNull();
     expect(result.payload.tier).toBe('pro');
-    expect(result.payload.customerId).toBe('allevia');
+    expect(result.payload.customerId).toBe('acme');
   });
 
   it('round-trips: issued JWT validates back to the same payload', async () => {
@@ -105,7 +105,7 @@ describe('issueRevForgeLicense', () => {
     await expect(
       issueRevForgeLicense(
         // biome-ignore lint/suspicious/noExplicitAny: invalid tier on purpose
-        { slug: 'allevia', tier: 'free' as any },
+        { slug: 'acme', tier: 'free' as any },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/Invalid --tier/);
@@ -114,7 +114,7 @@ describe('issueRevForgeLicense', () => {
   it('rejects perpetual + expiresInDays combined', async () => {
     await expect(
       issueRevForgeLicense(
-        { slug: 'allevia', tier: 'pro', perpetual: true, expiresInDays: 30 },
+        { slug: 'acme', tier: 'pro', perpetual: true, expiresInDays: 30 },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/mutually exclusive/);
@@ -123,14 +123,14 @@ describe('issueRevForgeLicense', () => {
   it('rejects non-positive expiresInDays', async () => {
     await expect(
       issueRevForgeLicense(
-        { slug: 'allevia', tier: 'pro', expiresInDays: 0 },
+        { slug: 'acme', tier: 'pro', expiresInDays: 0 },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/positive integer/);
 
     await expect(
       issueRevForgeLicense(
-        { slug: 'allevia', tier: 'pro', expiresInDays: -1 },
+        { slug: 'acme', tier: 'pro', expiresInDays: -1 },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/positive integer/);
@@ -139,14 +139,14 @@ describe('issueRevForgeLicense', () => {
   it('rejects non-positive maxSites / maxUsers', async () => {
     await expect(
       issueRevForgeLicense(
-        { slug: 'allevia', tier: 'pro', maxSites: 0 },
+        { slug: 'acme', tier: 'pro', maxSites: 0 },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/--max-sites/);
 
     await expect(
       issueRevForgeLicense(
-        { slug: 'allevia', tier: 'pro', maxUsers: -5 },
+        { slug: 'acme', tier: 'pro', maxUsers: -5 },
         { privateKey, publicKey },
       ),
     ).rejects.toThrow(/--max-users/);

--- a/scripts/electric-latency-probe/README.md
+++ b/scripts/electric-latency-probe/README.md
@@ -8,9 +8,9 @@ in a meeting, with a header that identifies which backend was measured.
 
 ## Why local, not prod
 
-- Allevia's Forge deployment is local-box, not cloud. The honest
+- The first Forge customer's deployment is local-box, not cloud. The honest
   number is the local number; the cloud path adds Vercel→Railway
-  and Railway→Supabase hops that Allevia won't experience.
+  and Railway→Supabase hops that the customer won't experience.
 - Avoids writing 50 POSTs into a prod shape other subscribers read.
 - Secrets posture: the script pulls from revvault rather than
   env-vars you have to paste anywhere.

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -502,9 +502,9 @@ ${samples
 
 - Concurrent-write load. This is an unloaded serial measurement.
   Propagation under 50 concurrent agents is unknown.
-- The Vercel→Railway→Supabase cloud path. Allevia's Forge deployment
-  is local-box; cloud measurement would add hops that won't exist on
-  the customer's box.
+- The Vercel→Railway→Supabase cloud path. The first Forge customer's
+  deployment is local-box; cloud measurement would add hops that won't
+  exist on the customer's box.
 `;
 
   mkdirSync(dirname(NOTES_PATH), { recursive: true });

--- a/scripts/setup/issue-revforge-license.ts
+++ b/scripts/setup/issue-revforge-license.ts
@@ -12,7 +12,7 @@
  *
  * Usage:
  *   revvault export-env -- pnpm tsx scripts/setup/issue-revforge-license.ts \
- *     --slug allevia --tier enterprise --expires-in-days 30
+ *     --slug acme --tier enterprise --expires-in-days 30
  *
  *   # Perpetual (one-time purchase), full JSON output
  *   ... --slug bigcorp --tier enterprise --perpetual --json
@@ -125,9 +125,9 @@ Required env (source from revvault):
   REVEALUI_LICENSE_PUBLIC_KEY   Ed25519 public key (PEM, may be \\n-encoded).
 
 Examples:
-  # 30-day trial license for Allevia
+  # 30-day trial license
   revvault export-env -- pnpm tsx scripts/setup/issue-revforge-license.ts \\
-    --slug allevia --tier enterprise --expires-in-days 30
+    --slug acme --tier enterprise --expires-in-days 30
 
   # Perpetual enterprise license, full JSON output
   revvault export-env -- pnpm tsx scripts/setup/issue-revforge-license.ts \\


### PR DESCRIPTION
## Summary

Anonymizes customer-specific references across docs, marketing copy,
tests, and scripts so public-repo content never names a specific
customer. Customer engagements belong in the private engagement
docs, not in the public monorepo.

## Files

| File | Change |
|---|---|
| `docs/REVFLEET.md` | Tier-6 row + Fleet-kit prose: drop specific customer naming; keep generic "customer-stamped Fleet instances" |
| `docs/glossary.md` | Remove tier-6-specific glossary entry; replace customer name in RevealUI Fleet entry |
| `docs/MASTER_PLAN.md` | Phase 7 Crucible origin + seed-artifact prose: anonymize |
| `docs/MARKETING_METRICS.md` | RevForge row + Tier-6 callout: generic phrasing |
| `apps/marketing/app/content/products.ts` | RevForge body copy on revealui.com: drop `e.g. ...` parenthetical |
| `apps/admin/src/lib/components/BrandedAuthLayout.tsx` | Docstring example for `REVEALUI_TENANT_HIDE_NAME`: use generic placeholder wordmark |
| `apps/server/src/lib/__tests__/validate-startup.test.ts` | `customerId` test fixture |
| `packages/core/src/__tests__/revforge-license.test.ts` | `slug` + `customerId` test fixtures (7× call sites) |
| `scripts/setup/issue-revforge-license.ts` | CLI usage examples (header + `printUsage()`) |
| `scripts/electric-latency-probe/{README.md,probe.ts}` | "Why local, not prod" + "What it does NOT measure" prose |

## Replacement vocabulary

- Test slugs / `customerId`: `'acme'` (conventional placeholder)
- BrandedAuthLayout docstring wordmark example: `"acmeinc"`
- Marketing + docs prose: "customer-stamped Fleet instances", "an
  enterprise customer", "the first Forge customer's deployment" —
  generic phrasing that preserves the original meaning

## Verification

- `grep -ri <former-customer-name> .` → 0 matches across the working tree (pattern omitted to keep public docs clean of the historical name)
- No behavior change; tests still pass against the new fixture slug
  (the slug value is opaque to the license JWT issuer)

## Test plan

- [ ] CI green (lint, typecheck, tests, build)
- [ ] Manual: `grep -ri <former-customer-slug> .` → 0 matches (pattern omitted)
- [ ] Vercel preview shows `/products` RevForge card without the
      parenthetical
- [ ] `pnpm tsx scripts/validate/claim-drift.ts` passes (no marketing
      claim drift introduced)

## Out of scope

- Git history rewrite to scrub the same string from older commits +
  commit messages (tracked separately as the next step in this lane).
- PR title/body edits on prior PRs that mention the customer (also
  tracked separately).


