### PR TITLE
fix(db): handle pg pool 'error' events in the client to prevent idle-client crashes

### DIFF
--- a/.changeset/db-client-pool-error-handler.md
+++ b/.changeset/db-client-pool-error-handler.md
@@ -1,0 +1,5 @@
+---
+"@revealui/db": patch
+---
+
+Attach an `'error'` event handler to the pg pools created by the database client (localhost / self-hosted Postgres path). A pg `Pool` is an EventEmitter, and an unhandled `'error'` event — emitted when an idle connection is dropped by the server (admin termination, autosuspend, network blip) — throws and crashes the process. The handler logs the error and keeps the pool alive, matching the existing behavior in `pool.ts` (Neon-backed deployments use the HTTP driver and are unaffected).

--- a/packages/db/src/__tests__/client/pool.test.ts
+++ b/packages/db/src/__tests__/client/pool.test.ts
@@ -13,11 +13,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // ============================================================================
 
 const mockPoolEnd = vi.fn().mockResolvedValue(undefined);
+const mockPoolOn = vi.fn();
 const mockPoolInstance = {
   totalCount: 5,
   idleCount: 3,
   waitingCount: 0,
   end: mockPoolEnd,
+  on: mockPoolOn,
 };
 
 vi.mock('pg', () => {
@@ -26,6 +28,7 @@ vi.mock('pg', () => {
     idleCount = mockPoolInstance.idleCount;
     waitingCount = mockPoolInstance.waitingCount;
     end = mockPoolInstance.end;
+    on = mockPoolInstance.on;
   }
   return { Pool: MockPool };
 });
@@ -144,6 +147,16 @@ describe('client/index  -  pool management', () => {
       });
 
       expect(db).toBeDefined();
+    });
+
+    it("registers an 'error' handler on the pg Pool to prevent idle-client crashes", () => {
+      createClient({
+        connectionString: 'postgresql://user:pass@localhost:5432/testdb',
+      });
+
+      // pg Pool is an EventEmitter; an unhandled 'error' event (e.g. a dropped idle
+      // connection) would otherwise crash the process. See onClientPoolError.
+      expect(mockPoolOn).toHaveBeenCalledWith('error', expect.any(Function));
     });
 
     it('passes logger option through to Drizzle', () => {

--- a/packages/db/src/__tests__/client/transactions.test.ts
+++ b/packages/db/src/__tests__/client/transactions.test.ts
@@ -23,6 +23,7 @@ vi.mock('pg', () => {
     idleCount = 3;
     waitingCount = 0;
     end = mockPoolEnd;
+    on = vi.fn();
   }
   return { Pool: MockPool };
 });

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -23,6 +23,7 @@ import { neon } from '@neondatabase/serverless';
 // Direct ESM import - the Proxy ensures no validation occurs until properties are accessed
 import configModule from '@revealui/config';
 import { getSSLConfig } from '@revealui/utils/database';
+import { logger } from '@revealui/utils/logger';
 import { drizzle as drizzleNeon, type NeonHttpDatabase } from 'drizzle-orm/neon-http';
 import { drizzle as drizzlePg, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
@@ -103,8 +104,23 @@ function isLocalhostConnection(connectionString: string): boolean {
     // Any non-Neon host should use pg — Neon HTTP driver requires a Neon endpoint.
     return !host.endsWith('.neon.tech') && url.protocol !== 'wss:';
   } catch {
-    return !connectionString.includes('.neon.tech') && !connectionString.startsWith('wss://');
+    return !(connectionString.includes('.neon.tech') || connectionString.startsWith('wss://'));
   }
+}
+
+/**
+ * Logs an unexpected error emitted by an idle pg pool client.
+ *
+ * pg `Pool` is an EventEmitter: an unhandled `'error'` event — emitted when an
+ * idle connection is dropped by the server (admin termination, autosuspend,
+ * network blip) — throws and crashes the process. Attaching a listener keeps the
+ * pool alive and surfaces the error instead. Mirrors `onPoolError` in `../pool.ts`.
+ */
+function onClientPoolError(err: unknown): void {
+  logger.error(
+    'Unexpected error on idle database pool client',
+    err instanceof Error ? err : new Error(String(err)),
+  );
 }
 
 /**
@@ -148,6 +164,8 @@ export function createClient(
       idleTimeoutMillis: poolIdleTimeout,
       connectionTimeoutMillis: 10_000, // 10 seconds
     });
+    // Prevent an idle-client error from crashing the process (unhandled 'error' event).
+    pool.on('error', onClientPoolError);
 
     // Track pool and register cleanup
     const poolId = `pool-${activePools.size + 1}`;
@@ -287,6 +305,8 @@ function getClientByType(type: DatabaseType): Database {
         idleTimeoutMillis: poolIdleTimeout,
         connectionTimeoutMillis: 10_000,
       });
+      // Prevent an idle-client error from crashing the process (unhandled 'error' event).
+      pool.on('error', onClientPoolError);
       restPool = pool;
       const poolId = `rest-pool`;
       activePools.set(poolId, pool);


### PR DESCRIPTION
## Problem

`packages/db/src/client/index.ts` creates `pg.Pool` instances for the localhost / self-hosted Postgres path (Neon connections use the HTTP driver and have no pool). A `pg.Pool` is an EventEmitter — an **unhandled `'error'` event crashes the Node process**. That event fires when the server drops an idle connection (admin termination, autosuspend, network blip).

`pool.ts` already guards `getPool()` with an `onPoolError` listener, but the two pools created in `client/index.ts` (`createClient` and `getRestClient`/`getRestPool`) did not — so a dropped idle connection there would take the process down.

Surfaced as a follow-up from the GAP-220 passkey-500 diagnosis, which flagged the unhandled pg-pool `'error'` path as a separate robustness gap. Neon-backed prod is unaffected (it uses the HTTP driver); this protects dev/test and self-hosted Postgres / Fleet-kit deployments.

## Fix

- Add a shared `onClientPoolError` handler (mirrors `pool.ts`'s `onPoolError`) and attach `pool.on('error', …)` to both pools.

## Tests

- The client pool/transaction test mocks didn't implement `.on()` (which the new code now calls); added it so the existing localhost-client tests keep passing, plus a test asserting the `'error'` handler is registered. (`connection-failures.test.ts` already mocked `.on()`.)
- Biome clean locally; the full unit suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
