### PR TITLE
fix(marketing): amber chips text-amber-800 + dark:text-amber-200 (AA both modes)

### DIFF
--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -237,7 +237,7 @@ export function PricingPage() {
               >
                 {tier.comingSoon && (
                   <div className="absolute right-4 top-4">
-                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-600">
+                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
                       Coming soon
                     </span>
                   </div>
@@ -288,7 +288,7 @@ export function PricingPage() {
                 {PRICING_AGENTS_SECTION.heading}
               </h2>
               <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENTS_SECTION.subhead}</p>
-              <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-600 ring-1 ring-amber-500/30">
+              <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-800 dark:text-amber-200 ring-1 ring-amber-500/30">
                 {PRICING_AGENTS_SECTION.badge}
               </span>
             </div>


### PR DESCRIPTION
## What

Third (and hopefully final) a11y contrast fix for the #1126 test→main promotion gate.

After #1127 fixed the muted-foreground + Hero CLI contrast violations, the next run of `Accessibility (E2E)` surfaced **one remaining type of violation** — `text-amber-600` on `bg-amber-500/15` = **2.59:1** (fails AA 4.5:1). This is the opacity-based amber-chip pattern I introduced in [#1124](https://github.com/RevealUIStudio/revealui/pull/1124) for the pricing "Coming soon" + "In Development" status badges. Amber's hue sits too close to its own tinted bg in light mode for a single mid-tone shade to clear AA.

## Fix

Bump the two badge text-colors:
- **Light mode:** `text-amber-600` → `text-amber-800` (sRGB ~`#92400e`, lum ~0.10) → ~**6.5:1** contrast on the light amber tint.
- **Dark mode:** add `dark:text-amber-200` (~`#fde68a`, lum ~0.77) → ~**5.5:1** on the dark amber tint.

AA-comfortable in both modes. The post-flip `dark:` variant aligns with `prefers-color-scheme` so this works in the truly system-adaptive site.

Only the two chips I introduced in #1124 are touched. The pre-existing amber patterns elsewhere (`Primitives` badge styles, `RoadmapPage` category colors, `FairSourcePage` status pills using `bg-amber-50/100 + text-amber-700`) were not flagged by axe and stay as-is.

## Verification

- `pnpm --filter marketing typecheck` clean, `biome check` clean.
- Once on `test`, #1126's `Accessibility (E2E)` will re-run against the fix.
