### PR TITLE
feat(marketing): pricing copy + tone voice-sweep (PR2, re-lands #1113)

### DIFF
--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -11,7 +11,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'Can I use the Free tier for commercial projects?',
     answer:
-      'Yes! The Free tier is fully open-source (MIT) and can be used for commercial projects. You get full source code access and can deploy it anywhere you like.',
+      'Yes. The Free tier is fully open-source (MIT) and can be used for commercial projects. You get full source code access and can deploy it anywhere you like.',
   },
   {
     question: 'What happens after the free trial ends?',
@@ -21,7 +21,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'How does agent task billing work?',
     answer:
-      'Every paid subscription includes generous task allowances. Agent task usage billing is coming soon — for now, all tiers include unlimited agent tasks during early access.',
+      'Every paid subscription includes a monthly task allowance. Agent task usage billing is coming soon — for now, all tiers include unlimited agent tasks during early access.',
   },
   {
     question: 'What are perpetual licenses?',
@@ -48,7 +48,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   },
   {
     question: 'Do you offer custom pricing for large teams?',
-    answer: `Yes! If you need more than what the Enterprise tier offers, contact us at ${SITE.emails.support} to discuss custom pricing and SLAs.`,
+    answer: `Yes. If you need more than what the Enterprise tier offers, contact us at ${SITE.emails.support} to discuss custom pricing and SLAs.`,
   },
   {
     question: 'What is RevFleet?',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -52,6 +52,7 @@ export const PRICING_VALUE_BAND = {
     'One runtime, not five separate SaaS subscriptions',
     'Self-host on Vercel, Cloudflare, Fly, Hetzner, or your own metal',
     'Full source code access on every tier',
+    "Open-weight AI by default — your bill doesn't scale with usage",
   ],
 } as const;
 
@@ -108,7 +109,7 @@ export const PRICING_AGENT_CTA_LINKS = {
 } as const;
 
 export const PRICING_AGENCY_SECTION = {
-  heading: 'Need help adopting RevealUI?',
+  heading: 'Adoption help from RevealUI Studio',
   body: 'Architecture reviews, migrations, and launch support are offered separately by RevealUI Studio (the agency). Engagements are scoped per-project.',
   cta: {
     label: 'Visit revealuistudio.com →',
@@ -118,8 +119,8 @@ export const PRICING_AGENCY_SECTION = {
 } as const;
 
 export const PRICING_FINAL_CTA: SectionHeading = {
-  title: 'Ready to get started?',
-  subtitle: 'Start free with full source code access. Upgrade when your business needs it.',
+  title: 'Start free with full source access.',
+  subtitle: 'Every tier ships the complete source. Upgrade when your business needs Pro features.',
 };
 
 export const PRICING_FINAL_CTA_LINKS = {
@@ -133,4 +134,4 @@ export const PRICING_FINAL_CTA_LINKS = {
   } satisfies Cta,
 } as const;
 
-export const PRICING_NEWSLETTER_LABEL = 'Not ready yet? Stay in the loop.' as const;
+export const PRICING_NEWSLETTER_LABEL = 'Not ready yet? Get release updates by email.' as const;

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -147,7 +147,7 @@ export function PricingPage() {
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
               {PRICING_VALUE_BAND.body}
             </p>
-            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
               {PRICING_VALUE_BAND.points.map((point) => (
                 <li key={point} className="flex items-start gap-2 text-sm text-gray-700">
                   <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />


### PR DESCRIPTION
## What

Pricing **copy + tone voice-sweep** — this is the pricing lane's PR2 (the copy/tone deliverable that follows the #1111 design/brand/layout redesign, now merged to `test`).

This re-lands the work from **#1113**, which GitHub auto-closed when its stacked base branch (`feat/pricing-redesign`) was deleted by the #1111 squash-merge. The original copy/tone commit (`85d684142`, RevealUI Studio) is **cherry-picked verbatim** onto current `test` — so this is exactly the PR2 delta, with attribution preserved and zero redesign churn. Supersedes #1113.

## Changes (voice-and-headline-rules.md)

- **Exclamation points removed** from FAQ answers: "Yes!" → "Yes." (×2).
- **Vague → specific:** "generous task allowances" → "a monthly task allowance".
- **Rhetorical-question H2s → declarative:**
  - Agency section: "Need help adopting RevealUI?" → "Adoption help from RevealUI Studio"
  - Final CTA: "Ready to get started?" → "Start free with full source access." (subtitle tightened to name the Pro upgrade trigger).
- **Newsletter label** made specific: "Not ready yet? Stay in the loop." → "Not ready yet? Get release updates by email."
- **Pillar-2 (open-model) value point** added to the value band: "Open-weight AI by default — your bill doesn't scale with usage" — value-band grid goes `sm:grid-cols-3` → `sm:grid-cols-2` to keep the now-4 points balanced.

Prices unchanged (sourced from `@revealui/contracts` / `/api/pricing`). No "live payments" claims; waitlist / Contact Sales CTAs stay honest.

## Verification

- `pnpm --filter marketing typecheck` clean; `biome check` clean.
- Content-only + one grid utility; no behavior change.

Supersedes #1113 (auto-closed by the stacked #1111 squash-merge).
