### PR TITLE
feat(server,marketing): source-tagged waitlist endpoint + wire email capture

### DIFF
--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -2,7 +2,7 @@ import { ButtonCVA as Button, Input } from '@revealui/presentation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 import { FO_MANAGED_WAITLIST } from '../../content/for-operators-managed';
-import { submitNewsletter } from '../../lib/api';
+import { submitWaitlist } from '../../lib/api';
 
 export function Waitlist() {
   const [email, setEmail] = useState('');
@@ -14,10 +14,9 @@ export function Waitlist() {
     if (!email || status === 'loading') return;
 
     setStatus('loading');
-    // NOTE: Phase 5 reuses the newsletter endpoint as the simplest mechanism
-    // that ships today. A dedicated waitlist source-tagging on the server
-    // is a follow-up — at that point, swap submitNewsletter for submitWaitlist.
-    const error = await submitNewsletter({ email });
+    // Source-tagged so RevealUI Cloud interest is queryable separately from
+    // newsletter signups (apps/server POST /api/waitlist → waitlist table).
+    const error = await submitWaitlist({ email, source: FO_MANAGED_WAITLIST.product });
     if (error === null) {
       setStatus('success');
       setMessage(FO_MANAGED_WAITLIST.successMessage);

--- a/apps/marketing/app/content/for-operators-managed.ts
+++ b/apps/marketing/app/content/for-operators-managed.ts
@@ -129,11 +129,11 @@ export const FO_MANAGED_TODAY = {
 export const FO_MANAGED_WAITLIST = {
   eyebrow: 'Waitlist',
   heading: 'Want it when it ships? Join the waitlist.',
-  body: 'Tell us your email. You will receive RevealUI product updates; RevealUI Cloud progress will be called out specifically as it advances toward shipping. (We do not have a Cloud-only list yet — that is part of the work.)',
+  body: 'Tell us your email and we will record your interest in RevealUI Cloud specifically. We will reach out when there is something to demo — not before.',
   product: 'managed-cloud',
   inputPlaceholder: 'you@company.com',
   buttonLabel: 'Join the waitlist',
   buttonLabelLoading: 'Joining…',
   successMessage:
-    'You are on the list. RevealUI Cloud progress will be called out in our updates as it advances.',
+    'You are on the RevealUI Cloud waitlist. We will email when there is something to demo.',
 } as const;

--- a/apps/marketing/app/lib/api.ts
+++ b/apps/marketing/app/lib/api.ts
@@ -20,6 +20,15 @@ export interface NewsletterPayload {
   email: string;
 }
 
+export interface WaitlistPayload {
+  email: string;
+  /**
+   * Segmentation key — matches the server's WAITLIST_SOURCES enum.
+   * e.g. 'managed-cloud' (RevealUI Cloud waitlist), 'newsletter'.
+   */
+  source: 'managed-cloud' | 'newsletter' | 'landing-page' | 'blog';
+}
+
 export interface BlogPost {
   id: string;
   title: string;
@@ -53,23 +62,36 @@ export async function submitContact(payload: ContactPayload): Promise<string | n
 }
 
 /**
- * Subscribe an email to the newsletter. Returns null on success; an error
- * message string on failure.
+ * Capture an email against a named waitlist source. Returns null on success;
+ * an error message string on failure. Backed by apps/server POST /api/waitlist
+ * (the `waitlist` table, segmented by `source`).
  */
-export async function submitNewsletter(payload: NewsletterPayload): Promise<string | null> {
+export async function submitWaitlist(payload: WaitlistPayload): Promise<string | null> {
   try {
-    const res = await fetch(`${API_URL}/api/newsletter`, {
+    const res = await fetch(`${API_URL}/api/waitlist`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: payload.email, source: 'marketing-site' }),
+      body: JSON.stringify({ email: payload.email, source: payload.source }),
     });
     if (res.ok) return null;
     // empty-catch-ok: malformed JSON from apps/server shouldn't crash the form; falls back to a generic status-coded message below.
-    const data = (await res.json().catch(() => ({}))) as { message?: string };
-    return data.message ?? `Subscription failed: ${res.status}`;
+    const data = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+    return data.error ?? data.message ?? `Signup failed: ${res.status}`;
   } catch {
     return 'Our service is temporarily unavailable. Please try again in a few minutes.';
   }
+}
+
+/**
+ * Subscribe an email to the newsletter. Returns null on success; an error
+ * message string on failure.
+ *
+ * Routes through the source-tagged waitlist endpoint (source: 'newsletter').
+ * Prior to this it POSTed to a non-existent /api/newsletter and 404'd;
+ * /api/waitlist is the canonical email-capture backend.
+ */
+export async function submitNewsletter(payload: NewsletterPayload): Promise<string | null> {
+  return submitWaitlist({ email: payload.email, source: 'newsletter' });
 }
 
 /**

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -118,6 +118,7 @@ import studioAuthRoute from './routes/studio-auth.js';
 import terminalAuthRoute from './routes/terminal-auth.js';
 import { createTerminalRoute } from './routes/terminal-ws.js';
 import ticketsRoute from './routes/tickets/index.js';
+import waitlistRoute from './routes/waitlist.js';
 import webhooksRoute from './routes/webhooks.js';
 
 // Ship warn+ logs to NeonDB in production
@@ -612,6 +613,15 @@ const contactLimit = rateLimitMiddleware({
 app.use('/api/contact', contactLimit);
 app.use('/api/v1/contact', contactLimit);
 
+// Public waitlist / email capture  -  same tight limit (unauthenticated, DB write)
+const waitlistLimit = rateLimitMiddleware({
+  maxRequests: 5,
+  windowMs: 15 * 60_000,
+  keyPrefix: 'waitlist',
+});
+app.use('/api/waitlist', waitlistLimit);
+app.use('/api/v1/waitlist', waitlistLimit);
+
 // Populate session if present (non-blocking  -  sets user context for all API routes)
 const optionalAuth = authMiddleware({ required: false });
 app.use('/api/*', optionalAuth);
@@ -1089,6 +1099,8 @@ app.route('/api/auth', authRoute);
 app.route('/api/billing', billingRoute);
 app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
+app.route('/api/waitlist', waitlistRoute);
+app.route('/api/v1/waitlist', waitlistRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/routes/__tests__/waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/waitlist.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the waitlist route — public source-tagged email capture.
+ *
+ * Covered:
+ *   - honeypot: non-empty `website` → 200, no DB write
+ *   - valid signup: inserts with onConflictDoUpdate, 200
+ *   - email is normalized (trim + lowercase) before insert
+ *   - source defaults to 'landing-page' when omitted
+ *   - invalid email → 400 (zValidator)
+ *   - invalid source → 400 (zValidator enum)
+ *   - DB error → 500 with friendly message
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  waitlist: { email: 'email' },
+}));
+
+import { getClient } from '@revealui/db';
+import waitlistApp from '../waitlist.js';
+
+const mockedGetClient = vi.mocked(getClient);
+
+/** Builds a chainable insert mock: insert().values().onConflictDoUpdate() */
+function makeDb(onConflict: ReturnType<typeof vi.fn>) {
+  const values = vi.fn(() => ({ onConflictDoUpdate: onConflict }));
+  const insert = vi.fn(() => ({ values }));
+  return { db: { insert }, insert, values, onConflict };
+}
+
+function createApp() {
+  const app = new Hono();
+  app.route('/waitlist', waitlistApp);
+  return app;
+}
+
+async function post(app: Hono, body: unknown) {
+  return app.request('/waitlist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('waitlist route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('trips the honeypot silently (200, no DB write)', async () => {
+    const { db, insert } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), {
+      email: 'bot@example.com',
+      source: 'managed-cloud',
+      website: 'http://spam.example',
+    });
+
+    expect(res.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('captures a valid signup (200, onConflictDoUpdate called)', async () => {
+    const onConflict = vi.fn().mockResolvedValue(undefined);
+    const { db, insert, values } = makeDb(onConflict);
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'managed-cloud' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'op@example.com', source: 'managed-cloud' }),
+    );
+    expect(onConflict).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes email (trim + lowercase) before insert', async () => {
+    const { db, values } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    await post(createApp(), { email: '  OP@Example.COM  ', source: 'newsletter' });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'op@example.com', source: 'newsletter' }),
+    );
+  });
+
+  it('defaults source to landing-page when omitted', async () => {
+    const { db, values } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    await post(createApp(), { email: 'op@example.com' });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ source: 'landing-page' }));
+  });
+
+  it('rejects an invalid email (400)', async () => {
+    const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'not-an-email', source: 'managed-cloud' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown source (400)', async () => {
+    const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'arbitrary-junk' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 with a friendly message on DB error', async () => {
+    const { db } = makeDb(vi.fn().mockRejectedValue(new Error('db down')));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'managed-cloud' });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('try again');
+  });
+});

--- a/apps/server/src/routes/waitlist.ts
+++ b/apps/server/src/routes/waitlist.ts
@@ -1,0 +1,120 @@
+/**
+ * Waitlist Routes — Public Email-Capture Endpoint
+ *
+ * POST /api/waitlist        — Capture an email against a named source
+ * POST /api/v1/waitlist     — Same, versioned alias
+ *
+ * Public (unauthenticated). Rate-limited at the app level
+ * (5 req / 15 min / IP, applied in index.ts via rateLimitMiddleware).
+ *
+ * Backed by the `waitlist` table (packages/db/src/schema/waitlist.ts):
+ * email (unique), source, referrer, user_agent, ip_address, created_at,
+ * notified_at. The `source` column is the segmentation key — signups are
+ * queryable per source (e.g. `WHERE source = 'managed-cloud'`).
+ *
+ * Used by:
+ *   - revealui.com /for-operators/managed — RevealUI Cloud waitlist
+ *     (source: 'managed-cloud')
+ *   - revealui.com footer + GetStarted     — newsletter capture
+ *     (source: 'newsletter')
+ *
+ * Email uniqueness is on `email` alone (not composite with source), so a
+ * repeat signup with a different source updates the row to the latest
+ * intent (ON CONFLICT (email) DO UPDATE). For pre-revenue volume this is
+ * the right default; a composite (email, source) unique is a future
+ * migration if multi-list membership per email becomes load-bearing.
+ *
+ * Honeypot: a hidden `website` field. Submissions with a non-empty value
+ * are silently 200'd (no DB write) so bots don't learn.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import type { DatabaseClient } from '@revealui/db/client';
+import { waitlist } from '@revealui/db/schema';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+// Closed enum keeps the segmentation column clean + queryable. Add a source
+// here when a new capture surface ships — a one-line API change, deliberate
+// so the `source` dimension never accumulates free-text drift.
+const WAITLIST_SOURCES = ['managed-cloud', 'newsletter', 'landing-page', 'blog'] as const;
+
+const WaitlistSchema = z.object({
+  // Normalize before validation so '  OP@Example.COM ' → 'op@example.com'.
+  email: z.string().trim().toLowerCase().email().max(254),
+  source: z.enum(WAITLIST_SOURCES).default('landing-page'),
+  // Honeypot — hidden via CSS in the form. Bots fill it; humans don't.
+  // Left unconstrained so a filled value reaches the handler and is silently
+  // 200'd (a max(0) reject would 400, handing bots a signal).
+  website: z.string().optional(),
+});
+
+type WaitlistInput = z.infer<typeof WaitlistSchema>;
+
+// `db` is injected by middleware in some contexts; fall back to getClient().
+type WaitlistVariables = { db?: DatabaseClient };
+
+const app = new Hono<{ Variables: WaitlistVariables }>();
+
+/**
+ * POST /
+ * Captures an email against a source. Idempotent on email: a repeat signup
+ * refreshes source + request metadata to the latest submission.
+ */
+app.post('/', zValidator('json', WaitlistSchema), async (c) => {
+  const body = c.req.valid('json') as WaitlistInput;
+  const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? null;
+  const referrer = c.req.header('referer') ?? c.req.header('referrer') ?? null;
+  const userAgent = c.req.header('user-agent') ?? null;
+
+  // Honeypot trip — silently 200 to deny bots a signal
+  if (body.website !== undefined && body.website.length > 0) {
+    logger.warn('Waitlist honeypot triggered', { ip, source: body.source });
+    return c.json({ success: true }, 200);
+  }
+
+  // email is already trimmed + lowercased by the schema transform.
+  const email = body.email;
+
+  try {
+    const db = c.get('db') ?? getClient();
+    await db
+      .insert(waitlist)
+      .values({
+        email,
+        source: body.source,
+        referrer,
+        userAgent,
+        ipAddress: ip,
+      })
+      .onConflictDoUpdate({
+        target: waitlist.email,
+        set: {
+          source: body.source,
+          referrer,
+          userAgent,
+          ipAddress: ip,
+        },
+      });
+
+    logger.info('Waitlist signup captured', { source: body.source });
+
+    return c.json({ success: true }, 200);
+  } catch (err) {
+    logger.error('Waitlist signup failed', {
+      err: err instanceof Error ? err.message : String(err),
+      source: body.source,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Could not record your signup. Please try again in a few minutes.',
+      },
+      500,
+    );
+  }
+});
+
+export default app;


### PR DESCRIPTION
## Summary

Adds the **source-tagged waitlist backend** the operator-lane Phase 5 page (`/for-operators/managed`) needs, so RevealUI Cloud interest is queryable separately from newsletter signups. Also fixes a **latent 404** discovered while building it.

## Audit finding (why this is more than a one-line follow-up)

The Phase 5 waitlist shipped reusing `submitNewsletter`. Auditing that path before wiring a dedicated endpoint surfaced two things:

1. **There is no `/api/newsletter` handler in apps/server.** `submitNewsletter` (used by `NewsletterSignup`, `GetStarted`, and the Phase 5 waitlist) POSTs to a route that isn't mounted → **404**. Email capture has been silently failing across the marketing site.
2. **The `waitlist` table exists but had zero runtime consumers.** It's defined in `packages/db/src/schema/waitlist.ts`, is in the latest migration snapshot, and is created in `0000_init.sql` (so it exists in prod) — but no route or client used it. A prior commit (`fix(landing): Replace in-memory waitlist with database storage`) added the table; the serving route was never wired in the current tree.

So the real follow-up was "build the waitlist backend that doesn't exist," not "tag an existing one."

## What this does

**Server — new `POST /api/waitlist` (+ `/api/v1/waitlist`):**
- Backed by the existing `waitlist` table, segmented by a closed `source` enum: `'managed-cloud' | 'newsletter' | 'landing-page' | 'blog'`.
- Idempotent on email: `ON CONFLICT (email) DO UPDATE` (latest-intent-wins).
- Honeypot (`website` field → silent 200, no DB write).
- Rate-limited 5 req / 15 min / IP (mirrors `/api/contact`).
- Captures `referrer`, `user-agent`, `ip` for analytics/fraud, as the table supports.
- Email normalized in the Zod schema (`.trim().toLowerCase().email()`).

**Marketing:**
- New `submitWaitlist({ email, source })` client helper → `/api/waitlist`.
- `submitNewsletter` now routes through it with `source: 'newsletter'` — **fixes the 404**.
- Phase 5 managed-page waitlist uses `source: 'managed-cloud'`. Cloud interest is now queryable: `SELECT … FROM waitlist WHERE source = 'managed-cloud'`.
- Phase 5 waitlist copy updated — the earlier "we do not have a Cloud-only list yet" caveat is obsolete now that signups are source-tagged. New copy: "we will record your interest in RevealUI Cloud specifically."

## Deliberately NOT in this PR

- **No schema migration, no contracts regen.** The table is used as-is. The `email`-unique (vs composite `email + source`) constraint means a single email maps to its *latest* source. A composite unique is a future migration if multi-list membership per email becomes load-bearing (noted in the route doc-comment). For pre-revenue volume, latest-intent-wins is the right default.
- **No founder-notification email.** A notification on high-signal `managed-cloud` signups (reuse `lib/email.ts` `sendEmail`, as `/api/contact` does) is a sensible follow-on but beyond "queryable separately." Flagged, not built.

## Verification

- ✅ **Unit tests** — `apps/server/src/routes/__tests__/waitlist.test.ts`, **7/7 pass**: honeypot silent-200 (no insert), valid insert + `onConflictDoUpdate`, email trim/lowercase normalization, source default, invalid email → 400, invalid source → 400, DB error → 500 with friendly message.
- ✅ **Biome** — clean (6 files).
- ✅ **Typecheck** — server clean, marketing clean (verified after building the workspace dep graph; two type errors found + fixed during review: a `c.get('db')` context-typing gap and the honeypot `z.string().max(0)` that would 400 instead of silently 200'ing).

## Files

| File | Status |
|---|---|
| `apps/server/src/routes/waitlist.ts` | NEW (route) |
| `apps/server/src/routes/__tests__/waitlist.test.ts` | NEW (7 tests) |
| `apps/server/src/index.ts` | import + rate-limit + route mount |
| `apps/marketing/app/lib/api.ts` | `submitWaitlist` + `submitNewsletter` repoint |
| `apps/marketing/app/components/for-operators-managed/Waitlist.tsx` | use `submitWaitlist` |
| `apps/marketing/app/content/for-operators-managed.ts` | honest copy update |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
