### PR TITLE
release: promote test to main — source-tagged waitlist endpoint (#1160)

### DIFF
--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -2,7 +2,7 @@ import { ButtonCVA as Button, Input } from '@revealui/presentation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 import { FO_MANAGED_WAITLIST } from '../../content/for-operators-managed';
-import { submitNewsletter } from '../../lib/api';
+import { submitWaitlist } from '../../lib/api';
 
 export function Waitlist() {
   const [email, setEmail] = useState('');
@@ -14,10 +14,9 @@ export function Waitlist() {
     if (!email || status === 'loading') return;
 
     setStatus('loading');
-    // NOTE: Phase 5 reuses the newsletter endpoint as the simplest mechanism
-    // that ships today. A dedicated waitlist source-tagging on the server
-    // is a follow-up — at that point, swap submitNewsletter for submitWaitlist.
-    const error = await submitNewsletter({ email });
+    // Source-tagged so RevealUI Cloud interest is queryable separately from
+    // newsletter signups (apps/server POST /api/waitlist → waitlist table).
+    const error = await submitWaitlist({ email, source: FO_MANAGED_WAITLIST.product });
     if (error === null) {
       setStatus('success');
       setMessage(FO_MANAGED_WAITLIST.successMessage);

--- a/apps/marketing/app/content/for-operators-managed.ts
+++ b/apps/marketing/app/content/for-operators-managed.ts
@@ -129,11 +129,11 @@ export const FO_MANAGED_TODAY = {
 export const FO_MANAGED_WAITLIST = {
   eyebrow: 'Waitlist',
   heading: 'Want it when it ships? Join the waitlist.',
-  body: 'Tell us your email. You will receive RevealUI product updates; RevealUI Cloud progress will be called out specifically as it advances toward shipping. (We do not have a Cloud-only list yet — that is part of the work.)',
+  body: 'Tell us your email and we will record your interest in RevealUI Cloud specifically. We will reach out when there is something to demo — not before.',
   product: 'managed-cloud',
   inputPlaceholder: 'you@company.com',
   buttonLabel: 'Join the waitlist',
   buttonLabelLoading: 'Joining…',
   successMessage:
-    'You are on the list. RevealUI Cloud progress will be called out in our updates as it advances.',
+    'You are on the RevealUI Cloud waitlist. We will email when there is something to demo.',
 } as const;

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -9,6 +9,13 @@
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.
 //
+// Status re-verified 2026-05-29 (owner directive: reflect what's completed vs.
+// soon-to-complete). RevKit promoted Planned → Active (MIT): the §2.1 table
+// flagged it "cross-check revkit/README.md", and that README confirms a working
+// MIT toolkit (bootstrap + render engine + 4 tier profiles) in active studio
+// use — not an unshipped/planned item. Hero subtitle sharpened to state what
+// ships today vs. what's on the way (RevMarket, the agent marketplace).
+//
 // Status semantics:
 //   Beta         — production-ready code, limited paying users / dogfooded
 //   Alpha        — development-preview quality; works, ships, may break
@@ -21,7 +28,7 @@ import type { Cta } from './types';
 export const PRODUCTS_PAGE_HERO = {
   h1: 'The RevFleet product family',
   subtitle:
-    'Start with the runtime, add the rest as you grow. Eight products on one foundation — each ships today or ships soon, all built and operated by RevealUI Studio.',
+    'Start with the runtime, add the rest as you grow. Eight products on one foundation, all built and operated by RevealUI Studio — every one shipping today except the agent marketplace, which is on the way.',
 } as const;
 
 export type ProductStatus = 'Beta' | 'Alpha' | 'Active (MIT)' | 'Planned';
@@ -191,7 +198,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
     name: 'RevKit',
     tagline: 'Portable WSL dev environment',
     body: 'Profile-based WSL bootstrap with parameterized templates and tier-aware resource configs. Reproducible developer machines.',
-    status: 'Planned',
+    status: 'Active (MIT)',
     iconPath:
       'M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z',
     primaryCta: {

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -3,8 +3,9 @@
 // Sourced from per-product README audit (2026-05-18) cross-referenced against
 // docs/lanes/marketing-overhaul/plan.md §2.1 (canonical status table). Owner
 // directive 2026-05-18 redirected /products from "5 primitives deep-dive" to
-// "RevFleet product family lineup". RevealCoin omitted per
-// project_revealcoin_shelved_2026_05_15 memory. The legacy primitives data
+// "RevFleet product family lineup". RevealCoin permanently excluded per
+// the 2026-05-29 cancellation ADR (.jv docs/decisions/2026-05-29-revealcoin-cancelled.md;
+// supersedes the prior shelved-state memory). The legacy primitives data
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.
 //

--- a/apps/marketing/app/lib/api.ts
+++ b/apps/marketing/app/lib/api.ts
@@ -20,6 +20,15 @@ export interface NewsletterPayload {
   email: string;
 }
 
+export interface WaitlistPayload {
+  email: string;
+  /**
+   * Segmentation key — matches the server's WAITLIST_SOURCES enum.
+   * e.g. 'managed-cloud' (RevealUI Cloud waitlist), 'newsletter'.
+   */
+  source: 'managed-cloud' | 'newsletter' | 'landing-page' | 'blog';
+}
+
 export interface BlogPost {
   id: string;
   title: string;
@@ -53,23 +62,36 @@ export async function submitContact(payload: ContactPayload): Promise<string | n
 }
 
 /**
- * Subscribe an email to the newsletter. Returns null on success; an error
- * message string on failure.
+ * Capture an email against a named waitlist source. Returns null on success;
+ * an error message string on failure. Backed by apps/server POST /api/waitlist
+ * (the `waitlist` table, segmented by `source`).
  */
-export async function submitNewsletter(payload: NewsletterPayload): Promise<string | null> {
+export async function submitWaitlist(payload: WaitlistPayload): Promise<string | null> {
   try {
-    const res = await fetch(`${API_URL}/api/newsletter`, {
+    const res = await fetch(`${API_URL}/api/waitlist`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: payload.email, source: 'marketing-site' }),
+      body: JSON.stringify({ email: payload.email, source: payload.source }),
     });
     if (res.ok) return null;
     // empty-catch-ok: malformed JSON from apps/server shouldn't crash the form; falls back to a generic status-coded message below.
-    const data = (await res.json().catch(() => ({}))) as { message?: string };
-    return data.message ?? `Subscription failed: ${res.status}`;
+    const data = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+    return data.error ?? data.message ?? `Signup failed: ${res.status}`;
   } catch {
     return 'Our service is temporarily unavailable. Please try again in a few minutes.';
   }
+}
+
+/**
+ * Subscribe an email to the newsletter. Returns null on success; an error
+ * message string on failure.
+ *
+ * Routes through the source-tagged waitlist endpoint (source: 'newsletter').
+ * Prior to this it POSTed to a non-existent /api/newsletter and 404'd;
+ * /api/waitlist is the canonical email-capture backend.
+ */
+export async function submitNewsletter(payload: NewsletterPayload): Promise<string | null> {
+  return submitWaitlist({ email: payload.email, source: 'newsletter' });
 }
 
 /**

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -118,6 +118,7 @@ import studioAuthRoute from './routes/studio-auth.js';
 import terminalAuthRoute from './routes/terminal-auth.js';
 import { createTerminalRoute } from './routes/terminal-ws.js';
 import ticketsRoute from './routes/tickets/index.js';
+import waitlistRoute from './routes/waitlist.js';
 import webhooksRoute from './routes/webhooks.js';
 
 // Ship warn+ logs to NeonDB in production
@@ -612,6 +613,15 @@ const contactLimit = rateLimitMiddleware({
 app.use('/api/contact', contactLimit);
 app.use('/api/v1/contact', contactLimit);
 
+// Public waitlist / email capture  -  same tight limit (unauthenticated, DB write)
+const waitlistLimit = rateLimitMiddleware({
+  maxRequests: 5,
+  windowMs: 15 * 60_000,
+  keyPrefix: 'waitlist',
+});
+app.use('/api/waitlist', waitlistLimit);
+app.use('/api/v1/waitlist', waitlistLimit);
+
 // Populate session if present (non-blocking  -  sets user context for all API routes)
 const optionalAuth = authMiddleware({ required: false });
 app.use('/api/*', optionalAuth);
@@ -1089,6 +1099,8 @@ app.route('/api/auth', authRoute);
 app.route('/api/billing', billingRoute);
 app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
+app.route('/api/waitlist', waitlistRoute);
+app.route('/api/v1/waitlist', waitlistRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/routes/__tests__/waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/waitlist.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the waitlist route — public source-tagged email capture.
+ *
+ * Covered:
+ *   - honeypot: non-empty `website` → 200, no DB write
+ *   - valid signup: inserts with onConflictDoUpdate, 200
+ *   - email is normalized (trim + lowercase) before insert
+ *   - source defaults to 'landing-page' when omitted
+ *   - invalid email → 400 (zValidator)
+ *   - invalid source → 400 (zValidator enum)
+ *   - DB error → 500 with friendly message
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  waitlist: { email: 'email' },
+}));
+
+import { getClient } from '@revealui/db';
+import waitlistApp from '../waitlist.js';
+
+const mockedGetClient = vi.mocked(getClient);
+
+/** Builds a chainable insert mock: insert().values().onConflictDoUpdate() */
+function makeDb(onConflict: ReturnType<typeof vi.fn>) {
+  const values = vi.fn(() => ({ onConflictDoUpdate: onConflict }));
+  const insert = vi.fn(() => ({ values }));
+  return { db: { insert }, insert, values, onConflict };
+}
+
+function createApp() {
+  const app = new Hono();
+  app.route('/waitlist', waitlistApp);
+  return app;
+}
+
+async function post(app: Hono, body: unknown) {
+  return app.request('/waitlist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('waitlist route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('trips the honeypot silently (200, no DB write)', async () => {
+    const { db, insert } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), {
+      email: 'bot@example.com',
+      source: 'managed-cloud',
+      website: 'http://spam.example',
+    });
+
+    expect(res.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('captures a valid signup (200, onConflictDoUpdate called)', async () => {
+    const onConflict = vi.fn().mockResolvedValue(undefined);
+    const { db, insert, values } = makeDb(onConflict);
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'managed-cloud' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'op@example.com', source: 'managed-cloud' }),
+    );
+    expect(onConflict).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes email (trim + lowercase) before insert', async () => {
+    const { db, values } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    await post(createApp(), { email: '  OP@Example.COM  ', source: 'newsletter' });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'op@example.com', source: 'newsletter' }),
+    );
+  });
+
+  it('defaults source to landing-page when omitted', async () => {
+    const { db, values } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    await post(createApp(), { email: 'op@example.com' });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ source: 'landing-page' }));
+  });
+
+  it('rejects an invalid email (400)', async () => {
+    const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'not-an-email', source: 'managed-cloud' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown source (400)', async () => {
+    const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'arbitrary-junk' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 with a friendly message on DB error', async () => {
+    const { db } = makeDb(vi.fn().mockRejectedValue(new Error('db down')));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'op@example.com', source: 'managed-cloud' });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('try again');
+  });
+});

--- a/apps/server/src/routes/waitlist.ts
+++ b/apps/server/src/routes/waitlist.ts
@@ -1,0 +1,120 @@
+/**
+ * Waitlist Routes — Public Email-Capture Endpoint
+ *
+ * POST /api/waitlist        — Capture an email against a named source
+ * POST /api/v1/waitlist     — Same, versioned alias
+ *
+ * Public (unauthenticated). Rate-limited at the app level
+ * (5 req / 15 min / IP, applied in index.ts via rateLimitMiddleware).
+ *
+ * Backed by the `waitlist` table (packages/db/src/schema/waitlist.ts):
+ * email (unique), source, referrer, user_agent, ip_address, created_at,
+ * notified_at. The `source` column is the segmentation key — signups are
+ * queryable per source (e.g. `WHERE source = 'managed-cloud'`).
+ *
+ * Used by:
+ *   - revealui.com /for-operators/managed — RevealUI Cloud waitlist
+ *     (source: 'managed-cloud')
+ *   - revealui.com footer + GetStarted     — newsletter capture
+ *     (source: 'newsletter')
+ *
+ * Email uniqueness is on `email` alone (not composite with source), so a
+ * repeat signup with a different source updates the row to the latest
+ * intent (ON CONFLICT (email) DO UPDATE). For pre-revenue volume this is
+ * the right default; a composite (email, source) unique is a future
+ * migration if multi-list membership per email becomes load-bearing.
+ *
+ * Honeypot: a hidden `website` field. Submissions with a non-empty value
+ * are silently 200'd (no DB write) so bots don't learn.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import type { DatabaseClient } from '@revealui/db/client';
+import { waitlist } from '@revealui/db/schema';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+// Closed enum keeps the segmentation column clean + queryable. Add a source
+// here when a new capture surface ships — a one-line API change, deliberate
+// so the `source` dimension never accumulates free-text drift.
+const WAITLIST_SOURCES = ['managed-cloud', 'newsletter', 'landing-page', 'blog'] as const;
+
+const WaitlistSchema = z.object({
+  // Normalize before validation so '  OP@Example.COM ' → 'op@example.com'.
+  email: z.string().trim().toLowerCase().email().max(254),
+  source: z.enum(WAITLIST_SOURCES).default('landing-page'),
+  // Honeypot — hidden via CSS in the form. Bots fill it; humans don't.
+  // Left unconstrained so a filled value reaches the handler and is silently
+  // 200'd (a max(0) reject would 400, handing bots a signal).
+  website: z.string().optional(),
+});
+
+type WaitlistInput = z.infer<typeof WaitlistSchema>;
+
+// `db` is injected by middleware in some contexts; fall back to getClient().
+type WaitlistVariables = { db?: DatabaseClient };
+
+const app = new Hono<{ Variables: WaitlistVariables }>();
+
+/**
+ * POST /
+ * Captures an email against a source. Idempotent on email: a repeat signup
+ * refreshes source + request metadata to the latest submission.
+ */
+app.post('/', zValidator('json', WaitlistSchema), async (c) => {
+  const body = c.req.valid('json') as WaitlistInput;
+  const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? null;
+  const referrer = c.req.header('referer') ?? c.req.header('referrer') ?? null;
+  const userAgent = c.req.header('user-agent') ?? null;
+
+  // Honeypot trip — silently 200 to deny bots a signal
+  if (body.website !== undefined && body.website.length > 0) {
+    logger.warn('Waitlist honeypot triggered', { ip, source: body.source });
+    return c.json({ success: true }, 200);
+  }
+
+  // email is already trimmed + lowercased by the schema transform.
+  const email = body.email;
+
+  try {
+    const db = c.get('db') ?? getClient();
+    await db
+      .insert(waitlist)
+      .values({
+        email,
+        source: body.source,
+        referrer,
+        userAgent,
+        ipAddress: ip,
+      })
+      .onConflictDoUpdate({
+        target: waitlist.email,
+        set: {
+          source: body.source,
+          referrer,
+          userAgent,
+          ipAddress: ip,
+        },
+      });
+
+    logger.info('Waitlist signup captured', { source: body.source });
+
+    return c.json({ success: true }, 200);
+  } catch (err) {
+    logger.error('Waitlist signup failed', {
+      err: err instanceof Error ? err.message : String(err),
+      source: body.source,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Could not record your signup. Please try again in a few minutes.',
+      },
+      500,
+    );
+  }
+});
+
+export default app;

--- a/docs/AUDIT_STATUS.md
+++ b/docs/AUDIT_STATUS.md
@@ -29,7 +29,7 @@
 
 ## Verification Checks (2026-04-18)
 
-- **Revealcoin keys:** Private key files on disk, never committed to git, gitignored, 0600 permissions. No rotation needed.
+- **Revealcoin keys:** Project CANCELLED 2026-05-29 — keypairs decommissioned via revvault rotate-and-destroy (`_decommissioned/revealcoin-2026-05-29/` namespace). No live custody surface. (Historical posture: private key files on disk, never committed to git, gitignored, 0600 permissions.)
 - **Config secret literal:** Comment/example only (line 87), not runtime code.
 - **RevDev socket:** No chmod 0600 in Rust source. Socket not running. Low priority.
 - **Dependabot PRs:** Zero open.

--- a/docs/CI_CD_GUIDE.md
+++ b/docs/CI_CD_GUIDE.md
@@ -49,7 +49,7 @@ All workflows live in [`.github/workflows/`](../.github/workflows/).
 | [`release.yml`](../.github/workflows/release.yml) | workflow_dispatch | OSS npm publish via OIDC trusted publishing (SLSA Build Level 2 provenance) |
 | [`docker.yml`](../.github/workflows/docker.yml) | workflow_dispatch | Build & push Fleet self-hosted Docker images (`server` + `admin`) to GHCR |
 | [`db-backup.yml`](../.github/workflows/db-backup.yml) | scheduled | NeonDB-side backup hooks (PITR coordination) |
-| [`reconciliation-crons.yml`](../.github/workflows/reconciliation-crons.yml) | scheduled | Stripe + RVC reconciliation jobs |
+| [`reconciliation-crons.yml`](../.github/workflows/reconciliation-crons.yml) | scheduled | Stripe reconciliation jobs (RVC retired 2026-05-29) |
 | [`webhook-reconciliation.yml`](../.github/workflows/webhook-reconciliation.yml) | scheduled | Stripe webhook event-replay safety net |
 | [`regen-visual-snapshots.yml`](../.github/workflows/regen-visual-snapshots.yml) | workflow_dispatch | Regenerate Playwright visual-regression snapshots |
 | [`system-tune-snapshot.yml`](../.github/workflows/system-tune-snapshot.yml) | scheduled | Performance-baseline snapshot |
@@ -65,7 +65,7 @@ The real pipeline is six stages, all defined in [`deploy.yml`](../.github/workfl
 
 1. **`validate`** — install, build `@revealui/db`, run `drizzle-kit generate` to detect uncommitted schema drift; pull Vercel `production` env for the `api` project; run `pnpm validate:prod-env` (mirrors `validateStartup` in [`apps/server/src/lib/validate-startup.ts`](../apps/server/src/lib/validate-startup.ts) — presence + format checks for every required var, including the `sk_test_` / live-mode mismatch trap and the `REVEALUI_CRON_SECRET ≥ 32 chars` rule that closed GAP-125).
 2. **`migrate`** — run `pnpm db:backfill-migrations` (defense against half-applied state), then `pnpm --filter @revealui/db db:migrate` (drizzle-kit), then `pnpm db:assert-migration-count` (post-migrate row-count assertion). Output forced to non-color and tee'd through `tr '\r' '\n'` so drizzle-kit's spinner doesn't eat the trailing error message on failure.
-3. **`detect`** — diff `HEAD~1..HEAD` to compute the affected-app list. Apps known to the matrix: `api`, `admin`, `marketing`, `docs`, `revealcoin`. Shared package or root config change → all apps. Workflow `inputs.apps` allows manual override (`all`, comma-list, or `auto`).
+3. **`detect`** — diff `HEAD~1..HEAD` to compute the affected-app list. Apps known to the matrix: `api`, `admin`, `marketing`, `docs`. Shared package or root config change → all apps. Workflow `inputs.apps` allows manual override (`all`, comma-list, or `auto`). (Pre-2026-05-29 the matrix also included `revealcoin`; removed when the dashboard was retired and the project cancelled.)
 4. **`deploy`** — fan-out matrix; each app pulls its own Vercel project env, builds via `vercel build --prod`, and publishes via `vercel deploy --prebuilt --prod`. Project IDs are hardcoded in the workflow (one per app).
 5. **`smoke-test`** — poll `${API_URL}/health/ready` (12 × 10 s) and `${ADMIN_URL}` for HTTP 200. The api `/health/ready` checks DB + memory + config (see [`apps/server/src/routes/health.ts`](../apps/server/src/routes/health.ts) and [`apps/admin/src/app/api/health/ready/route.ts`](../apps/admin/src/app/api/health/ready/route.ts)).
 6. **`smoke-test` failure path** — auto-rollback. Per-app: `vercel ls --prod` → take 2nd-most-recent ready URL → `vercel rollback <url>` → re-poll `vercel ls` to confirm the alias moved (GAP-128: `vercel rollback` with no URL is a status query, not an action — the URL must be passed). On any rollback failure, the workflow exits non-zero so the broken-deploy-still-live signal surfaces immediately.
@@ -126,7 +126,7 @@ Each app is a separate Vercel project (own project ID, own env scope). Build com
 pnpm vercel-build   # = "cd ../.. && pnpm turbo build --filter=<app>"
 ```
 
-Each app's `vercel-build` script lives in `apps/<app>/package.json`. Output directory is the standard Next.js `.next` (admin) or Vite `dist` (docs / marketing / revealcoin).
+Each app's `vercel-build` script lives in `apps/<app>/package.json`. Output directory is the standard Next.js `.next` (admin) or Vite `dist` (docs / marketing).
 
 ### Standalone output (admin)
 
@@ -141,7 +141,7 @@ vercel inspect <deployment-url>                     # deployment metadata
 vercel rollback <previous-good-url> --token=...     # alias swap (the rollback path used by deploy.yml)
 ```
 
-Hardcoded Vercel project IDs are stored in [`deploy.yml`](../.github/workflows/deploy.yml) (one per app: `api`, `admin`, `marketing`, `docs`, `revealcoin`).
+Hardcoded Vercel project IDs are stored in [`deploy.yml`](../.github/workflows/deploy.yml) (one per app: `api`, `admin`, `marketing`, `docs`).
 
 ---
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -40,7 +40,7 @@ note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (
 - **Infrastructure:** Nix flakes, direnv, Biome 2 (sole linter), Turborepo, pnpm 10
 - **Security:** 7 audit rounds complete. 0 CodeQL alerts, 0 Dependabot alerts, 0 avoidable `any` types, 0 production console statements. AES-256-GCM encryption, bcrypt passwords, RBAC+ABAC, timing-safe TOTP. AST-based code-pattern analyzer (execSync injection, TOCTOU, ReDoS). Pre-push gate runs affected tests on protected branches. SOC2 audit track documented with pentest RFP template.
 - **Entity:** REVEALUI STUDIO L.L.C. (Tennessee, formed 2026-04-28; EIN issued). DE flip deferred until SoloFounders acceptance or first outside raise.
-- **On-chain token:** Token-2022 symbol `RVC` (customer-facing).
+- **On-chain payments:** USDC settlement on Base via x402 (dormant until Stripe live-mode flip). RevealCoin (RVC) was cancelled 2026-05-29; the on-chain Token-2022 artifact at mint `4Ysb1gkz21FD2B9P8P5Pm8bHh4CAMKYU1L528e1MigPo` is dormant and authority keys destroyed. No RVC future-launch is planned.
 
 ### What Works
 
@@ -521,7 +521,7 @@ Phase E  -  Remote access gateway (agent + owner):
 | MCP Marketplace | Phase 5.5 (`packages/mcp`) | Agent/tool discovery, tenant scoping |
 | A2A Discovery | `apps/studio/src/lib/a2a-api.ts` | Cloud agent cards with skills/capabilities |
 | Agent Task Metering | Phase 5.1 (Stripe Billing Meter) | Per-task usage billing |
-| x402 Payments | Phase 5.2 (RevealCoin) | Per-task crypto payment |
+| x402 Payments | Phase 5.2 (USDC on Base) | Per-task crypto payment |
 | SpawnerPanel | `apps/studio/src/components/agent/` | Agent spawn with backend/model/prompt |
 | Harness Adapters | `packages/harnesses/src/adapters/` | Multi-tool agent adapters (stubs) |
 
@@ -552,7 +552,7 @@ Phase D  -  Agent publisher tools (agent):
 - [x] Version management (publish new versions, rollback)  -  version field in schema, draft→published flow  -  2026-04-07
 - [x] Analytics (usage, revenue, error rates)  -  /admin/marketplace/analytics with metrics table  -  2026-04-07
 
-**Exit criteria:** Users can browse agents by skill, submit tasks, and receive results without writing code. Agent publishers can list, price, and monitor their agents. Billing works via both Stripe metering and x402 RevealCoin. Task execution is sandboxed with audit trail.
+**Exit criteria:** Users can browse agents by skill, submit tasks, and receive results without writing code. Agent publishers can list, price, and monitor their agents. Billing works via both Stripe metering and x402 USDC settlement on Base. Task execution is sandboxed with audit trail.
 
 #### 5.17 Hardware-Aware Auto-Config (cross-platform, Fleet-wide)
 

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -1189,32 +1189,6 @@ Creates a Stripe refund for a payment intent or charge. Admin-only. Full or part
 
 ---
 
-### `POST` `/api/v1/billing/rvui-payment`
-
-**Pay for subscription with RevealCoin**
-
-Verifies an on-chain RVC (RevealCoin) payment transaction and activates the subscription tier. Applies the 15% RVC discount. Requires wallet address and transaction signature.
-
-> **Note:** The route path uses the internal project codename (`$RVUI`). The on-chain token symbol is **RVC**.
-
-**Request body** (JSON)
-
-| Field | Type | Required | Description |
-|-------|------|:--------:|-------------|
-| `txSignature` | `string` | ✓ |  |
-| `tier` | `string` | ✓ |  |
-| `walletAddress` | `string` | ✓ |  |
-| `network` | `string` |  -  |  |
-
-**Responses**
-
-- `200`  -  Payment verified and subscription activated
-- `400`  -  Validation failed
-- `401`  -  Authentication required
-- `403`  -  Payment rejected by safeguards
-
----
-
 ### `GET` `/api/v1/billing/metrics`
 
 **Revenue metrics (admin)**

--- a/docs/checklists/stripe-checkout-verification.md
+++ b/docs/checklists/stripe-checkout-verification.md
@@ -171,7 +171,7 @@ Use Stripe test card: `4242 4242 4242 4242` (any future expiry, any CVC).
 | Upgrade | | |
 | Downgrade | | |
 | Webhooks (failure/dispute/refund/trial) | | |
-| RVC disabled | | |
+| ~~RVC disabled~~ (retired 2026-05-29 — RevealCoin cancelled, no longer a gating concern) | n/a | n/a |
 | Edge cases | | |
 
 **All flows verified → checkout mechanics tested in TEST mode.**

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -27,7 +27,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | SVC-004 | docs | Documentation | Vite + React | 3002 | Vercel | Production | Founder | Public | Active |
 | SVC-005 | studio | Desktop Application | Tauri 2 + React 19 | N/A | Local distribution | User device | Founder | Internal | Active |
 | SVC-006 | terminal | CLI Tool | Go (Bubble Tea) | N/A | Local distribution | User device | Founder | Internal | Active |
-| SVC-007 | revealcoin | Token Service | N/A | N/A | TBD | N/A | Founder | Internal | Active |
+| ~~SVC-007~~ | ~~revealcoin~~ | (CANCELLED 2026-05-29 — project ended; repo private+archived; keys destroyed via revvault rotate-and-destroy) | N/A | N/A | N/A | N/A | N/A | N/A | Decommissioned |
 
 ### 2.2 OSS Packages (MIT License)
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -38,7 +38,7 @@ It is a working document. Comprehensive coverage will accrete over multiple sess
 | Application secrets | Database URLs, Stripe keys, OAuth client secrets, webhook signing secrets | Revvault (canonical), Vercel env vars (mirror) |
 | Audit trail | Append-only tamper-evident log of agent and admin actions | NeonDB `audit_log` table, HMAC chain |
 | Content | User-published content under their RevealUI-powered site | NeonDB `content_*` tables |
-| RevealCoin (RVC) keypairs | Mint authority, treasury, vesting wallets | Revvault `revealcoin/*` paths (encrypted) |
+| ~~RevealCoin (RVC) keypairs~~ | Project cancelled 2026-05-29; keypairs rotated-and-destroyed via revvault `_decommissioned/revealcoin-2026-05-29/` namespace. No live custody. | (decommissioned) |
 | npm packages | OSS + Pro packages published under `@revealui/*` | npm registry; build artifacts in GitHub Actions |
 | Source code | The monorepo itself | GitHub `RevealUIStudio/revealui`, branch protection on `main` and `test` |
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -148,7 +148,7 @@ pnpm mcp:next-devtools
 ### 8. Contracts Introspection
 **Status:** ✅ Active (no API key required, **not** Pro-license-gated)
 
-Phase 1 of the protocol-pyramid ADR ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](../../docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Exposes every `@revealui/contracts` category (representation, entities, content, admin, agents, security, secrets, a2a, api-auth, api-chat, api-gdpr, content-validation, devkit-profiles, generated, providers, revealcoin, stripe-webhook-events) as MCP **resources** (read-only JSON Schemas of every category schema) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
+Phase 1 of the protocol-pyramid ADR ([`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](../../docs/decisions/2026-05-03-contracts-protocol-pyramid.md)). Exposes every `@revealui/contracts` category (representation, entities, content, admin, agents, security, secrets, a2a, api-auth, api-chat, api-gdpr, content-validation, devkit-profiles, generated, providers, stripe-webhook-events) as MCP **resources** (read-only JSON Schemas of every category schema) and matching MCP **tools** that parse arbitrary JSON against any registered schema.
 
 - **Resources:** `revealui-contracts://catalog` (full discovery payload) + `revealui-contracts://<category>` (one per category, returns all schemas).
 - **Tools:** `contracts_list_categories`, `contracts_get_schema`, plus one `contracts_validate_<category>` per category.


### PR DESCRIPTION
## Summary

Promote `test` → `main`. Single commit: the **source-tagged waitlist endpoint** (#1160) that fixes a production bug.

## Why this is a production bugfix

The operator lane is already live on revealui.com. But the email-capture backend it (and the newsletter forms) depend on never existed:

- `/api/newsletter` was never mounted → all newsletter signups + the Phase 5 `/for-operators/managed` waitlist have been **404ing in production**.
- The `waitlist` table existed but had no serving route.

#1160 ships `POST /api/waitlist` (source-tagged, backed by the existing table), repoints `submitNewsletter` through it, and points the Cloud waitlist at `source: 'managed-cloud'`. Promoting this repairs the broken forms in production.

## Scope

One commit (#1160):
- New `apps/server/src/routes/waitlist.ts` + 7 passing unit tests
- `apps/server/src/index.ts` route mount + rate limit
- `apps/marketing/app/lib/api.ts` — `submitWaitlist` + `submitNewsletter` repoint
- Phase 5 waitlist component + copy

No schema migration, no contracts regen.

## Verification (on #1160, pre-merge to test)

Every check green: 15 SUCCESS (Quality, Typecheck, Unit Tests, Integration Tests, Integration Tests extended, Build, CodeQL, Security Gate, Drizzle Migrations, gitleaks ×2, Dependency Review, Submodule Audit, CI Feedback), 4 SKIPPED (path-conditional E2E suites — not applicable), 0 FAILURE.

## Merge style

Merge commit (preserves the #1160 commit on main), matching past promotions.

## Deploys on merge

Push to `main` triggers `deploy.yml` → production. After merge, newsletter + Cloud-waitlist capture work on revealui.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
