### PR TITLE
chore(gitignore): exclude design-system/ local canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,7 @@ apps/terminal/.ssh/
 # editor-configs (symlinked)
 .cursor/
 .zed/
+
+# Local design canvas — HTML mockups + drag-from-host design assets.
+# Not a source directory; promote to revskills/skills/<name>/ if/when committed.
+design-system/


### PR DESCRIPTION
## Summary

Gitignore `design-system/` — an untracked dir at the repo root containing HTML mockups + drag-from-host design assets (`*:Zone.Identifier` markers throughout).

The dir was sitting untracked in the working tree and would have been slurped by any `git add .` from anyone (agent or human) running broad-add. Not a source directory; if its skill-bundle shape (it carries its own `CLAUDE.md` / `SKILL.md` / `README.md`) is wanted in version control later, the right home is `revskills/skills/<name>/`, not the revealui monorepo root.

## Why

Prevents accidental commit of ~1MB of local design canvas assets.

## Test plan

- [x] CI checks pass on `test`
- [x] `.gitignore` change is additive — does not affect any currently-tracked path
