### PR TITLE
fix(server): make the Fly worker deploy build + boot

### DIFF
--- a/apps/server/Dockerfile.worker
+++ b/apps/server/Dockerfile.worker
@@ -31,7 +31,7 @@ RUN corepack enable
 
 # Copy workspace plumbing first for layer caching on dep changes.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
-COPY .npmrc* tsconfig.base.json ./
+COPY .npmrc* tsconfig.json ./
 
 # Copy all workspace packages — needed for workspace:* symlink resolution.
 COPY packages ./packages
@@ -39,7 +39,7 @@ COPY apps/server ./apps/server
 
 # Install + build only the server slice + its dependency closure.
 RUN pnpm install --frozen-lockfile --filter "server..."
-RUN pnpm --filter server build
+RUN pnpm --filter "server..." build
 
 # ─────────────────────────────────────────────────────────────────────
 # Stage 2: runtime — minimal Node 24 alpine + built worker

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -30,31 +30,40 @@ cd ~/revfleet/revealui
 flyctl auth login
 
 # 2. Create the Fly app (one-time per environment)
-flyctl apps create revealui-worker --org revealui-studio
+flyctl apps create revealui-worker --org personal
 
-# 3. Mirror prod secrets from revvault → Fly. Preferred — via the
-#    revvault `fly` sync target (revvault sync fly), driven by the
-#    manifest at scripts/sync/revvault-fly.toml:
+# 3. Mirror prod secrets from revvault → Fly.
 #
-#      revvault sync fly --manifest scripts/sync/revvault-fly.toml            # dry-run
-#      FLY_API_TOKEN="$(revvault --json get revealui/prod/fly/api-token | jq -r .value)" \
-#        revvault sync fly --manifest scripts/sync/revvault-fly.toml --apply
-#
-#    Or set them manually with flyctl:
-flyctl secrets set --app revealui-worker \
+#    NOTE: `revvault sync fly` is NOT YET IMPLEMENTED — the installed revvault
+#    CLI only supports `sync vercel`. Until it lands, set the secrets with
+#    `flyctl secrets set`, reading EVERY var under [fly-apps.revealui-worker.vars]
+#    in scripts/sync/revvault-fly.toml. The worker imports the full Hono app, so
+#    it needs API-PARITY env (same set as the Vercel revealui-api project) — a
+#    minimal subset fails startup validation. Example (abbreviated — include the
+#    full manifest set: R2_*, GOOGLE_*, EMAIL_*, PASSKEY_*, STRIPE price/webhook,
+#    CORS_ORIGIN, SESSION_COOKIE_DOMAIN, …):
+flyctl secrets set --stage --app revealui-worker \
   POSTGRES_URL="$(revvault --json get revealui/prod/db/postgres-url | jq -r .value)" \
   REVEALUI_SECRET="$(revvault --json get revealui/prod/secret | jq -r .value)" \
-  STRIPE_SECRET_KEY="$(revvault --json get revealui/prod/stripe/secret-key | jq -r .value)" \
-  STRIPE_WEBHOOK_SECRET="$(revvault --json get revealui/prod/stripe/webhook-secret | jq -r .value)" \
-  SENTRY_DSN="$(revvault --json get revealui/prod/sentry/dsn | jq -r .value)" \
+  REVEALUI_KEK="$(revvault --json get revealui/prod/kek | jq -r .value)" \
+  REVEALUI_PUBLIC_SERVER_URL="$(revvault --json get revealui/prod/public/server-url | jq -r .value)" \
+  NEXT_PUBLIC_SERVER_URL="$(revvault --json get revealui/prod/public/server-url | jq -r .value)" \
+  REVEALUI_ALERT_EMAIL="$(revvault --json get revealui/prod/alert-email | jq -r .value)" \
+  REVEALUI_BILLING_PORTAL_CONFIG_ID="$(revvault --json get revealui/prod/billing/portal-config-id | jq -r .value)" \
   REVEALUI_LICENSE_PRIVATE_KEY="$(revvault --json get revealui/prod/license/private-key | jq -r .value)" \
   REVEALUI_LICENSE_PUBLIC_KEY="$(revvault --json get revealui/prod/license/public-key | jq -r .value)" \
-  ELECTRIC_SERVICE_URL="$(revvault --json get revealui/prod/electric/service-url | jq -r .value)" \
-  ELECTRIC_SECRET="$(revvault --json get revealui/prod/electric/secret | jq -r .value)"
+  SENTRY_DSN="$(revvault --json get revealui/prod/sentry/dsn | jq -r .value)"
+
+# 3b. STRIPE — set Fly-direct, NOT from the vault secret-key path. In the current
+#     test-mode posture (STRIPE_LIVE_MODE unset), startup validation REQUIRES
+#     STRIPE_SECRET_KEY to be a sk_test_ key; revealui/prod/stripe/secret-key
+#     holds the staged LIVE key. Set the prod TEST key directly:
+flyctl secrets set --stage --app revealui-worker STRIPE_SECRET_KEY="sk_test_..."
 
 # 4. Deploy
 flyctl deploy --config apps/server/fly.toml \
-  --dockerfile apps/server/Dockerfile.worker
+  --dockerfile apps/server/Dockerfile.worker \
+  --remote-only
 
 # 5. Verify
 flyctl status --app revealui-worker
@@ -74,7 +83,8 @@ Manual deploys from the monorepo root:
 ```bash
 cd ~/revfleet/revealui
 flyctl deploy --config apps/server/fly.toml \
-  --dockerfile apps/server/Dockerfile.worker
+  --dockerfile apps/server/Dockerfile.worker \
+  --remote-only
 ```
 
 Automated deploys via GitHub Actions land in a future phase
@@ -83,11 +93,14 @@ Automated deploys via GitHub Actions land in a future phase
 ## Secrets
 
 All secrets live in revvault per [`docs/SECRETS.md`](../SECRETS.md).
-The mirror to Fly happens via the revvault `fly` sync target —
-`revvault sync fly --manifest scripts/sync/revvault-fly.toml --apply`
-(the Fly counterpart of the Vercel env sync; the manifest lists the
-worker's secret subset) — or manually via `flyctl secrets set` as
-shown above.
+The worker's full secret set (API-PARITY with the Vercel `revealui-api`
+project) is defined in
+[`scripts/sync/revvault-fly.toml`](../../scripts/sync/revvault-fly.toml).
+
+The `revvault sync fly` target that would push it is **not yet implemented**
+(the CLI only supports `sync vercel`); until it lands, set them manually with
+`flyctl secrets set` as in §First deploy. `STRIPE_SECRET_KEY` + `STRIPE_LIVE_MODE`
+are set Fly-direct (mode-gated), not synced.
 
 **Never** paste secrets into `apps/server/fly.toml` — that file is
 committed to the public repo. The `[env]` block in `fly.toml` is for

--- a/scripts/sync/revvault-fly.toml
+++ b/scripts/sync/revvault-fly.toml
@@ -1,54 +1,120 @@
 # revvault → Fly secrets sync manifest
 #
-# Drives `revvault sync fly --manifest scripts/sync/revvault-fly.toml [--apply]`
-# (the Fly counterpart of revvault-vercel.toml — see that file for the Vercel
-# side and the shared schema notes).
+# Intended to drive `revvault sync fly --manifest scripts/sync/revvault-fly.toml [--apply]`
+# (the Fly counterpart of revvault-vercel.toml).
+#
+# ⚠️  NOTE 2026-05-30: the `fly` sync target is NOT YET implemented in the
+# installed revvault CLI — `revvault sync` only supports `vercel`
+# ("Unknown sync target 'fly'"). Until it lands, provision the Fly secrets with
+# `flyctl secrets set` driven by this var list (see docs/deployment/fly.md
+# §First deploy). This manifest is the authoritative definition of the worker's
+# secret set either way.
 #
 # Schema (parsed by revvault-cli, commands/sync.rs::FlyManifest):
 #   - [fly-apps.<logical>]       — one block per Fly app
 #   - app                         — Fly app name (used as the GraphQL appId)
-#   - skip                        — secret names sync never touches (optional)
+#   - skip                        — secret names sync never touches (set Fly-direct)
 #   - [fly-apps.<logical>.vars]   — secret name → vault path (bare string), or
 #                                   { path = "...", shape = "..." } to add shape
-#                                   validation. Unlike the Vercel manifest there
-#                                   is NO prefix-scan: every managed secret must
-#                                   be listed explicitly. A worker's secret set
-#                                   is a curated subset, not "everything under a
-#                                   prefix".
+#                                   validation. No prefix-scan: every managed
+#                                   secret is listed explicitly.
 #
 # Fly hides secret VALUES (its API returns only names + digest), so sync cannot
 # value-match: a present name is re-Set, an absent one Added. Orphans (set on
 # Fly but absent here) are surfaced, never deleted.
 #
-# Auth: FLY_API_TOKEN env var or `--token`. A live `--apply` is owner-gated:
-# it needs that token vaulted (see docs/SECRETS.md) and the Fly app to exist
-# (drop-railway lane Phase 3). Never inline secret values here — revvault is
-# the source of truth; this manifest carries only vault *paths*.
+# Auth: FLY_API_TOKEN env var or `--token`, vaulted at revealui/prod/fly/api-token.
+# Never inline secret values here — revvault is the source of truth; this
+# manifest carries only vault *paths*.
 
 # ── revealui-worker ───────────────────────────────────────────────────────────
 # Long-running apps/server subset on Fly (alerting, Yjs + agent collab WS,
-# terminal-ws Forge-gated, RVMarket executor flag-gated). Secret subset mirrors
-# the worker bootstrap block in docs/deployment/fly.md (drop-railway Phase 4).
+# terminal-ws Forge-gated, RVMarket executor flag-gated). The worker imports the
+# full Hono app, so its boot runs the SAME config + startup validation as the
+# Vercel `revealui-api` deploy — it needs API-PARITY env, not a minimal subset.
+# This var set mirrors [projects.revealui-api.vars] in revvault-vercel.toml.
 [fly-apps.revealui-worker]
 app = "revealui-worker"
+
+# Fly-direct, mode-gated — NOT synced from revvault (mirrors how STRIPE_LIVE_MODE
+# is handled on Vercel). validate-startup.ts requires STRIPE_SECRET_KEY to be a
+# sk_test_ key when STRIPE_LIVE_MODE is unset/false (the current pre-flip
+# posture), but the vault path revealui/prod/stripe/secret-key holds the STAGED
+# LIVE key. So the operator sets the sk_test_ key DIRECTLY on Fly during the
+# gated period; at launch, flip STRIPE_LIVE_MODE=true + the live key together
+# (gated on the billing-readiness audit).
+skip = ["STRIPE_LIVE_MODE", "STRIPE_SECRET_KEY"]
 
 [fly-apps.revealui-worker.vars]
 # Database (Neon)
 POSTGRES_URL = "revealui/prod/db/postgres-url"
+DATABASE_URL = "revealui/prod/db/postgres-url"
 
-# Core signing / session + license validation
+# Core signing / session + license + audit + encryption
 REVEALUI_SECRET              = "revealui/prod/secret"
+REVEALUI_KEK                 = "revealui/prod/kek"
 REVEALUI_LICENSE_PRIVATE_KEY = "revealui/prod/license/private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/prod/license/public-key"
+REVEALUI_AUDIT_HMAC_SECRET   = "revealui/prod/audit-hmac-secret"
+REVEALUI_CRON_SECRET         = "revealui/prod/cron-secret"
+REVEALUI_ADMIN_API_KEY       = "revealui/prod/admin/api-key"
 
-# Stripe (billing path exercised by the executor + alerting)
-STRIPE_SECRET_KEY     = "revealui/prod/stripe/secret-key"
-STRIPE_WEBHOOK_SECRET = "revealui/prod/stripe/webhook-secret"
+# Public URLs (must be HTTPS + match each other per validate-startup.ts)
+REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
+
+# Required at prod boot (alerting + billing portal)
+REVEALUI_ALERT_EMAIL              = "revealui/prod/alert-email"
+REVEALUI_BILLING_PORTAL_CONFIG_ID = "revealui/prod/billing/portal-config-id"
+
+# Stripe — webhook + price/meter config. STRIPE_SECRET_KEY is set Fly-direct
+# (see `skip` above). These are the LIVE-staged values; they are only exercised
+# when the RVMarket executor is enabled (REVMARKET_EXECUTOR_ENABLED, default off).
+STRIPE_WEBHOOK_SECRET                = "revealui/prod/stripe/webhook-secret"
+STRIPE_WEBHOOK_SECRET_LIVE           = "revealui/prod/stripe/webhook-secret-live"
+STRIPE_AGENT_METER_EVENT_NAME        = "revealui/prod/stripe/agent-meter-event-name"
+STRIPE_PRO_PRICE_ID                  = "revealui/prod/stripe/pro-price-id"
+STRIPE_MAX_PRICE_ID                  = "revealui/prod/stripe/max-price-id"
+STRIPE_ENTERPRISE_PRICE_ID           = "revealui/prod/stripe/enterprise-price-id"
+STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/prod/stripe/max-annual-price-id"
+STRIPE_PERPETUAL_PRO_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
+STRIPE_PERPETUAL_MAX_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
+STRIPE_PERPETUAL_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
+STRIPE_CREDITS_STARTER_PRICE_ID      = "revealui/prod/stripe/credits-starter-price-id"
+STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-price-id"
+STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
+STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
 
 # Observability
 SENTRY_DSN = "revealui/prod/sentry/dsn"
 
-# Electric (real-time sync). The service URL flips to the Fly-hosted Electric
-# during Phase 5 cutover; the vault path itself is unchanged.
+# Object storage (Cloudflare R2 canonical; legacy Blob retiring)
+R2_ACCOUNT_ID         = "revealui/prod/r2/account-id"
+R2_ACCESS_KEY_ID      = "revealui/prod/r2/access-key-id"
+R2_SECRET_ACCESS_KEY  = "revealui/prod/r2/secret-access-key"
+R2_BUCKET             = "revealui/prod/r2/bucket"
+R2_PUBLIC_BASE_URL    = "revealui/prod/r2/public-base-url"
+BLOB_READ_WRITE_TOKEN = "revealui/prod/blob/read-write-token"
+
+# Email (Google Workspace)
+GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
+GOOGLE_PRIVATE_KEY           = "revealui/prod/google/private-key"
+EMAIL_FROM                   = "revealui/prod/email/from"
+EMAIL_REPLY_TO               = "revealui/prod/email/reply-to"
+
+# Passkeys / session / CORS
+PASSKEY_ORIGIN        = "revealui/prod/passkey/origin"
+PASSKEY_RP_ID         = "revealui/prod/passkey/rp-id"
+PASSKEY_RP_NAME       = "revealui/prod/passkey/rp-name"
+SESSION_COOKIE_DOMAIN = "revealui/prod/session-cookie-domain"
+CORS_ORIGIN           = "revealui/prod/cors-origin"
+
+# Marketplace (executor flag-gated)
+MARKETPLACE_CONNECT_RETURN_URL = "revealui/prod/marketplace-connect-return-url"
+
+# Electric (real-time sync). service-url flips to Fly-hosted Electric at the
+# Phase 5 cutover; the vault path is unchanged. electric/secret is currently
+# empty in the vault (GAP-230/231) — the worker does NOT require it (Electric is
+# consumed by the admin shape proxies, not the worker).
 ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
 ELECTRIC_SECRET      = "revealui/prod/electric/secret"


### PR DESCRIPTION
## What

Makes the Fly worker deploy path actually build and boot. The path
(`Dockerfile.worker` + `revvault-fly.toml` + `deployment/fly.md`) was scaffolded
in a prior PR but never validated by a real `flyctl deploy`. A first deploy
surfaced four blockers, all fixed here.

## Fixes

1. **`Dockerfile.worker` build context** — `COPY .npmrc* tsconfig.base.json`
   referenced a file that doesn't exist (root tsconfig is `tsconfig.json`). The
   build failed at this COPY. Fixed to `tsconfig.json`.
2. **`Dockerfile.worker` dependency build** — `pnpm --filter server build` never
   built the `@revealui/*` dependency packages' `dist/`, so tsup failed with 309
   unresolved imports. Fixed to `pnpm --filter "server..."`, which builds the
   dependency closure (deps first); the worker bundle resolves them from `dist/`.
3. **`revvault-fly.toml` completeness** — it listed only 9 vars. The worker
   imports the full Hono app, so it runs the same config + startup validation as
   the Vercel `revealui-api` deploy and needs **api-parity** env (~45 vars).
   Expanded to mirror `[projects.revealui-api.vars]`. `STRIPE_SECRET_KEY` +
   `STRIPE_LIVE_MODE` are set Fly-direct (mode-gated), mirroring how
   `STRIPE_LIVE_MODE` is already handled on Vercel.
4. **`deployment/fly.md` accuracy** — corrected the Fly org slug; removed the
   `revvault sync fly` instructions (that target is **not implemented** — the CLI
   only supports `sync vercel`) in favor of `flyctl secrets set` with the full
   manifest set; added `--remote-only` (local Docker isn't required); documented
   the Stripe test-key handling.

## Validation

- Image builds clean via Fly's remote builder (278 MB).
- Worker boots past config validation + the api-parity startup validation.
- Out of scope: the final boot needs the prod test Stripe key, which is
  operator-managed per the documented Fly-direct posture.

## Follow-up (separate)

- Implement the `revvault sync fly` target so the manifest can be synced rather
  than hand-applied via `flyctl secrets set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
