### PR TITLE
fix(core): route richtext RSC through client-safe @revealui/security/sanitize (node:crypto crash)

### DIFF
--- a/.changeset/security-sanitize-client-subpath.md
+++ b/.changeset/security-sanitize-client-subpath.md
@@ -1,0 +1,13 @@
+---
+'@revealui/security': minor
+'@revealui/core': patch
+---
+
+Add a client-safe `@revealui/security/sanitize` subpath and route rich-text RSC rendering through it — fixes a `node:crypto` client-bundle crash.
+
+`@revealui/core/richtext/rsc` imported `isSafeUrl` / `sanitizeUrl` from the `@revealui/security` barrel, which statically re-exports `auth.ts` and `gdpr.ts`. Both modules have a top-level `import { ... } from 'node:crypto'`, so the entire crypto graph was pulled into every client/RSC bundle that rendered rich text. In the browser `node:crypto` is unavailable, which crashed the bundle and blanked any route loading rich-text content (e.g. the marketing `/blog` route, on `main`/production).
+
+- `@revealui/security`: new `./sanitize` export (built as a separate tsup entry). It bundles only `src/sanitize.ts` + `parse5` — no `node:crypto` — so it is safe to import from a browser/RSC client path. The barrel is unchanged for server consumers.
+- `@revealui/core`: `richtext/exports/server/rsc.tsx` now imports the URL helpers from `@revealui/security/sanitize` instead of the barrel. No public API change; existing re-exports of `isSafeUrl` / `sanitizeUrl` are preserved.
+
+The sync `totpHmac` (TOTP) usage in `auth.ts` is intentionally left as a static import — converting it to a lazy `await import('node:crypto')` would force an async signature change rippling to all TOTP callers. Isolating the client path via the subpath avoids that blast radius entirely.

--- a/packages/core/src/richtext/exports/server/rsc.tsx
+++ b/packages/core/src/richtext/exports/server/rsc.tsx
@@ -5,7 +5,12 @@
  * Converts Lexical JSON state to React elements without requiring a browser.
  */
 
-import { isSafeUrl, sanitizeUrl } from '@revealui/security';
+// Import from the client-safe ./sanitize subpath, NOT the @revealui/security
+// barrel: the barrel statically re-exports auth.ts/gdpr.ts, whose top-level
+// `import 'node:crypto'` crashes this module's client/RSC bundle (blank render
+// on routes that load rich text, e.g. marketing /blog). ./sanitize imports only
+// parse5 and is browser-safe.
+import { isSafeUrl, sanitizeUrl } from '@revealui/security/sanitize';
 import type { SerializedEditorState, SerializedLexicalNode } from 'lexical';
 import { Fragment, type JSX } from 'react';
 

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -22,6 +22,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./sanitize": {
+      "types": "./dist/sanitize.d.ts",
+      "import": "./dist/sanitize.js"
     }
   },
   "files": [

--- a/packages/security/tsup.config.ts
+++ b/packages/security/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // src/sanitize.ts is built as a separate, client-safe entry: it imports only
+  // parse5 (no node:crypto), so consumers in a browser/RSC client bundle (e.g.
+  // @revealui/core/richtext/rsc) can pull isSafeUrl/sanitizeUrl via the
+  // ./sanitize subpath WITHOUT dragging in auth.ts/gdpr.ts top-level node:crypto
+  // imports through the barrel (which crashes the client bundle).
+  entry: ['src/index.ts', 'src/sanitize.ts'],
   format: ['esm'],
   dts: true,
   sourcemap: false,


### PR DESCRIPTION
## Summary

Fixes a `node:crypto` client-bundle crash that blanks any route rendering rich text (e.g. marketing `/blog`). **Confirmed present on `main` (production).**

`@revealui/core/richtext/rsc` imported `isSafeUrl` / `sanitizeUrl` from the `@revealui/security` **barrel**, which statically re-exports `auth.ts` + `gdpr.ts`. Both have a top-level `import { ... } from 'node:crypto'`, so the entire crypto graph was pulled into every client/RSC bundle that renders rich text. In the browser `node:crypto` is unavailable → bundle crash → blank render.

## Changes

- **`@revealui/security`** (minor): new client-safe `./sanitize` subpath, built as a separate tsup entry. Bundles only `src/sanitize.ts` + `parse5` (no `node:crypto`). The barrel is unchanged for server consumers.
- **`@revealui/core`** (patch): `richtext/exports/server/rsc.tsx` imports the URL helpers from `@revealui/security/sanitize` instead of the barrel. No public API change — `isSafeUrl` / `sanitizeUrl` re-exports preserved.

The sync `totpHmac` (TOTP) usage in `auth.ts` is intentionally left as a static import — converting it to a lazy `await import('node:crypto')` would force an async signature change rippling to all TOTP callers. Subpath isolation avoids that blast radius.

## Verification

- `dist/sanitize.js` → imports only `chunk-D7RRSNIK.js` (0 crypto refs); crypto stays isolated in `chunk-F3P6YAJP.js` + `index.js` (barrel)
- `@revealui/core` typecheck clean (resolves the new subpath)
- 2678 `@revealui/core` tests pass, incl. 83 url-sanitization tests
- Discovered by the marketing lane (site-wide dev-render blank); root-caused + fixed here

## Test plan

- [ ] CI green
- [ ] (post-merge) marketing `/blog` renders rich text without blanking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
