### PR TITLE
fix(forge): white-label leak sweep — admin shell + health + social meta + early signup gate

### DIFF
--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -14,11 +14,16 @@ type Args = {
   children: React.ReactNode;
 };
 
+// White-label: read tenant identity in the server component and prop-drill
+// to the client sidebar (env vars in `'use client'` files get inlined at
+// framework build time, missing the kit's stamped value at runtime).
+const siteName = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+
 const Layout = ({ children }: Args) => (
   <RootLayout config={config} importMap={importMap}>
     <LicenseProvider>
       <ErrorBoundary>
-        <AdminSidebarLayout>{children}</AdminSidebarLayout>
+        <AdminSidebarLayout siteName={siteName}>{children}</AdminSidebarLayout>
       </ErrorBoundary>
     </LicenseProvider>
   </RootLayout>

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -128,6 +128,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 export async function generateMetadata(): Promise<Metadata> {
   const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
   const adminLabel = `${name} admin`;
+  // White-label: REVEALUI_BRAND_TWITTER lets a kit set its own Twitter/X
+  // handle (e.g. '@AcmeCorp'); when unset, fall back to the canonical
+  // RevealUI handle ONLY if no brand override is in effect. A branded kit
+  // with no Twitter handle gets no `creator` meta — better than leaking
+  // the framework's account on customer share cards.
+  const brandOverridden =
+    Boolean(process.env.REVEALUI_BRAND_NAME) || Boolean(process.env.REVEALUI_TENANT_NAME);
+  const twitterCreator =
+    process.env.REVEALUI_BRAND_TWITTER ?? (brandOverridden ? undefined : '@RevealUI');
   return {
     title: {
       default: adminLabel,
@@ -137,7 +146,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: mergeOpenGraph(),
     twitter: {
       card: 'summary_large_image',
-      creator: '@RevealUI',
+      ...(twitterCreator ? { creator: twitterCreator } : {}),
     },
   };
 }

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -26,8 +26,39 @@ import {
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
+/**
+ * Early signup-closed gate.
+ *
+ * Returns true when the deployment has signup globally closed and no
+ * whitelist is in effect — in that case we can 403 the request before
+ * even parsing the body. Saves a body-validation round-trip for
+ * RevForge customer kits (which run with both env vars unset, the
+ * default-closed posture) and keeps the kit's auth surface from
+ * leaking its schema to anonymous probes.
+ *
+ * When REVEALUI_SIGNUP_WHITELIST is set, signups MAY be allowed for
+ * specific emails — we have to read the body to know. Those still
+ * land in the deeper `isSignupAllowed(email)` check below.
+ */
+function isSignupGloballyClosed(): boolean {
+  const open = process.env.REVEALUI_SIGNUP_OPEN === 'true';
+  const whitelisted = Boolean(process.env.REVEALUI_SIGNUP_WHITELIST);
+  return !open && !whitelisted;
+}
+
 async function signUpHandler(request: NextRequest): Promise<NextResponse> {
   try {
+    // White-label / fleet-mode: fail fast before body parse when signup is
+    // globally closed (default posture for RevForge kits). Returns a stable
+    // 403 with no schema leakage.
+    if (isSignupGloballyClosed()) {
+      return createApplicationErrorResponse(
+        'Signups are currently restricted. Contact the administrator for access.',
+        'SIGNUP_RESTRICTED',
+        403,
+      );
+    }
+
     let body: unknown;
     try {
       body = await request.json();

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -143,11 +143,17 @@ export async function GET(request: Request) {
   // Determine HTTP status code
   const httpStatus = overallStatus === 'healthy' ? 200 : 503;
 
+  // White-label: RevForge customer kits override the brand identity via
+  // REVEALUI_BRAND_NAME or REVEALUI_TENANT_NAME so uptime monitors / status
+  // pages show the operator's brand instead of the framework name.
+  const brandName =
+    process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+
   return NextResponse.json(
     {
       status: overallStatus,
       timestamp: new Date().toISOString(),
-      service: 'RevealUI Admin',
+      service: `${brandName} Admin`,
       version: process.env.npm_package_version || 'unknown',
       checks,
       metrics,

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -145,7 +145,7 @@ const bottomItems: NavItem[] = [
   },
 ];
 
-function AdminSidebarContent() {
+function AdminSidebarContent({ siteName }: { siteName: string }) {
   const pathname = usePathname();
 
   const isCurrent = (href: string) => {
@@ -201,15 +201,27 @@ function AdminSidebarContent() {
         </SidebarSection>
       </SidebarBody>
       <SidebarFooter>
-        <p className="text-xs text-zinc-500">RevealUI Admin</p>
+        <p className="text-xs text-zinc-500">{siteName} Admin</p>
       </SidebarFooter>
     </Sidebar>
   );
 }
 
-export function AdminSidebarLayout({ children }: { children: React.ReactNode }) {
+export function AdminSidebarLayout({
+  children,
+  siteName = 'RevealUI',
+}: {
+  children: React.ReactNode;
+  /**
+   * Resolved tenant name for the admin shell footer. Read by the parent
+   * server component from REVEALUI_BRAND_NAME / REVEALUI_TENANT_NAME and
+   * passed down — `process.env` references in this client file would be
+   * inlined at framework build time and miss the kit's stamped value.
+   */
+  siteName?: string;
+}) {
   return (
-    <SidebarLayout navbar={<span />} sidebar={<AdminSidebarContent />}>
+    <SidebarLayout navbar={<span />} sidebar={<AdminSidebarContent siteName={siteName} />}>
       {children}
     </SidebarLayout>
   );

--- a/apps/admin/src/lib/utilities/mergeOpenGraph.ts
+++ b/apps/admin/src/lib/utilities/mergeOpenGraph.ts
@@ -20,7 +20,7 @@ function getOpenGraphIdentity() {
   return { name, description: description === '' ? undefined : description };
 }
 
-function buildDefaultOpenGraph(): Metadata['openGraph'] {
+function buildDefaultOpenGraph(): NonNullable<Metadata['openGraph']> {
   const { name, description } = getOpenGraphIdentity();
   return {
     type: 'website',

--- a/apps/admin/src/lib/utilities/mergeOpenGraph.ts
+++ b/apps/admin/src/lib/utilities/mergeOpenGraph.ts
@@ -1,20 +1,44 @@
 import type { Metadata } from 'next';
 
-const defaultOpenGraph: Metadata['openGraph'] = {
-  type: 'website',
-  description: 'Agentic business runtime. Build your business, not your boilerplate.',
-  images: [
-    {
-      url: process.env.NEXT_PUBLIC_SERVER_URL
-        ? `${process.env.NEXT_PUBLIC_SERVER_URL.trim()}/favicon.svg`
-        : '/favicon.svg',
-    },
-  ],
-  siteName: 'RevealUI',
-  title: 'RevealUI',
-};
+/**
+ * Tenant identity for OpenGraph + social preview cards.
+ *
+ * Forge kits white-label by setting REVEALUI_BRAND_NAME or REVEALUI_TENANT_NAME.
+ * The same env-resolution chain is used by BrandedAuthLayout and the admin
+ * shell so all surfaces resolve to the same name.
+ *
+ * REVEALUI_BRAND_DESCRIPTION lets kits override the og:description; falls
+ * back to the canonical RevealUI marketing line. Kits that prefer no
+ * description can set REVEALUI_BRAND_DESCRIPTION='' (empty string opt-out).
+ */
+function getOpenGraphIdentity() {
+  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  const description =
+    process.env.REVEALUI_BRAND_DESCRIPTION ??
+    'Agentic business runtime. Build your business, not your boilerplate.';
+  // Empty string = explicit opt-out (kits that don't want a description).
+  return { name, description: description === '' ? undefined : description };
+}
+
+function buildDefaultOpenGraph(): Metadata['openGraph'] {
+  const { name, description } = getOpenGraphIdentity();
+  return {
+    type: 'website',
+    description,
+    images: [
+      {
+        url: process.env.NEXT_PUBLIC_SERVER_URL
+          ? `${process.env.NEXT_PUBLIC_SERVER_URL.trim()}/favicon.svg`
+          : '/favicon.svg',
+      },
+    ],
+    siteName: name,
+    title: name,
+  };
+}
 
 export const mergeOpenGraph = (og?: Metadata['openGraph']): Metadata['openGraph'] => {
+  const defaultOpenGraph = buildDefaultOpenGraph();
   return {
     ...defaultOpenGraph,
     ...og,

--- a/apps/server/src/routes/__tests__/health.test.ts
+++ b/apps/server/src/routes/__tests__/health.test.ts
@@ -63,6 +63,47 @@ describe('GET /  -  liveness probe', () => {
     const body = await parseBody(res);
     expect(body.service).toBe('RevealUI API');
   });
+
+  it('white-labels the service name from REVEALUI_TENANT_NAME', async () => {
+    const prev = process.env.REVEALUI_TENANT_NAME;
+    process.env.REVEALUI_TENANT_NAME = 'Acme';
+    try {
+      const app = createApp();
+      const res = await app.request('/');
+      const body = await parseBody(res);
+      expect(body.service).toBe('Acme API');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.REVEALUI_TENANT_NAME;
+      } else {
+        process.env.REVEALUI_TENANT_NAME = prev;
+      }
+    }
+  });
+
+  it('white-labels the service name from REVEALUI_BRAND_NAME (takes precedence over TENANT_NAME)', async () => {
+    const prevBrand = process.env.REVEALUI_BRAND_NAME;
+    const prevTenant = process.env.REVEALUI_TENANT_NAME;
+    process.env.REVEALUI_BRAND_NAME = 'BrandWins';
+    process.env.REVEALUI_TENANT_NAME = 'Tenant';
+    try {
+      const app = createApp();
+      const res = await app.request('/');
+      const body = await parseBody(res);
+      expect(body.service).toBe('BrandWins API');
+    } finally {
+      if (prevBrand === undefined) {
+        delete process.env.REVEALUI_BRAND_NAME;
+      } else {
+        process.env.REVEALUI_BRAND_NAME = prevBrand;
+      }
+      if (prevTenant === undefined) {
+        delete process.env.REVEALUI_TENANT_NAME;
+      } else {
+        process.env.REVEALUI_TENANT_NAME = prevTenant;
+      }
+    }
+  });
 });
 
 describe('GET /ready  -  readiness probe', () => {

--- a/apps/server/src/routes/health.ts
+++ b/apps/server/src/routes/health.ts
@@ -78,12 +78,25 @@ const livenessRoute = createRoute({
   },
 });
 
+/**
+ * Service identity for the liveness payload.
+ *
+ * White-label deployments (Forge customer kits) override the brand name via
+ * REVEALUI_BRAND_NAME or REVEALUI_TENANT_NAME — uptime monitors / status
+ * pages then show the operator's brand instead of the framework name.
+ * Hosted SaaS (no overrides) keeps the canonical "RevealUI API" identity.
+ */
+function getServiceName(): string {
+  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  return `${name} API`;
+}
+
 function livenessResponse() {
   return {
     status: 'ok' as const,
     timestamp: new Date().toISOString(),
     version: process.env.npm_package_version ?? '1.0.0',
-    service: 'RevealUI API',
+    service: getServiceName(),
     uptime: healthCheck.getUptime(),
   };
 }


### PR DESCRIPTION
## What

Three companion fixes for white-label leaks surfaced by a live RevForge customer-kit e2e audit:

1. **`/health` service identity** (`apps/server` + `apps/admin`) — hardcoded `"RevealUI API"` / `"RevealUI Admin"` in the response `service` field.
2. **Admin shell sidebar footer + social preview meta tags** — hardcoded `"RevealUI Admin"` in the post-login sidebar; hardcoded `siteName: 'RevealUI'`, `title: 'RevealUI'`, and `twitter.creator='@RevealUI'` in the metadata.
3. **Signup-closed gate position** — `POST /api/auth/sign-up` validated the request body BEFORE checking whether signup was allowed, so a kit running the default closed-signup posture leaked its schema to anonymous probes (returning `400 VALIDATION_ERROR` with field details instead of `403 SIGNUP_RESTRICTED`).

## Why

A customer kit successfully white-labels its login page (tenant name, logo, tagline, `--tenant-brand` CSS var) but the moment the user authenticates, the framework brand leaks back through the admin shell, the `/health` payload, and every social preview card. Same issue on the signup endpoint: even though signup IS closed by default, the layer-ordering meant the kit looked open to a probe and leaked its schema.

The existing `BrandedAuthLayout` + `generateMetadata` already use a consistent `REVEALUI_BRAND_NAME ?? REVEALUI_TENANT_NAME ?? 'RevealUI'` chain. These fixes extend the same chain to the previously-hardcoded callsites.

## Changes

### `apps/server/src/routes/health.ts`
- New `getServiceName()` helper resolves the brand name via the same env chain used elsewhere; suffixed with `' API'` for the public-identity wrap.
- `livenessResponse()` uses it.
- `apps/server/src/routes/__tests__/health.test.ts` adds two regression tests: one for `REVEALUI_TENANT_NAME` override, one for `REVEALUI_BRAND_NAME` precedence over tenant.

### `apps/admin/src/app/api/health/route.ts`
- Same resolution chain; emits `${brandName} Admin` in the `service` field.

### `apps/admin/src/lib/utilities/mergeOpenGraph.ts`
- New `getOpenGraphIdentity()` resolves name + description from env.
- `REVEALUI_BRAND_DESCRIPTION` is a new optional override; empty string = explicit opt-out (kits that want no description).
- `buildDefaultOpenGraph()` returns a per-request object so env reads are not pinned at module load.

### `apps/admin/src/app/(frontend)/layout.tsx`
- `twitter.creator` now respects an optional `REVEALUI_BRAND_TWITTER` override. When a brand override is in effect and no Twitter handle is set, `creator` is omitted entirely — better than leaking the framework's handle on customer share cards. Hosted SaaS (no overrides) keeps `@RevealUI`.

### `apps/admin/src/lib/components/AdminSidebarLayout.tsx` + `apps/admin/src/app/(backend)/layout.tsx`
- Sidebar footer reads `siteName` as a prop (was hardcoded "RevealUI Admin").
- Server-component `Layout` resolves the name from env and prop-drills into the client component, because `process.env` references in `'use client'` files get inlined at framework build time and would miss the kit's stamped runtime value.

### `apps/admin/src/app/api/auth/sign-up/route.ts`
- New `isSignupGloballyClosed()` returns true when neither `REVEALUI_SIGNUP_OPEN` nor `REVEALUI_SIGNUP_WHITELIST` is set (the default-closed posture).
- Route returns `403 SIGNUP_RESTRICTED` before parsing the body when that's the case.
- Per-email whitelist checks still land in the deeper `isSignupAllowed(email)` check below — that path needs the body.

## Verification

- New tests in `apps/server/src/routes/__tests__/health.test.ts` cover the brand-override precedence chain.
- Manual verification will run after merge: rebuild the kit images via `gh workflow run docker.yml --ref test`, re-pull on a test kit, and re-run the post-login grep audit that surfaced these leaks. Expecting:
  - `/admin` page visible text contains no "RevealUI" string when a tenant name is configured
  - `/health` returns `"service":"<tenant-name> API"` / `"<tenant-name> Admin"`
  - `og:siteName`, `og:title`, `twitter.creator` either omitted or reflect the tenant
  - `POST /api/auth/sign-up` with `{}` returns `403 SIGNUP_RESTRICTED` (not `400 VALIDATION_ERROR`)

## Out of scope

- The standalone "RevealUI" string in the admin shell nav (separate from the footer) appears to come from `@revealui/core/admin`'s `RootLayout`, which composes a config-driven brand surface — likely needs a follow-up touching the core package. Not blocking this PR; flagged for follow-up.
- Refactor of the 4 callsites that currently inline the env-resolution chain into a single shared helper in `@revealui/config` (`getBrandingConfig` already exists; the in-flight migration is a separate consolidation lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
