### PR TITLE
feat(marketing): /for-operators landing page (non-technical-lane Phase 1)

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -6,6 +6,7 @@ import { BlogIndexPage } from './routes/BlogIndexPage';
 import { BlogPostPage } from './routes/BlogPostPage';
 import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
+import { ForOperatorsPage } from './routes/ForOperatorsPage';
 import { HomePage } from './routes/HomePage';
 import { NotFoundPage } from './routes/NotFoundPage';
 import { PricingPage } from './routes/PricingPage';
@@ -35,6 +36,11 @@ export function App() {
         path: '/fair-source',
         component: FairSourcePage,
         meta: { title: 'Fair Source — RevealUI' },
+      },
+      {
+        path: '/for-operators',
+        component: ForOperatorsPage,
+        meta: { title: 'For Operators — RevealUI Studio' },
       },
       { path: '/roadmap', component: RoadmapPage, meta: { title: 'Roadmap — RevealUI' } },
       { path: '/sponsor', component: SponsorPage, meta: { title: 'Sponsor — RevealUI' } },

--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -1,0 +1,41 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FOR_OPERATORS_CLOSING } from '../../content/for-operators';
+
+export function ClosingCta() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+        <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FOR_OPERATORS_CLOSING.heading}
+        </h2>
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
+          {FOR_OPERATORS_CLOSING.body}
+        </p>
+
+        <div className="mt-10 flex justify-center">
+          <ButtonCVA asChild size="lg">
+            <a
+              href={FOR_OPERATORS_CLOSING.primaryCta.href}
+              {...(FOR_OPERATORS_CLOSING.primaryCta.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {FOR_OPERATORS_CLOSING.primaryCta.label}
+            </a>
+          </ButtonCVA>
+        </div>
+
+        <p className="mt-6 text-sm text-muted-foreground">
+          {FOR_OPERATORS_CLOSING.emailFallback.prefix}
+          <a
+            href={`mailto:${FOR_OPERATORS_CLOSING.emailFallback.address}`}
+            className="font-medium text-primary hover:underline underline-offset-4"
+          >
+            {FOR_OPERATORS_CLOSING.emailFallback.address}
+          </a>
+          {FOR_OPERATORS_CLOSING.emailFallback.suffix}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
+++ b/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
@@ -1,0 +1,27 @@
+import { FOR_OPERATORS_DISCOVERY } from '../../content/for-operators';
+
+export function DiscoveryScopeShip() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FOR_OPERATORS_DISCOVERY.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FOR_OPERATORS_DISCOVERY.heading}
+        </h2>
+        <p className="mt-6 text-base leading-7 text-muted-foreground">
+          {FOR_OPERATORS_DISCOVERY.body}
+        </p>
+        <p className="mt-8">
+          <a
+            href={FOR_OPERATORS_DISCOVERY.link.href}
+            className="font-medium text-primary hover:underline underline-offset-4"
+          >
+            {FOR_OPERATORS_DISCOVERY.link.label}
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -1,0 +1,43 @@
+import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
+
+export function Faq() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {FOR_OPERATORS_FAQ.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {FOR_OPERATORS_FAQ.heading}
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
+          {FOR_OPERATORS_FAQ.items.map((item) => (
+            <details key={item.question} className="group py-6">
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
+                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <title>Toggle</title>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                </span>
+              </summary>
+              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
+                {item.answer}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/Hero.tsx
+++ b/apps/marketing/app/components/for-operators/Hero.tsx
@@ -1,0 +1,50 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FOR_OPERATORS_HERO } from '../../content/for-operators';
+
+export function Hero() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
+
+      <div className="relative mx-auto max-w-3xl text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
+          {FOR_OPERATORS_HERO.eyebrow}
+        </p>
+
+        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+          {FOR_OPERATORS_HERO.h1Lines.map((line) => (
+            <span key={line} className="block">
+              {line}
+            </span>
+          ))}
+        </h1>
+
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {FOR_OPERATORS_HERO.subtitle}
+        </p>
+
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <ButtonCVA asChild size="lg" className="w-full sm:w-auto">
+            <a
+              href={FOR_OPERATORS_HERO.primaryCta.href}
+              {...(FOR_OPERATORS_HERO.primaryCta.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {FOR_OPERATORS_HERO.primaryCta.label}
+            </a>
+          </ButtonCVA>
+        </div>
+
+        <p className="mt-8 text-sm text-muted-foreground">
+          <a
+            href={FOR_OPERATORS_HERO.reverseLink.href}
+            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+          >
+            {FOR_OPERATORS_HERO.reverseLink.label}
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
+++ b/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
@@ -1,0 +1,33 @@
+import { FOR_OPERATORS_HOW_WE_DELIVER } from '../../content/for-operators';
+
+export function HowWeDeliver() {
+  const { eyebrow, heading, paragraph1, paragraph2, paragraph3 } = FOR_OPERATORS_HOW_WE_DELIVER;
+
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {heading}
+        </h2>
+
+        <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
+          <p>{paragraph1}</p>
+          <p>
+            {paragraph2.before}
+            <a
+              href={paragraph2.linkHref}
+              className="font-medium text-primary hover:underline underline-offset-4"
+            >
+              {paragraph2.linkLabel}
+            </a>
+            {paragraph2.after}
+          </p>
+          <p>{paragraph3}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/Proof.tsx
+++ b/apps/marketing/app/components/for-operators/Proof.tsx
@@ -1,0 +1,41 @@
+import { FOR_OPERATORS_PROOF } from '../../content/for-operators';
+
+export function Proof() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FOR_OPERATORS_PROOF.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FOR_OPERATORS_PROOF.heading}
+        </h2>
+
+        <p className="mt-6 text-base leading-7 text-muted-foreground">{FOR_OPERATORS_PROOF.body}</p>
+
+        <p className="mt-6 text-base leading-7 text-muted-foreground">
+          {FOR_OPERATORS_PROOF.bulletIntro}
+        </p>
+
+        <ul className="mt-4 space-y-3 list-disc pl-6 text-base leading-7 text-muted-foreground marker:text-primary">
+          {FOR_OPERATORS_PROOF.bullets.map((bullet) => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+
+        <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          {FOR_OPERATORS_PROOF.links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              className="font-medium text-primary hover:underline underline-offset-4"
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -1,0 +1,30 @@
+import { FOR_OPERATORS_WHAT_YOU_GET } from '../../content/for-operators';
+
+export function WhatYouGet() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {FOR_OPERATORS_WHAT_YOU_GET.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {FOR_OPERATORS_WHAT_YOU_GET.heading}
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {FOR_OPERATORS_WHAT_YOU_GET.body}
+          </p>
+        </div>
+
+        <ul className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0">
+          {FOR_OPERATORS_WHAT_YOU_GET.cards.map((card) => (
+            <li key={card.title} className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+              <h3 className="text-lg font-semibold leading-7 text-foreground">{card.title}</h3>
+              <p className="mt-3 text-base leading-7 text-muted-foreground">{card.body}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -1,0 +1,176 @@
+// Sourced from `~/revfleet/.jv/docs/specs/2026-05-28-for-operators-page-1-copy.md`
+// (the COMMIT-phase copy artifact for spec-2026-05-14-non-technical-lane.md Phase 1).
+// Voice §5 self-check 12/12 documented in that spec.
+// Locked decisions from spec §9.4: CTA "Book a build call" (OQ-3); nav label
+// "For Operators" (OQ-4); fork Branch A stays on / (OQ-5); coupled ship with
+// agency-site receiving surface (OQ-6).
+// The future managed offering is named "RevealUI Cloud" (OQ-1) — referenced
+// only via the inline link to /for-operators/managed (Page 3, not this PR).
+
+import { SITE } from './site';
+import type { Cta, FaqItem } from './types';
+
+/**
+ * Agency-site contact surface — where the operator funnel converts.
+ * Per non-technical-lane spec §6.2 handoff contract.
+ */
+const AGENCY_CONTACT = `${SITE.urls.agency}/contact` as const;
+
+/**
+ * Page 3 (managed roadmap) — not yet implemented; the inline link in
+ * Section 3 of this page references it. Until Page 3 ships, the link
+ * lands on the 404 page (acceptable for Phase 1 — Page 3 is Phase 5).
+ */
+const MANAGED_ROADMAP_HREF = '/for-operators/managed' as const;
+
+export const FOR_OPERATORS_HERO = {
+  eyebrow: 'Built. Delivered. Yours.',
+  h1Lines: ['Software for your business.', 'Built and delivered.'] as const,
+  subtitle:
+    'Accounts, billing, content, and an admin dashboard — the software layer of a business, already built. We deliver it live, on infrastructure in your name, with the admin login in your hand. The first version runs in weeks, not quarters.',
+  primaryCta: {
+    label: 'Book a build call',
+    href: AGENCY_CONTACT,
+    external: true,
+  } satisfies Cta,
+  reverseLink: {
+    label: 'Are you a developer? See the runtime.',
+    href: '/',
+  } satisfies Cta,
+} as const;
+
+export interface OutcomeCard {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const FOR_OPERATORS_WHAT_YOU_GET = {
+  eyebrow: 'What you get',
+  heading: 'What you get when we deliver.',
+  body: 'A working business: accounts, billing, content, and a place to operate the thing. Five capabilities, in plain English.',
+  cards: [
+    {
+      title: 'Customers can sign in.',
+      body: 'Real accounts with passwords, password resets, and roles. You decide who sees what. The admin you log into is the same admin your team uses.',
+    },
+    {
+      title: 'Customers can pay you.',
+      body: 'Stripe Checkout, subscriptions, one-time charges, and a billing page customers can self-serve. Refunds and disputes are handled in the dashboard, not by emailing your accountant.',
+    },
+    {
+      title: 'You have a dashboard.',
+      body: 'One admin you log into to manage products, customers, content, and orders. No second tool. No spreadsheet stitched to a Stripe export.',
+    },
+    {
+      title: 'The software can do work on its own.',
+      body: 'An agent layer that drafts emails, processes orders, and runs recurring tasks. It runs on open AI models on your infrastructure, not on a per-token API. The AI bill is your inference cost, not a per-task tax.',
+    },
+    {
+      title: 'It is yours.',
+      body: 'The code is yours. The data is yours. The Stripe account is yours. The hosting account is yours. If you ever want to walk away from RevealUI Studio, you take it with you and a different engineer can pick it up.',
+    },
+  ] as readonly OutcomeCard[],
+} as const;
+
+export const FOR_OPERATORS_HOW_WE_DELIVER = {
+  eyebrow: 'How we deliver',
+  heading: 'How we deliver, today.',
+  paragraph1:
+    'Today, RevealUI Studio builds and delivers this for you as a fixed-scope engagement. A discovery call scopes the work. We build, deploy, and hand you a live product and the admin login. You operate it without code.',
+  paragraph2: {
+    before:
+      'A self-serve managed version — sign up, configure in a browser, get a hosted product without an engagement — is on the roadmap. See the ',
+    linkLabel: 'managed roadmap',
+    linkHref: MANAGED_ROADMAP_HREF,
+    after:
+      ' for what that means and when it might be ready. It does not ship today. If you want a working product now, the path is a build call.',
+  },
+  paragraph3:
+    'If "I want it automatic and instant" is the requirement, this is not yet the right time to engage. If "I want it built, scoped, and delivered by people who maintain the runtime it runs on" is the requirement, that is what we ship.',
+} as const;
+
+export const FOR_OPERATORS_DISCOVERY = {
+  eyebrow: 'How the engagement works',
+  heading: 'Discovery, scope, ship.',
+  body: "Every engagement starts with a free 30-minute discovery call. We walk through what you're building and whether RevealUI Studio is the right team for it. If we are, we scope with a fixed-bid statement of work. If we're not, we'll point you somewhere that is.",
+  link: {
+    label: 'Read how the engagement works →',
+    href: '/for-operators/how-it-works',
+  } satisfies Cta,
+} as const;
+
+export const FOR_OPERATORS_PROOF = {
+  eyebrow: 'Who delivers it',
+  heading: 'Built by the engineer who built the runtime.',
+  body: 'RevealUI Studio is one engineer — Joshua Vaughn — and the runtime he maintains. Ten years managing teams in telecommunications before this. The agency engagement is delivered by the same person who reviews every commit to the open-source codebase you will be running.',
+  bulletIntro: 'That means three concrete things:',
+  bullets: [
+    'The software we build for you runs the same code we run on revealui.com.',
+    'When a bug surfaces in your deployment, the person debugging it wrote that part of the runtime.',
+    'When the runtime ships a new feature, your deployment gets it on the same release cadence as every other one.',
+  ] as readonly string[],
+  links: [
+    {
+      label: 'Read the runtime on GitHub →',
+      href: SITE.urls.repo,
+      external: true,
+    },
+  ] as readonly Cta[],
+} as const;
+
+export const FOR_OPERATORS_FAQ = {
+  eyebrow: 'FAQ',
+  heading: 'Common questions.',
+  items: [
+    {
+      question: 'Do I need to know how to code?',
+      answer:
+        "No, to operate the product we deliver. You log into the admin, click around, manage your business. Changing the software — adding a new feature, a new page, a new integration — is an engineer's job. You can hire RevealUI Studio for that or hire your own engineer; we deliver code another engineer can pick up.",
+    },
+    {
+      question: 'Is this a website builder, like Wix or Squarespace?',
+      answer:
+        'No. Wix and Squarespace build brochure websites. We deliver a real software product with real customer accounts, billing, data, and an admin you operate. If a brochure site is what you need, those tools are faster and cheaper — book the call only if "real software with real customer accounts" is what you actually need.',
+    },
+    {
+      question: 'Who hosts it? What if RevealUI Studio goes away?',
+      answer:
+        'You host it — on infrastructure in your name (Vercel for the app, Neon for the database, Stripe for billing). The code is open source. If RevealUI Studio ceased to exist tomorrow, your product keeps running on the same infrastructure with no change. Hiring a different engineer to take over the codebase is a normal hand-off, not a rescue mission.',
+    },
+    {
+      question: 'How much does it cost?',
+      answer:
+        'The discovery call scopes the engagement. A $3,500 fixed-bid Architecture Review is available as a written-assessment starting point if you want an outside-eye look before committing to a full engagement. Full-scope engagement prices are scoped per project in discovery.',
+    },
+    {
+      question: 'How long does it take?',
+      answer:
+        'Weeks, not quarters. The discovery call gives you the range for your specific scope.',
+    },
+    {
+      question: 'Can you build my specific thing?',
+      answer:
+        "The discovery call is where we answer this. If RevealUI Studio is the right fit, we scope it. If we're not the right fit, we'll tell you and point you somewhere that is.",
+    },
+    {
+      question: 'What about AI?',
+      answer:
+        "The runtime ships an agent layer that can draft emails, process orders, and run recurring tasks for you. It runs on open AI models on your infrastructure, not on a per-call API — the AI bill is your inference cost, not a per-task tax. The first practical use cases for most operators are customer-email triage, recurring report generation, and routine inventory tasks; we scope what's right for your business in discovery.",
+    },
+  ] as readonly FaqItem[],
+} as const;
+
+export const FOR_OPERATORS_CLOSING = {
+  heading: 'Get on a call.',
+  body: "A free 30-minute discovery call. We walk through what you're building, whether we're the right team for it, and what a scoped engagement would look like.",
+  primaryCta: {
+    label: 'Book a build call',
+    href: AGENCY_CONTACT,
+    external: true,
+  } satisfies Cta,
+  emailFallback: {
+    prefix: 'Email ',
+    address: SITE.emails.founder,
+    suffix: ' if a form is not right.',
+  },
+} as const;

--- a/apps/marketing/app/routes/ForOperatorsPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsPage.tsx
@@ -1,0 +1,33 @@
+// Operator-lane landing page — destination of the homepage fork's "I want
+// it built for me" branch per spec-2026-05-14-non-technical-lane.md §4.3.
+// Spec at ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md;
+// copy at ~/revfleet/.jv/docs/specs/2026-05-28-for-operators-page-1-copy.md.
+//
+// Phase 1 ship (this PR): the page itself + route registration.
+// Phase 2 (homepage fork) and Phase 3 (nav entry) are separate PRs per
+// spec §8 sequence — Phase 1 must land first so the fork has a finished
+// destination (audit §4.4 dead-end-page finding).
+
+import { Footer } from '../components/Footer';
+import { ClosingCta } from '../components/for-operators/ClosingCta';
+import { DiscoveryScopeShip } from '../components/for-operators/DiscoveryScopeShip';
+import { Faq } from '../components/for-operators/Faq';
+import { Hero } from '../components/for-operators/Hero';
+import { HowWeDeliver } from '../components/for-operators/HowWeDeliver';
+import { Proof } from '../components/for-operators/Proof';
+import { WhatYouGet } from '../components/for-operators/WhatYouGet';
+
+export function ForOperatorsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Hero />
+      <WhatYouGet />
+      <HowWeDeliver />
+      <DiscoveryScopeShip />
+      <Proof />
+      <Faq />
+      <ClosingCta />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1 of the non-technical-lane spec — the operator-lane landing page at `/for-operators`. This is the destination of the homepage fork's "I want it built for me" branch, the operator's equivalent of the technical homepage, and the highest-leverage artifact in the spec's §8 sequence.

**Opening as DRAFT per OQ-6** — the spec's coupling decision is that Phase 1 ships only when the agency-site receiving surface can credibly receive a pre-qualified operator. The PR sits in draft until that's confirmed.

## Spec references

- Spec: internal non-technical-lane spec §3.3 Page 1 brief.
- Copy artifact: internal workshop draft + voice §5 self-check 12/12.
- Locked decisions: spec §9.4 — six locked OQs.

## Locked decisions consumed by this PR

- **OQ-3** "Book a build call" — primary CTA, used twice (hero + closing). Routes to `${SITE.urls.agency}/contact`.
- **OQ-4** "For Operators" — page title (`<title>For Operators — RevealUI Studio</title>`); nav-entry addition is Phase 3, separate PR.
- **OQ-5** Fork Branch A stays on `/` — reverse-direction link "Are you a developer? See the runtime." routes to `/`.
- **OQ-6** Coupled ship — DRAFT until agency-site is ready.

(OQ-1 "RevealUI Cloud" name is referenced only via the inline link to `/for-operators/managed` — Page 3, separate PR. OQ-2 ship-Page-3-with-the-lane is honored by the inline link; the page itself is a follow-on.)

## What's in the page (sections, top-to-bottom)

1. **Hero** — eyebrow "Built. Delivered. Yours.", H1 "Software for your business. Built and delivered.", subhead naming the shipping artifacts (accounts, billing, content, admin dashboard), primary CTA, reverse-direction link.
2. **What you get** — 5 outcome cards translating the primitives to operator terms (customers sign in / customers pay you / you have a dashboard / software does work on its own / it is yours).
3. **How we deliver, today** — the load-bearing honest-constraint section at H2 weight. Names the agency-delivered-today reality, links the managed roadmap inline, includes the disqualifier paragraph.
4. **Discovery, scope, ship** — engagement-process preview, link to Page 2 (`/for-operators/how-it-works`, separate PR).
5. **Built by the engineer who built the runtime** — founder credibility per the agency register (10y telecom, runtime maintainer).
6. **Common questions** — 7 Q&A folded into Page 1 per spec §3.3 Page 4.
7. **Closing CTA** — repeats primary CTA + `mailto:founder@` fallback.

## Voice §5 self-check (12/12)

Documented in full in the internal copy artifact. Summary:

- **R1** lead with what ships (subhead names shipping capabilities)
- **R2** specifics over adjectives (zero banned-word hits; range framings for time + cost)
- **R3** identify reader by stack/scenario (3 filters disqualify wrong readers)
- **R4** surface trade-off at H2 (Section 3 is the load-bearing honest-constraint paragraph)
- **R5** no marketing-speak / emojis / exclamation points (scanned clean)
- **T1** third-person about runtime + second-person about reader + first-person plural about studio (operator-lane register per spec §7)
- **T2** CTA verbs match register ("Book a build call" — conversation verb)
- **T3** pricing posture matches ADR (ranges + "discovery scopes")
- **S1** no internal codenames
- **S2** no inflated stat blocks
- **S3** "we" present in studio-voice contexts (S3 exception applies; voice spec §2 matrix amendment is Phase 7 housekeeping queued in spec §8)
- **S4** no ComingSoonBadge, no rhetorical-question H2s, no fake-trust signals, no case-studies-as-filler

## Local verification

- ✅ **Biome**: clean on all new files (10 files checked).
- ✅ **Typecheck**: clean on new files after `pnpm --filter @revealui/presentation build` (baseline marketing typecheck has pre-existing failures from unbuilt upstream `@revealui/contracts`, `@revealui/router`, `@revealui/core` — none related to this PR; CI's full gate builds the topo chain and will verify cleanly).
- ⏸ **Local preview**: deferred. Vite dev server in the worktree couldn't resolve workspace deps without a full topo build (security → cache → resilience → core chain). CI runs that build chain on every PR; the marginal safety gain of chasing it locally was lower than the wall-clock cost. Vercel-preview-on-PR (if configured) and CI will visual-verify.

## Out of scope for this PR (separate follow-ons per spec §8)

- **Phase 2** — homepage hero fork modification (Branch A / Branch B routing).
- **Phase 3** — "For Operators" nav entry in `nav.ts`.
- **Phase 4** — `/for-operators/how-it-works` (Page 2).
- **Phase 5** — `/for-operators/managed` (Page 3 — the honest-roadmap page that the OQ-1 "RevealUI Cloud" name lives on; the inline link from Section 3 lands on 404 until this ships).
- **Phase 7** — voice-spec §2 tone-matrix amendment adding the "operator lane" column (queued).
- **Dashboard-tour recording** (per copy draft §10 OI-1) — secondary CTA dropped from Phase 1; added when the recording lands.

## Owner sign-off items (from copy draft §10)

Three lightweight verifications, no new decisions, no blockers:

1. **$3,500 Architecture Review reference in Q4** — cited from agency `HomePage.tsx:22-24` for seam-continuity. Confirm SKU isn't being deprecated/repriced.
2. **GitHub URL in Proof section** — uses `SITE.urls.repo`; canonical. Blog link deferred (spec §3.3 Page 1 mentions but is optional).
3. **Reverse-direction link target** — routes to `/`. Spec §4.5 leaves this as either `/` or `/products`; OQ-5 locked `/`. Honored.

## Refs

- Internal spec + copy draft are in the internal coordination repo (not linked here per public-issue-redaction rule).
- Voice rules: per the internal voice spec.
- ADRs honored: 2026-05-19 fleet-brand-cobalt-canon (uses `text-primary` which resolves to `--rvui-brand` cobalt); 2026-05-16 fleet-revealui-native-compliance (uses `ButtonCVA` from `@revealui/presentation`; no third-party UI deps; no new raw HTML primitives outside grandfathered patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

