### PR TITLE
fix(marketing): cobalt glow on fair-source + founder-framed products copy

### DIFF
--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -20,7 +20,7 @@ import type { Cta } from './types';
 export const PRODUCTS_PAGE_HERO = {
   h1: 'The RevFleet product family',
   subtitle:
-    'One foundation. Eight products. Each one ships today or ships soon — built and operated by RevealUI Studio.',
+    'Start with the runtime, add the rest as you grow. Eight products on one foundation — each ships today or ships soon, all built and operated by RevealUI Studio.',
 } as const;
 
 export type ProductStatus = 'Beta' | 'Alpha' | 'Active (MIT)' | 'Planned';
@@ -84,7 +84,7 @@ export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
   status: 'Beta',
   version: 'v0.3.0',
   tagline: 'The agentic business runtime',
-  body: 'Auth, content, products, payments, and intelligence — pre-wired and exposed to your agents via MCP. The runtime everything else in RevFleet plugs into.',
+  body: 'Auth, content, products, payments, and intelligence — pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
   iconPath: 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5',
   facts: [
     { stat: String(METRICS.packages), label: 'packages' },

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -39,7 +39,7 @@ export function FairSourcePage() {
         />
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,rgba(16,185,129,0.18),rgba(16,185,129,0.04)_60%,transparent_80%)] blur-2xl"
+          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,oklch(0.55_0.18_245/0.18),oklch(0.55_0.18_245/0.04)_60%,transparent_80%)] blur-2xl"
         />
 
         <div className="relative mx-auto max-w-3xl text-center">


### PR DESCRIPTION
## Summary

Follow-up to #1041 (merged — landed the `data-theme="light"` contrast/token fix, cobalt Hero glow, `h-11` arrow-anchor touch targets, and the home-page founder copy rewrite). This PR completes the visual sweep and extends the founder-first copy to the products page.

- **FairSource hero glow** — `FairSourcePage.tsx` had the *same* hardcoded emerald `rgba(16,185,129,…)` radial gradient I remapped in Hero. Swapped to the cobalt `oklch(0.55 0.18 245/…)` value so it respects the `index.css` palette remap. A full `apps/marketing` audit confirmed this was the **only** remaining raw-color escapee (utility classes like `text-emerald-700` are already caught by the remap; only literal colors in `bg-[…]` slip through).
- **products.ts founder copy** — hero subtitle now leads with the founder action ("Start with the runtime, add the rest as you grow"); the flagship body de-jargons "pre-wired and exposed to your agents via MCP" into "pre-wired into one runtime your team and your AI agents share through a single open protocol".

## Audit notes (no change needed)

A full `apps/marketing` sweep, prompted by #1041, verified two things that did **not** need fixing:

- **Gray-contrast**: all 33 `text-gray-400/500` occurrences are correctly scoped to dark surfaces (`bg-gray-950/900`), form placeholders, or terminal chrome — none are light-surface readable text bypassing the cobalt-ink `--color-muted-foreground` token. All ~40 `text-muted-foreground` usages were verified to sit on light surfaces (no regression from the L=0.48 mid-tone token).
- **Copy**: pricing / proof / capabilities / fair-source / marketplace / roadmap content was already founder-appropriate (the CFO $-comparison panel, fair-source's "three yeses and one no", honest "Planned — not built" roadmap framing) from the prior marketing-overhaul lane. Churning it would be net-negative.

## Test plan

- [x] claim-drift validator — 0 mismatches (all 9 gate categories green; numbers stay `METRICS`/`SITE` constants)
- [x] Biome — clean
- [x] TypeScript typecheck — EXIT=0
- [x] Marketing Vitest — 2/2 pass
- [ ] Visual review — local screenshots blocked by environment (Chrome-extension localhost gate + Playwright headless-shell blank-render); CSS/`data-theme=light` render confirmed. Recommend a `deploy-test.yml` preview for pixel review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
