### PR TITLE
fix(ai): kill test process tree on test_runner timeout (fixes flaky timeout test + process leak)

### DIFF
--- a/.changeset/ai-test-runner-process-tree-kill.md
+++ b/.changeset/ai-test-runner-process-tree-kill.md
@@ -1,0 +1,11 @@
+---
+'@revealui/ai': patch
+---
+
+Fix `test_runner` leaking the test process tree on timeout.
+
+The tool ran tests via `execSync(..., { timeout })`, whose timeout signal only reaches the immediate child (the shell). A grandchild — e.g. `pnpm test` → `node …` — was orphaned and kept running. An agent pointing `test_runner` at a hanging suite leaked a process on every timeout; in the unit suite these orphans accumulated and starved CI, flaking the timeout test and crashing sibling test files under load.
+
+`execute` now spawns the command detached (its own process group) and, on timeout, kills the whole group via `process.kill(-pid, 'SIGKILL')` — reaping the entire tree. Output capture is byte-capped instead of throwing on overflow. Behavior is otherwise unchanged: framework detection, command building, and result parsing are identical, and a real timeout still returns `{ success: false, error: 'Tests timed out after …' }`.
+
+Verified: full `@revealui/ai` suite passes 942/942 twice under concurrent load with zero leaked processes (previously 1 failed + 3 file-level crashes + 18 orphaned `node` processes).

--- a/packages/ai/src/__tests__/tools/coding/test-runner.test.ts
+++ b/packages/ai/src/__tests__/tools/coding/test-runner.test.ts
@@ -131,7 +131,11 @@ describe('test_runner tool', () => {
   it('reports timeout when command exceeds limit', async () => {
     // Create a standalone pnpm workspace so pnpm runs locally
     writeFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'packages: []\n');
-    writeFileSync(join(ROOT, 'block.js'), 'setInterval(() => {}, 1000);\n');
+    // Block well past the 4s tool timeout, but self-exit after 30s so an
+    // orphaned process (if the kill ever misses) can't leak indefinitely.
+    // The tool kills the whole process group on timeout, so this normally
+    // dies at ~4s; the self-exit is a belt-and-suspenders safety net.
+    writeFileSync(join(ROOT, 'block.js'), 'setTimeout(() => process.exit(0), 30000);\n');
     writeFileSync(
       join(ROOT, 'package.json'),
       JSON.stringify({

--- a/packages/ai/src/tools/coding/test-runner.ts
+++ b/packages/ai/src/tools/coding/test-runner.ts
@@ -6,7 +6,7 @@
  * and failure details.
  */
 
-import { execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod/v4';
@@ -165,6 +165,80 @@ function parseGenericOutput(output: string): TestSummary {
   };
 }
 
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+/**
+ * Run a shell command with a hard timeout, killing the ENTIRE process tree on
+ * timeout — not just the direct child.
+ *
+ * `execSync`'s timeout sends its kill signal only to the immediate child (the
+ * shell), so a grandchild (e.g. `pnpm test` → `node …`) is orphaned and keeps
+ * running. For a test runner that an agent points at a hanging suite, that
+ * leaks a process on every timeout. Spawning detached gives the child its own
+ * process group; killing the negative pid (`-pgid`) reaps the whole tree.
+ */
+function runCommand(
+  command: string,
+  opts: { cwd: string; timeoutMs: number; maxBuffer: number; env: NodeJS.ProcessEnv },
+): Promise<RunResult> {
+  return new Promise<RunResult>((resolve) => {
+    const child = spawn(command, {
+      cwd: opts.cwd,
+      env: opts.env,
+      shell: true,
+      detached: true, // own process group so the whole tree is killable
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let timedOut = false;
+    let settled = false;
+
+    const killTree = (signal: NodeJS.Signals): void => {
+      if (child.pid === undefined) return;
+      try {
+        // Negative pid targets the process group (created by `detached: true`).
+        process.kill(-child.pid, signal);
+      } catch {
+        // Group already exited — nothing to kill.
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killTree('SIGKILL');
+    }, opts.timeoutMs);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes <= opts.maxBuffer) stdout += chunk.toString('utf8');
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= opts.maxBuffer) stderr += chunk.toString('utf8');
+    });
+
+    const finish = (exitCode: number): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode, timedOut });
+    };
+
+    // `error` fires when the command can't be spawned (e.g. binary not found).
+    child.on('error', () => finish(127));
+    child.on('close', (code) => finish(code ?? 0));
+  });
+}
+
 export const testRunnerTool: Tool = {
   name: 'test_runner',
   label: 'Run Tests',
@@ -194,49 +268,29 @@ export const testRunnerTool: Tool = {
     const framework = detectFramework(config.projectRoot);
     const command = buildCommand(framework, file, grep);
 
-    let stdout = '';
-    let stderr = '';
-    let exitCode = 0;
+    const { stdout, stderr, exitCode, timedOut } = await runCommand(command, {
+      cwd: config.projectRoot,
+      timeoutMs,
+      maxBuffer: MAX_OUTPUT_BYTES,
+      env: {
+        ...process.env,
+        CI: 'true',
+        FORCE_COLOR: '0',
+        NODE_OPTIONS: '--experimental-vm-modules',
+      },
+    });
 
-    try {
-      stdout = execSync(command, {
-        cwd: config.projectRoot,
-        timeout: timeoutMs,
-        maxBuffer: MAX_OUTPUT_BYTES,
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: {
-          ...process.env,
-          CI: 'true',
-          FORCE_COLOR: '0',
-          NODE_OPTIONS: '--experimental-vm-modules',
+    if (timedOut) {
+      return {
+        success: false,
+        error: `Tests timed out after ${timeoutMs}ms`,
+        data: {
+          framework,
+          command,
+          exitCode: -1,
+          summary: { passed: 0, failed: 0, skipped: 0, total: 0, failures: [] },
         },
-      });
-    } catch (err) {
-      const execErr = err as {
-        status?: number | null;
-        stdout?: string;
-        stderr?: string;
-        killed?: boolean;
-        signal?: string;
       };
-
-      if (execErr.killed || execErr.signal === 'SIGTERM') {
-        return {
-          success: false,
-          error: `Tests timed out after ${timeoutMs}ms`,
-          data: {
-            framework,
-            command,
-            exitCode: -1,
-            summary: { passed: 0, failed: 0, skipped: 0, total: 0, failures: [] },
-          },
-        };
-      }
-
-      exitCode = execErr.status ?? 1;
-      stdout = (execErr.stdout ?? '').toString();
-      stderr = (execErr.stderr ?? '').toString();
     }
 
     const combined = [stdout, stderr].filter(Boolean).join('\n');


### PR DESCRIPTION
## Summary

Fixes the flaky `@revealui/ai` `test_runner` timeout test — and the underlying production bug it exposed: **`test_runner` leaks the test process tree on every timeout.**

The tool ran tests via `execSync(command, { timeout })`. `execSync`'s timeout signal reaches only the immediate child (the shell), so a grandchild — e.g. `pnpm test` → `node …` — is **orphaned and keeps running**. For an agent pointing `test_runner` at a hanging suite, that leaks a process on every timeout. In our own unit suite the orphaned `node` processes (infinite `setInterval` fixture) accumulated and starved the machine, which:
- flaked the `reports timeout when command exceeds limit` test (it would exit early as a non-timeout error → `success: true`), and
- crashed sibling test files (`agent-context-manager`, `node-id-service`) at the file level under concurrent load.

## Root cause (reproduced)

Running the full `@revealui/ai` suite under load produced **1 failed test + 3 file-level crashes + 18 orphaned `node block.js` processes** spanning multiple prior runs. The test passes reliably in isolation — it's purely a load/leak interaction.

## Fix

- **`test-runner.ts`**: `execute()` now spawns the command **detached** (its own process group) and, on timeout, kills the **whole group** via `process.kill(-pid, 'SIGKILL')` — reaping the entire tree. Output is byte-capped on the fly instead of `execSync` throwing on buffer overflow. Framework detection, command building, and result parsing are unchanged; a real timeout still returns `{ success: false, error: 'Tests timed out after …ms' }`.
- **`test-runner.test.ts`**: the `block.js` fixture self-exits after 30s — belt-and-suspenders so an orphan can't leak indefinitely if a kill ever misses.

## Verification

- `@revealui/ai` typecheck clean
- Full `@revealui/ai` suite: **942/942 passing twice in a row under concurrent load, zero leaked processes** (was 1 failed + 3 crashes + 18 leaks)
- Timeout test fires correctly at ~4060ms (just past the 4000ms tool timeout)

This removes the recurring barrier that forced `--no-verify` on `test`/`main` pushes from a loaded local machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
