### PR TITLE
ci: bump test-integration-extended timeout 20→30 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,7 +638,12 @@ jobs:
   test-integration-extended:
     name: Integration Tests (extended)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Bumped 20→30 min 2026-05-28. The suite consistently completes in
+    # ~18–20 min on GitHub-hosted runners under normal load but hit the
+    # 20-min wall on 2+ consecutive runs during the Phase A train (PR #1132).
+    # Bumping to 30 gives ~50% headroom without losing the "fail fast" signal
+    # if the suite genuinely diverges. Revisit if it ever takes >25 min.
+    timeout-minutes: 30
     needs: quality
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
The Integration Tests (extended) suite consistently completes in ~18-20 min on GitHub-hosted runners but hit the 20-min wall on 2+ consecutive runs during the Phase A moral-charge train (PR #1132). The suite content is unchanged; runner load just varies enough that a 20-min ceiling produces unbounded re-run cycles.

Bumping to 30 min gives ~50% headroom without losing the fail-fast signal — if the suite ever takes >25 min, something has genuinely diverged and we should investigate.

## Verified

- diff is 1 file, 6 insertions, 1 deletion in 
- targets the  job specifically; no other timeouts changed
- gitleaks pre-push scan: no leaks
- intentionally a standalone PR direct to  (no stacking) so it lands fast and the in-flight #1132-#1139 train can pick it up via update-branch

## Owner action

Merge this first; then update-branch #1132 and continue the Phase A train. The 30-min ceiling resolves the recurring timeout flake on the extended integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)