### PR TITLE
feat(admin): cobalt OKLCH bridge (DS-D3)

### DIFF
--- a/apps/admin/src/app/(frontend)/styles.css
+++ b/apps/admin/src/app/(frontend)/styles.css
@@ -24,85 +24,15 @@
     font-size: auto;
     font-weight: auto;
   }
-
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --card: 240 5% 96%;
-    --card-foreground: 222.2 84% 4.9%;
-
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 43.9%;
-
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 240 6% 90%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-
-    --radius: 0.2rem;
-
-    --success: 196 52% 74%;
-    --warning: 34 89% 85%;
-    --error: 10 100% 86%;
-  }
-
-  [data-theme="dark"] {
-    --background: 0 0% 0%;
-    --foreground: 210 40% 98%;
-
-    --card: 240 6% 10%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 240 4% 16%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-
-    --success: 196 100% 14%;
-    --warning: 34 51% 25%;
-    --error: 10 39% 43%;
-  }
 }
 
 @layer base {
   * {
-    border-color: hsl(var(--border));
+    border-color: var(--rvui-border);
   }
   body {
-    background-color: hsl(var(--background));
-    color: hsl(var(--foreground));
+    background-color: var(--rvui-surface-0);
+    color: var(--rvui-text-0);
   }
 }
 

--- a/apps/admin/src/app/(frontend)/tailwind-theme.css
+++ b/apps/admin/src/app/(frontend)/tailwind-theme.css
@@ -1,5 +1,6 @@
 /* Tailwind v4 Theme Configuration */
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
 
 /* Scan workspace packages for Tailwind class usage */
 @source "../../../../../packages/presentation/src/**/*.{ts,tsx}";
@@ -9,37 +10,35 @@
 @source "../../components/**/*.{ts,tsx}";
 
 /*
- * Semantic colors (shadcn/ui pattern).
- * Raw HSL values are defined in styles.css :root / [data-theme="dark"].
- * @theme inline tells Tailwind to generate utility classes (bg-card,
- * text-primary-foreground, border-border, etc.) without emitting static
- * custom properties — the values reference runtime CSS variables.
+ * Bridge --rvui-* canonical cobalt tokens into Tailwind's @theme namespace.
+ * tokens.css is the source of truth for all color values. Dark is the :root
+ * default; light activates via [data-theme="light"] (admin's theme toggle).
  */
 @theme inline {
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
-  --color-success: hsl(var(--success));
-  --color-warning: hsl(var(--warning));
-  --color-warning-foreground: hsl(var(--warning-foreground));
-  --color-error: hsl(var(--error));
-  --radius: var(--radius);
+  --color-background: var(--rvui-surface-0);
+  --color-foreground: var(--rvui-text-0);
+  --color-card: var(--rvui-surface-1);
+  --color-card-foreground: var(--rvui-text-0);
+  --color-popover: var(--rvui-surface-1);
+  --color-popover-foreground: var(--rvui-text-0);
+  --color-primary: var(--rvui-brand);
+  --color-primary-foreground: var(--rvui-text-on-brand);
+  --color-secondary: var(--rvui-surface-2);
+  --color-secondary-foreground: var(--rvui-text-0);
+  --color-muted: var(--rvui-surface-2);
+  --color-muted-foreground: var(--rvui-text-2);
+  --color-accent: var(--rvui-accent);
+  --color-accent-foreground: var(--rvui-text-on-accent);
+  --color-destructive: var(--rvui-error);
+  --color-destructive-foreground: var(--rvui-text-0);
+  --color-border: var(--rvui-border);
+  --color-input: var(--rvui-border);
+  --color-ring: var(--rvui-brand);
+  --color-success: var(--rvui-success);
+  --color-warning: var(--rvui-warning);
+  --color-warning-foreground: var(--rvui-warning-text);
+  --color-error: var(--rvui-error);
+  --radius: var(--rvui-radius-md);
 }
 
 @theme {

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",
+    "validate:brand-bridge": "tsx scripts/validate/brand-bridge.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -300,6 +300,11 @@ async function gate(): Promise<void> {
         args: ['validate:design-context'],
       },
       {
+        name: 'Brand bridge (hard fail)',
+        command: 'pnpm',
+        args: ['validate:brand-bridge'],
+      },
+      {
         name: 'Migration journal',
         command: 'pnpm',
         args: ['validate:migrations'],

--- a/scripts/validate/__tests__/brand-bridge.test.ts
+++ b/scripts/validate/__tests__/brand-bridge.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkFile, findBridgeFiles, run } from '../brand-bridge.ts';
+
+describe('brand-bridge', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'brand-bridge-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeFile(relativePath: string, content: string): string {
+    const full = path.join(tmp, relativePath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+    return full;
+  }
+
+  describe('checkFile', () => {
+    it('returns no violations when --color-primary uses var(--rvui-brand)', () => {
+      const filePath = writeFile(
+        'apps/admin/src/app/(frontend)/tailwind-theme.css',
+        `@theme inline {\n  --color-primary: var(--rvui-brand);\n  --color-ring: var(--rvui-brand);\n}\n`,
+      );
+      expect(checkFile(filePath)).toHaveLength(0);
+    });
+
+    it('returns violation when --color-primary uses hsl(var(--primary))', () => {
+      const filePath = writeFile(
+        'apps/admin/tailwind-theme.css',
+        `@theme inline {\n  --color-primary: hsl(var(--primary));\n  --color-ring: hsl(var(--ring));\n}\n`,
+      );
+      const violations = checkFile(filePath);
+      expect(violations).toHaveLength(2);
+      expect(violations[0].property).toBe('--color-primary');
+      expect(violations[1].property).toBe('--color-ring');
+    });
+
+    it('only flags --color-primary and --color-ring, not other hsl(var()) properties', () => {
+      const filePath = writeFile(
+        'apps/marketing/app/index.css',
+        `@theme inline {\n  --color-primary: var(--rvui-brand);\n  --color-ring: var(--rvui-brand);\n  --color-background: hsl(var(--background));\n}\n`,
+      );
+      expect(checkFile(filePath)).toHaveLength(0);
+    });
+
+    it('ignores --color-primary outside @theme inline blocks', () => {
+      const filePath = writeFile(
+        'apps/admin/styles.css',
+        `:root {\n  --color-primary: hsl(var(--primary));\n}\n`,
+      );
+      expect(checkFile(filePath)).toHaveLength(0);
+    });
+
+    it('detects violation after other properties in @theme inline', () => {
+      const filePath = writeFile(
+        'apps/admin/tailwind-theme.css',
+        `@theme inline {\n  --color-background: var(--rvui-surface-0);\n  --color-primary: hsl(var(--primary));\n  --color-ring: var(--rvui-brand);\n}\n`,
+      );
+      const violations = checkFile(filePath);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].property).toBe('--color-primary');
+    });
+
+    it('returns no violations for a file with no @theme inline block', () => {
+      const filePath = writeFile(
+        'apps/docs/app/index.css',
+        `@import "tailwindcss";\n\nbody { color: red; }\n`,
+      );
+      expect(checkFile(filePath)).toHaveLength(0);
+    });
+  });
+
+  describe('findBridgeFiles', () => {
+    it('finds real bridge files in the monorepo', () => {
+      const files = findBridgeFiles();
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    it('includes the admin tailwind-theme.css', () => {
+      const files = findBridgeFiles();
+      const hasAdmin = files.some((f) => f.includes('admin') && f.endsWith('tailwind-theme.css'));
+      expect(hasAdmin).toBe(true);
+    });
+
+    it('includes the marketing index.css', () => {
+      const files = findBridgeFiles();
+      const hasMarketing = files.some((f) => f.includes('marketing') && f.endsWith('index.css'));
+      expect(hasMarketing).toBe(true);
+    });
+  });
+
+  describe('run (integration)', () => {
+    it('exits 0 on the current tree (after cobalt bridge applied)', () => {
+      expect(() => run()).not.toThrow();
+    });
+  });
+});

--- a/scripts/validate/brand-bridge.ts
+++ b/scripts/validate/brand-bridge.ts
@@ -1,0 +1,179 @@
+// console-allowed
+/**
+ * Brand-Bridge Drift Detector (DS-D3)
+ *
+ * Ensures that every app's @theme inline bridge maps --color-primary and
+ * --color-ring to var(--rvui-*) tokens rather than the legacy hsl(var(...))
+ * pattern that causes admin to render default-shadcn slate instead of the
+ * fleet cobalt brand.
+ *
+ * Files scanned: apps/*\/app/index.css  and  apps/*\/(frontend)/tailwind-theme.css
+ * (the two bridge-file shapes that exist in this monorepo).
+ *
+ * Fail condition: any @theme inline block in those files maps either
+ * --color-primary or --color-ring to a value that contains "hsl(var(".
+ *
+ * Usage:
+ *   pnpm tsx scripts/validate/brand-bridge.ts
+ *
+ * Exit codes:
+ *   0 = all bridge files use --rvui-* tokens
+ *   1 = legacy hsl(var()) bridge detected
+ *
+ * This is a CLI script — console output is the program's purpose.
+ * The `console-allowed` marker on line 1 exempts the file from the
+ * no-console-log rule (per .revealui/code-standards.json).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+
+const HSL_VAR_MARKER = 'hsl(var(';
+
+interface Violation {
+  file: string;
+  property: string;
+  value: string;
+  line: number;
+}
+
+function findBridgeFiles(): string[] {
+  const files: string[] = [];
+  const appsDir = path.join(ROOT, 'apps');
+
+  let apps: fs.Dirent[];
+  try {
+    apps = fs.readdirSync(appsDir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  for (const app of apps) {
+    if (!app.isDirectory()) continue;
+    const candidates = [
+      path.join(appsDir, app.name, 'app', 'index.css'),
+      path.join(appsDir, app.name, 'src', 'app', '(frontend)', 'tailwind-theme.css'),
+    ];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        files.push(candidate);
+      }
+    }
+  }
+
+  return files;
+}
+
+const BRIDGE_PROPERTIES = new Set(['--color-primary', '--color-ring']);
+
+function checkFile(filePath: string): Violation[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  const violations: Violation[] = [];
+  const lines = content.split('\n');
+
+  let inThemeInline = false;
+  let braceDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (!inThemeInline) {
+      if (line.includes('@theme') && line.includes('inline')) {
+        inThemeInline = true;
+        braceDepth = 0;
+      }
+    }
+
+    if (inThemeInline) {
+      for (const char of line) {
+        if (char === '{') braceDepth++;
+        if (char === '}') braceDepth--;
+      }
+
+      const trimmed = line.trim();
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx !== -1) {
+        const prop = trimmed.slice(0, colonIdx).trim();
+        const value = trimmed.slice(colonIdx + 1).trim();
+
+        if (BRIDGE_PROPERTIES.has(prop)) {
+          if (value.includes(HSL_VAR_MARKER)) {
+            violations.push({
+              file: path.relative(ROOT, filePath),
+              property: prop,
+              value: value.replace(/;$/, '').trim(),
+              line: i + 1,
+            });
+          }
+        }
+      }
+
+      if (braceDepth <= 0 && inThemeInline) {
+        inThemeInline = false;
+      }
+    }
+  }
+
+  return violations;
+}
+
+function run(): void {
+  const bridgeFiles = findBridgeFiles();
+
+  if (bridgeFiles.length === 0) {
+    process.stderr.write('brand-bridge: no bridge files found under apps/\n');
+    process.exit(1);
+  }
+
+  const allViolations: Violation[] = [];
+
+  for (const file of bridgeFiles) {
+    const violations = checkFile(file);
+    allViolations.push(...violations);
+  }
+
+  process.stdout.write(`brand-bridge: scanned ${bridgeFiles.length} bridge file(s)\n`);
+  for (const f of bridgeFiles) {
+    process.stdout.write(`  ${path.relative(ROOT, f)}\n`);
+  }
+
+  if (allViolations.length === 0) {
+    process.stdout.write(
+      'brand-bridge: ok (all --color-primary and --color-ring entries use var(--rvui-*) tokens)\n',
+    );
+    return;
+  }
+
+  process.stderr.write(`\nbrand-bridge: ${allViolations.length} violation(s) found\n\n`);
+  for (const v of allViolations) {
+    process.stderr.write(`  ${v.file}:${v.line}\n`);
+    process.stderr.write(`    ${v.property}: ${v.value}\n`);
+    process.stderr.write(
+      `    Fix: replace hsl(var(...)) with var(--rvui-brand) for primary/ring\n\n`,
+    );
+  }
+  process.stderr.write(
+    'All @theme inline bridges must map --color-primary and --color-ring to var(--rvui-*) tokens,\n',
+  );
+  process.stderr.write(
+    `not to hsl(var(...)) intermediaries. The hsl() form expects HSL triplets but --rvui-* tokens\n`,
+  );
+  process.stderr.write(`are OKLCH values, producing invalid CSS.\n`);
+  process.exit(1);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const selfPath = path.resolve(import.meta.dirname, 'brand-bridge.ts');
+if (invokedPath === selfPath) {
+  run();
+}
+
+export { checkFile, findBridgeFiles, run };


### PR DESCRIPTION
## Summary

Admin was importing `@revealui/presentation/tokens.css` (so `--rvui-*` cobalt tokens were loaded) but then overriding them with a hand-rolled default-shadcn slate HSL palette in `styles.css`. The `@theme inline` bridge in `tailwind-theme.css` then mapped `--color-primary: hsl(var(--primary))` etc. — expecting HSL triplets, but `--primary` (from tokens.css) is an OKLCH value, producing invalid CSS. Result: admin rendered default shadcn slate, not the fleet cobalt brand.

This PR adopts marketing's proven bridge pattern (identical structure to `apps/marketing/app/index.css`) to make admin render the fleet cobalt brand.

**Changes:**

- `apps/admin/src/app/(frontend)/tailwind-theme.css` — replaces the `@theme inline` HSL bridge with direct `var(--rvui-*)` token references. Adds `@import "@revealui/presentation/tokens.css"` so the cascade has the variables at build time. Preserves the second `@theme` block (breakpoints, mist palette, fonts, scrap colors, font sizes, aspect ratios, widths) and the `.container` rule untouched.
- `apps/admin/src/app/(frontend)/styles.css` — removes the hand-rolled `:root { --background: 0 0% 100%; ... }` and `[data-theme="dark"] { ... }` slate HSL blocks. Fixes `border-color: hsl(var(--border))` → `var(--rvui-border)` and `background-color/color` body rules → direct `--rvui-surface-0` / `--rvui-text-0`. Preserves the mist `html` background, FOUC opacity guard, and heading reset.
- `scripts/validate/brand-bridge.ts` + `__tests__/brand-bridge.test.ts` — new validator (DS-D3 R7) that fails if any `apps/**/tailwind-theme.css` or `apps/**/index.css` `@theme inline` bridge maps `--color-primary` or `--color-ring` to `hsl(var(...))`. Implemented with `String.includes()` + `Set` — zero regex. 10 unit tests, all passing.
- `scripts/gates/ci-gate.ts` — wires `validate:brand-bridge` as a hard-fail in Phase 1, preventing admin's slate bridge from re-diverging.
- `package.json` — adds `validate:brand-bridge` script entry.

**Token mapping used:**

| `--color-*` | `--rvui-*` |
|---|---|
| `--color-background` | `--rvui-surface-0` |
| `--color-foreground` | `--rvui-text-0` |
| `--color-primary` | `--rvui-brand` |
| `--color-primary-foreground` | `--rvui-text-on-brand` |
| `--color-secondary` | `--rvui-surface-2` |
| `--color-secondary-foreground` | `--rvui-text-0` |
| `--color-muted` | `--rvui-surface-2` |
| `--color-muted-foreground` | `--rvui-text-2` |
| `--color-accent` | `--rvui-accent` |
| `--color-accent-foreground` | `--rvui-text-on-accent` |
| `--color-destructive` | `--rvui-error` |
| `--color-destructive-foreground` | `--rvui-text-0` |
| `--color-card` | `--rvui-surface-1` |
| `--color-card-foreground` | `--rvui-text-0` |
| `--color-popover` | `--rvui-surface-1` |
| `--color-popover-foreground` | `--rvui-text-0` |
| `--color-border` | `--rvui-border` |
| `--color-input` | `--rvui-border` |
| `--color-ring` | `--rvui-brand` |
| `--color-success` | `--rvui-success` |
| `--color-warning` | `--rvui-warning` |
| `--color-warning-foreground` | `--rvui-warning-text` |
| `--color-error` | `--rvui-error` |
| `--radius` | `--rvui-radius-md` |

**Dark-mode check:** tokens.css uses dark as the `:root` default (dark-first design). Light activates via `[data-theme="light"]`. Admin's manual theme toggle sets `data-theme="dark"` (stays on `:root` default — correct) and `data-theme="light"` (activates the `[data-theme="light"]` override in tokens.css — correct). No alignment issue.

**Visual smoke:** Not rendered — admin requires Neon/env to start. Verified via production build CSS inspection: `bg-primary` → `var(--rvui-brand)`, `text-primary-foreground` → `var(--rvui-text-on-brand)`, `ring-ring` → `var(--rvui-brand)`. Light-mode resolution shows `--rvui-brand: #0083c4` (cobalt OKLCH 0.36 0.190 240 resolved), confirming cobalt renders, not slate. A `deploy-test.yml` preview is the correct path for a visual eyeball.

## Test plan

- [x] `pnpm --filter admin typecheck` — clean (no output)
- [x] `pnpm --filter admin build` — succeeds (30s compile, all 11 warnings pre-existing)
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm exec tsx scripts/validate/brand-bridge.ts` — passes on current tree
- [x] Guard negative test: injecting `hsl(var(--primary))` into admin's bridge trips the guard (exit non-zero, correct violation output), then reverted
- [x] `pnpm exec vitest run scripts/validate/__tests__/brand-bridge.test.ts` — 10/10 pass
- [x] Pre-push gate (`pnpm gate --phase=1 --changed`) — all 18 checks pass including `Brand bridge (hard fail)`
- [ ] Visual render — requires `deploy-test.yml` preview with env secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
