### PR TITLE
fix(presentation): style PricingTable with cobalt semantic tokens

### DIFF
--- a/.changeset/pricing-table-semantic-tokens.md
+++ b/.changeset/pricing-table-semantic-tokens.md
@@ -1,0 +1,5 @@
+---
+"@revealui/presentation": minor
+---
+
+`PricingTable` now styles through the cobalt semantic tokens (`primary`, `success`, `card`, `secondary`, `muted-foreground`, `border`) instead of a hardcoded `blue`/`emerald`/`zinc` palette. It now adapts to light/dark themes and tenant brand on the public pricing surface. No API or behavior changes — props and markup are unchanged.

--- a/packages/presentation/src/__tests__/pricing-table.test.tsx
+++ b/packages/presentation/src/__tests__/pricing-table.test.tsx
@@ -205,3 +205,48 @@ describe('PricingTable  -  edge cases', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 });
+
+// =============================================================================
+// Semantic tokens (cobalt design system  -  no hardcoded palette)
+// =============================================================================
+
+describe('PricingTable  -  semantic tokens', () => {
+  // Render every visual branch: current tier, highlighted tier, default tiers,
+  // both link + button CTAs, and the compact layout.
+  function renderAllVariantsHtml(): string {
+    const { container: fullLinks } = render(<PricingTable tiers={mockTiers} currentTier="free" />);
+    const { container: fullButtons } = render(
+      <PricingTable tiers={mockTiers} currentTier="free" onSelectTier={vi.fn()} />,
+    );
+    const { container: compact } = render(
+      <PricingTable tiers={mockTiers} compact currentTier="free" onSelectTier={vi.fn()} />,
+    );
+    return [fullLinks, fullButtons, compact].map((c) => c.innerHTML).join('\n');
+  }
+
+  it('does not leak raw Tailwind palette colors', () => {
+    const html = renderAllVariantsHtml();
+    // The public pricing surface themes via tokens (light/dark/tenant brand), so
+    // no hardcoded palette family may regress back in.
+    const banned = ['blue-', 'indigo-', 'emerald-', 'zinc-', 'bg-white', 'text-white'];
+    for (const token of banned) {
+      expect(html.includes(token), `must not contain "${token}"`).toBe(false);
+    }
+  });
+
+  it('drives brand, surface, and current-plan state from semantic tokens', () => {
+    const html = renderAllVariantsHtml();
+    for (const token of [
+      'bg-card',
+      'bg-primary',
+      'ring-primary',
+      'text-primary-foreground',
+      'bg-secondary',
+      'text-muted-foreground',
+      'ring-border',
+      'text-success',
+    ]) {
+      expect(html.includes(token), `expected "${token}"`).toBe(true);
+    }
+  });
+});

--- a/packages/presentation/src/components/pricing-table.tsx
+++ b/packages/presentation/src/components/pricing-table.tsx
@@ -34,7 +34,7 @@ export interface PricingTableProps {
 function CheckIcon() {
   return (
     <svg
-      className="h-4 w-4 shrink-0 text-blue-600 mt-0.5"
+      className="mt-0.5 h-4 w-4 shrink-0 text-primary"
       fill="currentColor"
       viewBox="0 0 20 20"
       aria-hidden="true"
@@ -113,37 +113,33 @@ function PricingCardFull({
   return (
     <div
       className={cn(
-        'relative rounded-2xl bg-white p-8 shadow-lg dark:bg-zinc-900',
+        'relative rounded-2xl bg-card p-8 shadow-lg',
         isHighlighted
-          ? 'ring-2 ring-blue-600'
+          ? 'ring-2 ring-primary'
           : isCurrent
-            ? 'ring-2 ring-emerald-500'
-            : 'ring-1 ring-zinc-200 dark:ring-zinc-800',
+            ? 'ring-2 ring-success'
+            : 'ring-1 ring-border',
       )}
     >
       {isHighlighted && (
-        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-3 py-1.5 text-sm font-semibold text-white text-center shadow-lg">
+        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-primary px-3 py-1.5 text-center text-sm font-semibold text-primary-foreground shadow-lg">
           Most Popular
         </div>
       )}
       {isCurrent && (
-        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white text-center shadow-lg">
+        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-success/15 px-3 py-1.5 text-center text-sm font-semibold text-success ring-1 ring-inset ring-success/30">
           Current Plan
         </div>
       )}
 
       <div className="mb-8">
-        <h3 className="text-xl font-bold tracking-tight text-zinc-900 dark:text-white">
-          {tier.name}
-        </h3>
-        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{tier.description}</p>
+        <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
         <p className="mt-6 flex items-baseline gap-x-1">
-          <span className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-white">
+          <span className="text-4xl font-bold tracking-tight text-foreground">
             {tier.price ?? '-'}
           </span>
-          {tier.period && (
-            <span className="text-sm text-zinc-600 dark:text-zinc-400">{tier.period}</span>
-          )}
+          {tier.period && <span className="text-sm text-muted-foreground">{tier.period}</span>}
         </p>
       </div>
 
@@ -151,7 +147,7 @@ function PricingCardFull({
         {tier.features.map((feature) => (
           <li key={feature} className="flex items-start gap-x-3">
             <CheckIcon />
-            <span className="text-sm text-zinc-600 dark:text-zinc-400">{feature}</span>
+            <span className="text-sm text-muted-foreground">{feature}</span>
           </li>
         ))}
       </ul>
@@ -164,10 +160,10 @@ function PricingCardFull({
           className={cn(
             'block w-full rounded-md px-6 py-3 text-center text-sm font-semibold transition-colors',
             isCurrent
-              ? 'cursor-default bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
+              ? 'cursor-default bg-success/10 text-success'
               : isHighlighted
-                ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-sm'
-                : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {isCurrent ? 'Current Plan' : tier.cta}
@@ -178,8 +174,8 @@ function PricingCardFull({
           className={cn(
             'block w-full rounded-md px-6 py-3 text-center text-sm font-semibold transition-colors',
             isHighlighted
-              ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-sm'
-              : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
+              : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {tier.cta}
@@ -205,33 +201,27 @@ function PricingCardCompact({
   return (
     <div
       className={cn(
-        'flex-1 rounded-xl p-5 shadow-sm dark:bg-zinc-900',
+        'flex-1 rounded-xl bg-card p-5 shadow-sm',
         isCurrent
-          ? 'ring-2 ring-emerald-500 bg-emerald-50/50 dark:bg-emerald-900/10'
+          ? 'ring-2 ring-success bg-success/5'
           : tier.highlighted
-            ? 'ring-2 ring-blue-600 bg-blue-50/50 dark:bg-blue-900/10'
-            : 'ring-1 ring-zinc-200 bg-white dark:ring-zinc-800',
+            ? 'ring-2 ring-primary bg-primary/5'
+            : 'ring-1 ring-border',
       )}
     >
       <div className="flex items-baseline justify-between gap-2">
-        <h4 className="text-sm font-bold text-zinc-900 dark:text-white">{tier.name}</h4>
+        <h4 className="text-sm font-bold text-foreground">{tier.name}</h4>
         {isCurrent && (
-          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+          <span className="rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
             Current
           </span>
         )}
       </div>
       <p className="mt-1 flex items-baseline gap-x-1">
-        <span className="text-2xl font-bold text-zinc-900 dark:text-white">
-          {tier.price ?? '-'}
-        </span>
-        {tier.period && (
-          <span className="text-xs text-zinc-500 dark:text-zinc-400">{tier.period}</span>
-        )}
+        <span className="text-2xl font-bold text-foreground">{tier.price ?? '-'}</span>
+        {tier.period && <span className="text-xs text-muted-foreground">{tier.period}</span>}
       </p>
-      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400 line-clamp-2">
-        {tier.description}
-      </p>
+      <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{tier.description}</p>
 
       {onSelect ? (
         <button
@@ -241,10 +231,10 @@ function PricingCardCompact({
           className={cn(
             'mt-3 block w-full rounded-md px-3 py-2 text-center text-xs font-semibold transition-colors',
             isCurrent
-              ? 'cursor-default bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
+              ? 'cursor-default bg-success/10 text-success'
               : tier.highlighted
-                ? 'bg-blue-600 text-white hover:bg-blue-500'
-                : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {isCurrent ? 'Current' : tier.cta}
@@ -255,8 +245,8 @@ function PricingCardCompact({
           className={cn(
             'mt-3 block w-full rounded-md px-3 py-2 text-center text-xs font-semibold transition-colors',
             tier.highlighted
-              ? 'bg-blue-600 text-white hover:bg-blue-500'
-              : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {tier.cta}


### PR DESCRIPTION
## What

Converts the `PricingTable` component (`@revealui/presentation`) from a hardcoded Tailwind palette to the cobalt semantic design tokens, so it respects brand + dark mode + tenant brand.

## Why

`PricingTable` hardcoded `blue-600` CTAs, an `emerald-600` "Current Plan" badge, `ring-emerald-500`, and `zinc`/`white` surfaces. On the pricing surface this ignored the cobalt brand, didn't adapt to dark mode, and hand-duplicated light/dark variants.

## Changes

| Was | Now |
| --- | --- |
| `bg-blue-600` (brand CTA/ring) | `bg-primary` / `ring-primary` / `text-primary-foreground` |
| `bg-emerald-*` / `ring-emerald-500` (current plan) | `bg-success/10` · `text-success` · `ring-success` |
| `bg-white dark:bg-zinc-900` (card) | `bg-card` |
| `text-zinc-900 dark:text-white` | `text-foreground` |
| `text-zinc-600 dark:text-zinc-400` | `text-muted-foreground` |
| `ring-zinc-200 dark:ring-zinc-800` | `ring-border` |
| `bg-zinc-100 … dark:bg-zinc-800` (secondary CTA) | `bg-secondary text-secondary-foreground` |
| `from-blue-600 to-indigo-600` gradient | solid `bg-primary` ribbon |

No API or behavior change — props, markup, and interactions are identical.

## Testing

- `pnpm --filter @revealui/presentation typecheck` — clean
- `pnpm --filter @revealui/presentation test` (pricing-table) — 22/22 (20 existing + 2 new token-regression guards)
- `biome check` — clean
- Changeset added (`@revealui/presentation` minor)

## Notes

- There is no `--success-foreground` token in the bridge yet, so the "current plan" state uses the tinted `bg-success/10 text-success` treatment rather than a solid fill.
- A docs showcase was intentionally left out: the docs app's theme doesn't yet bridge the cobalt semantic tokens (`--color-primary/card/success/…`), so a showcase would render unstyled. Adding the docs-side bridge is design-system convergence work tracked separately.
