### PR TITLE
chore(marketing): normalize sign-up CTAs to canonical "Start free"

### DIFF
--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -229,7 +229,7 @@ export const HOME_GET_STARTED = {
   heading: 'Ready to build?',
   body: 'Users, content, products, payments, and AI, pre-wired. Start building locally in minutes; flip to live mode when you are ready.',
   cta: {
-    primary: { label: 'Get started free', href: SITE.urls.signup } satisfies Cta,
+    primary: { label: 'Start free', href: SITE.urls.signup } satisfies Cta,
     secondary: { label: 'Read the docs', href: SITE.urls.docs } satisfies Cta,
   },
   newsletter: {

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -14,7 +14,7 @@ export const NAV_LINKS: readonly NavLink[] = [
 
 export const NAV_AUTH = {
   login: { label: 'Log in', href: SITE.urls.adminLogin },
-  signup: { label: 'Get started free', href: SITE.urls.signup },
+  signup: { label: 'Start free', href: SITE.urls.signup },
 } as const;
 
 export interface FooterColumn {

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -33,7 +33,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
       'Self-host on any infra',
       'Bring your own model (open-weight default)',
     ],
-    cta: 'Get started free',
+    cta: 'Start free',
     href: SITE.urls.signup,
     highlight: false,
   },

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -159,7 +159,7 @@ export function BlogPostPage() {
               href="https://admin.revealui.com/signup"
               className="rounded-md bg-gray-950 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
             >
-              Get started free
+              Start free
             </a>
             <a
               href="https://docs.revealui.com"


### PR DESCRIPTION
## Summary

Normalizes 4 sign-up CTAs across the marketing site from "Get started free" to the design-system canonical **"Start free"**.

## DS grounding

`design-system/CLAUDE.md` — Voice & content rules:
> **Canonical CTAs** | "Start free", "See Pro pricing", "Talk to us" — never "Buy now" or "Subscribe"

`design-system/Assessment · Microcopy.html`:
> cta.signup → "Start free"

The kit's own `design-system/ui_kits/marketing/Hero.jsx` already uses `"Start free"` verbatim, confirming the canonical form.

## State before this PR

Audit found the codebase was inconsistent on the same action:

| Surface | Current copy | Canonical |
|---|---|---|
| `home.ts:30` — Hero primary CTA | "Start free" ✓ | "Start free" |
| `home.ts:232` — GetStarted footer CTA | "Get started free" | "Start free" |
| `nav.ts:17` — NavBar sign-up link | "Get started free" | "Start free" |
| `pricing-teaser.ts:36` — Free tier card | "Get started free" | "Start free" |
| `BlogPostPage.tsx:162` — Blog post CTA | "Get started free" | "Start free" |
| `pricing-teaser.ts:50` — Pro tier CTA | "See Pro pricing" ✓ | "See Pro pricing" |
| `pricing-teaser.ts:65` — Enterprise tier CTA | "Talk to us" ✓ | "Talk to us" |

Hero, Pro CTA, Enterprise CTA already canonical. This PR normalizes the four "Get started free" stragglers.

## What this PR does NOT change

- "Subscribe monthly or buy a perpetual license" in `pricing.ts:27` — descriptive prose about the pricing model, not a CTA. The DS rule is about CTA text only.
- Server-side access-denied messages (`apps/server/src/routes/**`) — audited and already follow the DS pattern of blaming the action ("Admin role required") rather than the user ("Your role can't"). No changes needed.
- Marketing copy outside CTA labels — not in scope for this PR.

## Files (4 changed, 4 lines)

- `apps/marketing/app/content/home.ts`
- `apps/marketing/app/content/nav.ts`
- `apps/marketing/app/content/pricing-teaser.ts`
- `apps/marketing/app/routes/BlogPostPage.tsx`

## Coordination

- Audited the closed `messaging-positioning` lane corpus (`docs/lanes/_closed/messaging-positioning/` in internal docs) for any countervailing pins on CTA wording — none found. No conflict with that lane's substantive locks.
- No open PRs from peers touching these files.

## Test plan

- [x] No test snapshots / fixtures reference the old wording
- [x] CTA href values unchanged (same destinations)
- [ ] CI gate passes (typecheck + biome + unit tests)
- [ ] After merge, marketing site shows "Start free" consistently across hero, nav, free-tier card, blog footer
