### PR TITLE
fix(server): bundle resvg wasm beside dist so /api/og works on Vercel

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,8 +55,9 @@
     }
   },
   "scripts": {
-    "build": "tsup && pnpm run copy-sandbox-runner",
+    "build": "tsup && pnpm run copy-sandbox-runner && pnpm run copy-resvg-wasm",
     "copy-sandbox-runner": "mkdir -p dist && cp src/services/revmarket-sandbox/revmarket-task-runner.mjs dist/",
+    "copy-resvg-wasm": "node scripts/copy-resvg-wasm.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "biome check .",
     "start": "node dist/index.js",

--- a/apps/server/scripts/copy-resvg-wasm.mjs
+++ b/apps/server/scripts/copy-resvg-wasm.mjs
@@ -1,0 +1,22 @@
+/**
+ * Copies the resvg WASM next to the built bundle (dist/index_bg.wasm).
+ *
+ * apps/server/src/routes/og.ts reads this file at runtime via readFileSync.
+ * @vercel/nft cannot trace that dynamic read into node_modules, so without a
+ * colocated copy (plus vercel.json `includeFiles`) the file is missing from
+ * the serverless function and GET /api/og throws ENOENT. Copying it into dist
+ * on every build keeps the endpoint working on Vercel, Fly, and Docker alike.
+ */
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const wasmSource = require.resolve('@resvg/resvg-wasm/index_bg.wasm');
+const distDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+const wasmDest = join(distDir, 'index_bg.wasm');
+
+mkdirSync(distDir, { recursive: true });
+copyFileSync(wasmSource, wasmDest);
+process.stdout.write(`copy-resvg-wasm: ${wasmSource} -> ${wasmDest}\n`);

--- a/apps/server/src/routes/og.ts
+++ b/apps/server/src/routes/og.ts
@@ -4,7 +4,7 @@
  * Renders a 1200×630 PNG with a title + description via satori (JSX → SVG)
  * and @resvg/resvg-wasm (SVG → PNG). The Inter Tight variable font is inlined
  * into the bundle via tsup's binary loader; satori extracts 400 + 700 weights
- * from the same buffer. The resvg WASM is read at runtime from node_modules.
+ * from the same buffer. The resvg WASM ships beside the built bundle (copy-resvg-wasm) and is read at runtime.
  *
  * Used by marketing + (future) blog post OG meta tags:
  *   <meta property="og:image"
@@ -16,6 +16,7 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { initWasm, Resvg } from '@resvg/resvg-wasm';
 import { Hono } from 'hono';
@@ -26,24 +27,42 @@ import InterTightVariable from '../assets/fonts/InterTight-Variable.ttf';
 // initialised module across requests; the shared promise makes concurrent
 // first-requests safe.
 //
-// The WASM bytes are read at runtime from `@resvg/resvg-wasm/index_bg.wasm`
-// in node_modules and compiled via `WebAssembly.compile`. The earlier
-// approach of `import resvgWasm from '...wasm'` (inlined via tsup's binary
-// loader) works in Vercel Edge / Cloudflare Workers because WASM imports
-// are first-class there — but crashes in Node, where the experimental WASM
-// ESM loader tries to resolve the wasm-bindgen `wbg` glue from the .wasm's
-// import section and fails (no `wbg` npm package; it's expected to be the
-// companion `index_bg.js` glue, which is unreachable when the .wasm is
-// imported directly). Reading the bytes manually bypasses that path;
-// `initWasm` supplies the `wbg` bindings internally.
+// The WASM bytes are read at runtime (not imported as an ES module) and
+// compiled via `WebAssembly.compile`. The earlier approach of `import resvgWasm
+// from '...wasm'` (inlined via tsup's binary loader) works in Vercel Edge /
+// Cloudflare Workers because WASM imports are first-class there — but crashes
+// in Node, where the experimental WASM ESM loader tries to resolve the
+// wasm-bindgen `wbg` glue from the .wasm's import section and fails (no `wbg`
+// npm package; it's expected to be the companion `index_bg.js` glue, which is
+// unreachable when the .wasm is imported directly). Reading the bytes manually
+// bypasses that path; `initWasm` supplies the `wbg` bindings internally.
 //
-// `import.meta.resolve` is sync in Node 20.6+ (engines requires >=24.13).
+// Resolution order: prefer the copy emitted next to the built bundle by the
+// `copy-resvg-wasm` build step (dist/index_bg.wasm). That colocated file is the
+// one shipped on Vercel — its `@vercel/nft` tracer can't follow a dynamic
+// `import.meta.resolve` into node_modules, which left `/api/og` throwing ENOENT
+// in production; `vercel.json` `includeFiles` ships the colocated copy into the
+// function. In dev (tsx, running from src/) the colocated file does not exist,
+// so fall back to the node_modules copy. `import.meta.resolve` is sync in
+// Node 20.6+ (engines requires >=24.13).
+function readResvgWasm(): Buffer {
+  // Prefer the copy emitted next to the built bundle by copy-resvg-wasm
+  // (dist/index_bg.wasm). Fall back to the node_modules copy in dev (tsx from
+  // src/). Read with try/catch rather than an existsSync probe to avoid a
+  // check-then-read race.
+  const colocated = join(dirname(fileURLToPath(import.meta.url)), 'index_bg.wasm');
+  try {
+    return readFileSync(colocated);
+  } catch {
+    const fromModules = fileURLToPath(import.meta.resolve('@resvg/resvg-wasm/index_bg.wasm'));
+    return readFileSync(fromModules);
+  }
+}
+
 let wasmInitPromise: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
   if (!wasmInitPromise) {
-    const wasmUrl = import.meta.resolve('@resvg/resvg-wasm/index_bg.wasm');
-    const wasmBytes = readFileSync(fileURLToPath(wasmUrl));
-    wasmInitPromise = initWasm(WebAssembly.compile(wasmBytes));
+    wasmInitPromise = initWasm(WebAssembly.compile(readResvgWasm()));
   }
   return wasmInitPromise;
 }

--- a/apps/server/src/routes/og.ts
+++ b/apps/server/src/routes/og.ts
@@ -45,7 +45,7 @@ import InterTightVariable from '../assets/fonts/InterTight-Variable.ttf';
 // function. In dev (tsx, running from src/) the colocated file does not exist,
 // so fall back to the node_modules copy. `import.meta.resolve` is sync in
 // Node 20.6+ (engines requires >=24.13).
-function readResvgWasm(): Buffer {
+function readResvgWasm() {
   // Prefer the copy emitted next to the built bundle by copy-resvg-wasm
   // (dist/index_bg.wasm). Fall back to the node_modules copy in dev (tsx from
   // src/). Read with try/catch rather than an existsSync probe to avoid a

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -5,7 +5,8 @@
   "functions": {
     "api/**": {
       "memory": 512,
-      "maxDuration": 30
+      "maxDuration": 30,
+      "includeFiles": "dist/index_bg.wasm"
     }
   },
   "crons": [{ "path": "/api/cron/dispatch", "schedule": "0 6 * * *" }],


### PR DESCRIPTION
## What

`GET /api/og` throws `ENOENT: no such file or directory` in production (Sentry `REVEALUI-SERVER-4/5/6`). The OG-image route reads the resvg WASM at runtime:

```
import.meta.resolve('@resvg/resvg-wasm/index_bg.wasm') + readFileSync
```

On **Vercel**, `@vercel/nft` can't trace a dynamic `import.meta.resolve`, so `index_bg.wasm` is never bundled into the `api/**` serverless function and the read fails. Docker/Fly keep `node_modules` intact, so those environments worked — which is why the error is environment-specific.

This is the same family of problem the runtime-load was introduced to dodge: #633 added the endpoint, #636 reverted it (Node can't `import` the `.wasm` as ESM — the wasm-bindgen `wbg` glue is unresolvable), #641 relanded with the manual `readFileSync`. That fixed Node/Docker but left the Vercel tracing gap.

## Fix

Make the wasm a real, traced build artifact instead of a dynamic `node_modules` lookup:

- **`copy-resvg-wasm`** build step copies `@resvg/resvg-wasm/index_bg.wasm` into `dist/` (mirrors the existing `copy-sandbox-runner`).
- **`og.ts`** reads the colocated `dist/index_bg.wasm` (it sits next to the bundled `index.js` at runtime), falling back to the `node_modules` copy in dev (`tsx` from `src/`). The Node-compatible manual load from #641 is preserved, and the existing unit test stays green (its mocks hit the dev fallback).
- **`vercel.json`** `includeFiles` ships `dist/index_bg.wasm` into the function so nft includes it.

Works across Vercel, Fly, and Docker.

## Validation

- ✅ `require.resolve('@resvg/resvg-wasm/index_bg.wasm')` + copy verified locally (valid 2.48 MB file).
- ✅ Biome clean on changed files.
- ⏳ CI runs the full gate (build incl. the new copy step, typecheck, unit tests).
- ⚠️ **Vercel packaging needs a preview deploy to confirm end-to-end** — CI can't exercise `@vercel/nft` bundling. Recommend a `deploy-test.yml` preview + hitting `/api/og` before promoting to main.

## Risk

Low. Additive build step + a runtime fallback that preserves current behavior everywhere the wasm was already resolvable.
