### PR TITLE
promote: test→main — admin CSP prod-inline fix (#1068) + forge migrate + backflow

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -1,126 +1,14 @@
 name: backflow-main-into-test
 
-# After main moves (test→main promotion or direct push), automatically
-# open or update a "backflow main into test" PR if test is behind main.
-# Companion to promotion-gate.yml — that workflow REJECTS stale promotions;
-# this one PROACTIVELY heals the staleness gap.
-#
-# Auth: uses a GitHub App installation token (actions/create-github-app-token)
-# instead of GITHUB_TOKEN, because (1) org policy blocks GITHUB_TOKEN from
-# creating pull requests, and (2) App-token-created PRs DO trigger CI (no
-# anti-loop guard), so the backflow PR runs the gate normally. App creds come
-# from the BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets; the App needs
-# Contents + Pull requests (read & write) on this repo.
-
+# Thin caller — delegates to the org-shared reusable backflow workflow:
+#   RevealUIStudio/.github/.github/workflows/backflow-reusable.yml
+# Requires the BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets + the
+# revfleet-backflow App installed on this repo (Contents + Pull requests r/w).
 on:
   push:
     branches: [main]
 
-permissions:
-  contents: read # all writes go through the App token, not GITHUB_TOKEN
-
 jobs:
   backflow:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        id: app-token
-        with:
-          app-id: ${{ secrets.BACKFLOW_APP_ID }}
-          private-key: ${{ secrets.BACKFLOW_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (resolved 2026-05-19)
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Check if test needs backflow
-        id: check
-        run: |
-          if ! git fetch origin test 2>/dev/null; then
-            echo "::warning::No 'test' branch on origin — skipping backflow"
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if git merge-base --is-ancestor origin/main origin/test; then
-            echo "test already contains main — no backflow needed ✓"
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-          else
-            behind=$(git rev-list --count origin/test..origin/main)
-            echo "test is $behind commit(s) behind main"
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-            echo "behind=$behind" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Configure git identity
-        if: steps.check.outputs.needed == 'true'
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-      - name: Attempt backflow merge
-        if: steps.check.outputs.needed == 'true'
-        id: merge
-        run: |
-          git checkout -B chore/backflow-main-into-test origin/test
-
-          missing=$(git log --oneline origin/test..origin/main | head -20)
-          {
-            echo "Merge main into test"
-            echo ""
-            echo "Auto-opened by .github/workflows/backflow-main-into-test.yml"
-            echo "after main moved forward. Merge commit (no squash) per"
-            echo "feedback_merge_main_into_test_must_use_merge_commit so main's"
-            echo "parentage is preserved and the next promotion-gate check passes."
-            echo ""
-            echo "Missing commits backflowed:"
-            echo "$missing"
-          } > /tmp/merge-msg.txt
-
-          if git merge --no-ff -F /tmp/merge-msg.txt origin/main; then
-            git push origin chore/backflow-main-into-test --force-with-lease
-            echo "merged=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error title=Backflow merge conflict::Auto-backflow hit content conflicts. Resolve manually: git checkout test && git fetch origin && git merge --no-ff origin/main && resolve && git push origin test"
-            exit 1
-          fi
-
-      - name: Open or update backflow PR
-        if: steps.check.outputs.needed == 'true' && steps.merge.outputs.merged == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BEHIND: ${{ steps.check.outputs.behind }}
-          REPO: ${{ github.repository }}
-        run: |
-          existing=$(gh pr list --repo "$REPO" --base test --head chore/backflow-main-into-test --json number --jq '.[0].number // empty')
-
-          title="chore(test): backflow main into test ($BEHIND commit(s) behind)"
-          {
-            echo "## Summary"
-            echo ""
-            echo "Auto-opened by \`.github/workflows/backflow-main-into-test.yml\` because \`main\` moved forward and \`test\` is $BEHIND commit(s) behind."
-            echo ""
-            echo "## Why this exists"
-            echo ""
-            echo "Without backflow, the next \`test\` → \`main\` promotion fails the \`promotion-gate\` check (it requires test to contain all of main). This PR catches \`test\` up so the next promotion lands cleanly."
-            echo ""
-            echo "## Merge instructions"
-            echo ""
-            echo "**Merge as a merge commit (NOT squash) per \`feedback_merge_main_into_test_must_use_merge_commit\`:**"
-            echo ""
-            echo '```'
-            echo "gh pr merge <PR#> --merge --delete-branch --repo $REPO"
-            echo '```'
-            echo ""
-            echo "Squash strips \`main\`'s parentage — \`promotion-gate\` will re-flag the same condition on the next push to main, and another backflow PR will auto-open."
-            echo ""
-            echo "_Opened via a GitHub App token, so CI runs normally on this PR. Per \`feedback_no_auto_merge\`: manual merge only — no \`--auto\`._"
-          } > /tmp/pr-body.md
-
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --repo "$REPO" --title "$title" --body-file /tmp/pr-body.md
-            echo "Updated existing backflow PR #$existing"
-          else
-            gh pr create --repo "$REPO" --base test --head chore/backflow-main-into-test --title "$title" --body-file /tmp/pr-body.md
-            echo "Created new backflow PR"
-          fi
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,13 @@ jobs:
           - app: admin
             dockerfile: apps/admin/Dockerfile.forge
             image: revealui-admin
+          # One-shot DB migrate image for self-hosted kits (built from the
+          # `migrate` stage of the server Dockerfile). The kit compose runs it
+          # once before api+admin so a fresh volume gets its schema.
+          - app: migrate
+            dockerfile: apps/server/Dockerfile.forge
+            target: migrate
+            image: revealui-migrate
 
     steps:
       - name: Checkout
@@ -72,6 +79,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          # Empty for server/admin (builds the final `runner` stage); `migrate`
+          # for the one-shot migrate image. Empty target = final stage.
+          target: ${{ matrix.target }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/apps/admin/csp.mjs
+++ b/apps/admin/csp.mjs
@@ -15,13 +15,17 @@ if (serverUrl) {
   connectOrigins.push(serverUrl);
 }
 
-// Build dynamic script-src origins
-// Both 'unsafe-inline' and 'unsafe-eval' are required only for Next.js/Turbopack HMR in dev.
-// Stripe.js and Lexical do not require either in production builds.
+// Build dynamic script-src origins.
+// Next.js App Router emits inline hydration/bootstrap scripts (e.g. self.__next_f)
+// that require either 'unsafe-inline' or a per-request nonce. We keep 'unsafe-inline'
+// in production for that reason — gating it to dev-only (without a nonce) breaks
+// hydration on prod (the admin login page). A per-request nonce is a tracked
+// follow-up that will let us drop 'unsafe-inline'. 'unsafe-eval' is dev/HMR-only.
 const isProduction = process.env.VERCEL_ENV === 'production';
 const scriptOrigins = [
   "'self'",
-  ...(isProduction ? [] : ["'unsafe-inline'", "'unsafe-eval'"]),
+  "'unsafe-inline'",
+  ...(isProduction ? [] : ["'unsafe-eval'"]),
   'https://checkout.stripe.com',
   'https://js.stripe.com',
   'https://maps.googleapis.com',

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -246,6 +246,10 @@ export default buildConfig({
         collection: 'users',
         limit: 1,
         depth: 0,
+        // Trusted env-driven bootstrap (guarded by totalDocs === 0 below):
+        // bypass access control so the first-admin seed works on a fresh Fleet
+        // kit, where no authenticated user exists yet to satisfy collection access.
+        overrideAccess: true,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -292,6 +296,10 @@ export default buildConfig({
       try {
         await revealui.create({
           collection: 'users',
+          // See the find() above: this first-admin bootstrap runs before any
+          // user exists, so core create()'s access enforcement would otherwise
+          // deny it ("Access denied: insufficient permissions to create").
+          overrideAccess: true,
           data: {
             name: 'Admin User',
             email: adminEmail,

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -180,7 +180,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     // Content Security Policy (CSP)
     const cspHeader = [
       "default-src 'self'",
-      `script-src 'self'${process.env.NODE_ENV === 'development' ? " 'unsafe-inline' 'unsafe-eval'" : ''} https://js.stripe.com https://cdn.vercel-insights.com`,
+      `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''} https://js.stripe.com https://cdn.vercel-insights.com`,
       `style-src 'self'${process.env.NODE_ENV === 'development' ? " 'unsafe-inline'" : ''}`,
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",

--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -48,6 +48,25 @@ RUN pnpm turbo run build --filter=server...
 RUN pnpm --filter server deploy /app/server-deploy --prod --legacy
 
 # ---------------------------------------------------------------------------
+# Migrate stage — one-shot `drizzle-kit migrate` for self-hosted Fleet kits.
+# ---------------------------------------------------------------------------
+# Reuses the build stage, which already carries drizzle-kit (a @revealui/db
+# devDependency, installed by the non-prod `pnpm install` above), the journalled
+# SQL in packages/db/migrations/, and drizzle.config.ts. Published as
+# ghcr.io/revealuistudio/revealui-migrate and run ONCE by the kit compose
+# `migrate` service (gated service_completed_successfully) BEFORE api + admin
+# start, so a freshly-stamped kit volume gets its schema. A fresh kit otherwise
+# boots with zero tables: migrations never run at app boot, only via this step.
+# Idempotent — drizzle records applied migrations in drizzle.__drizzle_migrations,
+# so re-running is a no-op. KIT-ONLY; hosted/Vercel migrates via deploy.yml CI.
+FROM build AS migrate
+WORKDIR /app/packages/db
+ENV NODE_ENV=production
+# drizzle-kit reads drizzle.config.ts (out=./migrations; dbCredentials.url from
+# POSTGRES_URL, supplied by the compose migrate service).
+CMD ["pnpm", "exec", "drizzle-kit", "migrate"]
+
+# ---------------------------------------------------------------------------
 # Runtime stage — minimal image, production only
 # ---------------------------------------------------------------------------
 FROM node:24-alpine AS runner


### PR DESCRIPTION
## Promotion: test → main (production deploy)

Ships from `test` to `main` (prod). **Merge with a MERGE COMMIT (not squash)** to preserve main parentage.

- **fix(admin): restore prod `'unsafe-inline'` in CSP `script-src` (#1068)** — the meaningful prod-facing change. Unblocks admin login: Next.js inline hydration scripts have been CSP-blocked on prod since #848 (which gated `'unsafe-inline'` to dev-only without adding a nonce). Fixes both `csp.mjs` and the `proxy.ts` middleware policy. `'unsafe-eval'` stays dev-only.
- feat(forge): kit schema migrate-at-boot + first-admin bootstrap fix (#1062) — forge-kit infra; inert on SaaS prod (the admin onInit seeder is guarded by `totalDocs===0`, so it no-ops where users already exist).
- ci(backflow): shared reusable workflow (#1066) + #1065 backflow merge — CI/workflow only, no runtime impact.

After deploy: verify admin login + passkey on prod (the CSP fix only takes effect at `VERCEL_ENV=production`).
