### PR TITLE
feat(marketing): /for-operators/managed (non-technical-lane Phase 5)

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -7,6 +7,7 @@ import { BlogPostPage } from './routes/BlogPostPage';
 import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
 import { ForOperatorsHowItWorksPage } from './routes/ForOperatorsHowItWorksPage';
+import { ForOperatorsManagedPage } from './routes/ForOperatorsManagedPage';
 import { ForOperatorsPage } from './routes/ForOperatorsPage';
 import { HomePage } from './routes/HomePage';
 import { NotFoundPage } from './routes/NotFoundPage';
@@ -50,6 +51,11 @@ export function App() {
         path: '/for-operators/how-it-works',
         component: ForOperatorsHowItWorksPage,
         meta: { title: 'How it works — RevealUI Studio' },
+      },
+      {
+        path: '/for-operators/managed',
+        component: ForOperatorsManagedPage,
+        meta: { title: 'RevealUI Cloud (roadmap) — RevealUI Studio' },
       },
       { path: '/roadmap', component: RoadmapPage, meta: { title: 'Roadmap — RevealUI' } },
       { path: '/sponsor', component: SponsorPage, meta: { title: 'Sponsor — RevealUI' } },

--- a/apps/marketing/app/components/for-operators-managed/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Hero.tsx
@@ -1,0 +1,36 @@
+import { FO_MANAGED_HERO } from '../../content/for-operators-managed';
+
+export function Hero() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
+
+      <div className="relative mx-auto max-w-3xl text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
+          {FO_MANAGED_HERO.eyebrow}
+        </p>
+
+        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+          {FO_MANAGED_HERO.h1Lines.map((line) => (
+            <span key={line} className="block">
+              {line}
+            </span>
+          ))}
+        </h1>
+
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {FO_MANAGED_HERO.subtitle}
+        </p>
+
+        <p className="mt-10 text-sm text-muted-foreground">
+          <a
+            href={FO_MANAGED_HERO.backLink.href}
+            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+          >
+            {FO_MANAGED_HERO.backLink.label}
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
@@ -1,0 +1,34 @@
+import { FO_MANAGED_PREREQS } from '../../content/for-operators-managed';
+
+export function Prerequisites() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_MANAGED_PREREQS.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_MANAGED_PREREQS.heading}
+        </h2>
+
+        <p className="mt-6 text-base leading-7 text-muted-foreground">{FO_MANAGED_PREREQS.intro}</p>
+
+        <ul className="mt-6 space-y-4 list-none p-0">
+          {FO_MANAGED_PREREQS.prerequisites.map((prereq) => (
+            <li
+              key={prereq.title}
+              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+            >
+              <h3 className="text-base font-semibold leading-7 text-foreground">{prereq.title}</h3>
+              <p className="mt-2 text-base leading-7 text-muted-foreground">{prereq.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-8 text-base leading-7 text-foreground font-medium">
+          {FO_MANAGED_PREREQS.closing}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-managed/Status.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Status.tsx
@@ -1,0 +1,22 @@
+import { FO_MANAGED_STATUS } from '../../content/for-operators-managed';
+
+export function Status() {
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_MANAGED_STATUS.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_MANAGED_STATUS.heading}
+        </h2>
+
+        <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
+          <p>{FO_MANAGED_STATUS.paragraph1}</p>
+          <p>{FO_MANAGED_STATUS.paragraph2}</p>
+          <p>{FO_MANAGED_STATUS.paragraph3}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-managed/Today.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Today.tsx
@@ -1,0 +1,42 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FO_MANAGED_TODAY } from '../../content/for-operators-managed';
+
+export function Today() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_MANAGED_TODAY.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_MANAGED_TODAY.heading}
+        </h2>
+
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
+          {FO_MANAGED_TODAY.body}
+        </p>
+
+        <div className="mt-10 flex flex-col items-center gap-4">
+          <ButtonCVA asChild size="lg">
+            <a
+              href={FO_MANAGED_TODAY.primaryCta.href}
+              {...(FO_MANAGED_TODAY.primaryCta.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {FO_MANAGED_TODAY.primaryCta.label}
+            </a>
+          </ButtonCVA>
+          <p className="text-sm">
+            <a
+              href={FO_MANAGED_TODAY.detailLink.href}
+              className="font-medium text-primary hover:underline underline-offset-4"
+            >
+              {FO_MANAGED_TODAY.detailLink.label}
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -1,0 +1,78 @@
+import { ButtonCVA as Button, Input } from '@revealui/presentation';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import { FO_MANAGED_WAITLIST } from '../../content/for-operators-managed';
+import { submitNewsletter } from '../../lib/api';
+
+export function Waitlist() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!email || status === 'loading') return;
+
+    setStatus('loading');
+    // NOTE: Phase 5 reuses the newsletter endpoint as the simplest mechanism
+    // that ships today. A dedicated waitlist source-tagging on the server
+    // is a follow-up — at that point, swap submitNewsletter for submitWaitlist.
+    const error = await submitNewsletter({ email });
+    if (error === null) {
+      setStatus('success');
+      setMessage(FO_MANAGED_WAITLIST.successMessage);
+      setEmail('');
+    } else {
+      setStatus('error');
+      setMessage(error);
+    }
+  }
+
+  return (
+    <section className="bg-muted py-24 sm:py-32">
+      <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          {FO_MANAGED_WAITLIST.eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {FO_MANAGED_WAITLIST.heading}
+        </h2>
+
+        <p className="mx-auto mt-6 max-w-xl text-base leading-7 text-muted-foreground">
+          {FO_MANAGED_WAITLIST.body}
+        </p>
+
+        {status === 'success' ? (
+          <p className="mt-10 animate-[fade-in_300ms_ease-out] text-base font-medium text-primary">
+            {message}
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="mx-auto mt-10 flex max-w-sm flex-col gap-3">
+            <label htmlFor="waitlist-email" className="sr-only">
+              Email address
+            </label>
+            <Input
+              id="waitlist-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={FO_MANAGED_WAITLIST.inputPlaceholder}
+              required
+            />
+            <Button
+              type="submit"
+              variant="primary"
+              isLoading={status === 'loading'}
+              disabled={status === 'loading'}
+            >
+              {status === 'loading'
+                ? FO_MANAGED_WAITLIST.buttonLabelLoading
+                : FO_MANAGED_WAITLIST.buttonLabel}
+            </Button>
+            {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
+++ b/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
@@ -1,0 +1,36 @@
+import { FO_MANAGED_WOULD_BE } from '../../content/for-operators-managed';
+
+export function WouldBe() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {FO_MANAGED_WOULD_BE.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {FO_MANAGED_WOULD_BE.heading}
+          </h2>
+        </div>
+
+        <ul className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
+          {FO_MANAGED_WOULD_BE.capabilities.map((capability) => (
+            <li
+              key={capability.title}
+              className="rounded-2xl border border-border bg-card p-6 shadow-sm"
+            >
+              <h3 className="text-lg font-semibold leading-7 text-foreground">
+                {capability.title}
+              </h3>
+              <p className="mt-2 text-base leading-7 text-muted-foreground">{capability.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mx-auto mt-12 max-w-2xl text-center text-base leading-7 text-foreground font-medium">
+          {FO_MANAGED_WOULD_BE.closing}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/for-operators-managed.ts
+++ b/apps/marketing/app/content/for-operators-managed.ts
@@ -1,0 +1,139 @@
+// Sourced from spec-2026-05-14-non-technical-lane.md §3.3 Page 3 brief.
+// Phase 5 of the non-technical-lane spec — the honest managed-roadmap page.
+//
+// Locked decisions consumed (from spec §9.4):
+// - OQ-1: "RevealUI Cloud" — locked working name for the future managed offering.
+// - OQ-2: ship Page 3 with the lane (operator arrives with SaaS mental model;
+//   silence causes misread of the agency engagement as a managed product).
+// - OQ-3: "Book a build call" — CTA for the impatient-operator path.
+// - OQ-6: agency-site coupling.
+//
+// Honesty doctrine (the page's load-bearing constraint):
+// - Names that RevealUI Cloud does NOT ship today at H2 weight.
+// - No prices, no dates, no signup buttons that imply the product exists,
+//   no present-tense feature claims as if the product ships.
+// - The waitlist is the ONLY conversion action, explicitly labeled as a waitlist.
+// - Impatient operators are routed back to /for-operators (the agency path
+//   that ships today).
+//
+// Voice rules: all 5 apply unchanged + operator-lane register per spec §7
+// (codified in voice-and-headline-rules.md §2.1).
+
+import { SITE } from './site';
+import type { Cta } from './types';
+
+const AGENCY_CONTACT = `${SITE.urls.agency}/contact` as const;
+
+export const FO_MANAGED_HERO = {
+  eyebrow: 'Roadmap',
+  h1Lines: ['RevealUI Cloud.', 'On the roadmap.'] as const,
+  subtitle:
+    'A self-serve managed version of the runtime — sign up in a browser, configure your business, get a hosted product without an agency engagement. It does not ship today. This page is the honest roadmap.',
+  backLink: {
+    label: '← Back to For Operators',
+    href: '/for-operators',
+  } satisfies Cta,
+} as const;
+
+export const FO_MANAGED_STATUS = {
+  eyebrow: 'Status',
+  heading: 'Not built. On the roadmap.',
+  paragraph1:
+    'RevealUI Cloud does not exist today. There is no signup, no billing, no managed hosting you can configure in a browser.',
+  paragraph2:
+    'What does exist today is the RevealUI Studio agency engagement — we build and deliver a working product for your business as a scoped engagement. See For Operators for the path that ships.',
+  paragraph3:
+    'This page is the honest version of the question "is there a managed offering?" — yes, on the roadmap; no, not yet.',
+} as const;
+
+export interface WouldBeCapability {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const FO_MANAGED_WOULD_BE = {
+  eyebrow: 'What it would be',
+  heading: 'When RevealUI Cloud ships, you would:',
+  capabilities: [
+    {
+      title: 'Sign up in a browser.',
+      body: 'No agency call required. Email, payment method, business name — the SaaS-shape onboarding most operators expect.',
+    },
+    {
+      title: 'Configure the business in a browser.',
+      body: 'Name, branding, products, billing rates, customer-facing copy — all set up through a configuration UI, no code.',
+    },
+    {
+      title: 'Get a hosted instance in your account.',
+      body: 'The runtime, deployed and managed by RevealUI Studio, on infrastructure registered to your business.',
+    },
+    {
+      title: 'Operate via the admin dashboard.',
+      body: 'Same admin UI as the agency-delivered version. Same RBAC, same audit chain, same primitives.',
+    },
+    {
+      title: 'Receive product support directly.',
+      body: 'Defined response times, defined escalation paths, included in the price. Not the bespoke retainer the agency offers — a productized support contract.',
+    },
+  ] as readonly WouldBeCapability[],
+  closing:
+    'This is the SaaS-shape mental model operators arrive with. RevealUI Cloud is what fulfills it — when it ships.',
+} as const;
+
+export interface Prerequisite {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const FO_MANAGED_PREREQS = {
+  eyebrow: 'Prerequisites',
+  heading: 'What has to be true before RevealUI Cloud ships.',
+  intro: 'Four things must be in place before the managed offering can move from roadmap to real:',
+  prerequisites: [
+    {
+      title: 'The runtime has to charge customers in live mode.',
+      body: 'A managed offering charges money. The runtime can charge today in test mode; live mode is gated on owner-side operational steps. Until that gate clears, no managed signup can complete a real transaction.',
+    },
+    {
+      title: 'A provisioning path that stands up a per-operator hosted instance, without a human.',
+      body: 'This is real engineering work, unbuilt today. The agency engagement stands up each operator manually; the managed offering needs that automated.',
+    },
+    {
+      title: 'An operator-legible configuration UI.',
+      body: 'The operator configures the business in a browser — branding, products, payments, copy. The UI to do that does not exist today.',
+    },
+    {
+      title: 'A defined support contract for self-serve operators.',
+      body: 'The agency engagement has support baked into the relationship. A self-serve tier needs an explicit shape — what is included, response times, escalation — that the agency motion does not currently formalize.',
+    },
+  ] as readonly Prerequisite[],
+  closing:
+    'Each prerequisite is a multi-week-to-multi-month engineering effort. The work is funded by revenue from the agency engagement.',
+} as const;
+
+export const FO_MANAGED_TODAY = {
+  eyebrow: 'If you want it today',
+  heading: 'Book the agency engagement.',
+  body: 'The path that ships, today, is the RevealUI Studio agency engagement. Discovery call → fixed-scope proposal → we build it → you get the keys. Weeks, not quarters.',
+  primaryCta: {
+    label: 'Book a build call',
+    href: AGENCY_CONTACT,
+    external: true,
+  } satisfies Cta,
+  detailLink: {
+    label: 'Read how the engagement works →',
+    href: '/for-operators/how-it-works',
+  } satisfies Cta,
+} as const;
+
+export const FO_MANAGED_WAITLIST = {
+  eyebrow: 'Waitlist',
+  heading: 'Want it when it ships? Join the waitlist.',
+  body: 'Tell us your email. You will receive RevealUI product updates; RevealUI Cloud progress will be called out specifically as it advances toward shipping. (We do not have a Cloud-only list yet — that is part of the work.)',
+  product: 'managed-cloud',
+  inputPlaceholder: 'you@company.com',
+  buttonLabel: 'Join the waitlist',
+  buttonLabelLoading: 'Joining…',
+  successMessage:
+    'You are on the list. RevealUI Cloud progress will be called out in our updates as it advances.',
+} as const;

--- a/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
@@ -1,0 +1,28 @@
+// Page 3 of the operator lane — the honest managed-roadmap page that names
+// the future self-serve "RevealUI Cloud" offering and disavows that it ships
+// today. Phase 5 of the non-technical-lane spec.
+//
+// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §3.3 Page 3.
+// Locked decisions: §9.4 OQ-1 ("RevealUI Cloud"), OQ-2 (ship with the lane).
+
+import { Footer } from '../components/Footer';
+import { Hero } from '../components/for-operators-managed/Hero';
+import { Prerequisites } from '../components/for-operators-managed/Prerequisites';
+import { Status } from '../components/for-operators-managed/Status';
+import { Today } from '../components/for-operators-managed/Today';
+import { Waitlist } from '../components/for-operators-managed/Waitlist';
+import { WouldBe } from '../components/for-operators-managed/WouldBe';
+
+export function ForOperatorsManagedPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Hero />
+      <Status />
+      <WouldBe />
+      <Prerequisites />
+      <Today />
+      <Waitlist />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 5 of the non-technical-lane spec — `/for-operators/managed`. The honest managed-roadmap page that names the future "RevealUI Cloud" self-serve offering and disavows it ships today at H2 weight. Page 3 of the operator lane.

This PR completes the operator lane's visible surfaces: Phase 1 landing → Phase 2 fork → Phase 3 nav → Phase 4 how-it-works → **Phase 5 managed roadmap (this PR)**.

## Spec references

- Spec: internal non-technical-lane spec §3.3 Page 3 brief.
- Decisions consumed: §9.4 OQ-1 (locked name "RevealUI Cloud"), OQ-2 (ship with the lane), OQ-3 (CTA), OQ-6 (agency-site coupling).

## Sections, top to bottom

1. **Hero** — eyebrow "Roadmap", H1 "RevealUI Cloud / On the roadmap" + subhead naming non-existence at full weight + back-link to `/for-operators`.
2. **Status** — `<h2>Not built. On the roadmap.</h2>` — the load-bearing honesty section. Three paragraphs: (1) RevealUI Cloud does not exist today; (2) what does exist is the agency engagement; (3) this page is the honest version of "is there a managed offering?"
3. **WouldBe** — 5 capability cards in conditional tense ("when it ships, you would: sign up in a browser / configure in a browser / get a hosted instance / operate via the admin / receive product support").
4. **Prerequisites** — 4 concrete prereqs that must be true before shipping: live-mode billing, automated provisioning, operator-legible configuration UI, defined self-serve support contract. Closes with "each prerequisite is a multi-week-to-multi-month engineering effort. The work is funded by revenue from the agency engagement."
5. **Today** — routes the impatient operator back to the agency engagement ("the path that ships, today"). Primary CTA "Book a build call" + secondary link to `/for-operators/how-it-works`.
6. **Waitlist** — email capture. The only conversion action on the page.

## Waitlist implementation

The spec calls for an "explicitly labeled as a waitlist" email capture. For Phase 5 minimum-viable shipment, this reuses the existing `submitNewsletter` endpoint at `/api/newsletter` (no server changes). The copy is **honest about the mechanism**:

- Body: "You will receive RevealUI product updates; RevealUI Cloud progress will be called out specifically as it advances toward shipping. (We do not have a Cloud-only list yet — that is part of the work.)"
- Success state: "You are on the list. RevealUI Cloud progress will be called out in our updates as it advances."

A dedicated source-tagged waitlist endpoint is a follow-up — the code carries a comment noting this.

## Voice §5 self-check

**R1** Lead with what ships: deliberately inverted — Page 3's load-bearing purpose is to name what does NOT ship (the spec explicitly directs this framing). What does ship (the agency engagement) is referenced at H2 weight in Section 2 and centered in Section 5 (Today). The page lives at peace with R1 by routing to what ships at multiple points.

**R2** Specifics over adjectives: the Prerequisites section names concrete prereqs (Stripe live-mode gate, provisioning automation, browser config UI, support contract shape). The WouldBe section names concrete capabilities (RBAC, audit chain, defined response times). Zero banned adjectives.

**R3** Reader identification: names "the SaaS-shape mental model operators arrive with" explicitly in WouldBe. The "impatient operator" / "patient operator" split in the page structure does the routing.

**R4** Surface the trade-off at H2: the whole page IS the trade-off. The Status section's H2 ("Not built. On the roadmap.") names it at full weight. No badges.

**R5** No marketing-speak, no emojis, no exclamation points: scanned clean. Conditional tense throughout WouldBe ("you would") prevents accidental future-as-present claims.

**T1** Third-person about runtime + second-person about reader + first-person plural about studio — honors the operator-lane register codified in the voice spec §2.1.

**T2** CTA verbs: "Book a build call" (Today), "Join the waitlist" (Waitlist). Conversational + honest about expectations.

**T3** Pricing posture: zero prices on this page. No dollar floors. Range framing reused from agency posture ("multi-week-to-multi-month engineering effort").

**S1** No internal codenames.

**S2** No inflated stat blocks (no metrics — process description).

**S3** "we" appears throughout as studio-voice per the operator-lane register exception.

**S4** No ComingSoonBadge. No rhetorical-question H2s. No fake-trust signals. No invented case studies.

## Files

| File | Status |
|---|---|
| `apps/marketing/app/content/for-operators-managed.ts` | NEW (content object) |
| `apps/marketing/app/routes/ForOperatorsManagedPage.tsx` | NEW (page composition) |
| `apps/marketing/app/components/for-operators-managed/Hero.tsx` | NEW |
| `apps/marketing/app/components/for-operators-managed/Status.tsx` | NEW |
| `apps/marketing/app/components/for-operators-managed/WouldBe.tsx` | NEW |
| `apps/marketing/app/components/for-operators-managed/Prerequisites.tsx` | NEW |
| `apps/marketing/app/components/for-operators-managed/Today.tsx` | NEW |
| `apps/marketing/app/components/for-operators-managed/Waitlist.tsx` | NEW (uses existing `submitNewsletter`) |
| `apps/marketing/app/App.tsx` | MODIFIED (import + route registration) |

10 files total.

## Local verification

- ✅ **Biome**: clean (3 auto-format fixes during draft).
- ✅ **Typecheck**: clean on new files after building `@revealui/presentation`. Baseline pre-existing failures unrelated to this PR; CI's full gate builds the topo chain.
- ⏸ **Local preview**: deferred (same workspace-topo-build pattern as #1151/#1153/#1155).

## Coordination

- Builds on the merged Phases 1-4 (#1151, #1153, #1154, #1155). The Hero's back-link, Today's secondary link, and the Phase 1 inline link to `/for-operators/managed` are all now connected.
- Updates the App.tsx route registration after `/for-operators/how-it-works`, keeping the operator routes contiguous.

## After this PR

The full operator lane is now visible. Recommend a `test → main` promotion PR to ship all 5 phases to production together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
