### PR TITLE
ci(backflow): self-heal on push to test + serialize runs

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -4,9 +4,23 @@ name: backflow-main-into-test
 #   RevealUIStudio/.github/.github/workflows/backflow-reusable.yml
 # Requires the BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets + the
 # revfleet-backflow App installed on this repo (Contents + Pull requests r/w).
+# Triggers on push to BOTH main and test:
+#   - push:main — main moved forward; open a backflow PR so test catches up.
+#   - push:test — self-heal: if a backflow PR was squash-merged (which strips
+#     main's parentage and leaves `test` not containing `main`), the next push
+#     to test re-detects the broken ancestry and re-opens a correct --no-ff
+#     backflow, instead of the gap lurking until the next promotion (where
+#     promotion-gate would then block it). The reusable no-ops when test already
+#     contains main, so the push:test path is a cheap guard.
 on:
   push:
-    branches: [main]
+    branches: [main, test]
+
+# Serialize backflow runs so the two triggers (and rapid pushes) can't race on
+# the force-push / PR open-or-update.
+concurrency:
+  group: backflow-main-into-test
+  cancel-in-progress: false
 
 jobs:
   backflow:


### PR DESCRIPTION
## What

Add `test` to the `backflow-main-into-test` workflow's push triggers, plus a `concurrency` group.

## Why

The backflow workflow opens a `main` → `test` sync PR whenever `test` falls behind `main` (e.g. after a `test` → `main` promotion creates a merge commit on `main`). The reusable workflow builds that sync as a **merge commit** (`--no-ff`) so `main`'s parentage is preserved and the next `promotion-gate` check passes.

The gap: if that backflow PR is **squash-merged** instead of merge-committed, the squash strips `main`'s parentage — `test` ends up with `main`'s *content* but not `main`'s *commits as ancestors*. Today that only re-surfaces on the **next push to `main`**, so the broken ancestry can sit unnoticed until the next promotion (where `promotion-gate` blocks it).

## Change

- **`push: [main, test]`** — a squash-merged backflow is itself a push to `test`, so the workflow now re-detects the broken ancestry immediately and re-opens a correct `--no-ff` backflow. The reusable already no-ops when `test` already contains `main`, so the new `push:test` path is a cheap guard on normal pushes.
- **`concurrency` group** — serializes backflow runs so the two triggers (and rapid pushes) can't race on the force-push / PR open-or-update.

No change to the reusable workflow or to merge semantics — this only widens *when* the existing healing logic runs.
