### PR TITLE
fix(server,admin): require Gmail email transport at boot in hosted prod

### DIFF
--- a/apps/admin/src/lib/utils/env-validation.ts
+++ b/apps/admin/src/lib/utils/env-validation.ts
@@ -157,6 +157,21 @@ export function validateRequiredEnvVars(
         missing.push(key);
       }
     }
+
+    // Transactional email transport (Gmail API — packages/services/src/email).
+    // The signup VERIFICATION email is sent from THIS admin app; without both
+    // vars getEmailProvider() falls back to a no-op that drops every send, so a
+    // non-first signup is created with no session and no email and (after the
+    // 24h grace) is locked out with no working recovery. Required in hosted
+    // production so a misconfigured deploy fails fast at boot (instrumentation.ts)
+    // instead of silently locking out every new user. Fleet kits are exempt
+    // (no Workspace email) via the !isFleetMode guard above.
+    const emailTransportVars = ['GOOGLE_SERVICE_ACCOUNT_EMAIL', 'GOOGLE_PRIVATE_KEY'];
+    for (const key of emailTransportVars) {
+      if (!process.env[key]) {
+        missing.push(key);
+      }
+    }
   }
 
   const valid = missing.length === 0;

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -801,6 +801,8 @@ describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () 
       STRIPE_WEBHOOK_SECRET: '',
       STRIPE_LIVE_MODE: '',
       REVEALUI_BILLING_PORTAL_CONFIG_ID: '',
+      GOOGLE_SERVICE_ACCOUNT_EMAIL: '',
+      GOOGLE_PRIVATE_KEY: '',
       ...overrides,
     };
   }

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -27,6 +27,8 @@ function validLiveProdEnv(overrides: EnvMap = {}): EnvMap {
     REVEALUI_ALERT_EMAIL: 'ops@revealui.com',
     SENTRY_DSN: 'https://abc123@o123456.ingest.sentry.io/456789',
     REVEALUI_BILLING_PORTAL_CONFIG_ID: 'bpc_test_fixture',
+    GOOGLE_SERVICE_ACCOUNT_EMAIL: 'svc@project.iam.gserviceaccount.com',
+    GOOGLE_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----',
     ...overrides,
   };
 }
@@ -127,6 +129,12 @@ describe('validateStartup — production presence', () => {
     const env = validLiveProdEnv();
     delete env.SENTRY_DSN;
     expect(() => validateStartup(env)).toThrow(/SENTRY_DSN/);
+  });
+
+  it('rejects missing Gmail email transport vars in production hosted env', () => {
+    const env = validLiveProdEnv();
+    delete env.GOOGLE_PRIVATE_KEY;
+    expect(() => validateStartup(env)).toThrow(/GOOGLE_PRIVATE_KEY/);
   });
 });
 

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -137,6 +137,16 @@ const REQUIRED_IN_PRODUCTION_HOSTED = [
   // back to Stripe's default (all plans visible, no flow customisation).
   // Required here so we never flip live-mode without the portal wired. (#827)
   'REVEALUI_BILLING_PORTAL_CONFIG_ID',
+  // Transactional email transport (Gmail API with domain-wide delegation — see
+  // packages/services/src/email/index.ts → getEmailProvider). Without BOTH of
+  // these, getEmailProvider() falls back to a no-op that drops every send, so
+  // receipt / license-activation / refund emails (and, in the admin app, signup
+  // verification) silently never arrive while the deploy boots clean with no
+  // signal. Require them so a hosted deploy with broken email transport fails
+  // loudly at boot instead of silently degrading. EMAIL_FROM is intentionally
+  // not required — it has a safe default (noreply@revealui.com).
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+  'GOOGLE_PRIVATE_KEY',
 ] as const;
 
 const REQUIRED_IN_PRODUCTION_FORGE = [


### PR DESCRIPTION
## Summary

`packages/services/src/email/index.ts` → `getEmailProvider()` selects the Gmail provider only when **both** `GOOGLE_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_PRIVATE_KEY` are set; otherwise it returns a no-op provider that drops every send. Neither app's boot validation required these, so a hosted deploy with email transport misconfigured booted **clean** and silently broke every transactional email.

The worst case is signup verification: it is sent (fire-and-forget) from the **admin** app, and a non-first signup only gets a session once verified. With email dead, every new free + paying user is created with no session and no email, and after the 24h grace period is locked out with no working recovery.

## Change

Require both vars at boot in **hosted, non-Fleet production**:

- **apps/server** — added to `REQUIRED_IN_PRODUCTION_HOSTED` in `validate-startup.ts` (guards server-side receipt / license-activation / refund emails) + updated the prod-env test fixture + a new presence test.
- **apps/admin** — added to the production block of `validateRequiredEnvVars` (`lib/utils/env-validation.ts`), which `instrumentation.ts` already enforces with `process.exit(1)` in production (guards signup verification).

Fleet / self-host kits are exempt (`!isFleetMode` / forge mode — no Workspace email). `EMAIL_FROM` is intentionally **not** required (safe default `noreply@revealui.com`).

## ⚠️ Before promoting to main

This makes hosted `apps/server` + `apps/admin` **refuse to boot** without email transport. Confirm `GOOGLE_SERVICE_ACCOUNT_EMAIL` + `GOOGLE_PRIVATE_KEY` are present in the prod Vercel env for **both** projects before this reaches production.

## Tests

`apps/server/.../validate-startup.test.ts`: fixture updated + a new test asserting a missing transport var throws at boot. (The admin validator reads `process.env` directly, so it is covered by the mirrored server test rather than a CI-env-flaky unit test.)

Found via an internal checkout/onboarding UX audit. Base `test`.
