### PR TITLE
docs: sync narrative MCP-server count to 14 (revealui-docs)

### DIFF
--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -8,7 +8,7 @@ RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on to
 |---------|---------|-------------|
 | [`@revealui/ai`](/pro/ai) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | AI agents, open-model inference, CRDT memory, A2A protocol |
 | [`@revealui/harnesses`](https://github.com/RevealUIStudio/revealui/tree/main/packages/harnesses) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | Harness adapters, workboard coordination |
-| [`@revealui/mcp`](/pro/mcp) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | MCP hypervisor, adapter framework, 13 first-party server launchers |
+| [`@revealui/mcp`](/pro/mcp) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | MCP hypervisor, adapter framework, 14 first-party server launchers |
 | [`@revealui/services`](https://github.com/RevealUIStudio/revealui/tree/main/packages/services) | Fair Source (FSL-1.1-MIT, MIT after 2 years) | Stripe, Solana (RVC), and Vercel integrations |
 | [Open-Model Inference](/pro/inference) | — | Default Ollama; Inference Snaps planned; Groq / HuggingFace / OpenAI-compatible opt-in |
 | [Editor Config Sync](/pro/editors) | — | Ships in the separate **RevCon** repo (not in this monorepo); not gated by Pro |

--- a/apps/docs/public/docs-pro/mcp/index.md
+++ b/apps/docs/public/docs-pro/mcp/index.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) servers for RevealUI. Connect your AI agents to Str
 
 ## Overview
 
-`@revealui/mcp` ships **13 first-party MCP server launchers** under `packages/mcp/src/servers/`. The full list lives in the source; a representative sample:
+`@revealui/mcp` ships **14 first-party MCP server launchers** under `packages/mcp/src/servers/`. The full list lives in the source; a representative sample:
 
 | Server | Launcher | Tools provided |
 |--------|----------|---------------|

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -94,7 +94,7 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 | Dashboard Agent Chat | **Shipped** | Live at admin.revealui.com. |
 | Documentation Site | **Shipped** | docs.revealui.com. |
 | x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant. "Designed; gated on Stripe live." |
-| MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (13 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
+| MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (14 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
 | Perpetual Licenses (Track C) | **Planned** | `comingSoon: true` in contracts. |
 | Self-Hosted Docker Images (RevealUI Fleet) | **Planned** | Designed, not built. |
 | Visual Builder | **Planned** | Backlog. |
@@ -148,7 +148,7 @@ Canonical defaults (when "open-model AI" is mentioned in marketing): Gemma 4, Ph
 Five testable rules — Phase 5 audits every page against these:
 
 1. **Lead with what ships today.** Every page's first sentence under H1 names a capability with a verifiable artifact.
-2. **Specifics over adjectives.** "Fast" → "13 first-party MCP servers." "Secure" → "Ed25519-signed license JWTs."
+2. **Specifics over adjectives.** "Fast" → "14 first-party MCP servers." "Secure" → "Ed25519-signed license JWTs."
 3. **Identify the reader by their stack, not job title.**
 4. **Surface the trade-off, don't bury it.** "Three yeses and one no" pattern.
 5. **No marketing-speak, no emojis, no exclamation points.** Banned adjective table in `voice-and-headline-rules.md` §1.

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -229,7 +229,7 @@ Some numbers on what's actually shipped:
 - **30 workspaces** across the monorepo (4 apps + 26 packages — 20 MIT, 5 Fair Source, 1 internal)
 - **85 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **59 UI components** in `@revealui/presentation` (80 counting the admin engine) — zero external UI dependencies, just Tailwind v4, clsx, and CVA
-- **13 first-party MCP servers** in `@revealui/mcp`
+- **14 first-party MCP servers** in `@revealui/mcp`
 - **Extensive test coverage** across unit, integration, and E2E layers (run `pnpm test` for the current count)
 - **Full OpenAPI spec** with Swagger UI at `/docs`
 - **Session auth** with bcrypt, rate limiting, brute force protection, and OAuth

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -126,7 +126,7 @@ Running locally doesn't mean running poorly. The RevealUI agent stack has the sa
 
 - **Planning and tools**  -  agents can create todos, read and write files, execute shell commands
 - **Memory**  -  episodic memory, working memory, CRDT-based persistence across sessions
-- **MCP integrations**  -  13 first-party MCP servers (Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, Next.js DevTools, plus RevealUI-internal Content / Email / Memory / Stripe servers, the contracts introspection server, and the adapter base class)
+- **MCP integrations**  -  14 first-party MCP servers (Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, Next.js DevTools, plus RevealUI-internal Content / Email / Memory / Stripe / Docs servers, the contracts introspection server, and the adapter base class)
 - **Orchestration**  -  multi-agent coordination, sub-agent spawning, streaming
 
 What you do give up: the raw capability of a 70B+ cloud model. Smaller local models like Gemma 4 are excellent for structured tasks  -  code generation, data processing, form filling, API orchestration  -  but won't match a frontier model on open-ended reasoning. For most business automation use cases, that's an acceptable trade.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -442,7 +442,7 @@ Memory operations use CRDTs (Conflict-free Replicated Data Types) for conflict r
 
 ### MCP servers
 
-RevealUI ships **13 first-party MCP (Model Context Protocol) servers** in `@revealui/mcp` (Fair Source, FSL-1.1-MIT — source-visible, converts to MIT two years after release). The most commonly used:
+RevealUI ships **14 first-party MCP (Model Context Protocol) servers** in `@revealui/mcp` (Fair Source, FSL-1.1-MIT — source-visible, converts to MIT two years after release). The most commonly used:
 
 | Server | Purpose |
 |--------|---------|

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -4,7 +4,7 @@ RevealUI is open source today; the commercial side is pre-launch. Before we talk
 
 This is a solo-founder project. I don't have a VC board to answer to or a growth team optimizing conversion funnels. I have a business model I believe in, and I'd rather explain it plainly than have you discover the trade-offs later.
 
-> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **x402 agent payments** — are **planned, not shipped**. The first-party MCP catalog (13 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
+> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **x402 agent payments** — are **planned, not shipped**. The first-party MCP catalog (14 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
 
 ---
 
@@ -20,7 +20,7 @@ I understand that risk. I accept it. Here's why.
 
 RevealUI is an open runtime for AI-native businesses. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
-The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 13 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
+The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 14 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
 What MIT means practically: you can take RevealUI, strip the branding, deploy it on your own infrastructure, and run your entire business on it without ever creating an account with us. You don't owe us attribution, revenue share, or even a thank-you. The code is yours.
 
@@ -39,7 +39,7 @@ RevealUI Pro includes:
 - **LLM orchestration** -- open-model inference via Ubuntu Inference Snaps and Ollama
 - **Editor integrations** -- daemon adapters for Zed, VS Code, and Neovim
 - **Harness coordination** -- workboard-based agent orchestration, JSON-RPC communication, daemon management
-- **MCP framework** -- the hypervisor, 13 first-party servers, and the adapter base class that connect agents to tools
+- **MCP framework** -- the hypervisor, 14 first-party servers, and the adapter base class that connect agents to tools
 
 These features are commercially licensed. The source code is available (you can read the compiled output on npm), but the license restricts redistribution and commercial use without a key.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -112,7 +112,7 @@ Four protocols converge to create the agent-first web. Each solves a different p
 | Protocol | Created by | Governed by | Purpose | RevealUI implementation |
 |---|---|---|---|---|
 | **A2A** (Agent-to-Agent) | Google | Linux Foundation (Agentic AI Foundation) | Agents discover and delegate work to other agents | Full A2A 1.0: Agent Cards, JSON-RPC task lifecycle (`tasks/send`, `tasks/get`, `tasks/cancel`), SSE streaming |
-| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 13 first-party MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, plus the RevealUI-internal Content / Email / Memory / Stripe servers, the contracts introspection server, and the adapter base class |
+| **MCP** (Model Context Protocol) | Anthropic | Open standard | Agents use tools exposed by MCP servers | 14 first-party MCP servers: Stripe, Supabase, Neon, Vercel, Code Validator, Playwright, Next.js DevTools, plus the RevealUI-internal Content / Email / Memory / Stripe / Docs servers, the contracts introspection server, and the adapter base class |
 | **x402** (HTTP 402 Payment Required) | Coinbase | Open standard | Internet-native micropayments for machine-to-machine commerce | Per-call USDC payments on Base, Coinbase facilitator verification, marketplace payment proxy |
 | **OpenAPI** | OpenAPI Initiative | Linux Foundation | Machine-readable API descriptions | Auto-generated from Hono route definitions with Zod schemas |
 
@@ -157,7 +157,7 @@ Agents use the host's configured inference path. The `createLLMClientFromEnv()` 
 
 The Model Context Protocol (MCP) defines how agents invoke tools. Where A2A is about agent-to-agent communication, MCP is about agent-to-tool communication. An MCP server exposes a set of tools -- functions that an agent can call with structured inputs and get structured outputs.
 
-RevealUI ships with 13 first-party MCP servers (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). The seven that cover the core infrastructure stack:
+RevealUI ships with 14 first-party MCP servers (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). The seven that cover the core infrastructure stack:
 
 - **Stripe** -- Create checkout sessions, manage subscriptions, query payment history
 - **Supabase** -- Vector storage, real-time auth, embedding operations

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -611,7 +611,7 @@ export REVEALUI_LICENSE_KEY=<your-pro-license-key>
 
 ### Connect MCP servers
 
-RevealUI ships with 13 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
+RevealUI ships with 14 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
 
 ### Add more collections
 

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -611,7 +611,7 @@ export REVEALUI_LICENSE_KEY=<your-pro-license-key>
 
 ### Connect MCP servers
 
-RevealUI ships with 14 open-source MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
+RevealUI ships with 14 first-party MCP (Model Context Protocol) servers — including Stripe, Supabase, Neon, Vercel, Playwright, Code Validator, and Next.js DevTools (full list in [`packages/mcp/src/servers/`](https://github.com/RevealUIStudio/revealui/tree/main/packages/mcp/src/servers)). Let your AI agents interact directly with your business infrastructure.
 
 ### Add more collections
 


### PR DESCRIPTION
Stacked follow-up to #1169 (which adds the 14th first-party MCP server, `revealui-docs`).

**Base:** `feat/mcp-docs-server`, not `test` — #1169 isn't merged yet, so the 14-server code and the gated-surface bumps live only on that branch. **Retarget this PR to `test` once #1169 lands.**

## Why
#1169 bumped every **gated** claim surface to 14 (README, AGENTS, `packages/mcp/README.md`, `mcp-manifest.ts`, `a2a.test.ts`, `docs/PRO.md`, marketing `site.ts` METRICS) — all enforced by `pnpm validate:claims`. The **non-gated narrative docs** still said "13 first-party MCP servers", so the corpus goes internally inconsistent the moment #1169 merges. This brings them current.

## Changes (2 commits)

**Count 13 → 14 — 13 refs / 9 files** (`2f8367c9e`)
- Prose counts: `docs/blog/01,05,06,07`, `apps/docs/public/docs-pro/{index,mcp/index}.md`, the `MARKETING_METRICS.md` voice-rule example (rule 2)
- Enumerated lists (`docs/blog/04`, `docs/blog/07`): inserted **RevealUI Docs** into the RevealUI-internal group so each list sums to 14
- Audit-found (beyond the obvious count refs): `docs/blog/06` status note, `docs/blog/08`, and the `MARKETING_METRICS.md` marketplace-status row — present-tense "13 servers" claims that would otherwise contradict the gated surfaces

**Wording fix** (`6a107021b`)
- `docs/blog/08` said "**open-source** MCP servers" — the MCP framework is Fair Source (FSL-1.1), not OSS (per `docs/blog/06`), and the same getting-started section tells readers to upgrade to Pro to unlock AI agents. Corrected to "**first-party** MCP servers" to match the rest of the corpus. Count unchanged.

## Left at 13 by intent
- `MARKETING_METRICS.md` L16 — historical past-tense ("pre-Phase-1 state")
- `packages/*/CHANGELOG.md`, `docs/archive/*` — version history

## Verification
- `validate:claims` (claim-drift) passes — **14 MCP servers, 73 claims scanned, 0 mismatches**
- No residual `open-source MCP` anywhere (excl. changelog/archive); residual `13 …(first-party|MCP)` across `docs/` + `docs-pro/` is only the historical L16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
