### PR TITLE
chore(secrets): retire dead 2FA-bypass npm automation token references

### DIFF
--- a/apps/docs/public/runbooks/secret-rotation.md
+++ b/apps/docs/public/runbooks/secret-rotation.md
@@ -60,7 +60,6 @@ revvault set revealui/prod/stripe/publishable-key --force
 # Other providers
 revvault set revealui/prod/sentry/auth-token --force          # Sentry → Auth Tokens (DSN is semi-public, optional)
 revvault set revealui/prod/blob/read-write-token --force      # Vercel → Storage → Blob
-revvault set revealui/prod/api-keys/npm-automation-token --force  # npm runtime token (scope to actual need; likely read-only)
 revvault set revealui/prod/google/private-key --force         # GCP IAM → SA → new key → paste private_key
 revvault set revealui/prod/db/neon-api-key --force            # Neon → API keys
 ```

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -189,7 +189,6 @@ revealui/prod/public/is-live     # NEXT_PUBLIC_IS_LIVE — feature-flag: Stripe 
 
 ```
 revealui/prod/api-keys/vercel-token         # VERCEL_TOKEN — Vercel API token for sync + deploy; also mirrored to GH secret VERCEL_TOKEN
-revealui/prod/api-keys/npm-automation-token # REVEALUI_NPM_TOKEN — npm publish automation (scope to actual need)
 ```
 
 #### API keys namespace
@@ -201,7 +200,6 @@ revealui/api-keys/ai-gateway
 revealui/api-keys/github-pat
 revealui/api-keys/huggingface
 revealui/api-keys/mcp
-revealui/api-keys/npm-automation-token   # workspace-level; prod mirror at revealui/prod/api-keys/npm-automation-token
 revealui/api-keys/openai-codex
 revealui/api-keys/openai-reveal-framework
 revealui/api-keys/openai-test
@@ -263,7 +261,9 @@ credentials/exa/api-key                 # Exa search
 ### CI / publishing
 
 ```
-credentials/npm/token   # RETIRED 2026-05-20 — canary publish dropped; main release uses OIDC (no token)
+# npm publish: OIDC trusted publishing only (no token). The 2FA-bypass automation token at
+# revealui/api-keys/npm-automation-token (+ prod mirror) was revoked on npm.org + removed from
+# the vault 2026-05-23 — see revealui#1016. (The credentials/npm/token path never existed.)
 credentials/sentry/auth-token           # error tracking (CI + runtime)
 ```
 

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -60,7 +60,6 @@ revvault set revealui/prod/stripe/publishable-key --force
 # Other providers
 revvault set revealui/prod/sentry/auth-token --force          # Sentry → Auth Tokens (DSN is semi-public, optional)
 revvault set revealui/prod/blob/read-write-token --force      # Vercel → Storage → Blob
-revvault set revealui/prod/api-keys/npm-automation-token --force  # npm runtime token (scope to actual need; likely read-only)
 revvault set revealui/prod/google/private-key --force         # GCP IAM → SA → new key → paste private_key
 revvault set revealui/prod/db/neon-api-key --force            # Neon → API keys
 ```

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -85,7 +85,8 @@ REVEALUI_ALERT_EMAIL = "revealui/prod/alert-email"
 
 # Storage + CI tokens
 BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
-REVEALUI_NPM_TOKEN    = "revealui/prod/api-keys/npm-automation-token"
+# REVEALUI_NPM_TOKEN dropped 2026-05-23: 2FA-bypass npm automation token retired
+# (revealui#1016); release.yml publishes via OIDC trusted publishing — no token.
 
 # Email transport (Gmail SA)
 GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"


### PR DESCRIPTION
## Summary

Retires the last repo references to the **2FA-bypass npm automation token** that
was dropped with the canary publish workflow in #1016 (2026-05-21) — that PR left
three live references behind.

The token (`revealui/api-keys/npm-automation-token` + its prod mirror) is **revoked
on npm.org** — verified `HTTP 401` from `registry.npmjs.org/-/whoami`. npm publishing
now runs exclusively through `release.yml` via **OIDC trusted publishing** (no
long-lived token, SLSA B2 provenance).

## Changes

- **`scripts/sync/revvault-vercel.toml`** — stop mirroring the dead token to Vercel as
  `REVEALUI_NPM_TOKEN`; the sync manifest still pushed it on every `vercel:sync`.
- **`docs/SECRETS.md`** — drop the two active index entries for the retired token, and
  correct the CI/publishing section. It marked a **phantom path** (`credentials/npm/token`)
  as retired — that path never existed in the vault; the real entries are the
  `npm-automation-token` paths above.
- **`docs/runbooks/secret-rotation.md`** — drop `npm-automation-token` from the Phase 1
  rotation list (Phase 4 already documented it retired — internal contradiction removed).

## Out-of-band cleanup (same session — not repo state)

- Vault entries `revealui/api-keys/npm-automation-token` + `revealui/prod/api-keys/npm-automation-token` removed.
- Stale Vercel `REVEALUI_NPM_TOKEN` env var removed.

## Deliberately not touched

`revealui/env/npm` is the **active** `@revealui/cli` `revealui auth` vault convention
(`packages/cli/src/commands/auth.ts` + `.envrc`) — separate from the retired automation
token, left in place.

## Test plan

Docs + sync-manifest only; no code paths changed. Full CI gate (Biome, boundary,
claim-drift, typecheck, tests, build) expected to pass unchanged.
