### PR TITLE
docs(db): fix ghost seed-sample-content.ts references

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -66,7 +66,10 @@ The older `pnpm db:*` scripts still exist and remain useful as lower-level build
 | `pnpm db:init`       | Initialize database connection and verify setup | `scripts/setup/database.ts`            | `POSTGRES_URL`, `DATABASE_URL`, or `SUPABASE_DATABASE_URI` |
 | `pnpm db:migrate`    | Run Drizzle migrations                          | `scripts/setup/migrations.ts`          | `POSTGRES_URL` or `DATABASE_URL`                           |
 | `pnpm db:reset`      | Drop all tables and recreate schema             | `scripts/setup/reset-database.ts`      | Same as init                                               |
-| `pnpm db:seed`       | Seed database with sample data                  | `scripts/setup/seed-sample-content.ts` | Same as init                                               |
+| `pnpm db:seed`       | Seed the database — composite of the three seeders below | `apps/admin/src/seed.ts`, `scripts/seed-fleet-marketing-site.ts`, `scripts/setup/seed-billing.ts` | Same as init                          |
+| `pnpm db:seed:admin` | Seed admin pages + content + cards + heros + events + banners | `apps/admin/src/seed.ts`               | Same as init                                               |
+| `pnpm db:seed:fleet-marketing` | Seed the fleet-marketing `sites` row              | `scripts/seed-fleet-marketing-site.ts` | Same as init                                               |
+| `pnpm db:seed:billing` | Seed the Stripe billing catalog (9 plans)       | `scripts/setup/seed-billing.ts`        | Same as init                                               |
 | `pnpm db:backup`     | Create JSON backup of all tables                | `scripts/commands/database/backup.ts`  | Same as init                                               |
 | `pnpm db:restore`    | Restore from backup file                        | `scripts/commands/database/restore.ts` | Same as init                                               |
 | `pnpm db:status`     | Check database connection and table count       | `scripts/commands/database/status.ts`  | Same as init                                               |

--- a/scripts/cli/_base.ts
+++ b/scripts/cli/_base.ts
@@ -551,7 +551,7 @@ export abstract class ExecutingCLI extends BaseCLI {
  *
  *   protected commandMap = {
  *     'fix-imports': 'scripts/commands/fix/fix-import-extensions.ts',
- *     'db:seed': 'scripts/setup/seed-sample-content.ts',
+ *     'db:seed:billing': 'scripts/setup/seed-billing.ts',
  *   }
  *
  *   defineCommands(): CommandDefinition[] {

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -25,7 +25,7 @@ revealui dev up --include mcp
 | `database.ts`            | `pnpm db:init`    | Initialize database schema and tables          |
 | `reset-database.ts`      | `pnpm db:reset`   | Drop all tables and reinitialize (DESTRUCTIVE) |
 | `migrations.ts`          | `pnpm db:migrate` | Run pending database migrations                |
-| `seed-sample-content.ts` | `pnpm db:seed`    | Populate database with sample data             |
+| `seed-billing.ts`        | `pnpm db:seed:billing` | Seed the Stripe billing catalog (`pnpm db:seed` runs this plus the admin + fleet-marketing seeders) |
 
 ### Advanced Database Scripts
 


### PR DESCRIPTION
## Summary

`pnpm db:seed` is a composite that runs three seeders (`db:seed:admin`, `db:seed:fleet-marketing`, `db:seed:billing`), but three docs still referenced a single `scripts/setup/seed-sample-content.ts` that does not exist in the tree. This corrects all three references to the real scripts.

- `docs/DATABASE.md` — fix the `db:seed` row and add the three real sub-command rows (`apps/admin/src/seed.ts`, `scripts/seed-fleet-marketing-site.ts`, `scripts/setup/seed-billing.ts`).
- `scripts/setup/README.md` — point the Core Database Scripts row at the real `seed-billing.ts` / `pnpm db:seed:billing`.
- `scripts/cli/_base.ts` — fix the `DispatcherCLI` `@example` to map to a real script path.

Doc/comment only; no behavior change.

## Type of Change

- [x] Documentation

## Checklist

- [x] `pnpm biome check` clean on the changed TypeScript file
- [x] No `any` types or `console.*` added
- [x] Doc/comment-only — no tests needed
