### PR TITLE
chore(sync): add R2 entries to vercel sync manifest + SECRETS.md

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -168,7 +168,12 @@ revealui/prod/sentry/project-admin   # SENTRY_PROJECT for apps/admin
 **Storage**
 
 ```
-revealui/prod/blob/read-write-token  # BLOB_READ_WRITE_TOKEN — Vercel Blob file uploads
+revealui/prod/r2/account-id          # R2_ACCOUNT_ID — Cloudflare R2 account ID (canonical object-storage backend)
+revealui/prod/r2/access-key-id       # R2_ACCESS_KEY_ID — R2 API token Access Key ID
+revealui/prod/r2/secret-access-key   # R2_SECRET_ACCESS_KEY — R2 API token Secret Access Key
+revealui/prod/r2/bucket              # R2_BUCKET — R2 bucket name (canonical: revealui-media)
+revealui/prod/r2/public-base-url     # R2_PUBLIC_BASE_URL — public-read base; sticky (baked into stored media URLs)
+revealui/prod/blob/read-write-token  # BLOB_READ_WRITE_TOKEN — legacy Vercel Blob fallback (retiring once R2 verified)
 ```
 
 **Billing**

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -83,7 +83,14 @@ REVEALUI_SECRET              = "revealui/prod/secret"
 REVEALUI_CRON_SECRET = "revealui/prod/cron-secret"
 REVEALUI_ALERT_EMAIL = "revealui/prod/alert-email"
 
-# Storage + CI tokens
+# Storage — Cloudflare R2 (canonical, S3-compatible). Set together; partial config
+# falls back to BLOB_READ_WRITE_TOKEN per @revealui/config storage module.
+R2_ACCOUNT_ID         = "revealui/prod/r2/account-id"
+R2_ACCESS_KEY_ID      = "revealui/prod/r2/access-key-id"
+R2_SECRET_ACCESS_KEY  = "revealui/prod/r2/secret-access-key"
+R2_BUCKET             = "revealui/prod/r2/bucket"
+R2_PUBLIC_BASE_URL    = "revealui/prod/r2/public-base-url"
+# Storage — legacy Vercel Blob (fallback; used only when R2_* are unset)
 BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
 # REVEALUI_NPM_TOKEN dropped 2026-05-23: 2FA-bypass npm automation token retired
 # (revealui#1016); release.yml publishes via OIDC trusted publishing — no token.
@@ -173,7 +180,14 @@ PASSKEY_RP_NAME        = "revealui/prod/passkey/rp-name"
 # Cron + alerting (parity with api)
 REVEALUI_CRON_SECRET = "revealui/prod/cron-secret"
 
-# Storage
+# Storage — Cloudflare R2 (canonical, S3-compatible). Set together; partial config
+# falls back to BLOB_READ_WRITE_TOKEN per @revealui/config storage module.
+R2_ACCOUNT_ID         = "revealui/prod/r2/account-id"
+R2_ACCESS_KEY_ID      = "revealui/prod/r2/access-key-id"
+R2_SECRET_ACCESS_KEY  = "revealui/prod/r2/secret-access-key"
+R2_BUCKET             = "revealui/prod/r2/bucket"
+R2_PUBLIC_BASE_URL    = "revealui/prod/r2/public-base-url"
+# Storage — legacy Vercel Blob (fallback; used only when R2_* are unset)
 BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
 
 # Email transport (parity with api — same Gmail SA credentials)


### PR DESCRIPTION
## Summary

Adds the five Cloudflare R2 env-var mappings to both `revealui-admin` and `revealui-api` blocks of the revvault → Vercel sync manifest, and documents the canonical `revealui/prod/r2/*` paths in `docs/SECRETS.md`. Manifest-only / docs-only follow-on to #1117 / #1119 (the Phase 4 Vercel Blob → Cloudflare R2 cutover that landed code-side on `main`).

## Context

After #1117 (R2 canonical) + #1119 (Blob plugin decommission) reached `main` on 2026-05-28, the prod runtime was still falling through to the Vercel Blob fallback because the five `R2_*` env vars weren't set on Vercel. The R2 vault paths got created this session (R2 credentials in `revealui/prod/r2/*`); the env vars were pushed to Vercel admin + api via the Vercel API directly (targeted insert).

That direct insert left the manifest out of sync with Vercel. This PR closes that gap so future `pnpm vercel:sync` runs reconcile the R2 paths idempotently.

## What changed

- `scripts/sync/revvault-vercel.toml`:
  - Added `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` / `R2_PUBLIC_BASE_URL` mappings to `[projects.revealui-api.vars]` and `[projects.revealui-admin.vars]`.
  - Reframed `BLOB_READ_WRITE_TOKEN` comment as legacy fallback (retiring once R2 prod-verified).
- `docs/SECRETS.md`:
  - Added the five `revealui/prod/r2/*` paths to the Storage section, with sticky-URL note on `public-base-url`.

## Why not a full sync

The `pnpm vercel:sync` dry-run flagged ~40 `~` updates across non-storage entries (vault-canonical reconciliation that would silently overwrite Vercel from vault). Three legacy paths are also envelope-corrupt in vault (Electric URL/secret + Blob token — pre-existing tech debt from the 2026-05-09 `--pull` incident). Rather than fire a broad sync mid-session, I added the R2 vars surgically and left the rest for an env-hygiene cleanup session (tracked separately).

## Verification

- Pre-push gate: PASS (19.6s)
- Vercel admin + api: 5 R2 vars present (added via API earlier this session)
- Deploy run `26614134092` in progress (api + admin redeploy to pick up the new env)

## Follow-on items (deferred)

Tracked separately:
- DNS → Cloudflare migration to bind `media.revealui.com`, replacing the r2.dev URL (sticky-URL trap)
- Electric secret rotation (vault envelope-corrupt)
- Electric URL recovery (vault envelope-corrupt)
- BLOB retirement (delete from Vercel + vault + manifest after R2 prod-verified)
- NEXT_PUBLIC + Sensitive contradictions (5 entries) + ~13 secret-named-not-Sensitive flag flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
