### PR TITLE
fix(deps): pin ws@8 >=8.20.1 to close GHSA-58qx-3vcg-4xpx (#88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
       "smol-toml": ">=1.6.1",
       "jsdom": "29.0.1",
       "uuid": ">=14.0.0",
+      "ws@8": ">=8.20.1",
       "@revealui/config": "workspace:*",
       "@revealui/contracts": "workspace:*",
       "@revealui/db": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,7 @@ overrides:
   smol-toml: '>=1.6.1'
   jsdom: 29.0.1
   uuid: '>=14.0.0'
+  ws@8: '>=8.20.1'
   '@revealui/config': workspace:*
   '@revealui/contracts': workspace:*
   '@revealui/db': workspace:*
@@ -1530,7 +1531,7 @@ importers:
         specifier: ^0.2.117
         version: 0.2.117
       ws:
-        specifier: ^8.20.1
+        specifier: '>=8.20.1'
         version: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       y-protocols:
         specifier: ^1.0.7
@@ -7010,7 +7011,7 @@ packages:
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.20.1'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -9208,30 +9209,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -14869,7 +14846,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15110,9 +15087,9 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
-  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isows@1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -17441,9 +17418,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.7(typescript@6.0.3)(zod@3.25.76)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17656,16 +17633,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary

Closes Dependabot alert #88 — `ws` uninitialized memory disclosure (GHSA-58qx-3vcg-4xpx, medium). Vulnerable range `>= 8.0.0, < 8.20.1`, patched in `8.20.1`.

## Fix

Scoped pnpm override `"ws@8": ">=8.20.1"` added to `package.json` `pnpm.overrides` — consistent with the repo's existing 40+ transitive-security-pin pattern.

**Why scoped to `ws@8` and not a blanket `"ws"` override:** the only vulnerable instances were `ws@8.18.3` and `ws@8.20.0` (transitive via `happy-dom`/`vitest`). A blanket floor would also force the unrelated `ws@7.5.10` consumer up across a major version — but `7.5.10` is outside the advisory range and is already the final 7.x security patch, so force-bumping it is avoidable blast radius. Scoping to the 8.x line is the surgical, durable fix.

## Verification

Lockfile regenerated via `pnpm install --lockfile-only`:
- `ws@8.18.3` + `ws@8.20.0` → collapsed to `ws@8.20.1` ✅
- `ws@7.5.10` → preserved (untouched) ✅
- zero other dependency churn (diff is ws-only)

After merge: **0 open Dependabot alerts** (CodeQL already clean).

## Test plan

- [ ] CI `pnpm install --frozen-lockfile` passes (lockfile consistent with the new override).
- [ ] Full gate green (no test/build regression from the ws@8.x patch bump).
- [ ] Dependabot alert #88 auto-resolves once merged to the default branch.
