### PR TITLE
chore(deploy): revvault-fly.toml manifest + fly.md wiring

### DIFF
--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -32,12 +32,18 @@ flyctl auth login
 # 2. Create the Fly app (one-time per environment)
 flyctl apps create revealui-worker --org revealui-studio
 
-# 3. Mirror prod secrets from revvault → Fly. The revvault-sync
-#    pipeline (Phase 4 of the lane) automates this; before that
-#    lands, set them manually:
+# 3. Mirror prod secrets from revvault → Fly. Preferred — via the
+#    revvault `fly` sync target (revvault sync fly), driven by the
+#    manifest at scripts/sync/revvault-fly.toml:
+#
+#      revvault sync fly --manifest scripts/sync/revvault-fly.toml            # dry-run
+#      FLY_API_TOKEN="$(revvault --json get revealui/prod/fly/api-token | jq -r .value)" \
+#        revvault sync fly --manifest scripts/sync/revvault-fly.toml --apply
+#
+#    Or set them manually with flyctl:
 flyctl secrets set --app revealui-worker \
   POSTGRES_URL="$(revvault --json get revealui/prod/db/postgres-url | jq -r .value)" \
-  REVEALUI_SECRET="$(revvault --json get revealui/prod/revealui-secret | jq -r .value)" \
+  REVEALUI_SECRET="$(revvault --json get revealui/prod/secret | jq -r .value)" \
   STRIPE_SECRET_KEY="$(revvault --json get revealui/prod/stripe/secret-key | jq -r .value)" \
   STRIPE_WEBHOOK_SECRET="$(revvault --json get revealui/prod/stripe/webhook-secret | jq -r .value)" \
   SENTRY_DSN="$(revvault --json get revealui/prod/sentry/dsn | jq -r .value)" \
@@ -77,8 +83,10 @@ Automated deploys via GitHub Actions land in a future phase
 ## Secrets
 
 All secrets live in revvault per [`docs/SECRETS.md`](../SECRETS.md).
-The mirror to Fly happens via `revvault-sync` (Phase 4 of the
-infra-consolidation lane) or manually via `flyctl secrets set` as
+The mirror to Fly happens via the revvault `fly` sync target —
+`revvault sync fly --manifest scripts/sync/revvault-fly.toml --apply`
+(the Fly counterpart of the Vercel env sync; the manifest lists the
+worker's secret subset) — or manually via `flyctl secrets set` as
 shown above.
 
 **Never** paste secrets into `apps/server/fly.toml` — that file is

--- a/scripts/sync/revvault-fly.toml
+++ b/scripts/sync/revvault-fly.toml
@@ -1,0 +1,54 @@
+# revvault → Fly secrets sync manifest
+#
+# Drives `revvault sync fly --manifest scripts/sync/revvault-fly.toml [--apply]`
+# (the Fly counterpart of revvault-vercel.toml — see that file for the Vercel
+# side and the shared schema notes).
+#
+# Schema (parsed by revvault-cli, commands/sync.rs::FlyManifest):
+#   - [fly-apps.<logical>]       — one block per Fly app
+#   - app                         — Fly app name (used as the GraphQL appId)
+#   - skip                        — secret names sync never touches (optional)
+#   - [fly-apps.<logical>.vars]   — secret name → vault path (bare string), or
+#                                   { path = "...", shape = "..." } to add shape
+#                                   validation. Unlike the Vercel manifest there
+#                                   is NO prefix-scan: every managed secret must
+#                                   be listed explicitly. A worker's secret set
+#                                   is a curated subset, not "everything under a
+#                                   prefix".
+#
+# Fly hides secret VALUES (its API returns only names + digest), so sync cannot
+# value-match: a present name is re-Set, an absent one Added. Orphans (set on
+# Fly but absent here) are surfaced, never deleted.
+#
+# Auth: FLY_API_TOKEN env var or `--token`. A live `--apply` is owner-gated:
+# it needs that token vaulted (see docs/SECRETS.md) and the Fly app to exist
+# (drop-railway lane Phase 3). Never inline secret values here — revvault is
+# the source of truth; this manifest carries only vault *paths*.
+
+# ── revealui-worker ───────────────────────────────────────────────────────────
+# Long-running apps/server subset on Fly (alerting, Yjs + agent collab WS,
+# terminal-ws Forge-gated, RVMarket executor flag-gated). Secret subset mirrors
+# the worker bootstrap block in docs/deployment/fly.md (drop-railway Phase 4).
+[fly-apps.revealui-worker]
+app = "revealui-worker"
+
+[fly-apps.revealui-worker.vars]
+# Database (Neon)
+POSTGRES_URL = "revealui/prod/db/postgres-url"
+
+# Core signing / session + license validation
+REVEALUI_SECRET              = "revealui/prod/secret"
+REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
+REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
+
+# Stripe (billing path exercised by the executor + alerting)
+STRIPE_SECRET_KEY     = "revealui/prod/stripe/secret-key"
+STRIPE_WEBHOOK_SECRET = "revealui/prod/stripe/webhook-secret"
+
+# Observability
+SENTRY_DSN = "revealui/prod/sentry/dsn"
+
+# Electric (real-time sync). The service URL flips to the Fly-hosted Electric
+# during Phase 5 cutover; the vault path itself is unchanged.
+ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
+ELECTRIC_SECRET      = "revealui/prod/electric/secret"


### PR DESCRIPTION
## What

Consuming side of the Railway → Fly secrets migration. Adds the secrets-sync manifest for the new revvault `fly` sync target and corrects `docs/deployment/fly.md`. Pairs with the `revvault sync fly` implementation (separate revvault PR).

## Changes

- **`scripts/sync/revvault-fly.toml`** (new) — `[fly-apps.revealui-worker]` block listing the worker's prod secret subset (`POSTGRES_URL`, `REVEALUI_SECRET`, license keypair, Stripe secret + webhook, Sentry DSN, Electric URL + secret). **Vault paths only** — no values; revvault stays the source of truth. Mirrors the worker bootstrap block in `fly.md`.
- **`docs/deployment/fly.md`** — bootstrap + Secrets sections now reference `revvault sync fly --manifest scripts/sync/revvault-fly.toml [--apply]` instead of the aspirational `revvault-sync` that never existed.
- **Fix:** the manual-bootstrap example used `revealui/prod/revealui-secret` for `REVEALUI_SECRET` — a nonexistent vault path. Corrected to the canonical `revealui/prod/secret` (matches `revvault-vercel.toml`).

## Notes

- Pure config + docs; no runtime code paths exercised. A live `revvault sync fly --apply` is owner-gated on a Fly API token + the `revealui-worker` Fly app existing, and on the revvault PR landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
