### PR TITLE
chore(scripts): add client-bundle-safety gate (node:crypto barrel leak guard)

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
+    "validate:client-safety": "tsx scripts/validate/client-safety.ts",
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",
     "validate:brand-bridge": "tsx scripts/validate/brand-bridge.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -325,6 +325,11 @@ async function gate(): Promise<void> {
         args: ['validate:stripe-client'],
       },
       {
+        name: 'Client-bundle safety (hard fail)',
+        command: 'pnpm',
+        args: ['validate:client-safety'],
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],

--- a/scripts/validate/__tests__/client-safety.test.ts
+++ b/scripts/validate/__tests__/client-safety.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { hasUseClientDirective, parseSource, runtimeModuleRefs } from '../client-safety.ts';
+
+/** Convenience: parse + collapse refs to `kind:specifier` tokens. */
+function refs(code: string, file = 'sample.tsx'): string[] {
+  return runtimeModuleRefs(parseSource(file, code)).map((r) => `${r.kind}:${r.specifier}`);
+}
+
+describe('runtimeModuleRefs — value vs type-only imports', () => {
+  it('flags a value named import of the security barrel', () => {
+    expect(refs("import { isSafeUrl } from '@revealui/security';")).toEqual([
+      'import:@revealui/security',
+    ]);
+  });
+
+  it('ignores a whole-clause `import type` (erased at build)', () => {
+    expect(refs("import type { AuditEvent, AuditSystem } from '@revealui/security';")).toEqual([]);
+  });
+
+  it('ignores a named import where every binding is `type`-qualified', () => {
+    expect(refs("import { type A, type B } from '@revealui/security';")).toEqual([]);
+  });
+
+  it('flags a mixed import (one runtime binding alongside type bindings)', () => {
+    expect(refs("import { a, type B } from 'x';")).toEqual(['import:x']);
+  });
+
+  it('flags default and namespace imports as runtime', () => {
+    expect(refs("import Foo from 'x';")).toEqual(['import:x']);
+    expect(refs("import * as ns from 'y';")).toEqual(['import:y']);
+  });
+
+  it('flags a bare side-effect import', () => {
+    expect(refs("import 'side-effect';")).toEqual(['import:side-effect']);
+  });
+
+  it('returns nothing for a module with no imports', () => {
+    expect(refs('export const x = 1;\nconst y = 2;\n')).toEqual([]);
+  });
+});
+
+describe('runtimeModuleRefs — re-exports', () => {
+  it('flags `export * from` as a runtime re-export', () => {
+    expect(refs("export * from '@revealui/security';")).toEqual(['export:@revealui/security']);
+  });
+
+  it('flags a value named re-export', () => {
+    expect(refs("export { isSafeUrl } from '@revealui/security';")).toEqual([
+      'export:@revealui/security',
+    ]);
+  });
+
+  it('ignores `export type { ... } from`', () => {
+    expect(refs("export type { AuditEvent } from '@revealui/security';")).toEqual([]);
+  });
+
+  it('ignores a re-export where every binding is `type`-qualified', () => {
+    expect(refs("export { type AuditEvent } from '@revealui/security';")).toEqual([]);
+  });
+
+  it('does not treat a local `export {}` (no module specifier) as a ref', () => {
+    expect(refs('const a = 1;\nexport { a };')).toEqual([]);
+  });
+});
+
+describe('runtimeModuleRefs — dynamic imports', () => {
+  it('flags a dynamic import of a node: builtin', () => {
+    expect(refs("const c = await import('node:crypto');")).toEqual(['dynamic:node:crypto']);
+  });
+
+  it('flags a dynamic import nested inside a function', () => {
+    expect(refs('async function f() { return import("@revealui/security"); }')).toEqual([
+      'dynamic:@revealui/security',
+    ]);
+  });
+});
+
+describe('hasUseClientDirective', () => {
+  const has = (code: string): boolean => hasUseClientDirective(parseSource('c.tsx', code));
+
+  it('detects a leading double-quoted directive', () => {
+    expect(has('"use client";\nimport { x } from "y";')).toBe(true);
+  });
+
+  it('detects a leading single-quoted directive', () => {
+    expect(has("'use client'\nexport const C = () => null;")).toBe(true);
+  });
+
+  it('detects the directive later in the prologue (after other directives)', () => {
+    expect(has('"use strict";\n"use client";\n')).toBe(true);
+  });
+
+  it('detects the directive after a leading line comment (comments are trivia)', () => {
+    expect(has('// banner\n"use client";\n')).toBe(true);
+  });
+
+  it('does not treat a string after a real statement as a directive', () => {
+    expect(has('import { x } from "y";\n"use client";')).toBe(false);
+  });
+
+  it('does not treat an in-function string as a directive', () => {
+    expect(has('function f() {\n  "use client";\n}')).toBe(false);
+  });
+
+  it('returns false when absent', () => {
+    expect(has('export const C = () => null;')).toBe(false);
+  });
+});

--- a/scripts/validate/client-safety-allowlist.json
+++ b/scripts/validate/client-safety-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "_comment": "Files that are genuinely server-only yet live under a tree scanned by scripts/validate/client-safety.ts. Each entry needs a non-empty reason. This is NOT a way to ship a real client leak — prefer importing a client-safe subpath (e.g. @revealui/security/sanitize) or moving the code to a server module. Schema: { path, rules: [client-barrel-import|client-node-builtin|client-safe-entry-node], reason }.",
+  "entries": []
+}

--- a/scripts/validate/client-safety.ts
+++ b/scripts/validate/client-safety.ts
@@ -1,0 +1,543 @@
+// console-allowed
+/**
+ * Client-Bundle Safety Validator
+ *
+ * Prevents the `node:crypto` client-bundle crash class fixed by PR #1046 from
+ * silently returning. That bug: `@revealui/core/richtext/rsc` imported
+ * `isSafeUrl`/`sanitizeUrl` from the `@revealui/security` barrel, which
+ * statically re-exports auth.ts + gdpr.ts (top-level `node:crypto`) and
+ * ssrf.ts (top-level `node:dns/promises`). Pulling the barrel into a browser /
+ * RSC client bundle dragged the node: graph in and blanked the rendered route
+ * (e.g. marketing /blog). The point fix routed that one file through the
+ * client-safe `@revealui/security/sanitize` subpath — but the barrel itself is
+ * still not client-safe, so any FUTURE client-path import of it re-detonates
+ * the same crash, silently, until someone hits the affected route.
+ *
+ * This validator is the durable guard. Two rules, both hard-fail:
+ *
+ *   Rule 1 — client-reachable source must not import a server-only barrel or a
+ *   `node:*` builtin (as a runtime/value import). "Client-reachable" =
+ *   declared client roots (richtext exports, presentation, the Vite SPA
+ *   `app/` trees) PLUS any file carrying a `'use client'` directive. Type-only
+ *   imports are erased at build and are allowed.
+ *
+ *   Rule 2 — every declared client-safe package entry (e.g.
+ *   `@revealui/security/sanitize`) must be free of `node:*` imports across its
+ *   within-package relative-import closure. Catches the providing package
+ *   silently regressing a client-safe entry.
+ *
+ * No authored regex (fleet no-regex rule, M2): import detection uses the
+ * TypeScript compiler API (AST), client-reachability uses path-prefix +
+ * `Set` lookups + AST directive detection, and node: detection is a string
+ * prefix check.
+ *
+ * Usage:
+ *   pnpm tsx scripts/validate/client-safety.ts
+ *   pnpm validate:client-safety        # same, via package.json
+ *
+ * Exit codes:
+ *   0 = no client-bundle-safety violations
+ *   1 = violations found (or a malformed allowlist)
+ *
+ * Escape hatch: scripts/validate/client-safety-allowlist.json — a path + rule +
+ * non-empty reason. Reserved for files that are genuinely server-only yet live
+ * under a scanned tree; not a way to ship a real client leak.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
+import ts from 'typescript';
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const ALLOWLIST_PATH = join(ROOT, 'scripts/validate/client-safety-allowlist.json');
+
+/**
+ * Module specifiers that pull a `node:*` graph in transitively and must never
+ * appear in a client bundle. The `@revealui/security` barrel (the bare `.`
+ * export) statically re-exports auth.ts/gdpr.ts (node:crypto) + ssrf.ts
+ * (node:dns). Subpaths such as `@revealui/security/sanitize` are client-safe
+ * and are intentionally NOT listed. Add new server-only barrels here as they
+ * are created.
+ */
+const SERVER_ONLY_SPECIFIERS = new Set<string>(['@revealui/security']);
+
+/**
+ * Directory trees that are bundled for the browser (Vite SPAs) or the RSC
+ * client graph. Everything here is client-reachable. `richtext/exports`
+ * includes the `server/` subdir on purpose: those RSC "server" files are
+ * still bundled into the Vite marketing/docs SPAs (that is exactly how #1046
+ * crashed). Next.js RSC client components elsewhere are covered by the
+ * `'use client'` directive scan instead of a blanket app root, so server
+ * components are not falsely flagged.
+ */
+const CLIENT_ROOTS = [
+  'packages/core/src/richtext/exports',
+  'packages/presentation/src',
+  'apps/marketing/app',
+  'apps/docs/app',
+];
+
+/**
+ * Declared client-safe package entry points (Rule 2). Each entry's source file
+ * and its within-package relative-import closure must be free of `node:*`
+ * imports. Extend as packages declare more client-safe subpaths.
+ */
+const CLIENT_SAFE_ENTRIES: { specifier: string; entry: string }[] = [
+  { specifier: '@revealui/security/sanitize', entry: 'packages/security/src/sanitize.ts' },
+];
+
+const SCAN_ROOTS = ['apps', 'packages'];
+
+const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  'opensrc',
+  '.git',
+]);
+
+type RuleId = 'client-barrel-import' | 'client-node-builtin' | 'client-safe-entry-node';
+
+export interface ClientSafetyIssue {
+  rule: RuleId;
+  file: string;
+  line: number;
+  specifier: string;
+  detail: string;
+}
+
+// =============================================================================
+// Path predicates (no regex — string ops + Set)
+// =============================================================================
+
+function toPosix(p: string): string {
+  return p.split('\\').join('/');
+}
+
+function isTestPath(rel: string): boolean {
+  return (
+    rel.includes('__tests__/') ||
+    rel.includes('__mocks__/') ||
+    rel.includes('/fixtures/') ||
+    rel.includes('.test.') ||
+    rel.includes('.spec.') ||
+    rel.includes('.e2e.')
+  );
+}
+
+/**
+ * Files that are server-only by naming convention (SSR entry, `*.server.*`).
+ * Currently matches nothing in the Vite SPA trees — present so a future SSR
+ * server entry dropped into a scanned `app/` tree is not falsely flagged.
+ */
+function isServerNamedFile(rel: string): boolean {
+  const base = basename(rel);
+  return (
+    base.endsWith('.server.ts') || base.endsWith('.server.tsx') || base.startsWith('entry.server.')
+  );
+}
+
+function isExcludedFromClientScan(rel: string): boolean {
+  return isTestPath(rel) || isServerNamedFile(rel) || rel.endsWith('.d.ts');
+}
+
+function isUnderClientRoot(rel: string): boolean {
+  return CLIENT_ROOTS.some((root) => rel === root || rel.startsWith(`${root}/`));
+}
+
+function isNodeBuiltinSpecifier(specifier: string): boolean {
+  return specifier.startsWith('node:');
+}
+
+// =============================================================================
+// TypeScript AST helpers (no regex)
+// =============================================================================
+
+interface ModuleRef {
+  specifier: string;
+  line: number;
+  kind: 'import' | 'export' | 'dynamic';
+}
+
+function scriptKindFor(file: string): ts.ScriptKind {
+  if (file.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (file.endsWith('.jsx')) return ts.ScriptKind.JSX;
+  if (file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs'))
+    return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+export function parseSource(file: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    scriptKindFor(file),
+  );
+}
+
+/** True when an import clause carries no runtime binding (fully type-only). */
+function isImportClauseTypeOnly(clause: ts.ImportClause): boolean {
+  if (clause.isTypeOnly) return true;
+  if (clause.name) return false; // default binding = runtime
+  const bindings = clause.namedBindings;
+  if (!bindings) return false; // `import 'x'` (side-effect) is handled by the no-clause path
+  if (ts.isNamespaceImport(bindings)) return false; // `import * as ns` = runtime
+  if (ts.isNamedImports(bindings)) {
+    if (bindings.elements.length === 0) return false; // `import {} from 'x'` = side-effect (runtime)
+    return bindings.elements.every((el) => el.isTypeOnly);
+  }
+  return false;
+}
+
+/** True when a re-export names only type bindings (fully elided). */
+function isExportClauseTypeOnly(decl: ts.ExportDeclaration): boolean {
+  if (decl.isTypeOnly) return true;
+  const clause = decl.exportClause;
+  if (clause && ts.isNamedExports(clause)) {
+    if (clause.elements.length === 0) return false;
+    return clause.elements.every((el) => el.isTypeOnly);
+  }
+  return false; // `export * from 'x'` = runtime re-export
+}
+
+/** Leading `'use client'` directive in the prologue. */
+export function hasUseClientDirective(sourceFile: ts.SourceFile): boolean {
+  for (const stmt of sourceFile.statements) {
+    if (ts.isExpressionStatement(stmt) && ts.isStringLiteralLike(stmt.expression)) {
+      if (stmt.expression.text === 'use client') return true;
+      continue; // still inside the directive prologue
+    }
+    break; // first real statement ends the prologue
+  }
+  return false;
+}
+
+/** All runtime (non-type-only) module specifiers referenced by a source file. */
+export function runtimeModuleRefs(sourceFile: ts.SourceFile): ModuleRef[] {
+  const refs: ModuleRef[] = [];
+  const lineOf = (pos: number): number => sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+      if (stmt.importClause && isImportClauseTypeOnly(stmt.importClause)) continue;
+      refs.push({
+        specifier: stmt.moduleSpecifier.text,
+        line: lineOf(stmt.moduleSpecifier.getStart(sourceFile)),
+        kind: 'import',
+      });
+    } else if (ts.isExportDeclaration(stmt)) {
+      if (!(stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier))) continue;
+      if (isExportClauseTypeOnly(stmt)) continue;
+      refs.push({
+        specifier: stmt.moduleSpecifier.text,
+        line: lineOf(stmt.moduleSpecifier.getStart(sourceFile)),
+        kind: 'export',
+      });
+    }
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const arg = node.arguments[0];
+      if (arg && ts.isStringLiteral(arg)) {
+        refs.push({ specifier: arg.text, line: lineOf(arg.getStart(sourceFile)), kind: 'dynamic' });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  return refs;
+}
+
+// =============================================================================
+// File collection
+// =============================================================================
+
+interface FoundFile {
+  abs: string;
+  rel: string;
+}
+
+function collectSourceFiles(dir: string, out: FoundFile[] = []): FoundFile[] {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectSourceFiles(join(dir, entry.name), out);
+      continue;
+    }
+    if (SOURCE_EXTS.has(extname(entry.name))) {
+      const abs = join(dir, entry.name);
+      out.push({ abs, rel: toPosix(relative(ROOT, abs)) });
+    }
+  }
+  return out;
+}
+
+// =============================================================================
+// Allowlist
+// =============================================================================
+
+interface AllowlistEntry {
+  path: string;
+  rules: RuleId[];
+  reason: string;
+}
+
+function loadAllowlist(): Map<string, Set<RuleId>> {
+  const map = new Map<string, Set<RuleId>>();
+  if (!existsSync(ALLOWLIST_PATH)) return map;
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as { entries?: AllowlistEntry[] };
+  for (const entry of raw.entries ?? []) {
+    if (!entry.reason?.trim()) {
+      throw new Error(
+        `client-safety-allowlist.json: entry "${entry.path}" is missing a non-empty reason.`,
+      );
+    }
+    map.set(toPosix(entry.path), new Set(entry.rules));
+  }
+  return map;
+}
+
+function isAllowlisted(allowlist: Map<string, Set<RuleId>>, rel: string, rule: RuleId): boolean {
+  return allowlist.get(rel)?.has(rule) ?? false;
+}
+
+// =============================================================================
+// Rule 1 — client-reachable source must not import server-only barrels / node:
+// =============================================================================
+
+function checkClientReachable(allowlist: Map<string, Set<RuleId>>): ClientSafetyIssue[] {
+  const issues: ClientSafetyIssue[] = [];
+
+  for (const root of SCAN_ROOTS) {
+    for (const file of collectSourceFiles(join(ROOT, root))) {
+      if (isExcludedFromClientScan(file.rel)) continue;
+
+      const underRoot = isUnderClientRoot(file.rel);
+      let content: string;
+      try {
+        content = readFileSync(file.abs, 'utf8');
+      } catch {
+        continue;
+      }
+      // Fast path: outside a declared client root, only files that mention the
+      // directive can be 'use client'. Avoids parsing the whole tree.
+      if (!(underRoot || content.includes('use client'))) continue;
+
+      const sourceFile = parseSource(file.abs, content);
+      const inScope = underRoot || hasUseClientDirective(sourceFile);
+      if (!inScope) continue;
+
+      for (const ref of runtimeModuleRefs(sourceFile)) {
+        if (SERVER_ONLY_SPECIFIERS.has(ref.specifier)) {
+          if (isAllowlisted(allowlist, file.rel, 'client-barrel-import')) continue;
+          issues.push({
+            rule: 'client-barrel-import',
+            file: file.rel,
+            line: ref.line,
+            specifier: ref.specifier,
+            detail: `${ref.kind} of server-only barrel '${ref.specifier}' (pulls node:crypto/node:dns into the client bundle — use a client-safe subpath, e.g. '${ref.specifier}/sanitize')`,
+          });
+        } else if (isNodeBuiltinSpecifier(ref.specifier)) {
+          if (isAllowlisted(allowlist, file.rel, 'client-node-builtin')) continue;
+          issues.push({
+            rule: 'client-node-builtin',
+            file: file.rel,
+            line: ref.line,
+            specifier: ref.specifier,
+            detail: `${ref.kind} of node: builtin '${ref.specifier}' from client-reachable code (absent in the browser — move to a server module)`,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// =============================================================================
+// Rule 2 — declared client-safe entries must be node:-free (within-package)
+// =============================================================================
+
+function packageRootOf(rel: string): string {
+  const parts = rel.split('/');
+  return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : rel;
+}
+
+function resolveRelativeImport(fromFileAbs: string, specifier: string): string | null {
+  const base = resolve(dirname(fromFileAbs), specifier);
+  const candidates: string[] = [];
+  // ESM imports reference compiled `.js`; the source is `.ts`/`.tsx`.
+  if (specifier.endsWith('.js')) {
+    const stem = base.slice(0, -3);
+    candidates.push(`${stem}.ts`, `${stem}.tsx`);
+  }
+  candidates.push(
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.mts`,
+    `${base}.cts`,
+    `${base}.js`,
+    `${base}.jsx`,
+    join(base, 'index.ts'),
+    join(base, 'index.tsx'),
+    join(base, 'index.js'),
+  );
+  for (const candidate of candidates) {
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // not this candidate
+    }
+  }
+  return null;
+}
+
+function checkClientSafeEntries(): ClientSafetyIssue[] {
+  const issues: ClientSafetyIssue[] = [];
+
+  for (const { specifier, entry } of CLIENT_SAFE_ENTRIES) {
+    const entryAbs = join(ROOT, entry);
+    if (!existsSync(entryAbs)) {
+      issues.push({
+        rule: 'client-safe-entry-node',
+        file: entry,
+        line: 0,
+        specifier,
+        detail: `declared client-safe entry source '${entry}' does not exist (stale CLIENT_SAFE_ENTRIES config)`,
+      });
+      continue;
+    }
+
+    const pkgRoot = packageRootOf(entry);
+    const visited = new Set<string>([entryAbs]);
+    const queue: string[] = [entryAbs];
+
+    while (queue.length > 0) {
+      const current = queue.pop() as string;
+      const rel = toPosix(relative(ROOT, current));
+      let content: string;
+      try {
+        content = readFileSync(current, 'utf8');
+      } catch {
+        continue;
+      }
+      const sourceFile = parseSource(current, content);
+
+      for (const ref of runtimeModuleRefs(sourceFile)) {
+        if (isNodeBuiltinSpecifier(ref.specifier)) {
+          issues.push({
+            rule: 'client-safe-entry-node',
+            file: rel,
+            line: ref.line,
+            specifier: ref.specifier,
+            detail: `node: builtin '${ref.specifier}' is reachable from the client-safe entry '${specifier}' (would crash the browser bundle)`,
+          });
+          continue;
+        }
+        if (SERVER_ONLY_SPECIFIERS.has(ref.specifier)) {
+          issues.push({
+            rule: 'client-safe-entry-node',
+            file: rel,
+            line: ref.line,
+            specifier: ref.specifier,
+            detail: `server-only barrel '${ref.specifier}' is reachable from the client-safe entry '${specifier}'`,
+          });
+          continue;
+        }
+        if (ref.specifier.startsWith('.')) {
+          const target = resolveRelativeImport(current, ref.specifier);
+          if (
+            target &&
+            toPosix(relative(ROOT, target)).startsWith(`${pkgRoot}/`) &&
+            !visited.has(target)
+          ) {
+            visited.add(target);
+            queue.push(target);
+          }
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// =============================================================================
+// Public API + CLI
+// =============================================================================
+
+export function findClientSafetyIssues(): ClientSafetyIssue[] {
+  const allowlist = loadAllowlist();
+  return [...checkClientReachable(allowlist), ...checkClientSafeEntries()];
+}
+
+function run(): void {
+  const sep = '='.repeat(64);
+  console.log(`\n${sep}`);
+  console.log('Client-Bundle Safety Validator');
+  console.log(sep);
+  console.log(`\n  Server-only barrels guarded: ${[...SERVER_ONLY_SPECIFIERS].join(', ')}`);
+  console.log(`  Client roots: ${CLIENT_ROOTS.join(', ')}`);
+  console.log(`  Client-safe entries: ${CLIENT_SAFE_ENTRIES.map((e) => e.specifier).join(', ')}`);
+
+  const issues = findClientSafetyIssues();
+
+  if (issues.length === 0) {
+    console.log(`\n  ✓ clean — no client-bundle-safety violations`);
+    console.log(`\n${sep}`);
+    console.log('Result: PASS (0 violations)');
+    console.log(sep);
+    process.exit(0);
+  }
+
+  console.log('');
+  for (const issue of issues) {
+    const at = issue.line > 0 ? `${issue.file}:${issue.line}` : issue.file;
+    console.log(`  ✗ [${issue.rule}] ${at}`);
+    console.log(`      ${issue.detail}`);
+  }
+
+  console.log(`\n${sep}`);
+  console.log(`Result: FAIL (${issues.length} violation${issues.length === 1 ? '' : 's'})`);
+  console.log('');
+  console.log('  Why this matters: the @revealui/security barrel re-exports node:crypto');
+  console.log('  (auth.ts/gdpr.ts) + node:dns (ssrf.ts). Importing it from client-reachable');
+  console.log('  code crashes the browser bundle silently (PR #1046).');
+  console.log('');
+  console.log('  Fix options:');
+  console.log("    1. Import the client-safe subpath (e.g. '@revealui/security/sanitize').");
+  console.log('    2. Move the code to a genuinely server-only module.');
+  console.log('    3. If the file is server-only but lives under a scanned tree, add an');
+  console.log('       entry to scripts/validate/client-safety-allowlist.json with a reason.');
+  console.log(sep);
+  process.exit(1);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+const selfPath = resolve(import.meta.dirname, 'client-safety.ts');
+if (invokedPath === selfPath) {
+  run();
+}


### PR DESCRIPTION
## What

Adds a durable, hard-fail CI gate — `validate:client-safety` (Phase 1) — that prevents the `node:crypto` client-bundle crash class fixed by #1046 from silently returning.

## Why

#1046 fixed **one** client-path import: `@revealui/core/richtext/rsc` pulled `isSafeUrl`/`sanitizeUrl` from the `@revealui/security` barrel, which statically re-exports `auth.ts`/`gdpr.ts` (top-level `node:crypto`) and `ssrf.ts` (top-level `node:dns/promises`). That dragged the node: graph into the browser bundle and blanked rich-text routes (e.g. marketing `/blog`). The point fix routed that file through the client-safe `@revealui/security/sanitize` subpath.

**But the barrel itself is still not client-safe.** Any future client-path import of the bare `@revealui/security` (`.`) export re-detonates the identical crash — silently, until someone navigates to the affected route. This PR closes that latent trap.

## Audit (audit-first)

- The barrel (`packages/security/src/index.ts`) statically re-exports **every** module, including three with top-level `node:*` imports: `auth.ts:8` (`node:crypto`), `gdpr.ts:7` (`node:crypto`), `ssrf.ts:9` (`node:dns/promises`). (`audit.ts` already uses the safe lazy `await import('node:crypto')` pattern.)
- Real direct-barrel consumers are few and light (`getClientIp`/request-ip, `assertPublicUrl`, type-only audit types); the crypto-heavy surface is consumed indirectly via `@revealui/core`'s `export *`.
- `dist/sanitize.js` chunk graph is crypto-free; the barrel `dist/index.js` carries `crypto` imports (esbuild strips the `node:` prefix to bare `crypto` at build — which is exactly why the browser bundle fails to resolve it).

## Approach: guard now (Option B); structural split deferred (Option A)

Three options were considered — (A) restructure the barrel into explicit server-only subpaths so `.` is itself client-safe; (B) a lint/CI guard; (C) both.

**Chose B.** A barrel restructure (A) would edit `packages/security/src/index.ts` + `package.json` + `ssrf.ts` — the exact files the in-flight #1034 (SSRF-safe fetch) is changing — a guaranteed conflict, plus a large blast radius through `@revealui/core`'s `export *`. The CI guard is conflict-free (zero edits to `packages/security/`), generalizes the whole class rather than this one barrel, and fails loudly at build instead of silently at runtime. **A remains a sensible future hardening once #1034 lands — it is no longer urgent, because this guard prevents the regression class.**

## The guard

`scripts/validate/client-safety.ts` — two hard-fail rules:

1. **Client-reachable source must not import a server-only barrel or a `node:*` builtin** (as a runtime/value import). Client-reachable = declared client roots (`packages/core/src/richtext/exports/**`, `packages/presentation/src/**`, `apps/{marketing,docs}/app/**`) ∪ any `'use client'` file. Type-only imports are allowed (erased at build); tests and `*.server.*` files are excluded.
2. **Declared client-safe package entries** (`@revealui/security/sanitize`) **must be `node:`-free** across their within-package relative-import closure.

AST-based (TypeScript compiler API) + `Set`/string predicates — **no authored regex** (M2). Escape hatch: `client-safety-allowlist.json` (path + rule + required reason). Wired into `scripts/gates/ci-gate.ts` Phase 1.

## Verification

- `pnpm validate:client-safety` → PASS (0 violations) on this base.
- **Negative tests**: injecting `import { isSafeUrl } from '@revealui/security'` into `packages/presentation/src/` → flagged `client-barrel-import`; injecting `import 'node:crypto'` → flagged `client-node-builtin`. The guard provably catches both.
- 21 unit tests (`scripts/validate/__tests__/client-safety.test.ts`) cover type-only / mixed / re-export / dynamic-import / `'use client'` edge cases.
- `pnpm gate:quick` (full Phase 1) green; standalone typecheck + Biome clean.
- `pnpm --filter @revealui/security build` → `dist/sanitize.js` crypto-free.

## Notes

- **No changeset**: touches only root `scripts/` + `ci-gate.ts` + the private root `package.json`; no publishable package changes (`@revealui/scripts` is changeset-ignored).
- Conflict-free with #1034 by design (no `packages/security/` edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
