### PR TITLE
refactor(marketing): correct RevKit status and sharpen products hero

### DIFF
--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -8,6 +8,13 @@
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.
 //
+// Status re-verified 2026-05-29 (owner directive: reflect what's completed vs.
+// soon-to-complete). RevKit promoted Planned → Active (MIT): the §2.1 table
+// flagged it "cross-check revkit/README.md", and that README confirms a working
+// MIT toolkit (bootstrap + render engine + 4 tier profiles) in active studio
+// use — not an unshipped/planned item. Hero subtitle sharpened to state what
+// ships today vs. what's on the way (RevMarket, the agent marketplace).
+//
 // Status semantics:
 //   Beta         — production-ready code, limited paying users / dogfooded
 //   Alpha        — development-preview quality; works, ships, may break
@@ -20,7 +27,7 @@ import type { Cta } from './types';
 export const PRODUCTS_PAGE_HERO = {
   h1: 'The RevFleet product family',
   subtitle:
-    'Start with the runtime, add the rest as you grow. Eight products on one foundation — each ships today or ships soon, all built and operated by RevealUI Studio.',
+    'Start with the runtime, add the rest as you grow. Eight products on one foundation, all built and operated by RevealUI Studio — every one shipping today except the agent marketplace, which is on the way.',
 } as const;
 
 export type ProductStatus = 'Beta' | 'Alpha' | 'Active (MIT)' | 'Planned';
@@ -190,7 +197,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
     name: 'RevKit',
     tagline: 'Portable WSL dev environment',
     body: 'Profile-based WSL bootstrap with parameterized templates and tier-aware resource configs. Reproducible developer machines.',
-    status: 'Planned',
+    status: 'Active (MIT)',
     iconPath:
       'M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z',
     primaryCta: {


### PR DESCRIPTION
## What

Accuracy pass on the `/products` page copy (`apps/marketing/app/content/products.ts`) so it reflects what's shipped today vs. what's coming. Owner-directed 2026-05-29 ("reflect current reality of completed and soon to be completed"); scope confirmed as a surgical accuracy pass, not a layout restructure.

## Changes

- **RevKit: `Planned` → `Active (MIT)`.** The canonical product status table flagged RevKit for cross-check against `revkit/README.md`. That README confirms a working, MIT-licensed toolkit — bootstrap script, template/render engine, four tier profiles, PowerShell module — in active studio use. "Planned" was stale. RevKit now sits with RevSkills (Active), ahead of the one genuinely-planned product (RevMarket).
- **Hero subtitle:** replaced the blanket _"each ships today or ships soon"_ with an honest completed-vs-coming split — _"every one shipping today except the agent marketplace, which is on the way."_ No hardcoded count, so it's durable to roster changes.
- Added a provenance comment documenting the re-verification.

## Not changed

The other seven statuses match the canonical status table and live code and were left as-is (RevVault `Cargo.toml` reconfirmed `0.2.0`). RevMarket stays `Planned` (first-party catalog ships; third-party publishing does not).

## Coordination

Complementary to #1145 (RevSkills / RevMarket _body wording_ rewrite). This PR edits different, non-overlapping lines (RevKit status + hero subtitle), so the two merge cleanly in either order.

## Verification

- `claim-drift`: 0 mismatches, all gates green (no number-claim collisions; marketing METRICS drift 0).
- Biome: clean on the changed file.
- Type-safe by construction: `Active (MIT)` is an existing `ProductStatus` and a defined `PRODUCT_STATUS_STYLES` key — RevKit renders with the existing badge. Full typecheck + build run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
