### PR TITLE
docs(server): correct license route table in README

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -91,9 +91,11 @@ pnpm test:coverage
 
 ### License
 
-| Method | Path                | Purpose                                      |
-| ------ | ------------------- | -------------------------------------------- |
-| GET    | `/license/validate` | Validate perpetual or deployment license key |
+| Method | Path                    | Purpose                                        |
+| ------ | ----------------------- | ---------------------------------------------- |
+| POST   | `/api/license/verify`   | Verify a license key (returns tier + features) |
+| POST   | `/api/license/generate` | Generate a signed license key (admin only)     |
+| GET    | `/api/license/features` | Feature flags available at each tier           |
 
 ### Observability
 


### PR DESCRIPTION
## What

The `apps/server` API route table documented the license endpoint as a single row:

```
| GET | `/license/validate` | Validate perpetual or deployment license key |
```

That row was wrong on two counts and incomplete:

- There is **no `/validate` route** — the path does not exist.
- Verification is **POST**, not GET.

## Fix

Replaced it with the three real routes defined in `apps/server/src/routes/license.ts`, mounted at `/api/license` (`apps/server/src/index.ts:1121`, also aliased at `/api/v1/license`):

| Method | Path | Purpose |
| ------ | ---- | ------- |
| POST | `/api/license/verify` | Verify a license key (returns tier + features) |
| POST | `/api/license/generate` | Generate a signed license key (admin only) |
| GET | `/api/license/features` | Feature flags by tier |

Verified against `license.ts` before editing (`verify` L119–121, `generate` L299–301, `features` L401–403).

## Context

Discovered while diagnosing a public status-page "License Service down" false alarm — the stale route table was a contributing red herring.

## Scope

Docs-only (`apps/server/README.md`, +5/−3). No code or behavior changes. Pre-push quality gate (incl. claim-drift + docs-import-drift hard-fail checks) passed locally.
