### PR TITLE
fix(admin): restore prod 'unsafe-inline' in CSP script-src (Next.js hydration / login)

### DIFF
--- a/apps/admin/csp.mjs
+++ b/apps/admin/csp.mjs
@@ -15,13 +15,17 @@ if (serverUrl) {
   connectOrigins.push(serverUrl);
 }
 
-// Build dynamic script-src origins
-// Both 'unsafe-inline' and 'unsafe-eval' are required only for Next.js/Turbopack HMR in dev.
-// Stripe.js and Lexical do not require either in production builds.
+// Build dynamic script-src origins.
+// Next.js App Router emits inline hydration/bootstrap scripts (e.g. self.__next_f)
+// that require either 'unsafe-inline' or a per-request nonce. We keep 'unsafe-inline'
+// in production for that reason — gating it to dev-only (without a nonce) breaks
+// hydration on prod (the admin login page). A per-request nonce is a tracked
+// follow-up that will let us drop 'unsafe-inline'. 'unsafe-eval' is dev/HMR-only.
 const isProduction = process.env.VERCEL_ENV === 'production';
 const scriptOrigins = [
   "'self'",
-  ...(isProduction ? [] : ["'unsafe-inline'", "'unsafe-eval'"]),
+  "'unsafe-inline'",
+  ...(isProduction ? [] : ["'unsafe-eval'"]),
   'https://checkout.stripe.com',
   'https://js.stripe.com',
   'https://maps.googleapis.com',

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -180,7 +180,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     // Content Security Policy (CSP)
     const cspHeader = [
       "default-src 'self'",
-      `script-src 'self'${process.env.NODE_ENV === 'development' ? " 'unsafe-inline' 'unsafe-eval'" : ''} https://js.stripe.com https://cdn.vercel-insights.com`,
+      `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''} https://js.stripe.com https://cdn.vercel-insights.com`,
       `style-src 'self'${process.env.NODE_ENV === 'development' ? " 'unsafe-inline'" : ''}`,
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",


### PR DESCRIPTION
## What
Restore `'unsafe-inline'` in the **production** `script-src` of both admin CSP sources, keeping `'unsafe-eval'` dev-only in each:
- `apps/admin/csp.mjs` — the `next.config.mjs` `headers()` policy
- `apps/admin/src/proxy.ts` — the middleware policy

## Why
PR #848 gated `'unsafe-inline'` to dev-only to harden CSP, but did **not** add a per-request nonce to replace it. Next.js App Router emits inline hydration/bootstrap scripts (`self.__next_f`, route payloads) that require `'unsafe-inline'` **or** a nonce — so production admin stopped hydrating and the login page's scripts were blocked:

```
Executing inline script violates ... script-src 'self' https://checkout.stripe.com https://js.stripe.com https://maps.googleapis.com https://res.cloudinary.com
```

`proxy.ts` carried the same dev-only gating. This restores the working pre-#848 behavior for production (inline allowed) while keeping `'unsafe-eval'` out of production. A follow-up will introduce a per-request nonce so `'unsafe-inline'` can be dropped durably.

## Test
- On a test preview: load the admin login page → no `script-src` CSP violations in the console; the page hydrates and sign-in/passkey work.
