### PR TITLE
feat(marketing): add three-actors explainer (developer/operator/agent)

### DIFF
--- a/apps/marketing/app/components/landing/Actors.tsx
+++ b/apps/marketing/app/components/landing/Actors.tsx
@@ -1,0 +1,41 @@
+// Three-actors explainer. Defines developer / operator / agent before the
+// audience fork uses those roles. Rendered between <Hero /> and <Fork /> in
+// HomePage.tsx so the hero's "agents" is defined within one scroll.
+
+import { HOME_ACTORS } from '../../content/home';
+
+export function Actors() {
+  return (
+    <section aria-label="Who does what in RevealUI" className="bg-background py-12 sm:py-16">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
+        <div className="text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {HOME_ACTORS.eyebrow}
+          </p>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            {HOME_ACTORS.heading}
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            {HOME_ACTORS.body}
+          </p>
+        </div>
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {HOME_ACTORS.actors.map((actor) => (
+            <div
+              key={actor.role}
+              className="rounded-2xl border border-border bg-card p-6 text-left shadow-sm"
+            >
+              <h3 className="text-lg font-semibold leading-7 text-foreground">
+                <span className="text-primary">{actor.role}</span> {actor.action}
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{actor.body}</p>
+            </div>
+          ))}
+        </div>
+        <p className="mt-8 text-center text-base font-medium text-foreground">
+          {HOME_ACTORS.tagline}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
-import { HOME_FORK } from '../home';
+import { HOME_ACTORS, HOME_FORK } from '../home';
 import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
 import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
 import { METRICS, SITE } from '../site';
@@ -112,6 +112,24 @@ describe('marketing content contracts', () => {
     it('the navigating branches each carry an href', () => {
       expect(HOME_FORK.branchB.href.length).toBeGreaterThan(0);
       expect(HOME_FORK.branchC.href.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('three actors', () => {
+    it('defines exactly three actors, each fully populated', () => {
+      expect(HOME_ACTORS.actors).toHaveLength(3);
+      for (const actor of HOME_ACTORS.actors) {
+        expect(actor.role.length, 'empty role').toBeGreaterThan(0);
+        expect(actor.action.length, 'empty action').toBeGreaterThan(0);
+        expect(actor.body.length, 'empty body').toBeGreaterThan(0);
+      }
+    });
+
+    it('names developer, operator, and agent', () => {
+      const roles = HOME_ACTORS.actors.map((a) => a.role.toLowerCase());
+      expect(roles.some((r) => r.includes('develop'))).toBe(true);
+      expect(roles.some((r) => r.includes('operator'))).toBe(true);
+      expect(roles.some((r) => r.includes('agent'))).toBe(true);
     });
   });
 });

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -241,6 +241,44 @@ export const HOME_GET_STARTED = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Three actors (cast explainer)
+// Defines the three roles the rest of the copy assumes: developer, operator,
+// agent. Two human roles (build, run) plus the AI role (work inside). Sits
+// between the hero and the audience fork so "agents" in the hero h1 is defined
+// within one scroll, before the visitor self-identifies in the fork below.
+// ---------------------------------------------------------------------------
+
+export interface Actor {
+  readonly role: string;
+  readonly action: string;
+  readonly body: string;
+}
+
+export const HOME_ACTORS = {
+  eyebrow: 'Who does what',
+  heading: 'Three actors, one runtime.',
+  body: 'RevealUI runs people and AI under one set of rules, with the same login and the same audit trail.',
+  actors: [
+    {
+      role: 'Developers',
+      action: 'build it.',
+      body: 'Install RevealUI, write the code, own the stack.',
+    },
+    {
+      role: 'Operators',
+      action: 'run it.',
+      body: 'Log into the admin to manage customers, content, and billing. No code required.',
+    },
+    {
+      role: 'Agents',
+      action: 'work inside it.',
+      body: 'An agent is an AI that does work on its own: drafts emails, processes orders, runs recurring tasks. It uses the same login, permissions, and audit trail as a person.',
+    },
+  ] as readonly Actor[],
+  tagline: 'Developers build it. Operators run it. Agents work in it.',
+} as const;
+
+// ---------------------------------------------------------------------------
 // Homepage audience fork
 // Per spec-2026-05-14-non-technical-lane.md §4.3 (Phase 2 of the spec sequence).
 // Three equal-weight branches; visitor self-identifies before the technical-lane

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -257,7 +257,7 @@ export interface Actor {
 export const HOME_ACTORS = {
   eyebrow: 'Who does what',
   heading: 'Three actors, one runtime.',
-  body: 'RevealUI runs people and AI under one set of rules, with the same login and the same audit trail.',
+  body: 'RevealUI runs people and AI under one set of rules: the same permissions and the same tamper-evident audit trail.',
   actors: [
     {
       role: 'Developers',
@@ -272,7 +272,7 @@ export const HOME_ACTORS = {
     {
       role: 'Agents',
       action: 'work inside it.',
-      body: 'An agent is an AI that does work on its own: drafts emails, processes orders, runs recurring tasks. It uses the same login, permissions, and audit trail as a person.',
+      body: 'An agent is an AI that works through the same APIs you do: read and update your data, send notifications, look up customers and billing. Every action runs under the same permissions and the same audit trail as a person.',
     },
   ] as readonly Actor[],
   tagline: 'Developers build it. Operators run it. Agents work in it.',

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '../components/Footer';
 import { GetStarted } from '../components/GetStarted';
+import { Actors } from '../components/landing/Actors';
 import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
 import { Fork } from '../components/landing/Fork';
@@ -15,6 +16,7 @@ export function HomePage() {
   return (
     <div className="min-h-screen bg-background">
       <Hero />
+      <Actors />
       <Fork />
       <Problem />
       <Demo />


### PR DESCRIPTION
## What

Adds a compact "three actors" explainer to the homepage, between the hero and the audience fork, that defines the three role words the rest of the copy assumes: **developer**, **operator**, **agent**.

The site uses these terms throughout (the hero h1 is "One runtime for humans and **agents**"; the nav has "For **Operators**") but never defines them where they are used. "Agent" especially was only explained deep in the FAQ, and technically. This names the cast up front.

## The band (copy)

> **Who does what**
> ### Three actors, one runtime.
> RevealUI runs people and AI under one set of rules: the same permissions and the same tamper-evident audit trail.
>
> **Developers** build it. Install RevealUI, write the code, own the stack.
> **Operators** run it. Log into the admin to manage customers, content, and billing. No code required.
> **Agents** work inside it. An agent is an AI that works through the same APIs you do: read and update your data, send notifications, look up customers and billing. Every action runs under the same permissions and the same audit trail as a person.
>
> *Developers build it. Operators run it. Agents work in it.*

## Design notes

- Two human roles (developers build, operators run) plus the AI role (agents work inside), consistent with the "humans and agents" framing: developers and operators are humans; agents are the non-human side.
- This **actors** trio answers "who acts in RevealUI." The existing **fork** below it (developer / operator / studio) answers "how do you want to engage." They share developer + operator and complement rather than echo.
- Placed directly under the hero so "agents" in the headline is defined within one scroll.

## Truthfulness (corrected)

The agent line was rewritten to code-verified shipped capability after an audit of the agent layer:

- **Removed** "processes orders" (no order-management tools ship) and "runs recurring tasks" (no scheduler/cron ships).
- **Removed** "same login" (agents are RBAC + audit-chain principals, not auth-login principals).
- **Kept / added** only verified-shipped capability: data read/update via MCP collections, notifications via the email MCP, customer/billing lookups via the Stripe MCP, plus the tamper-evident hash-chained audit (shipped, and a genuine edge no competitor claims).

## Files

- `content/home.ts`: `HOME_ACTORS` content object.
- `components/landing/Actors.tsx`: new component (mirrors `Fork.tsx`).
- `routes/HomePage.tsx`: render `<Actors />` between `<Hero />` and `<Fork />`.
- `content/__tests__/content.test.ts`: structural guard (three actors populated; names developer/operator/agent).

## Verification

- Biome clean on all changed files.
- Content-contract guard added; the CI gate validates typecheck, tests, and build.
- Disjoint from PR #1192 (warmth pass touches `primitives.ts` / `marketplace.ts` only), no file overlap.
