### PR TITLE
ci(dependabot-autofix): push lockfile fix via App token so CI re-fires

### DIFF
--- a/.github/workflows/dependabot-catalog-autofix.yml
+++ b/.github/workflows/dependabot-catalog-autofix.yml
@@ -15,18 +15,33 @@ name: Dependabot Catalog Lockfile Auto-Fix
 #   3. Runs `pnpm install --lockfile-only --ignore-scripts`, which
 #      regenerates importer specifiers back to 'catalog:' against the
 #      already-correct workspace catalog.
-#   4. If the lockfile drifted, commits the fix as github-actions[bot]
-#      and pushes to the PR head.
+#   4. If the lockfile drifted, commits the fix (authored by
+#      github-actions[bot]) and pushes to the PR head using a GitHub App
+#      installation token (the revfleet-backflow App), NOT GITHUB_TOKEN.
 #
-# Push-loop guard: the workflow only runs when `github.actor` is
-# dependabot[bot]. The auto-fix commit is authored by
-# github-actions[bot], so the resulting push event will re-trigger the
-# workflow but the actor check will short-circuit the job.
+# Why a GitHub App token instead of GITHUB_TOKEN: a push made with the
+# default GITHUB_TOKEN does NOT trigger `pull_request` /
+# `pull_request_target` workflows (GitHub loop-prevention). A GITHUB_TOKEN
+# push therefore left the corrected lockfile permanently "stale red" —
+# ci.yml never re-ran on the fix, so the PR kept showing the pre-fix
+# failure (or "no checks reported on the branch") and needed a manual
+# nudge (close/reopen, empty commit) to validate. Pushing with the App
+# installation token fires the `synchronize` event normally, so ci.yml
+# re-runs and the PR gets a real green check on the autofixed head.
+#
+# Push-loop guard: the App-token push DOES re-trigger this workflow, but
+# the re-triggered run's `github.actor` is the App's bot identity (not
+# dependabot[bot]), so the `if: github.actor == 'dependabot[bot]'` job
+# guard short-circuits it — no second fix, no loop. That same push re-runs
+# ci.yml under a non-dependabot actor, which is exactly the CI run we want.
 #
 # Security: `pull_request_target` runs with the BASE branch's workflow
 # definition, so a PR can't modify this workflow to escalate privileges.
-# `pnpm install --ignore-scripts` skips lifecycle scripts so a malicious
-# package.json change can't execute arbitrary code.
+# The job only runs for the dependabot[bot] actor (which an external PR
+# cannot spoof), and `pnpm install --ignore-scripts` skips lifecycle
+# scripts so a malicious package.json change can't execute arbitrary code.
+# The App token is minted per-run, scoped to `contents: write` on this
+# repo only, and expires within ~1h.
 
 on:
   pull_request_target:
@@ -34,9 +49,10 @@ on:
     paths:
       - 'pnpm-lock.yaml'
 
+# GITHUB_TOKEN stays read-only: every write (the lockfile-fix push) goes
+# through the scoped, short-lived App installation token minted in the job.
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 concurrency:
   group: dependabot-catalog-autofix-${{ github.event.pull_request.number }}
@@ -54,12 +70,26 @@ jobs:
     timeout-minutes: 8
 
     steps:
+      # Mint a GitHub App installation token so the lockfile-fix push
+      # re-fires CI (a GITHUB_TOKEN push would be loop-suppressed — see the
+      # header comment). Scoped to contents:write on this repo only. The
+      # BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets + the
+      # revfleet-backflow App installation are shared with
+      # backflow-main-into-test.yml.
+      - name: Mint backflow App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.BACKFLOW_APP_ID }}
+          private-key: ${{ secrets.BACKFLOW_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout PR head branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
           fetch-depth: 0
 


### PR DESCRIPTION
## Problem

`.github/workflows/dependabot-catalog-autofix.yml` (added in #987) repairs the pnpm-catalog lockfile mismatch Dependabot introduces on catalog-managed deps — it regenerates `specifier: 'catalog:'` in `pnpm-lock.yaml` and pushes the corrected lockfile to the PR head. But it pushed with the default `GITHUB_TOKEN`, and **GitHub's loop-prevention suppresses `pull_request` / `pull_request_target` runs for commits pushed by `GITHUB_TOKEN`.**

Result: every catalog-touching Dependabot group bump (devdependencies, production-frontend, production-server, production-tooling, …) lands **stale red** — the autofix commit is on the branch, but `ci.yml` never re-runs on it, so the PR keeps showing the pre-fix `ERR_PNPM_OUTDATED_LOCKFILE` failure (or "no checks reported on the branch") until a human nudges it (close/reopen, empty commit, re-dispatch). Recurring weekly-triage friction.

**Diagnosed on #1072** ("bump the devdependencies group with 8 updates"): the autofix ran green and committed `afcb48f01` ("fix(deps): restore catalog specifiers…"), but `gh pr checks 1072` reports no checks on that commit.

## Fix — Option A (App-token push)

Mint a `revfleet-backflow` GitHub App installation token (the same App that powers `backflow-main-into-test.yml`) and use it for the checkout + persisted push. An App-token push fires `synchronize` normally → `ci.yml` re-runs → the PR gets a real green check on the autofixed head.

- App token minted per-run via `actions/create-github-app-token`, scoped to **`contents: write` on this repo only** (~1h TTL).
- `GITHUB_TOKEN` downgraded to **`contents: read`** — it no longer does any writing.
- The existing `if: github.actor == 'dependabot[bot]'` guard becomes the **push-loop breaker**: the App-token push re-triggers this workflow under the App's bot actor (≠ `dependabot[bot]`), so the autofix job short-circuits — no second fix — while `ci.yml` still runs under that non-dependabot actor.

## Trade-off (why A over B / C)

| Option | What it does | Verdict |
|---|---|---|
| **A — App-token push** *(chosen)* | Push with the backflow App token → real `pull_request` CI re-fires on the corrected head, identical to any normal commit. | **Complete + durable.** Reuses infra that already exists (App installed; `BACKFLOW_*` secrets present since 2026-05-24). The PR gets the *same* gate every other PR gets. |
| B — re-dispatch CI (`gh workflow run` / `createWorkflowDispatch`) | After committing, dispatch `ci.yml` for the head ref. | **Partial.** `ci.yml` has no `workflow_dispatch` trigger; a dispatched run executes on a branch ref in `workflow_dispatch` event context — it is **not attached to the PR as a check**, and the `pull_request`/`--affected` logic diverges. `gh pr checks` would still show "no checks." Doesn't meet the bar. |
| C — validate inside the autofix workflow | Run typecheck/build in the autofix job and post a status check. | **Partial + non-durable.** Duplicates the full `ci.yml` gate inside a second workflow (drift + maintenance), and running the gate in `pull_request_target` context executes PR code. A parallel CI implementation is exactly the accidental duplication our audit-first SDLC avoids. |

A is the only option that puts the *actual* `ci.yml` checks on the corrected commit.

## Secrets

No hardcoded secrets. `BACKFLOW_APP_ID` / `BACKFLOW_APP_PRIVATE_KEY` are existing repo secrets (already set on this repo and already consumed by `backflow-main-into-test.yml`); referenced only as `${{ secrets.* }}`.

## Security

`pull_request_target` runs with the **base branch's** workflow definition, so a PR can't modify this workflow to escalate. The autofix job runs **only** for the `dependabot[bot]` actor (an external PR can't spoof it), and `pnpm install --ignore-scripts` skips lifecycle scripts so a bumped dependency can't execute code. Swapping `GITHUB_TOKEN` → App token adds no new code path to untrusted input; its only new capability is "its pushes re-fire CI," which is the goal.

## Verification

- ✅ Workflow YAML validates; `permission-contents: write` confirmed as the correct scoping input; checkout `token` wired to `steps.app-token.outputs.token`.
- ✅ **Actions secrets resolve in this Dependabot `pull_request_target` run** — confirmed empirically: the *existing* `GITHUB_TOKEN` push already lands a write commit on Dependabot PRs (`afcb48f01` on #1072), and GitHub gates token-write and secret-availability under the **same** condition, so secrets are available here. (`pull_request_target` is excepted from the standard Dependabot read-only/secret restriction.)
- ✅ Mechanism — "an App-token push fires `pull_request` workflows" — is established GitHub behaviour and already relied upon in-repo by `backflow-main-into-test.yml`.
- ✅ Local pre-push gate (Phase 1 quality + all validators) PASS.

**End-to-end is post-merge by construction.** `pull_request_target` always runs the **base-branch** copy of this workflow, and the job is gated to the `dependabot[bot]` actor — so the fixed workflow can't be exercised on this (non-Dependabot) PR, only on a real Dependabot catalog bump **after this lands on `test`**. To confirm then:

```
# On the next catalog-touching Dependabot bump (or re-trigger an existing one):
gh pr checks <n> --repo RevealUIStudio/revealui
# Expect: completed ci.yml checks on the autofix commit (github.actor = the App bot),
#         NOT "no checks reported on the branch".
```

Once on `test`, the currently-stuck catalog PRs (e.g. #1072) validate on their next `synchronize`.
