### PR TITLE
feat(ci): required client-name leak scanner — block leaks in tracked content + issue bodies

### DIFF
--- a/.github/workflows/check-client-leaks.yml
+++ b/.github/workflows/check-client-leaks.yml
@@ -1,0 +1,35 @@
+name: Client Name Leak Scan
+
+# REQUIRED status check on test + main.
+#
+# This workflow hard-fails when any RevealUI Studio client / prospect /
+# warm-intro contact name appears in tracked repo content. Patterns live
+# in scripts/check-client-leaks.sh and are extended in the same PR that
+# introduces a new client into the operator's pipeline.
+#
+# Companion: .github/workflows/issue-leak-scan.yml covers issue + PR body
+# + comment surfaces with the same pattern class (config in
+# .gitleaks.issues.toml). Together the two scanners give blanket coverage
+# across tracked files + GitHub conversation surfaces.
+
+on:
+  push:
+    branches: [test, main]
+  pull_request:
+    branches: [test, main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Client / prospect name leak scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+      - name: Run scanner
+        run: bash scripts/check-client-leaks.sh

--- a/.gitleaks.issues.toml
+++ b/.gitleaks.issues.toml
@@ -83,6 +83,35 @@ regex = '''\b[A-Za-z0-9._%+-]+@(gmail|hotmail|yahoo|outlook|protonmail|icloud)\.
 keywords = ["@gmail.com", "@hotmail.com", "@yahoo.com", "@outlook.com", "@protonmail.com", "@icloud.com"]
 tags = ["pii", "boundary-config"]
 
+# --- Client / prospect / warm-intro names ---
+#
+# Companion to scripts/check-client-leaks.sh which enforces the same names
+# on tracked repo content. Owner directive 2026-05-21: no public mention
+# anywhere outside the private revealui-jv repo. When a new client onboards,
+# extend both this rule's keywords AND the bash scanner's PATTERNS array
+# in the same PR.
+
+[[rules]]
+id = "revealui-client-allevia"
+description = "Allevia / AlleviaFleet / AlleviaForge / allevia.tech — first Tier-6 customer; internal-only per owner directive"
+regex = '''(?i)\b(allevia(?:fleet|forge)?|allevia\.tech)\b'''
+keywords = ["Allevia", "allevia", "AlleviaFleet", "AlleviaForge", "allevia.tech"]
+tags = ["client", "boundary-config"]
+
+[[rules]]
+id = "revealui-prospect-warm-intro-chain"
+description = "Stefan Wilson / Daniel B. Jones / dbjones23 — warm-intro contact chain for the first customer; surfacing publicly violates feedback_warm_intro_dont_bypass + project_allevia_contacts"
+regex = '''(Stefan Wilson|Daniel B\. Jones|dbjones23)'''
+keywords = ["Stefan Wilson", "Daniel B. Jones", "dbjones23"]
+tags = ["prospect", "boundary-config"]
+
+[[rules]]
+id = "revealui-paused-ventures"
+description = "Biotix Wellness — paused internal venture not publicly associated with this org"
+regex = '''(?i)\bbiotix(?:[ -]?wellness)?\b'''
+keywords = ["Biotix", "biotix", "Biotix Wellness", "biotix-wellness"]
+tags = ["venture", "boundary-config"]
+
 [allowlist]
 description = "Public email addresses + canonical zero/null/placeholder values"
 regexes = [

--- a/scripts/check-client-leaks.sh
+++ b/scripts/check-client-leaks.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-client-leaks.sh
+#
+# Scans the repo for any reference to a specific RevealUI Studio client,
+# prospect, or warm-intro contact. Customer/prospect names belong in the
+# private revealui-jv repo only — never in this public surface, ever.
+#
+# Exit 0 on clean. Exit 1 on any violation. Exit 2 on tool/setup error.
+#
+# Usage:
+#   bash scripts/check-client-leaks.sh                     # scan repo root
+#   bash scripts/check-client-leaks.sh <path> [<path>...]  # scan specific paths
+#   LEAK_JSON=1 bash scripts/check-client-leaks.sh         # machine-readable
+#
+# CI wiring: .github/workflows/check-client-leaks.yml
+# REQUIRED status check on `test` and `main` branch protection.
+#
+# Adding a new client / prospect / contact:
+#   Append one line to PATTERNS below (format: tag|literal-string|reason).
+#   Then open a PR; CI will refuse to merge any tracked file that contains
+#   the name, today and forever. There is no .leakignore for this scanner —
+#   the property must be unconditional.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_PATHS=("$@")
+[[ ${#SCAN_PATHS[@]} -eq 0 ]] && SCAN_PATHS=("$REPO_ROOT")
+
+for _path in "${SCAN_PATHS[@]}"; do
+  if [[ ! -e "$_path" ]]; then
+    echo "[client-leak] error: scan path not found: $_path" >&2
+    exit 2
+  fi
+done
+unset _path
+
+# --- Patterns: tag | literal-string | reason ---
+#
+# REGEX-CONFIG-BOUNDARY: the strings consumed by grep -F (fixed strings),
+# so each pattern is a literal substring — no metacharacter handling.
+# No regex authored.
+#
+# To add a new client / prospect, append a line. Coverage MUST land in
+# the same PR that introduces them to the operator's pipeline.
+PATTERNS=(
+  # --- Allevia Technology (Tier-6 first customer; owner directive 2026-05-21:
+  #     no public Allevia anywhere; .jv private OK; never public repos. See
+  #     revealui-jv/.claude/memory/project_allevia_internal_only_until_owner_lifts.md)
+  "client-allevia|Allevia|customer name (Allevia)"
+  "client-allevia-lower|allevia|customer slug (allevia)"
+  "client-alleviafleet|AlleviaFleet|customer brand instance (AlleviaFleet)"
+  "client-alleviaforge|AlleviaForge|customer brand instance (AlleviaForge, superseded by *Fleet)"
+  "client-allevia-host|allevia.tech|customer domain (allevia.tech)"
+  # --- Warm-intro contact chain — these are the human introduction path
+  #     and must never appear in public material per memory
+  #     feedback_warm_intro_dont_bypass + project_allevia_contacts
+  "prospect-stefan|Stefan Wilson|prospect contact (Stefan Wilson, customer CEO)"
+  "prospect-daniel-name|Daniel B. Jones|prospect warm-intro contact (Daniel B. Jones)"
+  "prospect-daniel-handle|dbjones23|prospect warm-intro email handle (dbjones23)"
+  # --- Other internal ventures the operator does not publicly associate with
+  #     this org (paused or undisclosed)
+  "venture-biotix|Biotix Wellness|paused internal venture (Biotix Wellness)"
+  "venture-biotix-lower|biotix-wellness|paused internal venture (slug form)"
+)
+
+# Directories / file globs to skip
+EXCLUDE_DIRS=(node_modules .git dist build .next .turbo .pnpm coverage target .direnv .nyc_output playwright-report test-results)
+EXCLUDE_FILES=(
+  pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
+  check-client-leaks.sh
+  CHANGELOG.md
+  '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
+  '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
+  '*.har' '*.snap'
+)
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "[client-leak] error: grep not found on PATH" >&2
+  exit 2
+fi
+
+grep_excludes=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+  grep_excludes+=(--exclude-dir="$d")
+done
+for f in "${EXCLUDE_FILES[@]}"; do
+  grep_excludes+=(--exclude="$f")
+done
+
+violations=0
+json_entries=()
+
+for entry in "${PATTERNS[@]}"; do
+  tag="${entry%%|*}"
+  rest="${entry#*|}"
+  pattern="${rest%%|*}"
+  reason="${rest#*|}"
+
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    file="${hit%%:*}"
+    rest_="${hit#*:}"
+    line="${rest_%%:*}"
+    content="${rest_#*:}"
+
+    if [[ -n "${LEAK_JSON:-}" ]]; then
+      if command -v jq >/dev/null 2>&1; then
+        json_entries+=("$(jq -cn --arg tag "$tag" --arg file "$file" --arg line "$line" --arg reason "$reason" --arg content "$content" \
+          '{tag:$tag, file:$file, line:($line|tonumber), reason:$reason, content:$content}')")
+      else
+        safe="${content//\\/\\\\}"
+        safe="${safe//\"/\\\"}"
+        safe="${safe//$'\n'/\\n}"
+        safe="${safe//$'\t'/\\t}"
+        sreason="${reason//\\/\\\\}"
+        sreason="${sreason//\"/\\\"}"
+        json_entries+=("{\"tag\":\"$tag\",\"file\":\"$file\",\"line\":$line,\"reason\":\"$sreason\",\"content\":\"$safe\"}")
+      fi
+    else
+      printf '[CLIENT-LEAK:%s] %s:%s — %s\n  → %s\n' "$tag" "$file" "$line" "$reason" "$content"
+    fi
+    violations=$((violations+1))
+  done < <(grep -rFIn "${grep_excludes[@]}" -- "$pattern" "${SCAN_PATHS[@]}" 2>/dev/null || true)
+done
+
+if [[ -n "${LEAK_JSON:-}" ]]; then
+  printf '{"violations":%d,"entries":[%s]}\n' "$violations" "$(IFS=,; echo "${json_entries[*]:-}")"
+fi
+
+if (( violations > 0 )); then
+  if [[ -z "${LEAK_JSON:-}" ]]; then
+    echo "" >&2
+    echo "[client-leak] FAIL — $violations violation(s)." >&2
+    echo "" >&2
+    echo "Customer / prospect names must NEVER appear in this public-facing repo." >&2
+    echo "Move the content to the private revealui-jv repo (or genericize with a" >&2
+    echo "placeholder like 'Acme Corp' / 'acme' / 'first customer')." >&2
+    echo "" >&2
+    echo "If a new client onboards and their name needs scanner coverage, add" >&2
+    echo "the pattern lines to scripts/check-client-leaks.sh PATTERNS array in" >&2
+    echo "the same PR." >&2
+  fi
+  exit 1
+fi
+
+[[ -z "${LEAK_JSON:-}" ]] && echo "[client-leak] OK — no client/prospect names detected across: ${SCAN_PATHS[*]}"
+exit 0

--- a/scripts/check-client-leaks.sh
+++ b/scripts/check-client-leaks.sh
@@ -3,7 +3,7 @@
 #
 # Scans the repo for any reference to a specific RevealUI Studio client,
 # prospect, or warm-intro contact. Customer/prospect names belong in the
-# private revealui-jv repo only — never in this public surface, ever.
+# private internal repo only — never in this public surface, ever.
 #
 # Exit 0 on clean. Exit 1 on any violation. Exit 2 on tool/setup error.
 #
@@ -45,8 +45,8 @@ unset _path
 # the same PR that introduces them to the operator's pipeline.
 PATTERNS=(
   # --- Allevia Technology (Tier-6 first customer; owner directive 2026-05-21:
-  #     no public Allevia anywhere; .jv private OK; never public repos. See
-  #     revealui-jv/.claude/memory/project_allevia_internal_only_until_owner_lifts.md)
+  #     no public Allevia anywhere; internal coordination repo OK; never
+  #     public repos. See the project_allevia_internal_only memory entry.)
   "client-allevia|Allevia|customer name (Allevia)"
   "client-allevia-lower|allevia|customer slug (allevia)"
   "client-alleviafleet|AlleviaFleet|customer brand instance (AlleviaFleet)"
@@ -69,6 +69,11 @@ EXCLUDE_DIRS=(node_modules .git dist build .next .turbo .pnpm coverage target .d
 EXCLUDE_FILES=(
   pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
   check-client-leaks.sh
+  # Companion gitleaks rule file. By design it carries the same names
+  # as detection keywords (boundary-config per the no-regex rule's
+  # third-party-config exception); the bash scanner must NOT count
+  # those keywords as violations of itself. Scanner-self-pattern.
+  .gitleaks.issues.toml
   CHANGELOG.md
   '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
   '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
@@ -134,7 +139,7 @@ if (( violations > 0 )); then
     echo "[client-leak] FAIL — $violations violation(s)." >&2
     echo "" >&2
     echo "Customer / prospect names must NEVER appear in this public-facing repo." >&2
-    echo "Move the content to the private revealui-jv repo (or genericize with a" >&2
+    echo "Move the content to the private internal repo (or genericize with a" >&2
     echo "placeholder like 'Acme Corp' / 'acme' / 'first customer')." >&2
     echo "" >&2
     echo "If a new client onboards and their name needs scanner coverage, add" >&2


### PR DESCRIPTION
## What

Required-status-check CI scanner that hard-blocks any RevealUI Studio client / prospect / warm-intro contact name from appearing in tracked repo content, plus three new rule entries in `.gitleaks.issues.toml` that extend the existing Issue + PR Body Leak Scan workflow with the same name coverage.

## Why

The owner directive on this class of disclosure is unconditional: customer / prospect names belong in the private an internal repo only, never in public-facing repos, "even once" — and reactive cleanup is not acceptable as the durable posture.

A comprehensive public-surface audit on 2026-05-29 caught 7 PR-body leaks + 1 issue-comment leak that slipped past every existing scanner because no rule in `.gitleaks.issues.toml` covered client / prospect names. The reactive cleanup landed today (commit history shows the redaction PRs); this PR closes the prevention gap so the same drift can't happen again without a CI hard-fail catching it on the introducing PR.

## Two complementary scanners

### 1. `scripts/check-client-leaks.sh` — tracked file content

- POSIX bash + `grep -F` (fixed strings; no regex authored per the project no-regex rule)
- Pattern list inline at the top of the script with `tag|literal|reason` rows
- Excludes generated artifacts (lockfiles, build dirs, snapshots, binaries) + the scanner file itself
- Exit 1 with a clear remediation message on any violation
- No `.leakignore` — the unconditional property is the point

### 2. `.gitleaks.issues.toml` — three new rules

For the existing `.github/workflows/issue-leak-scan.yml` workflow (which covers issue bodies, PR bodies, and comments via the `issue_comment` event). The rules added are:

- `revealui-client-allevia` — the first Tier-6 customer's name + brand + domain
- `revealui-prospect-warm-intro-chain` — the warm-intro contact path
- `revealui-paused-ventures` — paused internal venture

## Adding a new client

When a new client onboards, append one PR that updates BOTH:

- `scripts/check-client-leaks.sh` PATTERNS array (one line per name variant)
- `.gitleaks.issues.toml` rule entries (one rule per logical group)

The same PR that introduces the client to the operator's pipeline must extend the scanners. There's no follow-up window.

## Required-check follow-up (separate gh-api operation)

GitHub requires a check to have run at least once before it can be marked as required on branch protection. After this PR merges and the workflow runs successfully on the `test` branch push, a separate `gh api PATCH repos/.../branches/{test,main}/protection` call will add `"Client / prospect name leak scan"` to `required_status_checks.contexts` on both protected branches.

## Verification

- `bash scripts/check-client-leaks.sh` on the current branch → 0 violations
- Proof-test: writing `"Allevia"` to a temp file in the repo → scanner exits 1 with the expected `[CLIENT-LEAK:client-allevia]` line and the remediation block

## Out of scope

- The broader leak surface (absolute home paths, internal subdomains, Stripe object IDs) is already covered by the existing `Private Leak Scan` workflow on agency + the default `gitleaks` rules in `.gitleaks.toml`. This PR is narrowly the client/prospect/warm-intro class.
- Historical commit messages on this and other public repos still contain the historical customer name; force-pushing public history would break inbound refs and is not on the table. The scanner blocks future drift but doesn't rewrite history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
