### PR TITLE
chore(release): version packages (12 publishable bumps)

### DIFF
--- a/.changeset/admin-bootstrap-db-orm-subpath.md
+++ b/.changeset/admin-bootstrap-db-orm-subpath.md
@@ -1,7 +1,0 @@
----
-'@revealui/db': minor
----
-
-Add `@revealui/db/orm` subpath that re-exports Drizzle ORM query helpers (`eq`, `and`, `or`, `sql`, `inArray`, `desc`, `count`, ...).
-
-Worker scripts and apps should depend on Drizzle through this subpath instead of importing the bare `drizzle-orm` package. Under pnpm's isolated linker, `drizzle-orm` is materialized only inside the `node_modules` of packages that declare it (such as `@revealui/db`), not at the repo root — so a bare `import('drizzle-orm')` from repo-root `scripts/` fails with `ERR_MODULE_NOT_FOUND`. Importing through `@revealui/db/orm` resolves from any workspace location and guarantees the operators come from the same Drizzle instance as the db client and schema.

--- a/.changeset/db-client-pool-error-handler.md
+++ b/.changeset/db-client-pool-error-handler.md
@@ -1,5 +1,0 @@
----
-"@revealui/db": patch
----
-
-Attach an `'error'` event handler to the pg pools created by the database client (localhost / self-hosted Postgres path). A pg `Pool` is an EventEmitter, and an unhandled `'error'` event — emitted when an idle connection is dropped by the server (admin termination, autosuspend, network blip) — throws and crashes the process. The handler logs the error and keeps the pool alive, matching the existing behavior in `pool.ts` (Neon-backed deployments use the HTTP driver and are unaffected).

--- a/.changeset/fix-update-json-field-collections.md
+++ b/.changeset/fix-update-json-field-collections.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": patch
----
-
-Fix `update()` for JSON-field collections. `selectJsonByIdQuery` now selects `id` alongside `_json`, so the fetched row keeps an `id` and survives `safeParseRevealDocuments` (which drops rows whose `id` is not a string or number). Previously the id-less projection produced a dropped row and `update()` threw "Document not found" for every JSON-field collection.

--- a/.changeset/license-domain-lock-helper.md
+++ b/.changeset/license-domain-lock-helper.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": minor
----
-
-Add `hostMatchesLicensedDomains(host, domains)` to the license module — the single domain-match primitive for RevForge/Fleet domain-lock. Allowed domains are sourced from the signed JWT `domains` claim (cryptographically bound), consumed by the API's `requireDomain` middleware, the admin boot check, and `validateLicenseAtStartup`. Replaces the env-var-driven `REVFORGE_LICENSED_DOMAIN` host matching.

--- a/.changeset/r2-blob-decommission.md
+++ b/.changeset/r2-blob-decommission.md
@@ -1,9 +1,0 @@
----
-'@revealui/core': minor
----
-
-Complete the Vercel Blob → Cloudflare R2 object-storage cutover so the legacy Vercel Blob store can be decommissioned.
-
-- **`@revealui/core`:** replace the provider-specific `vercelBlobStorage` Payload plugin with the provider-agnostic `objectStorage` plugin. `objectStorage({ collections, resolveProvider, prefix? })` adapts any `StorageProvider` (Cloudflare R2 — canonical — Vercel Blob, mock) to the engine's collection upload-adapter interface, resolving the backend lazily on first upload via `resolveProvider` (so reading validated config never forces env validation at config-build time). **BREAKING:** `vercelBlobStorage` is removed from `@revealui/core` and `@revealui/core/server`; migrate to `objectStorage`. The `createVercelBlobProvider` StorageProvider and the `'vercel-blob'` `createStorage` tag remain for the migration-window Blob fallback.
-- **admin:** `apps/admin/revealui.config.ts` now uploads through `objectStorage`, resolving the provider from `@revealui/config`'s `config.storage` — Cloudflare R2 when fully configured, else the legacy Vercel Blob token. Media uploads no longer hard-depend on `BLOB_READ_WRITE_TOKEN`.
-- **server:** drop the now-unused `@vercel/blob` dependency (`apps/server` migrated its media route to `getMediaStorage()` in the prior phase). `@revealui/core` keeps `@vercel/blob` for the Vercel Blob StorageProvider.

--- a/.changeset/revealui-docs-server.md
+++ b/.changeset/revealui-docs-server.md
@@ -1,5 +1,0 @@
----
-"@revealui/mcp": minor
----
-
-Add the `revealui-docs` MCP server — first-party dependency intelligence. Resolves `@revealui/*` library names and serves curated docs (README + package metadata + public export subpaths) from the monorepo, exported via `@revealui/mcp/docs-server` with a stdio launcher at `servers/docs.ts`. Phase 1 covers first-party packages only; npm/third-party source via `opensrc` is a later phase.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @revealui/ai
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [96b1049]
+- Updated dependencies [e08adbe]
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/db@0.7.0
+  - @revealui/core@0.9.0
+  - @revealui/contracts@0.6.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/ai",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @revealui/auth
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [96b1049]
+- Updated dependencies [e08adbe]
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/db@0.7.0
+  - @revealui/core@0.9.0
+  - @revealui/contracts@0.6.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/cli
 
+## 0.7.3
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @revealui/core
 
+## 0.9.0
+
+### Minor Changes
+
+- ba61b20: Add `hostMatchesLicensedDomains(host, domains)` to the license module — the single domain-match primitive for RevForge/Fleet domain-lock. Allowed domains are sourced from the signed JWT `domains` claim (cryptographically bound), consumed by the API's `requireDomain` middleware, the admin boot check, and `validateLicenseAtStartup`. Replaces the env-var-driven `REVFORGE_LICENSED_DOMAIN` host matching.
+- 6545491: Complete the Vercel Blob → Cloudflare R2 object-storage cutover so the legacy Vercel Blob store can be decommissioned.
+
+  - **`@revealui/core`:** replace the provider-specific `vercelBlobStorage` Payload plugin with the provider-agnostic `objectStorage` plugin. `objectStorage({ collections, resolveProvider, prefix? })` adapts any `StorageProvider` (Cloudflare R2 — canonical — Vercel Blob, mock) to the engine's collection upload-adapter interface, resolving the backend lazily on first upload via `resolveProvider` (so reading validated config never forces env validation at config-build time). **BREAKING:** `vercelBlobStorage` is removed from `@revealui/core` and `@revealui/core/server`; migrate to `objectStorage`. The `createVercelBlobProvider` StorageProvider and the `'vercel-blob'` `createStorage` tag remain for the migration-window Blob fallback.
+  - **admin:** `apps/admin/revealui.config.ts` now uploads through `objectStorage`, resolving the provider from `@revealui/config`'s `config.storage` — Cloudflare R2 when fully configured, else the legacy Vercel Blob token. Media uploads no longer hard-depend on `BLOB_READ_WRITE_TOKEN`.
+  - **server:** drop the now-unused `@vercel/blob` dependency (`apps/server` migrated its media route to `getMediaStorage()` in the prior phase). `@revealui/core` keeps `@vercel/blob` for the Vercel Blob StorageProvider.
+
+### Patch Changes
+
+- f8c74e6: Fix `update()` for JSON-field collections. `selectJsonByIdQuery` now selects `id` alongside `_json`, so the fetched row keeps an `id` and survives `safeParseRevealDocuments` (which drops rows whose `id` is not a string or number). Previously the id-less projection produced a dropped row and `update()` threw "Document not found" for every JSON-field collection.
+  - @revealui/contracts@0.6.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.8
+
+### Patch Changes
+
+- @revealui/cli@0.7.3
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @revealui/db
 
+## 0.7.0
+
+### Minor Changes
+
+- 96b1049: Add `@revealui/db/orm` subpath that re-exports Drizzle ORM query helpers (`eq`, `and`, `or`, `sql`, `inArray`, `desc`, `count`, ...).
+
+  Worker scripts and apps should depend on Drizzle through this subpath instead of importing the bare `drizzle-orm` package. Under pnpm's isolated linker, `drizzle-orm` is materialized only inside the `node_modules` of packages that declare it (such as `@revealui/db`), not at the repo root — so a bare `import('drizzle-orm')` from repo-root `scripts/` fails with `ERR_MODULE_NOT_FOUND`. Importing through `@revealui/db/orm` resolves from any workspace location and guarantees the operators come from the same Drizzle instance as the db client and schema.
+
+### Patch Changes
+
+- e08adbe: Attach an `'error'` event handler to the pg pools created by the database client (localhost / self-hosted Postgres path). A pg `Pool` is an EventEmitter, and an unhandled `'error'` event — emitted when an idle connection is dropped by the server (admin termination, autosuspend, network blip) — throws and crashes the process. The handler logs the error and keeps the pool alive, matching the existing behavior in `pool.ts` (Neon-backed deployments use the HTTP driver and are unaffected).
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/db",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Drizzle ORM schema (85 tables) for RevealUI on NeonDB (Postgres). Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @revealui/engines
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies [96b1049]
+- Updated dependencies [e08adbe]
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/db@0.7.0
+  - @revealui/core@0.9.0
+  - @revealui/auth@0.4.3
+  - @revealui/contracts@0.6.0
+  - @revealui/services@0.7.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, intelligence.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/harnesses
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/core@0.9.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI harness integration — adapters, daemon, workboard coordination, JSON-RPC server.",
   "repository": {
     "type": "git",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @revealui/mcp
 
+## 0.6.0
+
+### Minor Changes
+
+- 239a642: Add the `revealui-docs` MCP server — first-party dependency intelligence. Resolves `@revealui/*` library names and serves curated docs (README + package metadata + public export subpaths) from the monorepo, exported via `@revealui/mcp/docs-server` with a stdio launcher at `servers/docs.ts`. Phase 1 covers first-party packages only; npm/third-party source via `opensrc` is a later phase.
+
+### Patch Changes
+
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/core@0.9.0
+  - @revealui/contracts@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Model Context Protocol framework — MCP server hypervisor, adapter pattern, tool discovery, and adapters for Stripe, Supabase, and Vercel.",
   "repository": {
     "type": "git",

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # revealui
 
+## 0.1.3
+
+### Patch Changes
+
+- create-revealui@0.5.8
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @revealui/services
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies [96b1049]
+- Updated dependencies [e08adbe]
+- Updated dependencies [f8c74e6]
+- Updated dependencies [ba61b20]
+- Updated dependencies [6545491]
+  - @revealui/db@0.7.0
+  - @revealui/core@0.9.0
+  - @revealui/contracts@0.6.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "External service integrations — Stripe (billing + circuit breaker), Vercel (deploy + DNS). Ships with RevealUI.",
   "repository": {
     "type": "git",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/sync
 
+## 0.3.11
+
+### Patch Changes
+
+- Updated dependencies [96b1049]
+- Updated dependencies [e08adbe]
+  - @revealui/db@0.7.0
+  - @revealui/contracts@0.6.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/sync",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Real-time sync layer wrapping ElectricSQL and Yjs CRDT — offline queue, shape cache, conflict resolution, collaborative documents. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Version packages for the launch release

Applies the 6 publishable changesets so `release.yml` publishes real bumped versions (the workflow only runs `changeset publish`, not `version`, so versions must be applied first).

### Bumps
- **Minor:** `@revealui/db` 0.8.0→0.9.0, `@revealui/core` 0.5.0→0.6.0, `@revealui/mcp` 0.6.0→0.7.0
- **Patch:** `@revealui/ai`, `@revealui/auth`, `@revealui/engines`, `@revealui/services`, `@revealui/sync`, `@revealui/harnesses`, `@revealui/cli`, `create-revealui`, `revealui`

### Notes
- 6 changesets referencing ignored apps (`server`, `admin`) correctly persist — apps deploy, they do not publish to npm.
- No `pnpm-lock.yaml` change (internal deps are `workspace:*`).
- After merge: promote test→main, then fire `release.yml` to publish.
