### PR TITLE
fix(docs): exclude internal ops/security docs from the published docs site

### DIFF
--- a/apps/docs/scripts/copy-docs.sh
+++ b/apps/docs/scripts/copy-docs.sh
@@ -25,6 +25,18 @@ INTERNAL_FILES=(
   "AUTOMATION.md"
   "STANDARDS.md"
   "SECRETS.md" # revvault secret-path inventory — must never be served publicly
+  # Internal ops / business docs — not for the public docs site
+  "AUDIT_STATUS.md"
+  "COMMERCIAL_READINESS.md"
+  "CREDENTIAL-ROTATION-RUNBOOK.md"
+  "DEPLOYMENT-RUNBOOK.md"
+  "LAUNCH-CHECKLIST.md"
+  "runbook-agent-dispatch-flag.md"
+  # audience: maintainer (operating RevealUI Studio's own infra/release, not framework-user docs)
+  "CI_CD_GUIDE.md"
+  "MARKETING_METRICS.md"
+  "PERFORMANCE.md"
+  "PUBLISHING.md"
 )
 
 # Clean previously-copied docs.
@@ -59,6 +71,16 @@ cp -r "$SOURCE_DOCS"/. "$TARGET_DOCS"/
 if [ -d "$TARGET_DOCS/archive" ]; then
   rm -rf "$TARGET_DOCS/archive"
 fi
+
+# Remove internal-only subdirectories (ops / security / business docs, never public).
+# IMPORTANT: Keep in sync with INTERNAL_DOC_DIRS in vite.config.ts
+INTERNAL_DIRS=( runbooks security checklists system-tune deployment )
+for d in "${INTERNAL_DIRS[@]}"; do
+  if [ -d "$TARGET_DOCS/$d" ]; then
+    rm -rf "$TARGET_DOCS/$d"
+    echo "   Excluded dir: $d/"
+  fi
+done
 
 # Remove internal-only files from the public directory
 echo "   Removing internal docs..."

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -27,7 +27,23 @@ const INTERNAL_DOC_FILES = new Set([
   'AUTOMATION.md',
   'STANDARDS.md',
   'SECRETS.md', // revvault secret-path inventory — must never be served publicly
+  // Internal ops / business docs — not for the public docs site
+  'AUDIT_STATUS.md',
+  'COMMERCIAL_READINESS.md',
+  'CREDENTIAL-ROTATION-RUNBOOK.md',
+  'DEPLOYMENT-RUNBOOK.md',
+  'LAUNCH-CHECKLIST.md',
+  'runbook-agent-dispatch-flag.md',
+  // audience: maintainer (operating RevealUI Studio's own infra/release, not framework-user docs)
+  'CI_CD_GUIDE.md',
+  'MARKETING_METRICS.md',
+  'PERFORMANCE.md',
+  'PUBLISHING.md',
 ]);
+
+// Internal-only docs/ subdirectories that must never be served publicly.
+// IMPORTANT: Keep in sync with INTERNAL_DIRS in scripts/copy-docs.sh
+const INTERNAL_DOC_DIRS = ['runbooks', 'security', 'checklists', 'system-tune', 'deployment'];
 
 function docsCopyPlugin() {
   const docsSource = path.resolve(import.meta.dirname, '../../docs');
@@ -150,7 +166,7 @@ function docsCopyPlugin() {
 
     // Skip ignored directories
     const parts = relativePath.split(path.sep);
-    const ignoreDirs = ['node_modules', '.next', 'dist', 'archive'];
+    const ignoreDirs = ['node_modules', '.next', 'dist', 'archive', ...INTERNAL_DOC_DIRS];
     if (parts.some((part) => ignoreDirs.includes(part))) {
       return;
     }
@@ -252,6 +268,7 @@ function docsCopyPlugin() {
         '.next',
         'dist',
         'archive', // Skip archive in public - too large
+        ...INTERNAL_DOC_DIRS,
       ]);
 
       if (DEBUG)


### PR DESCRIPTION
## Summary

Extends the docs-site publish exclusion from a 4-name file list to a
category-based deny that also covers internal **directories** and the remaining
internal ops/business docs. These are operational / business / security docs
(`audience: maintainer` or untagged ops docs), not framework-user documentation.

## Excluded (new)

- **Directories:** `runbooks/`, `security/`, `checklists/`, `system-tune/`, `deployment/`
- **Top-level files:** `AUDIT_STATUS`, `COMMERCIAL_READINESS`, `CREDENTIAL-ROTATION-RUNBOOK`, `DEPLOYMENT-RUNBOOK`, `LAUNCH-CHECKLIST`, `runbook-agent-dispatch-flag`, plus the `audience: maintainer` docs `CI_CD_GUIDE`, `MARKETING_METRICS`, `PERFORMANCE`, `PUBLISHING`

## Mechanism

A shared `INTERNAL_DOC_DIRS` const drives the directory exclusion in both the
dev-server plugin (`vite.config.ts`) and the production copy step
(`copy-docs.sh`), alongside the existing file-level `INTERNAL_DOC_FILES` /
`INTERNAL_FILES` lists (kept in sync).

## Public docs unaffected

Developer docs — `guides/`, `api/`, `architecture/`, `blog/`, `ai/`, `fleet/`,
`features/`, and all `audience: developer/enterprise/contributor/legal` docs —
continue to be served.

## Verification

After running `copy-docs.sh`: the excluded dirs/files are absent from
`apps/docs/public/`, and all public docs remain. Diff is the two config files only.
