### PR TITLE
fix(server): media uploads were body-capped at 1MB (dead 100MB limit)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -36,7 +36,6 @@ import { sites, users } from '@revealui/db/schema';
 import { OpenAPIHono } from '@revealui/openapi';
 import { configureClientIp } from '@revealui/security';
 import { sql } from 'drizzle-orm';
-import { bodyLimit } from 'hono/body-limit';
 import { createMiddleware } from 'hono/factory';
 import { logger as honoLogger } from 'hono/logger';
 // Side-effect import: registers durable-queue handlers at module top
@@ -54,6 +53,7 @@ import {
 import { auditMiddleware } from './middleware/audit.js';
 import { authMiddleware } from './middleware/auth.js';
 import { requirePermission } from './middleware/authorization.js';
+import { bodyLimitGate } from './middleware/body-limits.js';
 import { noCacheCacheMiddleware, noStoreCacheMiddleware } from './middleware/cache-control.js';
 import { csrfMiddleware } from './middleware/csrf.js';
 import { dbMiddleware } from './middleware/db.js';
@@ -262,31 +262,12 @@ const securityHeaders = new SecurityHeaders(securityPreset);
 // Global middleware
 app.use('*', domainLockMiddleware()); // Forge: reject requests from unlicensed domains
 app.use('*', requestIdMiddleware());
-// Media upload routes need a higher body limit
-app.use(
-  '/api/content/media/*',
-  bodyLimit({
-    maxSize: 100 * 1024 * 1024,
-    onError: (c) =>
-      c.json({ success: false, error: 'File too large. Maximum size is 100MB.' }, 413),
-  }),
-);
-app.use(
-  '/api/v1/content/media/*',
-  bodyLimit({
-    maxSize: 100 * 1024 * 1024,
-    onError: (c) =>
-      c.json({ success: false, error: 'File too large. Maximum size is 100MB.' }, 413),
-  }),
-);
-app.use(
-  '*',
-  bodyLimit({
-    maxSize: 1024 * 1024,
-    onError: (c) =>
-      c.json({ success: false, error: 'Request body too large. Maximum size is 1MB.' }, 413),
-  }),
-);
+// Body-size gate: media uploads (POST) get the per-type image ceiling (10MB);
+// every other route gets 1MB. A single path-aware middleware avoids the prior
+// bug where a global '*' 1MB limit registered after the media-specific limit ran
+// second in Hono's chain and rejected all media uploads >1MB (the 100MB media
+// limit was dead code). See ./middleware/body-limits.ts.
+app.use('*', bodyLimitGate());
 app.use('*', honoLogger());
 /** Check if origin matches Vercel preview URL pattern: https://revealui*-revealuistudios-projects.vercel.app */
 function isVercelPreviewOrigin(origin: string): boolean {

--- a/apps/server/src/middleware/__tests__/body-limits.test.ts
+++ b/apps/server/src/middleware/__tests__/body-limits.test.ts
@@ -1,0 +1,69 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { bodyLimitGate, isMediaUploadRequest } from '../body-limits.js';
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.use('*', bodyLimitGate());
+  app.post('/api/content/media', (c) => c.json({ ok: true }));
+  app.post('/api/v1/content/media', (c) => c.json({ ok: true }));
+  app.patch('/api/content/media/:id', (c) => c.json({ ok: true }));
+  app.post('/api/other', (c) => c.json({ ok: true }));
+  return app;
+}
+
+function withBody(mb: number): RequestInit {
+  const data = new Uint8Array(Math.round(mb * 1024 * 1024));
+  return { body: data, headers: { 'content-length': String(data.length) } };
+}
+
+describe('isMediaUploadRequest', () => {
+  it('matches POST to the media upload paths only', () => {
+    expect(isMediaUploadRequest('POST', '/api/content/media')).toBe(true);
+    expect(isMediaUploadRequest('POST', '/api/v1/content/media')).toBe(true);
+    expect(isMediaUploadRequest('POST', '/api/content/media/')).toBe(true); // trailing slash tolerated
+  });
+
+  it('does not match metadata methods, sub-paths, or other routes', () => {
+    expect(isMediaUploadRequest('PATCH', '/api/content/media/abc')).toBe(false);
+    expect(isMediaUploadRequest('DELETE', '/api/content/media/abc')).toBe(false);
+    expect(isMediaUploadRequest('GET', '/api/content/media')).toBe(false);
+    expect(isMediaUploadRequest('POST', '/api/other')).toBe(false);
+  });
+});
+
+describe('bodyLimitGate', () => {
+  it('allows a media upload up to 10MB (regression: the prior global 1MB rejected all media uploads)', async () => {
+    const res = await makeApp().request('/api/content/media', { method: 'POST', ...withBody(5) });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows the 10MB media path on v1 too', async () => {
+    const res = await makeApp().request('/api/v1/content/media', {
+      method: 'POST',
+      ...withBody(5),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a media upload over 10MB with 413', async () => {
+    const res = await makeApp().request('/api/content/media', { method: 'POST', ...withBody(11) });
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toContain('10MB');
+  });
+
+  it('caps media metadata methods (PATCH) at 1MB', async () => {
+    const res = await makeApp().request('/api/content/media/abc', {
+      method: 'PATCH',
+      ...withBody(5),
+    });
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toContain('1MB');
+  });
+
+  it('caps non-media routes at 1MB', async () => {
+    const res = await makeApp().request('/api/other', { method: 'POST', ...withBody(5) });
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toContain('1MB');
+  });
+});

--- a/apps/server/src/middleware/body-limits.ts
+++ b/apps/server/src/middleware/body-limits.ts
@@ -1,0 +1,64 @@
+/**
+ * Request body-size limits.
+ *
+ * A single path-aware gate: media uploads (POST to the media collection) get the
+ * image per-type ceiling; every other route gets 1MB.
+ *
+ * Why one middleware instead of separate `app.use('/media/*', big)` +
+ * `app.use('*', small)`: Hono runs every matching middleware in registration
+ * order. A global `app.use('*', 1MB)` registered after a media-specific limit
+ * runs SECOND and rejects all media uploads >1MB — which silently made the prior
+ * 100MB media limit dead code (every media upload was capped at 1MB). Choosing
+ * the size inside one middleware avoids that interaction.
+ *
+ * Larger/video uploads will move to a presigned direct-to-R2 upload path, where
+ * the bytes never buffer in the function. The per-type check in the media route
+ * remains the authoritative content-size enforcement after parse.
+ */
+import { FILE_SIZE_LIMITS } from '@revealui/contracts/entities';
+import type { MiddlewareHandler } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+
+/** Default body limit for all routes (1MB). */
+export const GLOBAL_BODY_LIMIT = 1024 * 1024;
+
+/** Body limit for media uploads — the image/document per-type ceiling (10MB). */
+export const MEDIA_UPLOAD_BODY_LIMIT = FILE_SIZE_LIMITS.IMAGE;
+
+/** POST paths that accept a media upload and therefore get the larger body limit. */
+const MEDIA_UPLOAD_PATHS = new Set(['/api/content/media', '/api/v1/content/media']);
+
+function normalizePath(path: string): string {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+/** True only for a POST to a media-upload path (the requests that get the larger limit). */
+export function isMediaUploadRequest(method: string, path: string): boolean {
+  return method === 'POST' && MEDIA_UPLOAD_PATHS.has(normalizePath(path));
+}
+
+function humanSize(bytes: number): string {
+  return `${Math.round(bytes / 1024 / 1024)}MB`;
+}
+
+/**
+ * Single body-size gate for the whole app. Apply once via `app.use('*', bodyLimitGate())`.
+ */
+export function bodyLimitGate(): MiddlewareHandler {
+  return (c, next) => {
+    const maxSize = isMediaUploadRequest(c.req.method, c.req.path)
+      ? MEDIA_UPLOAD_BODY_LIMIT
+      : GLOBAL_BODY_LIMIT;
+    return bodyLimit({
+      maxSize,
+      onError: (ctx) =>
+        ctx.json(
+          {
+            success: false,
+            error: `Request body too large. Maximum size is ${humanSize(maxSize)}.`,
+          },
+          413,
+        ),
+    })(c, next);
+  };
+}


### PR DESCRIPTION
## Summary

Media uploads were silently capped at **1MB**, not the intended limit. The media routes register a 100MB `bodyLimit`, but the global `app.use('*', 1MB)` is registered **after** it — Hono runs all matching middleware in registration order, so the 1MB limit ran second and rejected every media upload >1MB. The 100MB media limit was effectively dead code, and a normal 2–10MB image upload failed with `413 "Maximum size is 1MB"`.

## Fix

Replace the three separate `bodyLimit` registrations with one **path-aware gate** (`apps/server/src/middleware/body-limits.ts`):

- Media uploads (`POST` to `/api/content/media` + the v1 alias) → the image per-type ceiling (10MB, sourced from `FILE_SIZE_LIMITS`).
- Every other route → 1MB.

A single middleware avoids the registration-order interaction that caused the bug. The 10MB ceiling is conservative for now; larger/video uploads will move to a presigned direct-to-R2 path so bytes never buffer in the function. The per-type check in the media route remains the authoritative post-parse content-size check.

## Tests

`body-limits.test.ts` — 7 cases: the >1MB media-upload regression, the v1 path, >10MB rejection, and 1MB caps for metadata methods (PATCH) + non-media routes. All pass locally (`vitest run`).

Base: `test`.
