### PR TITLE
fix(server): forge api image runs worker.js (not index.js) in production

### DIFF
--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -77,4 +77,6 @@ USER hono
 
 EXPOSE 3004
 
-CMD ["node", "dist/index.js"]
+# Prod entry: index.ts is side-effect-free in production (it's the Vercel
+# serverless handler); worker.ts is the long-running entry that calls serve().
+CMD ["node", "dist/worker.js"]


### PR DESCRIPTION
## Summary

- `apps/server/src/index.ts` is intentionally side-effect-free in production (it's the Vercel serverless handler). Only `src/worker.ts` calls `serve()` — the long-running standalone/Fly entry.
- `apps/server/Dockerfile.forge` (the self-hosted kit's api image, built + pushed to GHCR by `docker.yml`) still ran `node dist/index.js`. With `NODE_ENV=production` (set in the kit's `docker-compose.yml`), that never binds an HTTP listener → the kit's api container starts but doesn't serve. This regressed when the Fly worker entry was extracted.
- Point the forge api image CMD at `dist/worker.js`. `tsup.config.ts` (`entry: ['src/index.ts', 'src/worker.ts']`) already emits both, so no build change is needed.

## Test plan

- [ ] CI builds the forge api image (`docker.yml`) green.
- [ ] After merge + GHCR rebuild: pull `ghcr.io/revealuistudio/revealui-api:latest`, run a stamped kit (`docker compose up`), confirm the api binds on `:3004` and `/health` returns 200 (it does not, in production, before this fix).
- [ ] Admin first-boot auto-seed + login work end-to-end against the running api.

Note: admin (Next.js) is unaffected — this is specific to the Hono server's index/worker split.
