### PR TITLE
fix(marketing): clear banned-word voice violations (Rule 5)

### DIFF
--- a/apps/marketing/app/content/capabilities.ts
+++ b/apps/marketing/app/content/capabilities.ts
@@ -48,7 +48,7 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     title: 'Circuit breakers + retry + bulkhead',
-    body: 'Production-grade resilience patterns wired into the runtime — adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
+    body: 'Production resilience patterns wired into the runtime — adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
     path: 'packages/resilience/src/circuit-breaker.ts',
     href: `${REPO_ROOT}/packages/resilience/src/circuit-breaker.ts`,
   },

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -159,7 +159,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
         'Define products, pricing tiers, and feature gates in one place. License enforcement and upgrade prompts are built in. Subscription billing via Stripe with perpetual license support.',
     },
     forAgents: {
-      headline: 'Feature gates control which agent capabilities unlock per tier',
+      headline: 'Feature gates control which agent capabilities are enabled per tier',
       description:
         'Agent capabilities are gated by the same tier system that governs human features. When a customer upgrades, their agents automatically gain access to more tools and higher task limits.',
     },

--- a/apps/marketing/app/content/sponsor.ts
+++ b/apps/marketing/app/content/sponsor.ts
@@ -84,7 +84,7 @@ export const SPONSOR_TIERS: readonly SponsorTier[] = [
     price: '$500',
     period: '/month',
     emoji: '\u{1F48E}',
-    description: 'Shape the future of RevealUI.',
+    description: 'Fund a release and help shape the roadmap.',
     benefits: [
       'All Gold Sponsor benefits',
       'Logo with link on landing page',


### PR DESCRIPTION
## What

Phase-5 voice-rule sweep over `apps/marketing/app`. The earlier copy overhaul (#1041, #1045) left three hits from the marketing voice **Rule 5** banned-word list.

## Fixes

| File | Before | After | Why |
|---|---|---|---|
| `sponsor.ts` | "Shape **the future of** RevealUI." | "Fund a release and help shape the roadmap." | banned connective; "the roadmap" is a concrete artifact |
| `capabilities.ts` | "**Production-grade** resilience…" | "Production resilience…" | banned adjective ("use 'production'") |
| `primitives.ts` | "…capabilities **unlock** per tier" | "…are enabled per tier" | banned hollow verb; "enabled" names the actual gate |

## Left intentionally (with reason)

- `site.ts` "AI-native businesses" — owner-locked hero tagline; "AI-native" is a conditionally-allowed positioning noun.
- `fair-source.ts` "the only restriction" — an honest factual count (the Fair Source yes/no pattern), not a marketing superlative.
- Sponsor **tier icons** (☕ ⭐ 🏆 💎) — decorative iconography, not prose. Converting them to the SVG `iconKey` pattern is a design change beyond a copy sweep; flagging for a possible follow-up rather than dropping icons here.

## Verification

- `biome check apps/marketing` clean
- `claim-drift` 0 mismatches
- Full banned-word + emoji sweep across `apps/marketing/app` — no remaining prose violations
