### PR TITLE
fix(admin): let non-admin subscribers reach /welcome after checkout

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -84,3 +84,34 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
     expect(a).not.toBe(b);
   });
 });
+
+describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ needed: false }) });
+  });
+
+  it('lets an authenticated non-admin (paying customer) reach /welcome without bouncing to /login', async () => {
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/welcome?success=true&tier=pro', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+      }),
+    );
+    // Post-checkout landing is session-gated, not admin-gated: no redirect.
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('still requires a session for /welcome (no session redirects to /login)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/welcome'));
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('still enforces the admin role on other backend pages (non-admin session redirects to /login)', async () => {
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/posts', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+      }),
+    );
+    expect(res.headers.get('location')).toContain('/login');
+  });
+});

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -47,6 +47,15 @@ const PUBLIC_PATHS = new Set([
   '/setup',
 ]);
 
+// Session-only paths in the (backend) route group: require an authenticated
+// session but NOT the admin role. `/welcome` is the post-checkout landing
+// (Stripe `success_url` in apps/server billing.ts) and every self-serve
+// subscriber has role `user`, not `admin` — gating it on admin would bounce a
+// paying customer to /login at the moment of conversion. The page is a client
+// component that renders only the user's own tier + generic CTAs (no privileged
+// data), so a valid session is sufficient.
+const SESSION_ONLY_PATHS = new Set(['/welcome']);
+
 // Legacy `/admin/*` paths from before the chip-2 URL flatten (#644) — 301 to
 // flat path. Catches stale bookmarks and any external links written against
 // the pre-flatten URLs. MUST be `/admin` (the historical prefix); empty
@@ -151,12 +160,16 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       return NextResponse.redirect(loginUrl);
     }
 
-    const role = request.cookies.get('revealui-role')?.value;
-    if (role !== 'admin') {
-      // User is authenticated but not admin — redirect to login (no admin home for non-admins)
-      const loginUrl = request.nextUrl.clone();
-      loginUrl.pathname = '/login';
-      return NextResponse.redirect(loginUrl);
+    // Admin-role requirement. Skipped for session-only paths (e.g. /welcome),
+    // which any authenticated user may reach.
+    if (!SESSION_ONLY_PATHS.has(pathname)) {
+      const role = request.cookies.get('revealui-role')?.value;
+      if (role !== 'admin') {
+        // User is authenticated but not admin — redirect to login (no admin home for non-admins)
+        const loginUrl = request.nextUrl.clone();
+        loginUrl.pathname = '/login';
+        return NextResponse.redirect(loginUrl);
+      }
     }
 
     // Password rotation enforcement — block protected pages until password is changed


### PR DESCRIPTION
## Summary

Stripe subscription checkout (`apps/server/src/routes/billing.ts`) sets `success_url` to `/welcome`, but `apps/admin/src/proxy.ts` gated every `(backend)` page on `revealui-role === 'admin'`. Only the first account is ever promoted to admin, so every self-serve subscriber (role `user`) was redirected to `/login` immediately after paying — a successful purchase appeared broken.

## Change

- Add `SESSION_ONLY_PATHS` (currently `/welcome`) and skip the admin-role check for those paths. A valid session is still required; admin gating is preserved for all other `(backend)` pages.
- `/welcome` is a client component that renders only the user's own tier + three generic CTAs (install CLI / clone source / quick-start) with no privileged data, so session-gating is sufficient.

## Tests

`apps/admin/src/__tests__/proxy-csp.test.ts` gains a gate block:
- authenticated non-admin reaches `/welcome` (no redirect)
- `/welcome` without a session still redirects to `/login`
- admin role still enforced on other backend pages (non-admin → `/login`)

Found via an internal checkout/onboarding UX audit. Base `test`.
