### PR TITLE
feat(marketing): flip to system-adaptive (real dark mode)

### DIFF
--- a/apps/marketing/app/index.css
+++ b/apps/marketing/app/index.css
@@ -34,16 +34,13 @@
   --color-secondary: var(--rvui-surface-2);
   --color-secondary-foreground: var(--rvui-text-0);
   --color-muted: var(--rvui-surface-2);
-  /* Secondary / muted text — deterministic deep cobalt-ink (brand hue ~248).
-   * Replaces var(--rvui-text-2): the token file is dark-first (:root = dark),
-   * so --rvui-text-2 resolved to a silvery oklch(0.65 …) that washed out and
-   * failed WCAG AA on this site's bg-white / bg-gray-50 sections. This fixed
-   * value tests ~5.8:1 on white (AA pass) and reads as intentional brand ink,
-   * not gray — every text-muted-foreground (eyebrows, captions, footnotes)
-   * picks it up with no per-component edits. Marketing uses muted text only on
-   * light surfaces, so a single fixed value is safe (dark panels use explicit
-   * text-gray-300/400 utilities, untouched). */
-  --color-muted-foreground: oklch(0.48 0.085 248);
+  /* Secondary / muted text — adaptive (dark-first, mirrors the token system).
+   * Dark default here (smoke-300 oklch(0.65), AA on midnight surfaces); the
+   * light value (deep cobalt-ink oklch(0.48), ~5.8:1 on paper) is applied by the
+   * [data-theme="light"] + prefers-color-scheme overrides below the @theme
+   * block. Kept as a dedicated light value rather than --rvui-text-2's light 0.50
+   * (which tests ~4.4:1, borderline AA on white). */
+  --color-muted-foreground: oklch(0.65 0.025 250);
   --color-accent: var(--rvui-accent);
   --color-accent-foreground: var(--rvui-text-on-accent);
   --color-destructive: var(--rvui-error);
@@ -66,6 +63,19 @@
    * Bump the utility so every section eyebrow flips at once
    * without editing components. */
   --tracking-widest: 0.20em;
+}
+
+/* ── Muted-foreground light overrides ──
+ * Dark default lives in the @theme inline block above. These restore the
+ * AA-on-paper cobalt-ink value when the visitor is in light mode (explicit
+ * attr or system preference), mirroring tokens.css's selector precedence. */
+[data-theme="light"] {
+  --color-muted-foreground: oklch(0.48 0.085 248);
+}
+@media (prefers-color-scheme: light) {
+  :root:not(.dark):not([data-theme="dark"]):not([data-theme="light"]) {
+    --color-muted-foreground: oklch(0.48 0.085 248);
+  }
 }
 
 /* ── Palette remap: emerald → cobalt, gray → cool smoke ──

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -81,7 +81,7 @@ export function BlogIndexPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-background to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Blog

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -12,7 +12,7 @@ import { WhatsShipped } from '../components/landing/WhatsShipped';
 
 export function HomePage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <Hero />
       <Problem />
       <Demo />

--- a/apps/marketing/app/routes/PrivacyPage.tsx
+++ b/apps/marketing/app/routes/PrivacyPage.tsx
@@ -3,7 +3,7 @@ import { PRIVACY_META, PRIVACY_SECTIONS } from '../content/legal/privacy';
 
 export function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
         <h1>{PRIVACY_META.title}</h1>
         <p className="text-sm text-muted-foreground">Last updated: {PRIVACY_META.lastUpdated}</p>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -17,7 +17,7 @@ export function ProductsPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             {PRODUCTS_PAGE_HERO.h1}

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -55,7 +55,7 @@ export function RoadmapPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-amber-50 via-background to-orange-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-amber-500/10 via-background to-orange-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Product

--- a/apps/marketing/app/routes/SponsorPage.tsx
+++ b/apps/marketing/app/routes/SponsorPage.tsx
@@ -69,7 +69,7 @@ export function SponsorPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-background to-indigo-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <section className="relative overflow-hidden bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             {SPONSOR_HERO.brand}
@@ -162,7 +162,7 @@ export function SponsorPage() {
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-3">
               {SPONSOR_SUPPORT_AREAS.map((area) => (
                 <div key={area.title} className="text-center">
-                  <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
+                  <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-500/10">
                     <SupportIcon iconKey={area.iconKey} />
                   </div>
                   <h3 className="mt-4 text-lg font-semibold text-foreground">{area.title}</h3>

--- a/apps/marketing/app/routes/TermsPage.tsx
+++ b/apps/marketing/app/routes/TermsPage.tsx
@@ -3,7 +3,7 @@ import { TERMS_META, TERMS_SECTIONS } from '../content/legal/terms';
 
 export function TermsPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background">
       <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
         <h1>{TERMS_META.title}</h1>
         <p className="text-sm text-muted-foreground">Last updated: {TERMS_META.lastUpdated}</p>

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
 <!--
-  data-theme="light" locks the marketing site to light mode. The brand token
-  set (@revealui/presentation/tokens.css) is dark-first (:root = dark), but
-  every marketing section paints explicit light backgrounds (bg-white /
-  bg-gray-50). Without this lock, semantic tokens (e.g. text-muted-foreground →
-  --rvui-text-2) resolved to their dark-mode silver values on white, both
-  washing the copy out and failing WCAG AA. Lock makes color deterministic.
+  System-adaptive: the marketing site follows the visitor's OS color scheme via
+  @revealui/presentation/tokens.css (dark-first :root + prefers-color-scheme:light
+  media query). Every section now uses adaptive semantic tokens (bg-background,
+  text-foreground, text-muted-foreground, …), so no data-theme lock is needed.
 -->
-<html lang="en" data-theme="light">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## What

**Turns on real system-adaptive dark mode** for the marketing site (`revealui.com`) — the owner-directed "go system-adaptive (real dark mode)" decision. The site now follows the visitor's OS color scheme: dark by default, light when the OS prefers light (or via an explicit `data-theme` toggle).

This is the **flip** — the final step of the marketing Cobalt overhaul. It's unblocked by the pricing dark-safe sweep ([#1124](https://github.com/RevealUIStudio/revealui/pull/1124)); the rest of the app was swept to semantic tokens across [#1114](https://github.com/RevealUIStudio/revealui/pull/1114) / [#1118](https://github.com/RevealUIStudio/revealui/pull/1118) / [#1120](https://github.com/RevealUIStudio/revealui/pull/1120) / [#1122](https://github.com/RevealUIStudio/revealui/pull/1122).

## How it works

`@revealui/presentation/tokens.css` is already dark-first with the right selector precedence:
- `:root` = dark
- `[data-theme="light"]` = explicit light
- `@media (prefers-color-scheme: light) :root:not([data-theme])` = **auto-follow-OS**

So removing the `data-theme="light"` lock from `index.html` is all it takes to make the site system-adaptive.

## Changes (5 files)

- **`index.html`** — drop `data-theme="light"` from `<html>`. Comment updated to describe the system-adaptive behavior.
- **`app/index.css`** — `--color-muted-foreground` was a hardcoded light value (`oklch(0.48)`) that *only the lock made safe* (it would be near-invisible on dark). Made adaptive: dark default `oklch(0.65)` (smoke-300, AA on midnight) + light `oklch(0.48)` (~5.8:1 on paper) via `[data-theme="light"]` + `prefers-color-scheme` overrides that mirror tokens.css's structure.
- **`HomePage` / `TermsPage` / `PrivacyPage`** — `min-h-screen bg-white` → `bg-background`. These were the **only** fixed-light page wrappers left app-wide (a whole-app grep found zero other theme-unsafe `bg-white`/`text-gray-*`/`text-black`/`ring-gray` outside the intentional always-dark `ProductMockup`).

## Kept intentionally (zero light-mode change)

- The `index.css` **emerald→cobalt palette remap stays**, so the **Content** primitive + **Beta** status badge keep rendering cobalt — no light-mode visual change.
- **ProductsPage** product-showcase heroes keep their white-on-cobalt treatment (brand surface — cobalt stays cobalt, white-on-cobalt is correct in both modes).
- **ProductMockup** stays an always-dark device illustration.

## Verification (dev server, LIGHT + DARK)

| Page | Dark | Light |
|------|------|-------|
| `/` (home) | ✅ dark bg, cobalt eyebrow/CTAs, readable muted body | ✅ (prior) |
| `/pricing` | ✅ (verified in #1124) | ✅ (verified in #1124) |
| `/products` | ✅ dark cards, white-on-cobalt hero intact, Beta badge cobalt | ✅ |
| `/terms` | ✅ dark page (was the white-wrapper risk), legal text readable | ✅ white page, dark text |

Booted **dark by default** under a dark-OS browser with no `data-theme` (confirmed `data-theme` absent, `bodyBg = oklch(0.16)`); flipping `data-theme="light"` returns the paper-white light theme. The adaptive `--color-muted-foreground` fix makes body/secondary text readable in dark (the original reason for the lock).

Build + biome clean. No prod promote (test-only).

## Follow-up (separate, owner-reviewed — a design fork, not needed for dark mode)

Remove the `emerald→cobalt` remap entirely and decide the **Content primitive / Beta badge** accent hue: keep it cobalt (= `primary`, matches today) **or** give it a distinct dark-safe green. The token system already moved `success` to teal-green to stay distinct from the cobalt brand, so a distinct hue is viable — but it's a visible design choice for the owner.
