### PR TITLE
feat(marketing): gate content metrics + add content contracts

### DIFF
--- a/apps/marketing/CONTRIBUTING.md
+++ b/apps/marketing/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to the marketing site (`apps/marketing`)
+
+`revealui.com` is a Vite + React SPA built on `@revealui/router`. Copy lives in
+typed `app/content/*.ts` modules; the route components in `app/routes/*.tsx` are
+pure renderers that consume that content. **Edit copy in `app/content/`, not in
+JSX.**
+
+## Where copy lives
+
+| File | Owns |
+|---|---|
+| `content/site.ts` | URLs, brand strings, and the canonical `METRICS` object |
+| `content/home.ts`, `primitives.ts`, `products.ts` | landing + `/products` copy |
+| `content/pricing.ts`, `pricing-faq.ts`, `pricing-teaser.ts` | `/pricing` copy (tier data re-exported from `@revealui/contracts/pricing`) |
+| `content/marketplace.ts`, `capabilities.ts`, `proof.ts` | marketplace + proof sections |
+| `content/roadmap.ts` | `/roadmap` page (Recently shipped / Coming next) |
+| `content/fair-source.ts`, `sponsor.ts`, `nav.ts`, `contact.ts` | the remaining surfaces |
+
+## Numbers are single-sourced
+
+Every count (packages, MCP servers, DB tables, UI components, …) lives once, in
+`METRICS` in `content/site.ts`. **Never hardcode a count in another content
+file — import `METRICS` instead.**
+
+`METRICS` mirrors `docs/MARKETING_METRICS.md` §1, the canonical pinned-truth
+doc. The values are gate-enforced: `scripts/validate/claim-drift.ts` computes
+each count from the codebase and fails CI if `METRICS` drifts. To change a
+number:
+
+1. Make the underlying code change (add a package, ship an MCP server, …).
+2. Update `docs/MARKETING_METRICS.md` §1.
+3. Update `METRICS` in `content/site.ts` to match.
+4. Run `pnpm tsx scripts/validate/claim-drift.ts` — it must exit 0.
+
+Marketing copy then reflects the new number automatically — no per-page edit.
+
+## Voice
+
+Customer-facing copy follows the five voice rules summarized in
+`docs/MARKETING_METRICS.md` (lead with what ships today; specifics over
+adjectives; identify the reader by stack; surface trade-offs in plain English;
+no marketing-speak, emojis, or exclamation points). `claim-drift` also enforces
+honest framing: no inflated counts, no unattributed fleet-product mentions, no
+internal-codename leaks, and no unqualified aspirational features.
+
+## Tests
+
+- `app/content/__tests__/content.test.ts` — structural contracts (five
+  primitives, capability count + file citations, roadmap honesty, `METRICS`
+  invariants).
+- `app/__tests__/routes.test.ts` — every advertised path resolves to a
+  component, and the legacy `/coming-soon` → `/roadmap` redirect stays in
+  `vercel.json`.
+
+Run `pnpm --filter marketing test`. New copy should keep both suites green and
+leave `pnpm tsx scripts/validate/claim-drift.ts` at exit 0.

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
+import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
+import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
+import { METRICS, SITE } from '../site';
+
+// Structural contracts for the marketing content modules. These guard the
+// invariants TypeScript can't: counts, internal consistency, and the honesty
+// rules the marketing-overhaul lane established. Metric VALUES are enforced
+// separately against the codebase by scripts/validate/claim-drift.ts.
+
+const FIVE_PRIMITIVES = ['Users', 'Content', 'Products', 'Payments', 'Intelligence'];
+
+describe('marketing content contracts', () => {
+  describe('primitives', () => {
+    it('home and products each expose exactly the five primitives', () => {
+      expect(HOME_PRIMITIVES).toHaveLength(5);
+      expect(PRODUCTS_PRIMITIVES).toHaveLength(5);
+    });
+
+    it('both primitive sets name the same five, in the same order', () => {
+      expect(HOME_PRIMITIVES.map((p) => p.label)).toEqual(FIVE_PRIMITIVES);
+      expect(PRODUCTS_PRIMITIVES.map((p) => p.name)).toEqual(FIVE_PRIMITIVES);
+    });
+  });
+
+  describe('capabilities', () => {
+    it('exposes nine capabilities, matching the section copy', () => {
+      expect(CAPABILITIES).toHaveLength(9);
+      // The heading copy spells the count ("Nine ...") — keep them in lockstep.
+      expect(CAPABILITIES_SECTION.body.toLowerCase()).toContain('nine');
+    });
+
+    it('every capability cites a real repo source file', () => {
+      for (const cap of CAPABILITIES) {
+        expect(cap.path.startsWith('packages/'), `${cap.title}: path not under packages/`).toBe(
+          true,
+        );
+        expect(cap.href.startsWith(SITE.urls.repo), `${cap.title}: href not in the repo`).toBe(
+          true,
+        );
+      }
+    });
+  });
+
+  describe('roadmap', () => {
+    it('the "recently shipped" section contains only shipped items', () => {
+      for (const item of ROADMAP_SHIPPED) {
+        expect(
+          ['Shipped', 'Available'],
+          `${item.name} is in the shipped section but marked "${item.status}"`,
+        ).toContain(item.status);
+      }
+    });
+
+    it('upcoming items are never labelled as shipped', () => {
+      for (const item of ROADMAP_UPCOMING) {
+        expect(['Shipped', 'Available']).not.toContain(item.status);
+      }
+    });
+
+    it('every roadmap item is fully populated', () => {
+      for (const item of [...ROADMAP_SHIPPED, ...ROADMAP_UPCOMING]) {
+        expect(item.name.length, 'empty name').toBeGreaterThan(0);
+        expect(item.description.length, `${item.name}: empty description`).toBeGreaterThan(0);
+        expect(item.status.length, `${item.name}: empty status`).toBeGreaterThan(0);
+        expect(item.category.length, `${item.name}: empty category`).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('metrics', () => {
+    const COUNT_KEYS = [
+      'packages',
+      'apps',
+      'workspaces',
+      'testFiles',
+      'uiComponents',
+      'mcpServers',
+      'dbTables',
+    ] as const;
+
+    it('every count is a positive integer', () => {
+      for (const key of COUNT_KEYS) {
+        expect(Number.isInteger(METRICS[key]), `METRICS.${key} not an integer`).toBe(true);
+        expect(METRICS[key], `METRICS.${key} not positive`).toBeGreaterThan(0);
+      }
+    });
+
+    it('workspaces equals packages plus apps', () => {
+      expect(METRICS.workspaces).toBe(METRICS.packages + METRICS.apps);
+    });
+
+    it('the license split sums to the package count', () => {
+      const { mit, fsl, internal } = METRICS.licenseSplit;
+      expect(mit + fsl + internal).toBe(METRICS.packages);
+    });
+  });
+});

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -37,7 +37,7 @@ export const METRICS = {
    */
   mcpServers: 13,
   /** Drizzle pgTable declarations across packages/db/src/schema/. Source: claim-drift countDbTables. */
-  dbTables: 86,
+  dbTables: 85,
   /** License split. Source: claim-drift licenseSplit. */
   licenseSplit: {
     /** MIT-licensed packages. */

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -29,7 +29,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-05-18 (
 | Test files | **912** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **59** | `countUIComponents()` | Marketing copy says "59 native React components" or similar. |
 | **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
-| DB tables (Drizzle pgTable) | **86** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | |
+| DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |
 | License: MIT packages | **20** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
 | License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1252,6 +1252,84 @@ function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {
 }
 
 // ---------------------------------------------------------------------------
+// Marketing METRICS drift (Phase 6 — marketing-overhaul lane)
+//
+// apps/marketing/app/content/site.ts exports a METRICS object that every
+// marketing content/* file imports instead of hardcoding integers. Those
+// values are `key: value` shaped (the number FOLLOWS the metric word), so the
+// prose claim-scanner above never matches them — `dbTables: 86` / `mcpServers:
+// 13` slip past the "N tables" / "N MCP servers" patterns. This check reads the
+// METRICS block directly and asserts each value equals the canonical count this
+// validator computes, so a stale METRICS integer fails CI.
+//
+// No authored regex (fleet no-regex rule): indexOf + Number.parseInt only.
+// ---------------------------------------------------------------------------
+
+const MARKETING_SITE_FILE = 'apps/marketing/app/content/site.ts';
+
+interface MarketingMetricCheck {
+  /** METRICS field name in site.ts (e.g. "dbTables", "mcpServers"). */
+  key: string;
+  /** Canonical count this validator computed from the codebase. */
+  actual: number;
+  /** Allowed |declared - actual| drift. Test files churn, so they get slack. */
+  tolerance?: number;
+}
+
+interface MarketingMetricDrift {
+  key: string;
+  /** null = key missing from the METRICS block. */
+  declared: number | null;
+  actual: number;
+}
+
+/**
+ * Parse a flat integer `<key>: <n>` out of the METRICS block. `Number.parseInt`
+ * skips leading whitespace and stops at the first non-digit, so the value in
+ * `dbTables: 85,` parses to 85. Returns null when the key is absent.
+ */
+function readDeclaredMetric(metricsBlock: string, key: string): number | null {
+  const token = `${key}:`;
+  const idx = metricsBlock.indexOf(token);
+  if (idx === -1) return null;
+  const parsed = Number.parseInt(metricsBlock.slice(idx + token.length), 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function checkMarketingMetrics(checks: MarketingMetricCheck[]): MarketingMetricDrift[] {
+  const full = path.join(ROOT, MARKETING_SITE_FILE);
+  let src: string;
+  try {
+    src = fs.readFileSync(full, 'utf8');
+  } catch {
+    throw new Error(
+      `claim-drift: cannot read ${MARKETING_SITE_FILE}. If apps/marketing moved, ` +
+        'update MARKETING_SITE_FILE in scripts/validate/claim-drift.ts.',
+    );
+  }
+  // Scope the parse to the METRICS object so SITE.urls etc. cannot collide.
+  const start = src.indexOf('export const METRICS');
+  if (start === -1) {
+    throw new Error(`claim-drift: METRICS export not found in ${MARKETING_SITE_FILE}.`);
+  }
+  const end = src.indexOf('export const SITE');
+  const block = src.slice(start, end === -1 ? undefined : end);
+
+  const drifts: MarketingMetricDrift[] = [];
+  for (const check of checks) {
+    const declared = readDeclaredMetric(block, check.key);
+    if (declared === null) {
+      drifts.push({ key: check.key, declared: null, actual: check.actual });
+      continue;
+    }
+    if (Math.abs(declared - check.actual) > (check.tolerance ?? 0)) {
+      drifts.push({ key: check.key, declared, actual: check.actual });
+    }
+  }
+  return drifts;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -1409,6 +1487,20 @@ function run(): void {
   const membershipMatches = scanForLicenseMembershipDrift(pkgMap);
   const incompleteProMatches = scanForIncompleteProList(pkgMap);
 
+  // Marketing METRICS drift (Phase 6) — site.ts METRICS vs canonical counts
+  const marketingMetricDrifts = checkMarketingMetrics([
+    { key: 'packages', actual: packages },
+    { key: 'apps', actual: apps },
+    { key: 'workspaces', actual: workspaces },
+    { key: 'uiComponents', actual: uiComponents },
+    { key: 'mcpServers', actual: mcpServers },
+    { key: 'dbTables', actual: dbTables },
+    { key: 'testFiles', actual: testFiles, tolerance: 100 },
+    { key: 'mit', actual: licenseSplit.mit },
+    { key: 'fsl', actual: licenseSplit.fsl },
+    { key: 'internal', actual: licenseSplit.internal },
+  ]);
+
   console.log('====================');
   console.log(`Claims scanned: ${claims.length}`);
   console.log(`Mismatches:     ${mismatches}`);
@@ -1421,6 +1513,7 @@ function run(): void {
   console.log(`Phantom-package mentions: ${phantomMatches.length}`);
   console.log(`License-membership mismatches: ${membershipMatches.length}`);
   console.log(`Incomplete Pro-list claims: ${incompleteProMatches.length}`);
+  console.log(`Marketing METRICS drift (site.ts): ${marketingMetricDrifts.length}`);
 
   if (futureClaims.length > 0) {
     console.log('\nUnlinked future-tense claims (convention: CONTRIBUTING.md):');
@@ -1505,6 +1598,19 @@ function run(): void {
     );
   }
 
+  if (marketingMetricDrifts.length > 0) {
+    console.log(
+      '\nMarketing METRICS drift — apps/marketing/app/content/site.ts out of sync with codebase:',
+    );
+    for (const d of marketingMetricDrifts) {
+      const declaredStr = d.declared === null ? 'MISSING' : String(d.declared);
+      console.log(`  METRICS.${d.key}: declares ${declaredStr}, actual ${d.actual}`);
+    }
+    console.log(
+      '\nUpdate METRICS in apps/marketing/app/content/site.ts (and docs/MARKETING_METRICS.md §1) to match the codebase counts above.',
+    );
+  }
+
   const anyFailures =
     mismatches > 0 ||
     futureClaims.length > 0 ||
@@ -1513,7 +1619,8 @@ function run(): void {
     rvuiLeaks.length > 0 ||
     phantomMatches.length > 0 ||
     membershipMatches.length > 0 ||
-    incompleteProMatches.length > 0;
+    incompleteProMatches.length > 0 ||
+    marketingMetricDrifts.length > 0;
 
   if (anyFailures) {
     if (mismatches > 0) {
@@ -1542,6 +1649,9 @@ function run(): void {
     }
     if (incompleteProMatches.length > 0) {
       console.log('\nFailed: incomplete Pro-package lists in docs.');
+    }
+    if (marketingMetricDrifts.length > 0) {
+      console.log('\nFailed: marketing METRICS out of sync with codebase counts.');
     }
     process.exit(1);
   } else {


### PR DESCRIPTION
## What

Phase-6 drift-prevention for the marketing site: the canonical `METRICS` in `apps/marketing/app/content/site.ts` (which every content module imports) are now **gate-enforced** against the codebase, and the content modules have structural contract tests.

## Changes

**`claim-drift` — new `checkMarketingMetrics()`**
Reads the `METRICS` block in `site.ts` and asserts each value equals the count the validator computes from the codebase (`packages`, `apps`, `workspaces`, `uiComponents`, `mcpServers`, `dbTables`, license split; `testFiles` with ±100 churn tolerance). These were invisible to the existing prose scanner because `METRICS` is `key: value` shaped — `dbTables: 86` never matched the "N tables" pattern. No authored regex (`indexOf` + `Number.parseInt`).

**Fix the drift it caught**
`dbTables` 86 → **85** (the live `pgTable(` count) in both `site.ts` and `docs/MARKETING_METRICS.md` §1.

**Content contract tests** (`app/content/__tests__/content.test.ts`)
- five primitives — home + products sets agree, in order
- nine capabilities, each citing a real repo source file (matches the "Nine" section copy)
- roadmap "recently shipped" holds only shipped items; upcoming items never marked shipped
- `METRICS` invariants — `workspaces = packages + apps`; license split sums to the package count

**`apps/marketing/CONTRIBUTING.md`**
Where copy lives, the single-sourced `METRICS` workflow, the voice-rule pointer, and the test/gate commands.

## Verification

- `claim-drift` exit 0 — and proven to **catch** a wrong `METRICS` integer (it failed on `dbTables` 86 vs 85 before the fix)
- content contract tests: 10/10
- `claim-drift` unit tests: 11/11
- `biome check` clean

CI runs `claim-drift` on every PR to `test`, so a future `METRICS` drift now fails CI.
