### PR TITLE
feat(marketing): /support page + live-probe /status page

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -14,6 +14,8 @@ import { ProductsPage } from './routes/ProductsPage';
 import { RoadmapPage } from './routes/RoadmapPage';
 import { SecurityPage } from './routes/SecurityPage';
 import { SponsorPage } from './routes/SponsorPage';
+import { StatusPage } from './routes/StatusPage';
+import { SupportPage } from './routes/SupportPage';
 import { TermsPage } from './routes/TermsPage';
 
 export function App() {
@@ -41,6 +43,8 @@ export function App() {
       { path: '/privacy', component: PrivacyPage, meta: { title: 'Privacy Policy — RevealUI' } },
       { path: '/terms', component: TermsPage, meta: { title: 'Terms of Service — RevealUI' } },
       { path: '/security', component: SecurityPage, meta: { title: 'Security — RevealUI' } },
+      { path: '/support', component: SupportPage, meta: { title: 'Support — RevealUI' } },
+      { path: '/status', component: StatusPage, meta: { title: 'Status — RevealUI' } },
       { path: '/*notfound', component: NotFoundPage, meta: { title: '404 — RevealUI' } },
     ]);
     registered.current = true;

--- a/apps/marketing/app/content/legal/support.ts
+++ b/apps/marketing/app/content/legal/support.ts
@@ -1,0 +1,89 @@
+// Support page content. Schema reused from LegalSection for layout
+// consistency with the other trust pages.
+
+import { SITE } from '../site';
+import type { LegalSection } from './privacy';
+
+export const SUPPORT_META = {
+  title: 'Support',
+  lastUpdated: 'May 28, 2026',
+  intro:
+    'RevealUI Studio is a solo-operator company. We want to help you succeed with RevealUI — and we want to be honest about what kind of help we can offer, on what timeline, and through which channels. This page covers all three.',
+} as const;
+
+export const SUPPORT_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Choose your channel',
+    listPreamble: 'Different questions land best in different places. In rough order of speed:',
+    listItems: [
+      `**Documentation** at https://docs.revealui.com — covers setup, configuration, the API surface, and most "how do I do X with RevealUI" questions. Always check here first; if the answer is there, you have it now instead of in 48 hours.`,
+      `**GitHub Discussions** at https://github.com/RevealUIStudio/revealui/discussions — community-friendly format for design questions, "is there a better way to do X", and ideas. Other users and the maintainer both watch this. Best for questions where a public answer benefits more than just you.`,
+      `**GitHub Issues** at https://github.com/RevealUIStudio/revealui/issues — for confirmed bugs and feature requests. Include reproduction steps. See §5 below for "bug vs support" guidance.`,
+      `**Email** at ${SITE.emails.support} — for account-specific issues (billing, license keys, your data), security concerns, and questions you cannot ask in public.`,
+    ],
+  },
+  {
+    heading: '2. Response SLA',
+    paragraphs: [
+      `Email to ${SITE.emails.support}: we aim for a substantive response within **48 business hours** (Monday through Friday, U.S. Central Time, excluding U.S. federal holidays). Acknowledgement is usually faster — within one business day — and complex issues may require multiple rounds of correspondence.`,
+      'GitHub Issues and Discussions: best-effort. We read them, but we may not respond instantly. If something is urgent, email is the right channel.',
+      'Security reports: see the dedicated security policy at https://revealui.com/security — those go to a separate address with separate SLAs.',
+    ],
+  },
+  {
+    heading: '3. What we can help with',
+    listItems: [
+      'Setup and installation issues with `create-revealui` and the published packages',
+      'Configuration questions about the admin engine, auth, billing integration, or AI agents',
+      'License key issues (lost keys, transfer, downgrade, refund within window)',
+      'Bugs in the published RevealUI source code (OSS and Pro packages)',
+      'Questions about the documented API surface',
+      'Account changes, plan changes, and cancellations',
+      'Genuine "is RevealUI the right tool for X" pre-purchase questions',
+    ],
+  },
+  {
+    heading: '4. What we cannot help with',
+    paragraphs: [
+      'We need to be honest about scope. A solo-operator support model only works if we say "no" to the things that would consume all our time without serving customers fairly.',
+    ],
+    listItems: [
+      'We do not write your application code for you. RevealUI is a framework; you build with it.',
+      'We do not review private codebases line by line. Public GitHub repos we can sometimes glance at; private repos require an Enterprise engagement (see Pricing).',
+      'We do not debug deployments to specific hosting environments (Kubernetes clusters, exotic Docker setups, customer VPNs) beyond the documented Vercel / Fly / Hetzner / Docker paths.',
+      'We cannot recover data from a self-hosted instance that has been lost — we do not have access to your database. Always maintain your own backups.',
+      'We do not provide free architectural consulting outside the documented patterns. Track D professional services (when published) is the right channel for that.',
+      'We do not provide live phone or video support at the Pro tier. Email-and-async only.',
+    ],
+  },
+  {
+    heading: '5. When to file a bug vs ask for support',
+    listPreamble: 'A useful rule of thumb when deciding where to take an issue:',
+    listItems: [
+      `**File a bug** (GitHub Issue) when: the documented behavior does not match the actual behavior; you have a reliable reproduction; the issue would affect other users; the fix probably lives in the public source code.`,
+      `**Email support** (${SITE.emails.support}) when: the issue is specific to your account or data; the issue involves a license, billing question, or refund; the issue is sensitive; you do not yet have a reproduction but something feels wrong.`,
+      `**Open a Discussion** when: you are not sure if it is a bug; you want input from the community; you want to influence the roadmap.`,
+    ],
+  },
+  {
+    heading: '6. Status and uptime',
+    paragraphs: [
+      'Live status of revealui.com, admin.revealui.com, api.revealui.com, and docs.revealui.com is published at https://revealui.com/status with a live probe of the API health endpoint and an honest disclosure of our monitoring posture (we are a solo-operator company; we do not run 24×7 manned monitoring).',
+      'If you are experiencing an outage that the status page does not yet reflect, email support and include the surface you are hitting and the time you first saw the issue.',
+    ],
+  },
+  {
+    heading: '7. Premium support',
+    paragraphs: [
+      'The published pricing page describes the response targets for the Pro tier (48 business hours), Max tier (24 business hours), and Enterprise tier (4-hour Slack SLA). These targets are aspirational at launch and we will publish the actual achieved response times once we have data — we would rather measure honestly than over-promise.',
+      'Enterprise customers who need a dedicated Slack channel, a named technical contact, or scheduled architecture reviews should contact us before purchase to confirm scope and timeline.',
+    ],
+  },
+  {
+    heading: '8. Contact',
+    paragraphs: [
+      `For support questions, email ${SITE.emails.support}. For account-specific or sensitive matters, you can also reach the founder directly at ${SITE.emails.founder}.`,
+    ],
+    contactEmail: SITE.emails.support,
+  },
+];

--- a/apps/marketing/app/routes/StatusPage.tsx
+++ b/apps/marketing/app/routes/StatusPage.tsx
@@ -1,0 +1,300 @@
+import { Callout } from '@revealui/presentation';
+import { useEffect, useState } from 'react';
+import { Footer } from '../components/Footer';
+import { SITE } from '../content/site';
+
+interface Surface {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly publicUrl: string;
+  readonly mode: 'self' | 'probe' | 'link';
+  readonly probeUrl?: string;
+}
+
+const SURFACES: readonly Surface[] = [
+  {
+    id: 'marketing',
+    label: 'Marketing site',
+    description: 'revealui.com',
+    publicUrl: 'https://revealui.com',
+    mode: 'self',
+  },
+  {
+    id: 'api',
+    label: 'API',
+    description: 'api.revealui.com',
+    publicUrl: SITE.urls.api,
+    mode: 'probe',
+    probeUrl: `${SITE.urls.api}/health`,
+  },
+  {
+    id: 'docs',
+    label: 'Documentation',
+    description: 'docs.revealui.com',
+    publicUrl: SITE.urls.docs,
+    mode: 'link',
+  },
+  {
+    id: 'admin',
+    label: 'Admin dashboard',
+    description: 'admin.revealui.com',
+    publicUrl: SITE.urls.admin,
+    mode: 'link',
+  },
+];
+
+type ProbeResult =
+  | { status: 'pending' }
+  | { status: 'up'; latencyMs: number; checkedAt: number }
+  | { status: 'down'; reason: string; checkedAt: number };
+
+function badgeFor(
+  state: { kind: 'self' } | { kind: 'link' } | { kind: 'probe'; result: ProbeResult },
+) {
+  if (state.kind === 'self') {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-green-200 dark:bg-green-950/30 dark:text-green-400 dark:ring-green-800">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-green-500" />
+        Operational (you are here)
+      </span>
+    );
+  }
+  if (state.kind === 'link') {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:ring-zinc-700">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-zinc-400" />
+        Visit to verify
+      </span>
+    );
+  }
+  const r = state.result;
+  if (r.status === 'pending') {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:ring-zinc-700">
+        <span aria-hidden="true" className="size-1.5 animate-pulse rounded-full bg-zinc-400" />
+        Checking…
+      </span>
+    );
+  }
+  if (r.status === 'up') {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-green-200 dark:bg-green-950/30 dark:text-green-400 dark:ring-green-800">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-green-500" />
+        Operational · {r.latencyMs}ms
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200 dark:bg-red-950/30 dark:text-red-400 dark:ring-red-800">
+      <span aria-hidden="true" className="size-1.5 rounded-full bg-red-500" />
+      Unreachable
+    </span>
+  );
+}
+
+function formatChecked(epochMs: number): string {
+  const seconds = Math.floor((Date.now() - epochMs) / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return new Date(epochMs).toLocaleTimeString();
+}
+
+export function StatusPage() {
+  const probeIds = SURFACES.filter((s) => s.mode === 'probe').map((s) => s.id);
+  const [probes, setProbes] = useState<Record<string, ProbeResult>>(() => {
+    const init: Record<string, ProbeResult> = {};
+    for (const id of probeIds) init[id] = { status: 'pending' };
+    return init;
+  });
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [, setTick] = useState(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is read as a trigger — incrementing it intentionally re-fires the probe.
+  useEffect(() => {
+    let cancelled = false;
+    const probesToRun = SURFACES.filter((s) => s.mode === 'probe');
+    for (const surface of probesToRun) {
+      if (!surface.probeUrl) continue;
+      const startedAt = performance.now();
+      fetch(surface.probeUrl, { cache: 'no-store' })
+        .then((response) => {
+          if (cancelled) return;
+          const latencyMs = Math.round(performance.now() - startedAt);
+          const checkedAt = Date.now();
+          if (response.ok) {
+            setProbes((prev) => ({
+              ...prev,
+              [surface.id]: { status: 'up', latencyMs, checkedAt },
+            }));
+          } else {
+            setProbes((prev) => ({
+              ...prev,
+              [surface.id]: {
+                status: 'down',
+                reason: `HTTP ${response.status}`,
+                checkedAt,
+              },
+            }));
+          }
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return;
+          const reason =
+            error instanceof Error ? error.message : 'Network error reaching the endpoint.';
+          setProbes((prev) => ({
+            ...prev,
+            [surface.id]: { status: 'down', reason, checkedAt: Date.now() },
+          }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  // Tick every 30s to keep "Xs ago" copy fresh without spamming probes.
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const probeResults = probeIds.map((id) => probes[id]);
+  const anyDown = probeResults.some((r) => r && r.status === 'down');
+  const anyPending = probeResults.some((r) => r && r.status === 'pending');
+  const overallTitle = anyPending
+    ? 'Checking current status…'
+    : anyDown
+      ? 'Some surfaces are not responding'
+      : 'All probed surfaces are operational';
+  const overallVariant: 'info' | 'success' | 'warning' = anyPending
+    ? 'info'
+    : anyDown
+      ? 'warning'
+      : 'success';
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
+        <Callout variant={overallVariant} title={overallTitle}>
+          This page probes the API health endpoint in your browser when you load it. It reflects
+          what your network sees right now, not a separate uptime service. Solo-operator company —
+          we do not run 24×7 manned monitoring you can subscribe to.{' '}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => {
+              setProbes((prev) => {
+                const next: Record<string, ProbeResult> = { ...prev };
+                for (const id of probeIds) next[id] = { status: 'pending' };
+                return next;
+              });
+              setRefreshKey((k) => k + 1);
+            }}
+          >
+            Re-check now
+          </button>
+          .
+        </Callout>
+      </div>
+
+      <section className="mx-auto max-w-3xl px-6 pt-10 lg:px-8">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Status</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Live probe and link surface for the four RevealUI properties. Last loaded:{' '}
+          {new Date().toLocaleString()}.
+        </p>
+
+        <ul className="mt-8 divide-y divide-border rounded-xl ring-1 ring-border">
+          {SURFACES.map((surface) => {
+            const result = surface.mode === 'probe' ? probes[surface.id] : undefined;
+            const state =
+              surface.mode === 'self'
+                ? ({ kind: 'self' } as const)
+                : surface.mode === 'link'
+                  ? ({ kind: 'link' } as const)
+                  : ({ kind: 'probe', result: result ?? { status: 'pending' } } as const);
+            return (
+              <li
+                key={surface.id}
+                className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium text-foreground">{surface.label}</p>
+                  <a
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                    href={surface.publicUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {surface.description}
+                  </a>
+                  {result && result.status === 'down' && (
+                    <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                      {result.reason} · checked {formatChecked(result.checkedAt)}
+                    </p>
+                  )}
+                  {result && result.status === 'up' && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Checked {formatChecked(result.checkedAt)}
+                    </p>
+                  )}
+                </div>
+                <div className="shrink-0">{badgeFor(state)}</div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
+        <h2>How we monitor</h2>
+        <p>
+          RevealUI Studio is a solo-operator company. We run a single API health endpoint that this
+          page probes when you load it. We do not currently offer email or SMS subscriptions for
+          status changes. Honest answers about what we do and do not have:
+        </p>
+        <ul>
+          <li>
+            <strong>What works today.</strong> The probe above reflects current API reachability
+            from your browser. Vercel runs its own platform health checks; we receive alerts when
+            their checks fail.
+          </li>
+          <li>
+            <strong>What we are watching but not publishing yet.</strong> A separate public uptime
+            history with subscribable incident channels (Instatus / BetterStack class) is queued for
+            after we have paying customers. Until then, this live-probe page is the honest interim.
+          </li>
+          <li>
+            <strong>What does not exist yet.</strong> A 24×7 on-call rotation. Multi-region
+            failover. A separate paid status page domain. We will publish these on this page when
+            they ship — not before.
+          </li>
+        </ul>
+
+        <h2>Incident history</h2>
+        <p>
+          No incidents have been disclosed here yet. When one occurs, we will post a brief notice
+          with timestamps, impact, root cause (once known), and remediation. We commit to disclosing
+          real incidents rather than hiding them.
+        </p>
+
+        <h2>Are you experiencing an outage?</h2>
+        <p>
+          If this page shows all surfaces operational but you are still seeing issues, the problem
+          is probably between your network and ours — or specific to a feature this page does not
+          probe yet. Email <a href={`mailto:${SITE.emails.support}`}>{SITE.emails.support}</a> with
+          the URL you hit, the time you first saw the issue, and any error message. We treat outage
+          reports as higher priority than standard support email.
+        </p>
+        <p>
+          For confirmed security incidents, follow the <a href="/security">security policy</a>{' '}
+          instead — that channel has different SLAs.
+        </p>
+      </article>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/marketing/app/routes/SupportPage.tsx
+++ b/apps/marketing/app/routes/SupportPage.tsx
@@ -1,0 +1,72 @@
+import { Callout } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import { SUPPORT_META, SUPPORT_SECTIONS } from '../content/legal/support';
+import { SITE } from '../content/site';
+
+export function SupportPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
+        <Callout variant="info" title="One channel for direct support, three for community + docs">
+          The fastest path is to check{' '}
+          <a className="underline" href={SITE.urls.docs} target="_blank" rel="noopener noreferrer">
+            the documentation
+          </a>{' '}
+          first. For account-specific issues, billing, or anything sensitive, email{' '}
+          <a className="underline" href={`mailto:${SITE.emails.support}`}>
+            {SITE.emails.support}
+          </a>{' '}
+          — we aim for a substantive reply within 48 business hours (Mon–Fri, U.S. Central).
+        </Callout>
+      </div>
+      <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
+        <h1>{SUPPORT_META.title}</h1>
+        <p className="text-sm text-muted-foreground">Last updated: {SUPPORT_META.lastUpdated}</p>
+
+        <p>{SUPPORT_META.intro}</p>
+
+        {SUPPORT_SECTIONS.map((section) => (
+          <div key={section.heading}>
+            <h2>{section.heading}</h2>
+
+            {section.subsections?.map((sub) => (
+              <div key={sub.heading}>
+                <h3>{sub.heading}</h3>
+                {sub.paragraph && <p>{sub.paragraph}</p>}
+                {sub.listItems && (
+                  <ul>
+                    {sub.listItems.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+
+            {section.listPreamble && <p>{section.listPreamble}</p>}
+
+            {section.listItems && (
+              <ul>
+                {section.listItems.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
+
+            {section.paragraphs?.map((para) =>
+              section.contactEmail ? (
+                <p key={para}>
+                  For support questions, email{' '}
+                  <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
+                </p>
+              ) : (
+                <p key={para}>{para}</p>
+              ),
+            )}
+          </div>
+        ))}
+      </article>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
_Re-opened from auto-closed [#1133](https://github.com/RevealUIStudio/revealui/pull/1133) — its base branch was deleted when [#1132](https://github.com/RevealUIStudio/revealui/pull/1132) merged with `--delete-branch`. Content identical to #1133; see that PR for full review history._

## Why

Phase A of the moral-charge launch-bar lane. Two more SPA-fallback ghost routes resolved into real pages.

The audit found `revealui.com/support` and `revealui.com/status` both returned 200 — but only because of the Vite SPA catch-all. No SupportPage or StatusPage existed; no published support channel; no status surface for a customer trying to figure out if a problem is theirs or ours.

## What

### A4 — SupportPage at /support
- 8-section page documenting how + when + where to ask for help, honestly scoped for a solo-operator company
- One direct channel (`support@revealui.com`) + three community channels (docs, GitHub Discussions, GitHub Issues)
- Published SLA: substantive reply within 48 business hours (Mon–Fri, U.S. Central) for support email; best-effort for GitHub
- Explicit "what we cannot help with" section: no writing your code, no private-repo line-by-line review, no debugging exotic Docker/K8s deployments, no live phone/video support at Pro tier
- "Bug vs support vs Discussion" channel-selection guide

### A6 — StatusPage at /status
- Live-probe page: fetches `https://api.revealui.com/health` from the user's browser on load
- 4 surfaces tracked: marketing (self), API (probe), docs (link), admin (link)
- "Re-check now" button re-runs probes without page reload
- Per-surface latency display + error reason on down
- Top banner Callout flips variant (info/success/warning) to match overall state
- Honest disclosure: solo-operator, no 24×7 monitoring

Production CORS verified: `api.revealui.com` sends `Access-Control-Allow-Origin: https://revealui.com` on /health, so the probe works in prod.

## Verified locally

Per the original #1133 verification: typecheck clean, biome clean, claim-drift 0, build success, dev-server preview rendered banners light + dark mode, console clean.

## Note on CI

The `Integration Tests (extended)` advisory check is currently failing fleet-wide (timeout regression — see closed [#1143](https://github.com/RevealUIStudio/revealui/pull/1143)). Branch protection on `test` does NOT require this check; mergeable=MERGEABLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
