### PR TITLE
chore(admin): drop unused sharp injection; note R2 as object storage

### DIFF
--- a/.changeset/drop-template-sharp.md
+++ b/.changeset/drop-template-sharp.md
@@ -1,0 +1,8 @@
+---
+"@revealui/cli": patch
+---
+
+Project templates no longer pass an unused `sharp` instance to `buildConfig`.
+The RevealUI engine does not decode images in-process (resizing is delegated to
+`next/image`), so the injection was a no-op. `sharp` remains available for
+Next.js image optimization in generated projects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Agentic business runtime. Users, content, products, payments, and AI  -  pre-wir
 - React 19, Next.js 16 (admin), Vite (docs / marketing), Hono (server), Node 24, TypeScript 6
 - pnpm 10, Turborepo, Biome 2, Vitest 4
 - Drizzle ORM (NeonDB), Tailwind CSS v4
+- Cloudflare R2 (S3-compatible object storage; replacing Vercel Blob)
 - Lexical (rich text), ElectricSQL (sync), Stripe (payments)
 
 ## Git Identity

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -22,7 +22,6 @@ import {
   vercelBlobStorage,
 } from '@revealui/core';
 import { en } from '@revealui/core/admin/i18n/en';
-import sharp from 'sharp';
 import { allCollections } from '@/lib/collections/registry';
 import Users from '@/lib/collections/Users';
 import { createTypedCollectionStorage } from '@/lib/db/typedCollectionStorage';
@@ -166,8 +165,9 @@ export default buildConfig({
     },
   }),
 
-  sharp,
-
+  // sharp is intentionally not injected here: the RevealUI engine does not decode
+  // images in-process — resizing is delegated to next/image. (sharp stays in
+  // dependencies only for Next.js's own image optimization.)
   plugins: [
     vercelBlobStorage({
       enabled: !!process.env.BLOB_READ_WRITE_TOKEN,

--- a/packages/cli/templates/basic-blog/revealui.config.ts
+++ b/packages/cli/templates/basic-blog/revealui.config.ts
@@ -1,6 +1,5 @@
 import config from '@revealui/config';
 import { buildConfig, universalPostgresAdapter } from '@revealui/core';
-import sharp from 'sharp';
 import { Posts } from './src/collections/Posts';
 
 export default buildConfig({
@@ -15,5 +14,4 @@ export default buildConfig({
   collections: [Posts],
   globals: [],
   plugins: [],
-  sharp,
 });

--- a/packages/cli/templates/e-commerce/revealui.config.ts
+++ b/packages/cli/templates/e-commerce/revealui.config.ts
@@ -1,6 +1,5 @@
 import config from '@revealui/config';
 import { buildConfig, universalPostgresAdapter } from '@revealui/core';
-import sharp from 'sharp';
 import { Orders } from './src/collections/Orders';
 import { Products } from './src/collections/Products';
 
@@ -16,5 +15,4 @@ export default buildConfig({
   collections: [Products, Orders],
   globals: [],
   plugins: [],
-  sharp,
 });

--- a/packages/cli/templates/portfolio/revealui.config.ts
+++ b/packages/cli/templates/portfolio/revealui.config.ts
@@ -1,6 +1,5 @@
 import config from '@revealui/config';
 import { buildConfig, universalPostgresAdapter } from '@revealui/core';
-import sharp from 'sharp';
 import { Projects } from './src/collections/Projects';
 
 export default buildConfig({
@@ -15,5 +14,4 @@ export default buildConfig({
   collections: [Projects],
   globals: [],
   plugins: [],
-  sharp,
 });

--- a/packages/cli/templates/starter/revealui.config.ts
+++ b/packages/cli/templates/starter/revealui.config.ts
@@ -1,6 +1,5 @@
 import config from '@revealui/config';
 import { buildConfig, universalPostgresAdapter } from '@revealui/core';
-import sharp from 'sharp';
 
 export default buildConfig({
   serverURL: config.reveal.publicServerURL || 'http://localhost:4000',
@@ -14,5 +13,4 @@ export default buildConfig({
   collections: [],
   globals: [],
   plugins: [],
-  sharp,
 });


### PR DESCRIPTION
## Summary

The `sharp` instance passed to `buildConfig` in the admin app (and the four
`create-revealui` templates) was never consumed. The RevealUI admin engine does
not decode images in-process — image resizing is delegated to `next/image` — and
the config validator strips the unknown key. The injection was a
Payload-compatibility artifact that misleadingly implied the CMS performs
in-process image decoding.

## Changes

- Remove the unused `import sharp` + `sharp` field from `apps/admin/revealui.config.ts` (with a clarifying comment).
- Remove the same unused injection from the `starter`, `basic-blog`, `portfolio`, and `e-commerce` templates.
- `sharp` remains in dependencies for Next.js's own image optimization.
- List Cloudflare R2 as the object-storage backend in the stack (replacing Vercel Blob).

## Risk

No behavior change: nothing reads `config.sharp` (verified repo-wide). A
`@revealui/cli` patch changeset is included for the template change.

## Verification

- Biome clean on all changed files.
- Typecheck (`tsc --noEmit`) + tests run in CI — this is a pure deletion of an unused import + excess property.

Base: `test` (not main).
