### PR TITLE
fix(marketing): pricing badges text-amber-600 → -700 (last #1126 a11y gate)

### DIFF
--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -237,7 +237,7 @@ export function PricingPage() {
               >
                 {tier.comingSoon && (
                   <div className="absolute right-4 top-4">
-                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-600">
+                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-700">
                       Coming soon
                     </span>
                   </div>
@@ -288,7 +288,7 @@ export function PricingPage() {
                 {PRICING_AGENTS_SECTION.heading}
               </h2>
               <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENTS_SECTION.subhead}</p>
-              <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-600 ring-1 ring-amber-500/30">
+              <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-700 ring-1 ring-amber-500/30">
                 {PRICING_AGENTS_SECTION.badge}
               </span>
             </div>


### PR DESCRIPTION
## What

Fixes the **last AA color-contrast violation** blocking PR #1126 (test→main promotion). After [#1127](https://github.com/RevealUIStudio/revealui/pull/1127) cleared the muted-foreground + Hero-CLI `text-primary` violations, axe-core surfaced one remaining bug on the marketing pricing page.

## Bug

Two badges in `apps/marketing/app/routes/PricingPage.tsx` use `bg-amber-500/15` + `text-amber-600`:
- Line 240: "Coming soon" tag on perpetual-license tiers
- Line 291: Agents-section pricing badge

axe-core measured `#e17100` on `#f2e6d2` = **2.59:1** (need 4.5:1 for WCAG 2.1 AA). Hit 5 viewports × retries = `3 failed`.

## Fix

`text-amber-600` → `text-amber-700` on both lines. This matches the **established codebase convention** — every other amber-on-light usage in marketing already uses `text-amber-700`:

- `apps/marketing/app/routes/RoadmapPage.tsx:30,72`
- `apps/marketing/app/routes/FairSourcePage.tsx:110`
- `apps/marketing/app/components/landing/Primitives.tsx:7`
- `apps/marketing/app/content/products.ts:42`

Tailwind v4 amber-700 (`oklch(0.555 0.163 49)`) on the rendered bg renders at ~5:1, comfortably clearing AA. Marketing `index.css:11` explicitly leaves amber-* unremapped, so no remap interaction to consider.

## Verification

- Diff is 2 class swaps, identical structure
- Same shade is already in production across 5 marketing surfaces without prior axe-core issues
- CI's `Accessibility (E2E)` job will run axe-core against `/pricing` on this PR — that is the authoritative proof
- `dark:` variants intentionally not added: this codebase pattern handles amber as a raw palette (semantic tokens are used for theme-adaptive text per `--rvui-text-*`); peer's #1127 followed the same constraint

## Coordination

- This is in the marketing-overhaul peer's lane; opened narrowly to unblock the promotion gate without expanding scope. Pattern matches #1127 (same author, same gate)
- No other changes touched; pricing copy, tiers, and structure are untouched
- Unblocks #1126 once `Accessibility (E2E)` re-fires green on the new test HEAD
