### PR TITLE
refactor(marketing): route pages + GetStarted to Cobalt semantic tokens

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -4,23 +4,18 @@ import { NewsletterSignup } from './NewsletterSignup';
 
 export function GetStarted() {
   return (
-    <section className="py-24 bg-gray-950 sm:py-32">
+    <section className="py-24 bg-card sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_GET_STARTED.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-400">{HOME_GET_STARTED.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_GET_STARTED.body}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">
+            <ButtonCVA asChild size="lg" variant="primary">
               <a href={HOME_GET_STARTED.cta.primary.href}>{HOME_GET_STARTED.cta.primary.label}</a>
             </ButtonCVA>
-            <ButtonCVA
-              asChild
-              variant="outline"
-              size="lg"
-              className="border-gray-700 text-gray-300 hover:text-white hover:border-gray-500"
-            >
+            <ButtonCVA asChild variant="outline" size="lg">
               <a href={HOME_GET_STARTED.cta.secondary.href}>
                 {HOME_GET_STARTED.cta.secondary.label}
                 <svg
@@ -42,8 +37,8 @@ export function GetStarted() {
           </div>
 
           {/* Newsletter */}
-          <div className="mt-16 pt-10 border-t border-gray-800">
-            <p className="text-sm font-medium text-gray-400 mb-4">
+          <div className="mt-16 pt-10 border-t border-border">
+            <p className="text-sm font-medium text-muted-foreground mb-4">
               {HOME_GET_STARTED.newsletter.label}
             </p>
             <NewsletterSignup variant="stacked" />

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -79,14 +79,14 @@ export function BlogIndexPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-background to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Blog
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
             Updates, guides, and insights from the RevealUI team.
           </p>
         </div>
@@ -97,7 +97,7 @@ export function BlogIndexPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           {posts.length === 0 ? (
             <div className="mx-auto max-w-2xl text-center">
-              <p className="text-lg text-gray-600">
+              <p className="text-lg text-muted-foreground">
                 No posts yet. Check back soon for updates from the RevealUI team.
               </p>
             </div>
@@ -106,7 +106,7 @@ export function BlogIndexPage() {
               {posts.map((post) => (
                 <article
                   key={post.id}
-                  className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200 hover:ring-blue-300 transition-all"
+                  className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-blue-300 transition-all"
                 >
                   <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
                     <time dateTime={post.publishedAt ?? post.createdAt}>
@@ -114,7 +114,7 @@ export function BlogIndexPage() {
                     </time>
                     {post.author && <span>{post.author}</span>}
                   </div>
-                  <h3 className="mt-3 text-xl font-bold tracking-tight text-gray-900">
+                  <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
                     <a
                       href={`/blog/${post.slug}`}
                       className="hover:text-blue-600 transition-colors"
@@ -122,7 +122,7 @@ export function BlogIndexPage() {
                       {post.title}
                     </a>
                   </h3>
-                  <p className="mt-4 text-sm leading-6 text-gray-600">
+                  <p className="mt-4 text-sm leading-6 text-muted-foreground">
                     {post.excerpt ?? getExcerpt(post.content)}
                   </p>
                   <a
@@ -137,9 +137,9 @@ export function BlogIndexPage() {
           )}
 
           {/* Newsletter capture */}
-          <div className="mx-auto mt-16 max-w-2xl rounded-2xl bg-gray-50 p-8 text-center ring-1 ring-gray-200">
-            <h3 className="text-lg font-semibold text-gray-900">Get notified when we publish</h3>
-            <p className="mt-2 text-sm text-gray-600 mb-6">
+          <div className="mx-auto mt-16 max-w-2xl rounded-2xl bg-secondary p-8 text-center ring-1 ring-border">
+            <h3 className="text-lg font-semibold text-foreground">Get notified when we publish</h3>
+            <p className="mt-2 text-sm text-muted-foreground mb-6">
               Engineering insights, product updates, and launch announcements. No spam.
             </p>
             <NewsletterSignup variant="stacked" />

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -78,7 +78,7 @@ export function BlogPostPage() {
 
   if (loading && !post) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-background">
         <div className="mx-auto max-w-3xl px-6 py-32 text-center text-muted-foreground">
           Loading…
         </div>
@@ -89,13 +89,13 @@ export function BlogPostPage() {
 
   if (!post) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-background">
         <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">404</p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+          <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Post not found
           </h1>
-          <p className="mt-4 max-w-md text-base text-gray-600">
+          <p className="mt-4 max-w-md text-base text-muted-foreground">
             That blog post does not exist or has been removed.
           </p>
           <a
@@ -111,7 +111,7 @@ export function BlogPostPage() {
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <article className="py-24 sm:py-32">
         <div className="mx-auto max-w-3xl px-6 lg:px-8">
           {/* Back link */}
@@ -130,7 +130,7 @@ export function BlogPostPage() {
               </time>
               {post.author && <span>{post.author}</span>}
             </div>
-            <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            <h1 className="mt-2 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
               {post.title}
             </h1>
           </header>
@@ -148,24 +148,24 @@ export function BlogPostPage() {
         </div>
       </article>
 
-      <section className="border-t border-gray-100 bg-gray-50 py-16 sm:py-20">
+      <section className="border-t border-border bg-secondary py-16 sm:py-20">
         <div className="mx-auto max-w-3xl px-6 lg:px-8 text-center">
-          <h2 className="text-2xl font-bold tracking-tight text-gray-950 sm:text-3xl">
+          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             Ready to build?
           </h2>
-          <p className="mt-4 text-base leading-7 text-gray-600">
+          <p className="mt-4 text-base leading-7 text-muted-foreground">
             Users, content, products, payments, and AI, pre-wired. Start locally in minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
               href="https://admin.revealui.com/signup"
-              className="rounded-md bg-gray-950 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
+              className="rounded-md bg-foreground px-6 py-3 text-sm font-semibold text-background shadow-sm hover:bg-foreground/80 transition-colors"
             >
               Start free
             </a>
             <a
               href="https://docs.revealui.com"
-              className="rounded-md bg-white px-6 py-3 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-gray-200 hover:bg-gray-50 transition-colors"
+              className="rounded-md bg-card px-6 py-3 text-sm font-semibold text-foreground shadow-sm ring-1 ring-border hover:bg-muted transition-colors"
             >
               Read the docs
             </a>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -4,14 +4,14 @@ import { CONTACT_HERO, CONTACT_METHODS } from '../content/contact';
 
 export function ContactPage() {
   return (
-    <div className="min-h-screen bg-white">
-      <section className="relative overflow-hidden bg-gradient-to-br from-gray-50 via-white to-gray-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+    <div className="min-h-screen bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-br from-secondary via-background to-secondary px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-2xl">
           <div className="text-center mb-12">
-            <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
               {CONTACT_HERO.title}
             </h1>
-            <p className="mt-6 text-lg leading-8 text-gray-600">{CONTACT_HERO.subtitle}</p>
+            <p className="mt-6 text-lg leading-8 text-muted-foreground">{CONTACT_HERO.subtitle}</p>
           </div>
 
           <ContactForm />
@@ -19,8 +19,8 @@ export function ContactPage() {
           <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-3 text-center">
             {CONTACT_METHODS.map((method) => (
               <div key={method.title}>
-                <h3 className="text-sm font-semibold text-gray-900">{method.title}</h3>
-                <p className="mt-2 text-sm text-gray-600">
+                <h3 className="text-sm font-semibold text-foreground">{method.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">
                   {method.body ? <>{method.body} </> : null}
                   <a
                     href={method.href}

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -30,12 +30,12 @@ export function FairSourcePage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative isolate overflow-hidden bg-white px-6 pt-20 pb-16 sm:pt-28 sm:pb-20 lg:px-8">
+      <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-16 sm:pt-28 sm:pb-20 lg:px-8">
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-emerald-50/40 via-white to-white"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
         />
         <div
           aria-hidden="true"
@@ -43,23 +43,23 @@ export function FairSourcePage() {
         />
 
         <div className="relative mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 mb-6">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 align-middle mr-2" />
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle mr-2" />
             {FAIR_SOURCE_HERO.eyebrow}
           </p>
-          <h1 className="text-5xl font-bold tracking-tight text-gray-950 sm:text-6xl lg:text-7xl">
+          <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
             {FAIR_SOURCE_HERO.headline}
-            <span className="block text-emerald-700">{FAIR_SOURCE_HERO.headlineHighlight}</span>
+            <span className="block text-primary">{FAIR_SOURCE_HERO.headlineHighlight}</span>
           </h1>
-          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-gray-600 sm:text-2xl">
+          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-muted-foreground sm:text-2xl">
             {FAIR_SOURCE_HERO.subhead}
           </p>
-          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-gray-600">
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
             {/* COUNT: packages-fsl = 5, packages-mit = 21 (of 26 total — see /packages/ in repo) */}
             {FAIR_SOURCE_HERO.body.prefix}{' '}
             <a
               href={FAIR_SOURCE_HERO.body.fslHref}
-              className="font-medium text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-800"
+              className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
             >
               {FAIR_SOURCE_HERO.body.fslLabel}
             </a>{' '}
@@ -69,13 +69,13 @@ export function FairSourcePage() {
       </section>
 
       {/* The contract */}
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-background py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_CONTRACT_SECTION.eyebrow}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {FAIR_SOURCE_CONTRACT_SECTION.heading}
             </h2>
           </div>
@@ -86,14 +86,14 @@ export function FairSourcePage() {
                 key={c.title}
                 className={`rounded-2xl p-6 ring-1 transition ${
                   c.kind === 'yes'
-                    ? 'bg-emerald-50/40 ring-emerald-200'
+                    ? 'bg-primary/10 ring-primary/20'
                     : 'bg-amber-50/40 ring-amber-200'
                 }`}
               >
                 <div className="flex items-start gap-3">
                   {c.kind === 'yes' ? (
                     <svg
-                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-emerald-600"
+                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-primary"
                       fill="currentColor"
                       viewBox="0 0 20 20"
                       aria-hidden="true"
@@ -121,8 +121,8 @@ export function FairSourcePage() {
                     </svg>
                   )}
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-950">{c.title}</h3>
-                    <p className="mt-2 text-sm leading-6 text-gray-700">{c.body}</p>
+                    <h3 className="text-lg font-semibold text-foreground">{c.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{c.body}</p>
                   </div>
                 </div>
               </div>
@@ -132,27 +132,27 @@ export function FairSourcePage() {
       </section>
 
       {/* Which packages */}
-      <section className="bg-gray-50 py-16 sm:py-24">
+      <section className="bg-secondary py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_PACKAGES_SECTION.eyebrow}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {FAIR_SOURCE_PACKAGES_SECTION.heading}
             </h2>
-            <p className="mt-6 text-base leading-7 text-gray-600">
+            <p className="mt-6 text-base leading-7 text-muted-foreground">
               {FAIR_SOURCE_PACKAGES_SECTION.body.prefix}{' '}
-              <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-sm text-gray-900">
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-sm text-foreground">
                 {FAIR_SOURCE_PACKAGES_SECTION.body.privatePackage}
               </code>{' '}
               {FAIR_SOURCE_PACKAGES_SECTION.body.suffix}
             </p>
           </div>
 
-          <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-white ring-1 ring-gray-950/5">
+          <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
             <table className="w-full text-left text-sm">
-              <thead className="bg-gray-100 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                 <tr>
                   <th className="px-6 py-3">Package</th>
                   <th className="px-6 py-3">Purpose</th>
@@ -160,13 +160,13 @@ export function FairSourcePage() {
                   <th className="px-6 py-3">Source</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
+              <tbody className="divide-y divide-border">
                 {FAIR_SOURCE_PACKAGES.map((p) => (
                   <tr key={p.name}>
-                    <td className="px-6 py-4 font-mono text-sm font-semibold text-gray-950">
+                    <td className="px-6 py-4 font-mono text-sm font-semibold text-foreground">
                       {p.name}
                     </td>
-                    <td className="px-6 py-4 text-gray-700">{p.purpose}</td>
+                    <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
                     <td className="px-6 py-4">
                       <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
                         {p.license}
@@ -177,16 +177,16 @@ export function FairSourcePage() {
                         href={p.repo}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-emerald-700 hover:text-emerald-800"
+                        className="text-primary hover:text-primary/80"
                       >
                         GitHub
                       </a>
-                      <span className="px-2 text-gray-300">·</span>
+                      <span className="px-2 text-muted-foreground/40">·</span>
                       <a
                         href={p.npm}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-emerald-700 hover:text-emerald-800"
+                        className="text-primary hover:text-primary/80"
                       >
                         npm
                       </a>
@@ -198,7 +198,7 @@ export function FairSourcePage() {
           </div>
           <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground">
             {FAIR_SOURCE_PACKAGES_SECTION.footer.prefix}{' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
               {FAIR_SOURCE_PACKAGES_SECTION.footer.command}
             </code>{' '}
             {FAIR_SOURCE_PACKAGES_SECTION.footer.suffix}
@@ -207,33 +207,33 @@ export function FairSourcePage() {
       </section>
 
       {/* The two-year clock */}
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-background py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_CLOCK_SECTION.eyebrow}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {FAIR_SOURCE_CLOCK_SECTION.heading}
             </h2>
-            <p className="mt-6 text-base leading-7 text-gray-600">
+            <p className="mt-6 text-base leading-7 text-muted-foreground">
               {FAIR_SOURCE_CLOCK_SECTION.body}
             </p>
           </div>
 
           <div className="mx-auto mt-12 max-w-3xl">
-            <ol className="relative border-l-2 border-emerald-200 pl-8">
+            <ol className="relative border-l-2 border-primary/20 pl-8">
               {FAIR_SOURCE_CLOCK_SECTION.steps.map((step) => (
                 <li key={step.title} className="mb-8 last:mb-0">
                   <span
-                    className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-white ${
-                      step.color === 'emerald' ? 'bg-emerald-600' : 'bg-amber-600'
+                    className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
+                      step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
                     }`}
                   >
                     <span className="h-1.5 w-1.5 rounded-full bg-white" />
                   </span>
-                  <h3 className="font-semibold text-gray-950">{step.title}</h3>
-                  <p className="mt-1 text-sm text-gray-600">{step.body}</p>
+                  <h3 className="font-semibold text-foreground">{step.title}</h3>
+                  <p className="mt-1 text-sm text-muted-foreground">{step.body}</p>
                 </li>
               ))}
             </ol>
@@ -242,13 +242,13 @@ export function FairSourcePage() {
       </section>
 
       {/* In good company */}
-      <section className="bg-gray-50 py-16 sm:py-24">
+      <section className="bg-secondary py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_PEERS_SECTION.eyebrow}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {FAIR_SOURCE_PEERS_SECTION.heading}
             </h2>
           </div>
@@ -260,11 +260,11 @@ export function FairSourcePage() {
                 href={p.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-2xl bg-white p-6 ring-1 ring-gray-950/5 no-underline transition hover:ring-gray-950/10"
+                className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
               >
-                <h3 className="text-lg font-semibold text-gray-950">{p.name}</h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">{p.note}</p>
-                <p className="mt-3 text-xs font-medium text-emerald-700">Read their post &rarr;</p>
+                <h3 className="text-lg font-semibold text-foreground">{p.name}</h3>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">{p.note}</p>
+                <p className="mt-3 text-xs font-medium text-primary">Read their post &rarr;</p>
               </a>
             ))}
           </div>
@@ -272,23 +272,23 @@ export function FairSourcePage() {
       </section>
 
       {/* FAQ */}
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-background py-16 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
               {FAIR_SOURCE_FAQ_SECTION.eyebrow}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {FAIR_SOURCE_FAQ_SECTION.heading}
             </h2>
           </div>
 
-          <div className="mx-auto mt-12 max-w-3xl divide-y divide-gray-200">
+          <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
             {FAIR_SOURCE_FAQS.map((f) => (
               <details key={f.question} className="group py-6">
                 <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                  <h3 className="text-lg font-semibold leading-7 text-gray-950">{f.question}</h3>
-                  <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition group-open:rotate-45 group-open:bg-emerald-50 group-open:text-emerald-700">
+                  <h3 className="text-lg font-semibold leading-7 text-foreground">{f.question}</h3>
+                  <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
                     <svg
                       className="h-4 w-4"
                       fill="none"
@@ -306,7 +306,9 @@ export function FairSourcePage() {
                     </svg>
                   </span>
                 </summary>
-                <div className="mt-4 pr-9 text-base leading-7 text-gray-600">{f.answer}</div>
+                <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
+                  {f.answer}
+                </div>
               </details>
             ))}
           </div>
@@ -314,22 +316,17 @@ export function FairSourcePage() {
       </section>
 
       {/* CTA */}
-      <section className="bg-gray-950 py-16 sm:py-24">
+      <section className="bg-card py-16 sm:py-24">
         <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {FAIR_SOURCE_CTA.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-400">{FAIR_SOURCE_CTA.body}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{FAIR_SOURCE_CTA.body}</p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <ButtonCVA asChild size="lg" className="bg-white text-gray-950 hover:bg-gray-100">
+            <ButtonCVA asChild size="lg" variant="primary">
               <a href={FAIR_SOURCE_CTA.primaryHref}>{FAIR_SOURCE_CTA.primaryLabel}</a>
             </ButtonCVA>
-            <ButtonCVA
-              asChild
-              variant="outline"
-              size="lg"
-              className="border-gray-700 text-gray-300 hover:text-white hover:border-gray-500"
-            >
+            <ButtonCVA asChild variant="outline" size="lg">
               <a href={FAIR_SOURCE_CTA.secondaryHref}>{FAIR_SOURCE_CTA.secondaryLabel}</a>
             </ButtonCVA>
           </div>

--- a/apps/marketing/app/routes/NotFoundPage.tsx
+++ b/apps/marketing/app/routes/NotFoundPage.tsx
@@ -2,13 +2,13 @@ import { Footer } from '../components/Footer';
 
 export function NotFoundPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
         <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">404</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-950 sm:text-4xl">
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Page not found
         </h1>
-        <p className="mt-4 max-w-md text-base text-gray-600">
+        <p className="mt-4 max-w-md text-base text-muted-foreground">
           The page you're looking for doesn't exist or has moved.
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@ export function NotFoundPage() {
           </a>
           <a
             href="/products"
-            className="inline-flex items-center gap-2 rounded-lg ring-1 ring-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-950 hover:ring-gray-300"
+            className="inline-flex items-center gap-2 rounded-lg ring-1 ring-border bg-card px-5 py-2.5 text-sm font-semibold text-foreground hover:ring-border/60"
           >
             View products
           </a>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -15,14 +15,14 @@ const ALL_PRODUCT_ANCHORS = [
 
 export function ProductsPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-emerald-50 via-white to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             {PRODUCTS_PAGE_HERO.h1}
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
             {PRODUCTS_PAGE_HERO.subtitle}
           </p>
           <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
@@ -30,7 +30,7 @@ export function ProductsPage() {
               <a
                 key={anchor.slug}
                 href={`#${anchor.slug}`}
-                className="rounded-full bg-white px-4 py-1.5 text-gray-700 ring-1 ring-gray-200 transition-colors hover:bg-emerald-50 hover:text-emerald-700 hover:ring-emerald-300"
+                className="rounded-full bg-card px-4 py-1.5 text-muted-foreground ring-1 ring-border transition-colors hover:bg-primary/10 hover:text-primary hover:ring-primary/30"
               >
                 {anchor.name}
               </a>
@@ -42,8 +42,8 @@ export function ProductsPage() {
       {/* Flagship — RevealUI featured card */}
       <section id={PRODUCTS_FLAGSHIP.slug} className="py-20 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-700 to-emerald-900 p-10 shadow-2xl ring-1 ring-emerald-900/20 sm:p-14">
-            <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-emerald-400/20 blur-3xl" />
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
+            <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
             <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
             <div className="relative">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -65,7 +65,7 @@ export function ProductsPage() {
                     </svg>
                   </div>
                   <div>
-                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-100/90">
+                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground/90">
                       {PRODUCTS_FLAGSHIP.eyebrow}
                     </p>
                     <h2 className="mt-1 text-3xl font-bold tracking-tight text-white sm:text-4xl">
@@ -83,10 +83,10 @@ export function ProductsPage() {
                 </div>
               </div>
 
-              <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-emerald-50">
+              <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-primary-foreground">
                 {PRODUCTS_FLAGSHIP.tagline}
               </p>
-              <p className="mt-3 max-w-3xl text-base leading-7 text-emerald-100/90">
+              <p className="mt-3 max-w-3xl text-base leading-7 text-primary-foreground/90">
                 {PRODUCTS_FLAGSHIP.body}
               </p>
 
@@ -96,7 +96,7 @@ export function ProductsPage() {
                     key={fact.label}
                     className="rounded-xl bg-white/10 px-4 py-3 ring-1 ring-white/20 backdrop-blur"
                   >
-                    <dt className="text-xs uppercase tracking-wide text-emerald-100/80">
+                    <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
                       {fact.label}
                     </dt>
                     <dd className="mt-1 text-2xl font-bold tracking-tight text-white">
@@ -109,13 +109,13 @@ export function ProductsPage() {
               <div className="mt-10 flex flex-col gap-3 sm:flex-row">
                 <a
                   href={PRODUCTS_FLAGSHIP.ctas.docs.href}
-                  className="rounded-md bg-white px-6 py-3 text-sm font-semibold text-emerald-800 shadow-sm transition-colors hover:bg-emerald-50"
+                  className="rounded-md bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary shadow-sm transition-colors hover:bg-primary-foreground/90"
                 >
                   {PRODUCTS_FLAGSHIP.ctas.docs.label}
                 </a>
                 <a
                   href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
-                  className="rounded-md bg-emerald-900/40 px-6 py-3 text-sm font-semibold text-white ring-1 ring-white/30 transition-colors hover:bg-emerald-900/60"
+                  className="rounded-md bg-primary-foreground/15 px-6 py-3 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 transition-colors hover:bg-primary-foreground/25"
                 >
                   {PRODUCTS_FLAGSHIP.ctas.pricing.label}
                 </a>
@@ -135,13 +135,13 @@ export function ProductsPage() {
       </section>
 
       {/* Sister products — uniform card grid */}
-      <section className="bg-gray-50 py-20 sm:py-24">
+      <section className="bg-secondary py-20 sm:py-24">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               And the rest of the fleet
             </h2>
-            <p className="mt-4 text-lg leading-7 text-gray-600">
+            <p className="mt-4 text-lg leading-7 text-muted-foreground">
               Sister products that extend the runtime — secrets, dev tooling, white-labeling,
               skills, and the agent tool catalog.
             </p>
@@ -154,13 +154,13 @@ export function ProductsPage() {
                 <li
                   key={product.slug}
                   id={product.slug}
-                  className="group relative flex flex-col rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200 transition-shadow hover:shadow-lg"
+                  className="group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm ring-1 ring-border transition-shadow hover:shadow-lg"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex items-center gap-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gray-50 ring-1 ring-gray-200">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary ring-1 ring-border">
                         <svg
-                          className="h-6 w-6 text-gray-700"
+                          className="h-6 w-6 text-muted-foreground"
                           fill="none"
                           viewBox="0 0 24 24"
                           strokeWidth={1.5}
@@ -171,10 +171,10 @@ export function ProductsPage() {
                         </svg>
                       </div>
                       <div>
-                        <h3 className="text-xl font-bold tracking-tight text-gray-900">
+                        <h3 className="text-xl font-bold tracking-tight text-foreground">
                           {product.name}
                         </h3>
-                        <p className="mt-0.5 text-sm font-medium text-gray-600">
+                        <p className="mt-0.5 text-sm font-medium text-muted-foreground">
                           {product.tagline}
                         </p>
                       </div>
@@ -193,12 +193,14 @@ export function ProductsPage() {
                     </div>
                   </div>
 
-                  <p className="mt-5 grow text-sm leading-6 text-gray-600">{product.body}</p>
+                  <p className="mt-5 grow text-sm leading-6 text-muted-foreground">
+                    {product.body}
+                  </p>
 
                   <div className="mt-6">
                     <a
                       href={product.primaryCta.href}
-                      className="inline-flex min-h-11 items-center text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
+                      className="inline-flex min-h-11 items-center text-sm font-semibold text-primary transition-colors hover:text-primary/80"
                       {...(product.primaryCta.external
                         ? { target: '_blank', rel: 'noreferrer' }
                         : {})}
@@ -214,21 +216,21 @@ export function ProductsPage() {
       </section>
 
       {/* Stats — production credibility */}
-      <section className="bg-gray-950 py-24 sm:py-32">
+      <section className="bg-card py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {PRODUCTS_STATS_SECTION.heading}
             </h2>
-            <p className="mt-4 text-lg text-gray-400">{PRODUCTS_STATS_SECTION.body}</p>
+            <p className="mt-4 text-lg text-muted-foreground">{PRODUCTS_STATS_SECTION.body}</p>
           </div>
           <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
             {PRODUCTS_STATS_SECTION.items.map((item) => (
               <div key={item.label} className="text-center">
-                <p className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                <p className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
                   {item.stat}
                 </p>
-                <p className="mt-2 text-sm text-gray-400">{item.label}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{item.label}</p>
               </div>
             ))}
           </div>
@@ -238,23 +240,25 @@ export function ProductsPage() {
       {/* CTA */}
       <section className="py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRODUCTS_CTA_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-gray-600">{PRODUCTS_CTA_SECTION.body}</p>
-          <div className="mt-8 rounded-lg bg-gray-950 px-6 py-4 text-left font-mono text-sm text-gray-300">
-            <span className="text-gray-500">$</span> {PRODUCTS_CTA_SECTION.cliSnippet}
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {PRODUCTS_CTA_SECTION.body}
+          </p>
+          <div className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background">
+            <span className="text-background/50">$</span> {PRODUCTS_CTA_SECTION.cliSnippet}
           </div>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
               href={PRODUCTS_CTA_SECTION.cta.docs.href}
-              className="rounded-md bg-emerald-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-emerald-500 transition-colors"
+              className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
             >
               {PRODUCTS_CTA_SECTION.cta.docs.label}
             </a>
             <a
               href={PRODUCTS_CTA_SECTION.cta.pricing.href}
-              className="rounded-md bg-gray-100 px-8 py-4 text-base font-semibold text-gray-900 hover:bg-gray-200 transition-colors"
+              className="rounded-md bg-secondary px-8 py-4 text-base font-semibold text-foreground hover:bg-muted transition-colors"
             >
               {PRODUCTS_CTA_SECTION.cta.pricing.label}
             </a>

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -17,24 +17,24 @@ const categoryColors: Record<string, string> = {
   billing: 'bg-purple-100 text-purple-700',
   ai: 'bg-violet-100 text-violet-700',
   infrastructure: 'bg-blue-100 text-blue-700',
-  docs: 'bg-emerald-100 text-emerald-700',
+  docs: 'bg-primary/10 text-primary',
   product: 'bg-pink-100 text-pink-700',
-  enterprise: 'bg-gray-100 text-gray-700',
+  enterprise: 'bg-muted text-muted-foreground',
 };
 
 function statusBadgeClass(status: string): string {
   if (status === 'Shipped' || status === 'Available') {
-    return 'text-emerald-700 bg-emerald-50 ring-emerald-200';
+    return 'text-primary bg-primary/10 ring-primary/20';
   }
   return 'text-amber-700 bg-amber-50 ring-amber-200';
 }
 
 function FeatureCard({ feature }: { feature: RoadmapItem }) {
   return (
-    <div className="rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200">
+    <div className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border">
       <div className="flex items-center gap-3 mb-4">
         <span
-          className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${categoryColors[feature.category.toLowerCase()] ?? 'bg-gray-100 text-gray-700'}`}
+          className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${categoryColors[feature.category.toLowerCase()] ?? 'bg-muted text-muted-foreground'}`}
         >
           {feature.category}
         </span>
@@ -44,25 +44,25 @@ function FeatureCard({ feature }: { feature: RoadmapItem }) {
           {feature.status}
         </span>
       </div>
-      <h3 className="text-lg font-bold tracking-tight text-gray-900">{feature.name}</h3>
-      <p className="mt-3 text-sm leading-6 text-gray-600">{feature.description}</p>
+      <h3 className="text-lg font-bold tracking-tight text-foreground">{feature.name}</h3>
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">{feature.description}</p>
     </div>
   );
 }
 
 export function RoadmapPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-amber-50 via-white to-orange-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-amber-50 via-background to-orange-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Product
             <span className="block bg-gradient-to-r from-amber-600 to-orange-600 bg-clip-text text-transparent">
               Roadmap
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
             {ROADMAP_HERO.subtitle} See our{' '}
             <a
               href={ROADMAP_HERO_LINK.href}
@@ -78,9 +78,9 @@ export function RoadmapPage() {
       </section>
 
       {/* Recently Shipped */}
-      <section className="py-16 sm:py-20 bg-gray-50">
+      <section className="py-16 sm:py-20 bg-secondary">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl mb-8">
+          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl mb-8">
             {ROADMAP_SHIPPED_SECTION.title}
           </h2>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -94,7 +94,7 @@ export function RoadmapPage() {
       {/* Coming Next */}
       <section className="py-16 sm:py-20">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl mb-8">
+          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl mb-8">
             {ROADMAP_UPCOMING_SECTION.title}
           </h2>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -106,18 +106,18 @@ export function RoadmapPage() {
       </section>
 
       {/* CTA */}
-      <section className="bg-gray-50 py-16">
+      <section className="bg-secondary py-16">
         <div className="mx-auto max-w-4xl px-6 text-center lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
+          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             {ROADMAP_CTA.title}
           </h2>
-          <p className="mt-4 text-lg text-gray-600">{ROADMAP_CTA.subtitle}</p>
+          <p className="mt-4 text-lg text-muted-foreground">{ROADMAP_CTA.subtitle}</p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
               href={ROADMAP_CTA_LINKS.requestFeature.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-md bg-gray-900 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
+              className="rounded-md bg-foreground px-6 py-3 text-sm font-semibold text-background shadow-sm hover:bg-foreground/80 transition-colors"
             >
               {ROADMAP_CTA_LINKS.requestFeature.label}
             </a>
@@ -125,7 +125,7 @@ export function RoadmapPage() {
               href={ROADMAP_CTA_LINKS.joinDiscussion.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-md bg-white px-6 py-3 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-gray-300 hover:bg-gray-50 transition-colors"
+              className="rounded-md bg-card px-6 py-3 text-sm font-semibold text-foreground shadow-sm ring-1 ring-border hover:bg-muted transition-colors"
             >
               {ROADMAP_CTA_LINKS.joinDiscussion.label}
             </a>
@@ -134,7 +134,7 @@ export function RoadmapPage() {
             See what's shipped today &rarr;{' '}
             <a
               href={ROADMAP_CTA_PRODUCTS_LINK.href}
-              className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
+              className="font-medium text-foreground hover:text-foreground/80 transition-colors"
             >
               {ROADMAP_CTA_PRODUCTS_LINK.label}
             </a>

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -66,17 +66,17 @@ function SupportIcon({ iconKey }: { iconKey: SupportArea['iconKey'] }) {
 
 export function SponsorPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-background to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             {SPONSOR_HERO.brand}
             <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
               {SPONSOR_HERO.brandHighlight}
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
             {SPONSOR_HERO.subhead}
           </p>
           <div className="mt-10 flex items-center justify-center gap-x-6">
@@ -96,25 +96,27 @@ export function SponsorPage() {
       <section className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center mb-16">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {SPONSOR_TIERS_SECTION.heading.title}
             </h2>
-            <p className="mt-4 text-lg text-gray-600">{SPONSOR_TIERS_SECTION.heading.subtitle}</p>
+            <p className="mt-4 text-lg text-muted-foreground">
+              {SPONSOR_TIERS_SECTION.heading.subtitle}
+            </p>
           </div>
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
             {SPONSOR_TIERS.map((tier) => (
               <div
                 key={tier.name}
-                className="relative rounded-2xl bg-white p-8 shadow-lg ring-1 ring-gray-200 hover:ring-blue-300 transition-all"
+                className="relative rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-blue-300 transition-all"
               >
                 <div className="text-4xl mb-4">{tier.emoji}</div>
-                <h3 className="text-xl font-bold tracking-tight text-gray-900">{tier.name}</h3>
-                <p className="mt-2 text-sm text-gray-600">{tier.description}</p>
+                <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
                 <p className="mt-4 flex items-baseline gap-x-1">
-                  <span className="text-4xl font-bold tracking-tight text-gray-900">
+                  <span className="text-4xl font-bold tracking-tight text-foreground">
                     {tier.price}
                   </span>
-                  <span className="text-sm text-gray-600">{tier.period}</span>
+                  <span className="text-sm text-muted-foreground">{tier.period}</span>
                 </p>
                 <ul className="mt-6 space-y-3">
                   {tier.benefits.map((benefit) => (
@@ -131,7 +133,7 @@ export function SponsorPage() {
                           clipRule="evenodd"
                         />
                       </svg>
-                      <span className="text-sm text-gray-600">{benefit}</span>
+                      <span className="text-sm text-muted-foreground">{benefit}</span>
                     </li>
                   ))}
                 </ul>
@@ -152,10 +154,10 @@ export function SponsorPage() {
       </section>
 
       {/* Why Sponsor */}
-      <section className="bg-gray-50 py-24 sm:py-32">
+      <section className="bg-secondary py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-3xl">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl text-center mb-12">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl text-center mb-12">
               {SPONSOR_SUPPORT_HEADING}
             </h2>
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-3">
@@ -164,8 +166,8 @@ export function SponsorPage() {
                   <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
                     <SupportIcon iconKey={area.iconKey} />
                   </div>
-                  <h3 className="mt-4 text-lg font-semibold text-gray-900">{area.title}</h3>
-                  <p className="mt-2 text-sm text-gray-600">{area.description}</p>
+                  <h3 className="mt-4 text-lg font-semibold text-foreground">{area.title}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{area.description}</p>
                 </div>
               ))}
             </div>
@@ -177,14 +179,14 @@ export function SponsorPage() {
         {SPONSOR_FOOTER_NOTE.prefix}
         <a
           href={SPONSOR_FOOTER_NOTE.productsLink.href}
-          className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          className="font-medium text-foreground hover:text-foreground/80 transition-colors"
         >
           {SPONSOR_FOOTER_NOTE.productsLink.label}
         </a>
         {SPONSOR_FOOTER_NOTE.separator}
         <a
           href={SPONSOR_FOOTER_NOTE.docsLink.href}
-          className="font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          className="font-medium text-foreground hover:text-foreground/80 transition-colors"
         >
           {SPONSOR_FOOTER_NOTE.docsLink.label}
         </a>


### PR DESCRIPTION
## What

Continues the Cobalt semantic-token sweep (after app-shell #1114, ContactForm #1110, landing #1118) across **8 route pages + GetStarted**: FairSource, Products, Sponsor, Roadmap, BlogIndex, BlogPost, Contact, NotFound.

- `gray-*`/`emerald-*` → `foreground`/`muted-foreground`/`background`/`card`/`secondary`/`border`/`primary` (+ `/10`, `/20` alphas)
- Dark sections → theme-following (`bg-card`); intentional-inverse kept for code/terminal blocks + the flagship **brand-gradient card** (always-Cobalt)
- CTAs → `ButtonCVA` where clean
- Multi-hue **primitive accents** (`blue`/`amber`/`cyan`/`violet`) preserved untouched
- `ProductMockup.tsx` intentionally unchanged (always-dark device/terminal mockup)

## Verification

- Zero residual raw `emerald-*`/`gray-*`; `pnpm --filter marketing typecheck` exit 0; biome clean.
- `/products` verified in a dev server, light + dark (flagship Cobalt card, chips, stats render correctly).

## Follow-ups (design alignment — separate pass)

- **CTA consistency:** standardize primary CTAs to Cobalt — some pages still use pre-existing `bg-blue-600` accent buttons (Sponsor, NotFound, a Blog CTA), and a couple of old dark buttons were mapped to `bg-foreground` (BlogPost "Start free", Roadmap "Request Feature"); these should align to the nav's Cobalt `ButtonCVA`.
- **ProductMockup:** flip-safe treatment (currently raw palette, rendered via the in-place remap).
- **Products-page metrics accuracy** — Phase D.
