### PR TITLE
feat(mcp): add revealui-docs MCP server (first-party dependency intelligence)

### DIFF
--- a/.changeset/revealui-docs-server.md
+++ b/.changeset/revealui-docs-server.md
@@ -1,0 +1,5 @@
+---
+"@revealui/mcp": minor
+---
+
+Add the `revealui-docs` MCP server — first-party dependency intelligence. Resolves `@revealui/*` library names and serves curated docs (README + package metadata + public export subpaths) from the monorepo, exported via `@revealui/mcp/docs-server` with a stdio launcher at `servers/docs.ts`. Phase 1 covers first-party packages only; npm/third-party source via `opensrc` is a later phase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ RevealUI is the agentic business runtime. Users, content, products, payments, an
 
 ## MCP Servers
 
-13 MCP servers ship with RevealUI — ground-truth count from `packages/mcp/src/servers/`, enforced by `pnpm validate:claims`:
+14 MCP servers ship with RevealUI — ground-truth count from `packages/mcp/src/servers/`, enforced by `pnpm validate:claims`:
 
 **External integrations:** Stripe, Supabase, Neon, Vercel, Playwright
 **Developer tools:** Code Validator, Next.js DevTools, Vultr Test

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You have:
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
 - **59 UI components:** built with Tailwind CSS v4, zero external UI dependencies
-- **13 MCP servers:** agents discover and use your business data through the same API humans use
+- **14 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
 No assembly required. Define your data once. Humans manage it through the dashboard, agents operate on it through MCP. Same permissions, same audit trail.
@@ -49,7 +49,7 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 | **Content**      | Collections, rich text (Lexical), media, draft/live, REST API    | Collections auto-exposed as MCP tools. No integration step.  |
 | **Products**     | Product catalog, pricing tiers, usage tracking                   | Feature gates control which agent capabilities unlock.       |
 | **Payments**     | Stripe checkout, subscriptions, webhooks, billing portal         | Same Stripe primitives, available to agents.                 |
-| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 13 MCP servers.                   |
+| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 14 MCP servers.                   |
 
 ## Open-model first
 

--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -8,7 +8,7 @@ RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on to
 |---------|---------|-------------|
 | [`@revealui/ai`](/pro/ai) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | AI agents, open-model inference, CRDT memory, A2A protocol |
 | [`@revealui/harnesses`](https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | Harness adapters, workboard coordination |
-| [`@revealui/mcp`](/pro/mcp) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | MCP hypervisor, adapter framework, 13 first-party server launchers |
+| [`@revealui/mcp`](/pro/mcp) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | MCP hypervisor, adapter framework, 14 first-party server launchers |
 | [`@revealui/services`](https://github.com/RevealUIStudio/revealui/tree/main/packages/services) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | Stripe, Solana (RVC), and Vercel integrations |
 | [Open-Model Inference](/pro/inference) | — | Default Ollama; Inference Snaps planned; Groq / HuggingFace / OpenAI-compatible opt-in |
 | [Editor Config Sync](/pro/editors) | — | Ships in the separate **RevCon** repo (not in this monorepo); not gated by Pro |

--- a/apps/docs/public/docs-pro/mcp/index.md
+++ b/apps/docs/public/docs-pro/mcp/index.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) servers for RevealUI. Connect your AI agents to Str
 
 ## Overview
 
-`@revealui/mcp` ships **13 first-party MCP server launchers** under `packages/mcp/src/servers/`. The full list lives in the source; a representative sample:
+`@revealui/mcp` ships **14 first-party MCP server launchers** under `packages/mcp/src/servers/`. The full list lives in the source; a representative sample:
 
 | Server | Launcher | Tools provided |
 |--------|----------|---------------|

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -35,7 +35,7 @@ export const METRICS = {
    * utilities). Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon concrete
    * adapter subclasses). Source: claim-drift countMCPServers.
    */
-  mcpServers: 13,
+  mcpServers: 14,
   /** Drizzle pgTable declarations across packages/db/src/schema/. Source: claim-drift countDbTables. */
   dbTables: 85,
   /** License split. Source: claim-drift licenseSplit. */

--- a/apps/server/src/lib/mcp-manifest.ts
+++ b/apps/server/src/lib/mcp-manifest.ts
@@ -9,7 +9,7 @@
  * affordances") at the discovery layer; complement to the /llms.txt prose
  * layer (revealui#720) and the existing /.well-known/agent.json A2A layer.
  *
- * Source of truth: `packages/mcp/README.md` ("13 MCP Servers" — enforced
+ * Source of truth: `packages/mcp/README.md` ("14 MCP Servers" — enforced
  * by `pnpm validate:claims`). This manifest mirrors that list 1:1 and
  * MUST be updated alongside any addition or removal in
  * `packages/mcp/src/servers/`.
@@ -83,6 +83,18 @@ export const MCP_SERVERS: readonly McpServerEntry[] = [
     category: 'introspection',
     transport: 'stdio',
     modulePath: '@revealui/mcp/dist/servers/contracts.js',
+    license: 'FSL-1.1-MIT',
+    proGated: false,
+    requiresCredentials: false,
+  },
+  {
+    id: 'docs',
+    name: 'RevealUI Docs',
+    description:
+      'First-party dependency intelligence — resolve @revealui/* package names and return curated docs (README + package metadata + export subpaths) from the monorepo. Public — not Pro-gated.',
+    category: 'introspection',
+    transport: 'stdio',
+    modulePath: '@revealui/mcp/dist/servers/docs.js',
     license: 'FSL-1.1-MIT',
     proGated: false,
     requiresCredentials: false,

--- a/apps/server/src/routes/__tests__/a2a.test.ts
+++ b/apps/server/src/routes/__tests__/a2a.test.ts
@@ -320,11 +320,11 @@ describe('GET /.well-known/mcp.json', () => {
     expect(Array.isArray(body.servers)).toBe(true);
   });
 
-  it('lists exactly 13 MCP servers (matches packages/mcp/README.md ground truth)', async () => {
+  it('lists exactly 14 MCP servers (matches packages/mcp/README.md ground truth)', async () => {
     const app = makeWellKnownApp();
     const res = await app.request(get('/mcp.json'));
     const body = (await res.json()) as { servers: unknown[] };
-    expect(body.servers).toHaveLength(13);
+    expect(body.servers).toHaveLength(14);
   });
 
   it('serves the manifest as public — no auth, no Pro license required', async () => {

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -94,7 +94,7 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 | Dashboard Agent Chat | **Shipped** | Live at admin.revealui.com. |
 | Documentation Site | **Shipped** | docs.revealui.com. |
 | x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant. "Designed; gated on Stripe live." |
-| MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (13 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
+| MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (14 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
 | Perpetual Licenses (Track C) | **Planned** | `comingSoon: true` in contracts. |
 | Self-Hosted Docker Images (RevealUI Fleet) | **Planned** | Designed, not built. |
 | Visual Builder | **Planned** | Backlog. |
@@ -148,7 +148,7 @@ Canonical defaults (when "open-model AI" is mentioned in marketing): Gemma 4, Ph
 Five testable rules — Phase 5 audits every page against these:
 
 1. **Lead with what ships today.** Every page's first sentence under H1 names a capability with a verifiable artifact.
-2. **Specifics over adjectives.** "Fast" → "13 first-party MCP servers." "Secure" → "Ed25519-signed license JWTs."
+2. **Specifics over adjectives.** "Fast" → "14 first-party MCP servers." "Secure" → "Ed25519-signed license JWTs."
 3. **Identify the reader by their stack, not job title.**
 4. **Surface the trade-off, don't bury it.** "Three yeses and one no" pattern.
 5. **No marketing-speak, no emojis, no exclamation points.** Banned adjective table in `voice-and-headline-rules.md` §1.

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -28,7 +28,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-05-18 (
 | Workspaces (monorepo total) | **30** | `countWorkspaces()` (= 26 packages + 4 apps) | |
 | Test files | **912** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **59** | `countUIComponents()` | Marketing copy says "59 native React components" or similar. |
-| **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
+| **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |
 | License: MIT packages | **20** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -120,7 +120,7 @@ For full decision context: [ADR-003: Fair Source Licensing](./architecture/ADR-0
 
 ## MCP Setup
 
-RevealUI ships **13 MCP servers** under `packages/mcp/src/servers/` for enhanced AI capabilities. Highlights:
+RevealUI ships **14 MCP servers** under `packages/mcp/src/servers/` for enhanced AI capabilities. Highlights:
 
 - **Code Validator MCP** - Static analysis and code quality checks
 - **Vercel MCP** - Deploy and manage Vercel projects

--- a/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
+++ b/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
@@ -137,7 +137,7 @@ Note: `npx create-revealui` scaffolds a working basic-blog from npm templates  -
 | Package | Docs claim | Actual state | Completeness |
 |---------|-----------|--------------|-------------|
 | `@revealui/ai` | AI agents, memory, LLM orchestration | 40+ files, 18 import subpaths, real agents | ~80% |
-| `@revealui/mcp` | 13 MCP servers | **13 server files** (plus adapters/utils) | ~90% |
+| `@revealui/mcp` | 14 MCP servers | **14 server files** (plus adapters/utils) | ~90% |
 | `@revealui/harnesses` | AI coordination, workboard | 196 tests, JSON-RPC 2.0, content layer | ~95% |
 | `@revealui/services` | Stripe + Supabase integrations | 354 tests passing | ~85% |
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -229,7 +229,7 @@ Some numbers on what's actually shipped:
 - **30 workspaces** across the monorepo (4 apps + 26 packages — 20 MIT, 5 Fair Source, 1 internal)
 - **85 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **59 UI components** in `@revealui/presentation` (80 counting the admin engine) — zero external UI dependencies, just Tailwind v4, clsx, and CVA
-- **13 first-party MCP servers** in `@revealui/mcp`
+- **14 first-party MCP servers** in `@revealui/mcp`
 - **Extensive test coverage** across unit, integration, and E2E layers (run `pnpm test` for the current count)
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -126,7 +126,7 @@ Running locally doesn't mean running poorly. The RevealUI agent stack has the sa
 
 - **Planning and tools**  -  agents can create todos, read and write files, execute shell commands
 - **Memory**  -  episodic memory, working memory, CRDT-based persistence across sessions
-- **MCP integrations**  -  13 first-party MCP servers (Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, Next.js DevTools, plus RevealUI-internal Content / Email / Memory / Stripe servers, the contracts introspection server, and the adapter base class)
+- **MCP integrations**  -  14 first-party MCP servers (Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, Next.js DevTools, plus RevealUI-internal Content / Email / Memory / Stripe / Docs servers, the contracts introspection server, and the adapter base class)
 - **Orchestration**  -  multi-agent coordination, sub-agent spawning, streaming
 
 What you do give up: the raw capability of a 70B+ cloud model. Smaller local models like Gemma 4 are excellent for structured tasks  -  code generation, data processing, form filling, API orchestration  -  but won't match a frontier model on open-ended reasoning. For most business automation use cases, that's an acceptable trade.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -442,7 +442,7 @@ Memory operations use CRDTs (Conflict-free Replicated Data Types) for conflict r
 
 ### MCP servers
 
-RevealUI ships **13 first-party MCP (Model Context Protocol) servers** in `@revealui/mcp` (Fair Source, FSL-1.1-MIT — source-visible, converts to MIT two years after release). The most commonly used:
+RevealUI ships **14 first-party MCP (Model Context Protocol) servers** in `@revealui/mcp` (Fair Source, FSL-1.1-MIT — source-visible, converts to MIT two years after release). The most commonly used:
 
 | Server | Purpose |
 |--------|---------|

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -4,7 +4,7 @@ RevealUI is open source today; the commercial side is pre-launch. Before we talk
 
 This is a solo-founder project. I don't have a VC board to answer to or a growth team optimizing conversion funnels. I have a business model I believe in, and I'd rather explain it plainly than have you discover the trade-offs later.
 
-> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **x402 agent payments** — are **planned, not shipped**. The first-party MCP catalog (13 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
+> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **x402 agent payments** — are **planned, not shipped**. The first-party MCP catalog (14 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
 
 ---
 
@@ -20,7 +20,7 @@ I understand that risk. I accept it. Here's why.
 
 RevealUI is an open runtime for AI-native businesses. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
-The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 13 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
+The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 14 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
 What MIT means practically: you can take RevealUI, strip the branding, deploy it on your own infrastructure, and run your entire business on it without ever creating an account with us. You don't owe us attribution, revenue share, or even a thank-you. The code is yours.
 
@@ -39,7 +39,7 @@ RevealUI Pro includes:
 - **LLM orchestration** -- open-model inference via Ubuntu Inference Snaps and Ollama
 - **Editor integrations** -- daemon adapters for Zed, VS Code, and Neovim
 - **Harness coordination** -- workboard-based agent orchestration, JSON-RPC communication, daemon management
-- **MCP framework** -- the hypervisor, 13 first-party servers, and the adapter base class that connect agents to tools
+- **MCP framework** -- the hypervisor, 14 first-party servers, and the adapter base class that connect agents to tools
 
 These features are commercially licensed. The source code is available (you can read the compiled output on npm), but the license restricts redistribution and commercial use without a key.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -4,7 +4,7 @@
 
 ---
 
-> **Status note (updated 2026-05-18):** This post discusses the **agent-first future** RevealUI is building toward. Specifically: x402 micropayments (USDC on Base) and the per-call MCP server marketplace are **designed but not transactable today**. The x402 endpoints are code-complete behind `X402_ENABLED=false`; the marketplace ships its first-party catalog (13 MCP servers) but third-party publishing, payment proxying, and per-call billing are unbuilt. The Agent Card endpoint (`/.well-known/agent.json`) ships today; `payment-methods.json` ships with an `X402_ENABLED=false` empty-payments shape. See [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status of every system mentioned below.
+> **Status note (updated 2026-05-18):** This post discusses the **agent-first future** RevealUI is building toward. Specifically: x402 micropayments (USDC on Base) and the per-call MCP server marketplace are **designed but not transactable today**. The x402 endpoints are code-complete behind `X402_ENABLED=false`; the marketplace ships its first-party catalog (14 MCP servers) but third-party publishing, payment proxying, and per-call billing are unbuilt. The Agent Card endpoint (`/.well-known/agent.json`) ships today; `payment-methods.json` ships with an `X402_ENABLED=false` empty-payments shape. See [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status of every system mentioned below.
 
 ---
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -112,7 +112,7 @@ Four protocols converge to create the agent-first web. Each solves a different p
 | Protocol | Created by | Governed by | Purpose | RevealUI implementation |
 |---|---|---|---|---|
 | **A2A** (Agent-to-Agent) | Google | Linux Foundation (Agentic AI Foundation) | Agents discover and delegate work to other agents | Full A2A 1.0: Agent Cards, JSON-RPC task lifecycle (`tasks/send`, `tasks/get`, `tasks/cancel`), SSE streaming |
-| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 13 first-party MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, plus the RevealUI-internal Content / Email / Memory / Stripe servers, the contracts introspection server, and the adapter base class |
+| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 14 first-party MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, plus the RevealUI-internal Content / Email / Memory / Stripe / Docs servers, the contracts introspection server, and the adapter base class |
 | **x402** (HTTP 402 Payment Required) | Coinbase | Open standard | Internet-native micropayments for machine-to-machine commerce | Per-call USDC payments on Base, Coinbase facilitator verification, marketplace payment proxy |
 | **OpenAPI** | OpenAPI Initiative | Linux Foundation | Machine-readable API descriptions | Auto-generated from Hono route definitions with Zod schemas |
 
@@ -157,7 +157,7 @@ Agents use the host's configured inference path. The `createLLMClientFromEnv()` 
 
 The Model Context Protocol (MCP) defines how agents invoke tools. Where A2A is about agent-to-agent communication, MCP is about agent-to-tool communication. An MCP server exposes a set of tools -- functions that an agent can call with structured inputs and get structured outputs.
 
-RevealUI ships with 13 first-party MCP servers (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). The seven that cover the core infrastructure stack:
+RevealUI ships with 14 first-party MCP servers (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). The seven that cover the core infrastructure stack:
 
 - **Stripe** -- Create checkout sessions, manage subscriptions, query payment history
 - **Supabase** -- Vector storage, real-time auth, embedding operations

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -611,7 +611,7 @@ export REVEALUI_LICENSE_KEY=<your-pro-license-key>
 
 ### Connect MCP servers
 
-RevealUI ships with 13 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
+RevealUI ships with 14 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
 
 ### Add more collections
 

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -611,7 +611,7 @@ export REVEALUI_LICENSE_KEY=<your-pro-license-key>
 
 ### Connect MCP servers
 
-RevealUI ships with 14 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
+RevealUI ships with 14 first-party MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
 
 ### Add more collections
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@ Centralized MCP server infrastructure, configuration, and documentation for Reve
 
 This package contains everything MCP-related:
 
-- **13 MCP Servers** — Code Validator, Contracts Introspection, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
+- **14 MCP Servers** — Code Validator, Contracts Introspection, RevealUI Docs, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
 - **Configuration Templates** - For Claude Code / Claude Desktop
 - **Utilities** - Config management, database adapters
 - **Documentation** - Complete guides and per-server docs

--- a/packages/mcp/docs/README.md
+++ b/packages/mcp/docs/README.md
@@ -21,7 +21,7 @@ Complete guide for setting up and using Model Context Protocol (MCP) servers in 
 
 ## Overview
 
-RevealUI includes 13 MCP servers for enhanced AI capabilities (ground-truth count enforced by `pnpm validate:claims`):
+RevealUI includes 14 MCP servers for enhanced AI capabilities (ground-truth count enforced by `pnpm validate:claims`):
 
 - **Code Validator MCP** — Static analysis and code quality checks
 - **Contracts Introspection MCP** — Read-only catalog of every `@revealui/contracts` category as MCP resources + per-category `validate_*` tools (F8 Phase 1 of the protocol-pyramid ADR; not Pro-gated)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -59,6 +59,10 @@
       "types": "./dist/servers/factories/contracts.d.ts",
       "import": "./dist/servers/factories/contracts.js"
     },
+    "./docs-server": {
+      "types": "./dist/servers/factories/docs.d.ts",
+      "import": "./dist/servers/factories/docs.js"
+    },
     "./hypervisor": {
       "types": "./dist/hypervisor.d.ts",
       "import": "./dist/hypervisor.js"

--- a/packages/mcp/src/__tests__/docs-server.test.ts
+++ b/packages/mcp/src/__tests__/docs-server.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  createDocsServer,
+  enumeratePackages,
+  getLibraryDoc,
+  listLibraries,
+  resolveLibrary,
+} from '../servers/factories/docs.js';
+
+let root: string;
+
+beforeAll(() => {
+  // Build a fake monorepo fixture: two first-party packages (one with a
+  // README, one without) plus a third-party package that must be excluded.
+  root = mkdtempSync(join(tmpdir(), 'revealui-docs-test-'));
+  const pkgs = join(root, 'packages');
+
+  const router = join(pkgs, 'router');
+  mkdirSync(router, { recursive: true });
+  writeFileSync(
+    join(router, 'package.json'),
+    JSON.stringify({
+      name: '@revealui/router',
+      version: '0.3.9',
+      description: 'File-based router',
+      license: 'MIT',
+      homepage: 'https://revealui.com',
+      exports: { '.': {}, './server': {} },
+    }),
+  );
+  writeFileSync(join(router, 'README.md'), '# @revealui/router\n\nRouting docs.');
+
+  const core = join(pkgs, 'core');
+  mkdirSync(core, { recursive: true });
+  writeFileSync(
+    join(core, 'package.json'),
+    JSON.stringify({
+      name: '@revealui/core',
+      version: '1.0.0',
+      description: 'Core engine',
+      license: 'MIT',
+    }),
+  );
+
+  const vendor = join(pkgs, 'vendor-thing');
+  mkdirSync(vendor, { recursive: true });
+  writeFileSync(
+    join(vendor, 'package.json'),
+    JSON.stringify({ name: 'some-vendor-lib', version: '2.0.0' }),
+  );
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('enumeratePackages', () => {
+  it('includes @revealui/* and excludes third-party', () => {
+    const m = enumeratePackages(root);
+    expect(m.has('@revealui/router')).toBe(true);
+    expect(m.has('@revealui/core')).toBe(true);
+    expect([...m.keys()]).not.toContain('some-vendor-lib');
+  });
+
+  it('parses exports subpaths, defaulting to "."', () => {
+    const m = enumeratePackages(root);
+    expect(m.get('@revealui/router')?.exports).toEqual(['.', './server']);
+    expect(m.get('@revealui/core')?.exports).toEqual(['.']);
+  });
+
+  it('returns an empty map for a root without packages/', () => {
+    expect(enumeratePackages(join(root, 'does-not-exist')).size).toBe(0);
+  });
+});
+
+describe('resolveLibrary', () => {
+  it('resolves short id, canonical name, and is case-insensitive', () => {
+    const m = enumeratePackages(root);
+    expect(resolveLibrary(m, 'router').id).toBe('@revealui/router');
+    expect(resolveLibrary(m, '@revealui/router').id).toBe('@revealui/router');
+    expect(resolveLibrary(m, 'ROUTER').id).toBe('@revealui/router');
+  });
+
+  it('does not resolve a bare third-party name and hints opensrc', () => {
+    const m = enumeratePackages(root);
+    const r = resolveLibrary(m, 'hono');
+    expect(r.resolved).toBe(false);
+    expect(r.hint).toContain('opensrc');
+  });
+
+  it('flags scoped third-party packages as out of scope', () => {
+    const m = enumeratePackages(root);
+    expect(resolveLibrary(m, '@hono/node-server').resolved).toBe(false);
+  });
+});
+
+describe('getLibraryDoc', () => {
+  it('returns README + metadata when a README exists', () => {
+    const m = enumeratePackages(root);
+    const doc = getLibraryDoc(m, 'router');
+    expect(doc?.name).toBe('@revealui/router');
+    expect(doc?.version).toBe('0.3.9');
+    expect(doc?.readme).toContain('Routing docs');
+    expect(doc?.exports).toEqual(['.', './server']);
+  });
+
+  it('returns null readme when the package has no README', () => {
+    const m = enumeratePackages(root);
+    const doc = getLibraryDoc(m, 'core');
+    expect(doc?.name).toBe('@revealui/core');
+    expect(doc?.readme).toBeNull();
+  });
+
+  it('returns null for an unknown id', () => {
+    const m = enumeratePackages(root);
+    expect(getLibraryDoc(m, 'nope')).toBeNull();
+  });
+});
+
+describe('listLibraries', () => {
+  it('lists first-party packages sorted by name', () => {
+    const m = enumeratePackages(root);
+    expect(listLibraries(m).map((l) => l.name)).toEqual(['@revealui/core', '@revealui/router']);
+  });
+});
+
+describe('createDocsServer', () => {
+  it('constructs a Server instance', () => {
+    expect(createDocsServer({ root, serverName: 'revealui-docs-test' })).toBeDefined();
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -173,6 +173,18 @@ export {
   REGISTERED_CATEGORIES,
   validatePayload,
 } from './servers/factories/contracts.js';
+// Docs server (dependency intelligence — first-party @revealui/* package docs)
+export {
+  type CreateDocsServerOptions,
+  createDocsServer,
+  enumeratePackages,
+  getLibraryDoc,
+  type LibraryDoc,
+  listLibraries,
+  type PackageEntry,
+  type ResolveResult,
+  resolveLibrary,
+} from './servers/factories/docs.js';
 // First-party server factories (Stage 1 PR-1.2 — dual-mode template)
 export {
   createRevealuiContentServer,

--- a/packages/mcp/src/servers/docs.ts
+++ b/packages/mcp/src/servers/docs.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * RevealUI Docs MCP Server — stdio launcher.
+ *
+ * Thin wrapper around `createDocsServer()` (see `./factories/docs.ts` for the
+ * full surface). Resolves the monorepo root so the server can read first-party
+ * `@revealui/*` packages, then speaks stdio-MCP — the canonical deployment for
+ * Claude Code / custom-agent integration and the hypervisor's spawn pipeline.
+ *
+ * Root resolution order:
+ *   1. `REVEALUI_ROOT` env var (when it contains a `pnpm-workspace.yaml`).
+ *   2. Walk up from `process.cwd()` to the first dir with `pnpm-workspace.yaml`.
+ *   3. Fall back to `process.cwd()` (the server then enumerates zero packages).
+ *
+ * **Not** Pro-license-gated — see the factory header for the rationale.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { logger } from '@revealui/core/observability/logger';
+import { createDocsServer } from './factories/docs.js';
+
+function resolveMonorepoRoot(): string {
+  const fromEnv = process.env.REVEALUI_ROOT;
+  if (fromEnv && existsSync(join(fromEnv, 'pnpm-workspace.yaml'))) return fromEnv;
+
+  let dir = process.cwd();
+  for (let depth = 0; depth < 64; depth += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd();
+}
+
+async function main(): Promise<void> {
+  const server = createDocsServer({ root: resolveMonorepoRoot() });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  logger.error('RevealUI Docs MCP error', err instanceof Error ? err : new Error(String(err)));
+  process.exit(1);
+});

--- a/packages/mcp/src/servers/factories/docs.ts
+++ b/packages/mcp/src/servers/factories/docs.ts
@@ -1,0 +1,429 @@
+/**
+ * Factory for the `revealui-docs` MCP server — first-party dependency
+ * intelligence.
+ *
+ * This is the RevealUI-native answer to external "library docs" MCP servers
+ * (e.g. context7): instead of routing queries to a third-party service, it
+ * serves curated docs for the fleet's own `@revealui/*` packages straight
+ * from the monorepo — README + package.json metadata + public export
+ * subpaths. Source is ground truth, and it covers first-party packages an
+ * external indexer cannot see at all.
+ *
+ * ## Phase 1 (this file)
+ *
+ * First-party `@revealui/*` packages only. Tools:
+ * - `docs_list_libraries` — enumerate every first-party package.
+ * - `docs_resolve_library` — normalize a name ("router", "@revealui/router")
+ *   to its canonical id.
+ * - `docs_get_library` — return curated docs for a package.
+ *
+ * Resource:
+ * - `revealui-docs://catalog` — the same list as `docs_list_libraries`.
+ *
+ * npm / third-party packages are out of scope for P1. `opensrc` already
+ * fetches real dependency source on demand; a later phase wires it in behind
+ * the same two tools so the ergonomics stay uniform.
+ *
+ * ## License
+ *
+ * **Not** Pro-gated. It surfaces only source-visible package metadata +
+ * READMEs (the `@revealui/*` packages are MIT or source-visible FSL) and is a
+ * developer tool for building on RevealUI — same rationale as the contracts
+ * server. Revisit only if it ever serves runtime/customer data.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  type ReadResourceRequest,
+  ReadResourceRequestSchema,
+  type Resource,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const SERVER_NAME = 'revealui-docs';
+const SERVER_VERSION = '0.1.0';
+
+const SCOPE_PREFIX = '@revealui/';
+const RESOURCE_URI_PREFIX = 'revealui-docs://';
+const CATALOG_URI = `${RESOURCE_URI_PREFIX}catalog`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A first-party package discovered in the monorepo. */
+export interface PackageEntry {
+  /** Canonical package name, e.g. `@revealui/router`. */
+  name: string;
+  /** Scope-stripped id, e.g. `router`. */
+  shortId: string;
+  /** Absolute path to the package directory. */
+  dir: string;
+  version: string;
+  description: string;
+  license?: string;
+  homepage?: string;
+  /** Public export subpaths from package.json `exports`, e.g. `['.', './server']`. */
+  exports: string[];
+}
+
+/** Curated docs for a single package. */
+export interface LibraryDoc {
+  name: string;
+  shortId: string;
+  version: string;
+  description: string;
+  license?: string;
+  homepage?: string;
+  exports: string[];
+  /** README.md contents, or null when the package has none. */
+  readme: string | null;
+}
+
+export interface ResolveResult {
+  resolved: boolean;
+  /** Canonical id when resolved. */
+  id?: string;
+  query: string;
+  /** Guidance when unresolved (e.g. third-party packages). */
+  hint?: string;
+  /** Near matches (substring) when unresolved. */
+  candidates?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+function readJson(file: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function extractExports(pkg: Record<string, unknown>): string[] {
+  const ex = pkg.exports;
+  if (ex && typeof ex === 'object' && !Array.isArray(ex)) {
+    const keys = Object.keys(ex as Record<string, unknown>);
+    return keys.length > 0 ? keys : ['.'];
+  }
+  return ['.'];
+}
+
+// ---------------------------------------------------------------------------
+// Enumeration + lookup (pure — exported for tests + reuse)
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate first-party packages under `<root>/packages/*`. Only entries
+ * whose package.json `name` is in the `@revealui/` scope (or the bare
+ * `revealui` meta-package) are included. Returns a map keyed by canonical
+ * package name. Never throws — unreadable entries are skipped.
+ */
+export function enumeratePackages(root: string): Map<string, PackageEntry> {
+  const out = new Map<string, PackageEntry>();
+  const pkgsDir = join(root, 'packages');
+  if (!existsSync(pkgsDir)) return out;
+
+  let names: string[];
+  try {
+    names = readdirSync(pkgsDir);
+  } catch {
+    return out;
+  }
+
+  for (const entry of names) {
+    const dir = join(pkgsDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const pkg = readJson(join(dir, 'package.json'));
+    if (!pkg) continue;
+    const pkgName = asString(pkg.name);
+    if (!pkgName) continue;
+    const isFirstParty = pkgName.startsWith(SCOPE_PREFIX) || pkgName === 'revealui';
+    if (!isFirstParty) continue;
+    const shortId = pkgName.startsWith(SCOPE_PREFIX) ? pkgName.slice(SCOPE_PREFIX.length) : pkgName;
+    out.set(pkgName, {
+      name: pkgName,
+      shortId,
+      dir,
+      version: asString(pkg.version) ?? '0.0.0',
+      description: asString(pkg.description) ?? '',
+      license: asString(pkg.license),
+      homepage: asString(pkg.homepage),
+      exports: extractExports(pkg),
+    });
+  }
+  return out;
+}
+
+/** Normalize a user query to a scope-stripped, lowercased short id. */
+function normalizeQuery(input: string): string {
+  let s = input.trim().toLowerCase();
+  if (s.startsWith(SCOPE_PREFIX)) s = s.slice(SCOPE_PREFIX.length);
+  else if (s.startsWith('revealui/')) s = s.slice('revealui/'.length);
+  return s;
+}
+
+function looksThirdParty(input: string): boolean {
+  const s = input.trim().toLowerCase();
+  if (!s) return false;
+  // A scoped name from another org, e.g. "@hono/node-server", or a bare npm
+  // name we don't recognize. Both are out of P1 scope.
+  return s.startsWith('@') && !s.startsWith(SCOPE_PREFIX);
+}
+
+/** Resolve a library name to a canonical first-party id. */
+export function resolveLibrary(packages: Map<string, PackageEntry>, input: string): ResolveResult {
+  const query = input.trim();
+  if (!query) {
+    return {
+      resolved: false,
+      query,
+      hint: 'Provide a package name, e.g. "router" or "@revealui/router".',
+    };
+  }
+  const shortId = normalizeQuery(query);
+
+  // Exact full-name match first, then short-id match.
+  for (const entry of packages.values()) {
+    if (entry.name === query || entry.shortId === shortId) {
+      return { resolved: true, id: entry.name, query };
+    }
+  }
+
+  const npmHint =
+    'Phase 1 of revealui-docs covers first-party @revealui/* packages only. ' +
+    'For an npm/third-party package, fetch its source with `opensrc <package>` ' +
+    '(a later phase will wire that in behind this tool).';
+  const candidates = [...packages.values()]
+    .filter((e) => e.shortId.includes(shortId) || e.name.includes(shortId))
+    .map((e) => e.name);
+
+  return {
+    resolved: false,
+    query,
+    hint: looksThirdParty(query)
+      ? npmHint
+      : `No first-party package matches "${query}". ${npmHint}`,
+    candidates: candidates.length > 0 ? candidates : undefined,
+  };
+}
+
+/** Read curated docs for a resolved package id (canonical name or short id). */
+export function getLibraryDoc(packages: Map<string, PackageEntry>, id: string): LibraryDoc | null {
+  const resolved = resolveLibrary(packages, id);
+  if (!(resolved.resolved && resolved.id)) return null;
+  const entry = packages.get(resolved.id);
+  if (!entry) return null;
+
+  let readme: string | null = null;
+  const readmePath = join(entry.dir, 'README.md');
+  if (existsSync(readmePath)) {
+    try {
+      readme = readFileSync(readmePath, 'utf8');
+    } catch {
+      readme = null;
+    }
+  }
+
+  return {
+    name: entry.name,
+    shortId: entry.shortId,
+    version: entry.version,
+    description: entry.description,
+    license: entry.license,
+    homepage: entry.homepage,
+    exports: entry.exports,
+    readme,
+  };
+}
+
+interface LibrarySummary {
+  name: string;
+  shortId: string;
+  version: string;
+  description: string;
+  exports: string[];
+}
+
+/** Summaries of every first-party package, sorted by name. */
+export function listLibraries(packages: Map<string, PackageEntry>): LibrarySummary[] {
+  return [...packages.values()]
+    .map((e) => ({
+      name: e.name,
+      shortId: e.shortId,
+      version: e.version,
+      description: e.description,
+      exports: e.exports,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ---------------------------------------------------------------------------
+// Tool + resource catalogs
+// ---------------------------------------------------------------------------
+
+function buildToolList(): Tool[] {
+  return [
+    {
+      name: 'docs_list_libraries',
+      description:
+        'List every first-party @revealui/* package available to this docs server, with version, description, and public export subpaths.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'docs_resolve_library',
+      description:
+        'Resolve a library name (e.g. "router", "@revealui/router") to its canonical first-party id. Returns guidance for third-party/npm packages (out of Phase 1 scope).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Library name to resolve.' },
+        },
+        required: ['name'],
+      },
+    },
+    {
+      name: 'docs_get_library',
+      description:
+        'Return curated docs for a first-party package: README + description + version + license + public export subpaths. Accepts a canonical name or a short id.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Canonical name ("@revealui/router") or short id ("router").',
+          },
+        },
+        required: ['id'],
+      },
+    },
+  ];
+}
+
+function textResult(
+  value: unknown,
+  isError = false,
+): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+} {
+  const result: {
+    content: Array<{ type: 'text'; text: string }>;
+    isError?: boolean;
+  } = { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+  if (isError) result.isError = true;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateDocsServerOptions {
+  /** Monorepo root containing `packages/`. The launcher resolves this. */
+  root: string;
+  /** Override the advertised server name (useful for tests). */
+  serverName?: string;
+}
+
+/**
+ * Create a fresh `revealui-docs` MCP Server. The package list is enumerated
+ * once at creation (cheap, name+metadata only); README contents are read
+ * lazily per `docs_get_library` call.
+ */
+export function createDocsServer(options: CreateDocsServerOptions): Server {
+  const packages = enumeratePackages(options.root);
+
+  const server = new Server(
+    { name: options.serverName ?? SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {}, resources: {} } },
+  );
+
+  const toolList = buildToolList();
+  const resourceList: Resource[] = [
+    {
+      uri: CATALOG_URI,
+      name: 'catalog',
+      description:
+        'List of first-party @revealui/* packages with version, description, and exports.',
+      mimeType: 'application/json',
+    },
+  ];
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolList }));
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: resourceList }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
+    const uri = request.params.uri;
+    if (uri !== CATALOG_URI) {
+      throw new Error(`Unknown resource URI (expected ${CATALOG_URI}): ${uri}`);
+    }
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(
+            { libraries: listLibraries(packages), total: packages.size },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    const toolName = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    try {
+      if (toolName === 'docs_list_libraries') {
+        return textResult({ libraries: listLibraries(packages), total: packages.size });
+      }
+
+      if (toolName === 'docs_resolve_library') {
+        const name = args.name;
+        if (typeof name !== 'string') {
+          return textResult({ error: '"name" (string) is required.' }, true);
+        }
+        return textResult(resolveLibrary(packages, name));
+      }
+
+      if (toolName === 'docs_get_library') {
+        const id = args.id;
+        if (typeof id !== 'string') {
+          return textResult({ error: '"id" (string) is required.' }, true);
+        }
+        const doc = getLibraryDoc(packages, id);
+        if (!doc) {
+          return textResult(resolveLibrary(packages, id), true);
+        }
+        return textResult(doc);
+      }
+
+      return textResult({ error: `Unknown tool: ${toolName}` }, true);
+    } catch (err) {
+      return textResult({ error: err instanceof Error ? err.message : String(err) }, true);
+    }
+  });
+
+  return server;
+}


### PR DESCRIPTION
## What

Add `revealui-docs` — a first-party MCP server providing **dependency intelligence** for the fleet's own `@revealui/*` packages. The RevealUI-native answer to external library-docs servers (e.g. context7): no third-party service, source is ground truth, and it covers first-party packages an external indexer can't see at all.

## Tools (Phase 1 — first-party only)

- `docs_list_libraries` — enumerate every `@revealui/*` package (version, description, export subpaths).
- `docs_resolve_library` — normalize a name (`router`, `@revealui/router`) to its canonical id; returns `opensrc` guidance for third-party/npm names.
- `docs_get_library` — curated docs for a package: README + description + version + license + public export subpaths.
- Resource `revealui-docs://catalog`.

Exported as `@revealui/mcp/docs-server` with a stdio launcher at `servers/docs.ts` (resolves the monorepo root via `REVEALUI_ROOT` or by walking up for `pnpm-workspace.yaml`).

## Design

- Mirrors the `revealui-contracts` factory pattern (factory + thin launcher + `index` re-export + subpath export + tests).
- **Not Pro-gated** — surfaces only source-visible metadata + READMEs and is a developer tool, same rationale as the contracts server.
- Package list enumerated once at server creation; README content read lazily per `docs_get_library`.
- No regex (string ops only), per the fleet posture.

## Scope

Phase 1 is first-party `@revealui/*` only. npm/third-party packages return a clear pointer to `opensrc` (real source fetch); wiring `opensrc` in behind the same tools is a later phase, followed by curated context packs for heavy deps.

## Also: MCP server count 13 → 14

The fleet enforces the MCP-server count (claim-drift `countMCPServers`). The 14th server bumps it, so this PR also updates every enforced count claim (READMEs, `AGENTS.md`, `docs/PRO.md`, blog, archive assessment, `MARKETING_METRICS`, and the `site.ts` METRICS source that propagates to all `${METRICS.mcpServers}` marketing copy) and adds the `docs` entry to the `/.well-known/mcp.json` manifest (`mcp-manifest.ts`) + its a2a test (`toHaveLength` 13 → 14).

## Verified

- `pnpm --filter @revealui/mcp typecheck` — clean.
- `pnpm --filter @revealui/mcp test` — 396 pass / 5 skip / 0 fail (incl. 11 new `docs-server` tests over a temp-fixture monorepo).
- `pnpm validate:claims` — clean.
- Full pre-push gate — PASS (19 checks incl. Biome, claim-drift, client-bundle safety, boundary, version policy).
