### PR TITLE
fix(ci): verify gitleaks tarball SHA256 before install

### DIFF
--- a/.github/workflows/issue-leak-scan.yml
+++ b/.github/workflows/issue-leak-scan.yml
@@ -30,6 +30,9 @@ jobs:
     timeout-minutes: 3
     env:
       GITLEAKS_VERSION: "8.30.0"
+      # SHA256 of gitleaks_<ver>_linux_x64.tar.gz (from gitleaks_<ver>_checksums.txt);
+      # verified before install to close the curl|tar supply-chain gap. Bump with VERSION.
+      GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -40,8 +43,10 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /tmp gitleaks
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" -o "/tmp/${tarball}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,6 +57,9 @@ jobs:
     timeout-minutes: 5
     env:
       GITLEAKS_VERSION: "8.30.0"
+      # SHA256 of gitleaks_<ver>_linux_x64.tar.gz (from gitleaks_<ver>_checksums.txt);
+      # verified before install to close the curl|tar supply-chain gap. Bump with VERSION.
+      GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
       GITLEAKS_HISTORY_SINCE: "2026-04-25" # post-#540 rotation; raise after future credential rotations
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -65,8 +68,10 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /tmp gitleaks
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" -o "/tmp/${tarball}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
       - name: Run gitleaks (post-cutoff history only)


### PR DESCRIPTION
## What

Pin + verify the gitleaks release tarball's SHA256 before installing it, in both gitleaks workflows (`security.yml`, `issue-leak-scan.yml`).

## Why

Both workflows streamed the gitleaks tarball straight from `curl` into `tar` and `sudo install`ed it with no integrity check — the same supply-chain gap Codex flagged (P1) on the fleet's other gitleaks jobs (revdev/revvault/revskills), now hardened across all of them. A tampered or corrupted release asset would otherwise execute in CI with the workflow token.

## How

Download to a file, `sha256sum -c` against a SHA256 pinned in the job `env`, then extract/install. The pinned hash is from gitleaks' published `gitleaks_8.30.0_checksums.txt`, cross-verified against a fresh download. Bump it alongside `GITLEAKS_VERSION`.

## Verification

- `security.yml`'s gitleaks job runs on this PR (triggers on `pull_request` → `test`).
- `issue-leak-scan.yml` uses `pull_request_target`, which executes the base-branch workflow, so the change takes effect on merge; the install+verify block is byte-identical to the verified one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
