### PR TITLE
fix(admin): externalize @simplewebauthn/server — prod passkey 500

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -85,6 +85,12 @@ const nextConfig = {
     '@libsql/client-wasm',
     '@revealui/ai',
     '@revealui/services',
+    // @simplewebauthn/server (+ its @peculiar/asn1-* / cbor deps) is ESM- and
+    // crypto-heavy and breaks at runtime when bundled into the standalone server
+    // output — fine in `next dev`, throws in the prod build. It reaches the bundle
+    // via @revealui/auth (transpilePackages). Externalize so it loads from
+    // node_modules at runtime. Fixes the prod passkey-options 500 (GAP-220).
+    '@simplewebauthn/server',
   ],
   // Transpile workspace packages - all now use bundler module resolution with extensionless imports
   // This works with Turbopack since we changed from NodeNext to bundler resolution

--- a/apps/admin/src/app/api/auth/passkey/[id]/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/[id]/route.ts
@@ -62,7 +62,10 @@ export async function PATCH(
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    logger.error('Error renaming passkey', { error });
+    logger.error(
+      'Error renaming passkey',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/[id]',
       operation: 'passkey_rename',
@@ -101,7 +104,10 @@ export async function DELETE(
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    logger.error('Error deleting passkey', { error });
+    logger.error(
+      'Error deleting passkey',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/[id]',
       operation: 'passkey_delete',

--- a/apps/admin/src/app/api/auth/passkey/authenticate-options/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-options/route.ts
@@ -44,7 +44,10 @@ async function authenticateOptionsHandler(_request: NextRequest): Promise<NextRe
 
     return response;
   } catch (error) {
-    logger.error('Error generating passkey authentication options', { error });
+    logger.error(
+      'Error generating passkey authentication options',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/authenticate-options',
       operation: 'passkey_authenticate_options',

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -189,7 +189,10 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
 
     return response;
   } catch (error) {
-    logger.error('Error verifying passkey authentication', { error });
+    logger.error(
+      'Error verifying passkey authentication',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/authenticate-verify',
       operation: 'passkey_authenticate_verify',

--- a/apps/admin/src/app/api/auth/passkey/list/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/list/route.ts
@@ -27,7 +27,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json({ passkeys: userPasskeys });
   } catch (error) {
-    logger.error('Error listing passkeys', { error });
+    logger.error(
+      'Error listing passkeys',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/list',
       operation: 'passkey_list',

--- a/apps/admin/src/app/api/auth/passkey/register-options/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-options/route.ts
@@ -146,7 +146,10 @@ async function registerOptionsHandler(request: NextRequest): Promise<NextRespons
 
     return response;
   } catch (error) {
-    logger.error('Error generating passkey registration options', { error });
+    logger.error(
+      'Error generating passkey registration options',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/register-options',
       operation: 'passkey_register_options',

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -297,7 +297,10 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
 
     return response;
   } catch (error) {
-    logger.error('Error verifying passkey registration', { error });
+    logger.error(
+      'Error verifying passkey registration',
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return createErrorResponse(error, {
       endpoint: '/api/auth/passkey/register-verify',
       operation: 'passkey_register_verify',


### PR DESCRIPTION
## Problem

`POST /api/auth/passkey/authenticate-options` (and the rest of the passkey ceremony — register + authenticate) returns **500 in production**, while working in `next dev` and in direct-function local repro.

## Root cause

`@simplewebauthn/server` is an ESM, crypto-heavy package (it pulls `@peculiar/asn1-*` + cbor). It reaches the admin **server bundle** through `@revealui/auth` (which is in `transpilePackages`), but it was **not** in `serverExternalPackages` — so Next bundles it into the standalone output, where it throws at runtime. `next dev` and unbundled function repro never exercise the bundled path, which is why it presented as "200 locally / 500 in prod" and earlier diagnosis stalled.

## Fix

1. Add `@simplewebauthn/server` to `serverExternalPackages` in `apps/admin/next.config.mjs` so it loads from `node_modules` at runtime instead of being bundled — same pattern as the existing `libsql` / Pro-package entries. This covers the **whole** passkey surface (register + authenticate), not just the one endpoint.
2. Fix error logging in all 6 passkey routes: they called `logger.error(msg, { error })`, but the logger takes the `Error` as the **2nd** arg (see `lib/middleware/rate-limit.ts`), so the error serialized to `{}` and hid the message/stack in prod logs. Now the `Error` instance is passed, so any remaining fault is visible.

## Verification

- Biome clean; typecheck + build run in CI.
- **Runtime confirmation is owner-gated** (needs promote → prod redeploy), then:
  ```
  curl -sS -X POST https://admin.revealui.com/api/auth/passkey/authenticate-options \
    -H 'Content-Type: application/json' -d '{}' -w '\n%{http_code}\n'   # expect 200
  ```
- I could not reproduce the prod standalone build locally (workstation RAM). This is a high-confidence root-cause fix; the logging change is a diagnostic safety net in case the externalize proves incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
