### PR TITLE
Promote test to main: #1190 admin /upgrade cobalt token fix + #1189 marketing studio fork

### DIFF
--- a/apps/admin/src/app/(backend)/custom.css
+++ b/apps/admin/src/app/(backend)/custom.css
@@ -1,6 +1,62 @@
-/* Tailwind v4 Theme Configuration */
-/* @theme is a valid Tailwind CSS v4 at-rule - CSS linter warnings can be ignored */
+/* Tailwind v4 Theme Configuration for the admin (backend) route group.
+ *
+ * Brought to parity with apps/admin/src/app/(frontend)/tailwind-theme.css so cobalt
+ * semantic-token utilities (bg-card, bg-primary, text-foreground, text-muted-foreground,
+ * ring-primary, etc.) and the catalyst SidebarLayout shell render correctly under
+ * (backend). Without the @source scans + @theme inline bridge below, Tailwind v4 does
+ * not generate those utilities for this entry (it only emits utilities for registered
+ * theme colors, and only scans @source-declared content), so presentation components
+ * that use semantic tokens (e.g. PricingTable on /upgrade) compile to no CSS.
+ *
+ * tokens.css stays the single source of truth for color VALUES; the @theme inline block
+ * only maps --rvui-* into Tailwind's @theme namespace. tokens.css is loaded by the
+ * route-group layout (apps/admin/src/app/(backend)/layout.tsx), so the inline var()
+ * references below resolve from it at runtime.
+ *
+ * @theme is a valid Tailwind CSS v4 at-rule; CSS linter warnings can be ignored.
+ */
 @import "tailwindcss";
+
+/* Scan workspace package sources so their Tailwind class usage is generated for this
+ * entry (matches the @source set in (frontend)/tailwind-theme.css). */
+@source "../../../../../packages/presentation/src/**/*.{ts,tsx}";
+@source "../../../../../packages/core/src/**/*.{ts,tsx}";
+@source "../../../../../packages/auth/src/**/*.{ts,tsx}";
+@source "../../lib/**/*.{ts,tsx}";
+@source "../../components/**/*.{ts,tsx}";
+
+/*
+ * Bridge --rvui-* canonical cobalt tokens into Tailwind's @theme namespace so that
+ * bg-card / text-foreground / bg-primary / etc. resolve to the live token values.
+ * `inline` keeps the var() reference in each utility so theme switching (dark :root
+ * default; light via [data-theme="light"] or prefers-color-scheme: light) stays live.
+ */
+@theme inline {
+  --color-background: var(--rvui-surface-0);
+  --color-foreground: var(--rvui-text-0);
+  --color-card: var(--rvui-surface-1);
+  --color-card-foreground: var(--rvui-text-0);
+  --color-popover: var(--rvui-surface-1);
+  --color-popover-foreground: var(--rvui-text-0);
+  --color-primary: var(--rvui-brand);
+  --color-primary-foreground: var(--rvui-text-on-brand);
+  --color-secondary: var(--rvui-surface-2);
+  --color-secondary-foreground: var(--rvui-text-0);
+  --color-muted: var(--rvui-surface-2);
+  --color-muted-foreground: var(--rvui-text-2);
+  --color-accent: var(--rvui-accent);
+  --color-accent-foreground: var(--rvui-text-on-accent);
+  --color-destructive: var(--rvui-error);
+  --color-destructive-foreground: var(--rvui-text-0);
+  --color-border: var(--rvui-border);
+  --color-input: var(--rvui-border);
+  --color-ring: var(--rvui-brand);
+  --color-success: var(--rvui-success);
+  --color-warning: var(--rvui-warning);
+  --color-warning-foreground: var(--rvui-warning-text);
+  --color-error: var(--rvui-error);
+  --radius: var(--rvui-radius-md);
+}
 
 @theme {
   /* Custom Screens */
@@ -8,6 +64,19 @@
   --breakpoint-8xl: 1920px;
   --breakpoint-9xl: 2560px;
   --breakpoint-10xl: 3840px;
+
+  /* RevealUI Theme - Mist Color Palette (OKLCH), parity with (frontend)/tailwind-theme.css */
+  --color-mist-50: oklch(98.7% 0.002 197.1);
+  --color-mist-100: oklch(96.3% 0.002 197.1);
+  --color-mist-200: oklch(92.5% 0.005 214.3);
+  --color-mist-300: oklch(87.2% 0.007 219.6);
+  --color-mist-400: oklch(72.3% 0.014 214.4);
+  --color-mist-500: oklch(56% 0.021 213.5);
+  --color-mist-600: oklch(45% 0.017 213.2);
+  --color-mist-700: oklch(37.8% 0.015 216);
+  --color-mist-800: oklch(27.5% 0.011 216.9);
+  --color-mist-900: oklch(21.8% 0.008 223.9);
+  --color-mist-950: oklch(14.8% 0.004 228.8);
 
   /* Custom Colors */
   --color-scrapBlack: #020617;
@@ -81,8 +150,16 @@
 
 /* Base styles for admin dashboard */
 @layer base {
+  /* Token-driven body (cobalt). Was `bg-gray-50 text-gray-900`, a pre-cobalt hardcode
+   * untouched since the cms->admin rename. The catalyst SidebarLayout shell covers the
+   * body, but token-driving it keeps the (backend) surface cobalt-coherent with
+   * (frontend) and prevents a hardcoded light-gray leaking at any uncovered edge.
+   * No FOUC `html { opacity: 0 }` guard here (unlike (frontend)/styles.css): (backend)
+   * has no InitTheme to set data-theme, so a guard would hide the page permanently. */
   body {
-    @apply bg-gray-50 text-gray-900 antialiased;
+    background-color: var(--rvui-surface-0);
+    color: var(--rvui-text-0);
+    @apply antialiased;
   }
 }
 

--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -31,11 +31,11 @@ export function Fork() {
 
   return (
     <section id="homepage-fork" aria-label="Choose your path" className="bg-muted py-12 sm:py-16">
-      <div className="mx-auto max-w-4xl px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
         <p className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-6">
-          Two ways to use RevealUI
+          Three ways to use RevealUI
         </p>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <button
             type="button"
             onClick={handleSelfBuildScroll}
@@ -60,6 +60,19 @@ export function Fork() {
             <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchB.body}</p>
             <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
               {HOME_FORK.branchB.cta}
+            </p>
+          </a>
+
+          <a
+            href={HOME_FORK.branchC.href}
+            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <h3 className="text-lg font-semibold leading-7 text-foreground">
+              {HOME_FORK.branchC.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchC.body}</p>
+            <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
+              {HOME_FORK.branchC.cta}
             </p>
           </a>
         </div>

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
+import { HOME_FORK } from '../home';
 import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
 import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
 import { METRICS, SITE } from '../site';
@@ -94,6 +95,23 @@ describe('marketing content contracts', () => {
     it('the license split sums to the package count', () => {
       const { mit, fsl, internal } = METRICS.licenseSplit;
       expect(mit + fsl + internal).toBe(METRICS.packages);
+    });
+  });
+
+  describe('homepage fork', () => {
+    it('exposes three self-identification branches, each fully populated', () => {
+      const branches = [HOME_FORK.branchA, HOME_FORK.branchB, HOME_FORK.branchC];
+      expect(branches).toHaveLength(3);
+      for (const branch of branches) {
+        expect(branch.title.length, 'empty title').toBeGreaterThan(0);
+        expect(branch.body.length, 'empty body').toBeGreaterThan(0);
+        expect(branch.cta.length, 'empty cta').toBeGreaterThan(0);
+      }
+    });
+
+    it('the navigating branches each carry an href', () => {
+      expect(HOME_FORK.branchB.href.length).toBeGreaterThan(0);
+      expect(HOME_FORK.branchC.href.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -243,9 +243,10 @@ export const HOME_GET_STARTED = {
 // ---------------------------------------------------------------------------
 // Homepage audience fork
 // Per spec-2026-05-14-non-technical-lane.md §4.3 (Phase 2 of the spec sequence).
-// Two equal-weight branches; visitor self-identifies before the technical-lane
+// Three equal-weight branches; visitor self-identifies before the technical-lane
 // content below. Branch A scrolls past the fork into the existing technical
-// homepage (OQ-5 locked); Branch B routes to /for-operators (Phase 1, PR #1151).
+// homepage (OQ-5 locked); Branch B routes to /for-operators (Phase 1, PR #1151);
+// Branch C routes studios/agencies to the Agency Perpetual pricing band.
 // Decisions consumed: §9.4 OQ-5 (Branch A stays on /).
 // ---------------------------------------------------------------------------
 
@@ -260,5 +261,11 @@ export const HOME_FORK = {
     body: 'RevealUI Studio scopes, builds, and delivers a working product. Weeks, not quarters.',
     cta: 'See how →',
     href: '/for-operators',
+  },
+  branchC: {
+    title: 'I build software for my clients.',
+    body: 'License once, then ship a branded, self-hosted instance for every client you serve.',
+    cta: 'See agency licensing →',
+    href: '/pricing#perpetual',
   },
 } as const;

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -64,6 +64,21 @@ export const PRICING_TRACK_C_SECTION = {
   body: 'Pay once, use forever. No subscription required. Support renewals are optional.',
 } as const;
 
+// Studio / agency reseller economics, rendered in the Perpetual section where the
+// Agency Perpetual (RevealUI Fleet) tier lives. Names no third-party prices, consistent
+// with PRICING_VALUE_BAND. Models the multi-client P&L the per-business cards do not show.
+export const PRICING_AGENCY_VALUE_BAND = {
+  eyebrow: 'For studios & agencies',
+  heading: 'One runtime. Every client gets their own.',
+  body: 'Building or reselling software for more than one client means re-licensing auth, billing, content, and an admin for every account you take on. An Agency Perpetual license covers the runtime once, so you ship a branded, self-hosted instance per client instead.',
+  points: [
+    'One license, a branded instance per client. No per-client SaaS re-licensing.',
+    'White-label stamping built in via RevForge trial kits.',
+    'Each client owns their data, infrastructure, and Stripe account. Clean handoff, no lock-in.',
+    'One runtime, one upgrade cadence across every client you serve.',
+  ],
+} as const;
+
 export const PRICING_AGENTS_SECTION = {
   eyebrow: 'Agent-Native',
   heading: 'RevealUI for AI Agents',

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -6,6 +6,7 @@ import { NewsletterSignup } from '../components/NewsletterSignup';
 import {
   PERPETUAL_TIERS,
   PRICING_AGENCY_SECTION,
+  PRICING_AGENCY_VALUE_BAND,
   PRICING_AGENT_A2A,
   PRICING_AGENT_CTA_LINKS,
   PRICING_AGENT_MCP,
@@ -229,6 +230,28 @@ export function PricingPage() {
             </h2>
             <p className="mt-4 text-lg text-muted-foreground">{PRICING_TRACK_C_SECTION.body}</p>
           </div>
+
+          {/* Studio / agency reseller value band: the multi-client P&L */}
+          <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+              {PRICING_AGENCY_VALUE_BAND.eyebrow}
+            </span>
+            <h3 className="mt-2 text-2xl font-bold tracking-tight text-foreground">
+              {PRICING_AGENCY_VALUE_BAND.heading}
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {PRICING_AGENCY_VALUE_BAND.body}
+            </p>
+            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
+                <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
             {perpetualTiers.map((tier) => (
               <div


### PR DESCRIPTION
## Promote `test` to `main`

Promotes the current `test` delta to production. Payload is 2 merged, CI-green PRs:

- **#1190** `fix(admin): bridge cobalt semantic tokens into (backend) entry` (`6ff19d895`) — adds the `@theme inline` cobalt semantic-token bridge + `@source` scans to the admin `(backend)` Tailwind entry, so cobalt presentation components (PricingTable, Card, Button) render correctly under `(backend)`.
- **#1189** `feat(marketing): studio/agency fork branch + pricing reseller value band` (`0859a3ce4`).

### Why now

`main` already carries the cobalt `PricingTable` (#1181 via #1182) but the admin `(backend)/custom.css` on `main` lacks the semantic-token bridge, so the in-app conversion surface `/upgrade` renders the pricing cards unstyled in production (no card background, no primary CTA fill). #1190 closes that gap. Build-verified: the chunk `/upgrade` loads now resolves `bg-card` / `bg-primary` / `text-foreground` / `ring-primary` / etc. to `var(--rvui-*)`.

### Merge method

Merge commit (not squash), per the `test` to `main` convention, to keep `main` and `test` aligned and avoid backflow conflicts. Merging triggers the production deploy via `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
