### PR TITLE
fix(server): validate STRIPE_WEBHOOK_SECRET_LIVE format at boot

### DIFF
--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -143,6 +143,21 @@ describe('validateStartup — production format checks (live mode)', () => {
     );
   });
 
+  it('rejects STRIPE_WEBHOOK_SECRET_LIVE without whsec_ prefix when set', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ STRIPE_WEBHOOK_SECRET_LIVE: 'not-a-secret' })),
+    ).toThrow('STRIPE_WEBHOOK_SECRET_LIVE');
+  });
+
+  it('accepts a valid or unset STRIPE_WEBHOOK_SECRET_LIVE', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ STRIPE_WEBHOOK_SECRET_LIVE: 'whsec_livedeadbeef' })),
+    ).not.toThrow();
+    expect(() =>
+      validateStartup(validLiveProdEnv({ STRIPE_WEBHOOK_SECRET_LIVE: '' })),
+    ).not.toThrow();
+  });
+
   it('rejects non-HTTPS REVEALUI_PUBLIC_SERVER_URL', () => {
     expect(() =>
       validateStartup(

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -321,6 +321,18 @@ export function validateStartup(
       errors.push('STRIPE_WEBHOOK_SECRET must start with "whsec_" in production.');
     }
 
+    // Live-mode webhook signing secret. The webhook handler PREFERS this over
+    // STRIPE_WEBHOOK_SECRET when set, so a malformed value boots clean and then
+    // silently 400s every live webhook (no boot signal — the alert path is
+    // post-verification). Validate format when set; empty = handler falls back
+    // to STRIPE_WEBHOOK_SECRET, so this is not required.
+    const liveWebhookSecret = (env.STRIPE_WEBHOOK_SECRET_LIVE ?? '').trim();
+    if (liveWebhookSecret && !liveWebhookSecret.startsWith('whsec_')) {
+      errors.push(
+        'STRIPE_WEBHOOK_SECRET_LIVE must start with "whsec_" when set (preferred by the webhook handler in live mode).',
+      );
+    }
+
     // Optional dual-secret rotation transition (GAP-144). Only validated when
     // present — empty/unset is the steady state. When set, must be a valid
     // whsec_ secret since the webhook handler will use it as a fallback verifier.


### PR DESCRIPTION
## What

Add boot-time format validation for `STRIPE_WEBHOOK_SECRET_LIVE` in `validateStartup`.

## Why

The webhook handler **prefers** `STRIPE_WEBHOOK_SECRET_LIVE` over `STRIPE_WEBHOOK_SECRET` when it's set. But startup validation only checked `STRIPE_WEBHOOK_SECRET` and `STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS` — not `_LIVE` itself. So a corrupted/mistyped `_LIVE` value boots clean and then **silently 400s every live webhook**, with no boot signal and no alert (the alert path runs only after signature verification succeeds). A quiet readiness gap on the live-payments path.

## Fix

Mirror the existing optional-secret guard (`STRIPE_WEBHOOK_SECRET_LIVE_PREVIOUS`): when `STRIPE_WEBHOOK_SECRET_LIVE` is set it must start with `whsec_`; empty/unset is fine (the handler falls back to `STRIPE_WEBHOOK_SECRET`, so it is not required).

## Tests

Added two cases to `validate-startup.test.ts`:
- malformed `_LIVE` when set → rejected,
- valid `_LIVE` and unset `_LIVE` → accepted.

(String-match assertion, no authored regex.)

## Verification note

Logic verified by inspection against the proven `_PREVIOUS` guard and the existing `STRIPE_WEBHOOK_SECRET` test. The new test executes in CI (the full gate runs typecheck + vitest + build); I did not run it locally because the isolated worktree has no `node_modules` and a full install was avoided on a RAM-constrained machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
