### PR TITLE
docs: public truth pass — RVC-cancelled + open-model-default + version honesty

### DIFF
--- a/docs/ai/PROMPT_CACHING.md
+++ b/docs/ai/PROMPT_CACHING.md
@@ -1,6 +1,6 @@
-# Anthropic Prompt Caching
+# Prompt Caching
 
-Get up to **90% cost reduction** on repeated context using Anthropic's prompt caching feature.
+RevealUI's AI layer is provider-agnostic: open-weight models (Gemma, Phi, etc. via Ollama or Inference Snaps) are the default runtime path, and cloud providers are opt-in adapters. Prompt caching is one such provider capability — when you opt into a cloud provider that supports it (e.g. Anthropic), you can get up to **90% cost reduction** on repeated context. This guide uses Anthropic as the worked example because its caching API is the most mature; the same `@revealui/ai` client interface applies to any provider, and caching is a no-op on providers that don't support it.
 
 ## Quick Start
 
@@ -298,9 +298,13 @@ await client.chat(messages, { enableCache: false })
 
 ### Provider Configuration
 
+The default runtime provider is an open-weight model (e.g. Ollama-served Gemma); the caching config below applies when you opt into a cloud provider that supports it. Anthropic shown as the example — swap `provider` + key for any supported provider:
+
 ```typescript
 import { LLMClient } from '@revealui/ai/llm/client'
 
+// Opt-in cloud provider (Anthropic example). The fleet runtime does NOT
+// depend on Anthropic — this is one selectable adapter among several.
 const client = new LLMClient({
   provider: 'anthropic',
   apiKey: process.env.ANTHROPIC_API_KEY!,

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-**Version:** 1.0.0
+**Version:** 0.1.0
 
 **Base URL (production):** `https://api.revealui.com/api`
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -26,7 +26,7 @@ Every artifact starts at `0.1.0`. `1.0.0` is a public contract claim — "consum
 
 Inside `0.x`: breaking changes bump minor (not major). Promotion to `1.0` requires real external consumers + stable contract for ≥1 release cycle.
 
-Exception: `@revealui/contracts` is grandfathered at `1.x` — documented in `docs/decisions/`.
+(`@revealui/contracts` was briefly published on the `1.x` line, then demoted to `0.x` to follow this rule — see the contracts-demotion ADR in `docs/decisions/`. It is now pre-1.0 like everything else.)
 
 ### Open-model AI runtime (M3)
 

--- a/examples/api/openapi.json
+++ b/examples/api/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "version": "1.0.0",
+    "version": "0.1.0",
     "title": "RevealUI API",
     "description": "REST API for RevealUI application with OpenAPI 3.0 specification"
   },
@@ -2559,54 +2559,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "/api/billing/rvui-payment": {
-      "post": {
-        "tags": ["billing"],
-        "summary": "Pay for subscription with RevealCoin",
-        "description": "Verifies an on-chain RVUI payment transaction and activates the subscription tier. Applies the 15% RVUI discount. Requires wallet address and transaction signature.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "txSignature": { "type": "string", "minLength": 1 },
-                  "tier": { "type": "string", "enum": ["Pro", "Max"] },
-                  "walletAddress": { "type": "string", "minLength": 1 },
-                  "network": {
-                    "type": "string",
-                    "enum": ["devnet", "mainnet-beta"],
-                    "default": "devnet"
-                  }
-                },
-                "required": ["txSignature", "tier", "walletAddress"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment verified and subscription activated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": { "type": "boolean" },
-                    "tier": { "type": "string" },
-                    "message": { "type": "string" }
-                  },
-                  "required": ["success", "tier", "message"]
-                }
-              }
-            }
-          },
-          "400": { "description": "Validation failed" },
-          "401": { "description": "Authentication required" },
-          "403": { "description": "Payment rejected by safeguards" }
         }
       }
     },
@@ -9336,54 +9288,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "/api/v1/billing/rvui-payment": {
-      "post": {
-        "tags": ["billing"],
-        "summary": "Pay for subscription with RevealCoin",
-        "description": "Verifies an on-chain RVUI payment transaction and activates the subscription tier. Applies the 15% RVUI discount. Requires wallet address and transaction signature.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "txSignature": { "type": "string", "minLength": 1 },
-                  "tier": { "type": "string", "enum": ["Pro", "Max"] },
-                  "walletAddress": { "type": "string", "minLength": 1 },
-                  "network": {
-                    "type": "string",
-                    "enum": ["devnet", "mainnet-beta"],
-                    "default": "devnet"
-                  }
-                },
-                "required": ["txSignature", "tier", "walletAddress"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment verified and subscription activated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": { "type": "boolean" },
-                    "tier": { "type": "string" },
-                    "message": { "type": "string" }
-                  },
-                  "required": ["success", "tier", "message"]
-                }
-              }
-            }
-          },
-          "400": { "description": "Validation failed" },
-          "401": { "description": "Authentication required" },
-          "403": { "description": "Payment rejected by safeguards" }
         }
       }
     },


### PR DESCRIPTION
## Public-doc truth pass — RVC-cancelled + open-model-default + version honesty

Fixes verified-real stale claims on **public** doc surfaces, surfaced by the 2026-05-29 fleet-docs audit (an internal repo internal). Each was re-checked against live state before editing — these are the items that were **still open** (most audit criticals had already been swept by peers; these had not).

### Changes

1. **`docs/ai/PROMPT_CACHING.md`** — was titled "Anthropic Prompt Caching" and presented `provider: 'anthropic'` + `ANTHROPIC_API_KEY` as the standard config. Reframed: open-weight models (Gemma/Phi via Ollama/Inference Snaps) are the default runtime path; Anthropic is one opt-in cloud adapter used as the worked example. Aligns with the fleet open-model-runtime rule (no Anthropic SDK dependency in the runtime). *(The `apps/docs/public/ai/` copy is a gitignored build artifact regenerated by `copy-docs.sh` — source only is edited here.)*

2. **`docs/methodology.md`** — corrected the `@revealui/contracts` versioning note: it said "grandfathered at 1.x", but contracts was demoted 1.4.0 → 0.x per the contracts-demotion ADR and is now `0.6.0`. Note now reflects the demotion.

3. **`docs/api/rest-api/README.md`** + **`examples/api/openapi.json`** — removed the `POST /api/billing/rvui-payment` + `/api/v1/billing/rvui-payment` endpoints (Pay-with-RevealCoin, 15% discount). RVC is cancelled (2026-05-29) and the endpoint is **already disabled in code** (`apps/server/.../billing-metrics.test.ts` §D "Disabled Endpoint"). The README section was already removed upstream; this PR removes the two matching `openapi.json` path blocks (so a README regen won't reintroduce them) and demotes the spec + README version `1.0.0` → `0.1.0` (pre-launch, no earned 1.0 promotion).

### Verification
- `openapi.json` validated: valid JSON, 184 paths, `info.version: 0.1.0`, zero `rvui` keys remaining.
- No test reads `examples/api/openapi.json`; the disabled-endpoint test exercises the live route, not the spec — removal is safe.
- Grep confirms no `rvui-payment` / `RevealCoin` left in either file.

### Scope / coordination
Docs + example-spec only; no runtime code. Built in an isolated worktree off `origin/test`. **Held for owner review — not auto-merged** (per standing manual-merge policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
