### PR TITLE
fix(presentation): lift dark-mode --rvui-brand to WCAG AA on midnight

### DIFF
--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -106,7 +106,7 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 
 | Surface | Value |
 |---|---|
-| Primary brand color (`--rvui-brand`) | `oklch(0.46 0.180 240)` (cobalt, dark mode default) |
+| Primary brand color (`--rvui-brand`) | `oklch(0.58 0.150 240)` (cobalt-300, dark mode default — AA-lifted 2026-05-19) |
 | Light mode brand | `oklch(0.36 0.190 240)` |
 | Source-of-truth file | `packages/presentation/src/tokens.css:109-116` (dark) + `:198-206` (light) |
 | Memory | `project_fleet_brand_emerald_convergence` (to be renamed post-merge: cobalt landed 2026-05-19) |

--- a/packages/presentation/src/tokens.css
+++ b/packages/presentation/src/tokens.css
@@ -106,14 +106,18 @@
  * DARK MODE — :root default (dark-first design)
  * ═══════════════════════════════════════════════════════════════ */
 :root {
-  /* ── Brand · Cobalt (Electric Verdigris) ── */
-  --rvui-brand:         oklch(0.46 0.180 240);
-  --rvui-brand-hover:   oklch(0.52 0.170 240);
+  /* ── Brand · Cobalt (Electric Verdigris) ──
+   * Dark-mode brand lifted to cobalt-300 (L=0.58) for WCAG AA on midnight.
+   * Prior dark brand at L=0.46 tested at 2.80:1 (FAIL); lifted value tests at 4.73:1.
+   * Source: design-system/Assessment · Contrast & Accessibility.html
+   */
+  --rvui-brand:         oklch(0.58 0.150 240);
+  --rvui-brand-hover:   oklch(0.65 0.130 240);
   --rvui-brand-strong:  oklch(0.36 0.190 240);
-  --rvui-brand-soft:    oklch(0.46 0.180 240 / 0.16);
-  --rvui-brand-subtle:  oklch(0.46 0.180 240 / 0.10);
+  --rvui-brand-soft:    oklch(0.58 0.150 240 / 0.16);
+  --rvui-brand-subtle:  oklch(0.58 0.150 240 / 0.10);
   --rvui-brand-text:    oklch(0.78 0.100 240);
-  --rvui-brand-glow:    oklch(0.46 0.180 240 / 0.42);
+  --rvui-brand-glow:    oklch(0.58 0.150 240 / 0.42);
 
   /* ── Accent · Solar Amber (honey-gold complement) ── */
   --rvui-accent:        oklch(0.80 0.165 85);


### PR DESCRIPTION
## Summary

Resolves WCAG AA fail #1 from `design-system/Assessment · Contrast & Accessibility.html` — dark-mode `--rvui-brand` tests at **2.80:1** against the midnight surface, failing AA 4.5:1.

Lifts the dark-mode brand to cobalt-300 oklch(0.58 0.150 240) ≈ `#4485bd`, which the design-system contrast audit grades at **4.73:1 AA**.

## DS grounding (per `design-system/CLAUDE.md` "before you make a change")

**DS files read:**
- `design-system/CLAUDE.md` (open-issue #1)
- `design-system/contrast-results.json` (the "Cobalt-300 on midnight" entry at 4.73 AA = target)
- `design-system/Assessment · Contrast & Accessibility.html` (via CLAUDE.md summary)

**Tokens edited:**
- `--rvui-brand` (dark): `oklch(0.46 0.180 240)` → `oklch(0.58 0.150 240)`
- `--rvui-brand-hover` (dark): `oklch(0.52 0.170 240)` → `oklch(0.65 0.130 240)` (brighter than base, ~6:1 on midnight)
- `--rvui-brand-soft` / `--rvui-brand-subtle` / `--rvui-brand-glow` (dark): alpha overlays re-base to oklch 0.58 so tinted backgrounds stay coherent with the new brand value
- `--rvui-brand-strong` / `--rvui-brand-text` untouched (strong is for press/deep-ink only; text already passes AAA at oklch 0.78)
- Light-mode brand untouched — `oklch(0.36 0.190 240)` passes AAA at 10.19:1 on paper

**Contrast math verification** (L³ approximation, calibrated against axe-reported values):

| Surface | Current | New | Threshold |
|---|---|---|---|
| `--rvui-brand` (dark) on midnight | 2.72:1 (axe: 2.80 FAIL) | 4.53:1 (axe target: 4.73 AA) | 4.5:1 ✓ |
| `--rvui-brand-hover` (dark) on midnight | 3.52:1 (axe: 3.73 AA-large) | 6.00:1 | 4.5:1 ✓ |

**Open-issue crossings:** Resolves DS open issue #1. Does not touch issues #2 (warning text), #3 (smoke-300 as text), #4 (status colors on dark), #5 (logo assets).

## Files (2 changed, 11 insertions / 7 deletions)

- `packages/presentation/src/tokens.css` — dark `:root` brand block, 6 lines
- `docs/MARKETING_METRICS.md` §4 — token-value reference updated

## Blast radius

Every dark-mode brand surface in the admin app: primary CTAs (`bg-primary` via shadcn bridge → `--rvui-brand`), focus rings (`ring-ring` → `--rvui-brand`), brand-tinted text using `--rvui-brand` directly. The hue shifts slightly (saturation drops as lightness rises — kept hue at 240 throughout).

## Test plan

- [x] Token math validated against `design-system/contrast-results.json`
- [ ] CI gate passes on this branch (typecheck + biome + unit tests)
- [ ] After merge to `test`, manual axe pass on admin in dark mode shows no `--rvui-brand`-related fails

## Stacked behind

- PR #994 (marketing landing a11y sweep) — independent, this PR can land before or after.
