### PR TITLE
refactor(marketing): landing components to Cobalt semantic tokens (system-adaptive)

### DIFF
--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -3,27 +3,27 @@ import { ProductMockup } from '../ProductMockup';
 
 export function Demo() {
   return (
-    <section id="demo" className="bg-gray-50 py-24 sm:py-32">
+    <section id="demo" className="bg-secondary py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {HOME_DEMO.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_DEMO.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_DEMO.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_DEMO.body}</p>
         </div>
 
         <div className="mx-auto mt-16 max-w-5xl">
-          <div className="relative rounded-3xl bg-gray-950 p-2 ring-1 ring-gray-950/10 shadow-2xl">
-            <div className="relative overflow-hidden rounded-2xl bg-white">
+          <div className="relative rounded-3xl bg-foreground p-2 ring-1 ring-foreground/10 shadow-2xl">
+            <div className="relative overflow-hidden rounded-2xl bg-background">
               <ProductMockup />
             </div>
           </div>
           <p className="mt-3 text-center text-xs text-muted-foreground">
             {HOME_DEMO.mockupCaption.prefix}{' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700">
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
               {HOME_DEMO.mockupCaption.code}
             </code>
             {HOME_DEMO.mockupCaption.suffix}
@@ -32,12 +32,12 @@ export function Demo() {
 
         <div className="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3">
           {HOME_DEMO.beats.map((b) => (
-            <div key={b.n} className="rounded-2xl bg-white p-8 ring-1 ring-gray-950/5">
-              <div className="font-mono text-xs font-semibold uppercase tracking-widest text-emerald-700">
+            <div key={b.n} className="rounded-2xl bg-card p-8 ring-1 ring-border">
+              <div className="font-mono text-xs font-semibold uppercase tracking-widest text-primary">
                 {b.n}
               </div>
-              <h3 className="mt-3 text-lg font-semibold text-gray-950">{b.title}</h3>
-              <p className="mt-3 text-sm leading-6 text-gray-600">{b.body}</p>
+              <h3 className="mt-3 text-lg font-semibold text-foreground">{b.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">{b.body}</p>
             </div>
           ))}
         </div>

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -2,24 +2,24 @@ import { HOME_FAQ } from '../../content/home';
 
 export function Faq() {
   return (
-    <section className="bg-white py-24 sm:py-32">
+    <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {HOME_FAQ.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_FAQ.heading}
           </h2>
         </div>
 
-        <div className="mx-auto mt-16 max-w-3xl divide-y divide-gray-200">
+        <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
           {HOME_FAQ.items.map((item) => (
             <details key={item.question} className="group py-6">
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3 className="text-lg font-semibold leading-7 text-gray-950">{item.question}</h3>
+                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
 
-                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
+                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
                   <svg
                     className="h-4 w-4"
                     fill="none"
@@ -32,7 +32,9 @@ export function Faq() {
                   </svg>
                 </span>
               </summary>
-              <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{item.answer}</div>
+              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
+                {item.answer}
+              </div>
             </details>
           ))}
         </div>

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -4,7 +4,7 @@ import { SITE } from '../../content/site';
 
 const backgroundPrimitives = [
   {
-    color: 'text-emerald-500',
+    color: 'text-primary',
     style: { left: '4%', top: '8%', transform: 'rotate(-14deg)', width: '200px', height: '200px' },
     path: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
   },
@@ -50,10 +50,10 @@ const backgroundPrimitives = [
 
 export function Hero() {
   return (
-    <section className="relative isolate overflow-hidden bg-white px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
       {/* Brand background: warm wash + radial spotlight + faint primitive symbols */}
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute inset-0 bg-gradient-to-b from-emerald-50/40 via-white to-white" />
+        <div className="absolute inset-0 bg-gradient-to-b from-primary/5 via-background to-background" />
         <div className="absolute -top-40 left-1/2 h-[700px] w-[1100px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,oklch(0.55_0.18_245/0.18),oklch(0.55_0.18_245/0.04)_60%,transparent_80%)] blur-2xl" />
         {backgroundPrimitives.map((p) => (
           <svg
@@ -73,19 +73,19 @@ export function Hero() {
 
       <div className="relative mx-auto max-w-7xl">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 mb-6">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle mr-2 animate-pulse" />
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle mr-2 animate-pulse" />
             {HOME_HERO.eyebrow}
           </p>
 
-          <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
+          <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
             {HOME_HERO.h1}
           </h1>
 
-          <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
-            <strong className="text-gray-900">{HOME_HERO.subtitle.strong}</strong>{' '}
+          <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+            <strong className="text-foreground">{HOME_HERO.subtitle.strong}</strong>{' '}
             {HOME_HERO.subtitle.body} &mdash;{' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-base text-gray-900">
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
               {SITE.cli.create}
             </code>{' '}
             {HOME_HERO.subtitle.cliSuffix}{' '}
@@ -93,7 +93,7 @@ export function Hero() {
               href={HOME_HERO.subtitle.agencyHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium text-emerald-700 hover:underline"
+              className="font-medium text-primary hover:underline"
             >
               {HOME_HERO.subtitle.agencyLabel}
             </a>{' '}
@@ -132,36 +132,36 @@ export function Hero() {
             </ButtonCVA>
           </div>
 
-          <p className="mt-6 text-sm text-gray-600">
+          <p className="mt-6 text-sm text-muted-foreground">
             {HOME_HERO.agencyCta.prefix}{' '}
             <a
               href={HOME_HERO.agencyCta.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium text-emerald-700 hover:underline"
+              className="font-medium text-primary hover:underline"
             >
               {HOME_HERO.agencyCta.label}
             </a>
           </p>
 
-          <div className="mt-10 inline-flex items-center gap-3 rounded-xl bg-gray-950 px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-white/10">
-            <span className="select-none text-gray-400">$</span>
-            <span className="text-emerald-400">npx</span>
-            <span className="text-white">create-revealui@latest</span>
+          <div className="mt-10 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10">
+            <span className="select-none text-background/50">$</span>
+            <span className="text-primary">npx</span>
+            <span className="text-background">create-revealui@latest</span>
             <span className="text-blue-300">my-app</span>
           </div>
 
           <p className="mt-4 text-sm text-muted-foreground">{HOME_HERO.cliCaption}</p>
 
-          <div className="mt-16 border-t border-gray-100 pt-10">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-600 mb-6">
+          <div className="mt-16 border-t border-border pt-10">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-6">
               {HOME_HERO.shipsToday.heading}
             </h2>
             <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
               {HOME_HERO.shipsToday.items.map((item) => (
                 <li key={item.metric} className="flex gap-3">
                   <svg
-                    className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500"
+                    className="mt-0.5 h-4 w-4 shrink-0 text-primary"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                     aria-hidden="true"
@@ -174,7 +174,7 @@ export function Hero() {
                     />
                   </svg>
                   <div>
-                    <p className="text-sm font-medium text-gray-900">{item.metric}</p>
+                    <p className="text-sm font-medium text-foreground">{item.metric}</p>
                     <p className="mt-0.5 text-sm text-muted-foreground">{item.detail}</p>
                   </div>
                 </li>

--- a/apps/marketing/app/components/landing/Persona.tsx
+++ b/apps/marketing/app/components/landing/Persona.tsx
@@ -2,29 +2,29 @@ import { PERSONA_CARD, PERSONA_SECTION } from '../../content/persona';
 
 export function Persona() {
   return (
-    <section className="bg-gray-50 py-24 sm:py-32">
+    <section className="bg-secondary py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {PERSONA_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PERSONA_SECTION.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl">
-          <div className="rounded-2xl bg-white p-10 ring-1 ring-gray-950/5 shadow-sm">
+          <div className="rounded-2xl bg-card p-10 ring-1 ring-border shadow-sm">
             <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
               {PERSONA_CARD.label}
             </p>
-            <p className="mt-4 text-xl leading-8 italic text-gray-700">{PERSONA_CARD.quote}</p>
+            <p className="mt-4 text-xl leading-8 italic text-foreground">{PERSONA_CARD.quote}</p>
 
             <ul className="mt-10 space-y-4">
               {PERSONA_CARD.checklist.map((item) => (
-                <li key={item} className="flex items-start gap-3 text-base text-gray-700">
+                <li key={item} className="flex items-start gap-3 text-base text-foreground">
                   <svg
-                    className="mt-1 h-5 w-5 flex-shrink-0 text-emerald-500"
+                    className="mt-1 h-5 w-5 flex-shrink-0 text-primary"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -43,9 +43,9 @@ export function Persona() {
 
           <p className="mt-8 text-center text-sm text-muted-foreground">
             {PERSONA_CARD.footer.prefix}{' '}
-            <span className="font-medium text-gray-700">{PERSONA_CARD.footer.sprawl}</span>{' '}
+            <span className="font-medium text-foreground">{PERSONA_CARD.footer.sprawl}</span>{' '}
             {PERSONA_CARD.footer.sprawlNote}{' '}
-            <span className="font-medium text-gray-700">{PERSONA_CARD.footer.studios}</span>{' '}
+            <span className="font-medium text-foreground">{PERSONA_CARD.footer.studios}</span>{' '}
             {PERSONA_CARD.footer.studiosNote}
           </p>
         </div>

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -51,16 +51,18 @@ export function PricingTeaser() {
   }, []);
 
   return (
-    <section className="bg-gray-50 py-24 sm:py-32">
+    <section className="bg-secondary py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {PRICING_TEASER_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_TEASER_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{PRICING_TEASER_SECTION.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {PRICING_TEASER_SECTION.body}
+          </p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
@@ -71,12 +73,12 @@ export function PricingTeaser() {
                 key={t.id}
                 className={`relative flex flex-col rounded-2xl p-8 ring-1 transition ${
                   t.highlight
-                    ? 'bg-gray-950 text-white ring-gray-950 shadow-xl'
-                    : 'bg-white text-gray-950 ring-gray-950/10 hover:ring-gray-950/20'
+                    ? 'bg-foreground text-background ring-foreground shadow-xl'
+                    : 'bg-card text-foreground ring-border hover:ring-border/80'
                 }`}
               >
                 {t.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-700 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary-foreground">
                     Most popular
                   </div>
                 )}
@@ -85,7 +87,7 @@ export function PricingTeaser() {
                   <span className="text-4xl font-bold tracking-tight">{price}</span>
                   {period && (
                     <span
-                      className={`text-sm ${t.highlight ? 'text-gray-400' : 'text-muted-foreground'}`}
+                      className={`text-sm ${t.highlight ? 'text-background/60' : 'text-muted-foreground'}`}
                     >
                       {period}
                     </span>
@@ -93,7 +95,7 @@ export function PricingTeaser() {
                 </div>
                 <p
                   className={`mt-4 text-sm leading-6 ${
-                    t.highlight ? 'text-gray-300' : 'text-gray-600'
+                    t.highlight ? 'text-background/70' : 'text-muted-foreground'
                   }`}
                 >
                   {t.description}
@@ -104,12 +106,12 @@ export function PricingTeaser() {
                     <li
                       key={f}
                       className={`flex items-start gap-2 text-sm ${
-                        t.highlight ? 'text-gray-200' : 'text-gray-700'
+                        t.highlight ? 'text-background/80' : 'text-foreground'
                       }`}
                     >
                       <svg
                         className={`mt-0.5 h-4 w-4 flex-shrink-0 ${
-                          t.highlight ? 'text-emerald-400' : 'text-emerald-500'
+                          t.highlight ? 'text-primary' : 'text-primary'
                         }`}
                         fill="currentColor"
                         viewBox="0 0 20 20"
@@ -131,7 +133,7 @@ export function PricingTeaser() {
                     <ButtonCVA
                       asChild
                       size="default"
-                      className="w-full bg-white text-gray-950 hover:bg-gray-100"
+                      className="w-full bg-background text-foreground hover:bg-secondary"
                     >
                       <a href={t.href}>{t.cta}</a>
                     </ButtonCVA>
@@ -157,7 +159,7 @@ export function PricingTeaser() {
           </ButtonCVA>
           <p className="mt-6 text-xs leading-5 text-muted-foreground">
             {PRICING_TEASER_FOOTER.caption.prefix}{' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700">
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
               {PRICING_TEASER_FOOTER.caption.code}
             </code>{' '}
             {PRICING_TEASER_FOOTER.caption.suffix}

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -2,7 +2,7 @@ import { ButtonCVA } from '@revealui/presentation';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 
 const accentBg: Record<string, string> = {
-  emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  emerald: 'bg-primary/10 text-primary ring-primary/20',
   blue: 'bg-blue-50 text-blue-700 ring-blue-200',
   amber: 'bg-amber-50 text-amber-700 ring-amber-200',
   cyan: 'bg-cyan-50 text-cyan-700 ring-cyan-200',
@@ -11,23 +11,25 @@ const accentBg: Record<string, string> = {
 
 export function Primitives() {
   return (
-    <section className="bg-white py-24 sm:py-32">
+    <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {HOME_PRIMITIVES_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_PRIMITIVES_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_PRIMITIVES_SECTION.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {HOME_PRIMITIVES_SECTION.body}
+          </p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
           {HOME_PRIMITIVES.map((p) => (
             <div
               key={p.label}
-              className="flex flex-col items-start rounded-2xl bg-white p-6 ring-1 ring-gray-950/5 transition hover:ring-gray-950/10"
+              className="flex flex-col items-start rounded-2xl bg-card p-6 ring-1 ring-border transition hover:ring-border/80"
             >
               <div
                 className={`mb-5 flex h-10 w-10 items-center justify-center rounded-xl ring-1 ${accentBg[p.color]}`}
@@ -43,8 +45,8 @@ export function Primitives() {
                   <path strokeLinecap="round" strokeLinejoin="round" d={p.iconPath} />
                 </svg>
               </div>
-              <h3 className="text-base font-semibold text-gray-950">{p.label}</h3>
-              <p className="mt-2 text-sm leading-6 text-gray-600">{p.body}</p>
+              <h3 className="text-base font-semibold text-foreground">{p.label}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{p.body}</p>
             </div>
           ))}
         </div>

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -2,19 +2,19 @@ import { HOME_PROBLEM } from '../../content/home';
 
 export function Problem() {
   return (
-    <section className="bg-white py-24 sm:py-32">
+    <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {HOME_PROBLEM.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_PROBLEM.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{HOME_PROBLEM.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
         </div>
 
-        <div className="mx-auto mt-16 max-w-6xl overflow-hidden rounded-2xl ring-1 ring-gray-950/10 shadow-sm">
+        <div className="mx-auto mt-16 max-w-6xl overflow-hidden rounded-2xl ring-1 ring-border shadow-sm">
           <section
             // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable comparison table — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally on narrow viewports
             tabIndex={0}
@@ -23,7 +23,7 @@ export function Problem() {
           >
             <table className="w-full text-left text-sm">
               <thead>
-                <tr className="bg-gray-50 text-xs font-semibold uppercase tracking-widest text-gray-600">
+                <tr className="bg-secondary text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
                     {HOME_PROBLEM.columns.capability}
                   </th>
@@ -33,21 +33,20 @@ export function Problem() {
                   <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
                     {HOME_PROBLEM.columns.agentOnly}
                   </th>
-                  <th
-                    scope="col"
-                    className="bg-emerald-50 px-4 py-3 text-emerald-800 sm:px-6 sm:py-4"
-                  >
+                  <th scope="col" className="bg-primary/10 px-4 py-3 text-primary sm:px-6 sm:py-4">
                     {HOME_PROBLEM.columns.revealui}
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
+              <tbody className="divide-y divide-border bg-card">
                 {HOME_PROBLEM.rows.map((r) => (
-                  <tr key={r.capability} className="hover:bg-gray-50/60 transition">
-                    <td className="px-4 py-4 font-medium text-gray-950 sm:px-6">{r.capability}</td>
-                    <td className="px-4 py-4 text-gray-600 sm:px-6">{r.sprawl}</td>
-                    <td className="px-4 py-4 text-gray-600 sm:px-6">{r.agentOnly}</td>
-                    <td className="bg-emerald-50/40 px-4 py-4 font-medium text-emerald-900 sm:px-6">
+                  <tr key={r.capability} className="hover:bg-secondary/60 transition">
+                    <td className="px-4 py-4 font-medium text-foreground sm:px-6">
+                      {r.capability}
+                    </td>
+                    <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.sprawl}</td>
+                    <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.agentOnly}</td>
+                    <td className="bg-primary/5 px-4 py-4 font-medium text-primary sm:px-6">
                       {r.revealui}
                     </td>
                   </tr>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -10,31 +10,31 @@ import {
 
 export function Proof() {
   return (
-    <section className="bg-white py-24 sm:py-32">
+    <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {PROOF_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PROOF_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{PROOF_SECTION.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Repo signals */}
-          <div className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-950/5">
+          <div className="rounded-2xl bg-secondary p-8 ring-1 ring-border">
             <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
               {PROOF_REPO_SIGNALS.eyebrow}
             </p>
-            <h3 className="mt-2 text-xl font-semibold text-gray-950">
+            <h3 className="mt-2 text-xl font-semibold text-foreground">
               {PROOF_REPO_SIGNALS.heading}
             </h3>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <a
                 href={PROOF_REPO_SIGNALS.repoHref}
-                className="inline-flex items-center gap-2 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:ring-gray-400 transition"
+                className="inline-flex items-center gap-2 rounded-md bg-card px-3 py-1.5 text-sm font-medium text-foreground ring-1 ring-border hover:ring-border/80 transition"
               >
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                   <title>GitHub</title>
@@ -51,31 +51,31 @@ export function Proof() {
               <img
                 alt="Contributors"
                 src="https://img.shields.io/github/contributors/RevealUIStudio/revealui?style=flat&label=Contributors&color=10b981"
-                className="h-7 rounded-md ring-1 ring-gray-300"
+                className="h-7 rounded-md ring-1 ring-border"
               />
               {/* biome-ignore lint/performance/noImgElement: dynamic shields.io SVG badge, no image optimizer in Vite SPA */}
               <img
                 alt="Last commit"
                 src="https://img.shields.io/github/last-commit/RevealUIStudio/revealui?style=flat&label=Last%20commit&color=10b981"
-                className="h-7 rounded-md ring-1 ring-gray-300"
+                className="h-7 rounded-md ring-1 ring-border"
               />
               {/* biome-ignore lint/performance/noImgElement: dynamic shields.io SVG badge, no image optimizer in Vite SPA */}
               <img
                 alt="License"
                 src="https://img.shields.io/github/license/RevealUIStudio/revealui?style=flat&color=10b981"
-                className="h-7 rounded-md ring-1 ring-gray-300"
+                className="h-7 rounded-md ring-1 ring-border"
               />
             </div>
 
-            <div className="mt-6 border-t border-gray-200 pt-6">
+            <div className="mt-6 border-t border-border pt-6">
               <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
                 {PROOF_REPO_SIGNALS.ciLabel}
               </p>
               <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {PROOF_CI_SIGNALS.map((s) => (
-                  <li key={s} className="flex items-center gap-2 text-sm text-gray-700">
+                  <li key={s} className="flex items-center gap-2 text-sm text-foreground">
                     <svg
-                      className="h-4 w-4 flex-shrink-0 text-emerald-500"
+                      className="h-4 w-4 flex-shrink-0 text-primary"
                       fill="currentColor"
                       viewBox="0 0 20 20"
                     >
@@ -94,21 +94,23 @@ export function Proof() {
           </div>
 
           {/* Stack standards */}
-          <div className="rounded-2xl bg-gray-950 p-8 text-white">
-            <p className="text-xs font-semibold uppercase tracking-widest text-emerald-400">
+          <div className="rounded-2xl bg-card p-8">
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary">
               {PROOF_STACK_PANEL.eyebrow}
             </p>
-            <h3 className="mt-2 text-xl font-semibold">{PROOF_STACK_PANEL.heading}</h3>
-            <p className="mt-3 text-sm leading-6 text-gray-300">{PROOF_STACK_PANEL.body}</p>
+            <h3 className="mt-2 text-xl font-semibold text-foreground">
+              {PROOF_STACK_PANEL.heading}
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{PROOF_STACK_PANEL.body}</p>
 
             <ul className="mt-6 grid grid-cols-2 gap-3">
               {PROOF_STACK.map((s) => (
                 <li
                   key={s.label}
-                  className="rounded-lg bg-white/5 px-3 py-2.5 ring-1 ring-white/10"
+                  className="rounded-lg bg-secondary px-3 py-2.5 ring-1 ring-border"
                 >
-                  <div className="text-sm font-semibold text-white">{s.label}</div>
-                  <div className="text-xs text-gray-400">{s.kind}</div>
+                  <div className="text-sm font-semibold text-foreground">{s.label}</div>
+                  <div className="text-xs text-muted-foreground">{s.kind}</div>
                 </li>
               ))}
             </ul>
@@ -121,33 +123,33 @@ export function Proof() {
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {PROOF_TRUST.eyebrow}
             </p>
-            <h3 className="mt-3 text-2xl font-bold tracking-tight text-gray-950 sm:text-3xl">
+            <h3 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
               {PROOF_TRUST.heading}
             </h3>
           </div>
 
           <div className="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-3">
-            <div className="rounded-2xl bg-emerald-50/40 p-6 ring-1 ring-emerald-200">
-              <p className="text-xs font-semibold uppercase tracking-widest text-emerald-800">
+            <div className="rounded-2xl bg-primary/10 p-6 ring-1 ring-primary/20">
+              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
                 {PROOF_TRUST.cards[0].eyebrow}
               </p>
-              <h4 className="mt-3 text-base font-semibold text-gray-950">
+              <h4 className="mt-3 text-base font-semibold text-foreground">
                 {PROOF_TRUST.cards[0].heading}
               </h4>
-              <p className="mt-2 text-sm leading-6 text-gray-700">
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 {PROOF_TRUST.cards[0].body.prefix}{' '}
                 <a
                   href={PROOF_TRUST.cards[0].body.licenseHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {PROOF_TRUST.cards[0].body.licenseLabel}
                 </a>{' '}
                 {PROOF_TRUST.cards[0].body.middle}{' '}
                 <a
                   href={PROOF_TRUST.cards[0].body.explainerHref}
-                  className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {PROOF_TRUST.cards[0].body.explainerLabel}
                 </a>
@@ -155,24 +157,26 @@ export function Proof() {
               </p>
             </div>
 
-            <div className="rounded-2xl bg-gray-950 p-6 ring-1 ring-gray-950/10 text-white">
-              <p className="text-xs font-semibold uppercase tracking-widest text-emerald-400">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
                 {PROOF_TRUST.cards[1].eyebrow}
               </p>
-              <h4 className="mt-3 text-base font-semibold">{PROOF_TRUST.cards[1].heading}</h4>
+              <h4 className="mt-3 text-base font-semibold text-foreground">
+                {PROOF_TRUST.cards[1].heading}
+              </h4>
               <pre
                 // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable code region — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally
                 tabIndex={0}
-                className="mt-3 overflow-x-auto rounded-lg bg-black/40 px-3 py-2 font-mono text-[11px] leading-5 text-gray-300 ring-1 ring-white/10"
+                className="mt-3 overflow-x-auto rounded-lg bg-secondary px-3 py-2 font-mono text-[11px] leading-5 text-muted-foreground ring-1 ring-border"
               >
                 {PROOF_TRUST.cards[1].codeSnippet}
               </pre>
-              <p className="mt-3 text-xs leading-5 text-gray-400">
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">
                 <a
                   href={PROOF_TRUST.cards[1].fileHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-emerald-400 underline decoration-emerald-700 underline-offset-4 hover:text-emerald-300"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {PROOF_TRUST.cards[1].fileLabel}
                 </a>{' '}
@@ -180,29 +184,29 @@ export function Proof() {
               </p>
             </div>
 
-            <div className="rounded-2xl bg-emerald-50/40 p-6 ring-1 ring-emerald-200">
-              <p className="text-xs font-semibold uppercase tracking-widest text-emerald-800">
+            <div className="rounded-2xl bg-primary/10 p-6 ring-1 ring-primary/20">
+              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
                 {PROOF_TRUST.cards[2].eyebrow}
               </p>
-              <h4 className="mt-3 text-base font-semibold text-gray-950">
+              <h4 className="mt-3 text-base font-semibold text-foreground">
                 {PROOF_TRUST.cards[2].heading}
               </h4>
-              <p className="mt-2 text-sm leading-6 text-gray-700">
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 {PROOF_TRUST.cards[2].body.prefix}{' '}
                 <a
                   href={PROOF_TRUST.cards[2].body.agencyHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {PROOF_TRUST.cards[2].body.agencyLabel}
                 </a>{' '}
                 {PROOF_TRUST.cards[2].body.middle}{' '}
-                <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-gray-900 ring-1 ring-emerald-200">
+                <code className="rounded bg-card px-1 py-0.5 font-mono text-xs text-foreground ring-1 ring-primary/20">
                   {PROOF_TRUST.cards[2].body.pkg1}
                 </code>{' '}
                 {PROOF_TRUST.cards[2].body.plus}{' '}
-                <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-gray-900 ring-1 ring-emerald-200">
+                <code className="rounded bg-card px-1 py-0.5 font-mono text-xs text-foreground ring-1 ring-primary/20">
                   {PROOF_TRUST.cards[2].body.pkg2}
                 </code>
                 {PROOF_TRUST.cards[2].body.suffix}{' '}
@@ -210,7 +214,7 @@ export function Proof() {
                   href={PROOF_TRUST.cards[2].body.sourceHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {PROOF_TRUST.cards[2].body.sourceLabel}
                 </a>

--- a/apps/marketing/app/components/landing/WhatsShipped.tsx
+++ b/apps/marketing/app/components/landing/WhatsShipped.tsx
@@ -2,16 +2,18 @@ import { CAPABILITIES, CAPABILITIES_SECTION } from '../../content/capabilities';
 
 export function WhatsShipped() {
   return (
-    <section className="bg-white py-24 sm:py-32">
+    <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
             {CAPABILITIES_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {CAPABILITIES_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{CAPABILITIES_SECTION.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {CAPABILITIES_SECTION.body}
+          </p>
         </div>
 
         <div className="mx-auto mt-16 grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -21,13 +23,13 @@ export function WhatsShipped() {
               href={c.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex flex-col rounded-2xl bg-gray-50 p-6 ring-1 ring-gray-200 no-underline transition hover:bg-white hover:ring-gray-950/10 hover:shadow-sm"
+              className="group flex flex-col rounded-2xl bg-secondary p-6 ring-1 ring-border no-underline transition hover:bg-card hover:ring-border/80 hover:shadow-sm"
             >
-              <h3 className="text-base font-semibold text-gray-950 group-hover:text-emerald-800">
+              <h3 className="text-base font-semibold text-foreground group-hover:text-primary">
                 {c.title}
               </h3>
-              <p className="mt-2 flex-1 text-sm leading-6 text-gray-600">{c.body}</p>
-              <code className="mt-4 inline-block self-start rounded bg-white px-2 py-1 font-mono text-[11px] text-emerald-800 ring-1 ring-emerald-200 group-hover:bg-emerald-50">
+              <p className="mt-2 flex-1 text-sm leading-6 text-muted-foreground">{c.body}</p>
+              <code className="mt-4 inline-block self-start rounded bg-card px-2 py-1 font-mono text-[11px] text-primary ring-1 ring-primary/20 group-hover:bg-primary/10">
                 {c.path}
               </code>
             </a>


### PR DESCRIPTION
## What

Sweeps the 9 marketing **landing components** from raw `emerald-*`/`gray-*` Tailwind utilities to theme-following **semantic tokens**, so they render correctly in light **and** dark — continuing the Cobalt system-adaptive adoption (after the app-shell + `@source` fix in #1114).

Files: `Hero`, `Proof`, `PricingTeaser`, `Problem`, `Demo`, `Persona`, `WhatsShipped`, `Primitives`, `Faq`.

- `gray-*` → `foreground` / `muted-foreground` / `background` / `card` / `secondary` / `border`
- `emerald-*` (brand) → `primary` / `primary/10` / `primary/20`
- **Dark sections** reclassified: theme-following (`bg-card`/`bg-secondary`) where the darkness was stylistic; **intentional-inverse** (`bg-foreground text-background`) for the Hero CLI block, the PricingTeaser highlight CTA card, and the Demo device bezel (kept high-contrast against the page).
- Multi-hue **primitive accents** (`blue`/`amber`/`cyan`/`violet` — Content/Products/Payments/Intelligence) preserved untouched.

## Verification

- Zero residual raw `emerald-*`/`gray-*`/`white` in the 9 files.
- `pnpm --filter marketing typecheck` clean (exit 0); `biome check` clean.
- Dev server, **both themes**: Hero / Demo / pricing teaser / etc. render correctly — light surfaces in light, dark in dark; CTAs filled Cobalt; primitive accents intact.

## Notes / follow-up

- `components/ProductMockup.tsx` (outside this chunk's `landing/` scope) still uses raw palette (renders via the in-place remap) + shows a `vercelBlobStorage` example string — to be refreshed in a later chunk / the copy pass.
- The theme "flip" (removing the `data-theme="light"` lock + palette-remap) stays a later, coordinated step (gated on the pricing peer's dark-safe sweep).
