### PR TITLE
fix(marketing): Phase B5 — sweep text-gray-N on light routes to text-muted-foreground

### DIFF
--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -108,7 +108,7 @@ export function BlogIndexPage() {
                   key={post.id}
                   className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200 hover:ring-blue-300 transition-all"
                 >
-                  <div className="flex items-center gap-x-4 text-xs text-gray-500">
+                  <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
                     <time dateTime={post.publishedAt ?? post.createdAt}>
                       {formatDate(post.publishedAt ?? post.createdAt)}
                     </time>

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -79,7 +79,9 @@ export function BlogPostPage() {
   if (loading && !post) {
     return (
       <div className="min-h-screen bg-white">
-        <div className="mx-auto max-w-3xl px-6 py-32 text-center text-gray-500">Loading…</div>
+        <div className="mx-auto max-w-3xl px-6 py-32 text-center text-muted-foreground">
+          Loading…
+        </div>
         <Footer />
       </div>
     );
@@ -122,7 +124,7 @@ export function BlogPostPage() {
 
           {/* Header */}
           <header className="mb-12">
-            <div className="flex items-center gap-x-4 text-sm text-gray-500">
+            <div className="flex items-center gap-x-4 text-sm text-muted-foreground">
               <time dateTime={post.publishedAt ?? post.createdAt}>
                 {formatDate(post.publishedAt ?? post.createdAt)}
               </time>
@@ -140,7 +142,7 @@ export function BlogPostPage() {
             ) : typeof post.content === 'string' ? (
               <Markdown>{post.content}</Markdown>
             ) : (
-              <p className="text-gray-500 italic">Content rendering coming soon.</p>
+              <p className="text-muted-foreground italic">Content rendering coming soon.</p>
             )}
           </div>
         </div>

--- a/apps/marketing/app/routes/ComingSoonPage.tsx
+++ b/apps/marketing/app/routes/ComingSoonPage.tsx
@@ -130,7 +130,7 @@ export function ComingSoonPage() {
               {ROADMAP_CTA_LINKS.joinDiscussion.label}
             </a>
           </div>
-          <p className="mt-8 text-sm text-gray-500">
+          <p className="mt-8 text-sm text-muted-foreground">
             See what's shipped today &rarr;{' '}
             <a
               href={ROADMAP_CTA_PRODUCTS_LINK.href}

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -72,7 +72,7 @@ export function FairSourcePage() {
       <section className="bg-white py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_CONTRACT_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
@@ -135,7 +135,7 @@ export function FairSourcePage() {
       <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_PACKAGES_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
@@ -152,7 +152,7 @@ export function FairSourcePage() {
 
           <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-white ring-1 ring-gray-950/5">
             <table className="w-full text-left text-sm">
-              <thead className="bg-gray-100 text-xs font-semibold uppercase tracking-widest text-gray-500">
+              <thead className="bg-gray-100 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                 <tr>
                   <th className="px-6 py-3">Package</th>
                   <th className="px-6 py-3">Purpose</th>
@@ -196,7 +196,7 @@ export function FairSourcePage() {
               </tbody>
             </table>
           </div>
-          <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-gray-500">
+          <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground">
             {FAIR_SOURCE_PACKAGES_SECTION.footer.prefix}{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
               {FAIR_SOURCE_PACKAGES_SECTION.footer.command}
@@ -210,7 +210,7 @@ export function FairSourcePage() {
       <section className="bg-white py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_CLOCK_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
@@ -245,7 +245,7 @@ export function FairSourcePage() {
       <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_PEERS_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
@@ -275,7 +275,7 @@ export function FairSourcePage() {
       <section className="bg-white py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_FAQ_SECTION.eyebrow}
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -67,7 +67,7 @@ export function PricingPage() {
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
             {PRICING_HERO.subtitle}
           </p>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-gray-500">
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
             {PRICING_HERO_SUBTEXT.prefix}{' '}
             <a
               href={PRICING_HERO_SUBTEXT.linkHref}
@@ -121,7 +121,7 @@ export function PricingPage() {
                   key={item.label}
                   className={`flex items-baseline gap-2${i === PRICING_CFO_PANEL.lineItems.length - 1 ? ' sm:col-span-2' : ''}`}
                 >
-                  <span className="text-gray-500">&bull;</span>
+                  <span className="text-muted-foreground">&bull;</span>
                   <span>
                     <span className="font-semibold text-gray-900">{item.label}</span> {item.amount}
                   </span>
@@ -227,12 +227,12 @@ export function PricingPage() {
                   </div>
                 )}
                 <h3 className="text-lg font-bold text-gray-900">{tier.name}</h3>
-                <p className="mt-1 text-sm text-gray-500">{tier.description}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{tier.description}</p>
                 <p className="mt-4 flex items-baseline gap-x-1">
                   <span className="text-4xl font-bold text-gray-900">{tier.price ?? ' - '}</span>
-                  <span className="text-sm text-gray-500">{tier.priceNote ?? ''}</span>
+                  <span className="text-sm text-muted-foreground">{tier.priceNote ?? ''}</span>
                 </p>
-                <p className="mt-1 text-xs text-gray-500">{tier.renewal ?? ' - '}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{tier.renewal ?? ' - '}</p>
                 <ul className="mt-6 mb-8 space-y-3">
                   {tier.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-x-3">

--- a/apps/marketing/app/routes/PrivacyPage.tsx
+++ b/apps/marketing/app/routes/PrivacyPage.tsx
@@ -6,7 +6,7 @@ export function PrivacyPage() {
     <div className="min-h-screen bg-white">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
         <h1>{PRIVACY_META.title}</h1>
-        <p className="text-sm text-gray-500">Last updated: {PRIVACY_META.lastUpdated}</p>
+        <p className="text-sm text-muted-foreground">Last updated: {PRIVACY_META.lastUpdated}</p>
 
         <p>{PRIVACY_META.intro}</p>
 

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -186,7 +186,7 @@ export function ProductsPage() {
                         {product.status}
                       </span>
                       {product.version ? (
-                        <span className="font-mono text-[0.7rem] text-gray-500">
+                        <span className="font-mono text-[0.7rem] text-muted-foreground">
                           {product.version}
                         </span>
                       ) : null}

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -173,7 +173,7 @@ export function SponsorPage() {
         </div>
       </section>
 
-      <div className="py-8 text-center text-sm text-gray-500">
+      <div className="py-8 text-center text-sm text-muted-foreground">
         {SPONSOR_FOOTER_NOTE.prefix}
         <a
           href={SPONSOR_FOOTER_NOTE.productsLink.href}

--- a/apps/marketing/app/routes/TermsPage.tsx
+++ b/apps/marketing/app/routes/TermsPage.tsx
@@ -6,7 +6,7 @@ export function TermsPage() {
     <div className="min-h-screen bg-white">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
         <h1>{TERMS_META.title}</h1>
-        <p className="text-sm text-gray-500">Last updated: {TERMS_META.lastUpdated}</p>
+        <p className="text-sm text-muted-foreground">Last updated: {TERMS_META.lastUpdated}</p>
 
         <p>{TERMS_META.intro}</p>
 


### PR DESCRIPTION
## Summary

Phase 2 of the fleet text-palette sweep (ADR `2026-05-19-semantic-text-tokens` in an internal repo). Continuation of #994 (landing components) — extends to marketing routes and non-landing components.

Replaces `text-gray-500` and `text-gray-400` with the theme-aware `text-muted-foreground` semantic utility wherever the parent surface is LIGHT. Routes through `--rvui-text-2`:
- Light (paper): `oklch(0.50 ...)` ≈ `#4f6580` — **5.73:1 AA** ✓
- Dark (midnight): `oklch(0.65 ...)` ≈ `#8298b3` — **6.29:1 AA** ✓

Both surfaces pass AA, vs palette-locked `text-gray-500`'s **4.43:1 FAIL** on paper.

## DS grounding

- `design-system/Assessment · Contrast & Accessibility.html` finding #3 (smoke-300-as-text caution)
- `design-system/CLAUDE.md` substitution table (`#6b7280` / `#6b7d96` → `var(--mkt-fg-muted)` / equivalently `text-muted-foreground` via shadcn bridge)
- Driven by the audit script from #998 (`pnpm audit:palette-text`)
- Convention codified in ADR `2026-05-19-semantic-text-tokens`

## Files (9 changed, 21 line swaps)

| File | Swaps | What changed |
|---|---|---|
| `routes/PricingPage.tsx` | 5 | hero subtext, CFO panel bullet, perpetual tier metadata |
| `routes/FairSourcePage.tsx` | 7 | 5 section eyebrows + packages table `<thead>` + footer note |
| `routes/BlogPostPage.tsx` | 3 | loading state, article metadata, italic fallback |
| `routes/BlogIndexPage.tsx` | 1 | post-card metadata |
| `routes/TermsPage.tsx` | 1 | last-updated |
| `routes/PrivacyPage.tsx` | 1 | last-updated |
| `routes/ProductsPage.tsx` | 1 | sister-product version badge |
| `routes/SponsorPage.tsx` | 1 | Why Sponsor footer |
| `routes/ComingSoonPage.tsx` | 1 | CTA section footer |

## INTENTIONAL palette-locks preserved (27 occurrences)

Per ADR §Decision rule 2: raw palette text utilities are allowed when the immediate surface is also palette-locked.

- **`Footer.tsx`** (all `text-gray-400`) — entire component on `bg-gray-950`
- **`NewsletterSignup.tsx:74`** (`text-gray-400` stacked variant) — renders inside the `bg-gray-950` Footer
- **`ContactForm.tsx`** (3× `placeholder:text-gray-400`) — placeholder text. WCAG SC 1.4.3 explicitly carves out placeholder text from minimum contrast.
- **`PricingPage.tsx`** §`#for-agents` + Final CTA — all on `bg-gray-950`
- **`ProductsPage.tsx`** stats section + CLI mockup — `bg-gray-950`
- **`FairSourcePage.tsx`** §CTA section — `bg-gray-950`
- **`ProductMockup.tsx`** (explicit scope-out) — browser-chrome simulation, forced-light `bg-white`; already palette-locked appropriately
- **`GetStarted.tsx`** (explicit scope-out) — `bg-gray-950` section
- **`landing/*.tsx`** — handled by #994 already

## Out of scope (deferred to future PRs)

- `apps/admin/**/*.tsx` — admin is dark-mode-first; most palette utilities are intentional. Separate audit pass needed.
- `apps/docs/**/*.tsx` — docs surface; not on the conversion path.
- `packages/presentation/**/*.tsx` — primitive surface needs careful per-component review.

`pnpm audit:palette-text` (from #998) will continue to report these counts and guide subsequent sweeps. The Phase 3 CI hard-fail flip (separate ADR amendment) happens after admin + docs are clean.

## Test plan

- [x] No remaining `text-gray-500` or `text-gray-400` on light surfaces in `apps/marketing/app/routes/*.tsx`
- [x] Biome formatter clean
- [x] Sub-agent classified all 48 candidates: 21 AVOIDABLE (swapped) + 27 INTENTIONAL (preserved with documented reason)
- [x] One trust-but-verify spot-check confirmed `ProductsPage.tsx:246` `<span className="text-gray-500">$</span>` inside `bg-gray-950` CLI mockup is correctly preserved
- [ ] CI gate passes
- [ ] After merge, axe-core scans on marketing routes show no `text-gray-500`-class fails

## Stacked PRs (sequence)

This is the 5th of 5 PRs in the Phase B design-system rollout:

1. ✓ [revealui#996](https://github.com/RevealUIStudio/revealui/pull/996) — dark-mode `--rvui-brand` AA lift
2. ✓ [revealui#997](https://github.com/RevealUIStudio/revealui/pull/997) — `--rvui-warning-text` for AA-safe warning text
3. ✓ [revealui#998](https://github.com/RevealUIStudio/revealui/pull/998) — AST audit script
4. ✓ [revealui#999](https://github.com/RevealUIStudio/revealui/pull/999) — microcopy CTAs to canonical "Start free"
5. ✓ This PR — fleet `text-gray-N` sweep beyond marketing homepage

ADR `2026-05-19-semantic-text-tokens.md` already on an internal repo main (`56c8618c9`).
