### PR TITLE
fix(contracts): correct dormant SERVICE_OFFERINGS cal.com slug (404 -> /discovery)

### DIFF
--- a/.changeset/fix-pricing-cal-com-slug.md
+++ b/.changeset/fix-pricing-cal-com-slug.md
@@ -1,0 +1,5 @@
+---
+"@revealui/contracts": patch
+---
+
+Fix the `SERVICE_OFFERINGS` discovery-call `ctaHref` slug. `cal.com/revealuistudio/revealui-discovery-call` returns HTTP 404; the live event slug is `discovery`. These offerings are dormant (the pricing API intentionally returns `services: []` until the `service` billing track is built), but the data is now correct for when they're wired — and the agency site already uses the correct `/discovery` link.

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -287,7 +287,7 @@ export const SERVICE_OFFERINGS: ServiceOffering[] = [
     ],
     deliverable: 'Written report delivered within 5 business days',
     cta: 'Book a Discovery Call',
-    ctaHref: 'https://cal.com/revealuistudio/revealui-discovery-call',
+    ctaHref: 'https://cal.com/revealuistudio/discovery',
   },
   {
     id: 'launch-package',
@@ -305,7 +305,7 @@ export const SERVICE_OFFERINGS: ServiceOffering[] = [
     ],
     deliverable: 'Production-ready deployment within 2-4 weeks',
     cta: 'Book a Discovery Call',
-    ctaHref: 'https://cal.com/revealuistudio/revealui-discovery-call',
+    ctaHref: 'https://cal.com/revealuistudio/discovery',
   },
   {
     id: 'migration-assist',
@@ -323,7 +323,7 @@ export const SERVICE_OFFERINGS: ServiceOffering[] = [
     ],
     deliverable: 'Working migration with verified data integrity',
     cta: 'Get an Estimate',
-    ctaHref: 'https://cal.com/revealuistudio/revealui-discovery-call',
+    ctaHref: 'https://cal.com/revealuistudio/discovery',
   },
   {
     id: 'consulting-hour',
@@ -339,7 +339,7 @@ export const SERVICE_OFFERINGS: ServiceOffering[] = [
     ],
     deliverable: 'Session recording and written follow-up notes',
     cta: 'Book a Session',
-    ctaHref: 'https://cal.com/revealuistudio/revealui-discovery-call',
+    ctaHref: 'https://cal.com/revealuistudio/discovery',
   },
 ];
 


### PR DESCRIPTION
## What

Corrects the Cal.com discovery-call slug in `@revealui/contracts` `SERVICE_OFFERINGS` — all 4 `ctaHref`s pointed at `.../revealui-discovery-call` (HTTP 404); the live event slug is `discovery`.

## Why

The slug 404s. These offerings are **dormant** — `apps/server/src/routes/pricing.ts` intentionally returns `services: []` until the `service` billing track is built (documented inline) — so there's no runtime impact today, but the data is now correct for when the track is wired. The agency site (separate repo) already uses `/discovery`; this brings the platform contract in line.

## Scope

- Data-only fix (string value × 4). No type/shape change.
- `SERVICE_OFFERINGS` is **retained** (tested + a documented re-enable path) — deliberately not removed.

## Verification

- biome clean on the changed file
- `@revealui/contracts` typecheck clean
- `pricing.test.ts` — 39 tests pass (assertions check `ctaHref` *contains* `cal.com/revealuistudio`, unaffected by the slug change)
- Changeset: `@revealui/contracts` patch

Base: `test`.
