### PR TITLE
fix(core,server): use heap_size_limit for memory health/alert checks

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ if (process.env.SENTRY_DSN) {
 }
 
 import { readFileSync } from 'node:fs';
+import { getHeapStatistics } from 'node:v8';
 import { serve } from '@hono/node-server';
 import { initializeLicense } from '@revealui/core/license';
 import {
@@ -1224,7 +1225,7 @@ export function initAlerting(): void {
   alerting.registerRule(
     createMemoryUsageAlert(() => {
       const mem = process.memoryUsage();
-      return Math.round((mem.heapUsed / mem.heapTotal) * 100);
+      return Math.round((mem.heapUsed / getHeapStatistics().heap_size_limit) * 100);
     }, 85),
   );
 

--- a/packages/core/src/__tests__/observability/health-check.test.ts
+++ b/packages/core/src/__tests__/observability/health-check.test.ts
@@ -18,6 +18,7 @@ vi.mock('node:util', () => ({
 }));
 
 import { execFile } from 'node:child_process';
+import { getHeapStatistics } from 'node:v8';
 import {
   createAPIHealthCheck,
   createCustomHealthCheck,
@@ -320,10 +321,10 @@ describe('createMemoryHealthCheck', () => {
   });
 
   it('returns degraded when memory exceeds 80% of threshold', async () => {
-    // This is tricky since we can't control actual memory usage
-    // Use a threshold that is above actual usage but whose 80% is below
+    // Mirror the source denominator (heap_size_limit, not heapTotal) when
+    // choosing a threshold that lands actual usage in the "high" (degraded) band.
     const usage = process.memoryUsage();
-    const usedPercent = (usage.heapUsed / usage.heapTotal) * 100;
+    const usedPercent = (usage.heapUsed / getHeapStatistics().heap_size_limit) * 100;
 
     // Pick a threshold where usedPercent > threshold * 0.8 but usedPercent <= threshold
     const threshold = usedPercent + 1;

--- a/packages/core/src/observability/health-check.ts
+++ b/packages/core/src/observability/health-check.ts
@@ -6,6 +6,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { getHeapStatistics } from 'node:v8';
 import { logger } from './logger.js';
 
 const execFileAsync = promisify(execFile);
@@ -190,7 +191,12 @@ export function createMemoryHealthCheck(thresholdPercent: number = 90): HealthCh
       }
 
       const usage = process.memoryUsage();
-      const usedPercent = (usage.heapUsed / usage.heapTotal) * 100;
+      // heapTotal is V8's currently-committed heap, not the ceiling — it sits
+      // just above heapUsed and grows on demand toward heap_size_limit
+      // (--max-old-space-size), so heapUsed/heapTotal reads ~90%+ during normal
+      // operation. heap_size_limit is the real OOM-proximity denominator.
+      const heapLimit = getHeapStatistics().heap_size_limit;
+      const usedPercent = (usage.heapUsed / heapLimit) * 100;
 
       let status: HealthStatus = 'healthy';
       let message = 'Memory usage normal';
@@ -209,6 +215,7 @@ export function createMemoryHealthCheck(thresholdPercent: number = 90): HealthCh
         details: {
           heapUsed: usage.heapUsed,
           heapTotal: usage.heapTotal,
+          heapLimit,
           usedPercent: usedPercent.toFixed(2),
           external: usage.external,
           rss: usage.rss,


### PR DESCRIPTION
## Summary

`/health/ready` has been returning `status: degraded` in production (HTTP 200, memory check `unhealthy`) — re-verified still reproducing 2026-05-29 (8/8 probes degraded; see #951 for the full trace).

**Root cause:** the memory health check computed `heapUsed / heapTotal`. `heapTotal` is V8's *currently-committed* heap, not the ceiling — it tracks just above `heapUsed` and grows on demand toward `heap_size_limit` (`--max-old-space-size`). So the ratio sits at ~90%+ during normal operation and trips the 90% threshold. Live proof: `heapTotal` ~96 MB while `rss` ~229 MB — no actual memory pressure. False-positive degradation (the `createMemoryUsageAlert` rule at threshold 85 had the same flaw).

## Changes

- **`packages/core/src/observability/health-check.ts`** — `createMemoryHealthCheck` divides by `v8.getHeapStatistics().heap_size_limit` (the real OOM-proximity ceiling) instead of `heapTotal`. `heapLimit` added to reported `details` for transparency; `heapTotal` retained.
- **`apps/server/src/index.ts`** — the `createMemoryUsageAlert` rule uses the same `heap_size_limit` denominator.
- **`packages/core/src/__tests__/observability/health-check.test.ts`** — the degraded-band test mirrors the new denominator.

## Verification

- `@revealui/core` unit tests: **43/43 pass** (`health-check.test.ts`).
- `@revealui/core` typecheck: clean (`tsc --noEmit`).
- Biome: clean on all 3 changed files.
- Pre-push quality gate: **PASS** (all checks green).

Closes #951
