### PR TITLE
chore(marketing): warm human-user/customer copy to the possessive

### DIFF
--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -53,7 +53,7 @@ export const MARKETPLACE_DISCOVERY_STEPS: readonly DiscoveryStep[] = [
     step: '2',
     title: 'Authenticate',
     description:
-      'The agent authenticates using the same RBAC system that governs human users. Permissions are scoped per tenant and per role.',
+      'The agent authenticates using the same RBAC system that governs your users. Permissions are scoped per tenant and per role.',
   },
   {
     step: '3',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -101,7 +101,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     forAgents: {
       headline: 'RBAC governs agent access per tenant',
       description:
-        'Every agent action is scoped by the same role and permission system that governs human users. Audit logs track every agent operation with full attribution.',
+        'Every agent action is scoped by the same role and permission system that governs your users. Audit logs track every agent operation with full attribution.',
     },
     together: {
       headline: 'Set permissions once. Agents respect them automatically.',
@@ -196,7 +196,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     together: {
       headline: 'Humans monetize. Agents transact. One billing infrastructure.',
       description:
-        'Human customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
+        'Your customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
     },
     features: [
       'Stripe checkout and subscriptions',


### PR DESCRIPTION
## What

Warms three audience-adjacent uses of "human users / human customers" (the reader's own people) to the benefit-framed possessive "your users / your customers".

| File | Context | Before | After |
| --- | --- | --- | --- |
| `primitives.ts` | Auth / forAgents | "governs **human users**" | "governs **your users**" |
| `primitives.ts` | Payments / together | "**Human customers** pay through Stripe" | "**Your customers** pay through Stripe" |
| `marketplace.ts` | Discovery step 2 | "governs **human users**" | "governs **your users**" |

## Deliberately NOT changed

The "humans and agents" dual-principal claims stay intact, because there "humans" is the people-vs-AI contrast (the architectural point), not the buyer. Untouched: the hero (`One runtime for humans and agents`), the hash-chain / RBAC / CRDT capability lines (`by humans or agents`, `humans, agents, and service accounts`), and the Payments headline (`Humans monetize. Agents transact.`).

## Why

In customer-facing copy the possessive reads warmer and more concrete ("your customers" over "human customers"), while the "humans vs agents" framing stays crisp where it actually carries meaning.

## Verification

- Biome clean on both files.
- No content-contract test asserts these strings (the tests check primitive counts and labels, not body copy); the CI gate validates typecheck, tests, and build.
- Scope: marketing copy only, no logic change.
