### PR TITLE
refactor(marketing): rename /coming-soon to /roadmap + 308 redirect

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -4,7 +4,6 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootLayout } from './layouts/RootLayout';
 import { BlogIndexPage } from './routes/BlogIndexPage';
 import { BlogPostPage } from './routes/BlogPostPage';
-import { ComingSoonPage } from './routes/ComingSoonPage';
 import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
 import { HomePage } from './routes/HomePage';
@@ -13,6 +12,7 @@ import { NotFoundPage } from './routes/NotFoundPage';
 import { PricingPage } from './routes/PricingPage';
 import { PrivacyPage } from './routes/PrivacyPage';
 import { ProductsPage } from './routes/ProductsPage';
+import { RoadmapPage } from './routes/RoadmapPage';
 import { SponsorPage } from './routes/SponsorPage';
 import { TermsPage } from './routes/TermsPage';
 
@@ -41,11 +41,7 @@ export function App() {
         component: FairSourcePage,
         meta: { title: 'Fair Source — RevealUI' },
       },
-      {
-        path: '/coming-soon',
-        component: ComingSoonPage,
-        meta: { title: 'Roadmap — RevealUI' },
-      },
+      { path: '/roadmap', component: RoadmapPage, meta: { title: 'Roadmap — RevealUI' } },
       { path: '/sponsor', component: SponsorPage, meta: { title: 'Sponsor — RevealUI' } },
       { path: '/privacy', component: PrivacyPage, meta: { title: 'Privacy Policy — RevealUI' } },
       { path: '/terms', component: TermsPage, meta: { title: 'Terms of Service — RevealUI' } },

--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { Router } from '@revealui/router';
 import { describe, expect, it } from 'vitest';
 import { BlogIndexPage } from '../routes/BlogIndexPage';
@@ -73,8 +74,10 @@ describe('marketing route registry', () => {
   it('redirects the legacy /coming-soon path to /roadmap', () => {
     // /coming-soon was the route's path before the Phase 4 rename. A permanent
     // edge redirect (vercel.json) keeps old bookmarks and indexed links alive.
+    // Resolve from cwd (the marketing package root under vitest), not
+    // import.meta.url — vitest's module URL is not a file: scheme in CI.
     const vercelConfig = JSON.parse(
-      readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8'),
+      readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8'),
     ) as { redirects?: Array<{ source: string; destination: string; permanent?: boolean }> };
     const redirect = vercelConfig.redirects?.find((entry) => entry.source === '/coming-soon');
     expect(redirect, 'the /coming-soon → /roadmap redirect must survive the rename').toBeDefined();

--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -1,8 +1,8 @@
+import { readFileSync } from 'node:fs';
 import { Router } from '@revealui/router';
 import { describe, expect, it } from 'vitest';
 import { BlogIndexPage } from '../routes/BlogIndexPage';
 import { BlogPostPage } from '../routes/BlogPostPage';
-import { ComingSoonPage } from '../routes/ComingSoonPage';
 import { ContactPage } from '../routes/ContactPage';
 import { FairSourcePage } from '../routes/FairSourcePage';
 import { HomePage } from '../routes/HomePage';
@@ -11,6 +11,7 @@ import { NotFoundPage } from '../routes/NotFoundPage';
 import { PricingPage } from '../routes/PricingPage';
 import { PrivacyPage } from '../routes/PrivacyPage';
 import { ProductsPage } from '../routes/ProductsPage';
+import { RoadmapPage } from '../routes/RoadmapPage';
 import { SponsorPage } from '../routes/SponsorPage';
 import { TermsPage } from '../routes/TermsPage';
 
@@ -26,7 +27,7 @@ describe('marketing route registry', () => {
       { path: '/blog/:slug', component: BlogPostPage },
       { path: '/contact', component: ContactPage },
       { path: '/fair-source', component: FairSourcePage },
-      { path: '/coming-soon', component: ComingSoonPage },
+      { path: '/roadmap', component: RoadmapPage },
       { path: '/sponsor', component: SponsorPage },
       { path: '/privacy', component: PrivacyPage },
       { path: '/terms', component: TermsPage },
@@ -45,7 +46,7 @@ describe('marketing route registry', () => {
       '/blog/getting-started',
       '/contact',
       '/fair-source',
-      '/coming-soon',
+      '/roadmap',
       '/sponsor',
       '/privacy',
       '/terms',
@@ -67,5 +68,17 @@ describe('marketing route registry', () => {
     const match = router.match('/nonexistent-path');
     expect(match).not.toBeNull();
     expect(match?.route.component).toBe(NotFoundPage);
+  });
+
+  it('redirects the legacy /coming-soon path to /roadmap', () => {
+    // /coming-soon was the route's path before the Phase 4 rename. A permanent
+    // edge redirect (vercel.json) keeps old bookmarks and indexed links alive.
+    const vercelConfig = JSON.parse(
+      readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8'),
+    ) as { redirects?: Array<{ source: string; destination: string; permanent?: boolean }> };
+    const redirect = vercelConfig.redirects?.find((entry) => entry.source === '/coming-soon');
+    expect(redirect, 'the /coming-soon → /roadmap redirect must survive the rename').toBeDefined();
+    expect(redirect?.destination).toBe('/roadmap');
+    expect(redirect?.permanent).toBe(true);
   });
 });

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -31,7 +31,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
       { label: 'Pricing', href: '/pricing' },
       { label: 'Documentation', href: SITE.urls.docs },
       { label: 'Blog', href: '/blog' },
-      { label: 'Roadmap', href: '/coming-soon' },
+      { label: 'Roadmap', href: '/roadmap' },
     ],
   },
   {

--- a/apps/marketing/app/content/roadmap.ts
+++ b/apps/marketing/app/content/roadmap.ts
@@ -1,5 +1,5 @@
-// Sourced from: app/routes/ComingSoonPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
-// File named roadmap.ts per Phase 4 /roadmap rename plan; route stays ComingSoonPage.tsx for now.
+// Sourced from: app/routes/RoadmapPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Phase 4 complete: page renders at /roadmap via RoadmapPage.tsx; /coming-soon 308-redirects in vercel.json.
 
 import { SITE } from './site';
 import type { Cta, SectionHeading } from './types';

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -50,7 +50,7 @@ function FeatureCard({ feature }: { feature: RoadmapItem }) {
   );
 }
 
-export function ComingSoonPage() {
+export function RoadmapPage() {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -36,7 +36,7 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://revealui.com/coming-soon</loc>
+    <loc>https://revealui.com/roadmap</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -41,6 +41,7 @@
       "permanent": true
     },
     { "source": "/pro", "destination": "/pricing", "permanent": false },
+    { "source": "/coming-soon", "destination": "/roadmap", "permanent": true },
     {
       "source": "/community",
       "destination": "https://revnation.discourse.group",


### PR DESCRIPTION
## What

Completes the `/coming-soon` → `/roadmap` route rename for the marketing site. The roadmap page was rendering at the legacy `/coming-soon` path while the footer link and page content already said "Roadmap" — this aligns URL, label, and component.

## Changes

- `ComingSoonPage.tsx` → `RoadmapPage.tsx` (export + route component)
- `App.tsx` + `routes.test.ts`: route path `/coming-soon` → `/roadmap`
- `nav.ts` footer link + `public/sitemap.xml` `<loc>` → `/roadmap`
- `vercel.json`: permanent (308) `/coming-soon` → `/roadmap` redirect so old bookmarks and indexed links keep working
- `routes.test.ts`: new regression test asserting the redirect stays in place

## Verification

- `biome check apps/marketing` clean
- `claim-drift` 0 mismatches
- Route-registry + redirect-config unit tests added (run in CI)

The 308 redirect is edge config (`vercel.json`) — not exercised by `vite dev`, so it's covered by the config-assertion test + CI rather than local preview.
