### PR TITLE
fix(deploy): track REVEALUI_KEK in revealui-admin sync block

### DIFF
--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -154,6 +154,10 @@ NEON_API_KEY  = "revealui/prod/db/neon-api-key"
 REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
 REVEALUI_SECRET              = "revealui/prod/secret"
+# REVEALUI_KEK — required by admin prod env-validation at boot (parity with the
+# api project above). Was absent from this block, so sync did not manage it on
+# the admin project; tracked here so it stays populated.
+REVEALUI_KEK                 = "revealui/prod/kek"
 
 # Cron + alerting (parity with api)
 REVEALUI_CRON_SECRET = "revealui/prod/cron-secret"


### PR DESCRIPTION
## What

Adds `REVEALUI_KEK = "revealui/prod/kek"` to the `[projects.revealui-admin.vars]` block of `scripts/sync/revvault-vercel.toml`. It was present in the `revealui-api` block but missing from `revealui-admin`.

## Why

`REVEALUI_KEK` is required by the admin app at boot (production env-validation, parity with api). Because it wasn't in the admin sync block, the revvault→Vercel sync never managed it on the admin project — so if the value is lost on Vercel, sync won't restore it. Adding it brings admin to parity with api and lets `revvault sync vercel --apply` keep it populated.

## Notes

- Config-only (one manifest line); no code change. Vault path only — no value (revvault stays the source of truth).
- Follow-up (not in this PR): a broader audit comparing every var the admin app requires at boot against the admin manifest block, in case other required vars are similarly untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
