### PR TITLE
fix(admin): seed first admin at boot on self-hosted Forge kits

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -67,6 +67,13 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+# GAP-214: run the engine's onInit (first-admin seeder) at runtime, not build.
+# `next build` sets NEXT_PHASE so the build still correctly skips onInit; this
+# only flips the *running* container out of RevealUIInstance's build-time guard
+# (NODE_ENV=production && !RUNTIME_INIT). Without it a fresh kit boots healthy
+# but never seeds an admin, so login is impossible (signup is closed in fleet
+# mode). Paired with the deterministic boot init in src/instrumentation-node.ts.
+ENV RUNTIME_INIT=1
 
 WORKDIR /app
 

--- a/apps/admin/src/__tests__/instrumentation-node.test.ts
+++ b/apps/admin/src/__tests__/instrumentation-node.test.ts
@@ -1,0 +1,68 @@
+/**
+ * GAP-214 regression guard for the deterministic boot-time engine init.
+ *
+ * Protects three properties of `initEngineAtBoot` (apps/admin/src/instrumentation-node.ts):
+ *  1. On a Forge kit (RUNTIME_INIT set) it initializes the engine at boot, which
+ *     is what runs config.onInit → the first-admin seeder. Without this a fresh
+ *     kit boots healthy but can never be logged into.
+ *  2. On hosted boot (RUNTIME_INIT unset) it does nothing — hosted seeds via
+ *     account_entitlements and must not pay an eager engine init at every cold start.
+ *  3. It never throws, honoring Next.js's instrumentation "never throw" contract.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getRevealUIInstance } = vi.hoisted(() => ({ getRevealUIInstance: vi.fn() }));
+
+vi.mock('@/lib/utilities/revealui-singleton', () => ({ getRevealUIInstance }));
+
+async function loadInitEngineAtBoot() {
+  return (await import('../instrumentation-node')).initEngineAtBoot;
+}
+
+describe('initEngineAtBoot (GAP-214 boot-time first-admin seed)', () => {
+  const originalRuntimeInit = process.env.RUNTIME_INIT;
+
+  beforeEach(() => {
+    // mockReset (not clearAllMocks) so a prior test's rejected impl can't bleed in.
+    getRevealUIInstance.mockReset();
+    getRevealUIInstance.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    if (originalRuntimeInit === undefined) {
+      delete process.env.RUNTIME_INIT;
+    } else {
+      process.env.RUNTIME_INIT = originalRuntimeInit;
+    }
+  });
+
+  it('initializes the engine at boot when RUNTIME_INIT is set (Forge kit)', async () => {
+    process.env.RUNTIME_INIT = '1';
+    const initEngineAtBoot = await loadInitEngineAtBoot();
+
+    await initEngineAtBoot();
+
+    expect(getRevealUIInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize the engine when RUNTIME_INIT is unset (hosted boot unchanged)', async () => {
+    delete process.env.RUNTIME_INIT;
+    const initEngineAtBoot = await loadInitEngineAtBoot();
+
+    await initEngineAtBoot();
+
+    expect(getRevealUIInstance).not.toHaveBeenCalled();
+  });
+
+  it('never throws when engine init fails (instrumentation never-throw contract)', async () => {
+    process.env.RUNTIME_INIT = '1';
+    getRevealUIInstance.mockRejectedValue(new Error('db unreachable'));
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const initEngineAtBoot = await loadInitEngineAtBoot();
+
+    await expect(initEngineAtBoot()).resolves.toBeUndefined();
+    expect(stderr).toHaveBeenCalled();
+
+    stderr.mockRestore();
+  });
+});

--- a/apps/admin/src/instrumentation-node.ts
+++ b/apps/admin/src/instrumentation-node.ts
@@ -1,0 +1,47 @@
+/**
+ * Node.js-only instrumentation.
+ *
+ * Imported by `instrumentation.ts` ONLY behind `process.env.NEXT_RUNTIME ===
+ * 'nodejs'`. Anything that pulls in Node-only dependencies — here the RevealUI
+ * engine (`getRevealUIInstance` → `@revealui/core/nextjs` → `@revealui/db`) —
+ * MUST live in this module, never directly in `instrumentation.ts`, so it is
+ * never traced into the Edge runtime bundle. (Next.js statically traces every
+ * import in `instrumentation.ts`, even dynamic ones; the `NEXT_RUNTIME` guard
+ * around the import of this file is what excludes it from the Edge build.)
+ */
+
+/**
+ * GAP-214: deterministically initialize the RevealUI engine once at container
+ * boot on self-hosted RevForge kits, so `config.onInit` — the first-admin
+ * seeder in `apps/admin/revealui.config.ts` — runs reliably instead of relying
+ * on a lazy, unreliable first-request init.
+ *
+ * Scoped to `RUNTIME_INIT`, which is set only on Forge kits (see
+ * `apps/admin/Dockerfile.forge` and the revforge `docker-compose.yml`). Hosted
+ * SaaS leaves `RUNTIME_INIT` unset and seeds the first admin via
+ * `account_entitlements`, so its boot path is unchanged and the engine (+
+ * `@revealui/db`) is never even imported here.
+ *
+ * Idempotent: `onInit` checks `users === 0` before creating the admin, so a
+ * second boot is a no-op. Never throws: the Next.js instrumentation contract is
+ * "never throw — it kills the runtime", so any failure is logged and swallowed
+ * (a retry on the next boot is safe because of idempotency).
+ */
+export async function initEngineAtBoot(): Promise<void> {
+  if (!process.env.RUNTIME_INIT) {
+    return;
+  }
+
+  try {
+    const { getRevealUIInstance } = await import('@/lib/utilities/revealui-singleton');
+    await getRevealUIInstance();
+  } catch (err) {
+    // Write straight to stderr — the structured logger may not be wired this
+    // early in boot, and we must not let this reject (see contract above).
+    process.stderr.write(
+      `[GAP-214] boot-time engine init failed (non-fatal): ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -228,6 +228,34 @@ export async function register() {
   } catch (error) {
     void error;
   }
+
+  // ── GAP-214: deterministic boot-time engine init (self-hosted Forge kits) ──
+  // The first-admin seeder (config.onInit in apps/admin/revealui.config.ts) only
+  // fires when the engine is initialized AND RevealUIInstance treats this as
+  // runtime rather than build-time. On a Forge kit (NODE_ENV=production) the
+  // engine is otherwise initialized lazily on the first request that needs it —
+  // too unreliable for seeding the kit's only admin account. Trigger it once,
+  // explicitly, at boot instead.
+  //
+  // getRevealUIInstance → @revealui/core/nextjs → @revealui/db is Node-only, so
+  // it lives in a separate module imported ONLY behind NEXT_RUNTIME==='nodejs'.
+  // That keeps @revealui/db out of the Edge bundle — the same reason the
+  // telemetry transport above uses fetch() instead of importing @revealui/db
+  // directly. The dispatch is wrapped so it can never throw out of
+  // instrumentation (which would kill the runtime); the eager init itself is
+  // gated on RUNTIME_INIT, so hosted/Vercel boot is unchanged.
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    try {
+      const { initEngineAtBoot } = await import('./instrumentation-node');
+      await initEngineAtBoot();
+    } catch (err) {
+      process.stderr.write(
+        `Boot-time engine init dispatch failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
+  }
 }
 
 // Auto-capture server-side request errors (server actions, RSC, route

--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -54,6 +54,11 @@ FROM node:24-alpine AS runner
 
 ENV NODE_ENV=production
 ENV PORT=3004
+# GAP-214 (parity with admin): flip the running container out of
+# RevealUIInstance's build-time guard (NODE_ENV=production && !RUNTIME_INIT) so
+# any runtime engine init runs onInit rather than being treated as build-time.
+# The build still skips onInit because turbo build does not set RUNTIME_INIT.
+ENV RUNTIME_INIT=1
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

A fresh self-hosted **RevealUI Fleet** (Forge) kit booted healthy — Postgres, API, and Admin all up, license valid, REST serving — but **could never be logged into**: the `users` table was empty and there was no way to create the first admin. Sign-up is closed in fleet mode, so the engine's `onInit` first-admin seeder is the only intended path, and it wasn't firing.

## Root cause

`onInit` runs only when `RevealUIInstance` treats the process as runtime, not build-time:

```
isBuildTime = NEXT_PHASE === 'phase-production-build'
           || (NODE_ENV === 'production' && !RUNTIME_INIT)
```

A Forge kit runs `NODE_ENV=production` and sets no `RUNTIME_INIT`, so `isBuildTime` is `true` at runtime → `onInit` is skipped → the admin is never seeded. A second layer: even with `RUNTIME_INIT` set, the engine initialized lazily on the first request that needed it, which proved unreliable for seeding.

## Fix

- **`RUNTIME_INIT=1`** in the runtime stage of `apps/admin/Dockerfile.forge` (and `apps/server/Dockerfile.forge` for parity). `next build` / `turbo build` set `NEXT_PHASE`, so the **build** still correctly skips `onInit`; only the running container flips out of the build-time guard.
- **Deterministic boot-time engine init** from `apps/admin/src/instrumentation.ts`, replacing reliance on the lazy first-request init.
  - The engine (`getRevealUIInstance` → `@revealui/core/nextjs` → `@revealui/db`) is Node-only, so it lives in a new `apps/admin/src/instrumentation-node.ts` imported **only** behind `NEXT_RUNTIME === 'nodejs'`. This keeps `@revealui/db` out of the Edge bundle — the same reason the telemetry transport in `instrumentation.ts` uses `fetch()` instead of importing `@revealui/db` directly.
  - Gated on `RUNTIME_INIT`, so **hosted/Vercel boot is unchanged** (hosted seeds via `account_entitlements`, not `onInit`, and shouldn't pay an eager engine init per cold start).
  - Idempotent (`onInit` checks `users === 0`) and never throws (honors the Next.js instrumentation "never throw" contract).

## Verification

- `pnpm --filter admin typecheck` ✅
- New unit test `apps/admin/src/__tests__/instrumentation-node.test.ts` — 3 cases: initializes when `RUNTIME_INIT` set, no-op when unset, never throws when the engine init fails ✅
- **Fresh-kit boot** (rebuild the forge admin image → `docker compose down -v && up` → assert exactly one super-admin row + headless `POST /api/auth/sign-in` → 200) — to be confirmed on this branch's image before merge.

## Scope

Behavior change is confined to self-hosted Forge kits (`RUNTIME_INIT=1`). Hosted SaaS boot is untouched.
