### PR TITLE
refactor(marketing): standardize CTAs to Cobalt ButtonCVA + align pairs

### DIFF
--- a/apps/marketing/app/components/ErrorBoundary.tsx
+++ b/apps/marketing/app/components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { ButtonCVA } from '@revealui/presentation';
 import { Component, type ReactNode } from 'react';
 
 interface Props {
@@ -31,20 +32,17 @@ export class ErrorBoundary extends Component<Props, State> {
 
 function DefaultErrorFallback({ error }: { error: Error | null }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-white p-8 text-center">
-      <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">Error</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight text-gray-950 sm:text-3xl">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-8 text-center">
+      <p className="text-sm font-semibold uppercase tracking-widest text-primary">Error</p>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
         Something went wrong
       </h1>
-      <p className="mt-4 max-w-md text-sm text-gray-600">
+      <p className="mt-4 max-w-md text-sm text-muted-foreground">
         {error?.message ?? 'An unexpected error occurred while rendering this page.'}
       </p>
-      <a
-        href="/"
-        className="mt-6 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-500"
-      >
-        Return home
-      </a>
+      <ButtonCVA asChild variant="primary" className="mt-6">
+        <a href="/">Return home</a>
+      </ButtonCVA>
     </div>
   );
 }

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -106,7 +106,7 @@ export function BlogIndexPage() {
               {posts.map((post) => (
                 <article
                   key={post.id}
-                  className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-blue-300 transition-all"
+                  className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-primary/40 transition-all"
                 >
                   <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
                     <time dateTime={post.publishedAt ?? post.createdAt}>
@@ -115,10 +115,7 @@ export function BlogIndexPage() {
                     {post.author && <span>{post.author}</span>}
                   </div>
                   <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
-                    <a
-                      href={`/blog/${post.slug}`}
-                      className="hover:text-blue-600 transition-colors"
-                    >
+                    <a href={`/blog/${post.slug}`} className="hover:text-primary transition-colors">
                       {post.title}
                     </a>
                   </h3>
@@ -127,7 +124,7 @@ export function BlogIndexPage() {
                   </p>
                   <a
                     href={`/blog/${post.slug}`}
-                    className="mt-4 inline-block text-sm font-semibold text-blue-600 hover:text-blue-500 transition-colors"
+                    className="mt-4 inline-block text-sm font-semibold text-primary hover:text-primary/80 transition-colors"
                   >
                     Read more &rarr;
                   </a>

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -1,4 +1,5 @@
 import { RichTextContent, type SerializedEditorState } from '@revealui/core/richtext/rsc';
+import { ButtonCVA } from '@revealui/presentation';
 import { useParams } from '@revealui/router';
 import { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
@@ -91,19 +92,16 @@ export function BlogPostPage() {
     return (
       <div className="min-h-screen bg-background">
         <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">404</p>
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">404</p>
           <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Post not found
           </h1>
           <p className="mt-4 max-w-md text-base text-muted-foreground">
             That blog post does not exist or has been removed.
           </p>
-          <a
-            href="/blog"
-            className="mt-8 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Back to Blog
-          </a>
+          <ButtonCVA asChild variant="primary" className="mt-8">
+            <a href="/blog">Back to Blog</a>
+          </ButtonCVA>
         </section>
         <Footer />
       </div>
@@ -117,7 +115,7 @@ export function BlogPostPage() {
           {/* Back link */}
           <a
             href="/blog"
-            className="inline-flex items-center gap-x-1 text-sm font-semibold text-blue-600 hover:text-blue-500 transition-colors mb-8"
+            className="inline-flex items-center gap-x-1 text-sm font-semibold text-primary hover:text-primary/80 transition-colors mb-8"
           >
             &larr; Back to Blog
           </a>
@@ -157,18 +155,12 @@ export function BlogPostPage() {
             Users, content, products, payments, and AI, pre-wired. Start locally in minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href="https://admin.revealui.com/signup"
-              className="rounded-md bg-foreground px-6 py-3 text-sm font-semibold text-background shadow-sm hover:bg-foreground/80 transition-colors"
-            >
-              Start free
-            </a>
-            <a
-              href="https://docs.revealui.com"
-              className="rounded-md bg-card px-6 py-3 text-sm font-semibold text-foreground shadow-sm ring-1 ring-border hover:bg-muted transition-colors"
-            >
-              Read the docs
-            </a>
+            <ButtonCVA asChild size="lg" variant="primary">
+              <a href="https://admin.revealui.com/signup">Start free</a>
+            </ButtonCVA>
+            <ButtonCVA asChild size="lg" variant="outline">
+              <a href="https://docs.revealui.com">Read the docs</a>
+            </ButtonCVA>
           </div>
         </div>
       </section>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -26,7 +26,7 @@ export function ContactPage() {
                     href={method.href}
                     target={method.external ? '_blank' : undefined}
                     rel={method.external ? 'noopener noreferrer' : undefined}
-                    className="text-blue-600 hover:text-blue-500 underline"
+                    className="text-primary hover:text-primary/80 underline"
                   >
                     {method.linkLabel}
                   </a>

--- a/apps/marketing/app/routes/NotFoundPage.tsx
+++ b/apps/marketing/app/routes/NotFoundPage.tsx
@@ -1,10 +1,11 @@
+import { ButtonCVA } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 
 export function NotFoundPage() {
   return (
     <div className="min-h-screen bg-background">
       <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
-        <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">404</p>
+        <p className="text-sm font-semibold uppercase tracking-widest text-primary">404</p>
         <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Page not found
         </h1>
@@ -12,18 +13,12 @@ export function NotFoundPage() {
           The page you're looking for doesn't exist or has moved.
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <a
-            href="/"
-            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-500"
-          >
-            Return home
-          </a>
-          <a
-            href="/products"
-            className="inline-flex items-center gap-2 rounded-lg ring-1 ring-border bg-card px-5 py-2.5 text-sm font-semibold text-foreground hover:ring-border/60"
-          >
-            View products
-          </a>
+          <ButtonCVA asChild variant="primary">
+            <a href="/">Return home</a>
+          </ButtonCVA>
+          <ButtonCVA asChild variant="outline">
+            <a href="/products">View products</a>
+          </ButtonCVA>
         </div>
       </section>
       <Footer />

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -1,3 +1,4 @@
+import { ButtonCVA } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import {
   ROADMAP_CTA,
@@ -113,22 +114,24 @@ export function RoadmapPage() {
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">{ROADMAP_CTA.subtitle}</p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href={ROADMAP_CTA_LINKS.requestFeature.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md bg-foreground px-6 py-3 text-sm font-semibold text-background shadow-sm hover:bg-foreground/80 transition-colors"
-            >
-              {ROADMAP_CTA_LINKS.requestFeature.label}
-            </a>
-            <a
-              href={ROADMAP_CTA_LINKS.joinDiscussion.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md bg-card px-6 py-3 text-sm font-semibold text-foreground shadow-sm ring-1 ring-border hover:bg-muted transition-colors"
-            >
-              {ROADMAP_CTA_LINKS.joinDiscussion.label}
-            </a>
+            <ButtonCVA asChild size="lg" variant="primary">
+              <a
+                href={ROADMAP_CTA_LINKS.requestFeature.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {ROADMAP_CTA_LINKS.requestFeature.label}
+              </a>
+            </ButtonCVA>
+            <ButtonCVA asChild size="lg" variant="outline">
+              <a
+                href={ROADMAP_CTA_LINKS.joinDiscussion.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {ROADMAP_CTA_LINKS.joinDiscussion.label}
+              </a>
+            </ButtonCVA>
           </div>
           <p className="mt-8 text-sm text-muted-foreground">
             See what's shipped today &rarr;{' '}

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -1,3 +1,4 @@
+import { ButtonCVA } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import {
   SPONSOR_FOOTER_NOTE,
@@ -80,14 +81,11 @@ export function SponsorPage() {
             {SPONSOR_HERO.subhead}
           </p>
           <div className="mt-10 flex items-center justify-center gap-x-6">
-            <a
-              href={SPONSOR_HERO.cta.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
-            >
-              {SPONSOR_HERO.cta.label}
-            </a>
+            <ButtonCVA asChild size="lg" variant="primary">
+              <a href={SPONSOR_HERO.cta.href} target="_blank" rel="noopener noreferrer">
+                {SPONSOR_HERO.cta.label}
+              </a>
+            </ButtonCVA>
           </div>
         </div>
       </section>
@@ -107,7 +105,7 @@ export function SponsorPage() {
             {SPONSOR_TIERS.map((tier) => (
               <div
                 key={tier.name}
-                className="relative rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-blue-300 transition-all"
+                className="relative rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-primary/40 transition-all"
               >
                 <div className="text-4xl mb-4">{tier.emoji}</div>
                 <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
@@ -141,14 +139,15 @@ export function SponsorPage() {
             ))}
           </div>
           <div className="mt-16 text-center">
-            <a
-              href={SPONSOR_TIERS_SECTION.ctaBottom.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-blue-500 transition-colors"
-            >
-              {SPONSOR_TIERS_SECTION.ctaBottom.label}
-            </a>
+            <ButtonCVA asChild size="lg" variant="primary">
+              <a
+                href={SPONSOR_TIERS_SECTION.ctaBottom.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {SPONSOR_TIERS_SECTION.ctaBottom.label}
+              </a>
+            </ButtonCVA>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## What

Standardizes every primary CTA in the marketing app on the native `ButtonCVA` (Cobalt brand) and fixes the resulting button-pair alignment. Before this, CTAs were a mix of hand-rolled `bg-blue-600` buttons and neutral-inverse `bg-foreground` buttons — neither matched the nav "Start free" button or the landing-page CTAs (Hero / GetStarted / FairSource already use `ButtonCVA`).

This is the "CTA + alignment polish" track of the marketing overhaul lane (follows the Cobalt semantic-token sweep in #1114 / #1118 / #1120 and the marketplace reframe in #1121).

## CTAs converted to `ButtonCVA`

| Page | Primary | Secondary |
|------|---------|-----------|
| NotFoundPage | "Return home" | "View products" (outline) |
| BlogPostPage (404) | "Back to Blog" | — |
| BlogPostPage ("Ready to build?") | "Start free" | "Read the docs" (outline) |
| SponsorPage | hero + bottom "Become a Sponsor" | — |
| RoadmapPage | "Request a feature" | "Join the discussion" (outline) |
| ErrorBoundary | "Return home" | — |

`variant="primary"` → Cobalt (`bg-primary text-primary-foreground`); `variant="outline"` → bordered `bg-background`.

## Alignment fix

The hand-rolled outline buttons carried a `ring-1` that made them ~2px taller than their solid sibling, so primary/secondary pairs were vertically misaligned. `ButtonCVA`'s size token normalizes both to the same box. Verified on `/roadmap`, `/blog/getting-started`, and the 404 page: primary + outline render **same height (48px) and same top**.

## Brand-accent consistency

Raw blue text/interactive states moved onto Cobalt tokens (they would not adapt and read off-brand next to Cobalt CTAs):

- 404 eyebrows, error eyebrow, blog back-link, blog "Read more", blog post-title hover, contact link: `text-blue-600` / `hover:text-blue-500` → `text-primary` / `hover:text-primary/80`
- card hover rings: `hover:ring-blue-300` → `hover:ring-primary/40`

`ErrorBoundary` was missed by the #1120 route sweep, so its raw palette is brought onto semantic tokens here (`bg-white` → `bg-background`, `text-gray-950` → `text-foreground`, `text-gray-600` → `text-muted-foreground`).

## Deliberately preserved (out of scope)

- **Decorative accent systems** that need a holistic Cobalt + dark-safe pass and belong to the gated system-adaptive flip: Sponsor/Blog hero gradients (`from-blue-50`/`indigo-50`), Sponsor brand-highlight gradient text, `bg-blue-100` icon circles, Sponsor support icons, Roadmap amber/orange hero gradient + category badges.
- **ProductsPage CTAs** — already Cobalt / on-brand-section inverse treatment.
- **ProductMockup** — always-dark device mockup, raw palette by design.
- **`primitives.ts` `text-blue-600`** — Content primitive accent (intentional).
- **Hero / ProductsPage `bg-foreground`** — CLI/code display blocks, not CTAs.
- **PricingPage** — active in a peer lane; untouched.

## Known follow-up (flagged, not introduced here)

`ButtonCVA` `outline` styles its border with Tailwind's `dark:` variant (`dark:border-zinc-700`), which follows `prefers-color-scheme`, while marketing light-locks via `data-theme="light"`. A visitor whose OS is in dark mode therefore gets a zinc-700 outline border on the light-locked page. This is **pre-existing and shared by every existing `ButtonCVA` outline usage** (Hero/GetStarted/FairSource) — not introduced here. The system-adaptive flip lane should reconcile the `dark:` strategy (wire `@custom-variant dark` to follow `data-theme`) so the lock controls all utilities.

## Verification

- `pnpm --filter marketing typecheck` clean
- `biome check` clean (auto-wrapped 2 long attribute lines)
- `pnpm --filter marketing test` → 14/14 (4 route + 10 content)
- `pnpm --filter marketing build` green
- Dev-server visual check on `/sponsor`, `/roadmap`, a 404, `/blog`, `/blog/getting-started`: primaries render Cobalt `oklch(0.36 0.19 240)`, pairs aligned.
