### PR TITLE
release: promote test to main (marketing SPA nav)

### DIFF
--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,13 +1,45 @@
 import { LinkButton, useEscapeKey, useFocusTrap, useScrollLock } from '@revealui/presentation';
-import { useRef, useState } from 'react';
+import { Link, useLocation } from '@revealui/router';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { NAV_AUTH, NAV_LINKS } from '../content/nav';
 
 const MOBILE_MENU_ID = 'marketing-mobile-menu';
+
+/**
+ * Internal (relative) paths navigate client-side through @revealui/router so
+ * the marketing site dogfoods its own router; absolute URLs (docs, GitHub, the
+ * admin app) stay full-page anchors.
+ */
+function NavLink({
+  href,
+  className,
+  onClick,
+  children,
+}: {
+  href: string;
+  className?: string;
+  onClick?: () => void;
+  children: ReactNode;
+}) {
+  if (href.startsWith('/')) {
+    return (
+      <Link to={href} className={className} onClick={onClick}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a href={href} className={className} onClick={onClick}>
+      {children}
+    </a>
+  );
+}
 
 export function NavBar() {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const close = () => setOpen(false);
+  const { pathname } = useLocation();
 
   // Use the modal primitives @revealui/presentation already ships: lock body
   // scroll, trap focus inside the open menu, and close on Escape.
@@ -15,19 +47,26 @@ export function NavBar() {
   useFocusTrap(menuRef, open);
   useEscapeKey(close, open);
 
+  // Close the mobile menu after a client-side navigation (covers browser
+  // back/forward, where a link's own onClick never fires).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intended re-run trigger, not read in the body
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background backdrop-blur-md supports-[backdrop-filter]:bg-background/80">
       <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 lg:px-8">
-        <a href="/" className="text-xl font-bold tracking-tight text-foreground">
+        <NavLink href="/" className="text-xl font-bold tracking-tight text-foreground">
           RevealUI
-        </a>
+        </NavLink>
 
         {/* Desktop links */}
         <div className="hidden items-center gap-8 text-sm font-medium text-muted-foreground lg:flex">
           {NAV_LINKS.map(({ label, href }) => (
-            <a key={label} href={href} className="transition-colors hover:text-foreground">
+            <NavLink key={label} href={href} className="transition-colors hover:text-foreground">
               {label}
-            </a>
+            </NavLink>
           ))}
           <a
             href="https://github.com/RevealUIStudio/revealui"
@@ -48,12 +87,12 @@ export function NavBar() {
         </div>
 
         <div className="flex items-center gap-3">
-          <a
+          <NavLink
             href={NAV_AUTH.login.href}
             className="hidden text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:inline-flex"
           >
             {NAV_AUTH.login.label}
-          </a>
+          </NavLink>
           <LinkButton href={NAV_AUTH.signup.href}>{NAV_AUTH.signup.label}</LinkButton>
 
           {/* Hamburger - mobile only. 44x44 tap target per WCAG 2.5.5 / Apple HIG. */}
@@ -115,14 +154,14 @@ export function NavBar() {
           >
             <div className="flex flex-col gap-1">
               {NAV_LINKS.map(({ label, href }) => (
-                <a
+                <NavLink
                   key={label}
                   href={href}
                   className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   onClick={close}
                 >
                   {label}
-                </a>
+                </NavLink>
               ))}
               <a
                 href="https://github.com/RevealUIStudio/revealui"
@@ -135,13 +174,13 @@ export function NavBar() {
               </a>
             </div>
             <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
-              <a
+              <NavLink
                 href={NAV_AUTH.login.href}
                 className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 onClick={close}
               >
                 {NAV_AUTH.login.label}
-              </a>
+              </NavLink>
               <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">
                 {NAV_AUTH.signup.label}
               </LinkButton>

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+import { Router, RouterProvider } from '@revealui/router';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { NavBar } from '../NavBar';
@@ -7,9 +8,19 @@ afterEach(cleanup);
 
 const MENU_ID = 'marketing-mobile-menu';
 
+// NavBar now navigates via the router (Link + useLocation), so it must render
+// inside a RouterProvider.
+function renderNavBar() {
+  return render(
+    <RouterProvider router={new Router()}>
+      <NavBar />
+    </RouterProvider>,
+  );
+}
+
 describe('NavBar (marketing)', () => {
   it('renders a 44x44 hamburger wired as an ARIA disclosure trigger', () => {
-    render(<NavBar />);
+    renderNavBar();
     const toggle = screen.getByRole('button', { name: 'Open menu' });
     // WCAG 2.5.5 / Apple HIG minimum 44x44 tap target.
     expect(toggle.className).toContain('h-11');
@@ -20,7 +31,7 @@ describe('NavBar (marketing)', () => {
   });
 
   it('opens the menu and points the trigger at it via aria-controls/id', () => {
-    render(<NavBar />);
+    renderNavBar();
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
 
     const menu = document.getElementById(MENU_ID);
@@ -33,7 +44,7 @@ describe('NavBar (marketing)', () => {
   });
 
   it('gives every mobile menu link a >=44px tap target', () => {
-    render(<NavBar />);
+    renderNavBar();
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
 
     const links = document.getElementById(MENU_ID)?.querySelectorAll('a') ?? [];
@@ -46,7 +57,7 @@ describe('NavBar (marketing)', () => {
   });
 
   it('closes the menu when Escape is pressed', () => {
-    render(<NavBar />);
+    renderNavBar();
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
     expect(document.getElementById(MENU_ID)).toBeInTheDocument();
 
@@ -55,7 +66,7 @@ describe('NavBar (marketing)', () => {
   });
 
   it('closes the menu when the backdrop is tapped (tap-outside)', () => {
-    render(<NavBar />);
+    renderNavBar();
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
 
     const closers = screen.getAllByRole('button', { name: 'Close menu' });
@@ -68,7 +79,7 @@ describe('NavBar (marketing)', () => {
   });
 
   it('locks body scroll while open and restores it on close', () => {
-    render(<NavBar />);
+    renderNavBar();
     expect(document.body.style.overflow).toBe('');
 
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
@@ -76,5 +87,17 @@ describe('NavBar (marketing)', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('routes internal nav links through the SPA router; external links stay anchors', () => {
+    renderNavBar();
+    // Internal route -> router Link that intercepts the click (no full reload).
+    const pricing = screen.getByRole('link', { name: 'Pricing' });
+    expect(pricing).toHaveAttribute('href', '/pricing');
+    expect(fireEvent.click(pricing)).toBe(false); // default prevented = intercepted
+
+    // Absolute URL -> plain anchor, left for a full-page load.
+    const docs = screen.getByRole('link', { name: 'Docs' });
+    expect(docs).toHaveAttribute('href', 'https://docs.revealui.com');
   });
 });


### PR DESCRIPTION
Promotes `test` to `main` (production deploy).

New since the last promotion (gated on `test` CI):

- #1184 — feat(marketing): navigate internal nav links client-side via the router (SPA nav on the marketing NavBar)

(plus the routine main→test backflow merge already present on `main`.)

Merge with a **merge commit** (not squash) to preserve parentage for the promotion gate.
