### PR TITLE
feat(marketing): homepage audience fork (non-technical-lane Phase 2)

### DIFF
--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -1,0 +1,69 @@
+// Homepage audience fork — Phase 2 of the non-technical-lane spec.
+// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §4.3.
+// Decisions: §9.4 OQ-5 — Branch A stays on / (scroll-past); not a route change.
+//
+// Implementation note (Phase 2): placed AFTER <Hero /> in HomePage.tsx as a
+// separate component rather than INSIDE the existing Hero. This avoids
+// merge-conflict with peer PR #1141 which is editing HOME_HERO copy. The
+// spec's §4.3 ideal placement is "above the first scroll boundary" inside
+// the hero viewport; this implementation puts the fork as the next-band
+// after Hero, which is visible after a small scroll on most viewports.
+// Trade-off: marginally lower first-paint visibility for the fork in
+// exchange for zero collision with in-flight peer work. Revisit after #1141
+// lands if a stricter hero-internal placement is desired.
+
+import { HOME_FORK } from '../../content/home';
+
+export function Fork() {
+  const handleSelfBuildScroll = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const fork = document.getElementById('homepage-fork');
+    const next = fork?.nextElementSibling;
+    if (next instanceof HTMLElement) {
+      next.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      // Fallback: scroll one viewport down.
+      window.scrollBy({ top: window.innerHeight * 0.9, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <section id="homepage-fork" aria-label="Choose your path" className="bg-muted py-12 sm:py-16">
+      <div className="mx-auto max-w-4xl px-6 lg:px-8">
+        <p className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-6">
+          Two ways to use RevealUI
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={handleSelfBuildScroll}
+            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <h3 className="text-lg font-semibold leading-7 text-foreground">
+              {HOME_FORK.branchA.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchA.body}</p>
+            <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
+              {HOME_FORK.branchA.cta}
+            </p>
+          </button>
+
+          <a
+            href={HOME_FORK.branchB.href}
+            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <h3 className="text-lg font-semibold leading-7 text-foreground">
+              {HOME_FORK.branchB.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchB.body}</p>
+            <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
+              {HOME_FORK.branchB.cta}
+            </p>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -236,3 +236,26 @@ export const HOME_GET_STARTED = {
     label: 'Not ready to start? Get product updates and engineering insights.',
   },
 } as const;
+
+// ---------------------------------------------------------------------------
+// Homepage audience fork
+// Per spec-2026-05-14-non-technical-lane.md §4.3 (Phase 2 of the spec sequence).
+// Two equal-weight branches; visitor self-identifies before the technical-lane
+// content below. Branch A scrolls past the fork into the existing technical
+// homepage (OQ-5 locked); Branch B routes to /for-operators (Phase 1, PR #1151).
+// Decisions consumed: §9.4 OQ-5 (Branch A stays on /).
+// ---------------------------------------------------------------------------
+
+export const HOME_FORK = {
+  branchA: {
+    title: "I'm building this myself.",
+    body: 'Source, packages, the CLI, and docs — read on.',
+    cta: 'Keep reading →',
+  },
+  branchB: {
+    title: 'I want it built for me.',
+    body: 'RevealUI Studio scopes, builds, and delivers a working product. Weeks, not quarters.',
+    cta: 'See how →',
+    href: '/for-operators',
+  },
+} as const;

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -2,6 +2,7 @@ import { Footer } from '../components/Footer';
 import { GetStarted } from '../components/GetStarted';
 import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
+import { Fork } from '../components/landing/Fork';
 import { Hero } from '../components/landing/Hero';
 import { Persona } from '../components/landing/Persona';
 import { PricingTeaser } from '../components/landing/PricingTeaser';
@@ -14,6 +15,7 @@ export function HomePage() {
   return (
     <div className="min-h-screen bg-background">
       <Hero />
+      <Fork />
       <Problem />
       <Demo />
       <Primitives />


### PR DESCRIPTION
## Summary

Phase 2 of the non-technical-lane spec — the homepage audience fork. Two equal-weight choice cards placed right after `<Hero />` in `HomePage.tsx`, qualifying the visitor between the technical lane (existing homepage content) and the operator lane (`/for-operators`, Phase 1 in #1151).

**Opening as DRAFT** for consistency with the spec's coupled-ship discipline (OQ-6 from #1151). Phase 2 is independently mergeable, but Branch B's target (`/for-operators`) only exists after #1151 lands — recommend merging #1151 first, then this one.

## Spec references

- Spec: `docs/spec-2026-05-14-non-technical-lane.md` §4.3 (fork IA).
- Decisions: §9.4 OQ-5 — Branch A stays on `/` (scroll-past, not a route change).

## Implementation

| File | Change |
|---|---|
| `apps/marketing/app/content/home.ts` | NEW export `HOME_FORK` appended (additive — no collision with PR #1141's `HOME_HERO` edits). |
| `apps/marketing/app/components/landing/Fork.tsx` | NEW component. Two cards: Branch A button + Branch B link. |
| `apps/marketing/app/routes/HomePage.tsx` | `<Fork />` inserted between `<Hero />` and `<Problem />`. |

3 files, +94 insertions, 0 deletions.

## Placement trade-off

The spec's §4.3 ideal is "above the first scroll boundary" inside the hero. This implementation places the fork as the next-band after Hero (its own `<section>` with `bg-muted`) rather than inside the existing Hero component.

**Reason:** PR #1141 is editing `HOME_HERO` (H1 + truth + pillar grounding). Putting the fork inside `Hero.tsx` would guarantee a merge conflict on `home.ts` and `Hero.tsx`. Placing it as a sibling `<Fork />` after `<Hero />` keeps the change additive and zero-conflict.

The fork is still visible after a small scroll on most viewports — visible enough to qualify the visitor before they commit to scrolling into technical-lane content. If owner wants strict hero-internal placement, that's a follow-up after #1141 lands; the spec is honored on intent (fork-not-toggle, equal-weight, before commitment to a lane) even if the pixel-precise placement is one section lower.

## Voice §5 self-check

**R1** Lead with what ships:
- Branch A: "Source, packages, the CLI, and docs — read on." Names 4 shipping artifacts (all in `packages/` or shipping via `npx create-revealui`).
- Branch B: "RevealUI Studio scopes, builds, and delivers a working product. Weeks, not quarters." Names 3 concrete actions the agency does today + range framing.

**R2** Specifics over adjectives: zero banned-word hits. Concrete nouns + verbs throughout.

**R3** Reader identification: Branch A → "I'm building this myself" (technical-lane reader); Branch B → "I want it built for me" (operator-lane reader). Self-qualifying. Wrong reader correctly bounces by clicking the other card.

**R4** Surface the trade-off: the fork itself IS the trade-off — "two ways to use RevealUI" stated at the top of the band. No buried asterisks. Branch B's body names the engagement-format reality ("scopes, builds, delivers") instead of implying self-serve.

**R5** No marketing-speak / emojis / exclamation points: scanned clean.

**T1** Third-person about runtime + second-person about reader + first-person plural about studio:
- Branch A body: third-person about the runtime ("source, packages, the CLI, and docs").
- Branch B body: first-person plural about the studio ("RevealUI Studio scopes, builds, and delivers"). This is the operator-lane register; honors the operator-lane S3 carve-out per spec §7.

**T2** CTA verbs: "Keep reading →" / "See how →" — conversational, not transactional. Branch A's button uses `scrollIntoView`; Branch B is a plain `<a href="/for-operators">`.

**T3** Pricing posture: no dollar floors in the fork (correctly — the fork is a routing UI, not a pricing surface). Range framing "weeks, not quarters" on Branch B matches the agency-pricing-floors ADR posture.

**S1** No internal codenames.

**S2** No inflated stat blocks.

**S3** "we" in Branch B body is studio-voice per spec §7 operator-lane register exception.

**S4** No ComingSoonBadge. No rhetorical-question H2/H3. No fake-trust signals.

## Accessibility

- Section has `aria-label="Choose your path"` for screen-reader grouping.
- Branch A is a `<button>` with `type="button"`, keyboard-focusable, smooth-scrolls to the next section via `scrollIntoView`.
- Branch B is a plain `<a>` with href, keyboard-focusable, real link.
- Both use `focus-visible:ring-2 focus-visible:ring-primary` for visible focus state.
- Card hover/focus states use `--rvui-brand` (Cobalt) via `text-primary` / `border-primary/50` — honors the 2026-05-19 fleet-brand-cobalt-canon ADR.

## Local verification

- ✅ **Biome**: clean on all 3 files (1 auto-format fix applied during draft).
- ✅ **Typecheck**: clean on modified files (`NO_ERRORS_IN_MODIFIED_FILES`). Baseline marketing typecheck has pre-existing failures from unbuilt upstream `@revealui/contracts`, `@revealui/router`, `@revealui/core` — none related to this PR; CI's full gate builds the topo chain.
- ⏸ **Local preview**: deferred — same workspace-topo-build chain issue as #1151. Vercel-on-PR + CI will visual-verify.

## Coordination

- PR #1141 (`refactor/marketing-home-truth-and-pillars`) edits `HOME_HERO` in `home.ts`. This PR adds `HOME_FORK` as a separate export at the end of the same file. Auto-merge should resolve cleanly; if not, rebase reads "add HOME_FORK at end" and applies.
- PR #1151 (`feat/for-operators-page`, Phase 1) creates the `/for-operators` route this PR's Branch B targets. Merge #1151 first.

## Refs

- Internal spec + Phase 1 copy are in the internal coordination repo (not linked per public-issue-redaction rule).
- Voice rules: per the internal voice spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

