### PR TITLE
fix(docs): exclude SECRETS.md from the published docs site

### DIFF
--- a/apps/docs/scripts/copy-docs.sh
+++ b/apps/docs/scripts/copy-docs.sh
@@ -24,6 +24,7 @@ INTERNAL_FILES=(
   "AI-AGENT-RULES.md"
   "AUTOMATION.md"
   "STANDARDS.md"
+  "SECRETS.md" # revvault secret-path inventory — must never be served publicly
 )
 
 # Clean previously-copied docs.

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -26,6 +26,7 @@ const INTERNAL_DOC_FILES = new Set([
   'AI-AGENT-RULES.md',
   'AUTOMATION.md',
   'STANDARDS.md',
+  'SECRETS.md', // revvault secret-path inventory — must never be served publicly
 ]);
 
 function docsCopyPlugin() {


### PR DESCRIPTION
## Summary

`SECRETS.md` is an internal operations doc that should be excluded from the
published docs site, alongside the internal docs already excluded
(`MASTER_PLAN.md`, `AI-AGENT-RULES.md`, `AUTOMATION.md`, `STANDARDS.md`). It
was missing from the exclusion lists, so the build was copying it into
`apps/docs/public/`.

## Change

Add `SECRETS.md` to both kept-in-sync exclusion lists:
- `INTERNAL_DOC_FILES` in `apps/docs/vite.config.ts` (dev server + build plugin)
- `INTERNAL_FILES` in `apps/docs/scripts/copy-docs.sh` (production build)

## Verification

After running `copy-docs.sh`, `apps/docs/public/SECRETS.md` is no longer
produced. Existing exclusions (`MASTER_PLAN.md` etc.) confirmed still working.
Diff is the two exclusion-list lines only.

## Related

Broader docs-publishing hygiene (untracking generated `public/` artifacts) is
handled in parallel by `chore/untrack-docs-public-artifacts`.
