### PR TITLE
chore: sweep stale RevealCoin references from live docs (cancelled 2026-05-29)

### DIFF
--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -3,8 +3,9 @@
 // Sourced from per-product README audit (2026-05-18) cross-referenced against
 // docs/lanes/marketing-overhaul/plan.md §2.1 (canonical status table). Owner
 // directive 2026-05-18 redirected /products from "5 primitives deep-dive" to
-// "RevFleet product family lineup". RevealCoin omitted per
-// project_revealcoin_shelved_2026_05_15 memory. The legacy primitives data
+// "RevFleet product family lineup". RevealCoin permanently excluded per
+// the 2026-05-29 cancellation ADR (.jv docs/decisions/2026-05-29-revealcoin-cancelled.md;
+// supersedes the prior shelved-state memory). The legacy primitives data
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.
 //

--- a/docs/AUDIT_STATUS.md
+++ b/docs/AUDIT_STATUS.md
@@ -29,7 +29,7 @@
 
 ## Verification Checks (2026-04-18)
 
-- **Revealcoin keys:** Private key files on disk, never committed to git, gitignored, 0600 permissions. No rotation needed.
+- **Revealcoin keys:** Project CANCELLED 2026-05-29 — keypairs decommissioned via revvault rotate-and-destroy (`_decommissioned/revealcoin-2026-05-29/` namespace). No live custody surface. (Historical posture: private key files on disk, never committed to git, gitignored, 0600 permissions.)
 - **Config secret literal:** Comment/example only (line 87), not runtime code.
 - **RevDev socket:** No chmod 0600 in Rust source. Socket not running. Low priority.
 - **Dependabot PRs:** Zero open.

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -49,7 +49,7 @@ All workflows live in [`.github/workflows/`](../.github/workflows/).
 | [`release.yml`](../.github/workflows/release.yml) | workflow_dispatch | OSS npm publish via OIDC trusted publishing (SLSA Build Level 2 provenance) |
 | [`docker.yml`](../.github/workflows/docker.yml) | workflow_dispatch | Build & push Fleet self-hosted Docker images (`server` + `admin`) to GHCR |
 | [`db-backup.yml`](../.github/workflows/db-backup.yml) | scheduled | NeonDB-side backup hooks (PITR coordination) |
-| [`reconciliation-crons.yml`](../.github/workflows/reconciliation-crons.yml) | scheduled | Stripe + RVC reconciliation jobs |
+| [`reconciliation-crons.yml`](../.github/workflows/reconciliation-crons.yml) | scheduled | Stripe reconciliation jobs (RVC retired 2026-05-29) |
 | [`webhook-reconciliation.yml`](../.github/workflows/webhook-reconciliation.yml) | scheduled | Stripe webhook event-replay safety net |
 | [`regen-visual-snapshots.yml`](../.github/workflows/regen-visual-snapshots.yml) | workflow_dispatch | Regenerate Playwright visual-regression snapshots |
 | [`system-tune-snapshot.yml`](../.github/workflows/system-tune-snapshot.yml) | scheduled | Performance-baseline snapshot |
@@ -65,7 +65,7 @@ The real pipeline is six stages, all defined in [`deploy.yml`](../.github/workfl
 
 1. **`validate`** — install, build `@revealui/db`, run `drizzle-kit generate` to detect uncommitted schema drift; pull Vercel `production` env for the `api` project; run `pnpm validate:prod-env` (mirrors `validateStartup` in [`apps/server/src/lib/validate-startup.ts`](../apps/server/src/lib/validate-startup.ts) — presence + format checks for every required var, including the `sk_test_` / live-mode mismatch trap and the `REVEALUI_CRON_SECRET ≥ 32 chars` rule that closed GAP-125).
 2. **`migrate`** — run `pnpm db:backfill-migrations` (defense against half-applied state), then `pnpm --filter @revealui/db db:migrate` (drizzle-kit), then `pnpm db:assert-migration-count` (post-migrate row-count assertion). Output forced to non-color and tee'd through `tr '\r' '\n'` so drizzle-kit's spinner doesn't eat the trailing error message on failure.
-3. **`detect`** — diff `HEAD~1..HEAD` to compute the affected-app list. Apps known to the matrix: `api`, `admin`, `marketing`, `docs`, `revealcoin`. Shared package or root config change → all apps. Workflow `inputs.apps` allows manual override (`all`, comma-list, or `auto`).
+3. **`detect`** — diff `HEAD~1..HEAD` to compute the affected-app list. Apps known to the matrix: `api`, `admin`, `marketing`, `docs`. Shared package or root config change → all apps. Workflow `inputs.apps` allows manual override (`all`, comma-list, or `auto`). (Pre-2026-05-29 the matrix also included `revealcoin`; removed when the dashboard was retired and the project cancelled.)
 4. **`deploy`** — fan-out matrix; each app pulls its own Vercel project env, builds via `vercel build --prod`, and publishes via `vercel deploy --prebuilt --prod`. Project IDs are hardcoded in the workflow (one per app).
 5. **`smoke-test`** — poll `${API_URL}/health/ready` (12 × 10 s) and `${ADMIN_URL}` for HTTP 200. The api `/health/ready` checks DB + memory + config (see [`apps/server/src/routes/health.ts`](../apps/server/src/routes/health.ts) and [`apps/admin/src/app/api/health/ready/route.ts`](../apps/admin/src/app/api/health/ready/route.ts)).
 6. **`smoke-test` failure path** — auto-rollback. Per-app: `vercel ls --prod` → take 2nd-most-recent ready URL → `vercel rollback <url>` → re-poll `vercel ls` to confirm the alias moved (GAP-128: `vercel rollback` with no URL is a status query, not an action — the URL must be passed). On any rollback failure, the workflow exits non-zero so the broken-deploy-still-live signal surfaces immediately.
@@ -126,7 +126,7 @@ Each app is a separate Vercel project (own project ID, own env scope). Build com
 pnpm vercel-build   # = "cd ../.. && pnpm turbo build --filter=<app>"
 ```
 
-Each app's `vercel-build` script lives in `apps/<app>/package.json`. Output directory is the standard Next.js `.next` (admin) or Vite `dist` (docs / marketing / revealcoin).
+Each app's `vercel-build` script lives in `apps/<app>/package.json`. Output directory is the standard Next.js `.next` (admin) or Vite `dist` (docs / marketing).
 
 ### Standalone output (admin)
 
@@ -141,7 +141,7 @@ vercel inspect <deployment-url>                     # deployment metadata
 vercel rollback <previous-good-url> --token=...     # alias swap (the rollback path used by deploy.yml)
 ```
 
-Hardcoded Vercel project IDs are stored in [`deploy.yml`](../.github/workflows/deploy.yml) (one per app: `api`, `admin`, `marketing`, `docs`, `revealcoin`).
+Hardcoded Vercel project IDs are stored in [`deploy.yml`](../.github/workflows/deploy.yml) (one per app: `api`, `admin`, `marketing`, `docs`).
 
 ---
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -40,7 +40,7 @@ note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (
 - **Infrastructure:** Nix flakes, direnv, Biome 2 (sole linter), Turborepo, pnpm 10
 - **Security:** 7 audit rounds complete. 0 CodeQL alerts, 0 Dependabot alerts, 0 avoidable `any` types, 0 production console statements. AES-256-GCM encryption, bcrypt passwords, RBAC+ABAC, timing-safe TOTP. AST-based code-pattern analyzer (execSync injection, TOCTOU, ReDoS). Pre-push gate runs affected tests on protected branches. SOC2 audit track documented with pentest RFP template.
 - **Entity:** REVEALUI STUDIO L.L.C. (Tennessee, formed 2026-04-28; EIN issued). DE flip deferred until SoloFounders acceptance or first outside raise.
-- **On-chain token:** Token-2022 symbol `RVC` (customer-facing).
+- **On-chain payments:** USDC settlement on Base via x402 (dormant until Stripe live-mode flip). RevealCoin (RVC) was cancelled 2026-05-29; the on-chain Token-2022 artifact at mint `4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo` is dormant and authority keys destroyed. No RVC future-launch is planned.
 
 ### What Works
 
@@ -521,7 +521,7 @@ Phase E  -  Remote access gateway (agent + owner):
 | MCP Marketplace | Phase 5.5 (`packages/mcp`) | Agent/tool discovery, tenant scoping |
 | A2A Discovery | `apps/studio/src/lib/a2a-api.ts` | Cloud agent cards with skills/capabilities |
 | Agent Task Metering | Phase 5.1 (Stripe Billing Meter) | Per-task usage billing |
-| x402 Payments | Phase 5.2 (RevealCoin) | Per-task crypto payment |
+| x402 Payments | Phase 5.2 (USDC on Base) | Per-task crypto payment |
 | SpawnerPanel | `apps/studio/src/components/agent/` | Agent spawn with backend/model/prompt |
 | Harness Adapters | `packages/harnesses/src/adapters/` | Multi-tool agent adapters (stubs) |
 
@@ -552,7 +552,7 @@ Phase D  -  Agent publisher tools (agent):
 - [x] Version management (publish new versions, rollback)  -  version field in schema, draft→published flow  -  2026-04-07
 - [x] Analytics (usage, revenue, error rates)  -  /admin/marketplace/analytics with metrics table  -  2026-04-07
 
-**Exit criteria:** Users can browse agents by skill, submit tasks, and receive results without writing code. Agent publishers can list, price, and monitor their agents. Billing works via both Stripe metering and x402 RevealCoin. Task execution is sandboxed with audit trail.
+**Exit criteria:** Users can browse agents by skill, submit tasks, and receive results without writing code. Agent publishers can list, price, and monitor their agents. Billing works via both Stripe metering and x402 USDC settlement on Base. Task execution is sandboxed with audit trail.
 
 #### 5.17 Hardware-Aware Auto-Config (cross-platform, Fleet-wide)
 

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -1189,32 +1189,6 @@ Creates a Stripe refund for a payment intent or charge. Admin-only. Full or part
 
 ---
 
-### `POST` `/api/v1/billing/rvui-payment`
-
-**Pay for subscription with RevealCoin**
-
-Verifies an on-chain RVC (RevealCoin) payment transaction and activates the subscription tier. Applies the 15% RVC discount. Requires wallet address and transaction signature.
-
-> **Note:** The route path uses the internal project codename (`$RVUI`). The on-chain token symbol is **RVC**.
-
-**Request body** (JSON)
-
-| Field | Type | Required | Description |
-|-------|------|:--------:|-------------|
-| `txSignature` | `string` | ✓ |  |
-| `tier` | `string` | ✓ |  |
-| `walletAddress` | `string` | ✓ |  |
-| `network` | `string` |  -  |  |
-
-**Responses**
-
-- `200`  -  Payment verified and subscription activated
-- `400`  -  Validation failed
-- `401`  -  Authentication required
-- `403`  -  Payment rejected by safeguards
-
----
-
 ### `GET` `/api/v1/billing/metrics`
 
 **Revenue metrics (admin)**

--- a/docs/checklists/stripe-checkout-verification.md
+++ b/docs/checklists/stripe-checkout-verification.md
@@ -171,7 +171,7 @@ Use Stripe test card: `4242 4242 4242 4242` (any future expiry, any CVC).
 | Upgrade | | |
 | Downgrade | | |
 | Webhooks (failure/dispute/refund/trial) | | |
-| RVC disabled | | |
+| ~~RVC disabled~~ (retired 2026-05-29 — RevealCoin cancelled, no longer a gating concern) | n/a | n/a |
 | Edge cases | | |
 
 **All flows verified → checkout mechanics tested in TEST mode.**

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -27,7 +27,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | SVC-004 | docs | Documentation | Vite + React | 3002 | Vercel | Production | Founder | Public | Active |
 | SVC-005 | studio | Desktop Application | Tauri 2 + React 19 | N/A | Local distribution | User device | Founder | Internal | Active |
 | SVC-006 | terminal | CLI Tool | Go (Bubble Tea) | N/A | Local distribution | User device | Founder | Internal | Active |
-| SVC-007 | revealcoin | Token Service | N/A | N/A | TBD | N/A | Founder | Internal | Active |
+| ~~SVC-007~~ | ~~revealcoin~~ | (CANCELLED 2026-05-29 — project ended; repo private+archived; keys destroyed via revvault rotate-and-destroy) | N/A | N/A | N/A | N/A | N/A | N/A | Decommissioned |
 
 ### 2.2 OSS Packages (MIT License)
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -38,7 +38,7 @@ It is a working document. Comprehensive coverage will accrete over multiple sess
 | Application secrets | Database URLs, Stripe keys, OAuth client secrets, webhook signing secrets | Revvault (canonical), Vercel env vars (mirror) |
 | Audit trail | Append-only tamper-evident log of agent and admin actions | NeonDB `audit_log` table, HMAC chain |
 | Content | User-published content under their RevealUI-powered site | NeonDB `content_*` tables |
-| RevealCoin (RVC) keypairs | Mint authority, treasury, vesting wallets | Revvault `revealcoin/*` paths (encrypted) |
+| ~~RevealCoin (RVC) keypairs~~ | Project cancelled 2026-05-29; keypairs rotated-and-destroyed via revvault `_decommissioned/revealcoin-2026-05-29/` namespace. No live custody. | (decommissioned) |
 | npm packages | OSS + Pro packages published under `@revealui/*` | npm registry; build artifacts in GitHub Actions |
 | Source code | The monorepo itself | GitHub `RevealUIStudio/revealui`, branch protection on `main` and `test` |
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -148,7 +148,7 @@ pnpm mcp:next-devtools
 ### 8. Contracts Introspection
 **Status:** ✅ Active (no API key required, **not** Pro-license-gated)
 
-Phase 1 of the protocol-pyramid ADR ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](../../docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Exposes every `@revealui/contracts` category (representation, entities, content, admin, agents, security, secrets, a2a, api-auth, api-chat, api-gdpr, content-validation, devkit-profiles, generated, providers, revealcoin, stripe-webhook-events) as MCP **resources** (read-only JSON Schemas of every category schema) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
+Phase 1 of the protocol-pyramid ADR ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](../../docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Exposes every `@revealui/contracts` category (representation, entities, content, admin, agents, security, secrets, a2a, api-auth, api-chat, api-gdpr, content-validation, devkit-profiles, generated, providers, stripe-webhook-events) as MCP **resources** (read-only JSON Schemas of every category schema) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
 
 - **Resources:** `revealui-contracts://catalog` (full discovery payload) + `revealui-contracts://<category>` (one per category, returns all schemas).
 - **Tools:** `contracts_list_categories`, `contracts_get_schema`, plus one `contracts_validate_<category>` per category.


### PR DESCRIPTION
## Summary

Documentation sweep to bring live revealui docs in line with the RevealCoin
permanent cancellation (owner directive 2026-05-29). Companion to the ADR
landing in internal docs at `docs/decisions/2026-05-29-revealcoin-cancelled.md`.

Runtime code was already removed via #1032 (2026-05-22) — this PR catches
the documentation drift that lingered.

## Posture change

| Before | After |
|---|---|
| RVC shelved 2026-05-15 pending revenue + lawyer | RVC cancelled 2026-05-29; no revival plan |
| Ticker split: `$RVUI` internal, `RVC` customer-facing | Both terms banned in customer copy |
| Decoupling lane "active" | Repo private+archived; keys destroyed |
| "RevealCoin returns to portfolio after gates close" | Permanent removal |

x402 USDC-on-Base **stays** (already isolated by #1032). Cancellation does
not touch the crypto-payment rail; it cancels THIS token.

## Files changed

9 files, +15 / -40 lines:

- **`apps/marketing/app/content/products.ts`** — comment cite updated from
  shelved memory → cancellation ADR
- **`docs/MASTER_PLAN.md`** — entity bullet flipped (RVC on-chain →
  USDC-on-Base via x402); Phase 5.16 RevMarket table + exit criteria
  updated (3 spots)
- **`docs/CI_CD_GUIDE.md`** — 4 spots: reconciliation-crons description,
  apps matrix list, Vite output dir list, Vercel project ID list — all
  stripped of `revealcoin` (workflows were already RVC-free; docs were
  stale)
- **`docs/checklists/stripe-checkout-verification.md`** — "RVC disabled"
  row marked retired
- **`docs/security/THREAT_MODEL.md`** — RVC keypairs asset row marked
  decommissioned
- **`docs/security/ASSET_INVENTORY.md`** — SVC-007 revealcoin marked
  decommissioned
- **`docs/AUDIT_STATUS.md`** — "Revealcoin keys" verification check
  annotated cancelled
- **`docs/api/rest-api/README.md`** — DELETED stale `/api/v1/billing/
  rvui-payment` endpoint section (the route was deleted in #1032)
- **`packages/mcp/README.md`** — §8 Contracts Introspection category list:
  dropped `revealcoin` (category was deleted in #1032)

## NOT touched

By design (audit trail / frozen / generated):

- `packages/db/migrations/0016_drop_revealcoin_tables.sql` + earlier
  migration snapshots — frozen schema audit
- CHANGELOGs across packages — historical record
- `docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md` — archived
- `scripts/validate/*.ts` that reference migration 0016 by name — those
  refer to the migration file (correctly named), not the live system

## Follow-up (out of scope here)

- **`examples/api/openapi.json`** still has the `/api/billing/rvui-payment`
  and `/api/v1/billing/rvui-payment` endpoint sections (lines 2565+ and
  9342+). The hand-maintained spec is stale vs the runtime contract.
  Either a regen pass against the current Hono routes, or a surgical JSON
  delete — defer to a clean follow-up so the diff stays surveyable.

## Verify (this PR)

- `biome check` on touched files — clean
- `pnpm validate:claims` — green: 0 mismatches, 0 `$RVUI` ticker leaks,
  0 phantom mentions, 0 future-tense issues, 0 license drift
- `grep -i 'revealcoin\|RVC\|rvui' .github/workflows/` returns nothing
  (workflows already RVC-free; the doc updates just bring documentation
  in line)

## Owner actions still pending (from the ADR)

1. `gh repo edit an internal repo --visibility private && gh repo archive an internal repo
2. `git bundle create /mnt/e/professional/archived-bundles/revealcoin-2026-05-29.bundle --all` (from revealcoin repo)
3. Pull `apps/dashboard` from Vercel + Cloudflare DNS
4. `revvault mv revealcoin _decommissioned/revealcoin-2026-05-29/` → verify → `revvault rm` originals
5. Memory updates (via memory tool): `project_revealcoin_shelved_2026_05_15` → cancelled; `project_revealcoin_ticker_split` retire; `project_revealcoin_key_storage` annotate

All listed in the ADR's "Implementation order" + the design system audit
handoff's Lane D section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
