### PR TITLE
chore(secrets): retire 4 unconsumed env vars from the sync manifest + docs

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -89,16 +89,6 @@ NEXT_PRIVATE_STRIPE_PUBLISHABLE_KEY=pk_test_...
 # Expose live/test mode to the client (used for the test-mode banner):
 NEXT_PUBLIC_IS_LIVE=false
 
-# -----------------------------------------------------------------------------
-# Draft / Preview
-# -----------------------------------------------------------------------------
-REVEALUI_PUBLIC_DRAFT_SECRET=your-draft-secret-min-32-chars
-NEXT_PRIVATE_REVEALUI_DRAFT_SECRET=your-draft-secret-min-32-chars
-
-# Revalidation key for on-demand ISR
-REVEALUI_REVALIDATION_KEY=your-revalidation-key-min-32-chars
-NEXT_PRIVATE_REVEALUI_REVALIDATION_KEY=your-revalidation-key-min-32-chars
-
 # Public seed flag (controls whether DB seed runs in this env)
 # REVEALUI_PUBLIC_SEED=false
 

--- a/docs/CREDENTIAL-ROTATION-RUNBOOK.md
+++ b/docs/CREDENTIAL-ROTATION-RUNBOOK.md
@@ -9,7 +9,7 @@ Cross-reference `docs/ENVIRONMENT-VARIABLES-GUIDE.md` for env var details.
 
 | Cadence | Credentials |
 |---------|------------|
-| **90 days** | REVEALUI_SECRET, REVEALUI_KEK*, REVEALUI_LICENSE_ENCRYPTION_KEY*, REVEALUI_CRON_SECRET, REVEALUI_PUBLIC_DRAFT_SECRET, REVEALUI_REVALIDATION_KEY, REVEALUI_ADMIN_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, TAVILY_API_KEY, HF_TOKEN, VERCEL_API_KEY, RESEND_API_KEY, NEON_API_KEY, MCP_API_KEY |
+| **90 days** | REVEALUI_SECRET, REVEALUI_KEK*, REVEALUI_LICENSE_ENCRYPTION_KEY*, REVEALUI_CRON_SECRET, REVEALUI_ADMIN_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, TAVILY_API_KEY, HF_TOKEN, VERCEL_API_KEY, RESEND_API_KEY, NEON_API_KEY, MCP_API_KEY |
 | **Quarterly** | STRIPE_SECRET_KEY, GOOGLE_CLIENT_SECRET, GOOGLE_PRIVATE_KEY, GITHUB_CLIENT_SECRET, REVEALUI_GITHUB_TOKEN, SENTRY_AUTH_TOKEN, SUPABASE_SERVICE_ROLE_KEY, ELECTRIC_API_KEY, ELECTRIC_DATABASE_URL (password) |
 | **Annually** | REVEALUI_LICENSE_PRIVATE_KEY (Ed25519 pair), GOOGLE_CLIENT_ID, GITHUB_CLIENT_ID, VERCEL_CLIENT_ID, YOUTUBE_API_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY |
 | **As-needed** | STRIPE_WEBHOOK_SECRET (endpoint change), REVFORGE_LICENSE_KEY (renewal), X402_RECEIVING_ADDRESS (wallet change), POSTGRES_URL (provider migration) |
@@ -74,18 +74,14 @@ revvault set revealui/env/core REVEALUI_SECRET "$NEW_SECRET"
 
 **Impact:** Every logged-in user is signed out. Schedule during low-traffic window and communicate.
 
-#### REVEALUI_CRON_SECRET / REVEALUI_PUBLIC_DRAFT_SECRET / REVEALUI_REVALIDATION_KEY
+#### REVEALUI_CRON_SECRET
 
 ```bash
-# All follow the same pattern: generate, update, redeploy
 openssl rand -hex 32  # → new value
 revvault set revealui/env/cron REVEALUI_CRON_SECRET "$(openssl rand -hex 32)"
-revvault set revealui/env/core REVEALUI_PUBLIC_DRAFT_SECRET "$(openssl rand -hex 32)"
-revvault set revealui/env/core REVEALUI_REVALIDATION_KEY "$(openssl rand -hex 32)"
-# Update paired NEXT_PRIVATE_ variants in Vercel too
 ```
 
-**Impact:** DRAFT_SECRET invalidates existing preview links. CRON_SECRET requires updating cron job headers.
+**Impact:** CRON_SECRET requires updating cron job headers.
 
 #### REVEALUI_ADMIN_API_KEY (inter-service auth)
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -80,8 +80,6 @@ revealui/prod/marketplace-connect-return-url  # MARKETPLACE_CONNECT_RETURN_URL
 revealui/prod/admin/api-key          # REVEALUI_ADMIN_API_KEY
 revealui/prod/admin/email            # REVEALUI_ADMIN_EMAIL
 revealui/prod/admin/password         # REVEALUI_ADMIN_PASSWORD
-revealui/prod/admin/revalidation-key # REVEALUI_REVALIDATION_KEY
-revealui/prod/admin/draft-secret     # REVEALUI_PUBLIC_DRAFT_SECRET
 ```
 
 **Database**
@@ -145,13 +143,6 @@ revealui/prod/license/public-key    # REVEALUI_LICENSE_PUBLIC_KEY — rotating i
 revealui/prod/passkey/origin    # PASSKEY_ORIGIN
 revealui/prod/passkey/rp-id     # PASSKEY_RP_ID
 revealui/prod/passkey/rp-name   # PASSKEY_RP_NAME
-```
-
-**CMS**
-
-```
-revealui/prod/cms/admin-email     # CMS_ADMIN_EMAIL
-revealui/prod/cms/admin-password  # CMS_ADMIN_PASSWORD
 ```
 
 **Observability (Sentry)**

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -82,9 +82,7 @@ Safe to loop (effect on redeploy only; `revealui/prod/secret` also invalidates a
 for p in \
   revealui/prod/secret \
   revealui/prod/cron-secret \
-  revealui/prod/admin/api-key \
-  revealui/prod/admin/revalidation-key \
-  revealui/prod/admin/draft-secret ; do
+  revealui/prod/admin/api-key ; do
   revvault generate "$p" --force --length 48 --no-symbols --no-ambiguous && echo "rotated $p"
 done
 ```
@@ -93,7 +91,6 @@ Rotate **individually, with awareness** (each has a side effect):
 revvault generate revealui/prod/audit-hmac-secret --force --length 48 --no-symbols --no-ambiguous
 #   ↑ pre-rotation audit-log HMACs stop verifying
 revvault generate revealui/prod/admin/password     --force --length 32 --no-ambiguous
-revvault generate revealui/prod/cms/admin-password --force --length 32 --no-ambiguous
 #   ↑ admin login changes — retrieve the new value from revvault to log in
 revvault generate revealui/prod/electric/secret    --force --length 48 --no-symbols --no-ambiguous
 #   ↑ ALSO set the Electric service to the same value, or realtime sync breaks
@@ -146,8 +143,8 @@ Stripe price IDs (`*-price-id`) + `agent-meter-event-name` · passkey `origin`/`
 all `NEXT_PUBLIC_*` + `public/server-url` + `public/api-url` + `public/is-live` ·
 `session-cookie-domain` · `cors-origin` · `email/from` + `email/reply-to` · `alert-email` ·
 `marketplace-connect-return-url` · `electric/service-url` · `sentry/org` + `sentry/project*` +
-`sentry/dsn*` (DSNs are embeddable) · `google/service-account-email` · `admin/email` +
-`cms/admin-email` · `VERCEL_ORG_ID`.
+`sentry/dsn*` (DSNs are embeddable) · `google/service-account-email` · `admin/email` ·
+`VERCEL_ORG_ID`.
 
 ## See also
 - [`vercel-env-sync.md`](./vercel-env-sync.md) — day-to-day single-secret sync workflow

--- a/scripts/secrets/rotate.ts
+++ b/scripts/secrets/rotate.ts
@@ -6,7 +6,7 @@
  * Prints a rotation checklist for the given secret name and generates a new value.
  *
  * Usage:
- *   pnpm secrets:rotate CMS_ADMIN_PASSWORD
+ *   pnpm secrets:rotate REVEALUI_ADMIN_PASSWORD
  *   pnpm secrets:rotate STRIPE_SECRET_KEY
  */
 
@@ -26,7 +26,7 @@ const secretName = process.argv[2];
 
 if (!secretName) {
   console.error('Usage: pnpm secrets:rotate <SECRET_NAME>');
-  console.error('Example: pnpm secrets:rotate CMS_ADMIN_PASSWORD');
+  console.error('Example: pnpm secrets:rotate REVEALUI_ADMIN_PASSWORD');
   process.exit(1);
 }
 

--- a/scripts/setup/environment.ts
+++ b/scripts/setup/environment.ts
@@ -54,8 +54,6 @@ function parseArgs(): SetupOptions {
 // Variables that can be generated automatically from crypto
 const AUTO_GENERATE: Record<string, () => string> = {
   REVEALUI_SECRET: () => generateSecret(32),
-  REVEALUI_PUBLIC_DRAFT_SECRET: () => generateSecret(32),
-  REVEALUI_REVALIDATION_KEY: () => generateSecret(32),
   REVEALUI_ADMIN_PASSWORD: () => generatePassword(16),
 };
 

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -212,10 +212,6 @@ REVEALUI_API_URL           = "revealui/prod/public/api-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
 REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 
-# CMS bootstrap creds (canonical paths under cms/)
-CMS_ADMIN_EMAIL    = "revealui/prod/cms/admin-email"
-CMS_ADMIN_PASSWORD = "revealui/prod/cms/admin-password"
-
 # Observability — Sentry (Next.js admin; DSN is client-bundled via NEXT_PUBLIC_,
 # auth-token + org + project are build-time for source-map upload via withSentryConfig)
 NEXT_PUBLIC_SENTRY_DSN = "revealui/prod/sentry/dsn-admin"
@@ -227,8 +223,6 @@ SENTRY_PROJECT         = "revealui/prod/sentry/project-admin"
 REVEALUI_ADMIN_EMAIL         = "revealui/prod/admin/email"
 REVEALUI_ADMIN_PASSWORD      = "revealui/prod/admin/password"
 REVEALUI_ADMIN_API_KEY       = "revealui/prod/admin/api-key"
-REVEALUI_REVALIDATION_KEY    = "revealui/prod/admin/revalidation-key"
-REVEALUI_PUBLIC_DRAFT_SECRET = "revealui/prod/admin/draft-secret"
 
 
 # ── revealui-marketing ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Retires four environment variables that appear in the revvault->Vercel sync manifest (`scripts/sync/revvault-vercel.toml`) and the secret docs but are read by **no runtime code**.

Verified across `apps/`, `packages/`, `scripts/`, and the `@revealui/config` env schema (direct `process.env.*` reads + the config indirection + parity twins).

| Var | Why unused |
|---|---|
| `CMS_ADMIN_EMAIL` / `CMS_ADMIN_PASSWORD` | Duplicate the canonical admin bootstrap pair `REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD` (`apps/admin/revealui.config.ts`). Pre-standardization naming. |
| `REVEALUI_REVALIDATION_KEY` | No on-demand ISR route reads it. The `VITE_REVALIDATION_KEY` in `packages/services` is a different var. |
| `REVEALUI_PUBLIC_DRAFT_SECRET` | Admin preview uses Next.js's built-in cookie-based `draftMode()`. |

## Changed

- `scripts/sync/revvault-vercel.toml` — manifest entries
- `docs/SECRETS.md` — index entries
- `docs/CREDENTIAL-ROTATION-RUNBOOK.md` + `docs/runbooks/secret-rotation.md` — rotation tables (kept `REVEALUI_CRON_SECRET`)
- `apps/admin/.env.example` — template lines (plus the unused `NEXT_PRIVATE_*` siblings)
- `scripts/setup/environment.ts` — generator map entries
- `scripts/secrets/rotate.ts` — usage example repointed to a live secret

## Deliberately kept

`NEXT_PUBLIC_IS_LIVE` and `STRIPE_MAX_ANNUAL_PRICE_ID` are also currently unread, but they are provisioned ahead of their consumers on purpose (client live-flag + annual Max tier), so they stay.

## Notes

No runtime behavior change. Removing any corresponding Vercel env values is a separate operator step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
