### PR TITLE
feat(marketing): add "For Operators" nav entry (non-technical-lane Phase 3)

### DIFF
--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -9,6 +9,7 @@ export const NAV_LINKS: readonly NavLink[] = [
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: SITE.urls.docs },
   { label: 'Blog', href: '/blog' },
+  { label: 'For Operators', href: '/for-operators' },
 ] as const;
 
 export const NAV_AUTH = {


### PR DESCRIPTION
## Summary

Phase 3 of the non-technical-lane spec — adds the **"For Operators"** entry to the global marketing nav. This is the catch-all per spec §4.5 for visitors who scrolled past the homepage fork (Phase 2, PR #1153) or arrived deep-linked on a technical page.

**Single-line addition** to `apps/marketing/app/content/nav.ts`. No other files touched. The existing `NavBar` component iterates `NAV_LINKS` — the entry surfaces automatically.

Opening as **DRAFT** for consistency with #1151 + #1153 in the same lane. Merge order: #1151 → #1153 → this. Each depends on the previous landing first to avoid pointing nav/fork at a 404.

## Spec references

- Spec: `docs/spec-2026-05-14-non-technical-lane.md` §4.5 (nav placement).
- Decisions: §9.4 **OQ-4** — label locked as **"For Operators"**.

## Why "For Operators" and not "Built for you"

OQ-4 considered both. The locked rationale:
- Parallels a potential future "For Developers" (industry-standard B2B nav pattern).
- Allevia (the named first lead, an MSP principal) recognizes "operator" as the term.
- The homepage fork (Phase 2) does the qualification work for non-self-identifying visitors — the nav is the catch-all, not the qualifier.
- Label change is cheap if user testing later shows the non-technical-founder persona doesn't self-identify into "operator."

## Why at the end of NAV_LINKS

Spec §4.5: "visible but not dominate — the technical lane is the larger surface." Putting "For Operators" at the end keeps the primary technical-lane scan path (Products → Pricing → Docs → Blog) intact while still being scannable.

The diff:
```diff
 export const NAV_LINKS: readonly NavLink[] = [
   { label: 'Products', href: '/products' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: SITE.urls.docs },
   { label: 'Blog', href: '/blog' },
+  { label: 'For Operators', href: '/for-operators' },
 ] as const;
```

## Verification

- ✅ **Biome**: clean.
- ✅ **Typecheck**: trivially correct — entry conforms to existing `NavLink` shape (`{ label: string; href: string; external?: boolean }`).
- ⏸ **Local preview**: deferred (same workspace-topo-build chain as #1151 + #1153).

## Coordination

- Depends on **PR #1151** (`/for-operators` route registration). If this PR merges before #1151, the nav entry 404s.
- No conflict with **PR #1141** (`HOME_HERO` edits) — different files.
- No conflict with **PR #1153** (homepage fork) — different files; complementary surfaces.

## Refs

- The other two phases of this lane: #1151 (Phase 1 — landing page) + #1153 (Phase 2 — homepage fork). Together with this nav entry, Phases 1+2+3 form the coherent minimum operator lane per spec §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
