### PR TITLE
feat(marketing): reframe hero to lead with the uncontested differentiator

### DIFF
--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -17,10 +17,11 @@ import type { Cta, FaqItem } from './types';
 
 export const HOME_HERO = {
   eyebrow: 'Open source. Self-hostable. Audit-ready.',
-  h1: 'Five primitives. One runtime for humans and agents.',
+  h1: 'Run your whole business on one runtime you own.',
   subtitle: {
-    strong: 'An open-source framework. The business logic every product needs, pre-wired.',
-    body: 'Spin up a working app — users, Stripe payments, an admin dashboard, and an AI agent layer, all sharing one login and one audit trail. Build it yourself',
+    strong:
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
+    body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
     agencyHref: SITE.urls.agency,
@@ -63,7 +64,7 @@ export const HOME_HERO = {
         detail: 'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
       },
       {
-        metric: 'Same login. Same audit chain. Same API.',
+        metric: 'Same permissions. Same audit chain. Same API.',
         detail:
           'One permission model and one tamper-evident chain — for your team and your agents alike. See the [architecture](https://docs.revealui.com/architecture).',
       },


### PR DESCRIPTION
## What

Reframes the homepage hero to lead with RevealUI's **uncontested** differentiator instead of its most-contested one.

## Why (competitive research)

A scan of 20 competitors (10 backend/framework, 10 agent-infra/identity) found:

- **9 of 10** backend/framework rivals prominently claim "AI / agents." It no longer differentiates.
- "Humans + agents under one governance" is claimed near-verbatim by **Okta** ("first-class identities"), **Microsoft Entra Agent ID** ("same interface as human users"), **Descope** ("alongside human users, not a parallel silo"), and **Cerbos** ("one place for agents, users, and services"). Leading with it invites a losing comparison to identity incumbents.
- The **uncontested white space** (claimed by nobody in the scan): a self-hostable, multi-tenant runtime that ships auth + content + products + **payments** *and* **stamps a branded copy per client**. This also matches the locked category claim (which bans "AI-native / agentic platform").

## Current vs reframed

- **Current h1:** "Five primitives. One runtime for humans and agents."
- **Reframed h1:** "Run your whole business on one runtime you own."

The sub now leads with the commerce + white-label + self-host runtime, and demotes humans+agents to a supporting clause anchored on the **tamper-evident audit chain**, the one governance edge no competitor in the scan claims.

## Truthfulness

- Dropped "all sharing one login" from the body and "Same login" from the `shipsToday` metric. Agents are governed by the same RBAC and logged to the same audit chain, but they are **not** auth-login principals. Restated to "same permissions."
- Every lead claim is shipped: self-host, auth/content/products/payments pre-wired, per-client white-label stamping (RevForge), tamper-evident hash-chained audit.

## Scope

- `content/home.ts`: `HOME_HERO` (h1, subtitle.strong, subtitle.body, one `shipsToday` metric). Content-only.
- `Hero.tsx` consumes `HOME_HERO` by field; no component change. No test asserts the hero copy.
- "Five primitives" stays as framework vocabulary (the primitives band + "what ships today"), just not the headline.

## Preview

Preview deploy triggered (deploy-test). Homepage hero.
