### PR TITLE
docs(agents): correct + complete the package license split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ Full details in `docs/PRO.md`.
 
 ## License
 
-- **OSS (MIT):** core, contracts, db, auth, presentation, router, config, utils, cli, setup, sync, cache, resilience, security, mcp, services
-- **Commercial (source-available):** ai, editors, harnesses
+- **OSS (MIT):** @revealui/auth, @revealui/cache, @revealui/cli, @revealui/config, @revealui/contracts, @revealui/core, @revealui/db, @revealui/dev, @revealui/openapi, @revealui/paywall, @revealui/presentation, @revealui/resilience, @revealui/router, @revealui/security, @revealui/setup, @revealui/sync, @revealui/utils, plus create-revealui, revealui, and test
+- **Pro packages (FSL-1.1-MIT, source-available):** @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services
+- **Internal (no published license):** @revealui/scripts
 
 ## Pricing Tiers
 


### PR DESCRIPTION
## What

Corrects and completes the package license breakdown in `AGENTS.md`.

The list was both wrong and incomplete:
- `editors` — listed as commercial, but no such package exists (`@revealui/editors` is a known phantom; editor configs ship as RevCon).
- `mcp` and `services` — listed as **OSS (MIT)**, but their `package.json` files carry **FSL-1.1-MIT** (source-available). A real licensing-accuracy error.
- `engines` (FSL-1.1-MIT) was missing; 7 packages were omitted entirely.

## Fix

Rebuilt the split from each package's actual `license` field — the source of truth `pnpm validate:claims` enforces:

- **OSS (MIT)** — 20 packages
- **Pro (FSL-1.1-MIT, source-available)** — ai, engines, harnesses, mcp, services
- **Internal (no published license)** — scripts

Switched to `@revealui/`-scoped names so the **claim-drift same-line guard now covers this list**. The bare names previously used slipped past the guard — which is exactly how `mcp`/`services`/`editors` drifted unnoticed.

## Verification

`pnpm validate:claims` (claim-drift) passes: **0 license-membership mismatches, 0 phantom-package mentions**, split reported as `20 MIT | 5 FSL-1.1-MIT | 1 internal/none`.

Surfaced by the 2026-05-29 fleet rules-docs sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
