### PR TITLE
feat(marketing): public trust pages — terms/privacy honesty + /security + security.txt

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -12,6 +12,7 @@ import { PricingPage } from './routes/PricingPage';
 import { PrivacyPage } from './routes/PrivacyPage';
 import { ProductsPage } from './routes/ProductsPage';
 import { RoadmapPage } from './routes/RoadmapPage';
+import { SecurityPage } from './routes/SecurityPage';
 import { SponsorPage } from './routes/SponsorPage';
 import { TermsPage } from './routes/TermsPage';
 
@@ -39,6 +40,7 @@ export function App() {
       { path: '/sponsor', component: SponsorPage, meta: { title: 'Sponsor — RevealUI' } },
       { path: '/privacy', component: PrivacyPage, meta: { title: 'Privacy Policy — RevealUI' } },
       { path: '/terms', component: TermsPage, meta: { title: 'Terms of Service — RevealUI' } },
+      { path: '/security', component: SecurityPage, meta: { title: 'Security — RevealUI' } },
       { path: '/*notfound', component: NotFoundPage, meta: { title: '404 — RevealUI' } },
     ]);
     registered.current = true;

--- a/apps/marketing/app/content/legal/security.ts
+++ b/apps/marketing/app/content/legal/security.ts
@@ -1,0 +1,110 @@
+// Security policy page content. Schema reused from LegalSection for layout
+// consistency with TermsPage + PrivacyPage; the page itself is a trust
+// signal, not a contract, but the long-form prose-article rendering is the
+// same shape.
+
+import { SITE } from '../site';
+import type { LegalSection } from './privacy';
+
+export const SECURITY_META = {
+  title: 'Security',
+  lastUpdated: 'May 28, 2026',
+  intro:
+    'RevealUI Studio is a solo-operator company building production software. Security is not a marketing line for us — it is a discipline we apply every day, and it determines whether real customers can trust us with their data. This page describes how we accept vulnerability reports, what we commit to in return, and the security posture our customers inherit when they self-host.',
+} as const;
+
+export const SECURITY_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Reporting a vulnerability',
+    paragraphs: [
+      `If you believe you have found a security vulnerability in RevealUI or any of our hosted properties (revealui.com, admin.revealui.com, api.revealui.com, docs.revealui.com), email ${SITE.emails.security} with a clear description, reproduction steps, and the affected URL or component. If you need a backup address, use ${SITE.emails.founder}.`,
+      'We do not currently publish a PGP key. If your report contains sensitive material (proof-of-concept payloads, user data exposure, exploit details), email us first and we will arrange an encrypted channel before you share specifics.',
+      'We acknowledge receipt within 2 business days and aim to provide a substantive initial response within 5 business days. As a solo-operator company we cannot promise 24×7 triage, but we treat real security reports as our highest priority.',
+    ],
+  },
+  {
+    heading: '2. Our commitment to good-faith researchers',
+    listPreamble: 'If you act in good faith and follow this policy, we commit to:',
+    listItems: [
+      'Not pursue or support legal action against you for your research.',
+      'Not contact law enforcement or your employer about your report.',
+      'Work with you to understand and resolve the issue without unnecessary delay.',
+      'Credit you publicly on this page when the issue is resolved, if you wish to be named. We will never publish your identity without your consent.',
+    ],
+    paragraphs: [
+      'We do not currently run a paid bug-bounty program. We are pre-revenue and cannot honestly promise bounty payouts that we may not be able to fund. If you find a material issue we will discuss recognition, swag, or — once we are revenue-generating — a discretionary reward.',
+    ],
+  },
+  {
+    heading: '3. Scope',
+    listPreamble: 'In scope:',
+    listItems: [
+      'revealui.com (marketing site)',
+      'admin.revealui.com (admin dashboard)',
+      'api.revealui.com (REST API)',
+      'docs.revealui.com (documentation site)',
+      'The published source code in the RevealUIStudio organization on GitHub',
+    ],
+  },
+  {
+    heading: '4. Out of scope',
+    listItems: [
+      'Third-party services we use (Vercel, NeonDB, Stripe, Cloudflare, etc.) — report directly to those vendors.',
+      'Social-engineering attacks against employees, contractors, or customers.',
+      'Denial-of-service attacks, traffic flooding, or any test that affects availability.',
+      'Vulnerabilities in software you have self-hosted using RevealUI but modified — please report against an unmodified build.',
+      'Findings that require physical access to a device we do not own.',
+      'Reports of missing security headers without a demonstrated exploit.',
+      'Reports based solely on automated-scanner output without manual verification.',
+    ],
+  },
+  {
+    heading: '5. What we will not do',
+    listItems: [
+      'We will not silently fix issues without notifying the reporter when a fix ships.',
+      'We will not delay disclosure indefinitely to avoid embarrassment. We aim to publish a brief notice within 90 days of resolution, or sooner if the issue has been independently disclosed.',
+      'We will not retaliate against researchers who follow this policy.',
+    ],
+  },
+  {
+    heading: '6. Our security posture (summary)',
+    paragraphs: [
+      'Customers who run RevealUI inherit a security baseline we take seriously. The current posture, in plain English:',
+    ],
+    listItems: [
+      'Authentication uses session cookies signed with a server-side secret, with bcrypt password hashing (cost factor 12), brute-force protection, and rate limiting.',
+      'Authorization is enforced by an RBAC + ABAC policy engine with database-level access checks on every collection operation.',
+      'Encryption for sensitive fields uses AES-256-GCM with non-extractable keys by default.',
+      'Standard browser security headers (CSP, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy) are configured on every deployed app.',
+      'Continuous integration runs CodeQL, Gitleaks, dependency auditing, and an AST-based code-pattern analyzer on every push.',
+      'GitHub branch protection requires CI passage before merge to main; production deploys are gated on the deploy workflow, not direct pushes.',
+      'Internal security documentation — incident response runbook, information security policy, credential rotation runbook — is maintained alongside this site and available for customer review on request.',
+    ],
+  },
+  {
+    heading: '7. Compliance',
+    paragraphs: [
+      'RevealUI Studio is a Tennessee LLC operating as a solo-operator company. We do not currently hold SOC 2, ISO 27001, or PCI DSS attestations. These are planned for later phases of the company; we will publish progress on this page when those audits begin.',
+      'For data protection: we are GDPR-aware in our framework design (consent, deletion, anonymization primitives are in the platform), but a Data Processing Agreement template is not yet finalized for EU B2B customers. If you require a DPA before purchase, contact us before signing up.',
+    ],
+  },
+  {
+    heading: '8. Machine-readable policy',
+    paragraphs: [
+      'This policy is also published as an RFC 9116 security.txt file at https://revealui.com/.well-known/security.txt. Automated security tooling should read that file for contact and policy URLs.',
+    ],
+  },
+  {
+    heading: '9. Hall of fame',
+    paragraphs: [
+      'We will list researchers here as they are credited. The list is empty today — pre-launch — but we plan to keep it updated as the program runs.',
+    ],
+  },
+  {
+    heading: '10. Contact',
+    paragraphs: [
+      `For security questions or to submit a report, contact us at ${SITE.emails.security}.`,
+    ],
+    contactEmail: SITE.emails.security,
+  },
+];

--- a/apps/marketing/app/content/legal/terms.ts
+++ b/apps/marketing/app/content/legal/terms.ts
@@ -5,7 +5,7 @@ import type { LegalSection } from './privacy';
 
 export const TERMS_META = {
   title: 'Terms of Service',
-  lastUpdated: 'March 4, 2026',
+  lastUpdated: 'May 28, 2026',
   intro:
     'These Terms of Service ("Terms") govern your use of the RevealUI platform provided by REVEALUI STUDIO L.L.C., a Tennessee limited liability company ("we", "us", "our"). By creating an account or using the Service, you agree to these Terms.',
 } as const;
@@ -38,17 +38,15 @@ export const TERMS_SECTIONS: readonly LegalSection[] = [
       {
         heading: 'Billing',
         listItems: [
-          'Pro: $49/month, billed monthly. Includes a 7-day free trial.',
-          'Max: $149/month, billed monthly. Includes a 7-day free trial.',
-          'Enterprise: $299/month, billed monthly. Contact sales for annual pricing.',
-          'All prices are in USD and exclude applicable taxes.',
-          "Payment is processed by Stripe. You agree to Stripe's terms of service.",
+          'Subscription prices for Pro, Max, and Enterprise are as published at https://revealui.com/pricing at the time of purchase, in U.S. dollars and exclusive of applicable taxes. You will see the price you agree to before completing checkout.',
+          'Pro and Max include a 7-day free trial. Enterprise pricing is published with the option to contact sales for annual rates.',
+          "Payment is processed by Stripe. You agree to Stripe's terms of service when you complete checkout.",
         ],
       },
       {
         heading: 'Trial',
         paragraph:
-          'The Pro tier includes a 7-day free trial. You will not be charged during the trial period. If you do not cancel before the trial ends, your subscription will automatically begin and you will be charged the applicable monthly rate.',
+          'The Pro and Max tiers include a 7-day free trial. You will not be charged during the trial period. If you do not cancel before the trial ends, your subscription will automatically begin and you will be charged the applicable monthly rate.',
       },
       {
         heading: 'Cancellation',

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -81,6 +81,7 @@ export const SITE = {
   emails: {
     support: 'support@revealui.com',
     founder: 'founder@revealui.com',
+    security: 'security@revealui.com',
   },
   cli: {
     create: 'npx create-revealui@latest my-app',

--- a/apps/marketing/app/routes/PrivacyPage.tsx
+++ b/apps/marketing/app/routes/PrivacyPage.tsx
@@ -1,10 +1,24 @@
+import { Callout } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import { PRIVACY_META, PRIVACY_SECTIONS } from '../content/legal/privacy';
+import { SITE } from '../content/site';
 
 export function PrivacyPage() {
   return (
     <div className="min-h-screen bg-background">
-      <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
+      <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
+        <Callout variant="info" title="Status: drafted in good faith, pending counsel review">
+          This page describes our actual privacy practices today. The wording has not yet been
+          reviewed by an attorney; we disclose this rather than hide it. The substance will not
+          change after review — only the wording may tighten. Privacy questions or data-rights
+          requests in the meantime:{' '}
+          <a className="underline" href={`mailto:${SITE.emails.support}`}>
+            {SITE.emails.support}
+          </a>
+          .
+        </Callout>
+      </div>
+      <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
         <h1>{PRIVACY_META.title}</h1>
         <p className="text-sm text-muted-foreground">Last updated: {PRIVACY_META.lastUpdated}</p>
 

--- a/apps/marketing/app/routes/SecurityPage.tsx
+++ b/apps/marketing/app/routes/SecurityPage.tsx
@@ -1,0 +1,73 @@
+import { Callout } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import { SECURITY_META, SECURITY_SECTIONS } from '../content/legal/security';
+import { SITE } from '../content/site';
+
+export function SecurityPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
+        <Callout variant="success" title="Safe-harbor commitment to good-faith researchers">
+          If you act in good faith and follow this policy, we will not pursue or support legal
+          action against you for your security research. Email{' '}
+          <a className="underline" href={`mailto:${SITE.emails.security}`}>
+            {SITE.emails.security}
+          </a>{' '}
+          to report a vulnerability. The machine-readable policy is at{' '}
+          <a className="underline" href="/.well-known/security.txt">
+            /.well-known/security.txt
+          </a>
+          .
+        </Callout>
+      </div>
+      <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
+        <h1>{SECURITY_META.title}</h1>
+        <p className="text-sm text-muted-foreground">Last updated: {SECURITY_META.lastUpdated}</p>
+
+        <p>{SECURITY_META.intro}</p>
+
+        {SECURITY_SECTIONS.map((section) => (
+          <div key={section.heading}>
+            <h2>{section.heading}</h2>
+
+            {section.subsections?.map((sub) => (
+              <div key={sub.heading}>
+                <h3>{sub.heading}</h3>
+                {sub.paragraph && <p>{sub.paragraph}</p>}
+                {sub.listItems && (
+                  <ul>
+                    {sub.listItems.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+
+            {section.listPreamble && <p>{section.listPreamble}</p>}
+
+            {section.listItems && (
+              <ul>
+                {section.listItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
+
+            {section.paragraphs?.map((para) =>
+              section.contactEmail ? (
+                <p key={para}>
+                  For security questions or to submit a report, contact us at{' '}
+                  <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
+                </p>
+              ) : (
+                <p key={para}>{para}</p>
+              ),
+            )}
+          </div>
+        ))}
+      </article>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/marketing/app/routes/TermsPage.tsx
+++ b/apps/marketing/app/routes/TermsPage.tsx
@@ -1,10 +1,23 @@
+import { Callout } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import { TERMS_META, TERMS_SECTIONS } from '../content/legal/terms';
+import { SITE } from '../content/site';
 
 export function TermsPage() {
   return (
     <div className="min-h-screen bg-background">
-      <article className="mx-auto max-w-3xl px-6 py-24 lg:px-8 prose prose-gray">
+      <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
+        <Callout variant="info" title="Status: drafted in good faith, pending counsel review">
+          This page describes our actual practices and commitments today. The wording has not yet
+          been reviewed by an attorney; we disclose this rather than hide it. The substance will not
+          change after review — only the wording may tighten. Questions in the meantime?{' '}
+          <a className="underline" href={`mailto:${SITE.emails.support}`}>
+            {SITE.emails.support}
+          </a>
+          .
+        </Callout>
+      </div>
+      <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
         <h1>{TERMS_META.title}</h1>
         <p className="text-sm text-muted-foreground">Last updated: {TERMS_META.lastUpdated}</p>
 

--- a/apps/marketing/public/.well-known/security.txt
+++ b/apps/marketing/public/.well-known/security.txt
@@ -1,0 +1,13 @@
+# Security policy for revealui.com (RFC 9116).
+# Plain-text version: https://revealui.com/security
+
+Contact: mailto:security@revealui.com
+Contact: mailto:founder@revealui.com
+Expires: 2027-05-28T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://revealui.com/.well-known/security.txt
+Policy: https://revealui.com/security
+
+# We do not currently publish a PGP key. If you need encrypted communication
+# for a sensitive report, email security@revealui.com first and we will
+# arrange a channel.

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -31,6 +31,13 @@
         { "key": "X-Robots-Tag", "value": "noindex" },
         { "key": "Cache-Control", "value": "no-store" }
       ]
+    },
+    {
+      "source": "/.well-known/security.txt",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=86400" }
+      ]
     }
   ],
   "redirects": [
@@ -58,6 +65,7 @@
   "rewrites": [
     { "source": "/robots.txt", "destination": "/robots.txt" },
     { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
+    { "source": "/.well-known/(.*)", "destination": "/.well-known/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -83,7 +83,7 @@ Honest list of things that are not done, not deployed, or not verified.
 - **REVEALUI_KEK rotation tooling is not yet built** (GAP-126 open). KEK rotation requires a coordinated maintenance window with manual data re-encryption today.
 - **No status page publicly advertised.** Uptime monitoring is configured.
 - **No public support channel.** There is no public support email, chat, or ticketing system yet.
-- **No Terms of Service or Privacy Policy.** Legal documents are pending lawyer review.
+- **Terms of Service and Privacy Policy are live, but not yet lawyer-reviewed.** Drafted in good faith by RevealUI Studio and published at [/terms](https://revealui.com/terms) and [/privacy](https://revealui.com/privacy). Each page carries an explicit "draft pending counsel review" banner — we disclose this rather than hide it. Counsel review is scheduled post-first-revenue. Subscription prices are referenced as "published at /pricing at the time of purchase" rather than hardcoded, so the pricing page is the single source of truth.
 - **No SOC2 or ISO 27001.** Security certifications are planned for Phase 6, not current.
 - **MCP marketplace is preview, not live.** Publish/list/invoke/onboard endpoints are wired; payouts open with the billing-readiness audit.
 - **No SSO / SCIM in code.** Roadmap items.


### PR DESCRIPTION
## Why

Phase A of the moral-charge launch-bar lane (internal). This PR groups the two coherent **"public trust pages"** changes from the lane: honesty pass on Terms + Privacy, plus the missing Security page + RFC 9116 `security.txt`.

The lane started with a live audit of revealui.com surfaces vs. what the internal honesty doc claims vs. what `COMMERCIAL_READINESS.md` says is the bar for moral charging. Findings:

- `/terms` and `/privacy` ARE live (good drafts), but `WHAT_WORKS_TODAY.md` was telling visitors the opposite ("No Terms of Service or Privacy Policy")
- Terms §4 Billing hardcoded subscription prices ($49 / $149 / $299) — silent drift risk vs. `@revealui/contracts/pricing`
- `/security` and `/.well-known/security.txt` were both returning 200 — but only because Vite's catch-all rewrite was serving the SPA shell. **No SecurityPage component existed; no static security.txt file existed.**

## What

### Commit 1 — `docs(marketing): honesty pass on terms + privacy pages`

**A1 — `docs/WHAT_WORKS_TODAY.md`** — replace the "No Terms of Service or Privacy Policy" line with the honest reality: both pages are live and drafted in good faith, with an explicit "draft pending counsel review" banner on each. Counsel review is scheduled post-first-revenue.

**A11 — `apps/marketing/app/content/legal/terms.ts` §4 Billing** — replace hardcoded prices with the standard "as published at time of purchase" pattern. Trial subsection also updated (was Pro-only despite Max also having a trial). `lastUpdated` bumped to 2026-05-28.

**A12 — `apps/marketing/app/routes/{TermsPage,PrivacyPage}.tsx`** — add a `Callout variant="info"` banner above the article:

> *Status: drafted in good faith, pending counsel review. This page describes our actual practices and commitments today. The wording has not yet been reviewed by an attorney; we disclose this rather than hide it. The substance will not change after review — only the wording may tighten.*

### Commit 2 — `feat(marketing): add /security page + RFC 9116 security.txt`

**A2 — `apps/marketing/public/.well-known/security.txt`** — RFC 9116 compliant static file: two Contact addresses, 1-year Expires (2027-05-28), Preferred-Languages, Canonical, Policy URL. Explicit honest "no PGP key today" disclosure with instructions for sensitive reports. `vercel.json` updated with (a) header rule forcing `Content-Type: text/plain; charset=utf-8` + 24h cache, (b) rewrite rule `/.well-known/(.*) → /.well-known/$1` BEFORE the SPA catch-all so the file is served as-is.

**A3 — `apps/marketing/app/routes/SecurityPage.tsx`** — 10-section page following the same prose-article pattern as Terms + Privacy:

1. Reporting a vulnerability (2 business days to acknowledge, 5 substantive)
2. Our commitment to good-faith researchers (safe-harbor in plain language)
3. Scope (production domains + GitHub org)
4. Out of scope (third-party, social engineering, DoS, automated-scanner output)
5. What we will not do (no silent fixes, no indefinite delay, no retaliation)
6. Security posture summary (RBAC + ABAC, AES-256-GCM, CSP/HSTS, CodeQL, branch protection — plain English, no internals)
7. Compliance (honest "no SOC 2 / ISO 27001 / PCI DSS today" + DPA-not-yet)
8. Machine-readable policy → `.well-known/security.txt`
9. Hall of fame (empty today, framework set up)
10. Contact (`security@revealui.com`)

Page wears a `Callout variant="success"` banner with the safe-harbor commitment up-front. Visually distinct from the info banner on Terms/Privacy by intent.

The page is honest about what is NOT in place: no PGP key, no paid bug bounty, no SOC 2 today, no DPA template today. Each gap is disclosed in plain language with what we will do instead.

**Supporting changes**:
- `apps/marketing/app/content/legal/security.ts` — content split out (LegalSection schema reused for layout consistency)
- `apps/marketing/app/content/site.ts` — added `emails.security: 'security@revealui.com'` alongside support + founder
- `apps/marketing/app/App.tsx` — register `/security` route before the catch-all

## Verified locally

- `pnpm --filter marketing typecheck` — clean (both commits)
- `pnpm exec biome check` on touched files — clean
- `pnpm validate:claims` — 0 mismatches
- `pnpm --filter marketing build` — 854ms, no errors
- pre-push gate — PASS (23s, all hard-fail gates green)
- Dev server preview:
  - `/terms` + `/privacy` banners verified light + dark mode (system-adaptive `prefers-color-scheme`); banner `backgroundColor` swaps from light-info `oklch(0.97 0.014 254.604)` to dark variant
  - `/security` renders all 10 sections + safe-harbor banner with mailto + `.well-known` link; light banner `oklch(0.982 0.018 155.826)` (success variant)
  - `/.well-known/security.txt` returns 200, `text/plain`, RFC 9116 body (verified via `fetch` from page context)
  - Console clean across all 3 pages

## Owner action

- **Verify** `security@revealui.com` Google Workspace alias routes to a real inbox (free; add as group alias to founder@ if not already). Same for `support@revealui.com`.
- Merge when green. No auto-merge per standing policy.

## Out of scope (queued in lane plan as separate stacked PRs)

- SupportPage + StatusPage — **PR3** (next, will stack on this branch)
- SubprocessorsPage + Footer overhaul + solo-operator + cookie disclosure + training-data promise — PR4
- `/api/health` path mismatch — PR5
- Sentry SDK + CSP allowlist (all 3 apps) — PR6
- License fail-mode communication in Terms — PR7 (translates internal ADR to public language)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
