### PR TITLE
feat(forge): kit schema migrate-at-boot + first-admin bootstrap fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,13 @@ jobs:
           - app: admin
             dockerfile: apps/admin/Dockerfile.forge
             image: revealui-admin
+          # One-shot DB migrate image for self-hosted kits (built from the
+          # `migrate` stage of the server Dockerfile). The kit compose runs it
+          # once before api+admin so a fresh volume gets its schema.
+          - app: migrate
+            dockerfile: apps/server/Dockerfile.forge
+            target: migrate
+            image: revealui-migrate
 
     steps:
       - name: Checkout
@@ -72,6 +79,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          # Empty for server/admin (builds the final `runner` stage); `migrate`
+          # for the one-shot migrate image. Empty target = final stage.
+          target: ${{ matrix.target }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -246,6 +246,10 @@ export default buildConfig({
         collection: 'users',
         limit: 1,
         depth: 0,
+        // Trusted env-driven bootstrap (guarded by totalDocs === 0 below):
+        // bypass access control so the first-admin seed works on a fresh Fleet
+        // kit, where no authenticated user exists yet to satisfy collection access.
+        overrideAccess: true,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -292,6 +296,10 @@ export default buildConfig({
       try {
         await revealui.create({
           collection: 'users',
+          // See the find() above: this first-admin bootstrap runs before any
+          // user exists, so core create()'s access enforcement would otherwise
+          // deny it ("Access denied: insufficient permissions to create").
+          overrideAccess: true,
           data: {
             name: 'Admin User',
             email: adminEmail,

--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -48,6 +48,25 @@ RUN pnpm turbo run build --filter=server...
 RUN pnpm --filter server deploy /app/server-deploy --prod --legacy
 
 # ---------------------------------------------------------------------------
+# Migrate stage — one-shot `drizzle-kit migrate` for self-hosted Fleet kits.
+# ---------------------------------------------------------------------------
+# Reuses the build stage, which already carries drizzle-kit (a @revealui/db
+# devDependency, installed by the non-prod `pnpm install` above), the journalled
+# SQL in packages/db/migrations/, and drizzle.config.ts. Published as
+# ghcr.io/revealuistudio/revealui-migrate and run ONCE by the kit compose
+# `migrate` service (gated service_completed_successfully) BEFORE api + admin
+# start, so a freshly-stamped kit volume gets its schema. A fresh kit otherwise
+# boots with zero tables: migrations never run at app boot, only via this step.
+# Idempotent — drizzle records applied migrations in drizzle.__drizzle_migrations,
+# so re-running is a no-op. KIT-ONLY; hosted/Vercel migrates via deploy.yml CI.
+FROM build AS migrate
+WORKDIR /app/packages/db
+ENV NODE_ENV=production
+# drizzle-kit reads drizzle.config.ts (out=./migrations; dbCredentials.url from
+# POSTGRES_URL, supplied by the compose migrate service).
+CMD ["pnpm", "exec", "drizzle-kit", "migrate"]
+
+# ---------------------------------------------------------------------------
 # Runtime stage — minimal image, production only
 # ---------------------------------------------------------------------------
 FROM node:24-alpine AS runner


### PR DESCRIPTION
## What

Two fixes for **self-hosted Fleet kits** (the `docker compose` distribution) — both required for a freshly-stamped kit to boot to a working admin login.

### 1. First-admin bootstrap: pass `overrideAccess` — `apps/admin/revealui.config.ts`
The `onInit` first-admin seeder runs before any user exists. Core `create()` enforces collection access, so the seed INSERT was denied (`Access denied: insufficient permissions to create`). The seeder is a trusted, env-driven bootstrap guarded by `totalDocs === 0`; pass `overrideAccess: true` on its `find` + `create`. The `create()` read-back already uses `overrideAccess` internally — this aligns the seeder call sites.

### 2. Migrate schema at boot — `apps/server/Dockerfile.forge`, `.github/workflows/docker.yml`
A fresh kit volume came up with **zero tables**: migrations only run via `pnpm db:migrate`, never at container boot. So even with the seeder firing, the INSERT hit missing tables.

- New `migrate` stage in the server `Dockerfile.forge`, reusing the build stage (which already carries `drizzle-kit` + `packages/db/migrations/` + `drizzle.config.ts`) to run `drizzle-kit migrate` once.
- `docker.yml` publishes it as `ghcr.io/revealuistudio/revealui-migrate` (new matrix row + build `target`).
- The kit compose (separate repo) runs it once via `service_completed_successfully` before `api` + `admin`, so a fresh volume gets its schema.

Idempotent (drizzle tracks applied migrations in `__drizzle_migrations`). **Kit-only** — hosted/Vercel continue to migrate via `deploy.yml` CI, never at app cold start.

## Why this approach
Canonical `drizzle-kit migrate` — the same path CI/prod use, which the migration-journal discipline tooling is built around — gates both apps symmetrically, and keeps migration out of app boot. The alternative (bundle the migrator into the api image + run at boot) was rejected: it diverges the migrate code path and couples migration to app startup.

## Verification (required before merge — NOT covered by CI)
CI unit/integration run on PGlite, not a forge-image docker boot, so this must be verified against rebuilt forge images on a fresh-volume kit:

- the `migrate` service applies the full schema (tables > 0) and exits 0
- admin auto-seeds the first super-admin (`users` row present) with no manual `db:migrate`
- headless sign-in returns 200
- re-boot (`up` without `down -v`) is a no-op (idempotent)

**Status: code complete; e2e fresh-kit boot pending (heavy forge-image rebuild). Do not merge until that passes.** Companion kit-compose change (migrate service + `depends_on`) lands in the revforge repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
