### PR TITLE
release: promote test to main (nav a11y + pricing tokens + license docs)

### DIFF
--- a/.changeset/pricing-table-semantic-tokens.md
+++ b/.changeset/pricing-table-semantic-tokens.md
@@ -1,0 +1,5 @@
+---
+"@revealui/presentation": minor
+---
+
+`PricingTable` now styles through the cobalt semantic tokens (`primary`, `success`, `card`, `secondary`, `muted-foreground`, `border`) instead of a hardcoded `blue`/`emerald`/`zinc` palette. It now adapts to light/dark themes and tenant brand on the public pricing surface. No API or behavior changes — props and markup are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ Full details in `docs/PRO.md`.
 
 ## License
 
-- **OSS (MIT):** core, contracts, db, auth, presentation, router, config, utils, cli, setup, sync, cache, resilience, security, mcp, services
-- **Commercial (source-available):** ai, editors, harnesses
+- **OSS (MIT):** @revealui/auth, @revealui/cache, @revealui/cli, @revealui/config, @revealui/contracts, @revealui/core, @revealui/db, @revealui/dev, @revealui/openapi, @revealui/paywall, @revealui/presentation, @revealui/resilience, @revealui/router, @revealui/security, @revealui/setup, @revealui/sync, @revealui/utils, plus create-revealui, revealui, and test
+- **Pro packages (FSL-1.1-MIT, source-available):** @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services
+- **Internal (no published license):** @revealui/scripts
 
 ## Pricing Tiers
 

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,21 +1,31 @@
-import { LinkButton } from '@revealui/presentation';
-import { useState } from 'react';
+import { LinkButton, useEscapeKey, useFocusTrap, useScrollLock } from '@revealui/presentation';
+import { useRef, useState } from 'react';
 import { NAV_AUTH, NAV_LINKS } from '../content/nav';
+
+const MOBILE_MENU_ID = 'marketing-mobile-menu';
 
 export function NavBar() {
   const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const close = () => setOpen(false);
+
+  // Use the modal primitives @revealui/presentation already ships: lock body
+  // scroll, trap focus inside the open menu, and close on Escape.
+  useScrollLock(open);
+  useFocusTrap(menuRef, open);
+  useEscapeKey(close, open);
 
   return (
-    <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border">
-      <nav className="mx-auto max-w-7xl px-6 lg:px-8 flex items-center justify-between h-16">
+    <header className="sticky top-0 z-50 border-b border-border bg-background backdrop-blur-md supports-[backdrop-filter]:bg-background/80">
+      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 lg:px-8">
         <a href="/" className="text-xl font-bold tracking-tight text-foreground">
           RevealUI
         </a>
 
         {/* Desktop links */}
-        <div className="hidden sm:flex items-center gap-8 text-sm font-medium text-muted-foreground">
+        <div className="hidden items-center gap-8 text-sm font-medium text-muted-foreground lg:flex">
           {NAV_LINKS.map(({ label, href }) => (
-            <a key={label} href={href} className="hover:text-foreground transition-colors">
+            <a key={label} href={href} className="transition-colors hover:text-foreground">
               {label}
             </a>
           ))}
@@ -23,7 +33,7 @@ export function NavBar() {
             href="https://github.com/RevealUIStudio/revealui"
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
+            className="transition-colors hover:text-foreground"
             aria-label="GitHub"
           >
             <span className="sr-only">GitHub</span>
@@ -40,18 +50,19 @@ export function NavBar() {
         <div className="flex items-center gap-3">
           <a
             href={NAV_AUTH.login.href}
-            className="hidden sm:inline-flex text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            className="hidden text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:inline-flex"
           >
             {NAV_AUTH.login.label}
           </a>
           <LinkButton href={NAV_AUTH.signup.href}>{NAV_AUTH.signup.label}</LinkButton>
 
-          {/* Hamburger - mobile only */}
+          {/* Hamburger - mobile only. 44x44 tap target per WCAG 2.5.5 / Apple HIG. */}
           <button
             type="button"
-            className="sm:hidden -mr-1 flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted transition-colors"
+            className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted lg:hidden"
             aria-label={open ? 'Close menu' : 'Open menu'}
             aria-expanded={open}
+            aria-controls={MOBILE_MENU_ID}
             onClick={() => setOpen((o) => !o)}
           >
             {open ? (
@@ -87,45 +98,56 @@ export function NavBar() {
 
       {/* Mobile menu */}
       {open && (
-        <div className="sm:hidden border-t border-border bg-background px-6 py-4">
-          <div className="flex flex-col gap-1">
-            {NAV_LINKS.map(({ label, href }) => (
+        <>
+          {/* Backdrop: tap outside to close. Sits below the nav row (top-16) so
+              the trigger stays interactive; kept out of the tab order. */}
+          <button
+            type="button"
+            aria-label="Close menu"
+            tabIndex={-1}
+            onClick={close}
+            className="fixed inset-x-0 bottom-0 top-16 z-40 bg-foreground/10 lg:hidden"
+          />
+          <div
+            id={MOBILE_MENU_ID}
+            ref={menuRef}
+            className="relative z-50 border-t border-border bg-background px-6 py-4 lg:hidden"
+          >
+            <div className="flex flex-col gap-1">
+              {NAV_LINKS.map(({ label, href }) => (
+                <a
+                  key={label}
+                  href={href}
+                  className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={close}
+                >
+                  {label}
+                </a>
+              ))}
               <a
-                key={label}
-                href={href}
-                className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                onClick={() => setOpen(false)}
+                href="https://github.com/RevealUIStudio/revealui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={close}
               >
-                {label}
+                GitHub
               </a>
-            ))}
-            <a
-              href="https://github.com/RevealUIStudio/revealui"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              onClick={() => setOpen(false)}
-            >
-              GitHub
-            </a>
+            </div>
+            <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
+              <a
+                href={NAV_AUTH.login.href}
+                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={close}
+              >
+                {NAV_AUTH.login.label}
+              </a>
+              <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">
+                {NAV_AUTH.signup.label}
+              </LinkButton>
+            </div>
           </div>
-          <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
-            <a
-              href={NAV_AUTH.login.href}
-              className="rounded-md px-3 py-2.5 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              onClick={() => setOpen(false)}
-            >
-              {NAV_AUTH.login.label}
-            </a>
-            <LinkButton
-              href={NAV_AUTH.signup.href}
-              onClick={() => setOpen(false)}
-              className="w-full"
-            >
-              {NAV_AUTH.signup.label}
-            </LinkButton>
-          </div>
-        </div>
+        </>
       )}
     </header>
   );

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NavBar } from '../NavBar';
+
+afterEach(cleanup);
+
+const MENU_ID = 'marketing-mobile-menu';
+
+describe('NavBar (marketing)', () => {
+  it('renders a 44x44 hamburger wired as an ARIA disclosure trigger', () => {
+    render(<NavBar />);
+    const toggle = screen.getByRole('button', { name: 'Open menu' });
+    // WCAG 2.5.5 / Apple HIG minimum 44x44 tap target.
+    expect(toggle.className).toContain('h-11');
+    expect(toggle.className).toContain('w-11');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('opens the menu and points the trigger at it via aria-controls/id', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const menu = document.getElementById(MENU_ID);
+    expect(menu).toBeInTheDocument();
+
+    // Two "Close menu" buttons exist while open (trigger + backdrop); the
+    // trigger is the one carrying aria-expanded.
+    const toggle = screen.getByRole('button', { name: 'Close menu', expanded: true });
+    expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
+  });
+
+  it('gives every mobile menu link a >=44px tap target', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const links = document.getElementById(MENU_ID)?.querySelectorAll('a') ?? [];
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      // Plain text links use py-3 (~44px); the signup LinkButton uses h-11 (44px).
+      const meetsTarget = link.className.includes('py-3') || link.className.includes('h-11');
+      expect(meetsTarget, `link "${link.textContent?.trim()}" must be >=44px`).toBe(true);
+    }
+  });
+
+  it('closes the menu when Escape is pressed', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.getElementById(MENU_ID)).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('closes the menu when the backdrop is tapped (tap-outside)', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const closers = screen.getAllByRole('button', { name: 'Close menu' });
+    expect(closers).toHaveLength(2);
+    const backdrop = closers.find((b) => !b.hasAttribute('aria-expanded'));
+    expect(backdrop).toBeDefined();
+
+    fireEvent.click(backdrop as HTMLElement);
+    expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('locks body scroll while open and restores it on close', () => {
+    render(<NavBar />);
+    expect(document.body.style.overflow).toBe('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/packages/presentation/src/__tests__/pricing-table.test.tsx
+++ b/packages/presentation/src/__tests__/pricing-table.test.tsx
@@ -205,3 +205,48 @@ describe('PricingTable  -  edge cases', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 });
+
+// =============================================================================
+// Semantic tokens (cobalt design system  -  no hardcoded palette)
+// =============================================================================
+
+describe('PricingTable  -  semantic tokens', () => {
+  // Render every visual branch: current tier, highlighted tier, default tiers,
+  // both link + button CTAs, and the compact layout.
+  function renderAllVariantsHtml(): string {
+    const { container: fullLinks } = render(<PricingTable tiers={mockTiers} currentTier="free" />);
+    const { container: fullButtons } = render(
+      <PricingTable tiers={mockTiers} currentTier="free" onSelectTier={vi.fn()} />,
+    );
+    const { container: compact } = render(
+      <PricingTable tiers={mockTiers} compact currentTier="free" onSelectTier={vi.fn()} />,
+    );
+    return [fullLinks, fullButtons, compact].map((c) => c.innerHTML).join('\n');
+  }
+
+  it('does not leak raw Tailwind palette colors', () => {
+    const html = renderAllVariantsHtml();
+    // The public pricing surface themes via tokens (light/dark/tenant brand), so
+    // no hardcoded palette family may regress back in.
+    const banned = ['blue-', 'indigo-', 'emerald-', 'zinc-', 'bg-white', 'text-white'];
+    for (const token of banned) {
+      expect(html.includes(token), `must not contain "${token}"`).toBe(false);
+    }
+  });
+
+  it('drives brand, surface, and current-plan state from semantic tokens', () => {
+    const html = renderAllVariantsHtml();
+    for (const token of [
+      'bg-card',
+      'bg-primary',
+      'ring-primary',
+      'text-primary-foreground',
+      'bg-secondary',
+      'text-muted-foreground',
+      'ring-border',
+      'text-success',
+    ]) {
+      expect(html.includes(token), `expected "${token}"`).toBe(true);
+    }
+  });
+});

--- a/packages/presentation/src/components/pricing-table.tsx
+++ b/packages/presentation/src/components/pricing-table.tsx
@@ -34,7 +34,7 @@ export interface PricingTableProps {
 function CheckIcon() {
   return (
     <svg
-      className="h-4 w-4 shrink-0 text-blue-600 mt-0.5"
+      className="mt-0.5 h-4 w-4 shrink-0 text-primary"
       fill="currentColor"
       viewBox="0 0 20 20"
       aria-hidden="true"
@@ -113,37 +113,33 @@ function PricingCardFull({
   return (
     <div
       className={cn(
-        'relative rounded-2xl bg-white p-8 shadow-lg dark:bg-zinc-900',
+        'relative rounded-2xl bg-card p-8 shadow-lg',
         isHighlighted
-          ? 'ring-2 ring-blue-600'
+          ? 'ring-2 ring-primary'
           : isCurrent
-            ? 'ring-2 ring-emerald-500'
-            : 'ring-1 ring-zinc-200 dark:ring-zinc-800',
+            ? 'ring-2 ring-success'
+            : 'ring-1 ring-border',
       )}
     >
       {isHighlighted && (
-        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-3 py-1.5 text-sm font-semibold text-white text-center shadow-lg">
+        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-primary px-3 py-1.5 text-center text-sm font-semibold text-primary-foreground shadow-lg">
           Most Popular
         </div>
       )}
       {isCurrent && (
-        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white text-center shadow-lg">
+        <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-success/15 px-3 py-1.5 text-center text-sm font-semibold text-success ring-1 ring-inset ring-success/30">
           Current Plan
         </div>
       )}
 
       <div className="mb-8">
-        <h3 className="text-xl font-bold tracking-tight text-zinc-900 dark:text-white">
-          {tier.name}
-        </h3>
-        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{tier.description}</p>
+        <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
         <p className="mt-6 flex items-baseline gap-x-1">
-          <span className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-white">
+          <span className="text-4xl font-bold tracking-tight text-foreground">
             {tier.price ?? '-'}
           </span>
-          {tier.period && (
-            <span className="text-sm text-zinc-600 dark:text-zinc-400">{tier.period}</span>
-          )}
+          {tier.period && <span className="text-sm text-muted-foreground">{tier.period}</span>}
         </p>
       </div>
 
@@ -151,7 +147,7 @@ function PricingCardFull({
         {tier.features.map((feature) => (
           <li key={feature} className="flex items-start gap-x-3">
             <CheckIcon />
-            <span className="text-sm text-zinc-600 dark:text-zinc-400">{feature}</span>
+            <span className="text-sm text-muted-foreground">{feature}</span>
           </li>
         ))}
       </ul>
@@ -164,10 +160,10 @@ function PricingCardFull({
           className={cn(
             'block w-full rounded-md px-6 py-3 text-center text-sm font-semibold transition-colors',
             isCurrent
-              ? 'cursor-default bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
+              ? 'cursor-default bg-success/10 text-success'
               : isHighlighted
-                ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-sm'
-                : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {isCurrent ? 'Current Plan' : tier.cta}
@@ -178,8 +174,8 @@ function PricingCardFull({
           className={cn(
             'block w-full rounded-md px-6 py-3 text-center text-sm font-semibold transition-colors',
             isHighlighted
-              ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-sm'
-              : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
+              : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {tier.cta}
@@ -205,33 +201,27 @@ function PricingCardCompact({
   return (
     <div
       className={cn(
-        'flex-1 rounded-xl p-5 shadow-sm dark:bg-zinc-900',
+        'flex-1 rounded-xl bg-card p-5 shadow-sm',
         isCurrent
-          ? 'ring-2 ring-emerald-500 bg-emerald-50/50 dark:bg-emerald-900/10'
+          ? 'ring-2 ring-success bg-success/5'
           : tier.highlighted
-            ? 'ring-2 ring-blue-600 bg-blue-50/50 dark:bg-blue-900/10'
-            : 'ring-1 ring-zinc-200 bg-white dark:ring-zinc-800',
+            ? 'ring-2 ring-primary bg-primary/5'
+            : 'ring-1 ring-border',
       )}
     >
       <div className="flex items-baseline justify-between gap-2">
-        <h4 className="text-sm font-bold text-zinc-900 dark:text-white">{tier.name}</h4>
+        <h4 className="text-sm font-bold text-foreground">{tier.name}</h4>
         {isCurrent && (
-          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+          <span className="rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
             Current
           </span>
         )}
       </div>
       <p className="mt-1 flex items-baseline gap-x-1">
-        <span className="text-2xl font-bold text-zinc-900 dark:text-white">
-          {tier.price ?? '-'}
-        </span>
-        {tier.period && (
-          <span className="text-xs text-zinc-500 dark:text-zinc-400">{tier.period}</span>
-        )}
+        <span className="text-2xl font-bold text-foreground">{tier.price ?? '-'}</span>
+        {tier.period && <span className="text-xs text-muted-foreground">{tier.period}</span>}
       </p>
-      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400 line-clamp-2">
-        {tier.description}
-      </p>
+      <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{tier.description}</p>
 
       {onSelect ? (
         <button
@@ -241,10 +231,10 @@ function PricingCardCompact({
           className={cn(
             'mt-3 block w-full rounded-md px-3 py-2 text-center text-xs font-semibold transition-colors',
             isCurrent
-              ? 'cursor-default bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
+              ? 'cursor-default bg-success/10 text-success'
               : tier.highlighted
-                ? 'bg-blue-600 text-white hover:bg-blue-500'
-                : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {isCurrent ? 'Current' : tier.cta}
@@ -255,8 +245,8 @@ function PricingCardCompact({
           className={cn(
             'mt-3 block w-full rounded-md px-3 py-2 text-center text-xs font-semibold transition-colors',
             tier.highlighted
-              ? 'bg-blue-600 text-white hover:bg-blue-500'
-              : 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700',
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
         >
           {tier.cta}


### PR DESCRIPTION
Promotes `test` to `main` (production deploy).

New since the last promotion (all gated on `test` CI):

- #1180 — fix(marketing): repair mobile navigation accessibility
- #1181 — fix(presentation): style PricingTable with cobalt semantic tokens
- #1179 — docs(agents): correct and complete the package license split

(plus the routine main→test backflow merges already present on `main`.)

Merge with a **merge commit** (not squash) to preserve parentage for the promotion gate.
