### PR TITLE
feat(marketing): contrast, cobalt-ink copy, and touch-target fixes

### DIFF
--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -54,7 +54,7 @@ export function Hero() {
       {/* Brand background: warm wash + radial spotlight + faint primitive symbols */}
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute inset-0 bg-gradient-to-b from-emerald-50/40 via-white to-white" />
-        <div className="absolute -top-40 left-1/2 h-[700px] w-[1100px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,rgba(16,185,129,0.18),rgba(16,185,129,0.04)_60%,transparent_80%)] blur-2xl" />
+        <div className="absolute -top-40 left-1/2 h-[700px] w-[1100px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,oklch(0.55_0.18_245/0.18),oklch(0.55_0.18_245/0.04)_60%,transparent_80%)] blur-2xl" />
         {backgroundPrimitives.map((p) => (
           <svg
             key={p.path}

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -1,5 +1,5 @@
 import type { LicenseTierId, PricingResponse } from '@revealui/contracts/pricing';
-import { Button, ButtonCVA } from '@revealui/presentation';
+import { ButtonCVA } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import {
   PRICING_TEASER_FOOTER,
@@ -147,9 +147,14 @@ export function PricingTeaser() {
         </div>
 
         <div className="mt-12 text-center">
-          <Button plain href={PRICING_TEASER_FOOTER.moreHref} className="text-sm font-medium">
-            {PRICING_TEASER_FOOTER.moreLabel}
-          </Button>
+          <ButtonCVA
+            asChild
+            variant="link"
+            size="default"
+            className="items-center justify-center text-sm font-medium"
+          >
+            <a href={PRICING_TEASER_FOOTER.moreHref}>{PRICING_TEASER_FOOTER.moreLabel}</a>
+          </ButtonCVA>
           <p className="mt-6 text-xs leading-5 text-muted-foreground">
             {PRICING_TEASER_FOOTER.caption.prefix}{' '}
             <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700">

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { ButtonCVA } from '@revealui/presentation';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 
 const accentBg: Record<string, string> = {
@@ -50,13 +50,16 @@ export function Primitives() {
         </div>
 
         <div className="mt-12 text-center">
-          <Button
-            plain
-            href={HOME_PRIMITIVES_SECTION.docsLink.href}
-            className="text-sm font-medium"
+          <ButtonCVA
+            asChild
+            variant="link"
+            size="default"
+            className="items-center justify-center text-sm font-medium"
           >
-            {HOME_PRIMITIVES_SECTION.docsLink.label}
-          </Button>
+            <a href={HOME_PRIMITIVES_SECTION.docsLink.href}>
+              {HOME_PRIMITIVES_SECTION.docsLink.label}
+            </a>
+          </ButtonCVA>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { ButtonCVA } from '@revealui/presentation';
 import {
   PROOF_CI_SIGNALS,
   PROOF_REPO_SIGNALS,
@@ -221,9 +221,14 @@ export function Proof() {
         </div>
 
         <div className="mt-12 text-center">
-          <Button plain href={PROOF_TRUST.changelogCta.href} className="text-sm font-medium">
-            {PROOF_TRUST.changelogCta.label}
-          </Button>
+          <ButtonCVA
+            asChild
+            variant="link"
+            size="default"
+            className="items-center justify-center text-sm font-medium"
+          >
+            <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
+          </ButtonCVA>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -16,11 +16,11 @@ import type { Cta, FaqItem } from './types';
 // ---------------------------------------------------------------------------
 
 export const HOME_HERO = {
-  eyebrow: 'Open-source. Self-hostable. Audit-grade.',
-  h1: 'The open runtime for AI-native businesses.',
+  eyebrow: 'Open source. Self-hostable. Audit-ready.',
+  h1: 'Launch your AI product on a foundation that’s already built.',
   subtitle: {
-    strong: 'Yours to install. Ours to build for you.',
-    body: 'Auth, content, products, payments, and intelligence — five primitives, one policy plane, one hash-chained audit log. For founders shipping AI products who need audit trails and unified governance from day one — whether you build with',
+    strong: 'Auth, billing, content, and AI, wired together from day one.',
+    body: 'Spin up a working app — users, Stripe payments, an admin dashboard, and an AI agent layer, all sharing one login and one audit trail. Build it yourself',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
     agencyHref: SITE.urls.agency,
@@ -32,7 +32,7 @@ export const HOME_HERO = {
   },
   agencyCta: {
     prefix: 'Want it built for you?',
-    label: 'RevealUI Studio builds AI businesses on RevealUI →',
+    label: 'RevealUI Studio builds your AI product on RevealUI →',
     href: SITE.urls.agency,
   },
   cliCaption: 'Local dev stack in 60 seconds. No credit card.',
@@ -227,7 +227,7 @@ export const HOME_FAQ = {
 
 export const HOME_GET_STARTED = {
   heading: 'Ready to build?',
-  body: 'Users, content, products, payments, and AI, pre-wired. Start building locally in minutes; flip to live mode when you are ready.',
+  body: 'Auth, billing, content, and AI — already wired together. Build on your machine in minutes, then flip to live mode when you’re ready to charge real customers.',
   cta: {
     primary: { label: 'Start free', href: SITE.urls.signup } satisfies Cta,
     secondary: { label: 'Read the docs', href: SITE.urls.docs } satisfies Cta,

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -1,21 +1,24 @@
-// Sourced from: app/components/landing/Persona.tsx (Phase 1c, no copy changes).
+// Sourced from: app/components/landing/Persona.tsx (Phase 1c extraction).
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// 2026-05-23: founder-first plain-language rewrite of section heading + card
+//   copy (owner-directed). Jargon (procurement review, identity gates, RBAC +
+//   ABAC, hash-chained, runtime) translated into outcomes founders recognize.
 
 export const PERSONA_SECTION = {
   eyebrow: "Who it's for",
-  heading: 'Founders shipping AI products who need governance from day one.',
+  heading: 'For founders who need to ship fast — and still pass a security review.',
 } as const;
 
 export const PERSONA_CARD = {
   label: 'What this team needs before they can charge customers',
   quote:
-    'You have a working agent demo. Now your first procurement review wants audit trails, identity gates, and a story for who can revoke an agent at 3am — without rebuilding the runtime to get there.',
+    'You’ve got a working AI demo. Then your first serious customer asks the hard questions — who can see this data, who can shut an agent down at 3am, and can you prove everything it did? You need answers before you can charge them, and you shouldn’t have to rebuild what you’ve already shipped to get there.',
   checklist: [
-    'Hash-chained audit log of every action by every human and every agent — provable, not just observable',
-    'One RBAC + ABAC policy plane covering humans, agents, and service accounts',
-    'GDPR consent + deletion + anonymization scaffolded into the data model',
-    'Stripe webhook reconciliation that catches the events most apps lose silently',
-    'Source-visible Pro packages on Fair Source — auditable for procurement and security review',
+    'An audit trail of every action — by people and by agents — that you can prove was not edited after the fact',
+    'One set of permission rules covering your team, your agents, and your service accounts',
+    'GDPR consent, deletion, and anonymization built into the data model',
+    'Stripe billing that catches the payment events most apps quietly drop',
+    'Source-visible code your customer’s security team can actually read and review',
   ],
   footer: {
     prefix: 'Also a fit for',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -21,9 +21,9 @@ export interface HomePrimitive {
 }
 
 export const HOME_PRIMITIVES_SECTION = {
-  eyebrow: 'Five primitives. One audit log. One policy plane.',
+  eyebrow: 'Five primitives. One login. One audit trail.',
   heading: "Everything a business needs. Nothing you don't.",
-  body: 'Auth, content, products, payments, and intelligence — every action by every human and agent is RBAC-gated, ABAC-checked, and signed into a tamper-evident audit chain.',
+  body: 'Users, content, products, payments, and intelligence — the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 

--- a/apps/marketing/app/index.css
+++ b/apps/marketing/app/index.css
@@ -28,7 +28,16 @@
   --color-secondary: var(--rvui-surface-2);
   --color-secondary-foreground: var(--rvui-text-0);
   --color-muted: var(--rvui-surface-2);
-  --color-muted-foreground: var(--rvui-text-2);
+  /* Secondary / muted text — deterministic deep cobalt-ink (brand hue ~248).
+   * Replaces var(--rvui-text-2): the token file is dark-first (:root = dark),
+   * so --rvui-text-2 resolved to a silvery oklch(0.65 …) that washed out and
+   * failed WCAG AA on this site's bg-white / bg-gray-50 sections. This fixed
+   * value tests ~5.8:1 on white (AA pass) and reads as intentional brand ink,
+   * not gray — every text-muted-foreground (eyebrows, captions, footnotes)
+   * picks it up with no per-component edits. Marketing uses muted text only on
+   * light surfaces, so a single fixed value is safe (dark panels use explicit
+   * text-gray-300/400 utilities, untouched). */
+  --color-muted-foreground: oklch(0.48 0.085 248);
   --color-accent: var(--rvui-accent);
   --color-accent-foreground: var(--rvui-text-on-accent);
   --color-destructive: var(--rvui-error);

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -198,7 +198,7 @@ export function ProductsPage() {
                   <div className="mt-6">
                     <a
                       href={product.primaryCta.href}
-                      className="inline-flex items-center text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
+                      className="inline-flex min-h-11 items-center text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
                       {...(product.primaryCta.external
                         ? { target: '_blank', rel: 'noreferrer' }
                         : {})}

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -1,5 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<!--
+  data-theme="light" locks the marketing site to light mode. The brand token
+  set (@revealui/presentation/tokens.css) is dark-first (:root = dark), but
+  every marketing section paints explicit light backgrounds (bg-white /
+  bg-gray-50). Without this lock, semantic tokens (e.g. text-muted-foreground →
+  --rvui-text-2) resolved to their dark-mode silver values on white, both
+  washing the copy out and failing WCAG AA. Lock makes color deterministic.
+-->
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary

- **Contrast fix**: Lock marketing to `data-theme="light"` on `<html>` so `@revealui/presentation` tokens resolve against light backgrounds. Replace the dark-first `--rvui-text-2` silver token with a deterministic cobalt-ink value (`oklch(0.48 0.085 248)`) on `--color-muted-foreground` — passes WCAG AA (~5.8:1 on white) and reads as intentional brand ink rather than washed-out gray.
- **Hero glow**: Remap hardcoded emerald `rgba()` in the Hero radial glow to cobalt `oklch()` so it respects the palette remap in `index.css`.
- **Touch targets**: Route all arrow-link anchors through `ButtonCVA` (`h-11` = 44 px) so touch targets match the design-system button height. Add `min-h-11` to the bare `<a>` in `ProductsPage`.
- **Founder copy**: Rewrite hero, primitives section, and persona card — translate RBAC/ABAC/audit-chain/x402 jargon into plain outcomes founders recognise before their first enterprise deal.

## Files changed

| File | Change |
|------|--------|
| `apps/marketing/index.html` | `data-theme="light"` on `<html>` |
| `apps/marketing/app/index.css` | `--color-muted-foreground` → cobalt-ink literal |
| `apps/marketing/app/components/landing/Hero.tsx` | Cobalt oklch radial glow |
| `apps/marketing/app/components/landing/Primitives.tsx` | `Button plain` → `ButtonCVA` (h-11) |
| `apps/marketing/app/components/landing/Proof.tsx` | `Button plain` → `ButtonCVA` (h-11) |
| `apps/marketing/app/components/landing/PricingTeaser.tsx` | `Button plain` → `ButtonCVA` (h-11) |
| `apps/marketing/app/routes/ProductsPage.tsx` | `min-h-11` on bare `<a>` |
| `apps/marketing/app/content/home.ts` | Hero copy rewrite |
| `apps/marketing/app/content/primitives.ts` | Primitives section copy rewrite |
| `apps/marketing/app/content/persona.ts` | Persona card founder rewrite |

## Test plan

- [x] Biome lint — clean (pre-commit hook)
- [x] TypeScript typecheck — EXIT=0
- [x] claim-drift validator — 0 mismatches (all numbers still `METRICS`/`SITE` constants)
- [x] Marketing Vitest tests — 2/2 pass
- [x] Pre-push gate Phase 1 — PASS (all hard-fail checks green)
- [ ] Visual review at `http://localhost:3000/` — cobalt-ink muted text, cobalt glow, 44 px arrow anchors, new copy visible
- [ ] Deploy preview via `deploy-test.yml` workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
