### PR TITLE
feat(marketing): studio/agency fork branch + pricing reseller value band

### DIFF
--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -31,11 +31,11 @@ export function Fork() {
 
   return (
     <section id="homepage-fork" aria-label="Choose your path" className="bg-muted py-12 sm:py-16">
-      <div className="mx-auto max-w-4xl px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
         <p className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-6">
-          Two ways to use RevealUI
+          Three ways to use RevealUI
         </p>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <button
             type="button"
             onClick={handleSelfBuildScroll}
@@ -60,6 +60,19 @@ export function Fork() {
             <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchB.body}</p>
             <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
               {HOME_FORK.branchB.cta}
+            </p>
+          </a>
+
+          <a
+            href={HOME_FORK.branchC.href}
+            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <h3 className="text-lg font-semibold leading-7 text-foreground">
+              {HOME_FORK.branchC.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchC.body}</p>
+            <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
+              {HOME_FORK.branchC.cta}
             </p>
           </a>
         </div>

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
+import { HOME_FORK } from '../home';
 import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
 import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
 import { METRICS, SITE } from '../site';
@@ -94,6 +95,23 @@ describe('marketing content contracts', () => {
     it('the license split sums to the package count', () => {
       const { mit, fsl, internal } = METRICS.licenseSplit;
       expect(mit + fsl + internal).toBe(METRICS.packages);
+    });
+  });
+
+  describe('homepage fork', () => {
+    it('exposes three self-identification branches, each fully populated', () => {
+      const branches = [HOME_FORK.branchA, HOME_FORK.branchB, HOME_FORK.branchC];
+      expect(branches).toHaveLength(3);
+      for (const branch of branches) {
+        expect(branch.title.length, 'empty title').toBeGreaterThan(0);
+        expect(branch.body.length, 'empty body').toBeGreaterThan(0);
+        expect(branch.cta.length, 'empty cta').toBeGreaterThan(0);
+      }
+    });
+
+    it('the navigating branches each carry an href', () => {
+      expect(HOME_FORK.branchB.href.length).toBeGreaterThan(0);
+      expect(HOME_FORK.branchC.href.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -243,9 +243,10 @@ export const HOME_GET_STARTED = {
 // ---------------------------------------------------------------------------
 // Homepage audience fork
 // Per spec-2026-05-14-non-technical-lane.md §4.3 (Phase 2 of the spec sequence).
-// Two equal-weight branches; visitor self-identifies before the technical-lane
+// Three equal-weight branches; visitor self-identifies before the technical-lane
 // content below. Branch A scrolls past the fork into the existing technical
-// homepage (OQ-5 locked); Branch B routes to /for-operators (Phase 1, PR #1151).
+// homepage (OQ-5 locked); Branch B routes to /for-operators (Phase 1, PR #1151);
+// Branch C routes studios/agencies to the Agency Perpetual pricing band.
 // Decisions consumed: §9.4 OQ-5 (Branch A stays on /).
 // ---------------------------------------------------------------------------
 
@@ -260,5 +261,11 @@ export const HOME_FORK = {
     body: 'RevealUI Studio scopes, builds, and delivers a working product. Weeks, not quarters.',
     cta: 'See how →',
     href: '/for-operators',
+  },
+  branchC: {
+    title: 'I build software for my clients.',
+    body: 'License once, then ship a branded, self-hosted instance for every client you serve.',
+    cta: 'See agency licensing →',
+    href: '/pricing#perpetual',
   },
 } as const;

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -64,6 +64,21 @@ export const PRICING_TRACK_C_SECTION = {
   body: 'Pay once, use forever. No subscription required. Support renewals are optional.',
 } as const;
 
+// Studio / agency reseller economics, rendered in the Perpetual section where the
+// Agency Perpetual (RevealUI Fleet) tier lives. Names no third-party prices, consistent
+// with PRICING_VALUE_BAND. Models the multi-client P&L the per-business cards do not show.
+export const PRICING_AGENCY_VALUE_BAND = {
+  eyebrow: 'For studios & agencies',
+  heading: 'One runtime. Every client gets their own.',
+  body: 'Building or reselling software for more than one client means re-licensing auth, billing, content, and an admin for every account you take on. An Agency Perpetual license covers the runtime once, so you ship a branded, self-hosted instance per client instead.',
+  points: [
+    'One license, a branded instance per client. No per-client SaaS re-licensing.',
+    'White-label stamping built in via RevForge trial kits.',
+    'Each client owns their data, infrastructure, and Stripe account. Clean handoff, no lock-in.',
+    'One runtime, one upgrade cadence across every client you serve.',
+  ],
+} as const;
+
 export const PRICING_AGENTS_SECTION = {
   eyebrow: 'Agent-Native',
   heading: 'RevealUI for AI Agents',

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -6,6 +6,7 @@ import { NewsletterSignup } from '../components/NewsletterSignup';
 import {
   PERPETUAL_TIERS,
   PRICING_AGENCY_SECTION,
+  PRICING_AGENCY_VALUE_BAND,
   PRICING_AGENT_A2A,
   PRICING_AGENT_CTA_LINKS,
   PRICING_AGENT_MCP,
@@ -229,6 +230,28 @@ export function PricingPage() {
             </h2>
             <p className="mt-4 text-lg text-muted-foreground">{PRICING_TRACK_C_SECTION.body}</p>
           </div>
+
+          {/* Studio / agency reseller value band: the multi-client P&L */}
+          <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+              {PRICING_AGENCY_VALUE_BAND.eyebrow}
+            </span>
+            <h3 className="mt-2 text-2xl font-bold tracking-tight text-foreground">
+              {PRICING_AGENCY_VALUE_BAND.heading}
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {PRICING_AGENCY_VALUE_BAND.body}
+            </p>
+            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
+                <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
             {perpetualTiers.map((tier) => (
               <div


### PR DESCRIPTION
## What

Surfaces the studio / agency / white-label **reseller** buyer, who previously had no landing surface on revealui.com (only a persona footnote and a one-line pricing aside). Two small, content-driven additions:

**1. Homepage audience fork — Branch C.** The fork offered two paths ("I'm building this myself" / "I want it built for me"). This adds a third: **"I build software for my clients"**, routing studios and agencies to the Agency Perpetual pricing band. The eyebrow becomes "Three ways to use RevealUI" and the grid widens to three columns.

**2. Pricing — studio/agency value band.** The Perpetual section now carries a value band modelling the multi-client P&L the per-business cards don't: one license, a branded self-hosted instance per client, no per-client SaaS re-licensing. It names no third-party prices (consistent with the existing "You own the runtime" band).

## Why

A cheap demand-test for the reseller wedge before investing in a dedicated page. The reseller is the buyer who needs the full compound (multi-tenant + self-host + white-label stamping) and has real budget, but the funnel had no door for them. If Branch C draws clicks, the follow-up is a full `/for-studios` page (placement likely revealuistudio.com per the messaging audit).

## Changes

- `apps/marketing/app/content/home.ts` — `HOME_FORK.branchC`
- `apps/marketing/app/components/landing/Fork.tsx` — render branchC; eyebrow + 3-col grid
- `apps/marketing/app/content/pricing.ts` — `PRICING_AGENCY_VALUE_BAND`
- `apps/marketing/app/routes/PricingPage.tsx` — render the band in `#perpetual`
- `apps/marketing/app/content/__tests__/content.test.ts` — structural guard for the three branches

Both UI additions reuse already-shipped markup patterns (the value band mirrors the live "You own the runtime" block; Branch C mirrors the existing Branch B card).

## Verification

- Biome: clean (5 files)
- Content contract tests: **12/12 pass** (includes 2 new structural guards for the three fork branches)
- Typecheck: this change adds **zero** type errors. A standalone worktree typecheck surfaces only pre-existing `Cannot find module '@revealui/*'` resolution noise (workspace dep `.d.ts` not built in an isolated worktree — whole-app, not from these files). CI typecheck (deps built) is authoritative.
- Hosted preview: the marketing app **built + deployed clean** on CI via `deploy-test.yml` ([run 26674082692](https://github.com/RevealUIStudio/revealui/actions/runs/26674082692)) — production-mode `vercel build` succeeded, confirming the isolated-worktree typecheck noise was a dep-build artifact, not a real error. Preview URL shared with the owner (ephemeral Vercel preview).

## Notes

No new dependencies. Pure marketing-content + presentation change. No third-party prices named. The reseller proof/case-study is left generic pending owner sign-off on naming the reference deployment.
