### PR TITLE
feat(marketing): subprocessors + footer overhaul + privacy transparency

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -15,6 +15,7 @@ import { RoadmapPage } from './routes/RoadmapPage';
 import { SecurityPage } from './routes/SecurityPage';
 import { SponsorPage } from './routes/SponsorPage';
 import { StatusPage } from './routes/StatusPage';
+import { SubprocessorsPage } from './routes/SubprocessorsPage';
 import { SupportPage } from './routes/SupportPage';
 import { TermsPage } from './routes/TermsPage';
 
@@ -45,6 +46,11 @@ export function App() {
       { path: '/security', component: SecurityPage, meta: { title: 'Security — RevealUI' } },
       { path: '/support', component: SupportPage, meta: { title: 'Support — RevealUI' } },
       { path: '/status', component: StatusPage, meta: { title: 'Status — RevealUI' } },
+      {
+        path: '/legal/subprocessors',
+        component: SubprocessorsPage,
+        meta: { title: 'Subprocessors — RevealUI' },
+      },
       { path: '/*notfound', component: NotFoundPage, meta: { title: '404 — RevealUI' } },
     ]);
     registered.current = true;

--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -1,5 +1,11 @@
 import { BuiltWithRevealUI } from '@revealui/presentation';
-import { FOOTER_COLUMNS, FOOTER_LEGAL, FOOTER_LEGAL_LINKS, FOOTER_TAGLINE } from '../content/nav';
+import {
+  FOOTER_COLUMNS,
+  FOOTER_LEGAL,
+  FOOTER_LEGAL_LINKS,
+  FOOTER_SOLO_OPERATOR_NOTE,
+  FOOTER_TAGLINE,
+} from '../content/nav';
 import { SITE } from '../content/site';
 import { NewsletterSignup } from './NewsletterSignup';
 
@@ -8,12 +14,15 @@ export function Footer() {
   return (
     <footer className="bg-muted border-t border-border py-12">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
           <div className="lg:col-span-2">
             <div className="text-2xl font-bold tracking-tight text-foreground mb-4">
               {SITE.brand}
             </div>
             <p className="text-muted-foreground text-sm leading-6 max-w-sm">{FOOTER_TAGLINE}</p>
+            <p className="text-muted-foreground text-xs leading-6 max-w-sm mt-3">
+              {FOOTER_SOLO_OPERATOR_NOTE}
+            </p>
             <div className="mt-6">
               <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
                 Stay in the loop

--- a/apps/marketing/app/content/legal/privacy.ts
+++ b/apps/marketing/app/content/legal/privacy.ts
@@ -28,7 +28,7 @@ export interface ThirdParty {
 
 export const PRIVACY_META = {
   title: 'Privacy Policy',
-  lastUpdated: 'April 22, 2026',
+  lastUpdated: 'May 28, 2026',
   intro:
     'The RevealUI platform (revealui.com, admin.revealui.com, api.revealui.com, and docs.revealui.com — the "Service") is operated by REVEALUI STUDIO L.L.C., a Tennessee limited liability company ("we", "us", "our"). This Privacy Policy describes how we collect, use, and protect your personal information.',
 } as const;
@@ -96,6 +96,12 @@ export const PRIVACY_SECTIONS: readonly LegalSection[] = [
         policyUrl: 'https://vercel.com/legal/privacy-policy',
       },
       {
+        name: 'Cloudflare R2',
+        description: 'object storage (media uploads, generated assets)',
+        policyLabel: 'Cloudflare Privacy Policy',
+        policyUrl: 'https://www.cloudflare.com/privacypolicy/',
+      },
+      {
         name: 'Google Workspace',
         description: 'transactional email delivery via Gmail API',
         policyLabel: 'Google Privacy Policy',
@@ -110,15 +116,26 @@ export const PRIVACY_SECTIONS: readonly LegalSection[] = [
           'Error data may include browser context, page URL, and a partial session recording captured at the time of an error. No continuous session recording is performed.',
       },
     ],
+    paragraphs: [
+      'For the full dated list of subprocessors with regions, data categories, and DPA links, see our Subprocessors page at https://revealui.com/legal/subprocessors. The Subprocessors page is the authoritative source; this section is a summary kept in sync with it.',
+    ],
   },
   {
-    heading: '4. Data Retention',
+    heading: '4. Customer content and AI training',
+    paragraphs: [
+      'We do not use customer content (the data, prompts, files, and configurations you submit to the Service) to train any general-purpose model. This commitment applies to any model we operate and to any third-party model accessed through the Service via our infrastructure.',
+      'If you connect your own external LLM provider to RevealUI (your own OpenAI key, Anthropic key, or other provider), your data flows to that provider on terms you have agreed to with them. We do not intermediate those terms — you are responsible for understanding their training-data position.',
+      'The default RevealUI configuration uses local AI inference (Ollama or Inference Snaps) that runs entirely on your own infrastructure. In that configuration, customer content does not leave your boundary at all.',
+    ],
+  },
+  {
+    heading: '5. Data Retention',
     paragraphs: [
       'Account data is retained while your account is active. After account deletion, we permanently remove your personal data within 30 days. Application logs and error events are retained for 90 days. Agent activity audit logs are retained indefinitely for security and compliance purposes. Infrastructure server logs (IP address, request path, user agent) are retained by our hosting provider per their policy. Billing records are retained as required by tax law (typically 7 years).',
     ],
   },
   {
-    heading: '5. Your Rights (GDPR / CCPA)',
+    heading: '6. Your Rights (GDPR / CCPA)',
     listItems: [
       'Access your personal data, available via your account settings or by contacting us',
       'Export your data: use the GDPR export endpoint in the admin',
@@ -131,31 +148,38 @@ export const PRIVACY_SECTIONS: readonly LegalSection[] = [
     ],
   },
   {
-    heading: '6. Security',
+    heading: '7. Security',
     paragraphs: [
       'We protect your data using: bcrypt password hashing, session-based authentication with secure cookies, rate limiting and brute-force protection, HTTPS/TLS encryption in transit, and encrypted database connections.',
     ],
   },
   {
-    heading: '7. Cookies',
+    heading: '8. Cookies and trackers',
+    listPreamble:
+      'We use the following cookies and trackers across our public marketing site (revealui.com), the admin dashboard, and the API:',
+    listItems: [
+      'Session cookie (essential): set on sign-in to keep you authenticated. httpOnly, secure, sameSite=lax.',
+      'CSRF token cookie (essential): set on POST requests to prevent cross-site request forgery.',
+      'Vercel Speed Insights (performance telemetry, anonymous): loaded on the marketing site to measure Core Web Vitals (LCP, INP, CLS, etc.). Aggregated by Vercel; no personal identifiers; no cross-site tracking.',
+    ],
     paragraphs: [
-      'We use essential cookies only: a session cookie for authentication. We do not use tracking cookies, analytics cookies, or advertising cookies.',
+      'We do not use advertising cookies, third-party tracking cookies, or cross-site cookies. Vercel Speed Insights honors the `Do Not Track` browser signal and can be opted out at the browser level. We will surface any additional trackers — including Sentry, when wired — on this list in the same commit that adds them.',
     ],
   },
   {
-    heading: '8. Children',
+    heading: '9. Children',
     paragraphs: [
       'The Service is not intended for children under 13. We do not knowingly collect personal information from children under 13.',
     ],
   },
   {
-    heading: '9. Changes',
+    heading: '10. Changes',
     paragraphs: [
       'We may update this Privacy Policy from time to time. We will notify registered users of material changes via email.',
     ],
   },
   {
-    heading: '10. Contact',
+    heading: '11. Contact',
     paragraphs: [
       `For privacy-related questions or to exercise your data rights, contact us at ${SITE.emails.support}.`,
     ],

--- a/apps/marketing/app/content/legal/subprocessors.ts
+++ b/apps/marketing/app/content/legal/subprocessors.ts
@@ -1,0 +1,111 @@
+// Subprocessors page content. Custom shape (not LegalSection) — this page
+// is a tabular registry, not prose, so it has its own schema.
+
+export interface Subprocessor {
+  readonly name: string;
+  readonly role: string;
+  readonly location: string;
+  readonly dataCategories: readonly string[];
+  readonly privacyPolicyUrl: string;
+  readonly dpaUrl?: string;
+  /** Month we started using this vendor, YYYY-MM. */
+  readonly since: string;
+}
+
+export const SUBPROCESSORS_META = {
+  title: 'Subprocessors',
+  lastUpdated: 'May 28, 2026',
+  intro:
+    'A subprocessor is a third-party service we use to operate RevealUI on your behalf. Every entry below stores, processes, or transmits some category of customer data. The table is dated and we commit to updating it before adding a new subprocessor, not after — see the change-log at the bottom of this page.',
+} as const;
+
+/**
+ * Active subprocessors as of the lastUpdated date. Each entry must be
+ * accurate at the moment of publication. Changes to this list must also
+ * land in CHANGELOG below within the same commit.
+ */
+export const SUBPROCESSORS: readonly Subprocessor[] = [
+  {
+    name: 'Vercel',
+    role: 'Application hosting (marketing, admin, API, docs)',
+    location: 'United States (primary: us-east-1)',
+    dataCategories: [
+      'Application traffic',
+      'Build artifacts',
+      'Edge logs (IP, user agent, request path)',
+      'Speed Insights telemetry (anonymous)',
+    ],
+    privacyPolicyUrl: 'https://vercel.com/legal/privacy-policy',
+    dpaUrl: 'https://vercel.com/legal/dpa',
+    since: '2026-03',
+  },
+  {
+    name: 'NeonDB',
+    role: 'PostgreSQL database (primary store)',
+    location: 'United States (primary: us-east-1)',
+    dataCategories: [
+      'Account records',
+      'License records',
+      'Site and content data',
+      'Agent memory and audit logs',
+    ],
+    privacyPolicyUrl: 'https://neon.tech/privacy-policy',
+    dpaUrl: 'https://neon.tech/dpa',
+    since: '2026-03',
+  },
+  {
+    name: 'Cloudflare R2',
+    role: 'Object storage (media uploads, generated assets)',
+    location: 'United States',
+    dataCategories: ['Uploaded files', 'Generated images'],
+    privacyPolicyUrl: 'https://www.cloudflare.com/privacypolicy/',
+    dpaUrl: 'https://www.cloudflare.com/cloudflare-customer-dpa/',
+    since: '2026-05',
+  },
+  {
+    name: 'Stripe',
+    role: 'Payment processing (subscriptions, perpetual licenses, refunds)',
+    location: 'United States (PCI DSS Level 1)',
+    dataCategories: [
+      'Billing identity (name, email, billing address)',
+      'Payment method metadata',
+      'Transaction records',
+    ],
+    privacyPolicyUrl: 'https://stripe.com/privacy',
+    dpaUrl: 'https://stripe.com/legal/dpa',
+    since: '2026-04',
+  },
+  {
+    name: 'Google Workspace',
+    role: 'Transactional email delivery (receipts, license keys, support)',
+    location: 'United States',
+    dataCategories: ['Email address', 'Message content for delivery'],
+    privacyPolicyUrl: 'https://policies.google.com/privacy',
+    dpaUrl: 'https://workspace.google.com/terms/dpa_terms.html',
+    since: '2026-03',
+  },
+];
+
+export interface ChangeLogEntry {
+  readonly date: string;
+  readonly summary: string;
+}
+
+/**
+ * Append-only change log. Every change to SUBPROCESSORS above must add an
+ * entry here in the same commit. Entries are most-recent-first.
+ */
+export const SUBPROCESSORS_CHANGELOG: readonly ChangeLogEntry[] = [
+  {
+    date: '2026-05-28',
+    summary:
+      'Initial published list: Vercel, NeonDB, Cloudflare R2, Stripe, Google Workspace. Sentry is listed in the Privacy Policy as an anticipated subprocessor for error tracking; it will appear here once the SDK is wired and a DSN is configured.',
+  },
+];
+
+export const SUBPROCESSORS_NOTES = {
+  subscribeAdvice:
+    'There is no subscribe-to-changes channel for this page yet. Material customers can request notification by email and we will email them when an entry is added. Watch the RevealUI repository on GitHub to receive a notification when this file changes in source.',
+  contactPrefix:
+    'Questions about a specific subprocessor — including its DPA, regional data handling, or sub-processors of its own — should go to ',
+} as const;

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -43,10 +43,22 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
       { label: 'Contact', href: '/contact' },
     ],
   },
+  {
+    heading: 'Trust',
+    links: [
+      { label: 'Status', href: '/status' },
+      { label: 'Support', href: '/support' },
+      { label: 'Security', href: '/security' },
+      { label: 'Subprocessors', href: '/legal/subprocessors' },
+    ],
+  },
 ] as const;
 
 export const FOOTER_TAGLINE =
   'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and ready to deploy.' as const;
+
+export const FOOTER_SOLO_OPERATOR_NOTE =
+  'Built by one engineer in Tennessee. See Support for response SLAs.' as const;
 
 export const FOOTER_LEGAL = {
   operator: 'REVEALUI STUDIO L.L.C.',
@@ -55,6 +67,8 @@ export const FOOTER_LEGAL = {
 } as const;
 
 export const FOOTER_LEGAL_LINKS: readonly NavLink[] = [
-  { label: 'Privacy Policy', href: '/privacy' },
-  { label: 'Terms of Service', href: '/terms' },
+  { label: 'Privacy', href: '/privacy' },
+  { label: 'Terms', href: '/terms' },
+  { label: 'Security', href: '/security' },
+  { label: 'Subprocessors', href: '/legal/subprocessors' },
 ] as const;

--- a/apps/marketing/app/routes/SubprocessorsPage.tsx
+++ b/apps/marketing/app/routes/SubprocessorsPage.tsx
@@ -1,0 +1,154 @@
+import { Callout } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import {
+  SUBPROCESSORS,
+  SUBPROCESSORS_CHANGELOG,
+  SUBPROCESSORS_META,
+  SUBPROCESSORS_NOTES,
+} from '../content/legal/subprocessors';
+import { SITE } from '../content/site';
+
+export function SubprocessorsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-6 pt-24 lg:px-8">
+        <Callout variant="info" title="Dated subprocessor registry, updated before changes ship">
+          We commit to updating this page <em>before</em> adding a new subprocessor, not after.
+          Every entry in the table below is accurate as of the date in the header. There is no
+          subscribe-to-changes channel yet (queued for after we have customers); for now, watch this
+          file in the repository or email{' '}
+          <a className="underline" href={`mailto:${SITE.emails.support}`}>
+            {SITE.emails.support}
+          </a>{' '}
+          to be notified by email.
+        </Callout>
+      </div>
+
+      <section className="mx-auto max-w-4xl px-6 pt-10 lg:px-8">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          {SUBPROCESSORS_META.title}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: {SUBPROCESSORS_META.lastUpdated}
+        </p>
+        <p className="mt-6 text-base text-foreground">{SUBPROCESSORS_META.intro}</p>
+
+        <div className="mt-10 overflow-x-auto rounded-xl ring-1 ring-border">
+          <table className="w-full divide-y divide-border text-left text-sm">
+            <thead className="bg-muted text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Vendor
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Role
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Location
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Data
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Since
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Links
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {SUBPROCESSORS.map((sp) => (
+                <tr key={sp.name} className="align-top">
+                  <td className="px-4 py-4 font-medium text-foreground">{sp.name}</td>
+                  <td className="px-4 py-4 text-muted-foreground">{sp.role}</td>
+                  <td className="px-4 py-4 text-muted-foreground">{sp.location}</td>
+                  <td className="px-4 py-4 text-muted-foreground">
+                    <ul className="list-disc pl-4">
+                      {sp.dataCategories.map((category) => (
+                        <li key={category}>{category}</li>
+                      ))}
+                    </ul>
+                  </td>
+                  <td className="px-4 py-4 text-muted-foreground">{sp.since}</td>
+                  <td className="px-4 py-4">
+                    <ul className="space-y-1">
+                      <li>
+                        <a
+                          className="text-primary underline"
+                          href={sp.privacyPolicyUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Privacy policy
+                        </a>
+                      </li>
+                      {sp.dpaUrl && (
+                        <li>
+                          <a
+                            className="text-primary underline"
+                            href={sp.dpaUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            DPA
+                          </a>
+                        </li>
+                      )}
+                    </ul>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <article className="mx-auto max-w-4xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
+        <h2>Change log</h2>
+        <p>
+          Append-only. Every change to the table above lands here in the same commit. Most recent
+          first.
+        </p>
+        <ul>
+          {SUBPROCESSORS_CHANGELOG.map((entry) => (
+            <li key={entry.date}>
+              <strong>{entry.date}</strong> — {entry.summary}
+            </li>
+          ))}
+        </ul>
+
+        <h2>Questions about a specific subprocessor</h2>
+        <p>
+          {SUBPROCESSORS_NOTES.contactPrefix}
+          <a href={`mailto:${SITE.emails.support}`}>{SITE.emails.support}</a>. For privacy-specific
+          questions (data rights, DSR requests, GDPR / CCPA), see the{' '}
+          <a href="/privacy">Privacy Policy</a>.
+        </p>
+
+        <h2>What is not a subprocessor</h2>
+        <p>The following are NOT customer-data subprocessors and do not appear in the table:</p>
+        <ul>
+          <li>
+            <strong>GitHub</strong> — we use it for source code hosting only; customer data does not
+            flow through GitHub.
+          </li>
+          <li>
+            <strong>npm</strong> — we publish our packages there; customer data does not flow
+            through npm.
+          </li>
+          <li>
+            <strong>Local AI inference</strong> (Ollama, Inference Snaps) — runs on the customer's
+            own infrastructure, not ours; data does not leave the customer boundary.
+          </li>
+          <li>
+            <strong>Optional integrations</strong> the customer configures themselves (a customer's
+            own Sentry account, their own analytics, their own LLM provider) — those are the
+            customer's subprocessors, not ours.
+          </li>
+        </ul>
+      </article>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Phase A of the moral-charge launch-bar lane. The **transparency bundle**. **Stacked on [#1133](https://github.com/RevealUIStudio/revealui/pull/1133)** (which itself stacks on [#1132](https://github.com/RevealUIStudio/revealui/pull/1132)). Merge order: #1132 → #1133 → retarget this PR base → `test` → merge.

The audit found `revealui.com/legal/subprocessors` returned 200 only because of the Vite catch-all; no SubprocessorsPage existed. The Privacy Policy was silent on AI training (a critical claim for an AI-product), and the cookies section explicitly said "essential cookies only" while the marketing site was loading Vercel Speed Insights on every page. The Footer had Privacy + Terms but no link to Security, Support, Status, or Subprocessors — every other trust page was unreachable through navigation.

This PR fixes all of that as a single coherent transparency unit.

## What

### A5 — `SubprocessorsPage` at `/legal/subprocessors`

Dated tabular registry with 5 current entries:

| Vendor | Role | Location | Since |
|---|---|---|---|
| Vercel | Application hosting | US (us-east-1) | 2026-03 |
| NeonDB | PostgreSQL primary store | US (us-east-1) | 2026-03 |
| Cloudflare R2 | Object storage | US | 2026-05 |
| Stripe | Payment processing | US (PCI DSS L1) | 2026-04 |
| Google Workspace | Transactional email | US | 2026-03 |

Each row: data categories, privacy policy link, DPA link, "since" month. Real responsive HTML table inside a rounded ring container (not a prose list). Light + dark mode tokens.

- **Append-only change log** at the bottom — every change to the table commits in the same PR as a CHANGELOG entry
- **"What is not a subprocessor"** section names GitHub, npm, local AI inference, and customer-configured integrations as out-of-scope so the boundary is clear
- **Sentry explicitly listed as "anticipated"** — moves into the main table when the SDK is wired (PR6 in the train)
- **Callout banner commits** to "update this page BEFORE adding a new subprocessor, not after"

### A7 — Solo-operator disclosure in Footer

New `FOOTER_SOLO_OPERATOR_NOTE`: *"Built by one engineer in Tennessee. See Support for response SLAs."* Rendered as a subdued line under the tagline in the Footer brand area. Matches the existing `solo-operator-framing.md` ADR posture.

### A8 — Training-data promise (new Privacy §4)

New Privacy section "Customer content and AI training":
- We do NOT use customer content to train any general-purpose model. Applies to our models AND any third-party model accessed via our infrastructure
- If you connect your own external LLM provider (OpenAI / Anthropic / other), data flows to that provider on their terms — we do not intermediate
- The default RevealUI config uses local AI inference (Ollama / Inference Snaps) on your own infra; data does not leave your boundary at all

### A9 — Footer overhaul

- Footer grid expanded from 4 to 5 cols on `lg` (brand col-span-2, 3 link columns)
- New **"Trust"** column: Status / Support / Security / Subprocessors
- `FOOTER_LEGAL_LINKS` bottom row expanded from 2 → 4 (added Security + Subprocessors) for redundant reachability
- Footer now renders consistently on every marketing route

### A10 — Cookie / tracking disclosure (accurate Privacy §8)

Old §7 said *"essential cookies only"* — that was a false statement since Vercel Speed Insights is loaded on every page. New §8 "Cookies and trackers" enumerates exactly what loads:

- Session cookie (essential, `httpOnly` + `secure` + `sameSite=lax`)
- CSRF token cookie (essential)
- Vercel Speed Insights (anonymous performance telemetry, honors Do Not Track)

Explicit "no advertising cookies, no third-party tracking cookies, no cross-site cookies" preserved. Sentry marked as a future-tense entry that will appear here when wired.

### Privacy §3 additions

- **Cloudflare R2 added** to thirdParties (was missing — R2 is the canonical object storage backend per #1117/#1119)
- New paragraphs field at the end of §3 pointing customers at `/legal/subprocessors` as the dated authoritative source

### Privacy renumbering

- §4 NEW (Customer content and AI training)
- §4 Data Retention → §5
- §5 Your Rights → §6
- §6 Security → §7
- §7 Cookies → §8 (rewritten to be accurate)
- §8 Children → §9
- §9 Changes → §10
- §10 Contact → §11

Privacy `lastUpdated` bumped to May 28, 2026.

### `apps/marketing/app/App.tsx`

Register `/legal/subprocessors` route before the `/*notfound` catch-all.

## Verified locally

- `pnpm --filter marketing typecheck` — clean
- `pnpm exec biome check` on touched files — clean
- `pnpm validate:claims` — 0 mismatches
- `pnpm --filter marketing build` — success
- Dev server preview:
  - `/legal/subprocessors` renders 5-row vendor table + change log + "what is not" section + dated banner
  - `/privacy` renders all 11 sections in correct order with Cloudflare R2 in §3, full AI-training section as §4, accurate Cookies §8 mentioning Vercel Speed Insights
  - Footer has 3-column layout (Product / Community / Trust), Trust column has all 4 trust pages, solo-operator note line rendered under the tagline on every route
  - Console clean

## Owner action

- **Verify** Cloudflare R2 was correctly added to an internal repo subprocessors tracking if you keep an internal copy
- After merge, the Subprocessors page becomes the single source of truth — when a new vendor is added in code, the CHANGELOG section enforces the audit trail at commit time
- Merge order: **#1132 → #1133 → retarget this PR base → test → merge**

## Out of scope (queued in lane plan)

- `/api/health` path mismatch — PR5
- Sentry SDK + CSP allowlist (all 3 apps) — PR6
- License fail-mode communication in Terms — PR7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
