### PR TITLE
fix(marketing): repair mobile navigation accessibility

### DIFF
--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,21 +1,31 @@
-import { LinkButton } from '@revealui/presentation';
-import { useState } from 'react';
+import { LinkButton, useEscapeKey, useFocusTrap, useScrollLock } from '@revealui/presentation';
+import { useRef, useState } from 'react';
 import { NAV_AUTH, NAV_LINKS } from '../content/nav';
+
+const MOBILE_MENU_ID = 'marketing-mobile-menu';
 
 export function NavBar() {
   const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const close = () => setOpen(false);
+
+  // Use the modal primitives @revealui/presentation already ships: lock body
+  // scroll, trap focus inside the open menu, and close on Escape.
+  useScrollLock(open);
+  useFocusTrap(menuRef, open);
+  useEscapeKey(close, open);
 
   return (
-    <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border">
-      <nav className="mx-auto max-w-7xl px-6 lg:px-8 flex items-center justify-between h-16">
+    <header className="sticky top-0 z-50 border-b border-border bg-background backdrop-blur-md supports-[backdrop-filter]:bg-background/80">
+      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 lg:px-8">
         <a href="/" className="text-xl font-bold tracking-tight text-foreground">
           RevealUI
         </a>
 
         {/* Desktop links */}
-        <div className="hidden sm:flex items-center gap-8 text-sm font-medium text-muted-foreground">
+        <div className="hidden items-center gap-8 text-sm font-medium text-muted-foreground lg:flex">
           {NAV_LINKS.map(({ label, href }) => (
-            <a key={label} href={href} className="hover:text-foreground transition-colors">
+            <a key={label} href={href} className="transition-colors hover:text-foreground">
               {label}
             </a>
           ))}
@@ -23,7 +33,7 @@ export function NavBar() {
             href="https://github.com/RevealUIStudio/revealui"
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
+            className="transition-colors hover:text-foreground"
             aria-label="GitHub"
           >
             <span className="sr-only">GitHub</span>
@@ -40,18 +50,19 @@ export function NavBar() {
         <div className="flex items-center gap-3">
           <a
             href={NAV_AUTH.login.href}
-            className="hidden sm:inline-flex text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            className="hidden text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:inline-flex"
           >
             {NAV_AUTH.login.label}
           </a>
           <LinkButton href={NAV_AUTH.signup.href}>{NAV_AUTH.signup.label}</LinkButton>
 
-          {/* Hamburger - mobile only */}
+          {/* Hamburger - mobile only. 44x44 tap target per WCAG 2.5.5 / Apple HIG. */}
           <button
             type="button"
-            className="sm:hidden -mr-1 flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted transition-colors"
+            className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted lg:hidden"
             aria-label={open ? 'Close menu' : 'Open menu'}
             aria-expanded={open}
+            aria-controls={MOBILE_MENU_ID}
             onClick={() => setOpen((o) => !o)}
           >
             {open ? (
@@ -87,45 +98,56 @@ export function NavBar() {
 
       {/* Mobile menu */}
       {open && (
-        <div className="sm:hidden border-t border-border bg-background px-6 py-4">
-          <div className="flex flex-col gap-1">
-            {NAV_LINKS.map(({ label, href }) => (
+        <>
+          {/* Backdrop: tap outside to close. Sits below the nav row (top-16) so
+              the trigger stays interactive; kept out of the tab order. */}
+          <button
+            type="button"
+            aria-label="Close menu"
+            tabIndex={-1}
+            onClick={close}
+            className="fixed inset-x-0 bottom-0 top-16 z-40 bg-foreground/10 lg:hidden"
+          />
+          <div
+            id={MOBILE_MENU_ID}
+            ref={menuRef}
+            className="relative z-50 border-t border-border bg-background px-6 py-4 lg:hidden"
+          >
+            <div className="flex flex-col gap-1">
+              {NAV_LINKS.map(({ label, href }) => (
+                <a
+                  key={label}
+                  href={href}
+                  className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={close}
+                >
+                  {label}
+                </a>
+              ))}
               <a
-                key={label}
-                href={href}
-                className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                onClick={() => setOpen(false)}
+                href="https://github.com/RevealUIStudio/revealui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={close}
               >
-                {label}
+                GitHub
               </a>
-            ))}
-            <a
-              href="https://github.com/RevealUIStudio/revealui"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              onClick={() => setOpen(false)}
-            >
-              GitHub
-            </a>
+            </div>
+            <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
+              <a
+                href={NAV_AUTH.login.href}
+                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={close}
+              >
+                {NAV_AUTH.login.label}
+              </a>
+              <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">
+                {NAV_AUTH.signup.label}
+              </LinkButton>
+            </div>
           </div>
-          <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
-            <a
-              href={NAV_AUTH.login.href}
-              className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              onClick={() => setOpen(false)}
-            >
-              {NAV_AUTH.login.label}
-            </a>
-            <LinkButton
-              href={NAV_AUTH.signup.href}
-              onClick={() => setOpen(false)}
-              className="w-full"
-            >
-              {NAV_AUTH.signup.label}
-            </LinkButton>
-          </div>
-        </div>
+        </>
       )}
     </header>
   );

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NavBar } from '../NavBar';
+
+afterEach(cleanup);
+
+const MENU_ID = 'marketing-mobile-menu';
+
+describe('NavBar (marketing)', () => {
+  it('renders a 44x44 hamburger wired as an ARIA disclosure trigger', () => {
+    render(<NavBar />);
+    const toggle = screen.getByRole('button', { name: 'Open menu' });
+    // WCAG 2.5.5 / Apple HIG minimum 44x44 tap target.
+    expect(toggle.className).toContain('h-11');
+    expect(toggle.className).toContain('w-11');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('opens the menu and points the trigger at it via aria-controls/id', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const menu = document.getElementById(MENU_ID);
+    expect(menu).toBeInTheDocument();
+
+    // Two "Close menu" buttons exist while open (trigger + backdrop); the
+    // trigger is the one carrying aria-expanded.
+    const toggle = screen.getByRole('button', { name: 'Close menu', expanded: true });
+    expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
+  });
+
+  it('gives every mobile menu link a >=44px tap target', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const links = document.getElementById(MENU_ID)?.querySelectorAll('a') ?? [];
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      // Plain text links use py-3 (~44px); the signup LinkButton uses h-11 (44px).
+      const meetsTarget = link.className.includes('py-3') || link.className.includes('h-11');
+      expect(meetsTarget, `link "${link.textContent?.trim()}" must be >=44px`).toBe(true);
+    }
+  });
+
+  it('closes the menu when Escape is pressed', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.getElementById(MENU_ID)).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('closes the menu when the backdrop is tapped (tap-outside)', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const closers = screen.getAllByRole('button', { name: 'Close menu' });
+    expect(closers).toHaveLength(2);
+    const backdrop = closers.find((b) => !b.hasAttribute('aria-expanded'));
+    expect(backdrop).toBeDefined();
+
+    fireEvent.click(backdrop as HTMLElement);
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('locks body scroll while open and restores it on close', () => {
+    render(<NavBar />);
+    expect(document.body.style.overflow).toBe('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.body.style.overflow).toBe('');
+  });
+});


### PR DESCRIPTION
## What

Repairs the marketing site's mobile navigation, which was broken on touch devices. The `NavBar` imported `@revealui/presentation` but used none of the modal-quality hooks it ships, so the hamburger menu failed basic mobile accessibility.

## Why

The mobile nav had several issues on phones and tablets:

- **Hamburger tap target** was 36×36px (`h-9 w-9`), below the WCAG 2.5.5 / Apple HIG 44×44px minimum, and a negative margin pulled it to the screen edge.
- **No scroll lock / focus trap / Escape / tap-outside-to-close** — the page scrolled under the open menu and keyboard users couldn't dismiss it.
- **Broken ARIA disclosure** — `aria-expanded` was set but `aria-controls`/`id` were missing.
- **`sm:` breakpoint** (640px) crammed the full desktop nav onto tablets and landscape phones.
- **Menu link tap targets** were ~40px.
- **Translucent blurred header** had no fallback for browsers without `backdrop-filter`.

## Changes

- 44×44 hamburger; removed the edge-pulling negative margin.
- Wires `useScrollLock` + `useFocusTrap` + `useEscapeKey` (hooks the package already exports) plus a tap-outside backdrop.
- Adds `id` + `aria-controls` for a correct WAI-ARIA disclosure pattern.
- `sm:` → `lg:` so the higher-fidelity mobile drawer covers tablets too.
- Menu links bumped to a ≥44px tap target.
- Solid header background with a `supports-[backdrop-filter]` translucent override.
- Adds the first marketing component test (`NavBar.test.tsx`): tap target, disclosure wiring, Escape/backdrop close, and body scroll lock.

## Testing

- `pnpm --filter marketing typecheck` — clean
- `pnpm --filter marketing test` — 20/20 passing (6 new NavBar tests)
- `biome check` — clean

## Follow-up (not in this PR)

Internal nav links are still raw `<a>` (full page reload). Switching them to the router's `Link` for client-side navigation is a separate, behavior-changing follow-up.
