### PR TITLE
fix(sync): track REVEALUI_KEK in revealui-admin vercel env manifest

### DIFF
--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -151,6 +151,10 @@ POSTGRES_URL  = "revealui/prod/db/postgres-url"
 NEON_API_KEY  = "revealui/prod/db/neon-api-key"
 
 # Encryption + signing (parity with api — same license keypair + session secret)
+# REVEALUI_KEK - field-level encryption key (AES-256-GCM; packages/db/src/crypto.ts).
+# admin's production instrumentation hard-requires it (apps/admin/src/lib/utils/env-validation.ts);
+# leaving it untracked here is what let it go missing when the prod env was rebuilt (regression #928).
+REVEALUI_KEK                 = "revealui/prod/kek"
 REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
 REVEALUI_SECRET              = "revealui/prod/secret"


### PR DESCRIPTION
## Summary

Track `REVEALUI_KEK` in the `[projects.revealui-admin.vars]` block of `scripts/sync/revvault-vercel.toml`, so `revvault sync vercel` restores it to the admin Vercel project — at parity with the existing `[projects.revealui-api.vars]` mapping.

## Why

`REVEALUI_KEK` was mapped only for `revealui-api`, never for `revealui-admin`. When the admin production environment was rebuilt, KEK was the one required var that didn't get re-added — and nothing in the sync manifest would ever restore it.

admin's production instrumentation (`apps/admin/src/lib/utils/env-validation.ts`, invoked from `apps/admin/src/instrumentation.ts`) treats `REVEALUI_KEK` as required and **fail-fasts** (`process.exit(1)`) in production when it is missing. That kills the serverless function on cold start, so the whole `/api/*` surface returns 500. This is the root cause behind #928. (The security control did its job — it refused to boot rather than run encryption without a key.)

The live admin production environment has already been restored out-of-band — the var is set and the deployment was rolled forward, so `/api/health` is 200 again. **This PR is the durable fix**: making the var tracked so a future env rebuild / sync cannot silently drop it again.

## Audit (audit-first)

Diffed admin's full required set against the manifest block, from both sources of truth:

- `env-validation.ts` `baseRequired` + production-only checks: `REVEALUI_SECRET`, `REVEALUI_PUBLIC_SERVER_URL`, `POSTGRES_URL`, `REVEALUI_KEK`, `SESSION_COOKIE_DOMAIN`, `NEXT_PUBLIC_STRIPE_{PRO,MAX,ENTERPRISE}_PRICE_ID`.
- `@revealui/config` `requiredSchema`: `REVEALUI_SECRET`, `REVEALUI_PUBLIC_SERVER_URL`, `NEXT_PUBLIC_SERVER_URL`, `POSTGRES_URL`.

**`REVEALUI_KEK` was the only required-but-untracked var** for admin; every sibling is already present. (`REVEALUI_KEK` is `.optional()` in `@revealui/config`, so the boot-time requirement comes solely from the admin app's `env-validation.ts`.)

## Verification

- TOML parses; `admin.REVEALUI_KEK` now resolves to the same canonical vault path as `api.REVEALUI_KEK`.
- `pnpm vercel:drift-check` (manifest-vs-live) is owner-runnable; it couldn't be exercised here because the `VERCEL_TOKEN` vault path is currently empty (being reconciled in #1020). The required-var audit above does not depend on it. `revvault sync vercel` is dry-run unless `--apply`; applying will Skip this var (live value already matches the vault), so it is a no-op on values.

## Risk

Config-only change (one var→path mapping). No code, build, type, or test impact.

Refs #928
