### PR TITLE
docs(security): correct SOC-2 vendor currency (Supabase phase-out + Railway-to-Fly)

### DIFF
--- a/docs/security/ACCESS_REVIEW_POLICY.md
+++ b/docs/security/ACCESS_REVIEW_POLICY.md
@@ -1,7 +1,7 @@
 ---
 title: Access Review Policy
 description: Quarterly access review cadence, review template, and audit records for SOC 2 compliance.
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 review-cadence: quarterly
 owner: RevealUI Studio <founder@revealui.com>
 classification: internal
@@ -12,6 +12,8 @@ classification: internal
 ## 1. Purpose
 
 This policy establishes the cadence, process, and documentation requirements for periodic access reviews across all RevealUI systems and services. Access reviews ensure that permissions remain appropriate, accounts are active, and the principle of least privilege is maintained.
+
+> **Infrastructure-in-transition note (2026-05-29).** Supabase is a *legacy secondary* store being phased out (ADR 2026-05-01; new features must not depend on it) and the ElectricSQL host is migrating Railway → Fly.io (ADR 2026-05-18, phases 4–6 pending). Supabase/Railway references below remain in force **while those systems are in service**; see [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for the authoritative transition status.
 
 ## 2. Scope
 

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -1,7 +1,7 @@
 ---
 title: Asset Inventory
 description: Formal inventory of all services, data stores, third-party processors, and security tooling for SOC 2 compliance.
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 review-cadence: quarterly
 owner: RevealUI Studio <founder@revealui.com>
 classification: internal
@@ -14,6 +14,14 @@ classification: internal
 This document provides a comprehensive inventory of all assets managed under the RevealUI project, including deployed services, data stores, third-party processors, and security tooling. It supports SOC 2 Type II compliance by establishing a baseline for change management, risk assessment, and access reviews.
 
 This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair Source Pro packages) and all associated infrastructure.
+
+> **Infrastructure-in-transition note (added 2026-05-29).** Several entries below are mid-migration and their status is **transitional**, not steady-state:
+> - **Supabase (DS-002, TP-006)** is a *legacy secondary* store being phased out — target is NeonDB-primary + ElectricSQL; new features must not depend on Supabase (ADR [`2026-05-01-supabase-removal`](https://github.com/RevealUIStudio/revealui/blob/main/docs/decisions/2026-05-01-supabase-removal.md)). The retained Supabase MCP adapter is a customer-facing integration, separate from internal usage.
+> - The **ElectricSQL sync host (DS-003, TP-007)** is migrating **Railway → Fly.io** (infrastructure ADR dated 2026-05-18; migration phases 0–3 shipped, 4–6 pending). "Railway" rows reflect the current host until the cutover completes.
+> - **Storage** is Cloudflare R2 (S3-compatible); the legacy Vercel Blob backend is being retired (GAP-208).
+> - **RevealCoin (SVC-007)** was cancelled 2026-05-29 (repo private+archived, keys destroyed).
+>
+> Rows are retained (not deleted) until each migration completes, so the inventory stays a faithful map of what is *currently* deployed. Each migration's completion will flip the corresponding rows.
 
 ## 2. Service Inventory
 
@@ -65,8 +73,8 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | ID | Store | Type | Provider | Location | Data Classification | Encryption at Rest | Encryption in Transit | Backup Policy | Recovery Objective |
 |----|-------|------|----------|----------|---------------------|--------------------|-----------------------|---------------|-------------------|
 | DS-001 | NeonDB (Primary) | Managed PostgreSQL | Neon | Cloud (provider-managed) | Confidential | AES-256 (provider-managed) | TLS 1.2+ | Continuous (provider PITR) | RPO: near-zero; RTO: minutes |
-| DS-002 | Supabase (Secondary) | Managed PostgreSQL + pgvector | Supabase | Cloud (provider-managed) | Confidential | AES-256 (provider-managed) | TLS 1.2+ | Daily snapshots (provider) | RPO: 24 hours; RTO: hours |
-| DS-003 | ElectricSQL Proxy | Real-time sync proxy | Railway | Cloud (Railway) | Internal | Provider-managed | TLS 1.2+ | N/A (stateless proxy) | N/A |
+| DS-002 | Supabase (Secondary — **legacy, phasing out**) | Managed PostgreSQL + pgvector | Supabase | Cloud (provider-managed) | Confidential | AES-256 (provider-managed) | TLS 1.2+ | Daily snapshots (provider) | RPO: 24 hours; RTO: hours |
+| DS-003 | ElectricSQL Proxy | Real-time sync proxy | Railway (**migrating → Fly.io**, ADR 2026-05-18) | Cloud | Internal | Provider-managed | TLS 1.2+ | N/A (stateless proxy) | N/A |
 | DS-004 | PGlite (Browser/Test) | In-memory PostgreSQL | Local | Browser or CI runner | Internal | N/A (ephemeral) | N/A (local) | N/A (ephemeral) | N/A |
 
 ### 3.1 Data Categories by Store
@@ -81,7 +89,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 - GDPR consent and anonymization records
 - AI agent coordination data, CRDT operations
 
-**Supabase (DS-002):** Vector embeddings, secondary auth, and specialized workloads.
+**Supabase (DS-002 — legacy, phasing out):** Vector embeddings, secondary auth, and specialized workloads. Being consolidated onto NeonDB pgvector; new features must not depend on Supabase.
 - Vector embeddings for RAG (pgvector)
 - OAuth account linkage
 - Supabase Auth sessions (where used)
@@ -100,15 +108,15 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | TP-003 | GitHub | Source code hosting, CI/CD, package registry, security advisories | Source code, CI logs, secrets (encrypted), security alerts | GitHub DPA in effect | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
 | TP-004 | npm (GitHub) | Package distribution (public OSS packages) | Published package source, package metadata | Covered by GitHub DPA | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
 | TP-005 | Neon | Managed PostgreSQL (primary database) | All relational data (users, content, payments metadata, sessions) | Neon DPA in effect | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
-| TP-006 | Supabase | Managed PostgreSQL + vectors, secondary auth | Vector embeddings, OAuth linkage, secondary auth sessions | Supabase DPA in effect | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
-| TP-007 | Railway | ElectricSQL proxy hosting | Sync protocol traffic (encrypted in transit, no persistent storage) | Railway ToS | Review pending | 2026-04-12 | 2026-07-12 |
+| TP-006 | Supabase (**legacy, phasing out**) | Managed PostgreSQL + vectors, secondary auth | Vector embeddings, OAuth linkage, secondary auth sessions | Supabase DPA in effect | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
+| TP-007 | Railway (**migrating → Fly.io**, ADR 2026-05-18) | ElectricSQL proxy hosting | Sync protocol traffic (encrypted in transit, no persistent storage) | Railway ToS | Review pending | 2026-04-12 | 2026-07-12 |
 | TP-008 | Google Workspace | Email (Gmail API for transactional email) | Recipient email addresses, email content | Google Workspace DPA | SOC 2 Type II | 2026-04-12 | 2026-07-12 |
 
 ### 4.1 Subprocessor Notes
 
 - **Stripe** is a PCI DSS Level 1 service provider. RevealUI never stores, processes, or transmits cardholder data. Only Stripe customer IDs, subscription IDs, and webhook event metadata are persisted in NeonDB.
 - **npm** provenance attestations (SLSA Build Level 2) are generated via OIDC trusted publishing in the release workflow. No long-lived NPM_TOKEN is required.
-- **Railway** hosts the ElectricSQL sync proxy, which is stateless. Data passes through encrypted in transit but is not persisted on Railway infrastructure.
+- **Railway** currently hosts the ElectricSQL sync proxy, which is stateless. Data passes through encrypted in transit but is not persisted on the proxy host. This host is migrating Railway → Fly.io per ADR 2026-05-18 (phases 4–6 pending); the stateless property is unchanged by the move.
 
 ## 5. Security Tooling Inventory
 
@@ -193,9 +201,10 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
                                              |
                                              v
                                      +---------------+
-                                     | Railway       |
+                                     | Railway→Fly.io|
                                      | (TP-007)      |
                                      | Sync Hosting  |
+                                     | (migrating)   |
                                      +---------------+
 
               +------------------+    +------------------+

--- a/docs/security/BACKUP_VERIFICATION.md
+++ b/docs/security/BACKUP_VERIFICATION.md
@@ -1,7 +1,7 @@
 ---
 title: Backup Restore Verification Procedure
 description: Quarterly restore drill procedures, RTO/RPO targets, and verification checklists for all RevealUI data stores. Supports SOC2 compliance (CC6.1, CC7.5, A1.2, A1.3).
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 status: active
 ---
 
@@ -10,6 +10,8 @@ status: active
 ## 1. Purpose
 
 This document defines the backup inventory, restore drill procedures, and verification criteria for all RevealUI data stores. It ensures that backups are functional, recovery objectives are achievable, and audit evidence is collected for SOC2 compliance (specifically CC6.1, CC7.5, A1.2, and A1.3).
+
+> **Infrastructure-in-transition note (2026-05-29).** The Supabase secondary store is *legacy* and phasing out (ADR 2026-05-01 → NeonDB pgvector); its restore drill below remains valid **while Supabase is in service**. The ElectricSQL host is migrating Railway → Fly.io (ADR 2026-05-18) but holds no persistent data, so it is out of backup scope either way. See [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for authoritative transition status.
 
 Restore drills are conducted quarterly. Each drill validates at least one data store end to end, with a full rotation across all stores every 12 months.
 

--- a/docs/security/CHANGE_MANAGEMENT_POLICY.md
+++ b/docs/security/CHANGE_MANAGEMENT_POLICY.md
@@ -1,7 +1,7 @@
 ---
 title: Change Management Policy
 description: Formal change management procedures covering code review, deployment approvals, rollback, and emergency changes for SOC 2 compliance.
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 review-cadence: annually
 owner: RevealUI Studio <founder@revealui.com>
 classification: internal
@@ -12,6 +12,8 @@ classification: internal
 ## 1. Purpose
 
 This policy formalizes the change management procedures for all modifications to RevealUI source code, infrastructure, and configuration. It ensures that changes are reviewed, tested, approved, and deployed in a controlled manner with appropriate rollback capabilities.
+
+> **Infrastructure-in-transition note (2026-05-29).** The Supabase secondary store is *legacy* and phasing out (ADR 2026-05-01). Its rollback reference below remains valid while Supabase is in service; see [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for authoritative transition status.
 
 ## 2. Scope
 

--- a/docs/security/INCIDENT_RESPONSE.md
+++ b/docs/security/INCIDENT_RESPONSE.md
@@ -1,7 +1,7 @@
 ---
 title: Incident Response Plan
 description: Procedures for detecting, responding to, and recovering from security incidents in the RevealUI project.
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 ---
 
 # Incident Response Plan
@@ -9,6 +9,8 @@ last-updated: 2026-04-12
 ## 1. Purpose
 
 This document defines how RevealUI detects, responds to, and recovers from security incidents. It covers the production infrastructure (Vercel, NeonDB, Supabase, Stripe) and the open-source supply chain (npm, GitHub).
+
+> **Infrastructure-in-transition note (2026-05-29).** Supabase is a *legacy secondary* store phasing out (ADR 2026-05-01) and the ElectricSQL host is migrating Railway → Fly.io (ADR 2026-05-18). The Supabase/Railway key-rotation and log-review steps below remain valid **while those systems are in service**; see [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for authoritative transition status.
 
 ## 2. Contacts
 

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -1,7 +1,7 @@
 ---
 title: Information Security Policy
 description: Security policies governing the RevealUI open-source project, covering data protection, access control, encryption, and compliance.
-last-updated: 2026-04-12
+last-updated: 2026-05-29
 ---
 
 # Information Security Policy
@@ -9,6 +9,8 @@ last-updated: 2026-04-12
 ## 1. Purpose
 
 This policy defines how RevealUI protects user data, application secrets, and infrastructure across its open-core monorepo (MIT core + Fair Source Pro packages). It applies to all code, services, and data managed under the RevealUI project.
+
+> **Infrastructure-in-transition note (2026-05-29).** Supabase is a *legacy secondary* store phasing out (ADR 2026-05-01 → NeonDB-primary). Supabase references below remain in force while it is in service; new features must not add Supabase dependencies. See [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for authoritative transition status.
 
 ## 2. Scope
 

--- a/docs/security/SOC2_AUDIT_TRACK.md
+++ b/docs/security/SOC2_AUDIT_TRACK.md
@@ -2,7 +2,7 @@
 title: SOC2 Type II Audit Track
 status: planning
 owner: RevealUI Studio
-last-updated: 2026-04-15
+last-updated: 2026-05-29
 ---
 
 # SOC2 Type II Audit Track
@@ -10,6 +10,8 @@ last-updated: 2026-04-15
 ## Overview
 
 This document tracks progress toward SOC2 Type II certification covering the Common Criteria (Security) Trust Service Criteria. Required for Enterprise tier customers.
+
+> **Infrastructure-in-transition note (2026-05-29).** The infrastructure under audit is mid-migration: Supabase (secondary) is phasing out (ADR 2026-05-01), the ElectricSQL host is migrating Railway → Fly.io (ADR 2026-05-18), and RevealCoin was cancelled 2026-05-29. The audit baseline must track these to completion; see [ASSET_INVENTORY.md](./ASSET_INVENTORY.md) for authoritative current status.
 
 ## Prerequisites (Complete)
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,7 +1,7 @@
 ---
 title: Threat Model
 description: STRIDE-style threat model for the RevealUI security stack across four trust boundaries — Human↔App, App↔External services, Agent↔Tool (MCP), Agent↔Agent (RevDev daemon).
-last-updated: 2026-05-16
+last-updated: 2026-05-29
 ---
 
 # Threat Model

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -1,7 +1,7 @@
 ---
 title: Vendor Risk Assessments
-description: Third-party vendor risk assessments for Neon, Supabase, Vercel, Stripe, and GitHub covering SOC 2 compliance, data handling, and business continuity.
-last-updated: 2026-04-12
+description: Third-party vendor risk assessments for Neon, Supabase (legacy, phasing out), Vercel, Stripe, and GitHub covering SOC 2 compliance, data handling, and business continuity.
+last-updated: 2026-05-29
 review-cadence: quarterly
 owner: RevealUI Studio <founder@revealui.com>
 classification: internal
@@ -78,10 +78,12 @@ Each vendor is evaluated against the following criteria:
 
 ---
 
-### 3.2 Supabase (Secondary Database)
+### 3.2 Supabase (Secondary Database — legacy, phasing out)
+
+> **Status note (2026-05-29):** Supabase is a *legacy secondary* store being phased out per ADR [`2026-05-01-supabase-removal`](https://github.com/RevealUIStudio/revealui/blob/main/docs/decisions/2026-05-01-supabase-removal.md) (target: NeonDB-primary + ElectricSQL). It remains in service during phase-out, so this assessment stays in force; new features must not add Supabase dependencies. The retained Supabase MCP adapter is a customer-facing integration, separate from internal usage.
 
 **Vendor:** Supabase Inc.
-**Service:** Managed PostgreSQL + pgvector, Auth
+**Service:** Managed PostgreSQL + pgvector, Auth (legacy secondary — phase-out in progress)
 **Asset ID:** DS-002, TP-006 (see Asset Inventory)
 **Data classification:** Confidential (vector embeddings, OAuth linkage)
 
@@ -244,7 +246,7 @@ Each vendor is evaluated against the following criteria:
 | Vendor | Asset IDs | Risk Rating | Key Strengths | Watchlist Items |
 |--------|-----------|-------------|---------------|-----------------|
 | Neon | DS-001, TP-005 | Low | SOC 2 Type II, PITR, standard PostgreSQL | Monitor for pricing changes, verify DPA annually |
-| Supabase | DS-002, TP-006 | Low | SOC 2 Type II, RLS, pgvector | Monitor RLS configuration drift, verify DPA annually |
+| Supabase (legacy, phasing out) | DS-002, TP-006 | Low | SOC 2 Type II, RLS, pgvector | Phase-out in progress (ADR 2026-05-01) → NeonDB pgvector; no new Supabase dependencies; verify DPA while in service |
 | Vercel | TP-001 | Low | SOC 2 Type II, 99.99% SLA, instant rollback | Monitor for env var handling changes |
 | Stripe | TP-002 | Low | PCI DSS L1, SOC 2 Type II, no card data exposure | Monitor test-to-live mode transition readiness |
 | GitHub | TP-003, TP-004 | Low | SOC 2 Type II, OIDC publishing, secret scanning | Monitor for Actions pricing changes, audit log retention |


### PR DESCRIPTION
## SOC-2 cluster — infrastructure-currency correction (Supabase phase-out + Railway→Fly)

Corrects stale vendor status across the SOC-2 attestation docs, surfaced by the 2026-05-29 fleet-docs audit. **Dated correction notes, not silent rewrites** — every change is verifiable against current state and the relevant ADR.

### What was wrong vs. what's true (verified against live code/ADRs before editing)
- **Supabase** was presented as a steady-state secondary store. Reality: it's a **legacy secondary, phasing out** (ADR `2026-05-01-supabase-removal` → NeonDB-primary + ElectricSQL). It's still in service during phase-out (code still imports `@supabase/*`; the MCP adapter is intentionally retained as a customer integration), so the assessment/procedures stay in force — but nothing now reads as permanent.
- **ElectricSQL host** was listed as "Railway". Reality: **migrating Railway → Fly.io** (infra ADR 2026-05-18; phases 0–3 shipped, 4–6 pending). Rows now say "Railway (migrating → Fly.io)" and reflect the *current* host until cutover.
- **RevealCoin (SVC-007)** was already corrected by a prior change (Decommissioned 2026-05-29) — left intact.

> Note: the audit's framing ("Supabase decommissioned / Fly.io active") was itself drift — neither migration is complete. This PR states the **transitional** truth, not a premature "done".

### Approach
- **ASSET_INVENTORY.md** + **VENDOR_RISK_ASSESSMENTS.md** (the load-bearing estate/vendor docs): row-level annotations + a dated "infrastructure-in-transition" banner + data-flow diagram label + `last-updated` bump. Rows are **retained, not deleted** — the inventory must stay a faithful map of what's *currently* deployed; each migration's completion flips its rows.
- **THREAT_MODEL.md**: text was already accurate ("Supabase legacy"); `last-updated` bump only.
- **6 policy docs** (ACCESS_REVIEW, BACKUP_VERIFICATION, CHANGE_MANAGEMENT, INCIDENT_RESPONSE, INFORMATION_SECURITY, SOC2_AUDIT_TRACK): one dated transition note each, so no doc asserts permanence; their Supabase/Railway *procedures* (key rotation, restore drill, etc.) remain valid while those systems are in service.

### Safety / scope
- `docs/security/` is **internal-only** (stripped from the public docs site by `apps/docs/scripts/copy-docs.sh`) — not customer-served.
- No internal docs/private-repo paths introduced (the Railway ADR is internal docs-only, so it's referenced by bare date, not linked — avoids the `revealui-private-repo-path` gitleaks rule). The one public link (supabase-removal ADR) target verified to exist.
- 9 files, +43/−20. No number-claims added (claim-drift safe). Built in an isolated worktree off `origin/test`.

**Held for owner review — not auto-merged** (per standing manual-merge policy). These are formal attestation docs; please confirm the wording before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
