### PR TITLE
feat(marketing): /for-operators/how-it-works (non-technical-lane Phase 4)

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -6,6 +6,7 @@ import { BlogIndexPage } from './routes/BlogIndexPage';
 import { BlogPostPage } from './routes/BlogPostPage';
 import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
+import { ForOperatorsHowItWorksPage } from './routes/ForOperatorsHowItWorksPage';
 import { ForOperatorsPage } from './routes/ForOperatorsPage';
 import { HomePage } from './routes/HomePage';
 import { NotFoundPage } from './routes/NotFoundPage';
@@ -44,6 +45,11 @@ export function App() {
         path: '/for-operators',
         component: ForOperatorsPage,
         meta: { title: 'For Operators — RevealUI Studio' },
+      },
+      {
+        path: '/for-operators/how-it-works',
+        component: ForOperatorsHowItWorksPage,
+        meta: { title: 'How it works — RevealUI Studio' },
       },
       { path: '/roadmap', component: RoadmapPage, meta: { title: 'Roadmap — RevealUI' } },
       { path: '/sponsor', component: SponsorPage, meta: { title: 'Sponsor — RevealUI' } },

--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -1,0 +1,39 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FO_HIW_CLOSING } from '../../content/for-operators-how-it-works';
+
+export function ClosingCta() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+        <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_HIW_CLOSING.heading}
+        </h2>
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
+          {FO_HIW_CLOSING.body}
+        </p>
+
+        <div className="mt-10 flex justify-center">
+          <ButtonCVA asChild size="lg">
+            <a
+              href={FO_HIW_CLOSING.primaryCta.href}
+              {...(FO_HIW_CLOSING.primaryCta.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {FO_HIW_CLOSING.primaryCta.label}
+            </a>
+          </ButtonCVA>
+        </div>
+
+        <p className="mt-6 text-sm text-muted-foreground">
+          <a
+            href={FO_HIW_CLOSING.backLink.href}
+            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+          >
+            {FO_HIW_CLOSING.backLink.label}
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
@@ -1,0 +1,35 @@
+import { FO_HIW_STEPS } from '../../content/for-operators-how-it-works';
+
+export function EngagementSteps() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {FO_HIW_STEPS.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {FO_HIW_STEPS.heading}
+          </h2>
+        </div>
+
+        <ol className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
+          {FO_HIW_STEPS.steps.map((step) => (
+            <li
+              key={step.number}
+              className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary">
+                {step.number}
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold leading-7 text-foreground">{step.title}</h3>
+                <p className="mt-2 text-base leading-7 text-muted-foreground">{step.body}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
@@ -1,0 +1,35 @@
+import { FO_HIW_FEAR } from '../../content/for-operators-how-it-works';
+
+export function FearRemoval() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_HIW_FEAR.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_HIW_FEAR.heading}
+        </h2>
+
+        <p className="mt-8 text-base leading-7 text-muted-foreground">{FO_HIW_FEAR.paragraph1}</p>
+        <p className="mt-4 text-base leading-7 text-muted-foreground">{FO_HIW_FEAR.paragraph2}</p>
+
+        <ul className="mt-6 space-y-4 list-none p-0">
+          {FO_HIW_FEAR.options.map((option) => (
+            <li
+              key={option.title}
+              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+            >
+              <h3 className="text-base font-semibold leading-7 text-foreground">{option.title}</h3>
+              <p className="mt-1 text-base leading-7 text-muted-foreground">{option.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-8 text-base leading-7 text-foreground font-medium">
+          {FO_HIW_FEAR.closing}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
@@ -1,0 +1,50 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FO_HIW_HERO } from '../../content/for-operators-how-it-works';
+
+export function Hero() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
+
+      <div className="relative mx-auto max-w-3xl text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
+          {FO_HIW_HERO.eyebrow}
+        </p>
+
+        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+          {FO_HIW_HERO.h1Lines.map((line) => (
+            <span key={line} className="block">
+              {line}
+            </span>
+          ))}
+        </h1>
+
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {FO_HIW_HERO.subtitle}
+        </p>
+
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <ButtonCVA asChild size="lg" className="w-full sm:w-auto">
+            <a
+              href={FO_HIW_HERO.primaryCta.href}
+              {...(FO_HIW_HERO.primaryCta.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {FO_HIW_HERO.primaryCta.label}
+            </a>
+          </ButtonCVA>
+        </div>
+
+        <p className="mt-8 text-sm text-muted-foreground">
+          <a
+            href={FO_HIW_HERO.backLink.href}
+            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+          >
+            {FO_HIW_HERO.backLink.label}
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
@@ -1,0 +1,34 @@
+import { FO_HIW_OWNERSHIP } from '../../content/for-operators-how-it-works';
+
+export function Ownership() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_HIW_OWNERSHIP.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_HIW_OWNERSHIP.heading}
+        </h2>
+
+        <p className="mt-6 text-base leading-7 text-muted-foreground">{FO_HIW_OWNERSHIP.intro}</p>
+
+        <ul className="mt-6 space-y-4 list-none p-0">
+          {FO_HIW_OWNERSHIP.claims.map((claim) => (
+            <li
+              key={claim.title}
+              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+            >
+              <h3 className="text-base font-semibold leading-7 text-foreground">{claim.title}</h3>
+              <p className="mt-1 text-base leading-7 text-muted-foreground">{claim.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-8 text-base leading-7 text-foreground font-medium">
+          {FO_HIW_OWNERSHIP.differentiator}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
@@ -1,0 +1,23 @@
+import { FO_HIW_TIMELINE } from '../../content/for-operators-how-it-works';
+
+export function Timeline() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_HIW_TIMELINE.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_HIW_TIMELINE.heading}
+        </h2>
+
+        <p className="mt-6 text-base leading-7 text-muted-foreground">
+          {FO_HIW_TIMELINE.paragraph1}
+        </p>
+        <p className="mt-4 text-base leading-7 text-muted-foreground">
+          {FO_HIW_TIMELINE.paragraph2}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/for-operators-how-it-works.ts
+++ b/apps/marketing/app/content/for-operators-how-it-works.ts
@@ -1,0 +1,141 @@
+// Sourced from spec-2026-05-14-non-technical-lane.md §3.3 Page 2 brief.
+// Phase 4 of the non-technical-lane spec — the process page that removes
+// the operator's fear by making the engagement concrete and bounded.
+//
+// Locked decisions consumed (from spec §9.4):
+// - OQ-3: "Book a build call" — same CTA as Page 1, consistent across the seam.
+// - OQ-6: agency-site coupling — CTA routes to ${SITE.urls.agency}/contact.
+//
+// Voice constraints honored:
+// - The 5 voice rules (R1-R5) per docs/lanes/_closed/messaging-funnel-audit/
+//   voice-and-headline-rules.md.
+// - Operator-lane register per non-technical-lane spec §7 (first-person plural
+//   about the studio + third-person about the runtime + second-person about
+//   the operator).
+// - No specific day-counts as promises; range framing only ("weeks, not quarters").
+// - No specific dollar figures per agency-pricing-floors ADR.
+
+import { SITE } from './site';
+import type { Cta } from './types';
+
+const AGENCY_CONTACT = `${SITE.urls.agency}/contact` as const;
+
+export const FO_HIW_HERO = {
+  eyebrow: 'How the engagement works',
+  h1Lines: ['Discovery, scope,', 'build, deliver.'] as const,
+  subtitle:
+    'A discovery call scopes the work. We build, deploy, and hand over a live product with the admin login. Weeks, not quarters — the discovery call gives you the range for your specific scope.',
+  primaryCta: {
+    label: 'Book a build call',
+    href: AGENCY_CONTACT,
+    external: true,
+  } satisfies Cta,
+  backLink: {
+    label: '← Back to For Operators',
+    href: '/for-operators',
+  } satisfies Cta,
+} as const;
+
+export interface EngagementStep {
+  readonly number: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export const FO_HIW_STEPS = {
+  eyebrow: 'The five steps',
+  heading: 'What happens, in order.',
+  steps: [
+    {
+      number: '01',
+      title: 'Discovery call.',
+      body: "30 minutes, free. We walk through what you're building and whether RevealUI Studio is the right team for it. If we are, we move to scope. If we're not, we tell you and point you somewhere that is.",
+    },
+    {
+      number: '02',
+      title: 'Fixed-scope proposal.',
+      body: "A written statement of work — what we'll build, what the deliverable looks like, what's in and out of scope, and the engagement timeline. Fixed-bid. No surprise change orders.",
+    },
+    {
+      number: '03',
+      title: 'We build.',
+      body: 'You stay in the loop. We send a checkpoint at the end of each milestone with screenshots, links, and what is next. The build is the engagement; nothing is hidden until launch.',
+    },
+    {
+      number: '04',
+      title: 'You get the keys.',
+      body: 'At delivery, you receive: the admin login, the hosting account credentials in your name, the Stripe account in your name, and the source code in a Git repository you control. You operate the product without us.',
+    },
+    {
+      number: '05',
+      title: 'Ongoing support is optional.',
+      body: 'If you want a retainer for ongoing work — new features, scaled support, expansion engagements — we offer one. If you want to take it from here, you take it from here. There is no lock-in either way.',
+    },
+  ] as readonly EngagementStep[],
+} as const;
+
+export const FO_HIW_FEAR = {
+  eyebrow: 'The honest answer',
+  heading: 'Do I need a developer after this?',
+  paragraph1:
+    "No, to operate the product. You log into the admin, manage your products, customers, content, and orders. The dashboard is the interface; you don't touch the code.",
+  paragraph2:
+    'Yes, to change the software itself. Adding a new feature, a new page, a new integration — that is engineering work. Two honest options:',
+  options: [
+    {
+      title: 'Hire RevealUI Studio for the change.',
+      body: 'We know the codebase; we built it. This is a scoped follow-on engagement, not a retainer.',
+    },
+    {
+      title: 'Hire your own engineer.',
+      body: 'The code we hand over is standard TypeScript on standard tools — React, Vite, Hono, Drizzle. Any competent React engineer can pick it up.',
+    },
+  ] as readonly { readonly title: string; readonly body: string }[],
+  closing:
+    'We do not pretend you become self-sufficient on the codebase. We do promise you are self-sufficient on operating the product.',
+} as const;
+
+export const FO_HIW_OWNERSHIP = {
+  eyebrow: 'Ownership',
+  heading: 'What ownership means at delivery.',
+  intro: 'Three concrete claims, true today, not roadmap:',
+  claims: [
+    {
+      title: 'The code is yours.',
+      body: 'The open-source RevealUI runtime plus your configuration, in a Git repository you control.',
+    },
+    {
+      title: 'The infrastructure is in your name.',
+      body: 'Vercel account, Neon database, Stripe account — all registered to your business, not RevealUI Studio.',
+    },
+    {
+      title: 'There is no vendor lock-in.',
+      body: 'If you walk away from RevealUI Studio tomorrow, your product keeps running and a different engineer can pick up the codebase. No proprietary platform to migrate off.',
+    },
+  ] as readonly { readonly title: string; readonly body: string }[],
+  differentiator:
+    'This is a strong, honest differentiator from SaaS vendors who own your data and your platform.',
+} as const;
+
+export const FO_HIW_TIMELINE = {
+  eyebrow: 'Timeline',
+  heading: 'How long does it take?',
+  paragraph1:
+    'Weeks, not quarters. The discovery call gives you the range for your specific scope.',
+  paragraph2:
+    'We do not promise specific day-counts. The work is fixed-bid (Step 2), so the timeline is part of the scope you and we agree on in writing. What we do not do is "live in 14 days" — that is a marketing promise, not an engineering reality.',
+} as const;
+
+export const FO_HIW_CLOSING = {
+  heading: 'Ready to scope it?',
+  body: 'Book the discovery call. 30 minutes, free. We walk through your business and decide whether we are the right team for it.',
+  primaryCta: {
+    label: 'Book a build call',
+    href: AGENCY_CONTACT,
+    external: true,
+  } satisfies Cta,
+  backLink: {
+    label: '← Back to For Operators',
+    href: '/for-operators',
+  } satisfies Cta,
+} as const;

--- a/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
@@ -1,0 +1,26 @@
+// Page 2 of the operator lane — process description that removes the fear
+// by making the engagement concrete and bounded.
+// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §3.3 Page 2.
+// Phase 4 of the spec's §8 sequence.
+
+import { Footer } from '../components/Footer';
+import { ClosingCta } from '../components/for-operators-how-it-works/ClosingCta';
+import { EngagementSteps } from '../components/for-operators-how-it-works/EngagementSteps';
+import { FearRemoval } from '../components/for-operators-how-it-works/FearRemoval';
+import { Hero } from '../components/for-operators-how-it-works/Hero';
+import { Ownership } from '../components/for-operators-how-it-works/Ownership';
+import { Timeline } from '../components/for-operators-how-it-works/Timeline';
+
+export function ForOperatorsHowItWorksPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Hero />
+      <EngagementSteps />
+      <FearRemoval />
+      <Ownership />
+      <Timeline />
+      <ClosingCta />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 4 of the non-technical-lane spec — `/for-operators/how-it-works`. The process page that removes the operator's fear by making the engagement concrete and bounded. Page 2 of the operator lane per spec §3.3 Page 2 brief.

**Opening as DRAFT** for consistency with the lane's coupled-ship discipline (OQ-6). The page's back-link points at `/for-operators` (Phase 1, #1151) — recommend merging in order: 1151 → 1153 → 1154 → this PR.

## Spec references

- Spec: `docs/spec-2026-05-14-non-technical-lane.md` §3.3 Page 2 + §3.3 "Must say" requirements.
- Decisions consumed: §9.4 OQ-3 (CTA "Book a build call"), OQ-6 (agency-site coupling).

## What the page says, by section

1. **Hero** — eyebrow "How the engagement works", H1 "Discovery, scope, build, deliver." (mirrors agency's "Discovery → scope → ship" arc, extends with "deliver" to name the endpoint), subhead naming the discovery call + the deliverable + range framing, primary CTA, back-link to `/for-operators`.

2. **EngagementSteps** — 5 numbered steps:
   - 01 Discovery call — 30 min, free
   - 02 Fixed-scope proposal — written SOW, no surprise change orders
   - 03 We build — checkpoint at each milestone
   - 04 You get the keys — admin login, hosting + Stripe in your name, source code in your repo
   - 05 Ongoing support is optional — retainer offered; no lock-in either way

3. **FearRemoval** *(the load-bearing honesty section)* — "Do I need a developer after this?" Honestly distinguishes "operate" (you self-sufficient) from "change" (engineering required). Names two clean paths: hire RevealUI Studio for the change OR hire your own engineer (the code is standard TypeScript on standard tools). Closes with the explicit non-promise: *"We do not pretend you become self-sufficient on the codebase. We do promise you are self-sufficient on operating the product."*

4. **Ownership** — three concrete claims about what's yours at delivery: the code, the infrastructure, the absence of vendor lock-in. Honest differentiator from SaaS vendors.

5. **Timeline** — range framing only. Explicitly disavows day-count promises and "live in 14 days" marketing.

6. **ClosingCta** — repeats primary CTA + back-link.

## Voice §5 self-check

**R1** Lead with what ships:
- Hero subhead names shipping artifacts (admin login, the runtime).
- Steps 1-5 each name concrete operations the agency does today.
- Ownership section: every claim is current truth, not roadmap (the explicit intro says so).

**R2** Specifics over adjectives:
- Steps name specific tools (TypeScript, React, Vite, Hono, Drizzle).
- Step 04 names concrete deliverables (admin login, hosting credentials, Stripe account, Git repo).
- No banned adjectives.

**R3** Reader identification by stack/scenario:
- FearRemoval section identifies two reader-states (operate vs change), routes each clearly.
- Ownership section identifies the SaaS-vendor-fear reader, addresses it head-on.

**R4** Surface the trade-off at H2 weight:
- FearRemoval H2 is itself a question naming the operator's deepest fear.
- Timeline H2 disavows specific day-counts at full weight.

**R5** No marketing-speak / emojis / exclamation points: scanned clean. "live in 14 days" appears once as a *negative example* (what we do not do).

**T1** Third-person about runtime + second-person about reader + first-person plural about studio:
- "The dashboard is the interface" (third-person about runtime).
- "You log into the admin" (second-person about reader).
- "We build, deploy, and hand over" (first-person plural about studio).

**T2** CTA verbs: "Book a build call" (locked OQ-3). Back-links use "← Back to For Operators".

**T3** Pricing posture: no dollar figures. Timeline range framing. Discovery scopes per agency-pricing-floors ADR.

**S1** No internal codenames.

**S2** No inflated stat blocks (no metrics on this page — it's process description).

**S3** "we" appears throughout as studio-voice per spec §7 operator-lane register.

**S4** No ComingSoonBadge. No rhetorical-question H2s except the FearRemoval H2 which IS the operator's question rendered honestly — the spec brief explicitly directs this framing.

## Files

| File | Status |
|---|---|
| `apps/marketing/app/content/for-operators-how-it-works.ts` | NEW (content object) |
| `apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx` | NEW (page composition) |
| `apps/marketing/app/components/for-operators-how-it-works/Hero.tsx` | NEW |
| `apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx` | NEW |
| `apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx` | NEW |
| `apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx` | NEW |
| `apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx` | NEW |
| `apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx` | NEW |
| `apps/marketing/app/App.tsx` | MODIFIED (import + route registration) |

9 files, +389 lines.

## Local verification

- ✅ **Biome**: clean (2 auto-format fixes during draft).
- ✅ **Typecheck**: clean on new files after building `@revealui/presentation`. Baseline pre-existing failures unrelated to this PR; CI's full gate builds the topo chain.
- ⏸ **Local preview**: deferred (same workspace-topo-build-chain issue as #1151/#1153).

## Coordination

- **PR #1151** (Phase 1 — `/for-operators`): mergeable independently. This page's back-link goes there. Merge #1151 first.
- **PR #1153** (Phase 2 — homepage fork) + **#1154** (Phase 3 — nav entry): independent of this PR.
- **App.tsx**: inserted route after `/fair-source`, same anchor #1151 uses. If both PRs merge non-concurrently, expect a clean auto-merge in adjacent-line region; if conflict, order should be `/for-operators` (Phase 1) → `/for-operators/how-it-works` (this PR).

## Remaining phases

- **Phase 5** — `/for-operators/managed` (Page 3, "RevealUI Cloud" managed roadmap + waitlist). Needs waitlist mechanism decision (Mailchimp / Resend / Neon table / etc.).
- **Phase 7** — voice spec §2 tone-matrix amendment (housekeeping, ~15 min).

## Refs

- Internal spec lives in internal docs (not linked per public-issue-redaction rule).
- Voice rules: an internal repo `docs/lanes/_closed/messaging-funnel-audit/voice-and-headline-rules.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
