### PR TITLE
fix(admin): make (backend) pages theme-adaptive via cobalt tokens

### DIFF
--- a/apps/admin/src/__tests__/settings/account-page.test.tsx
+++ b/apps/admin/src/__tests__/settings/account-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Override the global useSearchParams mock for these tests
@@ -213,7 +213,7 @@ describe('AccountSettingsPage', () => {
 
     // Click the confirm "Unlink" button inside the dialog
     const dialog = screen.getByTestId('confirm-dialog');
-    const confirmButton = dialog.querySelector('button.bg-red-600') as HTMLButtonElement;
+    const confirmButton = within(dialog).getByRole('button', { name: 'Unlink' });
     await act(async () => {
       fireEvent.click(confirmButton);
     });
@@ -249,7 +249,7 @@ describe('AccountSettingsPage', () => {
       fireEvent.click(screen.getByText('Unlink'));
     });
     const dialog = screen.getByTestId('confirm-dialog');
-    const confirmButton = dialog.querySelector('button.bg-red-600') as HTMLButtonElement;
+    const confirmButton = within(dialog).getByRole('button', { name: 'Unlink' });
     await act(async () => {
       fireEvent.click(confirmButton);
     });
@@ -278,7 +278,7 @@ describe('AccountSettingsPage', () => {
       fireEvent.click(screen.getByText('Unlink'));
     });
     const dialog = screen.getByTestId('confirm-dialog');
-    const confirmButton = dialog.querySelector('button.bg-red-600') as HTMLButtonElement;
+    const confirmButton = within(dialog).getByRole('button', { name: 'Unlink' });
     await act(async () => {
       fireEvent.click(confirmButton);
     });
@@ -374,7 +374,7 @@ describe('AccountSettingsPage', () => {
       fireEvent.click(screen.getByText('Unlink'));
     });
     const dialog = screen.getByTestId('confirm-dialog');
-    const confirmButton = dialog.querySelector('button.bg-red-600') as HTMLButtonElement;
+    const confirmButton = within(dialog).getByRole('button', { name: 'Unlink' });
     await act(async () => {
       fireEvent.click(confirmButton);
     });
@@ -408,7 +408,7 @@ describe('AccountSettingsPage', () => {
       fireEvent.click(screen.getByText('Unlink'));
     });
     const dialog = screen.getByTestId('confirm-dialog');
-    const confirmButton = dialog.querySelector('button.bg-red-600') as HTMLButtonElement;
+    const confirmButton = within(dialog).getByRole('button', { name: 'Unlink' });
     await act(async () => {
       fireEvent.click(confirmButton);
     });

--- a/apps/admin/src/__tests__/settings/settings-layout.test.tsx
+++ b/apps/admin/src/__tests__/settings/settings-layout.test.tsx
@@ -101,8 +101,7 @@ describe('SettingsLayout', () => {
 
     const sidebar = screen.getByRole('complementary');
     const accountLink = within(sidebar).getByText('Account').closest('a');
-    expect(accountLink?.className).toContain('bg-zinc-800');
-    expect(accountLink?.className).toContain('text-white');
+    expect(accountLink).toHaveAttribute('aria-current', 'page');
   });
 
   it('highlights active API Keys link', () => {
@@ -116,11 +115,10 @@ describe('SettingsLayout', () => {
 
     const sidebar = screen.getByRole('complementary');
     const apiKeysLink = within(sidebar).getByText('API Keys').closest('a');
-    expect(apiKeysLink?.className).toContain('bg-zinc-800');
-    expect(apiKeysLink?.className).toContain('text-white');
+    expect(apiKeysLink).toHaveAttribute('aria-current', 'page');
 
     // Account should NOT be highlighted
     const accountLink = within(sidebar).getByText('Account').closest('a');
-    expect(accountLink?.className).not.toContain('bg-zinc-800');
+    expect(accountLink).not.toHaveAttribute('aria-current', 'page');
   });
 });

--- a/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
+++ b/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
@@ -26,7 +26,7 @@ export default async function Page({ params: _params, searchParams: _searchParam
     <div className="relative">
       <Link
         href="/settings"
-        className="absolute right-28 top-5 z-10 rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        className="absolute right-28 top-5 z-10 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         title="Settings"
       >
         <svg

--- a/apps/admin/src/app/(backend)/agent-tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/agent-tasks/page.tsx
@@ -173,13 +173,15 @@ function AgentTasksDashboard() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <h1 className="text-xl font-semibold text-white">Agent Tasks</h1>
-        <p className="mt-0.5 text-sm text-zinc-400">Task execution history across all AI agents</p>
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Agent Tasks</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Task execution history across all AI agents
+        </p>
       </div>
 
       {/* Stats bar */}
-      <div className="overflow-x-auto border-b border-zinc-800 bg-zinc-950 px-6 py-3">
+      <div className="overflow-x-auto border-b border-border bg-muted px-6 py-3">
         <div className="flex min-w-max gap-6">
           <StatPill label="Total" value={counts.all} />
           <StatPill label="Completed" value={counts.completed} color="emerald" />
@@ -190,7 +192,7 @@ function AgentTasksDashboard() {
       </div>
 
       {/* Date + status filter row */}
-      <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+      <div className="border-b border-border bg-muted px-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <div className="overflow-x-auto">
             <nav className="flex gap-1 -mb-px min-w-max" aria-label="Status filter">
@@ -201,8 +203,8 @@ function AgentTasksDashboard() {
                   onClick={() => dispatch({ type: 'SET_FILTER', filter: f })}
                   className={`border-b-2 px-4 py-3 text-sm font-medium capitalize transition-colors ${
                     statusFilter === f
-                      ? 'border-white text-white'
-                      : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {f} ({counts[f]})
@@ -218,7 +220,9 @@ function AgentTasksDashboard() {
                 type="button"
                 onClick={() => dispatch({ type: 'SET_DATE_FILTER', filter: d })}
                 className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
-                  dateFilter === d ? 'bg-zinc-700 text-white' : 'text-zinc-500 hover:text-zinc-300'
+                  dateFilter === d
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {d === 'all' ? 'All time' : d}
@@ -236,13 +240,13 @@ function AgentTasksDashboard() {
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
                 key={i}
-                className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-800/40 px-4 py-3"
+                className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <div className="h-5 w-16 rounded-full bg-zinc-700" />
-                  <div className="h-4 flex-1 rounded bg-zinc-700/60" />
-                  <div className="hidden h-3 w-20 rounded bg-zinc-700/40 sm:block" />
-                  <div className="h-3 w-32 rounded bg-zinc-700/40" />
+                  <div className="h-5 w-16 rounded-full bg-foreground/10" />
+                  <div className="h-4 flex-1 rounded bg-foreground/10" />
+                  <div className="hidden h-3 w-20 rounded bg-foreground/10 sm:block" />
+                  <div className="h-3 w-32 rounded bg-foreground/10" />
                 </div>
               </div>
             ))}
@@ -250,7 +254,7 @@ function AgentTasksDashboard() {
         ) : error ? (
           <div
             role="alert"
-            className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+            className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
           >
             {error}
           </div>
@@ -287,17 +291,17 @@ function StatPill({
   color?: 'emerald' | 'red' | 'blue' | 'zinc';
 }) {
   const colors = {
-    emerald: 'text-emerald-400',
-    red: 'text-red-400',
-    blue: 'text-blue-400',
-    zinc: 'text-zinc-400',
+    emerald: 'text-success',
+    red: 'text-error',
+    blue: 'text-primary',
+    zinc: 'text-muted-foreground',
   };
   return (
     <div className="flex items-center gap-1.5">
-      <span className={`text-sm font-semibold ${color ? colors[color] : 'text-white'}`}>
+      <span className={`text-sm font-semibold ${color ? colors[color] : 'text-foreground'}`}>
         {value}
       </span>
-      <span className="text-xs text-zinc-500">{label}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   );
 }
@@ -316,7 +320,7 @@ function TaskRow({
   const ts = new Date(task.startedAt).toLocaleString();
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 transition-colors hover:border-zinc-700">
+    <div className="rounded-lg border border-border bg-card transition-colors hover:border-border">
       <button
         type="button"
         onClick={onToggle}
@@ -325,43 +329,43 @@ function TaskRow({
       >
         <div className="flex items-center gap-3">
           <StatusBadge status={task.status} />
-          <span className="truncate text-sm text-zinc-300">{inputText ?? task.tool}</span>
-          <span className="ml-auto hidden shrink-0 text-xs text-zinc-600 sm:inline">
+          <span className="truncate text-sm text-muted-foreground">{inputText ?? task.tool}</span>
+          <span className="ml-auto hidden shrink-0 text-xs text-muted-foreground sm:inline">
             {task.agentId}
           </span>
-          <span className="shrink-0 font-mono text-xs text-zinc-600">{ts}</span>
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">{ts}</span>
           {task.durationMs != null && (
-            <span className="hidden shrink-0 text-xs text-zinc-500 sm:inline">
+            <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
               {task.durationMs}ms
             </span>
           )}
           <ChevronIcon expanded={expanded} />
         </div>
         {!expanded && outputText && (
-          <p className="mt-1.5 truncate text-xs text-zinc-500">
-            <span className="text-zinc-600">out: </span>
+          <p className="mt-1.5 truncate text-xs text-muted-foreground">
+            <span className="text-muted-foreground">out: </span>
             {outputText}
           </p>
         )}
       </button>
 
       {expanded && (
-        <div className="border-t border-zinc-800 px-4 py-3">
+        <div className="border-t border-border px-4 py-3">
           <div className="grid gap-4 text-sm lg:grid-cols-2">
             {/* Input */}
             <div>
-              <h4 className="mb-1 text-xs font-medium text-zinc-500">Input</h4>
-              <p className="whitespace-pre-wrap text-zinc-300">{inputText ?? ' - '}</p>
+              <h4 className="mb-1 text-xs font-medium text-muted-foreground">Input</h4>
+              <p className="whitespace-pre-wrap text-muted-foreground">{inputText ?? ' - '}</p>
             </div>
 
             {/* Output */}
             <div>
-              <h4 className="mb-1 text-xs font-medium text-zinc-500">Output</h4>
-              <p className="whitespace-pre-wrap text-zinc-300">{outputText ?? ' - '}</p>
+              <h4 className="mb-1 text-xs font-medium text-muted-foreground">Output</h4>
+              <p className="whitespace-pre-wrap text-muted-foreground">{outputText ?? ' - '}</p>
             </div>
 
             {/* Metadata row */}
-            <div className="col-span-full flex flex-wrap gap-4 border-t border-zinc-800 pt-3">
+            <div className="col-span-full flex flex-wrap gap-4 border-t border-border pt-3">
               <MetaField label="Tool" value={task.tool} />
               <MetaField label="Agent" value={task.agentId} />
               <MetaField label="Started" value={ts} />
@@ -380,17 +384,19 @@ function TaskRow({
 
             {/* Reasoning */}
             {task.reasoning && (
-              <div className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-zinc-500">Reasoning</h4>
-                <p className="whitespace-pre-wrap text-xs text-zinc-400">{task.reasoning}</p>
+              <div className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-muted-foreground">Reasoning</h4>
+                <p className="whitespace-pre-wrap text-xs text-muted-foreground">
+                  {task.reasoning}
+                </p>
               </div>
             )}
 
             {/* Error */}
             {task.error && (
-              <div role="alert" className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-red-500">Error</h4>
-                <p className="whitespace-pre-wrap text-xs text-red-400">{task.error}</p>
+              <div role="alert" className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-error">Error</h4>
+                <p className="whitespace-pre-wrap text-xs text-error">{task.error}</p>
               </div>
             )}
           </div>
@@ -403,21 +409,21 @@ function TaskRow({
 function MetaField({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <span className="text-xs text-zinc-600">{label}: </span>
-      <span className="font-mono text-xs text-zinc-400">{value}</span>
+      <span className="text-xs text-muted-foreground">{label}: </span>
+      <span className="font-mono text-xs text-muted-foreground">{value}</span>
     </div>
   );
 }
 
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
-    completed: 'bg-emerald-500/10 text-emerald-400',
-    failed: 'bg-red-500/10 text-red-400',
-    running: 'bg-blue-500/10 text-blue-400',
-    pending: 'bg-zinc-600/20 text-zinc-400',
-    cancelled: 'bg-zinc-600/20 text-zinc-400',
+    completed: 'bg-success/10 text-success',
+    failed: 'bg-error/10 text-error',
+    running: 'bg-primary/10 text-primary',
+    pending: 'bg-muted text-muted-foreground',
+    cancelled: 'bg-muted text-muted-foreground',
   };
-  const color = colors[status] ?? 'bg-zinc-700/20 text-zinc-400';
+  const color = colors[status] ?? 'bg-muted text-muted-foreground';
   return (
     <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
       {status}
@@ -428,7 +434,7 @@ function StatusBadge({ status }: { status: string }) {
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 shrink-0 text-zinc-600 transition-transform ${expanded ? 'rotate-180' : ''}`}
+      className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -455,9 +461,9 @@ function EmptyState({ filter, dateFilter }: { filter: StatusFilter; dateFilter: 
 
   return (
     <div className="flex flex-col items-center py-16">
-      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800">
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
         <svg
-          className="h-6 w-6 text-zinc-500"
+          className="h-6 w-6 text-muted-foreground"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -471,7 +477,7 @@ function EmptyState({ filter, dateFilter }: { filter: StatusFilter; dateFilter: 
           />
         </svg>
       </div>
-      <p className="text-sm text-zinc-500">{message}</p>
+      <p className="text-sm text-muted-foreground">{message}</p>
     </div>
   );
 }

--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -152,7 +152,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Breadcrumb header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="border-b border-border bg-card px-6 py-4">
           <Breadcrumb
             items={[
               { label: 'Admin', href: '/' },
@@ -165,14 +165,14 @@ export default function AgentDetailPage({ params }: PageProps) {
         <div className="p-6">
           {loading && (
             <div className="flex h-32 items-center justify-center">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-600 border-t-zinc-200" />
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-border border-t-foreground" />
             </div>
           )}
 
           {error && (
             <div
               role="alert"
-              className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+              className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
             >
               {error}
             </div>
@@ -183,13 +183,13 @@ export default function AgentDetailPage({ params }: PageProps) {
               {/* Left: Agent metadata */}
               <div className="flex flex-col gap-6">
                 {/* Identity */}
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+                <div className="rounded-xl border border-border bg-card p-5">
                   {isEditing ? (
                     <div className="flex flex-col gap-4">
                       <div>
                         <label
                           htmlFor="edit-name"
-                          className="block text-xs font-medium text-zinc-400 mb-1.5"
+                          className="block text-xs font-medium text-muted-foreground mb-1.5"
                         >
                           Name
                         </label>
@@ -202,13 +202,13 @@ export default function AgentDetailPage({ params }: PageProps) {
                               HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
                             >,
                           ) => setEditName(e.target.value)}
-                          className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                         />
                       </div>
                       <div>
                         <label
                           htmlFor="edit-description"
-                          className="block text-xs font-medium text-zinc-400 mb-1.5"
+                          className="block text-xs font-medium text-muted-foreground mb-1.5"
                         >
                           Description
                         </label>
@@ -221,13 +221,13 @@ export default function AgentDetailPage({ params }: PageProps) {
                               HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
                             >,
                           ) => setEditDescription(e.target.value)}
-                          className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                         />
                       </div>
                       <div>
                         <label
                           htmlFor="edit-system-prompt"
-                          className="block text-xs font-medium text-zinc-400 mb-1.5"
+                          className="block text-xs font-medium text-muted-foreground mb-1.5"
                         >
                           System Prompt
                         </label>
@@ -240,13 +240,13 @@ export default function AgentDetailPage({ params }: PageProps) {
                               HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
                             >,
                           ) => setEditSystemPrompt(e.target.value)}
-                          className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none resize-none"
+                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
                         />
                       </div>
                       {saveError && (
                         <div
                           role="alert"
-                          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+                          className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
                         >
                           {saveError}
                         </div>
@@ -256,7 +256,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                           type="button"
                           onClick={handleSave}
                           disabled={saving || !editName.trim()}
-                          className="rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {saving ? 'Saving...' : 'Save'}
                         </button>
@@ -264,7 +264,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                           type="button"
                           onClick={handleEditCancel}
                           disabled={saving}
-                          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
+                          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                         >
                           Cancel
                         </button>
@@ -273,24 +273,24 @@ export default function AgentDetailPage({ params }: PageProps) {
                   ) : (
                     <>
                       <div className="flex items-start justify-between gap-3">
-                        <h1 className="text-xl font-semibold text-white">{card.name}</h1>
+                        <h1 className="text-xl font-semibold text-foreground">{card.name}</h1>
                         <div className="flex shrink-0 items-center gap-2">
-                          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                          <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
                             v{card.version}
                           </span>
                           <button
                             type="button"
                             onClick={handleEditStart}
                             disabled={loadingDef}
-                            className="rounded-lg border border-zinc-700 px-3 py-1 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-500 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-lg border border-border px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             {loadingDef ? '...' : 'Edit'}
                           </button>
                         </div>
                       </div>
-                      <p className="mt-2 text-sm text-zinc-400">{card.description}</p>
+                      <p className="mt-2 text-sm text-muted-foreground">{card.description}</p>
                       {card.provider && (
-                        <p className="mt-3 text-xs text-zinc-600">
+                        <p className="mt-3 text-xs text-muted-foreground">
                           by {card.provider.organization}
                         </p>
                       )}
@@ -299,61 +299,67 @@ export default function AgentDetailPage({ params }: PageProps) {
                 </div>
 
                 {/* Capabilities */}
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <div className="rounded-xl border border-border bg-card p-5">
+                  <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Capabilities
                   </h2>
                   <dl className="space-y-2 text-sm">
                     <div className="flex justify-between">
-                      <dt className="text-zinc-400">Streaming</dt>
+                      <dt className="text-muted-foreground">Streaming</dt>
                       <dd
                         className={
-                          card.capabilities.streaming ? 'text-emerald-400' : 'text-zinc-600'
+                          card.capabilities.streaming ? 'text-success' : 'text-muted-foreground'
                         }
                       >
                         {card.capabilities.streaming ? 'yes' : 'no'}
                       </dd>
                     </div>
                     <div className="flex justify-between">
-                      <dt className="text-zinc-400">Push Notifications</dt>
+                      <dt className="text-muted-foreground">Push Notifications</dt>
                       <dd
                         className={
-                          card.capabilities.pushNotifications ? 'text-emerald-400' : 'text-zinc-600'
+                          card.capabilities.pushNotifications
+                            ? 'text-success'
+                            : 'text-muted-foreground'
                         }
                       >
                         {card.capabilities.pushNotifications ? 'yes' : 'no'}
                       </dd>
                     </div>
                     <div className="flex justify-between">
-                      <dt className="text-zinc-400">Auth</dt>
-                      <dd className="text-zinc-300">{card.authentication.schemes.join(', ')}</dd>
+                      <dt className="text-muted-foreground">Auth</dt>
+                      <dd className="text-muted-foreground">
+                        {card.authentication.schemes.join(', ')}
+                      </dd>
                     </div>
                     <div className="flex justify-between">
-                      <dt className="text-zinc-400">Input modes</dt>
-                      <dd className="text-zinc-300">{card.defaultInputModes.join(', ')}</dd>
+                      <dt className="text-muted-foreground">Input modes</dt>
+                      <dd className="text-muted-foreground">{card.defaultInputModes.join(', ')}</dd>
                     </div>
                   </dl>
                 </div>
 
                 {/* Skills */}
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <div className="rounded-xl border border-border bg-card p-5">
+                  <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Skills ({card.skills.length})
                   </h2>
                   <ul className="space-y-3">
                     {card.skills.map((skill) => (
                       <li
                         key={skill.id}
-                        className="border-t border-zinc-800 pt-3 first:border-0 first:pt-0"
+                        className="border-t border-border pt-3 first:border-0 first:pt-0"
                       >
-                        <p className="font-mono text-sm font-medium text-zinc-200">{skill.id}</p>
-                        <p className="mt-0.5 text-sm text-zinc-400">{skill.description}</p>
+                        <p className="font-mono text-sm font-medium text-muted-foreground">
+                          {skill.id}
+                        </p>
+                        <p className="mt-0.5 text-sm text-muted-foreground">{skill.description}</p>
                         {skill.tags && skill.tags.length > 0 && (
                           <div className="mt-1.5 flex flex-wrap gap-1">
                             {skill.tags.map((tag) => (
                               <span
                                 key={tag}
-                                className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-500"
+                                className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
                               >
                                 {tag}
                               </span>
@@ -370,25 +376,25 @@ export default function AgentDetailPage({ params }: PageProps) {
                   href={`${apiUrl}/.well-known/agents/${agentId}/agent.json`}
                   target="_blank"
                   rel="noreferrer"
-                  className="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2.5 text-center text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
+                  className="rounded-lg border border-border bg-muted px-4 py-2.5 text-center text-sm text-muted-foreground transition-colors hover:bg-muted/80"
                 >
                   View Agent Card JSON ↗
                 </a>
 
                 {/* Danger zone  -  built-in agents are protected */}
                 {!BUILTIN_AGENTS.has(agentId) && (
-                  <div className="rounded-xl border border-red-900/40 bg-red-950/10 p-5">
-                    <h2 className="mb-3 text-sm font-medium text-red-400">Danger Zone</h2>
+                  <div className="rounded-xl border border-error/30 bg-error/10 p-5">
+                    <h2 className="mb-3 text-sm font-medium text-error">Danger Zone</h2>
                     {isConfirmingRetire ? (
                       <div className="flex flex-col gap-3">
-                        <p className="text-sm text-zinc-300">
-                          Retire <strong className="text-white">{card.name}</strong>? This removes
-                          the agent from the registry. This action cannot be undone.
+                        <p className="text-sm text-muted-foreground">
+                          Retire <strong className="text-foreground">{card.name}</strong>? This
+                          removes the agent from the registry. This action cannot be undone.
                         </p>
                         {retireError && (
                           <div
                             role="alert"
-                            className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+                            className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
                           >
                             {retireError}
                           </div>
@@ -398,7 +404,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                             type="button"
                             onClick={handleRetire}
                             disabled={retiring}
-                            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-lg bg-error px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             {retiring ? 'Retiring...' : 'Confirm Retire'}
                           </button>
@@ -409,7 +415,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                               setRetireError(null);
                             }}
                             disabled={retiring}
-                            className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
+                            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                           >
                             Cancel
                           </button>
@@ -417,13 +423,13 @@ export default function AgentDetailPage({ params }: PageProps) {
                       </div>
                     ) : (
                       <div className="flex items-center justify-between gap-4">
-                        <p className="text-sm text-zinc-500">
+                        <p className="text-sm text-muted-foreground">
                           Remove this agent from the registry permanently.
                         </p>
                         <button
                           type="button"
                           onClick={() => setIsConfirmingRetire(true)}
-                          className="shrink-0 rounded-lg border border-red-800 px-3 py-1.5 text-sm font-medium text-red-400 transition-colors hover:border-red-600 hover:text-red-300"
+                          className="shrink-0 rounded-lg border border-error/30 px-3 py-1.5 text-sm font-medium text-error transition-colors hover:border-error/50 hover:text-error"
                         >
                           Retire Agent
                         </button>
@@ -435,14 +441,14 @@ export default function AgentDetailPage({ params }: PageProps) {
 
               {/* Right: Task tester + history */}
               <div className="flex flex-col gap-6">
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+                <div className="rounded-xl border border-border bg-card p-5">
                   <div className="mb-4 flex items-center justify-between gap-2">
-                    <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-500">
+                    <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                       Task Tester
                     </h2>
                     <a
                       href={`/agents/${encodeURIComponent(agentId)}/run`}
-                      className="rounded-md border border-emerald-700 bg-emerald-900/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-900/40"
+                      className="rounded-md border border-success/30 bg-success/10 px-3 py-1.5 text-xs font-medium text-success transition-colors hover:bg-success/20"
                       title="Stream agent execution live (Stage 5 surface)"
                     >
                       Watch live ↗
@@ -455,25 +461,29 @@ export default function AgentDetailPage({ params }: PageProps) {
                   />
                 </div>
 
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <div className="rounded-xl border border-border bg-card p-5">
+                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Agent Memory
-                    <span className="ml-2 text-xs font-normal normal-case text-zinc-600">live</span>
+                    <span className="ml-2 text-xs font-normal normal-case text-muted-foreground">
+                      live
+                    </span>
                   </h2>
                   <AgentMemory agentId={agentId} />
                 </div>
 
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <div className="rounded-xl border border-border bg-card p-5">
+                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Task History
                   </h2>
                   <TaskHistory agentId={agentId} refreshKey={taskRefreshKey} />
                 </div>
 
-                <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <div className="rounded-xl border border-border bg-card p-5">
+                  <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Agent Contexts
-                    <span className="ml-2 text-xs font-normal normal-case text-zinc-600">live</span>
+                    <span className="ml-2 text-xs font-normal normal-case text-muted-foreground">
+                      live
+                    </span>
                   </h2>
                   <AgentContexts agentId={agentId} />
                 </div>

--- a/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
@@ -51,15 +51,15 @@ export default function AgentRunPage({ params }: PageProps) {
         />
 
         <header className="space-y-2">
-          <h1 className="text-2xl font-semibold text-zinc-100">Run agent — live stream</h1>
-          <p className="text-sm text-zinc-400">
+          <h1 className="text-2xl font-semibold text-foreground">Run agent — live stream</h1>
+          <p className="text-sm text-muted-foreground">
             Submits an instruction to{' '}
-            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">/api/agent-stream</code> and
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">/api/agent-stream</code> and
             renders chunks in real time. Connected MCP servers can call{' '}
-            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">sampling/create</code> and{' '}
-            <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs">elicitation/create</code>{' '}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">sampling/create</code> and{' '}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">elicitation/create</code>{' '}
             mid-run; both surface here.{' '}
-            <Link href={`/agents/${agentId}`} className="text-emerald-400 hover:text-emerald-300">
+            <Link href={`/agents/${agentId}`} className="text-success hover:text-success">
               ← Back to agent detail
             </Link>
           </p>
@@ -67,9 +67,9 @@ export default function AgentRunPage({ params }: PageProps) {
 
         <form
           onSubmit={handleStart}
-          className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+          className="space-y-3 rounded-lg border border-border bg-card p-4"
         >
-          <label htmlFor="instruction" className="block text-sm font-medium text-zinc-200">
+          <label htmlFor="instruction" className="block text-sm font-medium text-muted-foreground">
             Instruction
           </label>
           <textarea
@@ -81,10 +81,10 @@ export default function AgentRunPage({ params }: PageProps) {
             disabled={stream.isStreaming}
             rows={4}
             placeholder="What would you like the agent to do?"
-            className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-60"
+            className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
           />
           <div className="flex items-center gap-3">
-            <label className="flex items-center gap-2 text-xs text-zinc-300">
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
               <span>Mode</span>
               <select
                 value={mode}
@@ -92,7 +92,7 @@ export default function AgentRunPage({ params }: PageProps) {
                   e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                 ) => setMode(e.target.value as 'admin' | 'coding')}
                 disabled={stream.isStreaming}
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-60"
+                className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
               >
                 <option value="admin">admin</option>
                 <option value="coding">coding</option>
@@ -103,7 +103,7 @@ export default function AgentRunPage({ params }: PageProps) {
               <button
                 type="submit"
                 disabled={!instruction.trim()}
-                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Start agent
               </button>
@@ -112,7 +112,7 @@ export default function AgentRunPage({ params }: PageProps) {
               <button
                 type="button"
                 onClick={stream.abort}
-                className="rounded-md border border-red-800 bg-red-900/30 px-4 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-900/50"
+                className="rounded-md border border-error/30 bg-error/10 px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/15"
               >
                 Cancel
               </button>
@@ -121,7 +121,7 @@ export default function AgentRunPage({ params }: PageProps) {
               <button
                 type="button"
                 onClick={stream.reset}
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
+                className="rounded-md border border-border bg-muted px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-foreground/10"
               >
                 Clear
               </button>
@@ -138,7 +138,7 @@ export default function AgentRunPage({ params }: PageProps) {
 
         {stream.pendingElicitations.length > 0 && (
           <section className="space-y-3">
-            <h2 className="text-sm font-medium text-blue-300">
+            <h2 className="text-sm font-medium text-primary">
               Pending input ({stream.pendingElicitations.length})
             </h2>
             {stream.pendingElicitations.map((pending) => (
@@ -156,15 +156,15 @@ export default function AgentRunPage({ params }: PageProps) {
         )}
 
         {stream.text && (
-          <section className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
-            <h2 className="mb-2 text-sm font-medium text-zinc-300">Agent output</h2>
-            <pre className="whitespace-pre-wrap text-sm text-zinc-100">{stream.text}</pre>
+          <section className="rounded-lg border border-border bg-card p-4">
+            <h2 className="mb-2 text-sm font-medium text-muted-foreground">Agent output</h2>
+            <pre className="whitespace-pre-wrap text-sm text-foreground">{stream.text}</pre>
           </section>
         )}
 
         {stream.chunks.length > 0 && (
           <section className="space-y-2">
-            <h2 className="text-sm font-medium text-zinc-300">Event log</h2>
+            <h2 className="text-sm font-medium text-muted-foreground">Event log</h2>
             <ol className="space-y-2">
               {stream.chunks.map((chunk, idx) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: streaming chunks are append-only, never reordered
@@ -191,26 +191,26 @@ interface StatusBarProps {
 
 function StatusBar({ isStreaming, sessionId, chunkCount, error }: StatusBarProps) {
   return (
-    <div className="flex items-center gap-3 rounded-md border border-zinc-800 bg-zinc-900/40 px-3 py-2 text-xs text-zinc-400">
+    <div className="flex items-center gap-3 rounded-md border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
       <span
         className={`inline-flex h-2 w-2 rounded-full ${
-          error ? 'bg-red-500' : isStreaming ? 'animate-pulse bg-emerald-500' : 'bg-zinc-600'
+          error ? 'bg-error' : isStreaming ? 'animate-pulse bg-success' : 'bg-foreground/10'
         }`}
         aria-hidden="true"
       />
       <span>{error ? 'Error' : isStreaming ? 'Streaming' : 'Idle'}</span>
-      <span className="text-zinc-600">·</span>
+      <span className="text-muted-foreground">·</span>
       <span>chunks: {chunkCount}</span>
       {sessionId && (
         <>
-          <span className="text-zinc-600">·</span>
-          <span className="font-mono text-zinc-500">session {sessionId.slice(0, 8)}</span>
+          <span className="text-muted-foreground">·</span>
+          <span className="font-mono text-muted-foreground">session {sessionId.slice(0, 8)}</span>
         </>
       )}
       {error && (
         <>
-          <span className="text-zinc-600">·</span>
-          <span className="text-red-400">{error}</span>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-error">{error}</span>
         </>
       )}
     </div>
@@ -239,10 +239,10 @@ function ElicitationCard({ namespace, requestedSchema, message, onSubmit }: Elic
   ) satisfies ElicitationSchema;
 
   return (
-    <div className="rounded-lg border border-blue-800 bg-blue-900/10 p-4">
-      <div className="mb-2 flex items-center gap-2 text-xs text-blue-300">
+    <div className="rounded-lg border border-primary/30 bg-primary/10 p-4">
+      <div className="mb-2 flex items-center gap-2 text-xs text-primary">
         <span className="font-mono">{namespace}</span>
-        <span className="text-blue-700">·</span>
+        <span className="text-primary">·</span>
         <span>requesting input</span>
       </div>
       <ElicitationForm message={message} requestedSchema={schema} onSubmit={onSubmit} />
@@ -258,42 +258,46 @@ function ChunkRow({ chunk, index }: { chunk: AgentStreamChunk; index: number }) 
   switch (chunk.type) {
     case 'session_info':
       return (
-        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-500">
-          <span className="font-mono text-zinc-600">[{index}]</span> session_info{' '}
+        <li className="rounded-md border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-mono text-muted-foreground">[{index}]</span> session_info{' '}
           <span className="font-mono">{chunk.sessionId?.slice(0, 8)}…</span>
         </li>
       );
     case 'text':
       return (
-        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs">
-          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
-          <span className="text-zinc-400">text</span>{' '}
-          <span className="text-zinc-200">{chunk.content?.slice(0, 80)}</span>
-          {chunk.content && chunk.content.length > 80 && <span className="text-zinc-500">…</span>}
+        <li className="rounded-md border border-border bg-card px-3 py-2 text-xs">
+          <span className="font-mono text-muted-foreground">[{index}]</span>{' '}
+          <span className="text-muted-foreground">text</span>{' '}
+          <span className="text-muted-foreground">{chunk.content?.slice(0, 80)}</span>
+          {chunk.content && chunk.content.length > 80 && (
+            <span className="text-muted-foreground">…</span>
+          )}
         </li>
       );
     case 'tool_call_start':
       return (
-        <li className="rounded-md border border-emerald-900 bg-emerald-900/10 px-3 py-2 text-xs">
-          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
-          <span className="font-medium text-emerald-300">tool call</span>{' '}
-          <span className="font-mono text-emerald-200">{chunk.toolCall?.name}</span>
+        <li className="rounded-md border border-success/30 bg-success/10 px-3 py-2 text-xs">
+          <span className="font-mono text-muted-foreground">[{index}]</span>{' '}
+          <span className="font-medium text-success">tool call</span>{' '}
+          <span className="font-mono text-success">{chunk.toolCall?.name}</span>
         </li>
       );
     case 'tool_call_result':
       return (
-        <li className="rounded-md border border-emerald-900 bg-emerald-900/10 px-3 py-2 text-xs">
-          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
-          <span className="text-emerald-300">tool result</span>
+        <li className="rounded-md border border-success/30 bg-success/10 px-3 py-2 text-xs">
+          <span className="font-mono text-muted-foreground">[{index}]</span>{' '}
+          <span className="text-success">tool result</span>
         </li>
       );
     case 'sampling_request':
       return (
-        <li className="rounded-md border border-purple-900 bg-purple-900/10 px-3 py-2 text-xs">
-          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
-          <span className="font-medium text-purple-300">sampling</span>{' '}
-          {chunk.namespace && <span className="font-mono text-purple-200">{chunk.namespace}</span>}{' '}
-          <span className="text-zinc-500">
+        <li className="rounded-md border border-accent/30 bg-accent/10 px-3 py-2 text-xs">
+          <span className="font-mono text-muted-foreground">[{index}]</span>{' '}
+          <span className="font-medium text-accent-foreground">sampling</span>{' '}
+          {chunk.namespace && (
+            <span className="font-mono text-accent-foreground">{chunk.namespace}</span>
+          )}{' '}
+          <span className="text-muted-foreground">
             model={chunk.sampling?.model}, messages={chunk.sampling?.messageCount}, maxTokens=
             {chunk.sampling?.maxTokens}
           </span>
@@ -301,30 +305,32 @@ function ChunkRow({ chunk, index }: { chunk: AgentStreamChunk; index: number }) 
       );
     case 'elicitation_request':
       return (
-        <li className="rounded-md border border-blue-900 bg-blue-900/10 px-3 py-2 text-xs">
-          <span className="font-mono text-zinc-600">[{index}]</span>{' '}
-          <span className="font-medium text-blue-300">elicitation</span>{' '}
-          {chunk.namespace && <span className="font-mono text-blue-200">{chunk.namespace}</span>}{' '}
-          <span className="text-zinc-500">id={chunk.elicitation?.elicitationId.slice(0, 8)}…</span>
+        <li className="rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs">
+          <span className="font-mono text-muted-foreground">[{index}]</span>{' '}
+          <span className="font-medium text-primary">elicitation</span>{' '}
+          {chunk.namespace && <span className="font-mono text-primary">{chunk.namespace}</span>}{' '}
+          <span className="text-muted-foreground">
+            id={chunk.elicitation?.elicitationId.slice(0, 8)}…
+          </span>
         </li>
       );
     case 'error':
       return (
-        <li className="rounded-md border border-red-800 bg-red-900/20 px-3 py-2 text-xs text-red-300">
-          <span className="font-mono text-zinc-600">[{index}]</span> error{' '}
-          <span className="text-red-200">{chunk.error}</span>
+        <li className="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-xs text-error">
+          <span className="font-mono text-muted-foreground">[{index}]</span> error{' '}
+          <span className="text-error">{chunk.error}</span>
         </li>
       );
     case 'done':
       return (
-        <li className="rounded-md border border-zinc-700 bg-zinc-800/30 px-3 py-2 text-xs text-zinc-300">
-          <span className="font-mono text-zinc-600">[{index}]</span> done
+        <li className="rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-mono text-muted-foreground">[{index}]</span> done
         </li>
       );
     default:
       return (
-        <li className="rounded-md border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-500">
-          <span className="font-mono text-zinc-600">[{index}]</span> {String(chunk.type)}
+        <li className="rounded-md border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-mono text-muted-foreground">[{index}]</span> {String(chunk.type)}
         </li>
       );
   }

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -228,7 +228,7 @@ export default function NewAgentPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="border-b border-border bg-card px-6 py-4">
           <Breadcrumb
             items={[
               { label: 'Admin', href: '/' },
@@ -236,14 +236,16 @@ export default function NewAgentPage() {
               { label: 'New Agent' },
             ]}
           />
-          <p className="mt-2 text-sm text-zinc-400">Scaffold a new AI agent from a template</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Scaffold a new AI agent from a template
+          </p>
         </div>
 
         <div className="mx-auto max-w-2xl p-6">
           <form onSubmit={handleSubmit} className="flex flex-col gap-8">
             {/* Step 1  -  Template */}
             <section>
-              <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-zinc-500">
+              <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                 1. Choose a template
               </h2>
               <div className="grid gap-3 sm:grid-cols-2">
@@ -254,26 +256,26 @@ export default function NewAgentPage() {
                     onClick={() => applyTemplate(t.key)}
                     className={`rounded-xl border p-4 text-left transition-all ${
                       selectedTemplate === t.key
-                        ? 'border-zinc-400 bg-zinc-800 ring-1 ring-zinc-400'
-                        : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700'
+                        ? 'border-border bg-muted ring-1 ring-ring'
+                        : 'border-border bg-card hover:border-border'
                     }`}
                   >
                     <div className="mb-1 flex items-center gap-2">
                       <TemplateIcon templateKey={t.key} />
-                      <span className="font-medium text-white text-sm">{t.label}</span>
+                      <span className="font-medium text-foreground text-sm">{t.label}</span>
                     </div>
-                    <p className="text-xs text-zinc-400 leading-relaxed">{t.description}</p>
+                    <p className="text-xs text-muted-foreground leading-relaxed">{t.description}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {t.capabilities.slice(0, 2).map((cap) => (
                         <span
                           key={cap}
-                          className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs text-zinc-300"
+                          className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
                         >
                           {cap}
                         </span>
                       ))}
                       {t.capabilities.length > 2 && (
-                        <span className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs text-zinc-300">
+                        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                           +{t.capabilities.length - 2}
                         </span>
                       )}
@@ -286,7 +288,7 @@ export default function NewAgentPage() {
             {/* Step 2  -  Details (shown after template selection) */}
             {selectedTemplate && (
               <section className="flex flex-col gap-4">
-                <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-500">
+                <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                   2. Configure agent
                 </h2>
 
@@ -294,9 +296,9 @@ export default function NewAgentPage() {
                 <div>
                   <label
                     htmlFor="agent-name"
-                    className="block text-sm font-medium text-zinc-300 mb-1.5"
+                    className="block text-sm font-medium text-muted-foreground mb-1.5"
                   >
-                    Name <span className="text-red-400">*</span>
+                    Name <span className="text-error">*</span>
                   </label>
                   <input
                     id="agent-name"
@@ -307,10 +309,10 @@ export default function NewAgentPage() {
                       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                     ) => handleNameChange(e.target.value)}
                     placeholder={`e.g. ${tpl?.label ?? 'My Agent'}`}
-                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                   />
                   {name.trim() && (
-                    <p className="mt-1 text-xs text-zinc-500">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Agent ID:{' '}
                       <code className="font-mono">
                         {name
@@ -327,7 +329,7 @@ export default function NewAgentPage() {
                 <div>
                   <label
                     htmlFor="agent-desc"
-                    className="block text-sm font-medium text-zinc-300 mb-1.5"
+                    className="block text-sm font-medium text-muted-foreground mb-1.5"
                   >
                     Description
                   </label>
@@ -339,7 +341,7 @@ export default function NewAgentPage() {
                       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                     ) => dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })}
                     placeholder={tpl?.description ?? 'What does this agent do?'}
-                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                   />
                 </div>
 
@@ -347,7 +349,7 @@ export default function NewAgentPage() {
                 <div>
                   <label
                     htmlFor="agent-prompt"
-                    className="block text-sm font-medium text-zinc-300 mb-1.5"
+                    className="block text-sm font-medium text-muted-foreground mb-1.5"
                   >
                     System Prompt
                   </label>
@@ -359,17 +361,17 @@ export default function NewAgentPage() {
                       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                     ) => dispatch({ type: 'SET_SYSTEM_PROMPT', value: e.target.value })}
                     placeholder="Describe the agent's role, personality, and constraints..."
-                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none resize-none"
+                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
                   />
                 </div>
 
                 {/* Model info (read-only) */}
-                <div className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3 text-xs text-zinc-400">
-                  <span className="font-medium text-zinc-300">Model:</span> {tpl?.model}
+                <div className="rounded-lg border border-border bg-card px-4 py-3 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">Model:</span> {tpl?.model}
                   &nbsp;·&nbsp;
-                  <span className="font-medium text-zinc-300">Temp:</span> {tpl?.temperature}
+                  <span className="font-medium text-foreground">Temp:</span> {tpl?.temperature}
                   &nbsp;·&nbsp;
-                  <span className="font-medium text-zinc-300">Max tokens:</span>{' '}
+                  <span className="font-medium text-foreground">Max tokens:</span>{' '}
                   {tpl?.maxTokens?.toLocaleString()}
                 </div>
 
@@ -377,7 +379,7 @@ export default function NewAgentPage() {
                 {error && (
                   <div
                     role="alert"
-                    className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+                    className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
                   >
                     {error}
                   </div>
@@ -388,13 +390,13 @@ export default function NewAgentPage() {
                   <button
                     type="submit"
                     disabled={submitting || !name.trim()}
-                    className="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {submitting ? 'Creating...' : 'Create Agent'}
                   </button>
                   <Link
                     href="/agents"
-                    className="rounded-lg border border-zinc-700 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
+                    className="rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                   >
                     Cancel
                   </Link>
@@ -417,7 +419,7 @@ function TemplateIcon({ templateKey }: { templateKey: TemplateKey }) {
     content: (
       <svg
         aria-hidden="true"
-        className="h-4 w-4 text-zinc-400"
+        className="h-4 w-4 text-muted-foreground"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -433,7 +435,7 @@ function TemplateIcon({ templateKey }: { templateKey: TemplateKey }) {
     code: (
       <svg
         aria-hidden="true"
-        className="h-4 w-4 text-zinc-400"
+        className="h-4 w-4 text-muted-foreground"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -449,7 +451,7 @@ function TemplateIcon({ templateKey }: { templateKey: TemplateKey }) {
     support: (
       <svg
         aria-hidden="true"
-        className="h-4 w-4 text-zinc-400"
+        className="h-4 w-4 text-muted-foreground"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -465,7 +467,7 @@ function TemplateIcon({ templateKey }: { templateKey: TemplateKey }) {
     analytics: (
       <svg
         aria-hidden="true"
-        className="h-4 w-4 text-zinc-400"
+        className="h-4 w-4 text-muted-foreground"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"

--- a/apps/admin/src/app/(backend)/agents/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/page.tsx
@@ -21,15 +21,15 @@ export default function AgentsPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Page header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-          <h1 className="text-xl font-semibold text-white">Agents</h1>
-          <p className="mt-0.5 text-sm text-zinc-400">
+        <div className="border-b border-border bg-card px-6 py-4">
+          <h1 className="text-xl font-semibold text-foreground">Agents</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             A2A agent cards and MCP server integrations
           </p>
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+        <div className="border-b border-border bg-muted px-6">
           <nav className="flex gap-1 -mb-px">
             {(['agents', 'mcp'] as Tab[]).map((t) => (
               <button
@@ -38,8 +38,8 @@ export default function AgentsPage() {
                 onClick={() => setTab(t)}
                 className={`border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
                   tab === t
-                    ? 'border-white text-white'
-                    : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {t === 'agents' ? 'Agent Cards' : 'MCP Servers'}
@@ -96,12 +96,12 @@ function AgentCardsPanel() {
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
             key={i}
-            className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-800/40 p-4"
+            className="animate-pulse rounded-lg border border-border bg-card p-4"
           >
-            <div className="mb-3 h-5 w-2/3 rounded bg-zinc-700" />
+            <div className="mb-3 h-5 w-2/3 rounded bg-foreground/10" />
             <div className="space-y-2">
-              <div className="h-3 w-full rounded bg-zinc-700/60" />
-              <div className="h-3 w-4/5 rounded bg-zinc-700/60" />
+              <div className="h-3 w-full rounded bg-foreground/10" />
+              <div className="h-3 w-4/5 rounded bg-foreground/10" />
             </div>
           </div>
         ))}
@@ -113,7 +113,7 @@ function AgentCardsPanel() {
     return (
       <div
         role="alert"
-        className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+        className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
       >
         {error}
       </div>
@@ -123,18 +123,18 @@ function AgentCardsPanel() {
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
-        <p className="text-sm text-zinc-400">{agents.length} agent(s) registered</p>
+        <p className="text-sm text-muted-foreground">{agents.length} agent(s) registered</p>
         <Link
           href="/agents/new"
-          className="rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           + New Agent
         </Link>
       </div>
 
       {agents.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-700 px-6 py-16 text-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-zinc-800 text-zinc-400">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border px-6 py-16 text-center">
+          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
             <svg
               className="size-6"
               fill="none"
@@ -150,13 +150,13 @@ function AgentCardsPanel() {
               />
             </svg>
           </div>
-          <h3 className="text-sm font-semibold text-white">No agents registered</h3>
-          <p className="mt-1 max-w-sm text-sm text-zinc-400">
+          <h3 className="text-sm font-semibold text-foreground">No agents registered</h3>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
             Create your first AI agent to get started with automated tasks and workflows.
           </p>
           <Link
             href="/agents/new"
-            className="mt-6 rounded-lg bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-200"
+            className="mt-6 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Create Agent
           </Link>
@@ -201,12 +201,12 @@ function McpServersPanel() {
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
             key={i}
-            className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-800/40 p-4"
+            className="animate-pulse rounded-lg border border-border bg-card p-4"
           >
-            <div className="mb-3 h-5 w-1/2 rounded bg-zinc-700" />
+            <div className="mb-3 h-5 w-1/2 rounded bg-foreground/10" />
             <div className="space-y-2">
-              <div className="h-3 w-full rounded bg-zinc-700/60" />
-              <div className="h-3 w-3/5 rounded bg-zinc-700/60" />
+              <div className="h-3 w-full rounded bg-foreground/10" />
+              <div className="h-3 w-3/5 rounded bg-foreground/10" />
             </div>
           </div>
         ))}
@@ -218,7 +218,7 @@ function McpServersPanel() {
     return (
       <div
         role="alert"
-        className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+        className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
       >
         {error}
       </div>
@@ -230,17 +230,17 @@ function McpServersPanel() {
   return (
     <div>
       <div className="mb-6 flex items-center gap-4">
-        <p className="text-sm text-zinc-400">
+        <p className="text-sm text-muted-foreground">
           {servers.length} server(s) · {total} tools
         </p>
-        <span className="text-xs text-zinc-600">
+        <span className="text-xs text-muted-foreground">
           Start with <code className="font-mono">revealui dev up --include mcp</code>
         </span>
       </div>
 
       {servers.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-700 px-6 py-16 text-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-zinc-800 text-zinc-400">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border px-6 py-16 text-center">
+          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
             <svg
               className="size-6"
               fill="none"
@@ -256,11 +256,11 @@ function McpServersPanel() {
               />
             </svg>
           </div>
-          <h3 className="text-sm font-semibold text-white">No MCP servers connected</h3>
-          <p className="mt-1 max-w-sm text-sm text-zinc-400">
+          <h3 className="text-sm font-semibold text-foreground">No MCP servers connected</h3>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
             Start your development environment with MCP support to connect servers.
           </p>
-          <code className="mt-4 rounded-lg bg-zinc-800 px-3 py-1.5 font-mono text-xs text-zinc-300">
+          <code className="mt-4 rounded-lg bg-muted px-3 py-1.5 font-mono text-xs text-muted-foreground">
             revealui dev up --include mcp
           </code>
         </div>

--- a/apps/admin/src/app/(backend)/audit/page.tsx
+++ b/apps/admin/src/app/(backend)/audit/page.tsx
@@ -61,9 +61,9 @@ function reducer(state: State, action: Action): State {
 // =============================================================================
 
 const SEVERITY_STYLES: Record<string, string> = {
-  critical: 'bg-red-900 text-red-200',
-  warn: 'bg-yellow-700 text-yellow-100',
-  info: 'bg-gray-700 text-gray-200',
+  critical: 'bg-error/15 text-error',
+  warn: 'bg-warning/15 text-warning-foreground',
+  info: 'bg-muted text-muted-foreground',
 };
 
 const SEVERITIES = ['info', 'warn', 'critical'] as const;
@@ -160,12 +160,12 @@ function AuditDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white">
+    <div className="min-h-screen text-foreground">
       {/* Header */}
-      <div className="flex flex-wrap items-center gap-4 border-b border-gray-700 bg-gray-900 p-4">
+      <div className="flex flex-wrap items-center gap-4 border-b border-border bg-card p-4">
         <div>
-          <h1 className="text-xl font-semibold text-white">Audit Trail</h1>
-          <p className="mt-0.5 text-sm text-gray-400">
+          <h1 className="text-xl font-semibold text-foreground">Audit Trail</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             AI agent activity and security audit events
           </p>
         </div>
@@ -174,7 +174,7 @@ function AuditDashboard() {
         <div className="ml-auto flex items-center gap-1 text-sm">
           <Link
             href={filterUrl({ severity: undefined })}
-            className={`rounded px-2 py-1 ${!filterSeverity ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+            className={`rounded px-2 py-1 ${!filterSeverity ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
           >
             All
           </Link>
@@ -182,7 +182,7 @@ function AuditDashboard() {
             <Link
               key={s}
               href={filterUrl({ severity: s })}
-              className={`rounded px-2 py-1 text-xs font-semibold uppercase ${filterSeverity === s ? (SEVERITY_STYLES[s] ?? '') : 'text-gray-400 hover:text-white'}`}
+              className={`rounded px-2 py-1 text-xs font-semibold uppercase ${filterSeverity === s ? (SEVERITY_STYLES[s] ?? '') : 'text-muted-foreground hover:text-foreground'}`}
             >
               {s}
             </Link>
@@ -190,24 +190,26 @@ function AuditDashboard() {
         </div>
       </div>
 
-      {loading && <div className="m-4 p-8 text-center text-gray-500">Loading audit log...</div>}
+      {loading && (
+        <div className="m-4 p-8 text-center text-muted-foreground">Loading audit log...</div>
+      )}
 
       {error && (
         <div
           role="alert"
-          className="m-4 rounded border border-red-700 bg-red-900 p-3 text-sm text-red-200"
+          className="m-4 rounded border border-error/30 bg-error/10 p-3 text-sm text-error"
         >
           Failed to load audit log: {error}
         </div>
       )}
 
       {!(loading || error) && rows.length === 0 && (
-        <div className="m-4 p-8 text-center text-gray-500">
+        <div className="m-4 p-8 text-center text-muted-foreground">
           No audit entries recorded yet.
           {filterSeverity || filterAgent ? (
             <span>
               {' '}
-              <Link href="/audit" className="text-blue-400 hover:underline">
+              <Link href="/audit" className="text-primary hover:underline">
                 Clear filters
               </Link>
             </span>
@@ -219,7 +221,7 @@ function AuditDashboard() {
 
       {rows.length > 0 && (
         <>
-          <div className="border-b border-gray-800 px-4 py-2 text-xs text-gray-500">
+          <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground">
             Showing {rows.length} of {total} entries
             {filterSeverity ? ` · severity: ${filterSeverity}` : ''}
             {filterAgent ? ` · agent: ${filterAgent}` : ''}
@@ -227,7 +229,7 @@ function AuditDashboard() {
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-gray-900 text-left text-gray-400">
+                <tr className="bg-card text-left text-muted-foreground">
                   <th className="whitespace-nowrap px-4 py-2 font-medium">Time</th>
                   <th className="px-4 py-2 font-medium">Severity</th>
                   <th className="px-4 py-2 font-medium">Event</th>
@@ -235,45 +237,42 @@ function AuditDashboard() {
                   <th className="w-1/3 px-4 py-2 font-medium">Payload</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-800">
+              <tbody className="divide-y divide-border">
                 {rows.map((row) => (
-                  <tr key={row.id} className="transition-colors hover:bg-gray-900">
-                    <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-400">
+                  <tr key={row.id} className="transition-colors hover:bg-muted">
+                    <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {formatTime(new Date(row.timestamp))}
                     </td>
                     <td className="px-4 py-2">
                       <span
-                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${SEVERITY_STYLES[row.severity] ?? 'bg-gray-700 text-gray-200'}`}
+                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${SEVERITY_STYLES[row.severity] ?? 'bg-muted text-muted-foreground'}`}
                       >
                         {row.severity}
                       </span>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-gray-300">
+                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-muted-foreground">
                       {row.eventType}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-gray-300">
-                      <Link
-                        href={filterUrl({ agent: row.agentId })}
-                        className="hover:text-blue-400"
-                      >
+                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-muted-foreground">
+                      <Link href={filterUrl({ agent: row.agentId })} className="hover:text-primary">
                         {row.agentId}
                       </Link>
                     </td>
-                    <td className="px-4 py-2 text-gray-200">
+                    <td className="px-4 py-2 text-muted-foreground">
                       {row.payload &&
                       typeof row.payload === 'object' &&
                       Object.keys(row.payload).length > 0 ? (
                         <details>
-                          <summary className="cursor-pointer text-xs text-gray-500">
+                          <summary className="cursor-pointer text-xs text-muted-foreground">
                             Payload
                           </summary>
-                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-gray-900 p-2 text-xs text-gray-400">
+                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-card p-2 text-xs text-muted-foreground">
                             {JSON.stringify(row.payload, null, 2)}
                           </pre>
                         </details>
                       ) : null}
                       {row.policyViolations.length > 0 && (
-                        <div className="mt-1 text-xs text-red-400">
+                        <div className="mt-1 text-xs text-error">
                           Violations: {row.policyViolations.join(', ')}
                         </div>
                       )}

--- a/apps/admin/src/app/(backend)/coordination/page.tsx
+++ b/apps/admin/src/app/(backend)/coordination/page.tsx
@@ -28,9 +28,9 @@ function isStaleSession(record: CoordinationSessionRecord): boolean {
 // =============================================================================
 
 const STATUS_COLORS: Record<string, string> = {
-  active: 'bg-emerald-500/10 text-emerald-400',
-  ended: 'bg-zinc-600/20 text-zinc-300',
-  crashed: 'bg-red-500/10 text-red-400',
+  active: 'bg-success/10 text-success',
+  ended: 'bg-muted text-muted-foreground',
+  crashed: 'bg-error/10 text-error',
 };
 
 function formatAge(seconds: number): string {
@@ -80,9 +80,9 @@ function CoordinationDashboard() {
   return (
     <div className="min-h-screen">
       {/* Page header */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <h1 className="text-xl font-semibold text-white">Active Agents</h1>
-        <p className="mt-0.5 text-sm text-zinc-400">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Active Agents</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Coordination sessions across the agent fleet. Daemons running with{' '}
           <code className="font-mono text-xs">POSTGRES_URL</code> set dual-write to{' '}
           <code className="font-mono text-xs">coordination_sessions</code>; this surface reads from
@@ -91,7 +91,7 @@ function CoordinationDashboard() {
       </div>
 
       {/* Stat row */}
-      <div className="overflow-x-auto border-b border-zinc-800 bg-zinc-950 px-6 py-3">
+      <div className="overflow-x-auto border-b border-border bg-muted px-6 py-3">
         <div className="flex min-w-max gap-6">
           <StatPill label="Active" value={activeCount} color="emerald" />
           <StatPill label="Total Agents" value={uniqueAgents} color="blue" />
@@ -104,7 +104,7 @@ function CoordinationDashboard() {
       </div>
 
       {/* Filter row */}
-      <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+      <div className="border-b border-border bg-muted px-6">
         <nav className="flex min-w-max gap-1 -mb-px" aria-label="Scope filter">
           {(['active', 'all'] as Scope[]).map((s) => (
             <button
@@ -116,8 +116,8 @@ function CoordinationDashboard() {
               }}
               className={`border-b-2 px-4 py-3 text-sm font-medium capitalize transition-colors ${
                 scope === s
-                  ? 'border-white text-white'
-                  : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
               }`}
             >
               {s === 'active' ? 'Active only' : 'All sessions'}
@@ -135,12 +135,12 @@ function CoordinationDashboard() {
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
                 key={i}
-                className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-800/40 px-4 py-3"
+                className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <div className="h-5 w-16 rounded-full bg-zinc-700" />
-                  <div className="h-4 flex-1 rounded bg-zinc-700/60" />
-                  <div className="h-3 w-32 rounded bg-zinc-700/40" />
+                  <div className="h-5 w-16 rounded-full bg-foreground/10" />
+                  <div className="h-4 flex-1 rounded bg-foreground/10" />
+                  <div className="h-3 w-32 rounded bg-foreground/10" />
                 </div>
               </div>
             ))}
@@ -148,7 +148,7 @@ function CoordinationDashboard() {
         ) : error ? (
           <div
             role="alert"
-            className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+            className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
           >
             {error.message}
           </div>
@@ -156,7 +156,7 @@ function CoordinationDashboard() {
           <EmptyState scope={scope} />
         ) : (
           <>
-            <div className="mb-3 text-xs text-zinc-500">
+            <div className="mb-3 text-xs text-muted-foreground">
               Showing {displayed.length} of {sessions.length} session
               {sessions.length === 1 ? '' : 's'}
             </div>
@@ -193,21 +193,21 @@ function StatPill({
   color: 'emerald' | 'blue' | 'zinc' | 'amber';
 }) {
   const colors = {
-    emerald: 'text-emerald-400',
-    blue: 'text-blue-400',
-    zinc: 'text-zinc-400',
-    amber: 'text-amber-400',
+    emerald: 'text-success',
+    blue: 'text-primary',
+    zinc: 'text-muted-foreground',
+    amber: 'text-warning-foreground',
   };
   return (
     <div className="flex items-center gap-1.5">
       <span className={`text-sm font-semibold ${colors[color]}`}>{value}</span>
-      <span className="text-xs text-zinc-500">{label}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   );
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const color = STATUS_COLORS[status] ?? 'bg-zinc-700/20 text-zinc-400';
+  const color = STATUS_COLORS[status] ?? 'bg-muted text-muted-foreground';
   return (
     <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
       {status}
@@ -228,7 +228,7 @@ function SessionRow({
   const stale = isStaleSession(session);
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 transition-colors hover:border-zinc-700">
+    <div className="rounded-lg border border-border bg-card transition-colors hover:border-ring">
       <button
         type="button"
         onClick={onToggle}
@@ -237,17 +237,19 @@ function SessionRow({
       >
         <div className="flex items-center gap-3">
           <StatusBadge status={session.status} />
-          <span className="truncate font-mono text-sm text-zinc-300">{session.agent_id}</span>
-          <span className="ml-auto shrink-0 text-xs text-zinc-500">
+          <span className="truncate font-mono text-sm text-muted-foreground">
+            {session.agent_id}
+          </span>
+          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
             {truncate(session.task, 60)}
           </span>
-          <span className="hidden shrink-0 font-mono text-xs text-zinc-600 sm:inline">
+          <span className="hidden shrink-0 font-mono text-xs text-muted-foreground sm:inline">
             {formatAge(age)}
           </span>
           {stale && (
             <span
               title="Session has not ended after 7+ days — likely a stale row"
-              className="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-400"
+              className="shrink-0 rounded-full bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning-foreground"
             >
               stale
             </span>
@@ -257,7 +259,7 @@ function SessionRow({
       </button>
 
       {expanded && (
-        <div className="border-t border-zinc-800 px-4 py-3">
+        <div className="border-t border-border px-4 py-3">
           <div className="grid gap-4 text-sm lg:grid-cols-2">
             <MetaField label="Session ID" value={session.id} mono />
             <MetaField label="Agent ID" value={session.agent_id} mono />
@@ -269,13 +271,13 @@ function SessionRow({
             <MetaField label="Task" value={session.task} />
 
             {session.tools && Object.keys(session.tools).length > 0 && (
-              <div className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-zinc-500">Tool counters</h4>
+              <div className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-muted-foreground">Tool counters</h4>
                 <div className="flex flex-wrap gap-2">
                   {Object.entries(session.tools).map(([tool, n]) => (
                     <span
                       key={tool}
-                      className="rounded bg-zinc-900 px-2 py-0.5 font-mono text-xs text-zinc-400"
+                      className="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground"
                     >
                       {tool}: {n}
                     </span>
@@ -293,8 +295,8 @@ function SessionRow({
 function MetaField({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div>
-      <span className="text-xs text-zinc-600">{label}: </span>
-      <span className={`text-xs text-zinc-400 ${mono ? 'font-mono' : ''}`}>{value}</span>
+      <span className="text-xs text-muted-foreground">{label}: </span>
+      <span className={`text-xs text-muted-foreground ${mono ? 'font-mono' : ''}`}>{value}</span>
     </div>
   );
 }
@@ -302,7 +304,7 @@ function MetaField({ label, value, mono }: { label: string; value: string; mono?
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 shrink-0 text-zinc-600 transition-transform ${expanded ? 'rotate-180' : ''}`}
+      className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -321,9 +323,9 @@ function EmptyState({ scope }: { scope: Scope }) {
 
   return (
     <div className="flex flex-col items-center py-16">
-      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800">
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
         <svg
-          className="h-6 w-6 text-zinc-500"
+          className="h-6 w-6 text-muted-foreground"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -337,7 +339,7 @@ function EmptyState({ scope }: { scope: Scope }) {
           />
         </svg>
       </div>
-      <p className="max-w-md text-center text-sm text-zinc-500">{message}</p>
+      <p className="max-w-md text-center text-sm text-muted-foreground">{message}</p>
     </div>
   );
 }

--- a/apps/admin/src/app/(backend)/errors/page.tsx
+++ b/apps/admin/src/app/(backend)/errors/page.tsx
@@ -65,9 +65,9 @@ function reducer(state: State, action: Action): State {
 // =============================================================================
 
 const LEVEL_STYLES: Record<string, string> = {
-  fatal: 'bg-red-900 text-red-200',
-  error: 'bg-red-700 text-red-100',
-  warn: 'bg-yellow-700 text-yellow-100',
+  fatal: 'bg-error/15 text-error',
+  error: 'bg-error/15 text-error',
+  warn: 'bg-warning/15 text-warning-foreground',
 };
 
 function formatTime(date: Date): string {
@@ -138,38 +138,42 @@ function ErrorsDashboard() {
   }, [apiUrl]);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white">
-      <div className="border-b border-gray-700 bg-gray-900 p-4">
-        <h1 className="text-xl font-semibold text-white">Error Events</h1>
-        <p className="mt-1 text-sm text-gray-400">Last 100 captured errors across all apps</p>
+    <div className="min-h-screen text-foreground">
+      <div className="border-b border-border bg-card p-4">
+        <h1 className="text-xl font-semibold text-foreground">Error Events</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Last 100 captured errors across all apps
+        </p>
       </div>
 
-      {loading && <div className="m-4 p-8 text-center text-gray-500">Loading error events...</div>}
+      {loading && (
+        <div className="m-4 p-8 text-center text-muted-foreground">Loading error events...</div>
+      )}
 
       {error && (
         <div
           role="alert"
-          className="m-4 rounded border border-red-700 bg-red-900 p-3 text-sm text-red-200"
+          className="m-4 rounded border border-error/30 bg-error/15 p-3 text-sm text-error"
         >
           Failed to load error events: {error}
         </div>
       )}
 
       {!(loading || error) && rows.length === 0 && (
-        <div className="m-4 p-8 text-center text-gray-500">
+        <div className="m-4 p-8 text-center text-muted-foreground">
           No errors recorded yet. This is a good sign.
         </div>
       )}
 
       {rows.length > 0 && (
         <>
-          <div className="border-b border-gray-800 px-4 py-2 text-xs text-gray-500">
+          <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground">
             Showing {rows.length} of {total} events
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-gray-900 text-left text-gray-400">
+                <tr className="bg-card text-left text-muted-foreground">
                   <th className="px-4 py-2 font-medium">Time</th>
                   <th className="px-4 py-2 font-medium">Level</th>
                   <th className="px-4 py-2 font-medium">App</th>
@@ -178,37 +182,39 @@ function ErrorsDashboard() {
                   <th className="px-4 py-2 font-medium">URL</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-800">
+              <tbody className="divide-y divide-border">
                 {rows.map((row) => (
-                  <tr key={row.id} className="transition-colors hover:bg-gray-900">
-                    <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-400">
+                  <tr key={row.id} className="transition-colors hover:bg-card">
+                    <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {formatTime(new Date(row.timestamp))}
                     </td>
                     <td className="px-4 py-2">
                       <span
-                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${LEVEL_STYLES[row.level] ?? 'bg-gray-700 text-gray-200'}`}
+                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${LEVEL_STYLES[row.level] ?? 'bg-muted text-muted-foreground'}`}
                       >
                         {row.level}
                       </span>
                     </td>
-                    <td className="px-4 py-2 font-mono text-xs text-gray-300">{row.app}</td>
-                    <td className="px-4 py-2 text-xs text-gray-500">{row.context ?? ' - '}</td>
-                    <td className="px-4 py-2 text-gray-200">
+                    <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{row.app}</td>
+                    <td className="px-4 py-2 text-xs text-muted-foreground">
+                      {row.context ?? ' - '}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
                       <div className="truncate" title={row.message}>
                         {row.message}
                       </div>
                       {row.stack && (
                         <details className="mt-1">
-                          <summary className="cursor-pointer text-xs text-gray-500">
+                          <summary className="cursor-pointer text-xs text-muted-foreground">
                             Stack trace
                           </summary>
-                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-gray-900 p-2 text-xs text-gray-400">
+                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-card p-2 text-xs text-muted-foreground">
                             {row.stack}
                           </pre>
                         </details>
                       )}
                     </td>
-                    <td className="px-4 py-2 text-xs text-gray-500">
+                    <td className="px-4 py-2 text-xs text-muted-foreground">
                       {row.url ? (
                         <span className="block truncate" title={row.url}>
                           {row.url}

--- a/apps/admin/src/app/(backend)/jobs/page.tsx
+++ b/apps/admin/src/app/(backend)/jobs/page.tsx
@@ -113,11 +113,11 @@ function reducer(state: State, action: Action): State {
 const STATE_ORDER: StateFilter[] = ['all', 'created', 'active', 'completed', 'failed', 'retry'];
 
 const STATE_COLORS: Record<string, string> = {
-  created: 'bg-zinc-600/20 text-zinc-300',
-  active: 'bg-blue-500/10 text-blue-400',
-  completed: 'bg-emerald-500/10 text-emerald-400',
-  failed: 'bg-red-500/10 text-red-400',
-  retry: 'bg-amber-500/10 text-amber-400',
+  created: 'bg-muted text-muted-foreground',
+  active: 'bg-primary/10 text-primary',
+  completed: 'bg-success/10 text-success',
+  failed: 'bg-error/10 text-error',
+  retry: 'bg-warning/15 text-warning-foreground',
 };
 
 function formatTimestamp(iso: string | null): string {
@@ -210,16 +210,16 @@ function JobsDashboard() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <h1 className="text-xl font-semibold text-white">Durable Work Queue</h1>
-        <p className="mt-0.5 text-sm text-zinc-400">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Durable Work Queue</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Background jobs processed by the CR8-P2-01 queue (agent dispatch, saga outbox, future
           handlers).
         </p>
       </div>
 
       {/* State stat row */}
-      <div className="overflow-x-auto border-b border-zinc-800 bg-zinc-950 px-6 py-3">
+      <div className="overflow-x-auto border-b border-border bg-muted px-6 py-3">
         <div className="flex min-w-max gap-6">
           <StatePill label="Created" value={summary?.stateCounts.created ?? 0} color="zinc" />
           <StatePill label="Active" value={summary?.stateCounts.active ?? 0} color="blue" />
@@ -230,7 +230,7 @@ function JobsDashboard() {
           />
           <StatePill label="Failed" value={summary?.stateCounts.failed ?? 0} color="red" />
           <StatePill label="Retry" value={summary?.stateCounts.retry ?? 0} color="amber" />
-          <span className="ml-auto text-xs text-zinc-600">
+          <span className="ml-auto text-xs text-muted-foreground">
             {summary ? `snapshot ${formatTimestamp(summary.timestamp)}` : ''}
           </span>
         </div>
@@ -238,8 +238,8 @@ function JobsDashboard() {
 
       {/* Per-handler 24h row */}
       {summary && summary.byHandler24h.length > 0 && (
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6 py-3">
-          <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+        <div className="border-b border-border bg-muted px-6 py-3">
+          <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Handlers (last 24h)
           </h2>
           <div className="flex flex-wrap gap-3">
@@ -251,7 +251,7 @@ function JobsDashboard() {
       )}
 
       {/* Filter row */}
-      <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+      <div className="border-b border-border bg-muted px-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
           <nav className="flex min-w-max gap-1 -mb-px" aria-label="State filter">
             {STATE_ORDER.map((s) => (
@@ -261,8 +261,8 @@ function JobsDashboard() {
                 onClick={() => dispatch({ type: 'SET_STATE_FILTER', filter: s })}
                 className={`border-b-2 px-4 py-3 text-sm font-medium capitalize transition-colors ${
                   stateFilter === s
-                    ? 'border-white text-white'
-                    : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {s}
@@ -271,7 +271,7 @@ function JobsDashboard() {
             ))}
           </nav>
           <div className="flex items-center gap-2 py-2">
-            <label htmlFor="name-filter" className="text-xs text-zinc-500">
+            <label htmlFor="name-filter" className="text-xs text-muted-foreground">
               Handler:
             </label>
             <select
@@ -280,7 +280,7 @@ function JobsDashboard() {
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => dispatch({ type: 'SET_NAME_FILTER', filter: e.target.value })}
-              className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-300 focus:border-zinc-500 focus:outline-none"
+              className="rounded border border-border bg-muted px-2 py-1 text-xs text-foreground focus:border-ring focus:outline-none"
             >
               <option value="">All handlers</option>
               {handlerNames.map((n) => (
@@ -301,12 +301,12 @@ function JobsDashboard() {
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
                 key={i}
-                className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-800/40 px-4 py-3"
+                className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <div className="h-5 w-16 rounded-full bg-zinc-700" />
-                  <div className="h-4 flex-1 rounded bg-zinc-700/60" />
-                  <div className="h-3 w-32 rounded bg-zinc-700/40" />
+                  <div className="h-5 w-16 rounded-full bg-foreground/10" />
+                  <div className="h-4 flex-1 rounded bg-foreground/10" />
+                  <div className="h-3 w-32 rounded bg-foreground/10" />
                 </div>
               </div>
             ))}
@@ -314,7 +314,7 @@ function JobsDashboard() {
         ) : error ? (
           <div
             role="alert"
-            className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+            className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
           >
             {error}
           </div>
@@ -322,7 +322,7 @@ function JobsDashboard() {
           <EmptyState stateFilter={stateFilter} nameFilter={nameFilter} />
         ) : (
           <>
-            <div className="mb-3 text-xs text-zinc-500">
+            <div className="mb-3 text-xs text-muted-foreground">
               Showing {jobs.length} of {total} matching jobs
             </div>
             <div className="flex flex-col gap-2">
@@ -356,16 +356,16 @@ function StatePill({
   color: 'emerald' | 'red' | 'blue' | 'zinc' | 'amber';
 }) {
   const colors = {
-    emerald: 'text-emerald-400',
-    red: 'text-red-400',
-    blue: 'text-blue-400',
-    zinc: 'text-zinc-400',
-    amber: 'text-amber-400',
+    emerald: 'text-success',
+    red: 'text-error',
+    blue: 'text-primary',
+    zinc: 'text-muted-foreground',
+    amber: 'text-warning-foreground',
   };
   return (
     <div className="flex items-center gap-1.5">
       <span className={`text-sm font-semibold ${colors[color]}`}>{value}</span>
-      <span className="text-xs text-zinc-500">{label}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   );
 }
@@ -382,12 +382,12 @@ function HandlerChip({
   running: number;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-xs">
-      <div className="font-mono text-zinc-300">{name}</div>
-      <div className="mt-1 flex gap-3 text-[11px] text-zinc-500">
-        <span className="text-emerald-400">{completed} ok</span>
-        <span className="text-red-400">{failed} fail</span>
-        {running > 0 && <span className="text-blue-400">{running} running</span>}
+    <div className="rounded-lg border border-border bg-card px-3 py-2 text-xs">
+      <div className="font-mono text-muted-foreground">{name}</div>
+      <div className="mt-1 flex gap-3 text-[11px] text-muted-foreground">
+        <span className="text-success">{completed} ok</span>
+        <span className="text-error">{failed} fail</span>
+        {running > 0 && <span className="text-primary">{running} running</span>}
       </div>
     </div>
   );
@@ -408,7 +408,7 @@ function JobRow({
       : null;
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 transition-colors hover:border-zinc-700">
+    <div className="rounded-lg border border-border bg-card transition-colors hover:border-border">
       <button
         type="button"
         onClick={onToggle}
@@ -417,36 +417,38 @@ function JobRow({
       >
         <div className="flex items-center gap-3">
           <StateBadge state={job.state} />
-          <span className="truncate font-mono text-sm text-zinc-300">{job.name}</span>
-          <span className="hidden shrink-0 text-xs text-zinc-600 sm:inline">
+          <span className="truncate font-mono text-sm text-muted-foreground">{job.name}</span>
+          <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
             {truncate(job.id, 32)}
           </span>
           {job.retryCount > 0 && (
             <span
               title={`retry ${job.retryCount}/${job.retryLimit}`}
-              className="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-400"
+              className="shrink-0 rounded-full bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning-foreground"
             >
               ↻ {job.retryCount}
             </span>
           )}
-          <span className="ml-auto shrink-0 font-mono text-xs text-zinc-600">
+          <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
             {formatTimestamp(job.createdAt)}
           </span>
           {durationMs != null && (
-            <span className="hidden shrink-0 text-xs text-zinc-500 sm:inline">{durationMs}ms</span>
+            <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+              {durationMs}ms
+            </span>
           )}
           <ChevronIcon expanded={expanded} />
         </div>
         {!expanded && job.lastError && (
-          <p className="mt-1.5 truncate text-xs text-red-400">
-            <span className="text-zinc-600">err: </span>
+          <p className="mt-1.5 truncate text-xs text-error">
+            <span className="text-muted-foreground">err: </span>
             {job.lastError}
           </p>
         )}
       </button>
 
       {expanded && (
-        <div className="border-t border-zinc-800 px-4 py-3">
+        <div className="border-t border-border px-4 py-3">
           <div className="grid gap-4 text-sm lg:grid-cols-2">
             <MetaField label="Job ID" value={job.id} mono />
             <MetaField label="Handler" value={job.name} mono />
@@ -467,27 +469,27 @@ function JobRow({
             )}
 
             {job.data != null && (
-              <div className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-zinc-500">Payload</h4>
-                <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-zinc-400">
+              <div className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-muted-foreground">Payload</h4>
+                <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-muted-foreground">
                   {JSON.stringify(job.data, null, 2)}
                 </pre>
               </div>
             )}
 
             {job.output != null && (
-              <div className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-zinc-500">Output</h4>
-                <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-zinc-400">
+              <div className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-muted-foreground">Output</h4>
+                <pre className="overflow-x-auto whitespace-pre-wrap text-xs text-muted-foreground">
                   {JSON.stringify(job.output, null, 2)}
                 </pre>
               </div>
             )}
 
             {job.lastError && (
-              <div role="alert" className="col-span-full border-t border-zinc-800 pt-3">
-                <h4 className="mb-1 text-xs font-medium text-red-500">Last error</h4>
-                <p className="whitespace-pre-wrap text-xs text-red-400">{job.lastError}</p>
+              <div role="alert" className="col-span-full border-t border-border pt-3">
+                <h4 className="mb-1 text-xs font-medium text-error">Last error</h4>
+                <p className="whitespace-pre-wrap text-xs text-error">{job.lastError}</p>
               </div>
             )}
           </div>
@@ -498,7 +500,7 @@ function JobRow({
 }
 
 function StateBadge({ state }: { state: string }) {
-  const color = STATE_COLORS[state] ?? 'bg-zinc-700/20 text-zinc-400';
+  const color = STATE_COLORS[state] ?? 'bg-muted text-muted-foreground';
   return (
     <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
       {state}
@@ -509,8 +511,8 @@ function StateBadge({ state }: { state: string }) {
 function MetaField({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div>
-      <span className="text-xs text-zinc-600">{label}: </span>
-      <span className={`text-xs text-zinc-400 ${mono ? 'font-mono' : ''}`}>{value}</span>
+      <span className="text-xs text-muted-foreground">{label}: </span>
+      <span className={`text-xs text-muted-foreground ${mono ? 'font-mono' : ''}`}>{value}</span>
     </div>
   );
 }
@@ -518,7 +520,7 @@ function MetaField({ label, value, mono }: { label: string; value: string; mono?
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 shrink-0 text-zinc-600 transition-transform ${expanded ? 'rotate-180' : ''}`}
+      className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -542,9 +544,9 @@ function EmptyState({ stateFilter, nameFilter }: { stateFilter: StateFilter; nam
 
   return (
     <div className="flex flex-col items-center py-16">
-      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800">
+      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
         <svg
-          className="h-6 w-6 text-zinc-500"
+          className="h-6 w-6 text-muted-foreground"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -558,7 +560,7 @@ function EmptyState({ stateFilter, nameFilter }: { stateFilter: StateFilter; nam
           />
         </svg>
       </div>
-      <p className="max-w-md text-center text-sm text-zinc-500">{message}</p>
+      <p className="max-w-md text-center text-sm text-muted-foreground">{message}</p>
     </div>
   );
 }

--- a/apps/admin/src/app/(backend)/logs/page.tsx
+++ b/apps/admin/src/app/(backend)/logs/page.tsx
@@ -63,9 +63,9 @@ function reducer(state: State, action: Action): State {
 // =============================================================================
 
 const LEVEL_STYLES: Record<string, string> = {
-  fatal: 'bg-red-900 text-red-200',
-  error: 'bg-red-700 text-red-100',
-  warn: 'bg-yellow-700 text-yellow-100',
+  fatal: 'bg-error/15 text-error',
+  error: 'bg-error/15 text-error',
+  warn: 'bg-warning/15 text-warning-foreground',
 };
 
 const APPS = ['admin', 'api', 'marketing'] as const;
@@ -164,12 +164,12 @@ function LogsDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white">
+    <div className="min-h-screen text-foreground">
       {/* Header */}
-      <div className="flex flex-wrap items-center gap-4 border-b border-gray-700 bg-gray-900 p-4">
+      <div className="flex flex-wrap items-center gap-4 border-b border-border bg-card p-4">
         <div>
-          <h1 className="text-xl font-semibold text-white">Application Logs</h1>
-          <p className="mt-0.5 text-sm text-gray-400">
+          <h1 className="text-xl font-semibold text-foreground">Application Logs</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Structured warn/error/fatal logs from all apps
           </p>
         </div>
@@ -178,7 +178,7 @@ function LogsDashboard() {
         <div className="ml-auto flex items-center gap-1 text-sm">
           <Link
             href={filterUrl({ app: undefined })}
-            className={`rounded px-2 py-1 ${!filterApp ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+            className={`rounded px-2 py-1 ${!filterApp ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
           >
             All apps
           </Link>
@@ -186,7 +186,7 @@ function LogsDashboard() {
             <Link
               key={a}
               href={filterUrl({ app: a })}
-              className={`rounded px-2 py-1 font-mono ${filterApp === a ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+              className={`rounded px-2 py-1 font-mono ${filterApp === a ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
             >
               {a}
             </Link>
@@ -197,7 +197,7 @@ function LogsDashboard() {
         <div className="flex items-center gap-1 text-sm">
           <Link
             href={filterUrl({ level: undefined })}
-            className={`rounded px-2 py-1 ${!filterLevel ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+            className={`rounded px-2 py-1 ${!filterLevel ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
           >
             All levels
           </Link>
@@ -205,7 +205,7 @@ function LogsDashboard() {
             <Link
               key={l}
               href={filterUrl({ level: l })}
-              className={`rounded px-2 py-1 text-xs font-semibold uppercase ${filterLevel === l ? (LEVEL_STYLES[l] ?? '') : 'text-gray-400 hover:text-white'}`}
+              className={`rounded px-2 py-1 text-xs font-semibold uppercase ${filterLevel === l ? (LEVEL_STYLES[l] ?? '') : 'text-muted-foreground hover:text-foreground'}`}
             >
               {l}
             </Link>
@@ -213,24 +213,24 @@ function LogsDashboard() {
         </div>
       </div>
 
-      {loading && <div className="m-4 p-8 text-center text-gray-500">Loading logs...</div>}
+      {loading && <div className="m-4 p-8 text-center text-muted-foreground">Loading logs...</div>}
 
       {error && (
         <div
           role="alert"
-          className="m-4 rounded border border-red-700 bg-red-900 p-3 text-sm text-red-200"
+          className="m-4 rounded border border-error/30 bg-error/10 p-3 text-sm text-error"
         >
           Failed to load logs: {error}
         </div>
       )}
 
       {!(loading || error) && rows.length === 0 && (
-        <div className="m-4 p-8 text-center text-gray-500">
+        <div className="m-4 p-8 text-center text-muted-foreground">
           No log entries recorded yet.
           {filterApp || filterLevel ? (
             <span>
               {' '}
-              <Link href="/logs" className="text-blue-400 hover:underline">
+              <Link href="/logs" className="text-primary hover:underline">
                 Clear filters
               </Link>
             </span>
@@ -242,7 +242,7 @@ function LogsDashboard() {
 
       {rows.length > 0 && (
         <>
-          <div className="border-b border-gray-800 px-4 py-2 text-xs text-gray-500">
+          <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground">
             Showing {rows.length} of {total} entries
             {filterApp ? ` · app: ${filterApp}` : ''}
             {filterLevel ? ` · level: ${filterLevel}` : ''}
@@ -250,7 +250,7 @@ function LogsDashboard() {
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-gray-900 text-left text-gray-400">
+                <tr className="bg-card text-left text-muted-foreground">
                   <th className="whitespace-nowrap px-4 py-2 font-medium">Time</th>
                   <th className="px-4 py-2 font-medium">Level</th>
                   <th className="px-4 py-2 font-medium">App</th>
@@ -258,35 +258,35 @@ function LogsDashboard() {
                   <th className="w-1/2 px-4 py-2 font-medium">Message / Data</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-800">
+              <tbody className="divide-y divide-border">
                 {rows.map((row) => (
-                  <tr key={row.id} className="transition-colors hover:bg-gray-900">
-                    <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-400">
+                  <tr key={row.id} className="transition-colors hover:bg-muted">
+                    <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {formatTime(new Date(row.timestamp))}
                     </td>
                     <td className="px-4 py-2">
                       <span
-                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${LEVEL_STYLES[row.level] ?? 'bg-gray-700 text-gray-200'}`}
+                        className={`inline-block rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase ${LEVEL_STYLES[row.level] ?? 'bg-muted text-muted-foreground'}`}
                       >
                         {row.level}
                       </span>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-gray-300">
+                    <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-muted-foreground">
                       {row.app}
                     </td>
-                    <td className="px-4 py-2 font-mono text-xs text-gray-600">
+                    <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
                       {row.requestId ? row.requestId.slice(0, 8) : ' - '}
                     </td>
-                    <td className="px-4 py-2 text-gray-200">
+                    <td className="px-4 py-2 text-muted-foreground">
                       <div className="truncate" title={row.message}>
                         {row.message}
                       </div>
                       {!!row.data && (
                         <details className="mt-1">
-                          <summary className="cursor-pointer text-xs text-gray-500">
+                          <summary className="cursor-pointer text-xs text-muted-foreground">
                             Context / data
                           </summary>
-                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-gray-900 p-2 text-xs text-gray-400">
+                          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-card p-2 text-xs text-muted-foreground">
                             {JSON.stringify(row.data, null, 2)}
                           </pre>
                         </details>

--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -87,12 +87,12 @@ export default function MarketplaceAgentDetailPage() {
   if (loading) {
     return (
       <div className="min-h-screen">
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-          <div className="h-5 w-48 animate-pulse rounded bg-zinc-800" />
+        <div className="border-b border-border bg-card px-6 py-4">
+          <div className="h-5 w-48 animate-pulse rounded bg-muted" />
         </div>
         <div className="p-6">
-          <div className="h-4 w-96 animate-pulse rounded bg-zinc-800" />
-          <div className="mt-3 h-3 w-64 animate-pulse rounded bg-zinc-800" />
+          <div className="h-4 w-96 animate-pulse rounded bg-muted" />
+          <div className="mt-3 h-3 w-64 animate-pulse rounded bg-muted" />
         </div>
       </div>
     );
@@ -101,12 +101,12 @@ export default function MarketplaceAgentDetailPage() {
   if (error || !agent) {
     return (
       <div className="min-h-screen p-6">
-        <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
           {error ?? 'Agent not found'}
         </div>
         <Link
           href="/marketplace"
-          className="mt-4 inline-block text-sm text-zinc-400 hover:text-white"
+          className="mt-4 inline-block text-sm text-muted-foreground hover:text-foreground"
         >
           Back to marketplace
         </Link>
@@ -118,30 +118,30 @@ export default function MarketplaceAgentDetailPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Breadcrumb + Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-          <Link href="/marketplace" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <div className="border-b border-border bg-card px-6 py-4">
+          <Link href="/marketplace" className="text-sm text-muted-foreground hover:text-foreground">
             RevMarket
           </Link>
-          <span className="mx-2 text-zinc-700">/</span>
-          <span className="text-sm text-zinc-300">{agent.name}</span>
+          <span className="mx-2 text-muted-foreground">/</span>
+          <span className="text-sm text-muted-foreground">{agent.name}</span>
 
           <div className="mt-3 flex items-start justify-between">
             <div>
-              <h1 className="text-xl font-semibold text-white">{agent.name}</h1>
-              <p className="mt-1 text-sm text-zinc-400">{agent.description}</p>
-              <div className="mt-2 flex items-center gap-3 text-xs text-zinc-500">
+              <h1 className="text-xl font-semibold text-foreground">{agent.name}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{agent.description}</p>
+              <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
                 <span className="flex items-center gap-1">
                   <StarIcon />
                   {agent.rating.toFixed(1)} ({agent.reviewCount} reviews)
                 </span>
                 <span>{agent.taskCount} tasks completed</span>
-                <span className="rounded bg-zinc-800 px-2 py-0.5">{agent.category}</span>
-                <span className="text-zinc-600">v{agent.version}</span>
+                <span className="rounded bg-muted px-2 py-0.5">{agent.category}</span>
+                <span className="text-muted-foreground">v{agent.version}</span>
               </div>
             </div>
             <div className="text-right">
-              <p className="text-lg font-semibold text-white">${agent.basePriceUsdc}</p>
-              <p className="text-xs text-zinc-500">
+              <p className="text-lg font-semibold text-foreground">${agent.basePriceUsdc}</p>
+              <p className="text-xs text-muted-foreground">
                 per {agent.pricingModel === 'per-task' ? 'task' : 'minute'}
               </p>
             </div>
@@ -149,7 +149,7 @@ export default function MarketplaceAgentDetailPage() {
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+        <div className="border-b border-border bg-muted px-6">
           <nav className="flex gap-1 -mb-px">
             {(['skills', 'reviews', 'submit'] as ActiveTab[]).map((t) => (
               <button
@@ -158,8 +158,8 @@ export default function MarketplaceAgentDetailPage() {
                 onClick={() => setTab(t)}
                 className={`border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
                   tab === t
-                    ? 'border-white text-white'
-                    : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {t === 'skills'
@@ -203,31 +203,31 @@ export default function MarketplaceAgentDetailPage() {
 
 function SkillsPanel({ skills }: { skills: AgentSkill[] }) {
   if (skills.length === 0) {
-    return <p className="text-sm text-zinc-500">No skills registered for this agent.</p>;
+    return <p className="text-sm text-muted-foreground">No skills registered for this agent.</p>;
   }
 
   return (
     <div className="space-y-4">
       {skills.map((skill) => (
-        <div key={skill.id} className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
-          <h3 className="font-medium text-white">{skill.name}</h3>
-          <p className="mt-1 text-sm text-zinc-400">{skill.description}</p>
+        <div key={skill.id} className="rounded-lg border border-border bg-card p-4">
+          <h3 className="font-medium text-foreground">{skill.name}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>
           {skill.inputSchema && (
             <details className="mt-3">
-              <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-300">
+              <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
                 Input Schema
               </summary>
-              <pre className="mt-2 overflow-x-auto rounded bg-zinc-950 p-3 text-xs text-zinc-400">
+              <pre className="mt-2 overflow-x-auto rounded bg-muted p-3 text-xs text-muted-foreground">
                 {JSON.stringify(skill.inputSchema, null, 2)}
               </pre>
             </details>
           )}
           {skill.outputSchema && (
             <details className="mt-2">
-              <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-300">
+              <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
                 Output Schema
               </summary>
-              <pre className="mt-2 overflow-x-auto rounded bg-zinc-950 p-3 text-xs text-zinc-400">
+              <pre className="mt-2 overflow-x-auto rounded bg-muted p-3 text-xs text-muted-foreground">
                 {JSON.stringify(skill.outputSchema, null, 2)}
               </pre>
             </details>
@@ -287,11 +287,11 @@ function ReviewsPanel({
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-zinc-300">{reviews.length} Reviews</h3>
+        <h3 className="text-sm font-medium text-muted-foreground">{reviews.length} Reviews</h3>
         <button
           type="button"
           onClick={() => setShowForm(!showForm)}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 transition-colors"
+          className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           Write Review
         </button>
@@ -300,10 +300,10 @@ function ReviewsPanel({
       {showForm && (
         <form
           onSubmit={handleSubmitReview}
-          className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900 p-4"
+          className="mb-6 rounded-lg border border-border bg-card p-4"
         >
           <div className="mb-3">
-            <span className="block text-sm text-zinc-400 mb-1">Rating</span>
+            <span className="block text-sm text-muted-foreground mb-1">Rating</span>
             <div className="flex gap-1" role="radiogroup" aria-label="Rating">
               {[1, 2, 3, 4, 5].map((n) => (
                 <button
@@ -311,7 +311,9 @@ function ReviewsPanel({
                   type="button"
                   onClick={() => setRating(n)}
                   className={`h-8 w-8 rounded transition-colors ${
-                    n <= rating ? 'bg-amber-500 text-black' : 'bg-zinc-800 text-zinc-600'
+                    n <= rating
+                      ? 'bg-warning text-warning-foreground'
+                      : 'bg-muted text-muted-foreground'
                   }`}
                 >
                   {n}
@@ -320,7 +322,7 @@ function ReviewsPanel({
             </div>
           </div>
           <div className="mb-3">
-            <label className="block text-sm text-zinc-400 mb-1">
+            <label className="block text-sm text-muted-foreground mb-1">
               Comment (optional)
               <textarea
                 value={comment}
@@ -328,7 +330,7 @@ function ReviewsPanel({
                   e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                 ) => setComment(e.target.value)}
                 rows={3}
-                className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+                className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                 placeholder="Share your experience..."
               />
             </label>
@@ -337,14 +339,14 @@ function ReviewsPanel({
             <button
               type="submit"
               disabled={submitting}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
             >
               {submitting ? 'Submitting...' : 'Submit Review'}
             </button>
             <button
               type="button"
               onClick={() => setShowForm(false)}
-              className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+              className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             >
               Cancel
             </button>
@@ -353,33 +355,37 @@ function ReviewsPanel({
       )}
 
       {reviews.length === 0 ? (
-        <p className="text-sm text-zinc-500">No reviews yet. Be the first to review this agent.</p>
+        <p className="text-sm text-muted-foreground">
+          No reviews yet. Be the first to review this agent.
+        </p>
       ) : (
         <div className="space-y-3">
           {reviews.map((review) => (
-            <div key={review.id} className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <div key={review.id} className="rounded-lg border border-border bg-card p-4">
               <div className="flex items-center gap-2">
                 <div className="flex gap-0.5">
                   {Array.from({ length: 5 }, (_, i) => (
                     <span
                       // biome-ignore lint/suspicious/noArrayIndexKey: fixed 5-star display
                       key={i}
-                      className={`text-sm ${i < review.rating ? 'text-amber-500' : 'text-zinc-700'}`}
+                      className={`text-sm ${i < review.rating ? 'text-warning' : 'text-foreground/10'}`}
                     >
                       ★
                     </span>
                   ))}
                 </div>
                 {review.verified === 1 && (
-                  <span className="rounded bg-green-900/50 px-2 py-0.5 text-xs text-green-400">
+                  <span className="rounded bg-success/10 px-2 py-0.5 text-xs text-success">
                     Verified
                   </span>
                 )}
-                <span className="text-xs text-zinc-600">
+                <span className="text-xs text-muted-foreground">
                   {new Date(review.createdAt).toLocaleDateString()}
                 </span>
               </div>
-              {review.comment && <p className="mt-2 text-sm text-zinc-400">{review.comment}</p>}
+              {review.comment && (
+                <p className="mt-2 text-sm text-muted-foreground">{review.comment}</p>
+              )}
             </div>
           ))}
         </div>
@@ -451,22 +457,22 @@ function SubmitTaskPanel({
 
   return (
     <form onSubmit={handleSubmit} className="max-w-2xl">
-      <h3 className="text-lg font-medium text-white mb-4">Submit a task to {agent.name}</h3>
+      <h3 className="text-lg font-medium text-foreground mb-4">Submit a task to {agent.name}</h3>
 
       {/* Skill selection */}
       <div className="mb-4">
         {/* biome-ignore lint/a11y/noLabelWithoutControl: select is inside the conditional branch */}
-        <label className="block text-sm text-zinc-400 mb-1">
+        <label className="block text-sm text-muted-foreground mb-1">
           Skill
           {skills.length === 0 ? (
-            <span className="block mt-1 text-zinc-500">No skills available</span>
+            <span className="block mt-1 text-muted-foreground">No skills available</span>
           ) : (
             <select
               value={selectedSkill}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => setSelectedSkill(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+              className="mt-1 w-full rounded-lg border border-border bg-card px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
             >
               {skills.map((skill) => (
                 <option key={skill.id} value={skill.name}>
@@ -480,7 +486,7 @@ function SubmitTaskPanel({
 
       {/* Input JSON */}
       <div className="mb-4">
-        <label className="block text-sm text-zinc-400 mb-1">
+        <label className="block text-sm text-muted-foreground mb-1">
           Input (JSON)
           <textarea
             value={inputJson}
@@ -488,7 +494,7 @@ function SubmitTaskPanel({
               e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
             ) => setInputJson(e.target.value)}
             rows={8}
-            className="mt-1 w-full font-mono rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+            className="mt-1 w-full font-mono rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
             placeholder='{"key": "value"}'
           />
         </label>
@@ -496,7 +502,7 @@ function SubmitTaskPanel({
 
       {/* Priority */}
       <div className="mb-4">
-        <label className="block text-sm text-zinc-400 mb-1">
+        <label className="block text-sm text-muted-foreground mb-1">
           Priority (1=low, 5=critical)
           <input
             type="range"
@@ -509,7 +515,7 @@ function SubmitTaskPanel({
             className="mt-1 w-full"
           />
         </label>
-        <div className="flex justify-between text-xs text-zinc-600">
+        <div className="flex justify-between text-xs text-muted-foreground">
           <span>Low</span>
           <span>Normal</span>
           <span>Critical</span>
@@ -517,15 +523,15 @@ function SubmitTaskPanel({
       </div>
 
       {/* Cost estimate */}
-      <div className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900 p-3">
-        <p className="text-sm text-zinc-400">
+      <div className="mb-6 rounded-lg border border-border bg-card p-3">
+        <p className="text-sm text-muted-foreground">
           Estimated cost:{' '}
-          <span className="font-medium text-white">${agent.basePriceUsdc} USDC</span>
+          <span className="font-medium text-foreground">${agent.basePriceUsdc} USDC</span>
         </p>
       </div>
 
       {error && (
-        <div className="mb-4 rounded-lg border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
+        <div className="mb-4 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
           {error}
         </div>
       )}
@@ -533,7 +539,7 @@ function SubmitTaskPanel({
       <button
         type="submit"
         disabled={submitting || skills.length === 0}
-        className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
       >
         {submitting ? 'Submitting...' : 'Submit Task'}
       </button>
@@ -548,7 +554,7 @@ function SubmitTaskPanel({
 function StarIcon() {
   return (
     <svg
-      className="h-3.5 w-3.5 fill-amber-500"
+      className="h-3.5 w-3.5 fill-warning"
       viewBox="0 0 20 20"
       role="img"
       aria-label="Star rating"

--- a/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
@@ -59,22 +59,25 @@ export default function AnalyticsPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="border-b border-border bg-card px-6 py-4">
           <div className="flex items-center justify-between">
             <div>
-              <Link href="/marketplace" className="text-sm text-zinc-500 hover:text-zinc-300">
+              <Link
+                href="/marketplace"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
                 RevMarket
               </Link>
-              <span className="mx-2 text-zinc-700">/</span>
-              <span className="text-sm text-zinc-300">Analytics</span>
-              <h1 className="mt-1 text-xl font-semibold text-white">Agent Analytics</h1>
-              <p className="mt-0.5 text-sm text-zinc-400">
+              <span className="mx-2 text-muted-foreground">/</span>
+              <span className="text-sm text-muted-foreground">Analytics</span>
+              <h1 className="mt-1 text-xl font-semibold text-foreground">Agent Analytics</h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">
                 Performance metrics and version history for your agents
               </p>
             </div>
             <Link
               href="/marketplace/publish"
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 transition-colors"
+              className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
             >
               Publish New Agent
             </Link>
@@ -86,7 +89,7 @@ export default function AnalyticsPage() {
           {loading ? (
             <AnalyticsSkeleton />
           ) : error ? (
-            <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
+            <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
               Failed to load analytics: {error}
             </div>
           ) : (
@@ -112,22 +115,22 @@ export default function AnalyticsPage() {
               </div>
 
               {/* Agent table */}
-              <h2 className="text-lg font-medium text-white mb-4">Your Agents</h2>
+              <h2 className="text-lg font-medium text-foreground mb-4">Your Agents</h2>
 
               {agents.length === 0 ? (
                 <div className="flex flex-col items-center py-12 text-center">
-                  <p className="text-zinc-400">No agents yet</p>
+                  <p className="text-muted-foreground">No agents yet</p>
                   <Link
                     href="/marketplace/publish"
-                    className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+                    className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
                   >
                     Publish Your First Agent
                   </Link>
                 </div>
               ) : (
-                <div className="overflow-x-auto rounded-lg border border-zinc-800">
+                <div className="overflow-x-auto rounded-lg border border-border">
                   <table className="w-full text-left text-sm">
-                    <thead className="bg-zinc-900 text-zinc-500">
+                    <thead className="bg-card text-muted-foreground">
                       <tr>
                         <th className="px-4 py-3 font-medium">Agent</th>
                         <th className="px-4 py-3 font-medium">Status</th>
@@ -138,47 +141,46 @@ export default function AnalyticsPage() {
                         <th className="px-4 py-3 font-medium">Created</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-zinc-800">
+                    <tbody className="divide-y divide-border">
                       {agents.map((agent) => {
                         const revenue = agent.taskCount * Number.parseFloat(agent.basePriceUsdc);
                         return (
-                          <tr
-                            key={agent.id}
-                            className="bg-zinc-950 hover:bg-zinc-900 transition-colors"
-                          >
+                          <tr key={agent.id} className="bg-muted hover:bg-card transition-colors">
                             <td className="px-4 py-3">
                               <Link
                                 href={`/marketplace/${agent.id}`}
-                                className="font-medium text-white hover:text-blue-400 transition-colors"
+                                className="font-medium text-foreground hover:text-primary transition-colors"
                               >
                                 {agent.name}
                               </Link>
-                              <p className="text-xs text-zinc-600">{agent.category}</p>
+                              <p className="text-xs text-muted-foreground">{agent.category}</p>
                             </td>
                             <td className="px-4 py-3">
                               <span
                                 className={`rounded px-2 py-0.5 text-xs ${
                                   agent.status === 'published'
-                                    ? 'bg-green-900/50 text-green-400'
+                                    ? 'bg-success/10 text-success'
                                     : agent.status === 'draft'
-                                      ? 'bg-yellow-900/50 text-yellow-400'
-                                      : 'bg-zinc-800 text-zinc-500'
+                                      ? 'bg-warning/15 text-warning-foreground'
+                                      : 'bg-muted text-muted-foreground'
                                 }`}
                               >
                                 {agent.status}
                               </span>
                             </td>
-                            <td className="px-4 py-3 text-zinc-400">v{agent.version}</td>
-                            <td className="px-4 py-3 text-right text-white">{agent.taskCount}</td>
-                            <td className="px-4 py-3 text-right">
-                              <span className="text-amber-400">★</span>{' '}
-                              <span className="text-white">{agent.rating.toFixed(1)}</span>
-                              <span className="text-zinc-600"> ({agent.reviewCount})</span>
+                            <td className="px-4 py-3 text-muted-foreground">v{agent.version}</td>
+                            <td className="px-4 py-3 text-right text-foreground">
+                              {agent.taskCount}
                             </td>
-                            <td className="px-4 py-3 text-right text-white">
+                            <td className="px-4 py-3 text-right">
+                              <span className="text-warning-foreground">★</span>{' '}
+                              <span className="text-foreground">{agent.rating.toFixed(1)}</span>
+                              <span className="text-muted-foreground"> ({agent.reviewCount})</span>
+                            </td>
+                            <td className="px-4 py-3 text-right text-foreground">
                               ${revenue.toFixed(2)}
                             </td>
-                            <td className="px-4 py-3 text-zinc-500">
+                            <td className="px-4 py-3 text-muted-foreground">
                               {new Date(agent.createdAt).toLocaleDateString()}
                             </td>
                           </tr>
@@ -210,10 +212,10 @@ function MetricCard({
   sublabel: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-5">
-      <p className="text-sm text-zinc-500">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-white">{value}</p>
-      <p className="mt-0.5 text-xs text-zinc-600">{sublabel}</p>
+    <div className="rounded-lg border border-border bg-card p-5">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-foreground">{value}</p>
+      <p className="mt-0.5 text-xs text-muted-foreground">{sublabel}</p>
     </div>
   );
 }
@@ -228,15 +230,15 @@ function AnalyticsSkeleton() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
         {Array.from({ length: 4 }, (_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-          <div key={i} className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 p-5">
-            <div className="h-3 w-16 rounded bg-zinc-800" />
-            <div className="mt-2 h-7 w-20 rounded bg-zinc-800" />
-            <div className="mt-1 h-2.5 w-12 rounded bg-zinc-800" />
+          <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
+            <div className="h-3 w-16 rounded bg-foreground/10" />
+            <div className="mt-2 h-7 w-20 rounded bg-foreground/10" />
+            <div className="mt-1 h-2.5 w-12 rounded bg-foreground/10" />
           </div>
         ))}
       </div>
-      <div className="h-5 w-28 rounded bg-zinc-800 mb-4" />
-      <div className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 h-64" />
+      <div className="h-5 w-28 rounded bg-foreground/10 mb-4" />
+      <div className="animate-pulse rounded-lg border border-border bg-card h-64" />
     </>
   );
 }

--- a/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
@@ -66,14 +66,14 @@ export default function EarningsDashboardPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-          <Link href="/marketplace" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <div className="border-b border-border bg-card px-6 py-4">
+          <Link href="/marketplace" className="text-sm text-muted-foreground hover:text-foreground">
             RevMarket
           </Link>
-          <span className="mx-2 text-zinc-700">/</span>
-          <span className="text-sm text-zinc-300">Earnings</span>
-          <h1 className="mt-1 text-xl font-semibold text-white">Publisher Earnings</h1>
-          <p className="mt-0.5 text-sm text-zinc-400">Revenue from your published agents</p>
+          <span className="mx-2 text-muted-foreground">/</span>
+          <span className="text-sm text-muted-foreground">Earnings</span>
+          <h1 className="mt-1 text-xl font-semibold text-foreground">Publisher Earnings</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">Revenue from your published agents</p>
         </div>
 
         {/* Content */}
@@ -81,11 +81,11 @@ export default function EarningsDashboardPage() {
           {loading ? (
             <EarningsSkeleton />
           ) : error ? (
-            <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
+            <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
               Failed to load earnings: {error}
             </div>
           ) : !summary ? (
-            <p className="text-sm text-zinc-500">No data available</p>
+            <p className="text-sm text-muted-foreground">No data available</p>
           ) : (
             <>
               {/* Summary cards */}
@@ -108,11 +108,13 @@ export default function EarningsDashboardPage() {
               </div>
 
               {/* Agent earnings breakdown */}
-              <h2 className="text-lg font-medium text-white mb-4">Earnings by Agent</h2>
+              <h2 className="text-lg font-medium text-foreground mb-4">Earnings by Agent</h2>
               {summary.agents.length === 0 ? (
                 <div className="flex flex-col items-center py-12 text-center">
-                  <p className="text-zinc-400">No published agents yet</p>
-                  <p className="mt-1 text-sm text-zinc-500">Publish an agent to start earning</p>
+                  <p className="text-muted-foreground">No published agents yet</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Publish an agent to start earning
+                  </p>
                 </div>
               ) : (
                 <div className="space-y-3">
@@ -121,16 +123,16 @@ export default function EarningsDashboardPage() {
                     return (
                       <div
                         key={agent.id}
-                        className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3"
+                        className="flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-3"
                       >
                         <div className="flex-1">
                           <Link
                             href={`/marketplace/${agent.id}`}
-                            className="text-sm font-medium text-white hover:text-blue-400 transition-colors"
+                            className="text-sm font-medium text-foreground hover:text-primary transition-colors"
                           >
                             {agent.name}
                           </Link>
-                          <div className="mt-0.5 flex items-center gap-3 text-xs text-zinc-500">
+                          <div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
                             <span>
                               ★ {agent.rating.toFixed(1)} ({agent.reviewCount})
                             </span>
@@ -138,8 +140,8 @@ export default function EarningsDashboardPage() {
                             <span
                               className={`rounded px-2 py-0.5 text-xs ${
                                 agent.status === 'published'
-                                  ? 'bg-green-900/50 text-green-400'
-                                  : 'bg-zinc-800 text-zinc-500'
+                                  ? 'bg-success/10 text-success'
+                                  : 'bg-muted text-muted-foreground'
                               }`}
                             >
                               {agent.status}
@@ -147,8 +149,12 @@ export default function EarningsDashboardPage() {
                           </div>
                         </div>
                         <div className="text-right">
-                          <p className="text-sm font-medium text-white">${earnings.toFixed(2)}</p>
-                          <p className="text-xs text-zinc-500">${agent.basePriceUsdc}/task</p>
+                          <p className="text-sm font-medium text-foreground">
+                            ${earnings.toFixed(2)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            ${agent.basePriceUsdc}/task
+                          </p>
                         </div>
                       </div>
                     );
@@ -177,10 +183,10 @@ function SummaryCard({
   sublabel: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-5">
-      <p className="text-sm text-zinc-500">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-white">{value}</p>
-      <p className="mt-0.5 text-xs text-zinc-600">{sublabel}</p>
+    <div className="rounded-lg border border-border bg-card p-5">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-foreground">{value}</p>
+      <p className="mt-0.5 text-xs text-muted-foreground">{sublabel}</p>
     </div>
   );
 }
@@ -195,24 +201,24 @@ function EarningsSkeleton() {
       <div className="grid gap-4 sm:grid-cols-3 mb-8">
         {Array.from({ length: 3 }, (_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-          <div key={i} className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 p-5">
-            <div className="h-3 w-20 rounded bg-zinc-800" />
-            <div className="mt-2 h-7 w-24 rounded bg-zinc-800" />
-            <div className="mt-1 h-2.5 w-16 rounded bg-zinc-800" />
+          <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
+            <div className="h-3 w-20 rounded bg-foreground/10" />
+            <div className="mt-2 h-7 w-24 rounded bg-foreground/10" />
+            <div className="mt-1 h-2.5 w-16 rounded bg-foreground/10" />
           </div>
         ))}
       </div>
-      <div className="h-5 w-32 rounded bg-zinc-800 mb-4" />
+      <div className="h-5 w-32 rounded bg-foreground/10 mb-4" />
       <div className="space-y-3">
         {Array.from({ length: 3 }, (_, i) => (
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
             key={i}
-            className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3"
+            className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
           >
             <div className="flex items-center gap-4">
-              <div className="h-4 w-40 rounded bg-zinc-800" />
-              <div className="ml-auto h-4 w-16 rounded bg-zinc-800" />
+              <div className="h-4 w-40 rounded bg-foreground/10" />
+              <div className="ml-auto h-4 w-16 rounded bg-foreground/10" />
             </div>
           </div>
         ))}

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -78,30 +78,30 @@ export default function MarketplacePage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="border-b border-border bg-card px-6 py-4">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-xl font-semibold text-white">RevMarket</h1>
-              <p className="mt-0.5 text-sm text-zinc-400">
+              <h1 className="text-xl font-semibold text-foreground">RevMarket</h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">
                 Browse autonomous agents - find the right agent for your task
               </p>
             </div>
             <div className="flex gap-2">
               <Link
                 href="/marketplace/tasks"
-                className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+                className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
               >
                 My Tasks
               </Link>
               <Link
                 href="/marketplace/analytics"
-                className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+                className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
               >
                 Analytics
               </Link>
               <Link
                 href="/marketplace/publish"
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 transition-colors"
+                className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
               >
                 Publish Agent
               </Link>
@@ -110,7 +110,7 @@ export default function MarketplacePage() {
         </div>
 
         {/* Search + Filters */}
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6 py-4">
+        <div className="border-b border-border bg-muted px-6 py-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
             {/* Search */}
             <input
@@ -120,7 +120,7 @@ export default function MarketplacePage() {
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => setSearch(e.target.value)}
-              className="flex-1 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
+              className="flex-1 rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
             />
 
             {/* Category filter */}
@@ -129,7 +129,7 @@ export default function MarketplacePage() {
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => setCategory(e.target.value)}
-              className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+              className="rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
             >
               {CATEGORIES.map((cat) => (
                 <option key={cat} value={cat}>
@@ -144,7 +144,7 @@ export default function MarketplacePage() {
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => setSort(e.target.value as SortOption)}
-              className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+              className="rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
             >
               <option value="rating">Highest Rated</option>
               <option value="tasks">Most Used</option>
@@ -159,19 +159,19 @@ export default function MarketplacePage() {
           {loading ? (
             <AgentGridSkeleton />
           ) : error ? (
-            <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
+            <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
               Failed to load agents: {error}
             </div>
           ) : agents.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
-              <p className="text-lg text-zinc-400">No agents found</p>
-              <p className="mt-1 text-sm text-zinc-500">
+              <p className="text-lg text-muted-foreground">No agents found</p>
+              <p className="mt-1 text-sm text-muted-foreground">
                 {search ? 'Try a different search term' : 'No agents published yet'}
               </p>
             </div>
           ) : (
             <>
-              <p className="mb-4 text-sm text-zinc-500">
+              <p className="mb-4 text-sm text-muted-foreground">
                 {total} agent{total !== 1 ? 's' : ''} found
               </p>
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -195,16 +195,16 @@ function MarketplaceAgentCard({ agent }: { agent: MarketplaceAgent }) {
   return (
     <Link
       href={`/marketplace/${agent.id}`}
-      className="group rounded-lg border border-zinc-800 bg-zinc-900 p-5 transition-colors hover:border-zinc-600 hover:bg-zinc-800/50"
+      className="group rounded-lg border border-border bg-card p-5 transition-colors hover:border-border hover:bg-muted"
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <h3 className="font-medium text-white group-hover:text-blue-400 transition-colors">
+          <h3 className="font-medium text-foreground group-hover:text-primary transition-colors">
             {agent.name}
           </h3>
-          <p className="mt-1 text-sm text-zinc-400 line-clamp-2">{agent.description}</p>
+          <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{agent.description}</p>
         </div>
-        <span className="ml-3 rounded-full bg-zinc-800 px-2.5 py-0.5 text-xs text-zinc-400">
+        <span className="ml-3 rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
           {agent.category}
         </span>
       </div>
@@ -213,24 +213,24 @@ function MarketplaceAgentCard({ agent }: { agent: MarketplaceAgent }) {
       {agent.tags.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
           {agent.tags.slice(0, 4).map((tag) => (
-            <span key={tag} className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-500">
+            <span key={tag} className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
               {tag}
             </span>
           ))}
           {agent.tags.length > 4 && (
-            <span className="text-xs text-zinc-600">+{agent.tags.length - 4}</span>
+            <span className="text-xs text-muted-foreground">+{agent.tags.length - 4}</span>
           )}
         </div>
       )}
 
       {/* Stats */}
-      <div className="mt-4 flex items-center gap-4 text-xs text-zinc-500">
+      <div className="mt-4 flex items-center gap-4 text-xs text-muted-foreground">
         <span className="flex items-center gap-1">
           <StarIcon />
           {agent.rating.toFixed(1)} ({agent.reviewCount})
         </span>
         <span>{agent.taskCount} tasks</span>
-        <span className="ml-auto font-medium text-zinc-300">
+        <span className="ml-auto font-medium text-foreground">
           ${agent.basePriceUsdc}/{agent.pricingModel === 'per-task' ? 'task' : 'min'}
         </span>
       </div>
@@ -247,13 +247,13 @@ function AgentGridSkeleton() {
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }, (_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-        <div key={i} className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 p-5">
-          <div className="h-4 w-2/3 rounded bg-zinc-800" />
-          <div className="mt-2 h-3 w-full rounded bg-zinc-800" />
-          <div className="mt-1 h-3 w-4/5 rounded bg-zinc-800" />
+        <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
+          <div className="h-4 w-2/3 rounded bg-foreground/10" />
+          <div className="mt-2 h-3 w-full rounded bg-foreground/10" />
+          <div className="mt-1 h-3 w-4/5 rounded bg-foreground/10" />
           <div className="mt-4 flex gap-4">
-            <div className="h-3 w-16 rounded bg-zinc-800" />
-            <div className="h-3 w-12 rounded bg-zinc-800" />
+            <div className="h-3 w-16 rounded bg-foreground/10" />
+            <div className="h-3 w-12 rounded bg-foreground/10" />
           </div>
         </div>
       ))}
@@ -268,7 +268,7 @@ function AgentGridSkeleton() {
 function StarIcon() {
   return (
     <svg
-      className="h-3.5 w-3.5 fill-amber-500"
+      className="h-3.5 w-3.5 fill-warning"
       viewBox="0 0 20 20"
       role="img"
       aria-label="Star rating"

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -203,20 +203,20 @@ export default function PublishAgentPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-          <Link href="/marketplace" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <div className="border-b border-border bg-card px-6 py-4">
+          <Link href="/marketplace" className="text-sm text-muted-foreground hover:text-foreground">
             RevMarket
           </Link>
-          <span className="mx-2 text-zinc-700">/</span>
-          <span className="text-sm text-zinc-300">Publish Agent</span>
-          <h1 className="mt-1 text-xl font-semibold text-white">Publish a New Agent</h1>
-          <p className="mt-0.5 text-sm text-zinc-400">
+          <span className="mx-2 text-muted-foreground">/</span>
+          <span className="text-sm text-muted-foreground">Publish Agent</span>
+          <h1 className="mt-1 text-xl font-semibold text-foreground">Publish a New Agent</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Define your agent, add skills, and publish to the marketplace
           </p>
         </div>
 
         {/* Step indicator */}
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6 py-3">
+        <div className="border-b border-border bg-muted px-6 py-3">
           <div className="flex gap-2">
             {[
               { num: 1, label: 'Basic Info' },
@@ -230,19 +230,19 @@ export default function PublishAgentPage() {
                 onClick={() => setStep(s.num)}
                 className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm transition-colors ${
                   step === s.num
-                    ? 'bg-zinc-800 text-white'
+                    ? 'bg-primary text-primary-foreground'
                     : step > s.num
-                      ? 'text-green-400'
-                      : 'text-zinc-600'
+                      ? 'text-success'
+                      : 'text-muted-foreground'
                 }`}
               >
                 <span
                   className={`flex h-6 w-6 items-center justify-center rounded-full text-xs ${
                     step === s.num
-                      ? 'bg-blue-600 text-white'
+                      ? 'bg-primary text-primary-foreground'
                       : step > s.num
-                        ? 'bg-green-900 text-green-400'
-                        : 'bg-zinc-800 text-zinc-600'
+                        ? 'bg-success/10 text-success'
+                        : 'bg-muted text-muted-foreground'
                   }`}
                 >
                   {step > s.num ? '✓' : s.num}
@@ -348,46 +348,46 @@ function StepBasicInfo({
 }) {
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-medium text-white">Basic Information</h2>
+      <h2 className="text-lg font-medium text-foreground">Basic Information</h2>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Agent Name</span>
+        <span className="text-sm text-muted-foreground">Agent Name</span>
         <input
           type="text"
           value={name}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setName(e.target.value)
           }
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
           placeholder="Code Reviewer Pro"
         />
-        {fieldError('name') && <p className="mt-1 text-xs text-red-400">{fieldError('name')}</p>}
+        {fieldError('name') && <p className="mt-1 text-xs text-error">{fieldError('name')}</p>}
       </label>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Description</span>
+        <span className="text-sm text-muted-foreground">Description</span>
         <textarea
           value={description}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setDescription(e.target.value)
           }
           rows={3}
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
           placeholder="An AI agent that reviews code for best practices, security issues, and performance..."
         />
         {fieldError('description') && (
-          <p className="mt-1 text-xs text-red-400">{fieldError('description')}</p>
+          <p className="mt-1 text-xs text-error">{fieldError('description')}</p>
         )}
       </label>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Category</span>
+        <span className="text-sm text-muted-foreground">Category</span>
         <select
           value={category}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setCategory(e.target.value)
           }
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
         >
           {CATEGORIES.map((cat) => (
             <option key={cat} value={cat}>
@@ -398,14 +398,14 @@ function StepBasicInfo({
       </label>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Tags (comma-separated)</span>
+        <span className="text-sm text-muted-foreground">Tags (comma-separated)</span>
         <input
           type="text"
           value={tags}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setTags(e.target.value)
           }
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
           placeholder="typescript, react, code-review"
         />
       </label>
@@ -414,7 +414,7 @@ function StepBasicInfo({
         <button
           type="button"
           onClick={onNext}
-          className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           Next: Configuration
         </button>
@@ -454,15 +454,15 @@ function StepConfiguration({
 }) {
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-medium text-white">Configuration</h2>
+      <h2 className="text-lg font-medium text-foreground">Configuration</h2>
 
       <div>
-        <span className="block text-sm text-zinc-400 mb-2">Pricing Model</span>
+        <span className="block text-sm text-muted-foreground mb-2">Pricing Model</span>
         <div className="space-y-2">
           {PRICING_MODELS.map((pm) => (
             <label
               key={pm.value}
-              className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900 p-3 cursor-pointer hover:border-zinc-600 transition-colors"
+              className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 cursor-pointer hover:border-border transition-colors"
             >
               <input
                 type="radio"
@@ -472,32 +472,32 @@ function StepConfiguration({
                 onChange={(
                   e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                 ) => setPricingModel(e.target.value)}
-                className="accent-blue-500"
+                className="accent-primary"
               />
-              <span className="text-sm text-zinc-300">{pm.label}</span>
+              <span className="text-sm text-muted-foreground">{pm.label}</span>
             </label>
           ))}
         </div>
       </div>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Base Price (USDC)</span>
+        <span className="text-sm text-muted-foreground">Base Price (USDC)</span>
         <input
           type="text"
           value={basePriceUsdc}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setBasePriceUsdc(e.target.value)
           }
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
           placeholder="0.10"
         />
         {fieldError('basePriceUsdc') && (
-          <p className="mt-1 text-xs text-red-400">{fieldError('basePriceUsdc')}</p>
+          <p className="mt-1 text-xs text-error">{fieldError('basePriceUsdc')}</p>
         )}
       </label>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Max Execution Time (seconds)</span>
+        <span className="text-sm text-muted-foreground">Max Execution Time (seconds)</span>
         <input
           type="number"
           value={maxExecutionSecs}
@@ -506,22 +506,22 @@ function StepConfiguration({
           }
           min={10}
           max={3600}
-          className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
         />
       </label>
 
       <label className="block">
-        <span className="text-sm text-zinc-400">Agent Definition (JSON)</span>
+        <span className="text-sm text-muted-foreground">Agent Definition (JSON)</span>
         <textarea
           value={definitionJson}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
             setDefinitionJson(e.target.value)
           }
           rows={8}
-          className="mt-1 w-full font-mono rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-white focus:border-zinc-500 focus:outline-none"
+          className="mt-1 w-full font-mono rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
         />
         {fieldError('definition') && (
-          <p className="mt-1 text-xs text-red-400">{fieldError('definition')}</p>
+          <p className="mt-1 text-xs text-error">{fieldError('definition')}</p>
         )}
       </label>
 
@@ -529,14 +529,14 @@ function StepConfiguration({
         <button
           type="button"
           onClick={onBack}
-          className="rounded-lg border border-zinc-700 px-6 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
         >
           Back
         </button>
         <button
           type="button"
           onClick={onNext}
-          className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           Next: Skills
         </button>
@@ -569,31 +569,31 @@ function StepSkills({
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-medium text-white">Skills</h2>
+        <h2 className="text-lg font-medium text-foreground">Skills</h2>
         <button
           type="button"
           onClick={addSkill}
-          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+          className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
         >
           + Add Skill
         </button>
       </div>
-      <p className="text-sm text-zinc-500">
+      <p className="text-sm text-muted-foreground">
         Define the capabilities your agent offers. Each skill has an input and output schema.
       </p>
 
       {skills.map((skill, i) => (
         <div
           key={skill.name || `skill-${i}`}
-          className="rounded-lg border border-zinc-800 bg-zinc-900 p-4 space-y-3"
+          className="rounded-lg border border-border bg-card p-4 space-y-3"
         >
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-zinc-300">Skill {i + 1}</h3>
+            <h3 className="text-sm font-medium text-foreground">Skill {i + 1}</h3>
             {skills.length > 1 && (
               <button
                 type="button"
                 onClick={() => removeSkill(i)}
-                className="text-xs text-red-400 hover:text-red-300"
+                className="text-xs text-error hover:text-error"
               >
                 Remove
               </button>
@@ -601,64 +601,64 @@ function StepSkills({
           </div>
 
           <label className="block">
-            <span className="text-xs text-zinc-500">Name</span>
+            <span className="text-xs text-muted-foreground">Name</span>
             <input
               type="text"
               value={skill.name}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => updateSkill(i, 'name', e.target.value)}
-              className="mt-1 w-full rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-sm text-white focus:border-zinc-500 focus:outline-none"
+              className="mt-1 w-full rounded border border-border bg-muted px-3 py-1.5 text-sm text-foreground focus:border-ring focus:outline-none"
               placeholder="code-review"
             />
             {fieldError(`skill-${i}-name`) && (
-              <p className="mt-1 text-xs text-red-400">{fieldError(`skill-${i}-name`)}</p>
+              <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-name`)}</p>
             )}
           </label>
 
           <label className="block">
-            <span className="text-xs text-zinc-500">Description</span>
+            <span className="text-xs text-muted-foreground">Description</span>
             <input
               type="text"
               value={skill.description}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => updateSkill(i, 'description', e.target.value)}
-              className="mt-1 w-full rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-sm text-white focus:border-zinc-500 focus:outline-none"
+              className="mt-1 w-full rounded border border-border bg-muted px-3 py-1.5 text-sm text-foreground focus:border-ring focus:outline-none"
               placeholder="Reviews code for bugs, security issues, and best practices"
             />
             {fieldError(`skill-${i}-description`) && (
-              <p className="mt-1 text-xs text-red-400">{fieldError(`skill-${i}-description`)}</p>
+              <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-description`)}</p>
             )}
           </label>
 
           <label className="block">
-            <span className="text-xs text-zinc-500">Input Schema (JSON)</span>
+            <span className="text-xs text-muted-foreground">Input Schema (JSON)</span>
             <textarea
               value={skill.inputSchema}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => updateSkill(i, 'inputSchema', e.target.value)}
               rows={3}
-              className="mt-1 w-full font-mono rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-white focus:border-zinc-500 focus:outline-none"
+              className="mt-1 w-full font-mono rounded border border-border bg-muted px-3 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none"
             />
             {fieldError(`skill-${i}-input`) && (
-              <p className="mt-1 text-xs text-red-400">{fieldError(`skill-${i}-input`)}</p>
+              <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-input`)}</p>
             )}
           </label>
 
           <label className="block">
-            <span className="text-xs text-zinc-500">Output Schema (JSON)</span>
+            <span className="text-xs text-muted-foreground">Output Schema (JSON)</span>
             <textarea
               value={skill.outputSchema}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
               ) => updateSkill(i, 'outputSchema', e.target.value)}
               rows={3}
-              className="mt-1 w-full font-mono rounded border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-white focus:border-zinc-500 focus:outline-none"
+              className="mt-1 w-full font-mono rounded border border-border bg-muted px-3 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none"
             />
             {fieldError(`skill-${i}-output`) && (
-              <p className="mt-1 text-xs text-red-400">{fieldError(`skill-${i}-output`)}</p>
+              <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-output`)}</p>
             )}
           </label>
         </div>
@@ -668,14 +668,14 @@ function StepSkills({
         <button
           type="button"
           onClick={onBack}
-          className="rounded-lg border border-zinc-700 px-6 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
         >
           Back
         </button>
         <button
           type="button"
           onClick={onNext}
-          className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           Next: Review
         </button>
@@ -717,57 +717,54 @@ function StepReview({
 }) {
   return (
     <div className="space-y-6">
-      <h2 className="text-lg font-medium text-white">Review & Publish</h2>
+      <h2 className="text-lg font-medium text-foreground">Review & Publish</h2>
 
       {/* Summary */}
-      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4 space-y-3">
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <span className="text-zinc-500">Name:</span>{' '}
-            <span className="text-white">{name || ' - '}</span>
+            <span className="text-muted-foreground">Name:</span>{' '}
+            <span className="text-foreground">{name || ' - '}</span>
           </div>
           <div>
-            <span className="text-zinc-500">Category:</span>{' '}
-            <span className="text-white">{category}</span>
+            <span className="text-muted-foreground">Category:</span>{' '}
+            <span className="text-foreground">{category}</span>
           </div>
           <div className="col-span-2">
-            <span className="text-zinc-500">Description:</span>{' '}
-            <span className="text-zinc-300">{description || ' - '}</span>
+            <span className="text-muted-foreground">Description:</span>{' '}
+            <span className="text-muted-foreground">{description || ' - '}</span>
           </div>
           <div>
-            <span className="text-zinc-500">Tags:</span>{' '}
-            <span className="text-zinc-300">{tags || 'none'}</span>
+            <span className="text-muted-foreground">Tags:</span>{' '}
+            <span className="text-muted-foreground">{tags || 'none'}</span>
           </div>
           <div>
-            <span className="text-zinc-500">Pricing:</span>{' '}
-            <span className="text-white">
+            <span className="text-muted-foreground">Pricing:</span>{' '}
+            <span className="text-foreground">
               ${basePriceUsdc} / {pricingModel}
             </span>
           </div>
           <div>
-            <span className="text-zinc-500">Max execution:</span>{' '}
-            <span className="text-white">{maxExecutionSecs}s</span>
+            <span className="text-muted-foreground">Max execution:</span>{' '}
+            <span className="text-foreground">{maxExecutionSecs}s</span>
           </div>
           <div>
-            <span className="text-zinc-500">Skills:</span>{' '}
-            <span className="text-white">{skills.filter((s) => s.name).length}</span>
+            <span className="text-muted-foreground">Skills:</span>{' '}
+            <span className="text-foreground">{skills.filter((s) => s.name).length}</span>
           </div>
         </div>
       </div>
 
       {/* Skills summary */}
       <div>
-        <h3 className="text-sm font-medium text-zinc-400 mb-2">Skills</h3>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">Skills</h3>
         <div className="space-y-2">
           {skills
             .filter((s) => s.name)
             .map((skill) => (
-              <div
-                key={skill.name}
-                className="rounded border border-zinc-800 bg-zinc-950 px-3 py-2"
-              >
-                <span className="text-sm font-medium text-white">{skill.name}</span>
-                <span className="ml-2 text-xs text-zinc-500">{skill.description}</span>
+              <div key={skill.name} className="rounded border border-border bg-muted px-3 py-2">
+                <span className="text-sm font-medium text-foreground">{skill.name}</span>
+                <span className="ml-2 text-xs text-muted-foreground">{skill.description}</span>
               </div>
             ))}
         </div>
@@ -775,11 +772,11 @@ function StepReview({
 
       {/* Errors */}
       {errors.length > 0 && (
-        <div className="rounded-lg border border-red-900 bg-red-950/50 p-4">
-          <p className="text-sm font-medium text-red-400 mb-2">Please fix the following:</p>
+        <div className="rounded-lg border border-error/30 bg-error/10 p-4">
+          <p className="text-sm font-medium text-error mb-2">Please fix the following:</p>
           <ul className="space-y-1">
             {errors.map((err) => (
-              <li key={err.field} className="text-sm text-red-400">
+              <li key={err.field} className="text-sm text-error">
                 {err.message}
               </li>
             ))}
@@ -792,7 +789,7 @@ function StepReview({
         <button
           type="button"
           onClick={onBack}
-          className="rounded-lg border border-zinc-700 px-6 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
         >
           Back
         </button>
@@ -800,13 +797,13 @@ function StepReview({
           type="button"
           onClick={onPublish}
           disabled={submitting}
-          className="rounded-lg bg-green-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
+          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
           {submitting ? 'Publishing...' : 'Publish Agent'}
         </button>
       </div>
 
-      <p className="text-xs text-zinc-600">
+      <p className="text-xs text-muted-foreground">
         Your agent will be created in draft status. You can publish it to the marketplace from your
         agent dashboard.
       </p>

--- a/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
@@ -21,12 +21,12 @@ interface TaskProgress {
 type StatusFilter = 'all' | 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-900/50 text-yellow-400',
-  queued: 'bg-blue-900/50 text-blue-400',
-  running: 'bg-cyan-900/50 text-cyan-400',
-  completed: 'bg-green-900/50 text-green-400',
-  failed: 'bg-red-900/50 text-red-400',
-  cancelled: 'bg-zinc-800 text-zinc-500',
+  pending: 'bg-warning/10 text-warning-foreground',
+  queued: 'bg-primary/10 text-primary',
+  running: 'bg-primary/10 text-primary',
+  completed: 'bg-success/10 text-success',
+  failed: 'bg-error/10 text-error',
+  cancelled: 'bg-muted text-muted-foreground',
 };
 
 // =============================================================================
@@ -52,16 +52,19 @@ export default function TaskDashboardPage() {
     <LicenseGate feature="ai">
       <div className="min-h-screen">
         {/* Header */}
-        <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+        <div className="border-b border-border bg-card px-6 py-4">
           <div className="flex items-center justify-between">
             <div>
-              <Link href="/marketplace" className="text-sm text-zinc-500 hover:text-zinc-300">
+              <Link
+                href="/marketplace"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
                 RevMarket
               </Link>
-              <span className="mx-2 text-zinc-700">/</span>
-              <span className="text-sm text-zinc-300">My Tasks</span>
-              <h1 className="mt-1 text-xl font-semibold text-white">Task Dashboard</h1>
-              <p className="mt-0.5 text-sm text-zinc-400">
+              <span className="mx-2 text-muted-foreground">/</span>
+              <span className="text-sm text-muted-foreground">My Tasks</span>
+              <h1 className="mt-1 text-xl font-semibold text-foreground">Task Dashboard</h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">
                 Track your submitted tasks - progress, cost, and artifacts
               </p>
             </div>
@@ -69,7 +72,7 @@ export default function TaskDashboardPage() {
         </div>
 
         {/* Status filter tabs */}
-        <div className="border-b border-zinc-800 bg-zinc-950 px-6">
+        <div className="border-b border-border bg-muted px-6">
           <nav className="flex gap-1 -mb-px overflow-x-auto">
             {(
               [
@@ -90,8 +93,8 @@ export default function TaskDashboardPage() {
                   onClick={() => setFilter(s)}
                   className={`whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
                     filter === s
-                      ? 'border-white text-white'
-                      : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)} ({count})
@@ -106,18 +109,18 @@ export default function TaskDashboardPage() {
           {isLoading ? (
             <TaskTableSkeleton />
           ) : error ? (
-            <div className="rounded-lg border border-red-900 bg-red-950/50 p-4 text-sm text-red-400">
+            <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
               Failed to load tasks: {error.message}
             </div>
           ) : filteredTasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
-              <p className="text-lg text-zinc-400">No tasks found</p>
-              <p className="mt-1 text-sm text-zinc-500">
+              <p className="text-lg text-muted-foreground">No tasks found</p>
+              <p className="mt-1 text-sm text-muted-foreground">
                 {filter !== 'all' ? 'Try a different filter' : 'Submit a task from the marketplace'}
               </p>
               <Link
                 href="/marketplace"
-                className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+                className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
               >
                 Browse Agents
               </Link>
@@ -181,26 +184,28 @@ function TaskRow({
     };
   }, [apiUrl, task.id, task.status]);
 
-  const statusClass = STATUS_COLORS[task.status] ?? 'bg-zinc-800 text-zinc-400';
+  const statusClass = STATUS_COLORS[task.status] ?? 'bg-muted text-muted-foreground';
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900">
+    <div className="rounded-lg border border-border bg-card">
       {/* Row header */}
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center gap-4 px-4 py-3 text-left hover:bg-zinc-800/50 transition-colors"
+        className="flex w-full items-center gap-4 px-4 py-3 text-left hover:bg-muted transition-colors"
       >
         <span className={`rounded px-2.5 py-0.5 text-xs font-medium ${statusClass}`}>
           {task.status}
         </span>
-        <span className="flex-1 text-sm text-white truncate">{task.skill_name}</span>
-        <span className="text-xs text-zinc-500">P{task.priority}</span>
-        {task.cost_usdc && <span className="text-xs text-zinc-400">${task.cost_usdc}</span>}
-        <span className="text-xs text-zinc-600">
+        <span className="flex-1 text-sm text-foreground truncate">{task.skill_name}</span>
+        <span className="text-xs text-muted-foreground">P{task.priority}</span>
+        {task.cost_usdc && <span className="text-xs text-muted-foreground">${task.cost_usdc}</span>}
+        <span className="text-xs text-muted-foreground">
           {new Date(task.created_at).toLocaleDateString()}
         </span>
-        <span className={`text-zinc-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+        <span
+          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+        >
           ▼
         </span>
       </button>
@@ -209,43 +214,45 @@ function TaskRow({
       {task.status === 'running' && progress && progress.progress > 0 && (
         <div className="px-4 pb-2">
           <div className="flex items-center gap-2">
-            <div className="flex-1 h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+            <div className="flex-1 h-1.5 rounded-full bg-foreground/10 overflow-hidden">
               <div
-                className="h-full rounded-full bg-cyan-500 transition-all"
+                className="h-full rounded-full bg-primary transition-all"
                 style={{ width: `${progress.progress}%` }}
               />
             </div>
-            <span className="text-xs text-zinc-500">{progress.progress}%</span>
+            <span className="text-xs text-muted-foreground">{progress.progress}%</span>
           </div>
-          {progress.message && <p className="mt-1 text-xs text-zinc-500">{progress.message}</p>}
+          {progress.message && (
+            <p className="mt-1 text-xs text-muted-foreground">{progress.message}</p>
+          )}
         </div>
       )}
 
       {/* Expanded details */}
       {isExpanded && (
-        <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+        <div className="border-t border-border px-4 py-3 space-y-3">
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <span className="text-zinc-500">Task ID:</span>{' '}
-              <span className="font-mono text-xs text-zinc-300">{task.id}</span>
+              <span className="text-muted-foreground">Task ID:</span>{' '}
+              <span className="font-mono text-xs text-foreground">{task.id}</span>
             </div>
             <div>
-              <span className="text-zinc-500">Agent:</span>{' '}
-              <span className="text-zinc-300">{task.agent_id ?? 'Unassigned'}</span>
+              <span className="text-muted-foreground">Agent:</span>{' '}
+              <span className="text-foreground">{task.agent_id ?? 'Unassigned'}</span>
             </div>
             <div>
-              <span className="text-zinc-500">Created:</span>{' '}
-              <span className="text-zinc-300">{new Date(task.created_at).toLocaleString()}</span>
+              <span className="text-muted-foreground">Created:</span>{' '}
+              <span className="text-foreground">{new Date(task.created_at).toLocaleString()}</span>
             </div>
             <div>
-              <span className="text-zinc-500">Updated:</span>{' '}
-              <span className="text-zinc-300">{new Date(task.updated_at).toLocaleString()}</span>
+              <span className="text-muted-foreground">Updated:</span>{' '}
+              <span className="text-foreground">{new Date(task.updated_at).toLocaleString()}</span>
             </div>
           </div>
 
           {/* Error message */}
           {task.error_message && (
-            <div className="rounded border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">
+            <div className="rounded border border-error/30 bg-error/10 p-3 text-sm text-error">
               {task.error_message}
             </div>
           )}
@@ -253,8 +260,8 @@ function TaskRow({
           {/* Output */}
           {task.output && (
             <div>
-              <p className="text-xs text-zinc-500 mb-1">Output:</p>
-              <pre className="overflow-x-auto rounded bg-zinc-950 p-3 text-xs text-zinc-400">
+              <p className="text-xs text-muted-foreground mb-1">Output:</p>
+              <pre className="overflow-x-auto rounded bg-muted p-3 text-xs text-muted-foreground">
                 {JSON.stringify(task.output, null, 2)}
               </pre>
             </div>
@@ -263,7 +270,7 @@ function TaskRow({
           {/* Artifacts */}
           {task.artifacts.length > 0 && (
             <div>
-              <p className="text-xs text-zinc-500 mb-1">Artifacts:</p>
+              <p className="text-xs text-muted-foreground mb-1">Artifacts:</p>
               <div className="space-y-1">
                 {task.artifacts.map((artifact) => (
                   <a
@@ -271,7 +278,7 @@ function TaskRow({
                     href={artifact.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block rounded border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-blue-400 hover:text-blue-300"
+                    className="block rounded border border-border bg-muted px-3 py-2 text-sm text-primary hover:text-primary/80"
                   >
                     {artifact.name} ({artifact.mimeType})
                   </a>
@@ -296,12 +303,12 @@ function TaskTableSkeleton() {
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
           key={i}
-          className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3"
+          className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
         >
           <div className="flex items-center gap-4">
-            <div className="h-5 w-16 rounded bg-zinc-800" />
-            <div className="h-4 w-48 rounded bg-zinc-800" />
-            <div className="ml-auto h-3 w-20 rounded bg-zinc-800" />
+            <div className="h-5 w-16 rounded bg-muted" />
+            <div className="h-4 w-48 rounded bg-muted" />
+            <div className="ml-auto h-3 w-20 rounded bg-muted" />
           </div>
         </div>
       ))}

--- a/apps/admin/src/app/(backend)/mcp/connect/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/connect/page.tsx
@@ -34,9 +34,9 @@ export default async function ConnectMcpServerPage({
 
   return (
     <div className="min-h-screen">
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <h1 className="text-xl font-semibold text-white">Connect MCP Server</h1>
-        <p className="mt-0.5 text-sm text-zinc-400">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Connect MCP Server</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Authorize a remote Model Context Protocol server via OAuth 2.1
         </p>
       </div>
@@ -45,7 +45,7 @@ export default async function ConnectMcpServerPage({
         {connected && (
           <div
             role="status"
-            className="mb-6 rounded-lg border border-emerald-800 bg-emerald-900/20 p-4 text-sm text-emerald-300"
+            className="mb-6 rounded-lg border border-success/30 bg-success/10 p-4 text-sm text-success"
           >
             Connected to <span className="font-mono font-semibold">{connected}</span>. Tokens are
             stored in revvault under{' '}
@@ -56,14 +56,14 @@ export default async function ConnectMcpServerPage({
         {error && (
           <div
             role="alert"
-            className="mb-6 rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-300"
+            className="mb-6 rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
           >
             <div className="font-semibold">
               Authorization failed{serverFromResult ? ` for ${serverFromResult}` : ''}
             </div>
-            <div className="mt-1 text-xs text-red-400">
+            <div className="mt-1 text-xs text-error">
               <span className="font-mono">{error}</span>
-              {detail ? <span className="ml-2 text-red-500">— {detail}</span> : null}
+              {detail ? <span className="ml-2 text-error">— {detail}</span> : null}
             </div>
           </div>
         )}
@@ -71,11 +71,14 @@ export default async function ConnectMcpServerPage({
         <form
           method="GET"
           action="/api/mcp/oauth/initiate"
-          className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-6"
+          className="rounded-lg border border-border bg-card p-6"
         >
           <div className="grid gap-4">
             <div>
-              <label htmlFor="tenant" className="mb-1.5 block text-sm font-medium text-zinc-300">
+              <label
+                htmlFor="tenant"
+                className="mb-1.5 block text-sm font-medium text-muted-foreground"
+              >
                 Tenant
               </label>
               <input
@@ -85,16 +88,19 @@ export default async function ConnectMcpServerPage({
                 required
                 pattern="[A-Za-z0-9_-]{1,64}"
                 placeholder="acme"
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-muted-foreground">
                 Identifier under which tokens are scoped in revvault. Alphanumeric, underscore,
                 hyphen.
               </p>
             </div>
 
             <div>
-              <label htmlFor="server" className="mb-1.5 block text-sm font-medium text-zinc-300">
+              <label
+                htmlFor="server"
+                className="mb-1.5 block text-sm font-medium text-muted-foreground"
+              >
                 Server name
               </label>
               <input
@@ -104,15 +110,18 @@ export default async function ConnectMcpServerPage({
                 required
                 pattern="[A-Za-z0-9_-]{1,64}"
                 placeholder="linear"
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-muted-foreground">
                 Short identifier for this MCP server. Used as the revvault path segment.
               </p>
             </div>
 
             <div>
-              <label htmlFor="serverUrl" className="mb-1.5 block text-sm font-medium text-zinc-300">
+              <label
+                htmlFor="serverUrl"
+                className="mb-1.5 block text-sm font-medium text-muted-foreground"
+              >
                 Server URL
               </label>
               <input
@@ -121,9 +130,9 @@ export default async function ConnectMcpServerPage({
                 type="url"
                 required
                 placeholder="https://mcp.example.com"
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-muted-foreground">
                 The MCP server&rsquo;s base URL. Must be HTTPS in production (localhost allowed for
                 dev).
               </p>
@@ -133,19 +142,19 @@ export default async function ConnectMcpServerPage({
           <div className="mt-6 flex items-center gap-3">
             <button
               type="submit"
-              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-zinc-900"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
             >
               Authorize
             </button>
-            <span className="text-xs text-zinc-500">
+            <span className="text-xs text-muted-foreground">
               You&rsquo;ll be redirected to the server&rsquo;s consent screen.
             </span>
           </div>
         </form>
 
-        <div className="mt-8 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
-          <h3 className="text-sm font-medium text-zinc-300">How it works</h3>
-          <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs text-zinc-500">
+        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+          <h3 className="text-sm font-medium text-muted-foreground">How it works</h3>
+          <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
             <li>
               The server discovers OAuth metadata via RFC 9728 / RFC 8414 well-known endpoints.
             </li>

--- a/apps/admin/src/app/(backend)/mcp/inspect/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/inspect/page.tsx
@@ -92,7 +92,7 @@ export default function InspectMcpServerPage() {
   if (!(tenant && server)) {
     return (
       <div className="mx-auto max-w-2xl p-6">
-        <div className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-300">
+        <div className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
           Missing <span className="font-mono">tenant</span> or{' '}
           <span className="font-mono">server</span> query parameter. Navigate from{' '}
           <a href="/mcp" className="underline">
@@ -106,26 +106,27 @@ export default function InspectMcpServerPage() {
 
   return (
     <div className="min-h-screen">
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+      <div className="border-b border-border bg-card px-6 py-4">
         <div className="flex items-center gap-3">
-          <a href="/mcp" className="text-sm text-zinc-400 hover:text-zinc-200">
+          <a href="/mcp" className="text-sm text-muted-foreground hover:text-foreground">
             ← Catalog
           </a>
-          <span className="text-zinc-600">/</span>
-          <h1 className="text-xl font-semibold text-white">
-            <span className="font-mono text-zinc-400">{tenant}</span>{' '}
-            <span className="text-zinc-600">/</span> <span className="font-mono">{server}</span>
+          <span className="text-muted-foreground">/</span>
+          <h1 className="text-xl font-semibold text-foreground">
+            <span className="font-mono text-muted-foreground">{tenant}</span>{' '}
+            <span className="text-muted-foreground">/</span>{' '}
+            <span className="font-mono">{server}</span>
           </h1>
         </div>
         {serverUrl && (
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-muted-foreground">
             {serverUrl} · {tools.length} {tools.length === 1 ? 'tool' : 'tools'}
           </p>
         )}
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-zinc-800 bg-zinc-900/70">
+      <div className="border-b border-border bg-card">
         <nav className="mx-auto flex max-w-5xl gap-1 px-6" aria-label="Inspector surfaces">
           {(['tools', 'resources', 'prompts', 'logs'] as InspectorTab[]).map((t) => (
             <button
@@ -134,8 +135,8 @@ export default function InspectMcpServerPage() {
               onClick={() => setActiveTab(t)}
               className={`-mb-px border-b-2 px-3 py-2 text-sm capitalize transition-colors ${
                 activeTab === t
-                  ? 'border-emerald-500 text-emerald-300'
-                  : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
               }`}
               aria-current={activeTab === t ? 'page' : undefined}
             >
@@ -153,8 +154,8 @@ export default function InspectMcpServerPage() {
                 role="alert"
                 className={`mb-6 rounded-lg border p-3 text-sm ${
                   state === 'error'
-                    ? 'border-red-800 bg-red-900/20 text-red-300'
-                    : 'border-zinc-800 bg-zinc-900/50 text-zinc-300'
+                    ? 'border-error/30 bg-error/10 text-error'
+                    : 'border-border bg-card text-muted-foreground'
                 }`}
               >
                 {message}
@@ -162,16 +163,16 @@ export default function InspectMcpServerPage() {
             )}
 
             {state === 'loading' && (
-              <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
                 Loading tools…
               </div>
             )}
 
             {state === 'ready' && tools.length === 0 && (
-              <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
                 This server doesn&rsquo;t advertise any tools, or the{' '}
-                <span className="font-mono text-zinc-400">tools</span> capability isn&rsquo;t
-                declared.
+                <span className="font-mono text-muted-foreground">tools</span> capability
+                isn&rsquo;t declared.
               </div>
             )}
 

--- a/apps/admin/src/app/(backend)/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/page.tsx
@@ -134,17 +134,17 @@ export default function McpCatalogPage() {
 
   return (
     <div className="min-h-screen">
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+      <div className="border-b border-border bg-card px-6 py-4">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold text-white">MCP</h1>
-            <p className="mt-0.5 text-sm text-zinc-400">
+            <h1 className="text-xl font-semibold text-foreground">MCP</h1>
+            <p className="mt-0.5 text-sm text-muted-foreground">
               Built-in and OAuth-authorized servers, content exposure, and per-meter usage
             </p>
           </div>
           <a
             href="/mcp/connect"
-            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90"
           >
             Connect new server
           </a>
@@ -152,7 +152,7 @@ export default function McpCatalogPage() {
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-zinc-800 bg-zinc-900/70">
+      <div className="border-b border-border bg-card">
         <nav className="mx-auto flex max-w-5xl gap-1 px-6" aria-label="MCP page tabs">
           {(['catalog', 'usage'] as CatalogTab[]).map((t) => (
             <button
@@ -161,8 +161,8 @@ export default function McpCatalogPage() {
               onClick={() => setActiveTab(t)}
               className={`-mb-px border-b-2 px-3 py-2 text-sm capitalize transition-colors ${
                 activeTab === t
-                  ? 'border-emerald-500 text-emerald-300'
-                  : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                  ? 'border-success text-success'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
               }`}
               aria-current={activeTab === t ? 'page' : undefined}
             >
@@ -180,7 +180,7 @@ export default function McpCatalogPage() {
             {message && (
               <div
                 role="status"
-                className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300"
+                className="mb-6 rounded-lg border border-border bg-card p-3 text-sm text-muted-foreground"
               >
                 {message}
               </div>
@@ -189,11 +189,11 @@ export default function McpCatalogPage() {
             {/* Tenant scope selector */}
             <form
               onSubmit={handleLoadTenant}
-              className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+              className="mb-8 rounded-lg border border-border bg-card p-4"
             >
               <label
                 htmlFor="tenant-input"
-                className="mb-1.5 block text-sm font-medium text-zinc-300"
+                className="mb-1.5 block text-sm font-medium text-muted-foreground"
               >
                 Tenant
               </label>
@@ -208,19 +208,19 @@ export default function McpCatalogPage() {
                   ) => setTenant(e.target.value)}
                   pattern="[A-Za-z0-9_-]{1,64}"
                   placeholder="acme"
-                  className="w-64 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                  className="w-64 rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
                 <button
                   type="submit"
                   disabled={!tenant.trim() || state === 'loading'}
-                  className="rounded-md bg-zinc-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-600 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {state === 'loading' ? 'Loading…' : 'Load'}
                 </button>
                 {activeTenant && state === 'ready' && (
-                  <span className="text-xs text-zinc-500">
+                  <span className="text-xs text-muted-foreground">
                     Showing remote servers for{' '}
-                    <span className="font-mono text-zinc-400">{activeTenant}</span>
+                    <span className="font-mono text-muted-foreground">{activeTenant}</span>
                   </span>
                 )}
               </div>
@@ -228,52 +228,62 @@ export default function McpCatalogPage() {
 
             {/* Remote servers (per tenant) */}
             <section className="mb-10">
-              <h2 className="mb-3 text-lg font-medium text-white">
+              <h2 className="mb-3 text-lg font-medium text-foreground">
                 Remote servers{' '}
-                <span className="text-sm font-normal text-zinc-500">
+                <span className="text-sm font-normal text-muted-foreground">
                   {activeTenant ? `(${activeTenant})` : '(select a tenant)'}
                 </span>
               </h2>
               {activeTenant && state === 'ready' && remotes.length === 0 && (
-                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
                   No remote servers connected for{' '}
-                  <span className="font-mono text-zinc-400">{activeTenant}</span>. Click{' '}
-                  <span className="font-medium text-zinc-300">Connect new server</span> to authorize
-                  one.
+                  <span className="font-mono text-muted-foreground">{activeTenant}</span>. Click{' '}
+                  <span className="font-medium text-foreground">Connect new server</span> to
+                  authorize one.
                 </div>
               )}
               {remotes.length > 0 && (
-                <div className="overflow-hidden rounded-lg border border-zinc-800">
+                <div className="overflow-hidden rounded-lg border border-border">
                   <table className="w-full text-sm">
-                    <thead className="bg-zinc-900/50">
+                    <thead className="bg-card">
                       <tr>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Server</th>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Tenant</th>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">State</th>
-                        <th className="px-4 py-3 text-right font-medium text-zinc-400">Actions</th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          Server
+                        </th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          Tenant
+                        </th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          State
+                        </th>
+                        <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                          Actions
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {remotes.map((r) => (
-                        <tr key={`${r.tenant}/${r.server}`} className="border-t border-zinc-800/50">
-                          <td className="px-4 py-3 font-mono text-zinc-300">{r.server}</td>
-                          <td className="px-4 py-3 font-mono text-xs text-zinc-500">{r.tenant}</td>
+                        <tr key={`${r.tenant}/${r.server}`} className="border-t border-border">
+                          <td className="px-4 py-3 font-mono text-muted-foreground">{r.server}</td>
+                          <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                            {r.tenant}
+                          </td>
                           <td className="px-4 py-3">
-                            <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                            <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
                               {r.connectionState}
                             </span>
                           </td>
                           <td className="flex items-center justify-end gap-3 px-4 py-3 text-right">
                             <a
                               href={`/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
-                              className="text-xs font-medium text-emerald-400 hover:text-emerald-300"
+                              className="text-xs font-medium text-success hover:text-success"
                             >
                               Inspect
                             </a>
                             <button
                               type="button"
                               onClick={() => void handleDisconnect(r.server)}
-                              className="text-xs font-medium text-red-400 hover:text-red-300"
+                              className="text-xs font-medium text-error hover:text-error"
                             >
                               Disconnect
                             </button>
@@ -288,43 +298,53 @@ export default function McpCatalogPage() {
 
             {/* Content exposure (tenant-agnostic in v1) */}
             <section className="mb-10">
-              <h2 className="mb-1 text-lg font-medium text-white">
+              <h2 className="mb-1 text-lg font-medium text-foreground">
                 Content exposure{' '}
-                <span className="text-sm font-normal text-zinc-500">({collections.length})</span>
+                <span className="text-sm font-normal text-muted-foreground">
+                  ({collections.length})
+                </span>
               </h2>
-              <p className="mb-3 text-xs text-zinc-500">
+              <p className="mb-3 text-xs text-muted-foreground">
                 Collections exposed to MCP clients as resources via the{' '}
-                <span className="font-mono text-zinc-400">revealui-content</span> server. Opt a
-                collection out by setting{' '}
-                <span className="font-mono text-zinc-400">mcpResource: false</span> in its
+                <span className="font-mono text-muted-foreground">revealui-content</span> server.
+                Opt a collection out by setting{' '}
+                <span className="font-mono text-muted-foreground">mcpResource: false</span> in its
                 CollectionConfig.
               </p>
               {collections.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
                   Loading collection exposure…
                 </div>
               ) : (
-                <div className="overflow-hidden rounded-lg border border-zinc-800">
+                <div className="overflow-hidden rounded-lg border border-border">
                   <table className="w-full text-sm">
-                    <thead className="bg-zinc-900/50">
+                    <thead className="bg-card">
                       <tr>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Slug</th>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Label</th>
-                        <th className="px-4 py-3 text-left font-medium text-zinc-400">Exposure</th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          Slug
+                        </th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          Label
+                        </th>
+                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                          Exposure
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {collections.map((c) => (
-                        <tr key={c.slug} className="border-t border-zinc-800/50">
-                          <td className="px-4 py-3 font-mono text-zinc-300">{c.slug}</td>
-                          <td className="px-4 py-3 text-zinc-400">{c.labelPlural ?? c.label}</td>
+                        <tr key={c.slug} className="border-t border-border">
+                          <td className="px-4 py-3 font-mono text-muted-foreground">{c.slug}</td>
+                          <td className="px-4 py-3 text-muted-foreground">
+                            {c.labelPlural ?? c.label}
+                          </td>
                           <td className="px-4 py-3">
                             {c.mcpResource ? (
-                              <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
                                 exposed
                               </span>
                             ) : (
-                              <span className="rounded-full bg-zinc-700/40 px-2 py-0.5 text-xs font-medium text-zinc-400">
+                              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                                 hidden
                               </span>
                             )}
@@ -339,12 +359,14 @@ export default function McpCatalogPage() {
 
             {/* Built-in servers (tenant-agnostic) */}
             <section>
-              <h2 className="mb-3 text-lg font-medium text-white">
+              <h2 className="mb-3 text-lg font-medium text-foreground">
                 Built-in servers{' '}
-                <span className="text-sm font-normal text-zinc-500">({builtins.length})</span>
+                <span className="text-sm font-normal text-muted-foreground">
+                  ({builtins.length})
+                </span>
               </h2>
               {builtins.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
                   Loading built-in servers…
                 </div>
               ) : (

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -122,7 +122,7 @@ function DropZone({
         if (e.dataTransfer.files.length > 0) onFiles(e.dataTransfer.files);
       }}
       className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
-        dragOver ? 'border-blue-500 bg-blue-500/10' : 'border-zinc-700 hover:border-zinc-500'
+        dragOver ? 'border-primary bg-primary/10' : 'border-border hover:border-ring'
       } ${uploading ? 'pointer-events-none opacity-50' : ''}`}
       onClick={() => inputRef.current?.click()}
       onKeyDown={(e) => {
@@ -131,7 +131,7 @@ function DropZone({
       tabIndex={0}
     >
       <svg
-        className="mb-2 h-8 w-8 text-zinc-500"
+        className="mb-2 h-8 w-8 text-muted-foreground"
         fill="none"
         viewBox="0 0 24 24"
         strokeWidth={1.5}
@@ -145,10 +145,10 @@ function DropZone({
           d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
         />
       </svg>
-      <p className="text-sm text-zinc-400">
+      <p className="text-sm text-muted-foreground">
         {uploading ? 'Uploading...' : 'Drop files here or click to upload'}
       </p>
-      <p className="mt-1 text-xs text-zinc-600">JPEG, PNG, WebP, GIF</p>
+      <p className="mt-1 text-xs text-muted-foreground">JPEG, PNG, WebP, GIF</p>
       <input
         ref={inputRef}
         type="file"
@@ -178,9 +178,9 @@ function MediaCard({
   const [deleting, setDeleting] = useState(false);
 
   return (
-    <div className="group relative overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900 transition-colors hover:border-zinc-600">
+    <div className="group relative overflow-hidden rounded-lg border border-border bg-card transition-colors hover:border-ring">
       <button type="button" onClick={() => onPreview(item)} className="block w-full">
-        <div className="flex h-40 items-center justify-center bg-zinc-950">
+        <div className="flex h-40 items-center justify-center bg-muted">
           {isImage(item.mimeType) ? (
             // biome-ignore lint/performance/noImgElement: external Blob URLs  -  next/image requires configured domains
             <img
@@ -191,7 +191,7 @@ function MediaCard({
             />
           ) : (
             <svg
-              className="h-12 w-12 text-zinc-600"
+              className="h-12 w-12 text-muted-foreground"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={1}
@@ -209,10 +209,10 @@ function MediaCard({
         </div>
       </button>
       <div className="p-3">
-        <p className="truncate text-sm font-medium text-white" title={item.filename}>
+        <p className="truncate text-sm font-medium text-foreground" title={item.filename}>
           {item.filename}
         </p>
-        <p className="mt-0.5 text-xs text-zinc-500">
+        <p className="mt-0.5 text-xs text-muted-foreground">
           {item.mimeType.split('/')[1]?.toUpperCase()} · {formatBytes(item.filesize)}
         </p>
       </div>
@@ -227,7 +227,7 @@ function MediaCard({
           }
         }}
         disabled={deleting}
-        className="absolute top-2 right-2 rounded-full bg-zinc-900/80 p-1.5 text-zinc-400 opacity-0 backdrop-blur transition-opacity hover:text-red-400 group-hover:opacity-100"
+        className="absolute top-2 right-2 rounded-full bg-card/80 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition-opacity hover:text-error group-hover:opacity-100"
         aria-label={`Delete ${item.filename}`}
       >
         <svg
@@ -259,13 +259,13 @@ function PreviewModal({ item, onClose }: { item: MediaItem; onClose: () => void 
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: click stops propagation to backdrop */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: modal content panel needs click stop-propagation */}
       <div
-        className="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-lg bg-zinc-900 p-4 shadow-2xl"
+        className="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-lg bg-popover p-4 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           type="button"
           onClick={onClose}
-          className="absolute top-3 right-3 rounded-full bg-zinc-800 p-1.5 text-zinc-400 hover:text-white"
+          className="absolute top-3 right-3 rounded-full bg-muted p-1.5 text-muted-foreground hover:text-foreground"
           aria-label="Close preview"
         >
           <svg
@@ -288,18 +288,20 @@ function PreviewModal({ item, onClose }: { item: MediaItem; onClose: () => void 
             className="max-h-[80vh] max-w-full rounded object-contain"
           />
         ) : (
-          <div className="flex h-64 w-96 items-center justify-center text-zinc-500">
+          <div className="flex h-64 w-96 items-center justify-center text-muted-foreground">
             File preview not available
           </div>
         )}
         <div className="mt-4 space-y-1 text-sm">
-          <p className="font-medium text-white">{item.filename}</p>
-          <p className="text-zinc-400">
+          <p className="font-medium text-foreground">{item.filename}</p>
+          <p className="text-muted-foreground">
             {item.mimeType} · {formatBytes(item.filesize)}
             {item.width != null && item.height != null && ` · ${item.width}x${item.height}`}
           </p>
-          {item.alt && <p className="text-zinc-500">Alt: {item.alt}</p>}
-          <p className="text-zinc-600">Uploaded {new Date(item.createdAt).toLocaleDateString()}</p>
+          {item.alt && <p className="text-muted-foreground">Alt: {item.alt}</p>}
+          <p className="text-muted-foreground">
+            Uploaded {new Date(item.createdAt).toLocaleDateString()}
+          </p>
         </div>
       </div>
     </div>
@@ -394,8 +396,8 @@ export default function MediaLibraryPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-white">Media Library</h1>
-          <p className="mt-1 text-sm text-zinc-400">
+          <h1 className="text-2xl font-bold text-foreground">Media Library</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
             {totalDocs} {totalDocs === 1 ? 'file' : 'files'}
           </p>
         </div>
@@ -405,7 +407,7 @@ export default function MediaLibraryPage() {
             onChange={(
               e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
             ) => handleFilterChange(e.target.value)}
-            className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-white"
+            className="rounded-md border border-border bg-muted px-3 py-1.5 text-sm text-foreground"
           >
             <option value="">All types</option>
             <option value="image/jpeg">JPEG</option>
@@ -418,7 +420,7 @@ export default function MediaLibraryPage() {
 
       {error && (
         <div
-          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+          className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
           role="alert"
         >
           {error}
@@ -433,14 +435,14 @@ export default function MediaLibraryPage() {
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable ID
               key={`skeleton-${i}`}
-              className="h-52 animate-pulse rounded-lg border border-zinc-800 bg-zinc-900"
+              className="h-52 animate-pulse rounded-lg border border-border bg-card"
             />
           ))}
         </div>
       ) : items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900 py-16">
+        <div className="flex flex-col items-center justify-center rounded-lg border border-border bg-card py-16">
           <svg
-            className="mb-3 h-12 w-12 text-zinc-700"
+            className="mb-3 h-12 w-12 text-muted-foreground"
             fill="none"
             viewBox="0 0 24 24"
             aria-hidden="true"
@@ -454,8 +456,8 @@ export default function MediaLibraryPage() {
               d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z"
             />
           </svg>
-          <p className="text-sm text-zinc-500">No media files yet</p>
-          <p className="mt-1 text-xs text-zinc-600">Upload images to get started</p>
+          <p className="text-sm text-muted-foreground">No media files yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">Upload images to get started</p>
         </div>
       ) : (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
@@ -466,8 +468,8 @@ export default function MediaLibraryPage() {
       )}
 
       {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t border-zinc-800 pt-4">
-          <p className="text-sm text-zinc-500">
+        <div className="flex items-center justify-between border-t border-border pt-4">
+          <p className="text-sm text-muted-foreground">
             Page {page + 1} of {totalPages}
           </p>
           <div className="flex gap-2">
@@ -475,7 +477,7 @@ export default function MediaLibraryPage() {
               type="button"
               onClick={() => handlePageChange(page - 1)}
               disabled={page === 0}
-              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+              className="rounded-md border border-border bg-muted px-3 py-1.5 text-sm text-foreground disabled:opacity-50"
             >
               Previous
             </button>
@@ -483,7 +485,7 @@ export default function MediaLibraryPage() {
               type="button"
               onClick={() => handlePageChange(page + 1)}
               disabled={page >= totalPages - 1}
-              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+              className="rounded-md border border-border bg-muted px-3 py-1.5 text-sm text-foreground disabled:opacity-50"
             >
               Next
             </button>

--- a/apps/admin/src/app/(backend)/monitoring/page.tsx
+++ b/apps/admin/src/app/(backend)/monitoring/page.tsx
@@ -7,9 +7,9 @@ export default function MonitoringPage() {
   return (
     <LicenseGate feature="dashboard">
       <div className="min-h-screen">
-        <div className="p-4 border-b border-gray-700 bg-gray-900">
-          <h1 className="text-xl font-semibold text-white">System Monitoring</h1>
-          <p className="text-sm text-gray-400 mt-1">
+        <div className="p-4 border-b border-border bg-card">
+          <h1 className="text-xl font-semibold text-foreground">System Monitoring</h1>
+          <p className="text-sm text-muted-foreground mt-1">
             Real-time system health, process tracking, and database pool metrics
           </p>
         </div>

--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -219,7 +219,7 @@ function RefundsDashboard() {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <div
-          className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-600 border-t-zinc-200"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-border border-t-foreground"
           aria-hidden="true"
         />
       </div>
@@ -230,11 +230,11 @@ function RefundsDashboard() {
   if (!user) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center p-6">
-        <div className="rounded-lg border border-red-800 bg-red-900/20 p-6 text-center">
-          <h2 className="text-lg font-semibold text-red-400">Authentication Required</h2>
-          <p className="mt-2 text-sm text-zinc-400">
+        <div className="rounded-lg border border-error/30 bg-error/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-error">Authentication Required</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             Please{' '}
-            <a href="/login?redirect=/refunds" className="text-emerald-400 underline">
+            <a href="/login?redirect=/refunds" className="text-primary underline">
               sign in
             </a>{' '}
             to access this page.
@@ -248,9 +248,9 @@ function RefundsDashboard() {
   if (!isAdmin) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center p-6">
-        <div className="rounded-lg border border-red-800 bg-red-900/20 p-6 text-center">
-          <h2 className="text-lg font-semibold text-red-400">Access Denied</h2>
-          <p className="mt-2 text-sm text-zinc-400">
+        <div className="rounded-lg border border-error/30 bg-error/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-error">Access Denied</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             Admin or owner role is required to issue refunds.
           </p>
         </div>
@@ -261,9 +261,9 @@ function RefundsDashboard() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <h1 className="text-xl font-semibold text-white">Refund Management</h1>
-        <p className="mt-0.5 text-sm text-zinc-400">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Refund Management</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Issue full or partial refunds for Stripe payments
         </p>
       </div>
@@ -272,9 +272,9 @@ function RefundsDashboard() {
         {/* Refund Form */}
         <form
           onSubmit={(e) => void handleSubmit(e)}
-          className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-6"
+          className="rounded-lg border border-border bg-card p-6"
         >
-          <h2 className="mb-4 text-lg font-medium text-white">Issue Refund</h2>
+          <h2 className="mb-4 text-lg font-medium text-foreground">Issue Refund</h2>
 
           {/* Status Message */}
           {message && (
@@ -282,15 +282,15 @@ function RefundsDashboard() {
               role="alert"
               className={`mb-4 flex items-center justify-between rounded-lg border p-3 text-sm ${
                 submitStatus === 'success'
-                  ? 'border-emerald-800 bg-emerald-900/20 text-emerald-400'
-                  : 'border-red-800 bg-red-900/20 text-red-400'
+                  ? 'border-success/30 bg-success/10 text-success'
+                  : 'border-error/30 bg-error/10 text-error'
               }`}
             >
               <span>{message}</span>
               <button
                 type="button"
                 onClick={() => dispatch({ type: 'DISMISS_MESSAGE' })}
-                className="ml-3 shrink-0 text-zinc-500 hover:text-zinc-300"
+                className="ml-3 shrink-0 text-muted-foreground hover:text-foreground"
                 aria-label="Dismiss message"
               >
                 <svg
@@ -316,7 +316,7 @@ function RefundsDashboard() {
             <div className="sm:col-span-2">
               <label
                 htmlFor="refund-identifier"
-                className="mb-1.5 block text-sm font-medium text-zinc-300"
+                className="mb-1.5 block text-sm font-medium text-foreground"
               >
                 Payment Intent or Charge ID
               </label>
@@ -329,9 +329,9 @@ function RefundsDashboard() {
                 ) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
                 placeholder="pi_abc123 or ch_abc123"
                 required
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-muted-foreground">
                 Prefix determines type: pi_ for payment intents, ch_ for charges
               </p>
             </div>
@@ -340,7 +340,7 @@ function RefundsDashboard() {
             <div>
               <label
                 htmlFor="refund-amount"
-                className="mb-1.5 block text-sm font-medium text-zinc-300"
+                className="mb-1.5 block text-sm font-medium text-foreground"
               >
                 Amount (USD)
               </label>
@@ -354,16 +354,18 @@ function RefundsDashboard() {
                 placeholder="Leave empty for full refund"
                 min="0.01"
                 step="0.01"
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-xs text-zinc-500">Optional. Omit for a full refund.</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Optional. Omit for a full refund.
+              </p>
             </div>
 
             {/* Reason */}
             <div>
               <label
                 htmlFor="refund-reason"
-                className="mb-1.5 block text-sm font-medium text-zinc-300"
+                className="mb-1.5 block text-sm font-medium text-foreground"
               >
                 Reason
               </label>
@@ -378,7 +380,7 @@ function RefundsDashboard() {
                     value: e.target.value as State['reason'],
                   })
                 }
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
               >
                 <option value="requested_by_customer">Requested by customer</option>
                 <option value="duplicate">Duplicate charge</option>
@@ -392,12 +394,12 @@ function RefundsDashboard() {
             <button
               type="submit"
               disabled={submitStatus === 'submitting' || !identifier.trim()}
-              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-zinc-900 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
             >
               {submitStatus === 'submitting' ? (
                 <span className="flex items-center gap-2">
                   <span
-                    className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                    className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground"
                     aria-hidden="true"
                   />
                   Processing...
@@ -407,7 +409,7 @@ function RefundsDashboard() {
               )}
             </button>
             {submitStatus === 'submitting' && (
-              <span className="text-xs text-zinc-500">This may take a few seconds...</span>
+              <span className="text-xs text-muted-foreground">This may take a few seconds...</span>
             )}
           </div>
         </form>
@@ -415,37 +417,51 @@ function RefundsDashboard() {
         {/* Refund History (session-local) */}
         {history.length > 0 && (
           <div className="mt-8">
-            <h2 className="mb-3 text-lg font-medium text-white">
+            <h2 className="mb-3 text-lg font-medium text-foreground">
               Recent Refunds{' '}
-              <span className="text-sm font-normal text-zinc-500">(this session)</span>
+              <span className="text-sm font-normal text-muted-foreground">(this session)</span>
             </h2>
-            <div className="overflow-x-auto rounded-lg border border-zinc-800">
+            <div className="overflow-x-auto rounded-lg border border-border">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-zinc-800 bg-zinc-900/50">
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Refund ID</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Status</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Amount</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Source</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Reason</th>
-                    <th className="px-4 py-3 text-left font-medium text-zinc-400">Time</th>
+                  <tr className="border-b border-border bg-card">
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Refund ID
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Amount
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Source
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Reason
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Time</th>
                   </tr>
                 </thead>
                 <tbody>
                   {history.map((record) => (
-                    <tr key={record.id} className="border-b border-zinc-800/50 last:border-b-0">
-                      <td className="px-4 py-3 font-mono text-xs text-zinc-300">{record.id}</td>
+                    <tr key={record.id} className="border-b border-border last:border-b-0">
+                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                        {record.id}
+                      </td>
                       <td className="px-4 py-3">
                         <RefundStatusBadge status={record.status} />
                       </td>
-                      <td className="px-4 py-3 text-zinc-300">
+                      <td className="px-4 py-3 text-foreground">
                         {formatAmount(record.amount, record.currency)}
                       </td>
-                      <td className="px-4 py-3 font-mono text-xs text-zinc-500">
+                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
                         {record.paymentIntentId ?? record.chargeId ?? '-'}
                       </td>
-                      <td className="px-4 py-3 text-zinc-400">{formatReason(record.reason)}</td>
-                      <td className="px-4 py-3 text-xs text-zinc-500">
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {formatReason(record.reason)}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">
                         {new Date(record.createdAt).toLocaleTimeString()}
                       </td>
                     </tr>
@@ -457,9 +473,9 @@ function RefundsDashboard() {
         )}
 
         {/* Help text */}
-        <div className="mt-8 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
-          <h3 className="text-sm font-medium text-zinc-300">Notes</h3>
-          <ul className="mt-2 space-y-1 text-xs text-zinc-500">
+        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+          <h3 className="text-sm font-medium text-foreground">Notes</h3>
+          <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
             <li>
               Full refunds automatically trigger license revocation via the charge.refunded webhook.
             </li>
@@ -474,7 +490,7 @@ function RefundsDashboard() {
                 href="https://dashboard.stripe.com/payments"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-emerald-400 underline"
+                className="text-primary underline"
               >
                 Stripe Dashboard
               </a>
@@ -493,13 +509,13 @@ function RefundsDashboard() {
 
 function RefundStatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
-    succeeded: 'bg-emerald-500/10 text-emerald-400',
-    pending: 'bg-yellow-500/10 text-yellow-400',
-    failed: 'bg-red-500/10 text-red-400',
-    canceled: 'bg-zinc-600/20 text-zinc-400',
-    requires_action: 'bg-blue-500/10 text-blue-400',
+    succeeded: 'bg-success/10 text-success',
+    pending: 'bg-warning/15 text-warning-foreground',
+    failed: 'bg-error/10 text-error',
+    canceled: 'bg-muted text-muted-foreground',
+    requires_action: 'bg-primary/10 text-primary',
   };
-  const color = colors[status] ?? 'bg-zinc-700/20 text-zinc-400';
+  const color = colors[status] ?? 'bg-muted text-muted-foreground';
   return <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>{status}</span>;
 }
 

--- a/apps/admin/src/app/(backend)/revenue/page.tsx
+++ b/apps/admin/src/app/(backend)/revenue/page.tsx
@@ -126,16 +126,16 @@ function RevenueDashboard() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
+      <div className="border-b border-border bg-card px-6 py-4">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-semibold text-white">Revenue</h1>
-            <p className="mt-0.5 text-sm text-zinc-400">
+            <h1 className="text-xl font-semibold text-foreground">Revenue</h1>
+            <p className="mt-0.5 text-sm text-muted-foreground">
               Billing health, subscriber metrics, and recent payment activity
             </p>
           </div>
           {lastUpdated ? (
-            <span className="text-xs text-zinc-600">Updated {lastUpdated}</span>
+            <span className="text-xs text-muted-foreground">Updated {lastUpdated}</span>
           ) : null}
         </div>
       </div>
@@ -147,7 +147,7 @@ function RevenueDashboard() {
         ) : error && !metrics ? (
           <div
             role="alert"
-            className="rounded-lg border border-red-800 bg-red-900/20 p-4 text-sm text-red-400"
+            className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
           >
             {error}
           </div>
@@ -174,33 +174,35 @@ function RevenueDashboard() {
             </div>
 
             {/* Tier Breakdown */}
-            <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-5">
-              <h2 className="mb-4 text-sm font-medium text-zinc-400">Subscriber Breakdown</h2>
+            <div className="rounded-lg border border-border bg-card p-5">
+              <h2 className="mb-4 text-sm font-medium text-muted-foreground">
+                Subscriber Breakdown
+              </h2>
               <div className="grid gap-4 sm:grid-cols-3">
-                <TierBar tier="Pro" count={metrics.tierBreakdown.pro} color="bg-emerald-500" />
-                <TierBar tier="Max" count={metrics.tierBreakdown.max} color="bg-blue-500" />
+                <TierBar tier="Pro" count={metrics.tierBreakdown.pro} color="bg-success" />
+                <TierBar tier="Max" count={metrics.tierBreakdown.max} color="bg-primary" />
                 <TierBar
                   tier="Enterprise"
                   count={metrics.tierBreakdown.enterprise}
-                  color="bg-violet-500"
+                  color="bg-accent"
                 />
               </div>
             </div>
 
             {/* Recent Events */}
-            <div className="rounded-lg border border-zinc-800 bg-zinc-800/40">
-              <div className="border-b border-zinc-800 px-5 py-3">
-                <h2 className="text-sm font-medium text-zinc-400">Recent Billing Events</h2>
+            <div className="rounded-lg border border-border bg-card">
+              <div className="border-b border-border px-5 py-3">
+                <h2 className="text-sm font-medium text-muted-foreground">Recent Billing Events</h2>
               </div>
               {metrics.recentEvents.length === 0 ? (
                 <div className="flex items-center justify-center py-10">
-                  <p className="text-sm text-zinc-600">No billing events recorded yet.</p>
+                  <p className="text-sm text-muted-foreground">No billing events recorded yet.</p>
                 </div>
               ) : (
                 <div className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
                     <thead>
-                      <tr className="border-b border-zinc-800 text-xs text-zinc-500">
+                      <tr className="border-b border-border text-xs text-muted-foreground">
                         <th className="px-5 py-2.5 font-medium">Event</th>
                         <th className="px-5 py-2.5 font-medium">Tier</th>
                         <th className="px-5 py-2.5 font-medium text-right">Date</th>
@@ -210,13 +212,15 @@ function RevenueDashboard() {
                       {metrics.recentEvents.map((event) => (
                         <tr
                           key={`${event.createdAt}-${event.type}`}
-                          className="border-b border-zinc-800/50 last:border-b-0"
+                          className="border-b border-border/50 last:border-b-0"
                         >
                           <td className="px-5 py-3">
                             <EventBadge type={event.type} />
                           </td>
-                          <td className="px-5 py-3 capitalize text-zinc-400">{event.tier}</td>
-                          <td className="px-5 py-3 text-right font-mono text-xs text-zinc-600">
+                          <td className="px-5 py-3 capitalize text-muted-foreground">
+                            {event.tier}
+                          </td>
+                          <td className="px-5 py-3 text-right font-mono text-xs text-muted-foreground">
                             {new Date(event.createdAt).toLocaleString()}
                           </td>
                         </tr>
@@ -229,9 +233,9 @@ function RevenueDashboard() {
 
             {/* Refresh indicator */}
             {loading ? (
-              <div className="flex items-center gap-2 text-xs text-zinc-600">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <div
-                  className="h-3 w-3 animate-spin rounded-full border border-zinc-600 border-t-zinc-300"
+                  className="h-3 w-3 animate-spin rounded-full border border-border border-t-foreground"
                   aria-hidden="true"
                 />
                 Refreshing...
@@ -260,15 +264,15 @@ function KpiCard({
   sublabel?: string;
 }) {
   const accentColors = {
-    emerald: 'text-emerald-400',
-    blue: 'text-blue-400',
+    emerald: 'text-success',
+    blue: 'text-primary',
   };
 
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-5">
-      <p className="text-xs font-medium text-zinc-500">{label}</p>
+    <div className="rounded-lg border border-border bg-card p-5">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
       <p className={`mt-1.5 text-2xl font-semibold ${accentColors[accent]}`}>{value}</p>
-      {sublabel ? <p className="mt-0.5 text-xs text-zinc-600">{sublabel}</p> : null}
+      {sublabel ? <p className="mt-0.5 text-xs text-muted-foreground">{sublabel}</p> : null}
     </div>
   );
 }
@@ -277,10 +281,10 @@ function TierBar({ tier, count, color }: { tier: string; count: number; color: s
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-zinc-300">{tier}</span>
-        <span className="font-mono text-sm font-semibold text-white">{count}</span>
+        <span className="text-sm text-muted-foreground">{tier}</span>
+        <span className="font-mono text-sm font-semibold text-foreground">{count}</span>
       </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-700">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-foreground/10">
         <div
           className={`h-full rounded-full transition-all ${color}`}
           style={{ width: count > 0 ? `${Math.max(8, Math.min(100, count * 10))}%` : '0%' }}
@@ -294,27 +298,27 @@ function EventBadge({ type }: { type: string }) {
   const config: Record<string, { label: string; className: string }> = {
     subscription_created: {
       label: 'Subscription Created',
-      className: 'bg-emerald-500/10 text-emerald-400',
+      className: 'bg-success/10 text-success',
     },
     subscription_cancelled: {
       label: 'Subscription Cancelled',
-      className: 'bg-red-500/10 text-red-400',
+      className: 'bg-error/10 text-error',
     },
     subscription_updated: {
       label: 'Subscription Updated',
-      className: 'bg-blue-500/10 text-blue-400',
+      className: 'bg-primary/10 text-primary',
     },
     payment_succeeded: {
       label: 'Payment Succeeded',
-      className: 'bg-emerald-500/10 text-emerald-400',
+      className: 'bg-success/10 text-success',
     },
     payment_failed: {
       label: 'Payment Failed',
-      className: 'bg-red-500/10 text-red-400',
+      className: 'bg-error/10 text-error',
     },
   };
 
-  const entry = config[type] ?? { label: type, className: 'bg-zinc-600/20 text-zinc-400' };
+  const entry = config[type] ?? { label: type, className: 'bg-muted text-muted-foreground' };
 
   return (
     <span
@@ -332,35 +336,35 @@ function LoadingSkeleton() {
       {/* KPI skeleton */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {[1, 2, 3].map((n) => (
-          <div key={n} className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-5">
-            <div className="h-3 w-24 animate-pulse rounded bg-zinc-700" />
-            <div className="mt-3 h-7 w-20 animate-pulse rounded bg-zinc-700" />
+          <div key={n} className="rounded-lg border border-border bg-card p-5">
+            <div className="h-3 w-24 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-7 w-20 animate-pulse rounded bg-foreground/10" />
           </div>
         ))}
       </div>
       {/* Tier breakdown skeleton */}
-      <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-5">
-        <div className="mb-4 h-3 w-32 animate-pulse rounded bg-zinc-700" />
+      <div className="rounded-lg border border-border bg-card p-5">
+        <div className="mb-4 h-3 w-32 animate-pulse rounded bg-foreground/10" />
         <div className="grid gap-4 sm:grid-cols-3">
           {[1, 2, 3].map((n) => (
             <div key={n}>
-              <div className="mb-2 h-3 w-16 animate-pulse rounded bg-zinc-700" />
-              <div className="h-2 w-full animate-pulse rounded-full bg-zinc-700" />
+              <div className="mb-2 h-3 w-16 animate-pulse rounded bg-foreground/10" />
+              <div className="h-2 w-full animate-pulse rounded-full bg-foreground/10" />
             </div>
           ))}
         </div>
       </div>
       {/* Events skeleton */}
-      <div className="rounded-lg border border-zinc-800 bg-zinc-800/40">
-        <div className="border-b border-zinc-800 px-5 py-3">
-          <div className="h-3 w-36 animate-pulse rounded bg-zinc-700" />
+      <div className="rounded-lg border border-border bg-card">
+        <div className="border-b border-border px-5 py-3">
+          <div className="h-3 w-36 animate-pulse rounded bg-foreground/10" />
         </div>
         <div className="flex flex-col gap-3 p-5">
           {[1, 2, 3, 4, 5].map((n) => (
             <div key={n} className="flex items-center gap-4">
-              <div className="h-5 w-32 animate-pulse rounded-full bg-zinc-700" />
-              <div className="h-3 w-16 animate-pulse rounded bg-zinc-700" />
-              <div className="ml-auto h-3 w-28 animate-pulse rounded bg-zinc-700" />
+              <div className="h-5 w-32 animate-pulse rounded-full bg-foreground/10" />
+              <div className="h-3 w-16 animate-pulse rounded bg-foreground/10" />
+              <div className="ml-auto h-3 w-28 animate-pulse rounded bg-foreground/10" />
             </div>
           ))}
         </div>

--- a/apps/admin/src/app/(backend)/settings/account/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/account/page.tsx
@@ -107,9 +107,9 @@ export default function AccountSettingsPage() {
     <Suspense
       fallback={
         <div className="p-4 sm:p-6 max-w-lg">
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-            <div className="h-5 w-48 animate-pulse rounded bg-zinc-800" />
-            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-zinc-800" />
+          <div className="rounded-xl border border-border bg-card p-5">
+            <div className="h-5 w-48 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-foreground/10" />
           </div>
         </div>
       }
@@ -242,8 +242,8 @@ function AccountSettingsContent() {
       <div className="p-4 sm:p-6 max-w-lg">
         {/* Success banner */}
         {success && (
-          <output className="mb-6 flex items-center gap-2 rounded-lg border border-emerald-800/50 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-400">
-            <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <output className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+            <span className="h-2 w-2 rounded-full bg-success" />
             {success}
           </output>
         )}
@@ -252,9 +252,9 @@ function AccountSettingsContent() {
         {error && (
           <div
             role="alert"
-            className="mb-6 flex items-center gap-2 rounded-lg border border-red-800/50 bg-red-900/20 px-4 py-3 text-sm text-red-400"
+            className="mb-6 flex items-center gap-2 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
           >
-            <span className="h-2 w-2 rounded-full bg-red-400" />
+            <span className="h-2 w-2 rounded-full bg-error" />
             {error}
           </div>
         )}
@@ -264,13 +264,13 @@ function AccountSettingsContent() {
           <section
             aria-busy="true"
             aria-label="Loading account settings"
-            className="rounded-xl border border-zinc-800 bg-zinc-900 p-5"
+            className="rounded-xl border border-border bg-card p-5"
           >
-            <div className="h-5 w-48 animate-pulse rounded bg-zinc-800" />
-            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-zinc-800" />
+            <div className="h-5 w-48 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-foreground/10" />
             <div className="mt-6 space-y-3">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-16 animate-pulse rounded-lg bg-zinc-800" />
+                <div key={i} className="h-16 animate-pulse rounded-lg bg-foreground/10" />
               ))}
             </div>
           </section>
@@ -279,26 +279,26 @@ function AccountSettingsContent() {
         {/* Account info */}
         {!loading && user && (
           <>
-            <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-              <h1 className="text-base font-semibold text-white">Account</h1>
+            <div className="mb-6 rounded-xl border border-border bg-card p-5">
+              <h1 className="text-base font-semibold text-foreground">Account</h1>
               <div className="mt-3 space-y-2 text-sm">
                 <div className="flex items-center justify-between gap-4">
-                  <span className="shrink-0 text-zinc-400">Email</span>
-                  <span className="truncate text-zinc-200">{user.email}</span>
+                  <span className="shrink-0 text-muted-foreground">Email</span>
+                  <span className="truncate text-muted-foreground">{user.email}</span>
                 </div>
                 {user.name && (
                   <div className="flex items-center justify-between gap-4">
-                    <span className="shrink-0 text-zinc-400">Name</span>
-                    <span className="truncate text-zinc-200">{user.name}</span>
+                    <span className="shrink-0 text-muted-foreground">Name</span>
+                    <span className="truncate text-muted-foreground">{user.name}</span>
                   </div>
                 )}
                 <div className="flex items-center justify-between gap-4">
-                  <span className="shrink-0 text-zinc-400">Role</span>
-                  <span className="text-zinc-200 capitalize">{user.role}</span>
+                  <span className="shrink-0 text-muted-foreground">Role</span>
+                  <span className="text-muted-foreground capitalize">{user.role}</span>
                 </div>
                 <div className="flex items-center justify-between gap-4">
-                  <span className="shrink-0 text-zinc-400">Password</span>
-                  <span className={user.hasPassword ? 'text-emerald-400' : 'text-zinc-500'}>
+                  <span className="shrink-0 text-muted-foreground">Password</span>
+                  <span className={user.hasPassword ? 'text-success' : 'text-muted-foreground'}>
                     {user.hasPassword ? 'Set' : 'Not set'}
                   </span>
                 </div>
@@ -306,23 +306,26 @@ function AccountSettingsContent() {
             </div>
 
             {/* Password */}
-            <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+            <div className="mb-6 rounded-xl border border-border bg-card p-5">
               <div className="flex items-center justify-between">
-                <h2 className="text-base font-semibold text-white">Password</h2>
+                <h2 className="text-base font-semibold text-foreground">Password</h2>
                 {user.hasPassword && !showPasswordForm && (
                   <button
                     type="button"
                     onClick={() => setShowPasswordForm(true)}
-                    className="rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+                    className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
                   >
                     Change password
                   </button>
                 )}
               </div>
               {!user.hasPassword ? (
-                <p className="mt-2 text-sm text-zinc-400">
+                <p className="mt-2 text-sm text-muted-foreground">
                   No password set.{' '}
-                  <a href="/reset-password" className="text-zinc-200 underline hover:no-underline">
+                  <a
+                    href="/reset-password"
+                    className="text-foreground underline hover:no-underline"
+                  >
                     Use password reset
                   </a>{' '}
                   to set one.
@@ -333,14 +336,14 @@ function AccountSettingsContent() {
                   onCancel={() => setShowPasswordForm(false)}
                 />
               ) : (
-                <p className="mt-2 text-sm text-zinc-400">Password is set.</p>
+                <p className="mt-2 text-sm text-muted-foreground">Password is set.</p>
               )}
             </div>
 
             {/* Connected accounts */}
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-              <h2 className="text-base font-semibold text-white">Connected Accounts</h2>
-              <p className="mt-1 text-sm text-zinc-400">
+            <div className="rounded-xl border border-border bg-card p-5">
+              <h2 className="text-base font-semibold text-foreground">Connected Accounts</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
                 Link accounts to enable single sign-on. You must keep at least one sign-in method
                 active.
               </p>
@@ -355,19 +358,23 @@ function AccountSettingsContent() {
                   return (
                     <div
                       key={provider.id}
-                      className="flex items-center justify-between rounded-lg border border-zinc-800 px-4 py-3"
+                      className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
                     >
                       <div className="flex items-center gap-3">
-                        <Icon className="h-5 w-5 text-zinc-400" />
+                        <Icon className="h-5 w-5 text-muted-foreground" />
                         <div>
-                          <div className="text-sm font-medium text-zinc-200">{provider.label}</div>
+                          <div className="text-sm font-medium text-muted-foreground">
+                            {provider.label}
+                          </div>
                           {isLinked && linkedInfo?.email ? (
-                            <div className="text-xs text-zinc-500">
+                            <div className="text-xs text-muted-foreground">
                               {linkedInfo.name ? `${linkedInfo.name} · ` : ''}
                               {linkedInfo.email}
                             </div>
                           ) : (
-                            <div className="text-xs text-zinc-600">{provider.description}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {provider.description}
+                            </div>
                           )}
                         </div>
                       </div>
@@ -377,7 +384,7 @@ function AccountSettingsContent() {
                           type="button"
                           onClick={() => requestUnlink(provider.id)}
                           disabled={isUnlinking}
-                          className="rounded-md border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:border-red-700 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-error hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {isUnlinking ? 'Unlinking...' : 'Unlink'}
                         </button>
@@ -385,7 +392,7 @@ function AccountSettingsContent() {
                         <button
                           type="button"
                           onClick={() => handleLink(provider.id)}
-                          className="rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+                          className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
                         >
                           Link
                         </button>
@@ -397,13 +404,13 @@ function AccountSettingsContent() {
 
               {/* Safety notes */}
               {!user.hasPassword && linkedSet.size === 0 && (
-                <p className="mt-4 text-xs text-red-400">
+                <p className="mt-4 text-xs text-error">
                   You have no password and no linked accounts. Set a password or link a provider to
                   regain access.
                 </p>
               )}
               {!user.hasPassword && linkedSet.size === 1 && (
-                <p className="mt-4 text-xs text-amber-400/80">
+                <p className="mt-4 text-xs text-warning-foreground">
                   You have no password set. Unlinking your only connected account will lock you out.
                   Set a password first or link another provider.
                 </p>
@@ -423,14 +430,14 @@ function AccountSettingsContent() {
           <button
             type="button"
             onClick={cancelUnlink}
-            className="rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:text-zinc-200"
+            className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={() => void confirmUnlink()}
-            className="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700"
+            className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-error/90"
           >
             Unlink
           </button>

--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -115,8 +115,8 @@ export default function ApiKeysPage() {
         <div className="p-4 sm:p-6 max-w-lg">
           {/* Status banner */}
           {currentProvider && (
-            <div className="mb-6 flex items-center gap-2 rounded-lg border border-emerald-800/50 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-400">
-              <span className="h-2 w-2 rounded-full bg-emerald-400" />
+            <div className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+              <span className="h-2 w-2 rounded-full bg-success" />
               {PROVIDERS.find((p) => p.id === currentProvider)?.label ?? currentProvider} key
               configured{currentKeyHint ? ` (${currentKeyHint})` : ''} - tasks will use your key
             </div>
@@ -126,15 +126,15 @@ export default function ApiKeysPage() {
           {saveError && (
             <div
               role="alert"
-              className="mb-6 rounded-lg border border-red-800/50 bg-red-900/20 px-4 py-3 text-sm text-red-400"
+              className="mb-6 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
             >
               {saveError}
             </div>
           )}
 
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-            <h1 className="text-base font-semibold text-white">Inference Endpoint</h1>
-            <p className="mt-1 text-sm text-zinc-400">
+          <div className="rounded-xl border border-border bg-card p-5">
+            <h1 className="text-base font-semibold text-foreground">Inference Endpoint</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
               Configure your open-model inference endpoint. Keys are stored encrypted on RevealUI
               servers and only used server-side for agent tasks.
             </p>
@@ -144,7 +144,7 @@ export default function ApiKeysPage() {
               <div>
                 <label
                   htmlFor="provider-select"
-                  className="block text-xs font-medium text-zinc-400 mb-1.5"
+                  className="block text-xs font-medium text-muted-foreground mb-1.5"
                 >
                   Provider
                 </label>
@@ -154,7 +154,7 @@ export default function ApiKeysPage() {
                   onChange={(
                     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                   ) => setProvider(e.target.value as Provider)}
-                  className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-zinc-500 focus:outline-none"
+                  className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
                 >
                   {PROVIDERS.map((p) => (
                     <option key={p.id} value={p.id}>
@@ -168,7 +168,7 @@ export default function ApiKeysPage() {
               <div>
                 <label
                   htmlFor="api-key-input"
-                  className="block text-xs font-medium text-zinc-400 mb-1.5"
+                  className="block text-xs font-medium text-muted-foreground mb-1.5"
                 >
                   API Key
                   {activeProviderInfo && (
@@ -176,7 +176,7 @@ export default function ApiKeysPage() {
                       href={activeProviderInfo.docsUrl}
                       target="_blank"
                       rel="noreferrer"
-                      className="ml-2 text-zinc-500 hover:text-zinc-300 transition-colors"
+                      className="ml-2 text-muted-foreground hover:text-foreground transition-colors"
                     >
                       Get key ↗
                     </a>
@@ -191,12 +191,12 @@ export default function ApiKeysPage() {
                       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                     ) => setApiKey(e.target.value)}
                     placeholder={activeProviderInfo?.placeholder ?? ''}
-                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 pr-16 text-sm text-zinc-100 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none font-mono"
+                    className="w-full rounded-lg border border-border bg-muted px-3 py-2 pr-16 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none font-mono"
                   />
                   <button
                     type="button"
                     onClick={() => setShowKey((v) => !v)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-zinc-500 hover:text-zinc-300"
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
                   >
                     {showKey ? 'hide' : 'show'}
                   </button>
@@ -209,7 +209,7 @@ export default function ApiKeysPage() {
                   type="button"
                   onClick={handleSave}
                   disabled={!apiKey.trim()}
-                  className="rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {saved ? 'Saved ✓' : 'Save Key'}
                 </button>
@@ -217,7 +217,7 @@ export default function ApiKeysPage() {
                   <button
                     type="button"
                     onClick={handleClear}
-                    className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-400 transition-colors hover:border-zinc-500 hover:text-zinc-200"
+                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                   >
                     Clear
                   </button>

--- a/apps/admin/src/app/(backend)/settings/layout.tsx
+++ b/apps/admin/src/app/(backend)/settings/layout.tsx
@@ -16,11 +16,11 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col sm:flex-row">
       {/* Mobile: horizontal tab bar */}
-      <nav className="border-b border-zinc-800 bg-zinc-950 sm:hidden" aria-label="Settings">
+      <nav className="border-b border-border bg-muted sm:hidden" aria-label="Settings">
         <div className="flex items-center gap-1 overflow-x-auto px-4">
           <Link
             href="/"
-            className="shrink-0 py-3 pr-3 text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+            className="shrink-0 py-3 pr-3 text-xs text-muted-foreground transition-colors hover:text-foreground"
             aria-label="Back to Admin"
           >
             ←
@@ -33,8 +33,8 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
                 href={item.href}
                 className={`shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors ${
                   isActive
-                    ? 'border-white text-white'
-                    : 'border-transparent text-zinc-500 hover:text-zinc-300'
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {item.label}
@@ -45,11 +45,11 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
       </nav>
 
       {/* Desktop: sidebar */}
-      <aside className="hidden w-56 shrink-0 border-r border-zinc-800 bg-zinc-950 sm:block">
+      <aside className="hidden w-56 shrink-0 border-r border-border bg-muted sm:block">
         <div className="sticky top-0 flex flex-col gap-1 p-4">
           <Link
             href="/"
-            className="mb-4 flex items-center gap-2 text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+            className="mb-4 flex items-center gap-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
             <svg
               className="h-3.5 w-3.5"
@@ -64,7 +64,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
             Back to Admin
           </Link>
 
-          <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+          <h2 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Settings
           </h2>
 
@@ -76,8 +76,8 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
                 href={item.href}
                 className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                   isActive
-                    ? 'bg-zinc-800 text-white'
-                    : 'text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground'
                 }`}
               >
                 {item.label}

--- a/apps/admin/src/app/(backend)/settings/layout.tsx
+++ b/apps/admin/src/app/(backend)/settings/layout.tsx
@@ -31,6 +31,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
               <Link
                 key={item.href}
                 href={item.href}
+                aria-current={isActive ? 'page' : undefined}
                 className={`shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors ${
                   isActive
                     ? 'border-primary text-foreground'
@@ -74,6 +75,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
               <Link
                 key={item.href}
                 href={item.href}
+                aria-current={isActive ? 'page' : undefined}
                 className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                   isActive
                     ? 'bg-primary text-primary-foreground'

--- a/apps/admin/src/app/(backend)/settings/security/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/security/page.tsx
@@ -54,9 +54,9 @@ export default function SecuritySettingsPage() {
     <Suspense
       fallback={
         <div className="p-4 sm:p-6 max-w-lg">
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-            <div className="h-5 w-48 animate-pulse rounded bg-zinc-800" />
-            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-zinc-800" />
+          <div className="rounded-xl border border-border bg-card p-5">
+            <div className="h-5 w-48 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-foreground/10" />
           </div>
         </div>
       }
@@ -415,8 +415,8 @@ function SecuritySettingsContent() {
       <div className="p-4 sm:p-6 max-w-lg">
         {/* Success banner */}
         {success && (
-          <output className="mb-6 flex items-center gap-2 rounded-lg border border-emerald-800/50 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-400">
-            <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <output className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+            <span className="h-2 w-2 rounded-full bg-success" />
             {success}
           </output>
         )}
@@ -425,9 +425,9 @@ function SecuritySettingsContent() {
         {(error || mfaError || passkeyError) && (
           <div
             role="alert"
-            className="mb-6 flex items-center gap-2 rounded-lg border border-red-800/50 bg-red-900/20 px-4 py-3 text-sm text-red-400"
+            className="mb-6 flex items-center gap-2 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
           >
-            <span className="h-2 w-2 rounded-full bg-red-400" />
+            <span className="h-2 w-2 rounded-full bg-error" />
             {error || mfaError || passkeyError}
           </div>
         )}
@@ -437,13 +437,13 @@ function SecuritySettingsContent() {
           <section
             aria-busy="true"
             aria-label="Loading security settings"
-            className="rounded-xl border border-zinc-800 bg-zinc-900 p-5"
+            className="rounded-xl border border-border bg-card p-5"
           >
-            <div className="h-5 w-48 animate-pulse rounded bg-zinc-800" />
-            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-zinc-800" />
+            <div className="h-5 w-48 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-foreground/10" />
             <div className="mt-6 space-y-3">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-16 animate-pulse rounded-lg bg-zinc-800" />
+                <div key={i} className="h-16 animate-pulse rounded-lg bg-foreground/10" />
               ))}
             </div>
           </section>
@@ -455,27 +455,29 @@ function SecuritySettingsContent() {
             {/* ============================================================= */}
             {/* Section 1: Two-Factor Authentication                          */}
             {/* ============================================================= */}
-            <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+            <div className="mb-6 rounded-xl border border-border bg-card p-5">
               <div className="flex items-center justify-between">
-                <h1 className="text-base font-semibold text-white">Two-Factor Authentication</h1>
+                <h1 className="text-base font-semibold text-foreground">
+                  Two-Factor Authentication
+                </h1>
                 {mfaStatus && (
                   <span
                     className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
                       mfaStatus.enabled
-                        ? 'bg-emerald-900/30 text-emerald-400'
-                        : 'bg-zinc-800 text-zinc-400'
+                        ? 'bg-success/10 text-success'
+                        : 'bg-muted text-muted-foreground'
                     }`}
                   >
                     <span
                       className={`h-1.5 w-1.5 rounded-full ${
-                        mfaStatus.enabled ? 'bg-emerald-400' : 'bg-zinc-500'
+                        mfaStatus.enabled ? 'bg-success' : 'bg-muted-foreground'
                       }`}
                     />
                     {mfaStatus.enabled ? 'Enabled' : 'Not configured'}
                   </span>
                 )}
               </div>
-              <p className="mt-1 text-sm text-zinc-400">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Add an extra layer of security by requiring a one-time code from your authenticator
                 app.
               </p>
@@ -485,26 +487,28 @@ function SecuritySettingsContent() {
                 <div className="mt-5 space-y-4">
                   {/* OTP URI */}
                   <div>
-                    <p className="text-xs font-medium text-zinc-400">
+                    <p className="text-xs font-medium text-muted-foreground">
                       Copy this URI into your authenticator app
                     </p>
-                    <div className="mt-2 flex justify-center rounded-lg border border-zinc-700 bg-white p-4">
+                    <div className="mt-2 flex justify-center rounded-lg border border-border bg-white p-4">
                       <QRCodeSVG value={setupData.uri} size={200} level="M" />
                     </div>
-                    <p className="mt-2 text-xs text-zinc-500">Or copy the URI manually:</p>
-                    <div className="mt-1 rounded-lg border border-zinc-700 bg-zinc-950 p-3">
-                      <code className="block break-all text-xs text-zinc-300">{setupData.uri}</code>
+                    <p className="mt-2 text-xs text-muted-foreground">Or copy the URI manually:</p>
+                    <div className="mt-1 rounded-lg border border-border bg-muted p-3">
+                      <code className="block break-all text-xs text-muted-foreground">
+                        {setupData.uri}
+                      </code>
                     </div>
                   </div>
 
                   {/* Backup codes */}
                   <div>
-                    <p className="text-xs font-medium text-zinc-400">
+                    <p className="text-xs font-medium text-muted-foreground">
                       Backup codes - save these in a secure place
                     </p>
-                    <div className="mt-1 grid grid-cols-1 gap-1.5 rounded-lg border border-zinc-700 bg-zinc-950 p-3 sm:grid-cols-2">
+                    <div className="mt-1 grid grid-cols-1 gap-1.5 rounded-lg border border-border bg-muted p-3 sm:grid-cols-2">
                       {setupData.backupCodes.map((code) => (
-                        <code key={code} className="text-xs font-mono text-zinc-300">
+                        <code key={code} className="text-xs font-mono text-muted-foreground">
                           {code}
                         </code>
                       ))}
@@ -513,7 +517,10 @@ function SecuritySettingsContent() {
 
                   {/* Verification */}
                   <div>
-                    <label htmlFor="mfa-verify-code" className="text-xs font-medium text-zinc-400">
+                    <label
+                      htmlFor="mfa-verify-code"
+                      className="text-xs font-medium text-muted-foreground"
+                    >
                       Enter a code from your authenticator app to verify
                     </label>
                     <div className="mt-1 flex gap-2">
@@ -530,20 +537,20 @@ function SecuritySettingsContent() {
                           >,
                         ) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
                         placeholder="000000"
-                        className="w-32 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+                        className="w-32 rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                       />
                       <button
                         type="button"
                         onClick={() => void handleVerifySetup()}
                         disabled={verifyCode.length !== 6 || mfaLoading}
-                        className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="rounded-md bg-success px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {mfaLoading ? 'Verifying...' : 'Verify'}
                       </button>
                       <button
                         type="button"
                         onClick={cancelSetup}
-                        className="rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:text-zinc-200"
+                        className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
                       >
                         Cancel
                       </button>
@@ -560,7 +567,7 @@ function SecuritySettingsContent() {
                       type="button"
                       onClick={() => void handleEnableMFA()}
                       disabled={mfaLoading}
-                      className="rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {mfaLoading ? 'Setting up...' : 'Enable 2FA'}
                     </button>
@@ -570,10 +577,10 @@ function SecuritySettingsContent() {
                     <div className="space-y-3">
                       {/* Disable 2FA */}
                       {showDisableForm ? (
-                        <div className="rounded-lg border border-zinc-700 p-3">
+                        <div className="rounded-lg border border-border p-3">
                           <label
                             htmlFor="mfa-disable-password"
-                            className="text-xs font-medium text-zinc-400"
+                            className="text-xs font-medium text-muted-foreground"
                           >
                             Confirm your password to disable 2FA
                           </label>
@@ -588,13 +595,13 @@ function SecuritySettingsContent() {
                                 >,
                               ) => setDisablePassword(e.target.value)}
                               placeholder="Password"
-                              className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none sm:w-48"
+                              className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none sm:w-48"
                             />
                             <button
                               type="button"
                               onClick={() => void handleDisableMFA()}
                               disabled={disabling || !disablePassword.trim()}
-                              className="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                              className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
                             >
                               {disabling ? 'Disabling...' : 'Confirm'}
                             </button>
@@ -604,7 +611,7 @@ function SecuritySettingsContent() {
                                 setShowDisableForm(false);
                                 setDisablePassword('');
                               }}
-                              className="rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:text-zinc-200"
+                              className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
                             >
                               Cancel
                             </button>
@@ -614,7 +621,7 @@ function SecuritySettingsContent() {
                         <button
                           type="button"
                           onClick={() => setShowDisableForm(true)}
-                          className="rounded-md border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:border-red-700 hover:text-red-400"
+                          className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-error/50 hover:text-error"
                         >
                           Disable 2FA
                         </button>
@@ -626,7 +633,7 @@ function SecuritySettingsContent() {
                           type="button"
                           onClick={() => void handleRegenerateCodes()}
                           disabled={regenerating}
-                          className="rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {regenerating ? 'Regenerating...' : 'Regenerate backup codes'}
                         </button>
@@ -635,12 +642,12 @@ function SecuritySettingsContent() {
                       {/* Show regenerated codes */}
                       {regeneratedCodes && (
                         <div>
-                          <p className="text-xs font-medium text-zinc-400">
+                          <p className="text-xs font-medium text-muted-foreground">
                             New backup codes - save these in a secure place
                           </p>
-                          <div className="mt-1 grid grid-cols-1 gap-1.5 rounded-lg border border-zinc-700 bg-zinc-950 p-3 sm:grid-cols-2">
+                          <div className="mt-1 grid grid-cols-1 gap-1.5 rounded-lg border border-border bg-muted p-3 sm:grid-cols-2">
                             {regeneratedCodes.map((code) => (
-                              <code key={code} className="text-xs font-mono text-zinc-300">
+                              <code key={code} className="text-xs font-mono text-muted-foreground">
                                 {code}
                               </code>
                             ))}
@@ -648,7 +655,7 @@ function SecuritySettingsContent() {
                           <button
                             type="button"
                             onClick={() => setRegeneratedCodes(null)}
-                            className="mt-2 text-xs text-zinc-500 hover:text-zinc-300"
+                            className="mt-2 text-xs text-muted-foreground hover:text-foreground"
                           >
                             Dismiss
                           </button>
@@ -663,14 +670,14 @@ function SecuritySettingsContent() {
             {/* ============================================================= */}
             {/* Section 2: Passkeys                                           */}
             {/* ============================================================= */}
-            <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+            <div className="mb-6 rounded-xl border border-border bg-card p-5">
               <div className="flex items-center justify-between">
-                <h2 className="text-base font-semibold text-white">Passkeys</h2>
-                <span className="text-xs text-zinc-500">
+                <h2 className="text-base font-semibold text-foreground">Passkeys</h2>
+                <span className="text-xs text-muted-foreground">
                   {passkeys.length} of {MAX_PASSKEYS} passkeys
                 </span>
               </div>
-              <p className="mt-1 text-sm text-zinc-400">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Passkeys let you sign in securely without a password using biometrics or a security
                 key.
               </p>
@@ -681,11 +688,11 @@ function SecuritySettingsContent() {
                   {passkeys.map((passkey) => (
                     <div
                       key={passkey.id}
-                      className="flex items-center justify-between rounded-lg border border-zinc-800 px-4 py-3"
+                      className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
                     >
                       <div className="flex items-center gap-3">
                         <svg
-                          className="h-5 w-5 text-zinc-400"
+                          className="h-5 w-5 text-muted-foreground"
                           viewBox="0 0 24 24"
                           fill="none"
                           stroke="currentColor"
@@ -713,29 +720,29 @@ function SecuritySettingsContent() {
                                   if (e.key === 'Enter') void submitRename(passkey.id);
                                   if (e.key === 'Escape') cancelRename();
                                 }}
-                                className="w-36 rounded border border-zinc-700 bg-zinc-950 px-2 py-0.5 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+                                className="w-36 rounded border border-border bg-muted px-2 py-0.5 text-sm text-foreground focus:border-ring focus:outline-none"
                               />
                               <button
                                 type="button"
                                 onClick={() => void submitRename(passkey.id)}
-                                className="text-xs text-emerald-400 hover:text-emerald-300"
+                                className="text-xs text-success hover:text-success/80"
                               >
                                 Save
                               </button>
                               <button
                                 type="button"
                                 onClick={cancelRename}
-                                className="text-xs text-zinc-500 hover:text-zinc-300"
+                                className="text-xs text-muted-foreground hover:text-foreground"
                               >
                                 Cancel
                               </button>
                             </div>
                           ) : (
-                            <div className="text-sm font-medium text-zinc-200">
+                            <div className="text-sm font-medium text-muted-foreground">
                               {passkey.deviceName ?? 'Unnamed passkey'}
                             </div>
                           )}
-                          <div className="text-xs text-zinc-500">
+                          <div className="text-xs text-muted-foreground">
                             Added {formatDate(passkey.createdAt)}
                             {passkey.lastUsedAt && ` · Last used ${formatDate(passkey.lastUsedAt)}`}
                           </div>
@@ -747,7 +754,7 @@ function SecuritySettingsContent() {
                           <button
                             type="button"
                             onClick={() => startRename(passkey)}
-                            className="rounded-md px-2 py-1 text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+                            className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
                           >
                             Rename
                           </button>
@@ -755,7 +762,7 @@ function SecuritySettingsContent() {
                             type="button"
                             onClick={() => requestDelete(passkey.id)}
                             disabled={deletingId === passkey.id}
-                            className="rounded-md px-2 py-1 text-xs text-zinc-500 transition-colors hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             {deletingId === passkey.id ? 'Removing...' : 'Remove'}
                           </button>
@@ -769,7 +776,7 @@ function SecuritySettingsContent() {
               {/* Add passkey button */}
               <div className="mt-5">
                 {!passkeySupported ? (
-                  <p className="text-xs text-zinc-500">
+                  <p className="text-xs text-muted-foreground">
                     Passkeys are not supported in this browser.
                   </p>
                 ) : (
@@ -777,13 +784,13 @@ function SecuritySettingsContent() {
                     type="button"
                     onClick={() => void handleAddPasskey()}
                     disabled={passkeyLoading || passkeys.length >= MAX_PASSKEYS}
-                    className="rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {passkeyLoading ? 'Adding...' : 'Add passkey'}
                   </button>
                 )}
                 {passkeys.length >= MAX_PASSKEYS && (
-                  <p className="mt-2 text-xs text-amber-400/80">
+                  <p className="mt-2 text-xs text-warning-foreground/80">
                     Maximum number of passkeys reached. Remove one to add another.
                   </p>
                 )}
@@ -793,17 +800,19 @@ function SecuritySettingsContent() {
             {/* ============================================================= */}
             {/* Section 3: Account Recovery                                   */}
             {/* ============================================================= */}
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-              <h2 className="text-base font-semibold text-white">Account Recovery</h2>
-              <p className="mt-1 text-sm text-zinc-400">
+            <div className="rounded-xl border border-border bg-card p-5">
+              <h2 className="text-base font-semibold text-foreground">Account Recovery</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
                 If you lose access to all your devices, you can recover your account via email magic
                 link.
               </p>
               <div className="mt-4 space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-zinc-400">Backup codes remaining</span>
+                  <span className="text-muted-foreground">Backup codes remaining</span>
                   <span
-                    className={mfaStatus?.backupCodesRemaining ? 'text-zinc-200' : 'text-zinc-500'}
+                    className={
+                      mfaStatus?.backupCodesRemaining ? 'text-foreground' : 'text-muted-foreground'
+                    }
                   >
                     {mfaStatus?.enabled
                       ? (mfaStatus.backupCodesRemaining ?? 'Unknown')
@@ -811,14 +820,14 @@ function SecuritySettingsContent() {
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-zinc-400">Email recovery</span>
-                  <span className="text-emerald-400">Available</span>
+                  <span className="text-muted-foreground">Email recovery</span>
+                  <span className="text-success">Available</span>
                 </div>
               </div>
               {mfaStatus?.enabled &&
                 mfaStatus.backupCodesRemaining !== undefined &&
                 mfaStatus.backupCodesRemaining <= 2 && (
-                  <p className="mt-4 text-xs text-amber-400/80">
+                  <p className="mt-4 text-xs text-warning-foreground/80">
                     You have few backup codes remaining. Consider regenerating them above.
                   </p>
                 )}
@@ -827,35 +836,35 @@ function SecuritySettingsContent() {
             {/* ============================================================= */}
             {/* Section 4: Active Sessions                                    */}
             {/* ============================================================= */}
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-              <h2 className="text-base font-semibold text-white">Active Sessions</h2>
-              <p className="mt-1 text-sm text-zinc-400">
+            <div className="rounded-xl border border-border bg-card p-5">
+              <h2 className="text-base font-semibold text-foreground">Active Sessions</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
                 Devices and browsers currently signed in to your account.
               </p>
 
               {activeSessions.length === 0 ? (
-                <p className="mt-4 text-sm text-zinc-500">No other sessions found.</p>
+                <p className="mt-4 text-sm text-muted-foreground">No other sessions found.</p>
               ) : (
                 <div className="mt-5 space-y-3">
                   {activeSessions.map((session) => (
                     <div
                       key={session.id}
-                      className="flex items-start justify-between rounded-lg border border-zinc-800 px-4 py-3"
+                      className="flex items-start justify-between rounded-lg border border-border px-4 py-3"
                     >
                       <div className="min-w-0">
                         <div className="flex items-center gap-2">
-                          <span className="truncate text-sm text-zinc-200">
+                          <span className="truncate text-sm text-muted-foreground">
                             {session.userAgent
                               ? parseUserAgent(session.userAgent)
                               : 'Unknown device'}
                           </span>
                           {session.isCurrent && (
-                            <span className="shrink-0 rounded-full bg-emerald-900/30 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                            <span className="shrink-0 rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
                               Current
                             </span>
                           )}
                         </div>
-                        <div className="mt-0.5 text-xs text-zinc-500">
+                        <div className="mt-0.5 text-xs text-muted-foreground">
                           {session.ipAddress && <span>{session.ipAddress} · </span>}
                           Last active {formatRelative(session.lastActivityAt)}
                         </div>
@@ -866,7 +875,7 @@ function SecuritySettingsContent() {
                           onClick={() => void revokeSession(session.id)}
                           disabled={revokingId === session.id}
                           aria-label="Revoke this session"
-                          className="ml-4 shrink-0 rounded-md border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:border-red-700 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="ml-4 shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-error/50 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {revokingId === session.id ? 'Revoking...' : 'Revoke'}
                         </button>
@@ -886,7 +895,7 @@ function SecuritySettingsContent() {
                     }
                   }}
                   disabled={!!revokingId}
-                  className="mt-4 text-xs text-red-400 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="mt-4 text-xs text-error hover:text-error/80 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Revoke all other sessions
                 </button>
@@ -906,14 +915,14 @@ function SecuritySettingsContent() {
           <button
             type="button"
             onClick={cancelDelete}
-            className="rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:text-zinc-200"
+            className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={() => void confirmDelete()}
-            className="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700"
+            className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-error/90"
           >
             Remove
           </button>

--- a/apps/admin/src/app/(backend)/webhooks/page.tsx
+++ b/apps/admin/src/app/(backend)/webhooks/page.tsx
@@ -145,12 +145,12 @@ function WebhooksDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white">
+    <div className="min-h-screen text-foreground">
       {/* Header */}
-      <div className="flex flex-wrap items-center gap-4 border-b border-gray-700 bg-gray-900 p-4">
+      <div className="flex flex-wrap items-center gap-4 border-b border-border bg-card p-4">
         <div>
-          <h1 className="text-xl font-semibold text-white">Webhook Events</h1>
-          <p className="mt-0.5 text-sm text-gray-400">
+          <h1 className="text-xl font-semibold text-foreground">Webhook Events</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Processed Stripe webhook events - deduplication log
           </p>
         </div>
@@ -160,7 +160,7 @@ function WebhooksDashboard() {
           <div className="ml-auto flex flex-wrap items-center gap-1 text-sm">
             <Link
               href={filterUrl({ type: undefined })}
-              className={`rounded px-2 py-1 ${!filterType ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+              className={`rounded px-2 py-1 ${!filterType ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
             >
               All types
             </Link>
@@ -168,7 +168,7 @@ function WebhooksDashboard() {
               <Link
                 key={t}
                 href={filterUrl({ type: t })}
-                className={`rounded px-2 py-1 font-mono text-xs ${filterType === t ? 'bg-blue-700 text-white' : 'text-gray-400 hover:text-white'}`}
+                className={`rounded px-2 py-1 font-mono text-xs ${filterType === t ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
               >
                 {t}
               </Link>
@@ -178,25 +178,25 @@ function WebhooksDashboard() {
       </div>
 
       {loading && (
-        <div className="m-4 p-8 text-center text-gray-500">Loading webhook events...</div>
+        <div className="m-4 p-8 text-center text-muted-foreground">Loading webhook events...</div>
       )}
 
       {error && (
         <div
           role="alert"
-          className="m-4 rounded border border-red-700 bg-red-900 p-3 text-sm text-red-200"
+          className="m-4 rounded border border-error/30 bg-error/10 p-3 text-sm text-error"
         >
           Failed to load webhook events: {error}
         </div>
       )}
 
       {!(loading || error) && rows.length === 0 && (
-        <div className="m-4 p-8 text-center text-gray-500">
+        <div className="m-4 p-8 text-center text-muted-foreground">
           No webhook events processed yet.
           {filterType ? (
             <span>
               {' '}
-              <Link href="/webhooks" className="text-blue-400 hover:underline">
+              <Link href="/webhooks" className="text-primary hover:underline">
                 Clear filter
               </Link>
             </span>
@@ -208,34 +208,34 @@ function WebhooksDashboard() {
 
       {rows.length > 0 && (
         <>
-          <div className="border-b border-gray-800 px-4 py-2 text-xs text-gray-500">
+          <div className="border-b border-border px-4 py-2 text-xs text-muted-foreground">
             Showing {rows.length} of {total} events
             {filterType ? ` · type: ${filterType}` : ''}
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-gray-900 text-left text-gray-400">
+                <tr className="bg-card text-left text-muted-foreground">
                   <th className="whitespace-nowrap px-4 py-2 font-medium">Processed At</th>
                   <th className="px-4 py-2 font-medium">Event Type</th>
                   <th className="px-4 py-2 font-medium">Event ID</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-800">
+              <tbody className="divide-y divide-border">
                 {rows.map((row) => (
-                  <tr key={row.id} className="transition-colors hover:bg-gray-900">
-                    <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-400">
+                  <tr key={row.id} className="transition-colors hover:bg-card">
+                    <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {formatTime(new Date(row.processedAt))}
                     </td>
                     <td className="px-4 py-2">
                       <Link
                         href={filterUrl({ type: row.eventType })}
-                        className="font-mono text-xs text-gray-300 hover:text-blue-400"
+                        className="font-mono text-xs text-muted-foreground hover:text-primary"
                       >
                         {row.eventType}
                       </Link>
                     </td>
-                    <td className="px-4 py-2 font-mono text-xs text-gray-500">{row.id}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{row.id}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/admin/src/components/UpgradePrompt.tsx
+++ b/apps/admin/src/components/UpgradePrompt.tsx
@@ -37,8 +37,8 @@ export function UpgradePrompt({ feature, description, variant = 'default' }: Upg
 
   if (variant === 'sampling') {
     return (
-      <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-950/30">
-        <div className="flex-1 text-sm text-blue-700 dark:text-blue-300">
+      <div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/10 px-4 py-3">
+        <div className="flex-1 text-sm text-primary">
           {description ||
             'Free AI sampling quota reached. Upgrade to Pro for 10,000 tasks/month with full coding tools.'}
         </div>
@@ -67,10 +67,8 @@ export function UpgradePrompt({ feature, description, variant = 'default' }: Upg
         </Link>
 
         {upgradeTiers.length > 0 && (
-          <div className="pt-2 border-t dark:border-zinc-800">
-            <p className="mb-3 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-              Compare plans
-            </p>
+          <div className="pt-2 border-t border-border">
+            <p className="mb-3 text-xs font-medium text-muted-foreground">Compare plans</p>
             <PricingTable
               tiers={upgradeTiers}
               currentTier={currentTier ?? 'free'}

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -158,7 +158,7 @@ function AdminSidebarContent({ siteName }: { siteName: string }) {
       <SidebarHeader>
         <SidebarSection>
           <SidebarItem href="/" current={isCurrent('/')}>
-            <span className="text-lg font-bold text-white">RevealUI</span>
+            <span className="text-lg font-bold text-foreground">RevealUI</span>
           </SidebarItem>
         </SidebarSection>
       </SidebarHeader>
@@ -201,7 +201,7 @@ function AdminSidebarContent({ siteName }: { siteName: string }) {
         </SidebarSection>
       </SidebarBody>
       <SidebarFooter>
-        <p className="text-xs text-zinc-500">{siteName} Admin</p>
+        <p className="text-xs text-muted-foreground">{siteName} Admin</p>
       </SidebarFooter>
     </Sidebar>
   );

--- a/apps/admin/src/lib/components/Agent/index.tsx
+++ b/apps/admin/src/lib/components/Agent/index.tsx
@@ -241,29 +241,29 @@ function ToolCallBadge({ entry }: { entry: ToolCallEntry }) {
   const label = TOOL_LABELS[entry.name] ?? entry.name;
 
   return (
-    <div className="my-1.5 rounded-md border border-zinc-200 bg-zinc-50 text-sm dark:border-zinc-700 dark:bg-zinc-800/50">
+    <div className="my-1.5 rounded-md border border-border bg-muted text-sm">
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left"
       >
         {entry.status === 'running' && (
-          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-zinc-400 border-t-blue-500" />
+          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-foreground/10 border-t-primary" />
         )}
-        {entry.status === 'success' && <span className="text-emerald-500">&#10003;</span>}
-        {entry.status === 'error' && <span className="text-red-500">&#10007;</span>}
-        <span className="font-medium text-zinc-700 dark:text-zinc-300">{label}</span>
-        <span className="ml-auto text-xs text-zinc-400">{expanded ? '▲' : '▼'}</span>
+        {entry.status === 'success' && <span className="text-success">&#10003;</span>}
+        {entry.status === 'error' && <span className="text-error">&#10007;</span>}
+        <span className="font-medium text-foreground">{label}</span>
+        <span className="ml-auto text-xs text-muted-foreground">{expanded ? '▲' : '▼'}</span>
       </button>
       {expanded && (
-        <div className="border-t border-zinc-200 px-3 py-2 dark:border-zinc-700">
+        <div className="border-t border-border px-3 py-2">
           {entry.arguments && (
-            <pre className="mb-1 max-h-32 overflow-auto rounded bg-zinc-100 p-2 text-xs text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400">
+            <pre className="mb-1 max-h-32 overflow-auto rounded bg-card p-2 text-xs text-muted-foreground">
               {formatJson(entry.arguments)}
             </pre>
           )}
           {entry.result && (
-            <pre className="max-h-32 overflow-auto rounded bg-zinc-100 p-2 text-xs text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400">
+            <pre className="max-h-32 overflow-auto rounded bg-card p-2 text-xs text-muted-foreground">
               {entry.result}
             </pre>
           )}
@@ -283,7 +283,7 @@ function ChatMarkdown({ content }: { content: string }) {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-400 underline hover:text-blue-300"
+            className="text-primary underline hover:text-primary/80"
             {...props}
           >
             {children}
@@ -293,7 +293,7 @@ function ChatMarkdown({ content }: { content: string }) {
           const isBlock = className?.startsWith('language-');
           if (isBlock) {
             return (
-              <pre className="my-2 overflow-x-auto rounded-md bg-zinc-900 p-3 text-sm text-zinc-100">
+              <pre className="my-2 overflow-x-auto rounded-md bg-card p-3 text-sm text-foreground">
                 <code className={className} {...props}>
                   {children}
                 </code>
@@ -301,7 +301,7 @@ function ChatMarkdown({ content }: { content: string }) {
             );
           }
           return (
-            <code className="rounded bg-zinc-200 px-1 py-0.5 text-sm dark:bg-zinc-700" {...props}>
+            <code className="rounded bg-muted px-1 py-0.5 text-sm" {...props}>
               {children}
             </code>
           );
@@ -314,15 +314,12 @@ function ChatMarkdown({ content }: { content: string }) {
           </div>
         ),
         th: ({ children, ...props }) => (
-          <th
-            className="border-b border-zinc-300 px-3 py-1 text-left font-semibold dark:border-zinc-600"
-            {...props}
-          >
+          <th className="border-b border-border px-3 py-1 text-left font-semibold" {...props}>
             {children}
           </th>
         ),
         td: ({ children, ...props }) => (
-          <td className="border-b border-zinc-200 px-3 py-1 dark:border-zinc-700" {...props}>
+          <td className="border-b border-border px-3 py-1" {...props}>
             {children}
           </td>
         ),
@@ -346,7 +343,7 @@ function CopyButton({ text }: { text: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="mt-1 self-start rounded px-1.5 py-0.5 text-xs text-zinc-400 opacity-0 transition-opacity hover:bg-zinc-200 hover:text-zinc-600 group-hover:opacity-100 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+      className="mt-1 self-start rounded px-1.5 py-0.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
       aria-label="Copy message"
     >
       {copied ? 'Copied' : 'Copy'}
@@ -357,10 +354,10 @@ function CopyButton({ text }: { text: string }) {
 function MessageSkeleton() {
   return (
     <div className="flex animate-pulse gap-3">
-      <div className="h-8 w-8 shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-700" />
+      <div className="h-8 w-8 shrink-0 rounded-full bg-foreground/10" />
       <div className="flex-1 space-y-2 py-1">
-        <div className="h-3 w-3/4 rounded bg-zinc-200 dark:bg-zinc-700" />
-        <div className="h-3 w-1/2 rounded bg-zinc-200 dark:bg-zinc-700" />
+        <div className="h-3 w-3/4 rounded bg-foreground/10" />
+        <div className="h-3 w-1/2 rounded bg-foreground/10" />
       </div>
     </div>
   );
@@ -374,7 +371,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
       <div
         className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-medium ${
           isUser
-            ? 'bg-blue-600 text-white'
+            ? 'bg-primary text-primary-foreground'
             : 'bg-gradient-to-br from-violet-500 to-fuchsia-500 text-white'
         }`}
       >
@@ -383,9 +380,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
       <div className={`flex max-w-[85%] flex-col ${isUser ? 'items-end' : 'items-start'}`}>
         <div
           className={`rounded-2xl px-4 py-3 ${
-            isUser
-              ? 'bg-blue-600 text-white'
-              : 'bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'
+            isUser ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
           }`}
         >
           {isUser ? (
@@ -417,19 +412,15 @@ function ConfirmationCard({
   isLoading: boolean;
 }) {
   return (
-    <div className="mx-auto my-4 max-w-md rounded-xl border-2 border-amber-300 bg-amber-50 p-4 dark:border-amber-600 dark:bg-amber-900/20">
+    <div className="mx-auto my-4 max-w-md rounded-xl border-2 border-warning/30 bg-warning/15 p-4">
       <div className="mb-2 flex items-center gap-2">
         <span className="text-lg">&#x26A0;&#xFE0F;</span>
-        <span className="font-semibold text-amber-800 dark:text-amber-300">
-          Confirmation Required
-        </span>
+        <span className="font-semibold text-warning-foreground">Confirmation Required</span>
       </div>
-      <p className="mb-3 text-sm text-amber-700 dark:text-amber-400">{confirmation.description}</p>
+      <p className="mb-3 text-sm text-warning-foreground">{confirmation.description}</p>
       <details className="mb-3">
-        <summary className="cursor-pointer text-xs text-amber-600 dark:text-amber-500">
-          View details
-        </summary>
-        <pre className="mt-1 max-h-24 overflow-auto rounded bg-amber-100 p-2 text-xs dark:bg-amber-900/40">
+        <summary className="cursor-pointer text-xs text-warning-foreground">View details</summary>
+        <pre className="mt-1 max-h-24 overflow-auto rounded bg-warning/15 p-2 text-xs">
           {formatJson(JSON.stringify(confirmation.arguments))}
         </pre>
       </details>
@@ -438,7 +429,7 @@ function ConfirmationCard({
           type="button"
           onClick={onApprove}
           disabled={isLoading}
-          className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+          className="flex-1 rounded-lg bg-error px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:opacity-50"
         >
           {isLoading ? 'Executing...' : 'Approve'}
         </button>
@@ -446,7 +437,7 @@ function ConfirmationCard({
           type="button"
           onClick={onReject}
           disabled={isLoading}
-          className="flex-1 rounded-lg bg-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-600"
+          className="flex-1 rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
         >
           Reject
         </button>
@@ -791,10 +782,8 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
           <div className="flex h-full flex-col items-center justify-center gap-6">
             <div className="text-center">
               <div className="mb-2 text-4xl">&#x1F916;</div>
-              <h2 className="text-lg font-semibold text-zinc-700 dark:text-zinc-300">
-                admin Assistant
-              </h2>
-              <p className="mt-1 max-w-md text-sm text-zinc-500">
+              <h2 className="text-lg font-semibold text-foreground">admin Assistant</h2>
+              <p className="mt-1 max-w-md text-sm text-muted-foreground">
                 {agentMode === 'coding'
                   ? 'I can help you read, write, and search code, run commands, and manage your project. Try a suggestion below.'
                   : 'I can help you manage content, users, media, and settings. Ask me anything or try one of the suggestions below.'}
@@ -807,7 +796,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
                     key={prompt}
                     type="button"
                     onClick={() => handleSuggestedPrompt(prompt)}
-                    className="rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-700 transition-colors hover:border-blue-300 hover:bg-blue-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-blue-600 dark:hover:bg-zinc-700"
+                    className="rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition-colors hover:border-primary hover:bg-muted"
                   >
                     {prompt}
                   </button>
@@ -827,7 +816,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-fuchsia-500 text-sm font-medium text-white">
               AI
             </div>
-            <div className="max-w-[85%] rounded-2xl bg-zinc-100 px-4 py-3 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+            <div className="max-w-[85%] rounded-2xl bg-muted px-4 py-3 text-foreground">
               <div className="prose prose-sm max-w-none dark:prose-invert">
                 {activeToolCalls.current.map((tc) => (
                   <ToolCallBadge key={`${tc.name}-${tc.arguments.slice(0, 20)}`} entry={tc} />
@@ -835,7 +824,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
                 {stream.text ? (
                   <ChatMarkdown content={stream.text} />
                 ) : (
-                  <div className="flex items-center gap-2 text-sm text-zinc-500">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-violet-500" />
                     <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-violet-500 [animation-delay:150ms]" />
                     <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-violet-500 [animation-delay:300ms]" />
@@ -856,7 +845,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
         )}
 
         {stream.error && !stream.isStreaming && (
-          <div className="mx-auto max-w-md rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          <div className="mx-auto max-w-md rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
             <p className="font-medium">Something went wrong</p>
             <p className="mt-1 text-xs">{stream.error}</p>
             <div className="mt-3 flex items-center gap-3">
@@ -864,12 +853,12 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
                 <button
                   type="button"
                   onClick={handleRetry}
-                  className="rounded-md bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/40 dark:text-red-300 dark:hover:bg-red-900/60"
+                  className="rounded-md bg-error/15 px-3 py-1.5 text-xs font-medium text-error transition-colors hover:bg-error/25"
                 >
                   Retry
                 </button>
               )}
-              <p className="text-xs text-red-500">Contact support@revealui.com if this persists.</p>
+              <p className="text-xs text-error">Contact support@revealui.com if this persists.</p>
             </div>
           </div>
         )}
@@ -878,17 +867,17 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
       </div>
 
       {/* Input area */}
-      <div className="border-t border-zinc-200 bg-white px-3 py-3 sm:px-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="border-t border-border bg-card px-3 py-3 sm:px-4">
         <div className="mx-auto mb-2 flex max-w-3xl items-center gap-2">
-          <div className="flex items-center rounded-md border border-zinc-200 dark:border-zinc-700">
+          <div className="flex items-center rounded-md border border-border">
             <button
               type="button"
               onClick={() => setAgentMode('admin')}
               disabled={stream.isStreaming}
               className={`rounded-l-md px-2.5 py-1 text-xs font-medium transition-colors ${
                 agentMode === 'admin'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-zinc-50 text-zinc-500 hover:bg-zinc-100 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:text-foreground'
               }`}
             >
               admin
@@ -899,14 +888,14 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
               disabled={stream.isStreaming}
               className={`rounded-r-md px-2.5 py-1 text-xs font-medium transition-colors ${
                 agentMode === 'coding'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-zinc-50 text-zinc-500 hover:bg-zinc-100 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:text-foreground'
               }`}
             >
               Coding
             </button>
           </div>
-          <label htmlFor="model-select" className="text-xs text-zinc-400">
+          <label htmlFor="model-select" className="text-xs text-muted-foreground">
             Model
           </label>
           <select
@@ -914,7 +903,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
             value={selectedModel}
             onChange={(e) => setSelectedModel(e.target.value)}
             disabled={stream.isStreaming}
-            className="rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs text-zinc-600 outline-none focus:border-blue-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+            className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
           >
             {MODEL_OPTIONS.map((opt) => (
               <option key={opt.id} value={opt.id}>
@@ -923,7 +912,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
             ))}
           </select>
           {selectedModel !== 'auto' && (
-            <span className="hidden text-xs text-zinc-400 sm:inline">
+            <span className="hidden text-xs text-muted-foreground sm:inline">
               {MODEL_OPTIONS.find((m) => m.id === selectedModel)?.model || 'default'}
             </span>
           )}
@@ -931,7 +920,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
         <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl items-end gap-2 sm:gap-3">
           <textarea
             ref={textareaRef}
-            className="flex-1 resize-none rounded-xl border border-zinc-300 bg-zinc-50 px-3 py-2.5 text-sm outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-400/20 sm:px-4 sm:py-3 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+            className="flex-1 resize-none rounded-xl border border-border bg-muted px-3 py-2.5 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20 sm:px-4 sm:py-3"
             value={input}
             onChange={handleTextareaChange}
             onKeyDown={handleKeyDown}
@@ -947,7 +936,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
             <button
               type="button"
               onClick={stream.abort}
-              className="shrink-0 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-600 sm:px-5 sm:py-3"
+              className="shrink-0 rounded-xl bg-error px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 sm:px-5 sm:py-3"
             >
               Stop
             </button>
@@ -955,13 +944,13 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
             <button
               type="submit"
               disabled={!input.trim()}
-              className="shrink-0 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 sm:px-5 sm:py-3"
+              className="shrink-0 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40 sm:px-5 sm:py-3"
             >
               Send
             </button>
           )}
         </form>
-        <p className="mx-auto mt-2 max-w-3xl text-center text-xs text-zinc-400">
+        <p className="mx-auto mt-2 max-w-3xl text-center text-xs text-muted-foreground">
           Enter to send &middot; Shift+Enter for new line &middot; Esc to stop &middot; AI may make
           mistakes
         </p>

--- a/apps/admin/src/lib/components/DataPanel/index.tsx
+++ b/apps/admin/src/lib/components/DataPanel/index.tsx
@@ -56,13 +56,13 @@ export function DataPanel({
   const getStatusColor = () => {
     switch (status) {
       case 'healthy':
-        return 'bg-green-500';
+        return 'bg-success';
       case 'warning':
-        return 'bg-yellow-500';
+        return 'bg-warning';
       case 'critical':
-        return 'bg-red-500';
+        return 'bg-error';
       default:
-        return 'bg-gray-500';
+        return 'bg-muted-foreground';
     }
   };
 
@@ -77,15 +77,15 @@ export function DataPanel({
     return (
       <output
         ref={ref as React.Ref<HTMLOutputElement>}
-        className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}
+        className={`bg-card rounded-lg shadow p-6 ${className}`}
         style={style}
         aria-label={ariaLabel || `${title} panel`}
         data-status={status}
         aria-busy="true"
       >
         <div className="animate-pulse">
-          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-4"></div>
-          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
+          <div className="h-4 bg-foreground/10 rounded w-1/2 mb-4"></div>
+          <div className="h-8 bg-foreground/10 rounded w-3/4"></div>
         </div>
       </output>
     );
@@ -95,13 +95,13 @@ export function DataPanel({
     return (
       <div
         ref={ref}
-        className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}
+        className={`bg-card rounded-lg shadow p-6 ${className}`}
         style={style}
         role="alert"
         aria-label={ariaLabel || `${title} panel`}
         data-status={status}
       >
-        <div className="text-red-500">
+        <div className="text-error">
           <svg
             className="w-6 h-6 mb-2"
             fill="none"
@@ -129,7 +129,7 @@ export function DataPanel({
   return (
     <Component
       ref={ref as React.Ref<HTMLDivElement & HTMLButtonElement>}
-      className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 transition-all ${
+      className={`bg-card rounded-lg shadow p-6 transition-all ${
         onClick ? 'cursor-pointer hover:shadow-lg hover:scale-105' : ''
       } ${className}`}
       style={style}
@@ -146,10 +146,7 @@ export function DataPanel({
         data-status={status}
         tabIndex={onClick ? 0 : undefined}
       >
-        <h3
-          id={panelId}
-          className="text-sm font-medium text-gray-600 dark:text-gray-400 break-words"
-        >
+        <h3 id={panelId} className="text-sm font-medium text-muted-foreground break-words">
           {title}
         </h3>
         <div className="flex items-center gap-2">
@@ -159,16 +156,14 @@ export function DataPanel({
       </div>
 
       <div className="flex items-baseline gap-2 mb-2">
-        <p className="text-3xl font-bold text-gray-900 dark:text-white break-all">
-          {formatValue(value)}
-        </p>
-        {unit && <span className="text-sm text-gray-600 dark:text-gray-400">{unit}</span>}
+        <p className="text-3xl font-bold text-foreground break-all">{formatValue(value)}</p>
+        {unit && <span className="text-sm text-muted-foreground">{unit}</span>}
       </div>
 
       {trend !== undefined && (
         <output
           className={`flex items-center text-sm ${
-            trend > 0 ? 'text-green-600' : trend < 0 ? 'text-red-600' : 'text-gray-600'
+            trend > 0 ? 'text-success' : trend < 0 ? 'text-error' : 'text-muted-foreground'
           }`}
           aria-live="polite"
         >

--- a/apps/admin/src/lib/components/ErrorBoundary/index.tsx
+++ b/apps/admin/src/lib/components/ErrorBoundary/index.tsx
@@ -75,11 +75,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       // Default error UI
       return (
-        <div className="my-16 p-6 border border-red-500 rounded-lg bg-red-50">
+        <div className="my-16 p-6 border border-error/30 rounded-lg bg-error/10">
           <div className="flex flex-col gap-4">
             <div>
-              <h2 className="text-lg font-semibold text-red-800 mb-2">Something went wrong</h2>
-              <p className="text-red-700">
+              <h2 className="text-lg font-semibold text-error mb-2">Something went wrong</h2>
+              <p className="text-error">
                 An unexpected error occurred while rendering this component. Please try refreshing
                 the page. Contact support@revealui.com if this persists.
               </p>
@@ -87,15 +87,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
             {process.env.NODE_ENV === 'development' && this.state.error && (
               <details className="mt-4">
-                <summary className="cursor-pointer text-sm font-medium text-red-800 mb-2">
+                <summary className="cursor-pointer text-sm font-medium text-error mb-2">
                   Error Details (Development Only)
                 </summary>
-                <div className="mt-2 p-4 bg-red-100 rounded border border-red-300">
-                  <p className="text-sm font-mono text-red-900 mb-2">
-                    {this.state.error.toString()}
-                  </p>
+                <div className="mt-2 p-4 bg-error/15 rounded border border-error/30">
+                  <p className="text-sm font-mono text-error mb-2">{this.state.error.toString()}</p>
                   {this.state.errorInfo && (
-                    <pre className="text-xs text-red-800 overflow-auto">
+                    <pre className="text-xs text-error overflow-auto">
                       {this.state.errorInfo.componentStack}
                     </pre>
                   )}
@@ -105,7 +103,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
             <button
               onClick={this.handleReset}
-              className="self-start px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+              className="self-start px-4 py-2 bg-error text-primary-foreground rounded hover:bg-error/90 transition-colors"
               type="button"
             >
               Try Again

--- a/apps/admin/src/lib/components/LicenseGate.tsx
+++ b/apps/admin/src/lib/components/LicenseGate.tsx
@@ -29,7 +29,7 @@ export function LicenseGate({ feature, children, mode = 'inline' }: LicenseGateP
     return (
       <div className="flex min-h-[40vh] items-center justify-center">
         <div
-          className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700 dark:border-zinc-600 dark:border-t-zinc-200"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-foreground/10 border-t-foreground"
           aria-hidden="true"
         />
       </div>
@@ -45,7 +45,7 @@ export function LicenseGate({ feature, children, mode = 'inline' }: LicenseGateP
           <div className="pointer-events-none select-none blur-sm" aria-hidden="true">
             {children}
           </div>
-          <div className="absolute inset-0 flex items-start justify-center pt-12 bg-white/60 dark:bg-zinc-950/60">
+          <div className="absolute inset-0 flex items-start justify-center pt-12 bg-background/60">
             <div className="max-w-lg w-full">
               <UpgradePrompt feature={feature} />
             </div>

--- a/apps/admin/src/lib/components/SystemHealthMonitor/index.tsx
+++ b/apps/admin/src/lib/components/SystemHealthMonitor/index.tsx
@@ -115,17 +115,17 @@ export function SystemHealthMonitor({
   const getStatusColor = (status: string): string => {
     switch (status) {
       case 'running':
-        return 'text-green-400';
+        return 'text-success';
       case 'completed':
-        return 'text-blue-400';
+        return 'text-primary';
       case 'failed':
-        return 'text-red-400';
+        return 'text-error';
       case 'zombie':
-        return 'text-yellow-400';
+        return 'text-warning-foreground';
       case 'killed':
-        return 'text-orange-400';
+        return 'text-warning-foreground';
       default:
-        return 'text-gray-400';
+        return 'text-muted-foreground';
     }
   };
 
@@ -135,9 +135,9 @@ export function SystemHealthMonitor({
 
   if (isLoading) {
     return (
-      <div className="h-full bg-gray-900 flex items-center justify-center">
-        <div className="text-center text-gray-400">
-          <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-2"></div>
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-2"></div>
           <p>Loading health metrics...</p>
         </div>
       </div>
@@ -146,11 +146,11 @@ export function SystemHealthMonitor({
 
   if (error) {
     return (
-      <div className="h-full bg-gray-900 flex items-center justify-center">
-        <div className="text-center text-red-400">
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center text-error">
           <div className="text-4xl mb-2">⚠️</div>
           <p className="font-medium">Health monitoring unavailable</p>
-          <p className="text-sm text-gray-500 mt-1">{error}</p>
+          <p className="text-sm text-muted-foreground mt-1">{error}</p>
         </div>
       </div>
     );
@@ -161,14 +161,18 @@ export function SystemHealthMonitor({
   }
 
   return (
-    <div className="h-full bg-gray-900 flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden">
       {/* Header with staleness */}
       {lastUpdated && (
-        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2">
-          <span className="text-xs text-zinc-500">System Health</span>
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <span className="text-xs text-muted-foreground">System Health</span>
           <span
             className={`text-xs ${
-              staleness > 30 ? 'text-red-400' : staleness > 10 ? 'text-amber-400' : 'text-zinc-500'
+              staleness > 30
+                ? 'text-error'
+                : staleness > 10
+                  ? 'text-warning-foreground'
+                  : 'text-muted-foreground'
             }`}
           >
             {staleness > 30
@@ -183,34 +187,38 @@ export function SystemHealthMonitor({
         <div className="space-y-4">
           {/* System Metrics Cards */}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="bg-gray-800 rounded-lg p-3">
-              <div className="text-xs text-gray-400 mb-1">Memory</div>
-              <div className="text-xl font-semibold text-white">{metrics.system.memoryUsage}MB</div>
+            <div className="bg-card rounded-lg p-3">
+              <div className="text-xs text-muted-foreground mb-1">Memory</div>
+              <div className="text-xl font-semibold text-foreground">
+                {metrics.system.memoryUsage}MB
+              </div>
             </div>
-            <div className="bg-gray-800 rounded-lg p-3">
-              <div className="text-xs text-gray-400 mb-1">CPU</div>
-              <div className="text-xl font-semibold text-white">
+            <div className="bg-card rounded-lg p-3">
+              <div className="text-xs text-muted-foreground mb-1">CPU</div>
+              <div className="text-xl font-semibold text-foreground">
                 {metrics.system.cpuUsage.toFixed(1)}%
               </div>
             </div>
-            <div className="bg-gray-800 rounded-lg p-3">
-              <div className="text-xs text-gray-400 mb-1">Uptime</div>
-              <div className="text-xl font-semibold text-white">
+            <div className="bg-card rounded-lg p-3">
+              <div className="text-xs text-muted-foreground mb-1">Uptime</div>
+              <div className="text-xl font-semibold text-foreground">
                 {formatUptime(metrics.system.uptime)}
               </div>
             </div>
-            <div className="bg-gray-800 rounded-lg p-3">
-              <div className="text-xs text-gray-400 mb-1">Processes</div>
-              <div className="text-xl font-semibold text-white">{metrics.processes.active}</div>
+            <div className="bg-card rounded-lg p-3">
+              <div className="text-xs text-muted-foreground mb-1">Processes</div>
+              <div className="text-xl font-semibold text-foreground">
+                {metrics.processes.active}
+              </div>
             </div>
           </div>
 
           {/* Alerts */}
           {metrics.alerts.length > 0 && (
-            <div className="bg-gray-800 rounded-lg p-4">
-              <h3 className="text-white font-medium mb-3 flex items-center gap-2">
+            <div className="bg-card rounded-lg p-4">
+              <h3 className="text-foreground font-medium mb-3 flex items-center gap-2">
                 <span>Active Alerts</span>
-                <span className="bg-red-500 text-white text-xs px-2 py-0.5 rounded-full">
+                <span className="bg-error text-primary-foreground text-xs px-2 py-0.5 rounded-full">
                   {metrics.alerts.length}
                 </span>
               </h3>
@@ -220,15 +228,15 @@ export function SystemHealthMonitor({
                     key={`alert-${alert.timestamp}-${alert.level}-${alert.message}`}
                     className={`p-3 rounded ${
                       alert.level === 'critical'
-                        ? 'bg-red-900/20 border border-red-800'
-                        : 'bg-yellow-900/20 border border-yellow-800'
+                        ? 'bg-error/10 border border-error/30'
+                        : 'bg-warning/15 border border-warning/30'
                     }`}
                   >
                     <div className="flex items-start gap-2">
                       <span className="text-lg">{getAlertIcon(alert.level)}</span>
                       <div className="flex-1">
-                        <p className="text-white text-sm">{alert.message}</p>
-                        <p className="text-gray-400 text-xs mt-1">
+                        <p className="text-foreground text-sm">{alert.message}</p>
+                        <p className="text-muted-foreground text-xs mt-1">
                           {formatTimestamp(alert.timestamp)}
                         </p>
                       </div>
@@ -240,54 +248,58 @@ export function SystemHealthMonitor({
           )}
 
           {/* Process Statistics */}
-          <div className="bg-gray-800 rounded-lg p-4">
-            <h3 className="text-white font-medium mb-3">Process Statistics</h3>
+          <div className="bg-card rounded-lg p-4">
+            <h3 className="text-foreground font-medium mb-3">Process Statistics</h3>
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
-                <span className="text-gray-400">Active Processes:</span>
-                <span className="text-green-400 font-medium">{metrics.processes.active}</span>
+                <span className="text-muted-foreground">Active Processes:</span>
+                <span className="text-success font-medium">{metrics.processes.active}</span>
               </div>
               <div className="flex justify-between text-sm">
-                <span className="text-gray-400">Zombies:</span>
+                <span className="text-muted-foreground">Zombies:</span>
                 <span
                   className={
-                    metrics.processes.zombies > 0 ? 'text-yellow-400 font-medium' : 'text-gray-400'
+                    metrics.processes.zombies > 0
+                      ? 'text-warning-foreground font-medium'
+                      : 'text-muted-foreground'
                   }
                 >
                   {metrics.processes.zombies}
                 </span>
               </div>
               <div className="flex justify-between text-sm">
-                <span className="text-gray-400">Failed:</span>
+                <span className="text-muted-foreground">Failed:</span>
                 <span
                   className={
-                    metrics.processes.failed > 0 ? 'text-red-400 font-medium' : 'text-gray-400'
+                    metrics.processes.failed > 0
+                      ? 'text-error font-medium'
+                      : 'text-muted-foreground'
                   }
                 >
                   {metrics.processes.failed}
                 </span>
               </div>
               <div className="flex justify-between text-sm">
-                <span className="text-gray-400">Spawn Rate:</span>
-                <span className="text-blue-400 font-medium">{metrics.processes.spawnRate}/min</span>
+                <span className="text-muted-foreground">Spawn Rate:</span>
+                <span className="text-primary font-medium">{metrics.processes.spawnRate}/min</span>
               </div>
             </div>
 
             {/* Process by Source */}
-            <div className="mt-4 pt-4 border-t border-gray-700">
-              <h4 className="text-white text-sm font-medium mb-2">By Source</h4>
+            <div className="mt-4 pt-4 border-t border-border">
+              <h4 className="text-foreground text-sm font-medium mb-2">By Source</h4>
               <div className="space-y-2">
                 {Object.entries(metrics.processes.bySource).map(([source, count]) => {
                   if (count === 0) return null;
                   return (
                     <div key={source} className="flex items-center gap-2">
-                      <div className="flex-1 bg-gray-700 rounded-full h-2 overflow-hidden">
+                      <div className="flex-1 bg-foreground/10 rounded-full h-2 overflow-hidden">
                         <div
-                          className="bg-blue-500 h-full rounded-full"
+                          className="bg-primary h-full rounded-full"
                           style={{ width: `${(count / metrics.processes.active) * 100}%` }}
                         />
                       </div>
-                      <div className="text-xs text-gray-400 w-20 text-right">
+                      <div className="text-xs text-muted-foreground w-20 text-right">
                         {source}: {count}
                       </div>
                     </div>
@@ -299,32 +311,36 @@ export function SystemHealthMonitor({
 
           {/* Database Pools */}
           {(metrics.database.rest.length > 0 || metrics.database.vector.length > 0) && (
-            <div className="bg-gray-800 rounded-lg p-4">
-              <h3 className="text-white font-medium mb-3">Database Pools</h3>
+            <div className="bg-card rounded-lg p-4">
+              <h3 className="text-foreground font-medium mb-3">Database Pools</h3>
               <div className="space-y-3">
                 {metrics.database.rest.map((pool) => (
                   <div key={pool.name} className="text-sm">
                     <div className="flex justify-between mb-1">
-                      <span className="text-gray-400">REST: {pool.name}</span>
-                      <span className="text-white">
+                      <span className="text-muted-foreground">REST: {pool.name}</span>
+                      <span className="text-foreground">
                         {pool.totalCount - pool.idleCount}/{pool.totalCount} active
                       </span>
                     </div>
                     {pool.waitingCount > 0 && (
-                      <div className="text-yellow-400 text-xs">{pool.waitingCount} waiting</div>
+                      <div className="text-warning-foreground text-xs">
+                        {pool.waitingCount} waiting
+                      </div>
                     )}
                   </div>
                 ))}
                 {metrics.database.vector.map((pool) => (
                   <div key={pool.name} className="text-sm">
                     <div className="flex justify-between mb-1">
-                      <span className="text-gray-400">Vector: {pool.name}</span>
-                      <span className="text-white">
+                      <span className="text-muted-foreground">Vector: {pool.name}</span>
+                      <span className="text-foreground">
                         {pool.totalCount - pool.idleCount}/{pool.totalCount} active
                       </span>
                     </div>
                     {pool.waitingCount > 0 && (
-                      <div className="text-yellow-400 text-xs">{pool.waitingCount} waiting</div>
+                      <div className="text-warning-foreground text-xs">
+                        {pool.waitingCount} waiting
+                      </div>
                     )}
                   </div>
                 ))}
@@ -334,14 +350,14 @@ export function SystemHealthMonitor({
 
           {/* Process List */}
           {showProcessList && (
-            <div className="bg-gray-800 rounded-lg p-4">
+            <div className="bg-card rounded-lg p-4">
               <div className="flex justify-between items-center mb-3">
-                <h3 className="text-white font-medium">Recent Processes</h3>
+                <h3 className="text-foreground font-medium">Recent Processes</h3>
                 <div className="flex gap-2">
                   <select
                     value={selectedSource}
                     onChange={(e) => setSelectedSource(e.target.value)}
-                    className="bg-gray-700 text-white text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="bg-muted text-foreground text-xs rounded px-2 py-1 border border-border focus:outline-none focus:ring-1 focus:ring-ring"
                   >
                     <option value="all">All Sources</option>
                     <option value="exec">Exec</option>
@@ -353,7 +369,7 @@ export function SystemHealthMonitor({
                   <select
                     value={selectedStatus}
                     onChange={(e) => setSelectedStatus(e.target.value)}
-                    className="bg-gray-700 text-white text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="bg-muted text-foreground text-xs rounded px-2 py-1 border border-border focus:outline-none focus:ring-1 focus:ring-ring"
                   >
                     <option value="all">All Status</option>
                     <option value="running">Running</option>
@@ -366,36 +382,41 @@ export function SystemHealthMonitor({
               <div className="overflow-x-auto">
                 <table className="w-full text-xs">
                   <thead>
-                    <tr className="border-b border-gray-600">
-                      <th className="text-left text-gray-400 font-medium py-2 px-2">PID</th>
-                      <th className="text-left text-gray-400 font-medium py-2 px-2">Command</th>
-                      <th className="text-left text-gray-400 font-medium py-2 px-2">Source</th>
-                      <th className="text-left text-gray-400 font-medium py-2 px-2">Status</th>
-                      <th className="text-left text-gray-400 font-medium py-2 px-2">Started</th>
+                    <tr className="border-b border-border">
+                      <th className="text-left text-muted-foreground font-medium py-2 px-2">PID</th>
+                      <th className="text-left text-muted-foreground font-medium py-2 px-2">
+                        Command
+                      </th>
+                      <th className="text-left text-muted-foreground font-medium py-2 px-2">
+                        Source
+                      </th>
+                      <th className="text-left text-muted-foreground font-medium py-2 px-2">
+                        Status
+                      </th>
+                      <th className="text-left text-muted-foreground font-medium py-2 px-2">
+                        Started
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
                     {processes.length === 0 ? (
                       <tr>
-                        <td colSpan={5} className="text-center text-gray-500 py-4">
+                        <td colSpan={5} className="text-center text-muted-foreground py-4">
                           No processes found
                         </td>
                       </tr>
                     ) : (
                       processes.map((process) => (
-                        <tr
-                          key={process.pid}
-                          className="border-b border-gray-700 hover:bg-gray-700/50"
-                        >
-                          <td className="py-2 px-2 text-gray-300">{process.pid}</td>
-                          <td className="py-2 px-2 text-gray-300 truncate max-w-xs">
+                        <tr key={process.pid} className="border-b border-border hover:bg-muted">
+                          <td className="py-2 px-2 text-muted-foreground">{process.pid}</td>
+                          <td className="py-2 px-2 text-muted-foreground truncate max-w-xs">
                             {process.command} {process.args.slice(0, 2).join(' ')}
                           </td>
-                          <td className="py-2 px-2 text-gray-300">{process.source}</td>
+                          <td className="py-2 px-2 text-muted-foreground">{process.source}</td>
                           <td className={`py-2 px-2 ${getStatusColor(process.status)}`}>
                             {process.status}
                           </td>
-                          <td className="py-2 px-2 text-gray-400">
+                          <td className="py-2 px-2 text-muted-foreground">
                             {formatTimestamp(process.startTime)}
                           </td>
                         </tr>
@@ -409,19 +430,19 @@ export function SystemHealthMonitor({
 
           {/* Recent Zombies */}
           {metrics.recentZombies.length > 0 && (
-            <div className="bg-gray-800 rounded-lg p-4">
-              <h3 className="text-white font-medium mb-3">Recent Zombie Processes</h3>
+            <div className="bg-card rounded-lg p-4">
+              <h3 className="text-foreground font-medium mb-3">Recent Zombie Processes</h3>
               <div className="space-y-2">
                 {metrics.recentZombies.slice(0, 5).map((zombie, index) => (
                   <div
                     key={zombie.pid || `zombie-${index}`}
-                    className="flex justify-between text-sm bg-yellow-900/20 border border-yellow-800 rounded p-2"
+                    className="flex justify-between text-sm bg-warning/15 border border-warning/30 rounded p-2"
                   >
                     <div>
-                      <span className="text-yellow-400 font-medium">PID {zombie.pid}</span>
-                      <span className="text-gray-400 ml-2">{zombie.command}</span>
+                      <span className="text-warning-foreground font-medium">PID {zombie.pid}</span>
+                      <span className="text-muted-foreground ml-2">{zombie.command}</span>
                     </div>
-                    <span className="text-gray-500 text-xs">
+                    <span className="text-muted-foreground text-xs">
                       {formatTimestamp(zombie.detectedAt)}
                     </span>
                   </div>

--- a/apps/admin/src/lib/components/SystemHealthPanel/index.tsx
+++ b/apps/admin/src/lib/components/SystemHealthPanel/index.tsx
@@ -75,26 +75,26 @@ export function SystemHealthPanel({
   const getStatusColor = (status: HealthStatus) => {
     switch (status) {
       case 'healthy':
-        return 'bg-green-500';
+        return 'bg-success';
       case 'warning':
-        return 'bg-yellow-500';
+        return 'bg-warning';
       case 'critical':
-        return 'bg-red-500';
+        return 'bg-error';
       default:
-        return 'bg-gray-500';
+        return 'bg-muted';
     }
   };
 
   const getStatusTextColor = (status: HealthStatus) => {
     switch (status) {
       case 'healthy':
-        return 'text-green-600 dark:text-green-400';
+        return 'text-success';
       case 'warning':
-        return 'text-yellow-600 dark:text-yellow-400';
+        return 'text-warning-foreground';
       case 'critical':
-        return 'text-red-600 dark:text-red-400';
+        return 'text-error';
       default:
-        return 'text-gray-600 dark:text-gray-400';
+        return 'text-muted-foreground';
     }
   };
 
@@ -111,21 +111,18 @@ export function SystemHealthPanel({
     return (
       <div
         ref={ref}
-        className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}
+        className={`bg-card rounded-lg shadow p-6 ${className}`}
         role="status"
         aria-live="polite"
         aria-label="Loading system health data"
         aria-busy="true"
       >
         <div className="animate-pulse">
-          <div
-            className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-1/3 mb-4"
-            data-skeleton="true"
-          ></div>
+          <div className="h-6 bg-foreground/10 rounded w-1/3 mb-4" data-skeleton="true"></div>
           <div className="space-y-3">
-            <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" data-skeleton="true"></div>
-            <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" data-skeleton="true"></div>
-            <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" data-skeleton="true"></div>
+            <div className="h-16 bg-foreground/10 rounded" data-skeleton="true"></div>
+            <div className="h-16 bg-foreground/10 rounded" data-skeleton="true"></div>
+            <div className="h-16 bg-foreground/10 rounded" data-skeleton="true"></div>
           </div>
         </div>
       </div>
@@ -136,16 +133,16 @@ export function SystemHealthPanel({
     return (
       <div
         ref={ref}
-        className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}
+        className={`bg-card rounded-lg shadow p-6 ${className}`}
         role="alert"
         aria-live="assertive"
       >
-        <div className="text-red-500">
+        <div className="text-error">
           <h2 className="text-lg font-semibold mb-2">Error Loading Health Data</h2>
           <p className="mb-4">{error}</p>
           <button
             onClick={onRetry}
-            className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded transition-colors disabled:opacity-50"
+            className="bg-error text-primary-foreground hover:bg-error/90 px-4 py-2 rounded transition-colors disabled:opacity-50"
             type="button"
             disabled={!onRetry}
           >
@@ -158,18 +155,18 @@ export function SystemHealthPanel({
 
   if (!data || Object.keys(data.checks).length === 0) {
     return (
-      <div ref={ref} className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}>
+      <div ref={ref} className={`bg-card rounded-lg shadow p-6 ${className}`}>
         <h2 className="text-lg font-semibold mb-4">System Health</h2>
-        <p className="text-gray-600 dark:text-gray-400">No health checks available</p>
+        <p className="text-muted-foreground">No health checks available</p>
       </div>
     );
   }
 
   return (
-    <div ref={ref} className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 ${className}`}>
+    <div ref={ref} className={`bg-card rounded-lg shadow p-6 ${className}`}>
       <div className="mb-6">
         <div className="flex items-center justify-between mb-2">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">System Health</h2>
+          <h2 className="text-lg font-semibold text-foreground">System Health</h2>
           <div className="flex items-center gap-2">
             <span
               className={`text-sm font-medium ${getStatusTextColor(data.status || 'healthy')}`}
@@ -184,7 +181,7 @@ export function SystemHealthPanel({
             />
           </div>
         </div>
-        <p className="text-xs text-gray-600 dark:text-gray-400">
+        <p className="text-xs text-muted-foreground">
           Last updated: {formatTimestamp(lastUpdated)}
         </p>
       </div>
@@ -194,7 +191,7 @@ export function SystemHealthPanel({
           <button
             key={name}
             type="button"
-            className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer w-full text-left"
+            className="border border-border rounded-lg p-4 hover:bg-muted transition-colors cursor-pointer w-full text-left"
             onClick={() => toggleCheck(name)}
             aria-expanded={expandedChecks[name]}
             aria-label={`${name} health check: ${check.status}`}
@@ -208,23 +205,20 @@ export function SystemHealthPanel({
                 />
                 <div className="flex items-center gap-2">
                   <span
-                    className="font-medium text-gray-900 dark:text-white capitalize"
+                    className="font-medium text-foreground capitalize"
                     data-testid={`${name}-check-name`}
                   >
                     {name}
                   </span>
                   {check.latency !== undefined && (
-                    <span
-                      className="text-sm text-gray-600 dark:text-gray-400"
-                      data-testid={`${name}-latency`}
-                    >
+                    <span className="text-sm text-muted-foreground" data-testid={`${name}-latency`}>
                       ({check.latency} ms)
                     </span>
                   )}
                 </div>
               </div>
               <svg
-                className={`w-5 h-5 text-gray-400 transition-transform ${expandedChecks[name] ? 'rotate-180' : ''}`}
+                className={`w-5 h-5 text-muted-foreground transition-transform ${expandedChecks[name] ? 'rotate-180' : ''}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -240,9 +234,9 @@ export function SystemHealthPanel({
             </div>
 
             {expandedChecks[name] && (
-              <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-600">
-                <p className="text-sm text-gray-600 dark:text-gray-400">{check.message}</p>
-                <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-500 dark:text-gray-500">
+              <div className="mt-3 pt-3 border-t border-border">
+                <p className="text-sm text-muted-foreground">{check.message}</p>
+                <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
                   <div>
                     <span className="font-medium">Status:</span> {check.status}
                   </div>

--- a/apps/admin/src/lib/components/UpgradeDialog.tsx
+++ b/apps/admin/src/lib/components/UpgradeDialog.tsx
@@ -80,11 +80,7 @@ export function UpgradeDialog() {
           : 'Unlock more features by upgrading your plan.'}
       </DialogDescription>
       <DialogBody>
-        {error && (
-          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
-            {error}
-          </div>
-        )}
+        {error && <div className="mb-4 rounded-md bg-error/10 p-3 text-sm text-error">{error}</div>}
         <PricingTable
           tiers={upgradeTiers}
           currentTier={tier ?? 'free'}
@@ -95,7 +91,7 @@ export function UpgradeDialog() {
       <DialogActions>
         <Link
           href="/upgrade"
-          className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+          className="text-sm font-medium text-primary hover:underline"
           onClick={handleClose}
         >
           View full pricing
@@ -103,7 +99,7 @@ export function UpgradeDialog() {
         <button
           type="button"
           onClick={handleClose}
-          className="rounded-md px-3 py-2 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
+          className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
         >
           Maybe later
         </button>

--- a/apps/admin/src/lib/components/agents/agent-contexts.tsx
+++ b/apps/admin/src/lib/components/agents/agent-contexts.tsx
@@ -27,7 +27,7 @@ export function AgentContexts({ agentId }: AgentContextsProps) {
     return (
       <div
         role="alert"
-        className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+        className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
       >
         Failed to load agent contexts
       </div>
@@ -41,33 +41,37 @@ export function AgentContexts({ agentId }: AgentContextsProps) {
         role="status"
         aria-label="Loading contexts"
       >
-        <div className="h-3 w-3 animate-spin rounded-full border border-zinc-600 border-t-zinc-300" />
+        <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-foreground" />
       </div>
     );
   }
 
   if (agentContexts.length === 0) {
     return (
-      <p className="py-4 text-center text-sm text-zinc-600">No active contexts for this agent.</p>
+      <p className="py-4 text-center text-sm text-muted-foreground">
+        No active contexts for this agent.
+      </p>
     );
   }
 
   return (
     <ul className="space-y-2">
       {agentContexts.map((ctx) => (
-        <li key={ctx.id} className="rounded-lg border border-zinc-800 p-3">
+        <li key={ctx.id} className="rounded-lg border border-border p-3">
           <div className="mb-1.5 flex items-center gap-2">
-            <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-400">
+            <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
               priority {ctx.priority}
             </span>
-            <span className="text-xs text-zinc-600">{formatRelativeTime(ctx.created_at)}</span>
+            <span className="text-xs text-muted-foreground">
+              {formatRelativeTime(ctx.created_at)}
+            </span>
           </div>
           {Object.keys(ctx.context).length > 0 ? (
-            <pre className="overflow-auto rounded bg-zinc-950 p-2 font-mono text-xs text-zinc-300">
+            <pre className="overflow-auto rounded bg-muted p-2 font-mono text-xs text-muted-foreground">
               {JSON.stringify(ctx.context, null, 2)}
             </pre>
           ) : (
-            <p className="text-xs text-zinc-600">empty context</p>
+            <p className="text-xs text-muted-foreground">empty context</p>
           )}
         </li>
       ))}

--- a/apps/admin/src/lib/components/agents/agent-memory.tsx
+++ b/apps/admin/src/lib/components/agents/agent-memory.tsx
@@ -23,14 +23,14 @@ interface EnrichedMemory {
 }
 
 const MEMORY_TYPE_LABELS: Record<string, MemoryTypeInfo> = {
-  episodic: { label: 'Episodic', color: 'text-blue-400 bg-blue-500/10' },
-  semantic: { label: 'Semantic', color: 'text-purple-400 bg-purple-500/10' },
-  working: { label: 'Working', color: 'text-amber-400 bg-amber-500/10' },
+  episodic: { label: 'Episodic', color: 'text-primary bg-primary/10' },
+  semantic: { label: 'Semantic', color: 'text-accent-foreground bg-accent/10' },
+  working: { label: 'Working', color: 'text-warning-foreground bg-warning/15' },
 } as const;
 
 const FALLBACK_TYPE_INFO: MemoryTypeInfo = {
   label: '',
-  color: 'text-zinc-400 bg-zinc-500/10',
+  color: 'text-muted-foreground bg-muted',
 };
 
 function isMemoryExpired(expiresAt: string | null | undefined): boolean {
@@ -95,7 +95,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
     return (
       <div
         role="alert"
-        className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-400"
+        className="rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
       >
         Failed to load agent memory
       </div>
@@ -110,7 +110,9 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
           type="button"
           onClick={() => setFilter(null)}
           className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            filter === null ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'
+            filter === null
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground'
           }`}
         >
           All ({memories.length})
@@ -121,7 +123,9 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
             type="button"
             onClick={() => setFilter(filter === type ? null : type)}
             className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-              filter === type ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'
+              filter === type
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground'
             }`}
           >
             {label} ({typeCounts[type] ?? 0})
@@ -129,7 +133,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
         ))}
         {isLoading && (
           <div
-            className="ml-auto h-3 w-3 animate-spin rounded-full border border-zinc-600 border-t-zinc-300"
+            className="ml-auto h-3 w-3 animate-spin rounded-full border border-border border-t-foreground"
             aria-hidden="true"
           />
         )}
@@ -137,7 +141,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
 
       {/* Memory list */}
       {sorted.length === 0 ? (
-        <p className="py-8 text-center text-sm text-zinc-600">
+        <p className="py-8 text-center text-sm text-muted-foreground">
           {isLoading ? 'Loading memories...' : 'No memories recorded yet.'}
         </p>
       ) : (
@@ -145,7 +149,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
           {sorted.map((memory) => (
             <li
               key={memory.id}
-              className={`group rounded-lg border border-zinc-800 p-3 transition-colors hover:border-zinc-700 ${
+              className={`group rounded-lg border border-border p-3 transition-colors hover:border-border ${
                 memory.isExpired ? 'opacity-50' : ''
               }`}
             >
@@ -157,18 +161,20 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
                     >
                       {memory.typeInfo.label}
                     </span>
-                    {memory.isExpired && <span className="text-xs text-zinc-600">expired</span>}
-                    <span className="text-xs text-zinc-600">
+                    {memory.isExpired && (
+                      <span className="text-xs text-muted-foreground">expired</span>
+                    )}
+                    <span className="text-xs text-muted-foreground">
                       {formatRelativeTime(memory.created_at)}
                     </span>
                   </div>
-                  <p className="text-sm text-zinc-300 line-clamp-3">{memory.content}</p>
+                  <p className="text-sm text-muted-foreground line-clamp-3">{memory.content}</p>
                 </div>
                 <button
                   type="button"
                   onClick={() => handleRemove(memory.id)}
                   disabled={removingId === memory.id}
-                  className="shrink-0 rounded p-1 text-zinc-600 opacity-0 transition-all hover:bg-zinc-800 hover:text-red-400 group-hover:opacity-100 disabled:opacity-50"
+                  className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-error group-hover:opacity-100 disabled:opacity-50"
                   title="Delete memory"
                   aria-label="Delete memory"
                 >

--- a/apps/admin/src/lib/components/agents/mcp-server-card.tsx
+++ b/apps/admin/src/lib/components/agents/mcp-server-card.tsx
@@ -30,18 +30,18 @@ export function McpServerCard({ server }: McpServerCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const statusColors = {
-    configured: 'bg-yellow-500/10 text-yellow-400',
-    active: 'bg-emerald-500/10 text-emerald-400',
-    unavailable: 'bg-red-500/10 text-red-400',
+    configured: 'bg-warning/15 text-warning-foreground',
+    active: 'bg-success/10 text-success',
+    unavailable: 'bg-error/10 text-error',
   };
 
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+    <div className="rounded-xl border border-border bg-card p-5">
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="font-semibold text-white">{server.name}</h3>
-          <p className="mt-0.5 font-mono text-xs text-zinc-500">
+          <h3 className="font-semibold text-foreground">{server.name}</h3>
+          <p className="mt-0.5 font-mono text-xs text-muted-foreground">
             {server.packageName ?? server.remoteUrl ?? server.id}
           </p>
         </div>
@@ -53,7 +53,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
       </div>
 
       {/* Description */}
-      <p className="mt-3 text-sm text-zinc-400">{server.description}</p>
+      <p className="mt-3 text-sm text-muted-foreground">{server.description}</p>
 
       {/* Required env vars */}
       {server.envRequired.length > 0 && (
@@ -61,7 +61,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
           {server.envRequired.map((envVar) => (
             <span
               key={envVar}
-              className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-400"
+              className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
             >
               {envVar}
             </span>
@@ -75,7 +75,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            className="flex w-full items-center justify-between rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
+            className="flex w-full items-center justify-between rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-foreground/10"
           >
             <span>{server.tools.length} tools</span>
             <svg
@@ -95,16 +95,18 @@ export function McpServerCard({ server }: McpServerCardProps) {
               {server.tools.map((tool) => (
                 <li
                   key={tool.name}
-                  className="flex items-start gap-3 rounded-lg px-3 py-2 hover:bg-zinc-800"
+                  className="flex items-start gap-3 rounded-lg px-3 py-2 hover:bg-muted"
                 >
-                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-zinc-500" />
+                  <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground" />
                   <div className="min-w-0">
-                    <span className="font-mono text-xs font-medium text-zinc-200">{tool.name}</span>
-                    <p className="mt-0.5 text-xs text-zinc-500 leading-relaxed">
+                    <span className="font-mono text-xs font-medium text-foreground">
+                      {tool.name}
+                    </span>
+                    <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
                       {tool.description}
                     </p>
                   </div>
-                  <span className="ml-auto shrink-0 text-xs text-zinc-600">
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
                     {tool.parameterCount}p
                   </span>
                 </li>

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -67,7 +67,7 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
     return (
       <div className="flex h-16 items-center justify-center">
         <div
-          className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-600 border-t-zinc-300"
+          className="h-4 w-4 animate-spin rounded-full border-2 border-border border-t-foreground"
           aria-hidden="true"
         />
       </div>
@@ -75,7 +75,7 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
   }
 
   if (rows.length === 0) {
-    return <p className="text-sm text-zinc-600">No tasks recorded yet.</p>;
+    return <p className="text-sm text-muted-foreground">No tasks recorded yet.</p>;
   }
 
   return (
@@ -86,23 +86,23 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
         const ts = new Date(row.startedAt).toLocaleString();
 
         return (
-          <li key={row.id} className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-3">
+          <li key={row.id} className="rounded-lg border border-border bg-card p-3">
             <div className="flex items-center justify-between gap-2">
               <StatusBadge status={row.status} />
-              <span className="ml-auto shrink-0 font-mono text-xs text-zinc-600">{ts}</span>
+              <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">{ts}</span>
               {row.durationMs != null && (
-                <span className="shrink-0 text-xs text-zinc-600">{row.durationMs}ms</span>
+                <span className="shrink-0 text-xs text-muted-foreground">{row.durationMs}ms</span>
               )}
             </div>
             {inputText && (
-              <p className="mt-2 truncate text-xs text-zinc-400">
-                <span className="text-zinc-600">in: </span>
+              <p className="mt-2 truncate text-xs text-muted-foreground">
+                <span className="text-muted-foreground">in: </span>
                 {inputText}
               </p>
             )}
             {outputText && (
-              <p className="mt-0.5 truncate text-xs text-zinc-300">
-                <span className="text-zinc-600">out: </span>
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                <span className="text-muted-foreground">out: </span>
                 {outputText}
               </p>
             )}
@@ -115,11 +115,11 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
 
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
-    completed: 'bg-emerald-500/10 text-emerald-400',
-    failed: 'bg-red-500/10 text-red-400',
-    cancelled: 'bg-zinc-600/20 text-zinc-400',
+    completed: 'bg-success/10 text-success',
+    failed: 'bg-error/10 text-error',
+    cancelled: 'bg-muted text-muted-foreground',
   };
-  const color = colors[status] ?? 'bg-zinc-700/20 text-zinc-400';
+  const color = colors[status] ?? 'bg-muted text-muted-foreground';
   return <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>{status}</span>;
 }
 

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -91,8 +91,11 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
   return (
     <div className="flex flex-col gap-4">
       <div>
-        <label htmlFor="instruction" className="block text-sm font-medium text-zinc-300 mb-1.5">
-          Send a task to <span className="text-white">{agentName}</span>
+        <label
+          htmlFor="instruction"
+          className="block text-sm font-medium text-muted-foreground mb-1.5"
+        >
+          Send a task to <span className="text-foreground">{agentName}</span>
         </label>
         <textarea
           id="instruction"
@@ -100,7 +103,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
           value={instruction}
           onChange={(e) => setInstruction(e.target.value)}
           placeholder={`Tell ${agentName} what to do...`}
-          className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none resize-none"
+          className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
         />
       </div>
 
@@ -108,7 +111,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
         type="button"
         onClick={submit}
         disabled={state === 'submitting' || state === 'polling' || !instruction.trim()}
-        className="self-start rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+        className="self-start rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {state === 'submitting' ? 'Sending...' : state === 'polling' ? 'Working...' : 'Send Task'}
       </button>
@@ -118,23 +121,27 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
         <div className="flex items-center gap-2">
           <TaskStateBadge state={task.status.state} />
           {task.id && (
-            <span className="font-mono text-xs text-zinc-500">task:{task.id.slice(0, 8)}</span>
+            <span className="font-mono text-xs text-muted-foreground">
+              task:{task.id.slice(0, 8)}
+            </span>
           )}
         </div>
       )}
 
       {/* Response */}
       {responseText && (
-        <div className="rounded-lg border border-zinc-700 bg-zinc-800 p-4">
-          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">Response</p>
-          <p className="whitespace-pre-wrap text-sm text-zinc-200">{responseText}</p>
+        <div className="rounded-lg border border-border bg-muted p-4">
+          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Response
+          </p>
+          <p className="whitespace-pre-wrap text-sm text-muted-foreground">{responseText}</p>
         </div>
       )}
 
       {/* Error */}
       {errorMsg && (
-        <div role="alert" className="rounded-lg border border-red-800 bg-red-900/20 p-4">
-          <p className="text-sm text-red-400">{errorMsg}</p>
+        <div role="alert" className="rounded-lg border border-error/30 bg-error/10 p-4">
+          <p className="text-sm text-error">{errorMsg}</p>
         </div>
       )}
     </div>
@@ -143,15 +150,15 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
 
 function TaskStateBadge({ state }: { state: string }) {
   const configs: Record<string, { label: string; color: string }> = {
-    submitted: { label: 'Submitted', color: 'bg-zinc-700 text-zinc-300' },
-    working: { label: 'Working', color: 'bg-blue-500/10 text-blue-400' },
-    'input-required': { label: 'Input Required', color: 'bg-yellow-500/10 text-yellow-400' },
-    completed: { label: 'Completed', color: 'bg-emerald-500/10 text-emerald-400' },
-    canceled: { label: 'Canceled', color: 'bg-zinc-600 text-zinc-400' },
-    failed: { label: 'Failed', color: 'bg-red-500/10 text-red-400' },
-    unknown: { label: 'Unknown', color: 'bg-zinc-700 text-zinc-400' },
+    submitted: { label: 'Submitted', color: 'bg-muted text-muted-foreground' },
+    working: { label: 'Working', color: 'bg-primary/10 text-primary' },
+    'input-required': { label: 'Input Required', color: 'bg-warning/15 text-warning-foreground' },
+    completed: { label: 'Completed', color: 'bg-success/10 text-success' },
+    canceled: { label: 'Canceled', color: 'bg-muted text-muted-foreground' },
+    failed: { label: 'Failed', color: 'bg-error/10 text-error' },
+    unknown: { label: 'Unknown', color: 'bg-muted text-muted-foreground' },
   };
-  const cfg = configs[state] ?? { label: state, color: 'bg-zinc-700 text-zinc-300' };
+  const cfg = configs[state] ?? { label: state, color: 'bg-muted text-muted-foreground' };
   return (
     <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${cfg.color}`}>{cfg.label}</span>
   );

--- a/apps/admin/src/lib/components/mcp/elicitation-form.tsx
+++ b/apps/admin/src/lib/components/mcp/elicitation-form.tsx
@@ -58,17 +58,19 @@ export function ArgumentField({ name, prop, required, value, onChange }: Argumen
 
   return (
     <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-muted-foreground">
         {name}
-        {required && <span className="ml-1 text-red-400">*</span>}
-        <span className="ml-2 font-mono text-[10px] text-zinc-500">{prop.type ?? 'string'}</span>
+        {required && <span className="ml-1 text-error">*</span>}
+        <span className="ml-2 font-mono text-[10px] text-muted-foreground">
+          {prop.type ?? 'string'}
+        </span>
       </label>
       {prop.enum && prop.enum.length > 0 ? (
         <select
           id={inputId}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <option value="">—</option>
           {prop.enum.map((opt) => (
@@ -85,10 +87,12 @@ export function ArgumentField({ name, prop, required, value, onChange }: Argumen
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           required={required}
-          className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
         />
       )}
-      {prop.description && <p className="mt-1 text-[11px] text-zinc-500">{prop.description}</p>}
+      {prop.description && (
+        <p className="mt-1 text-[11px] text-muted-foreground">{prop.description}</p>
+      )}
     </div>
   );
 }
@@ -152,14 +156,14 @@ export function ElicitationForm({ message, requestedSchema, onSubmit }: Elicitat
   return (
     <form
       onSubmit={handleAccept}
-      className="mt-4 rounded-md border border-blue-800 bg-blue-900/10 p-3"
+      className="mt-4 rounded-md border border-primary/30 bg-primary/10 p-3"
     >
       {message && (
         <div className="mb-3 flex items-center gap-2 text-xs">
-          <span className="rounded-full bg-blue-500/20 px-2 py-0.5 font-medium text-blue-300">
+          <span className="rounded-full bg-primary/15 px-2 py-0.5 font-medium text-primary">
             Server request
           </span>
-          <span className="text-blue-200">{message}</span>
+          <span className="text-primary">{message}</span>
         </div>
       )}
       <div className="space-y-3">
@@ -177,21 +181,21 @@ export function ElicitationForm({ message, requestedSchema, onSubmit }: Elicitat
       <div className="mt-3 flex items-center gap-2">
         <button
           type="submit"
-          className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+          className="rounded-md bg-success px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-success/90"
         >
           Accept
         </button>
         <button
           type="button"
           onClick={() => void onSubmit('decline')}
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
+          className="rounded-md border border-border bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
         >
           Decline
         </button>
         <button
           type="button"
           onClick={() => void onSubmit('cancel')}
-          className="rounded-md border border-red-800 bg-red-900/20 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-900/40"
+          className="rounded-md border border-error/30 bg-error/10 px-3 py-1.5 text-xs font-medium text-error transition-colors hover:bg-error/20"
         >
           Cancel
         </button>

--- a/apps/admin/src/lib/components/mcp/logs-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/logs-panel.tsx
@@ -137,8 +137,8 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-        <label htmlFor="log-level" className="text-xs font-medium text-zinc-300">
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
+        <label htmlFor="log-level" className="text-xs font-medium text-muted-foreground">
           Level
         </label>
         <select
@@ -146,7 +146,7 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
           value={level}
           onChange={(e) => setLevel(e.target.value as Level)}
           disabled={state === 'streaming' || state === 'connecting'}
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 font-mono text-xs text-white focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+          className="rounded-md border border-border bg-muted px-2 py-1 font-mono text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
         >
           {LEVELS.map((l) => (
             <option key={l} value={l}>
@@ -158,7 +158,7 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
           <button
             type="button"
             onClick={stop}
-            className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+            className="rounded-md border border-border bg-muted px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted"
           >
             Stop
           </button>
@@ -166,7 +166,7 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
           <button
             type="button"
             onClick={() => void start()}
-            className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+            className="rounded-md bg-success px-3 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-success/90"
           >
             Start
           </button>
@@ -175,18 +175,18 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
           type="button"
           onClick={() => setEntries([])}
           disabled={entries.length === 0}
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md border border-border bg-muted px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
         >
           Clear
         </button>
-        <div className="ml-auto text-xs text-zinc-500">
+        <div className="ml-auto text-xs text-muted-foreground">
           {state === 'streaming' && (
             <span className="inline-flex items-center gap-1.5">
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" /> streaming
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-success" /> streaming
             </span>
           )}
           {state === 'connecting' && <span>connecting…</span>}
-          {state === 'error' && <span className="text-red-400">error</span>}
+          {state === 'error' && <span className="text-error">error</span>}
           {state === 'idle' && <span>idle</span>}
           <span className="ml-3">{entries.length} entries</span>
         </div>
@@ -195,26 +195,26 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
       {message && (
         <div
           role="alert"
-          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+          className="rounded-lg border border-error/30 bg-error/10 p-3 text-xs text-error"
         >
           {message}
         </div>
       )}
 
       {entries.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
-          No log messages yet. Click <span className="font-medium text-zinc-300">Start</span> to
+        <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-xs text-muted-foreground">
+          No log messages yet. Click <span className="font-medium text-foreground">Start</span> to
           subscribe.
         </div>
       ) : (
-        <ul className="max-h-[60vh] space-y-0.5 overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 font-mono text-[11px]">
+        <ul className="max-h-[60vh] space-y-0.5 overflow-y-auto rounded-lg border border-border bg-muted p-3 font-mono text-[11px]">
           {entries.map((entry) => (
-            <li key={entry.at} className="text-zinc-200">
-              <span className="mr-2 text-zinc-500">
+            <li key={entry.at} className="text-foreground">
+              <span className="mr-2 text-muted-foreground">
                 [{new Date(entry.at).toISOString().slice(11, 19)}]
               </span>
               <span className={levelColor(entry.level)}>{entry.level}</span>
-              {entry.logger && <span className="ml-1 text-zinc-500">({entry.logger})</span>}{' '}
+              {entry.logger && <span className="ml-1 text-muted-foreground">({entry.logger})</span>}{' '}
               {typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data)}
             </li>
           ))}
@@ -230,13 +230,13 @@ function levelColor(level: string): string {
     case 'critical':
     case 'alert':
     case 'emergency':
-      return 'text-red-400';
+      return 'text-error';
     case 'warning':
-      return 'text-yellow-400';
+      return 'text-warning-foreground';
     case 'notice':
     case 'info':
-      return 'text-emerald-400';
+      return 'text-success';
     default:
-      return 'text-zinc-400';
+      return 'text-muted-foreground';
   }
 }

--- a/apps/admin/src/lib/components/mcp/prompts-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/prompts-panel.tsx
@@ -76,18 +76,18 @@ export function PromptsPanel({ tenant, server }: PromptsPanelProps) {
       {message && (
         <div
           role="alert"
-          className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+          className="rounded-lg border border-error/30 bg-error/10 p-3 text-xs text-error"
         >
           {message}
         </div>
       )}
       {state === 'loading' && (
-        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+        <div className="rounded-lg border border-dashed border-border bg-card p-4 text-center text-xs text-muted-foreground">
           Loading prompts…
         </div>
       )}
       {state === 'ready' && prompts.length === 0 && (
-        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+        <div className="rounded-lg border border-dashed border-border bg-card p-4 text-center text-xs text-muted-foreground">
           No prompts advertised.
         </div>
       )}
@@ -150,20 +150,22 @@ function PromptCard({ prompt, tenant, server }: PromptCardProps) {
   };
 
   return (
-    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <details className="group rounded-lg border border-border bg-card p-4">
       <summary className="flex cursor-pointer items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="font-mono text-sm font-semibold text-white">{prompt.name}</div>
+          <div className="font-mono text-sm font-semibold text-foreground">{prompt.name}</div>
           {prompt.description && (
-            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{prompt.description}</div>
+            <div className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+              {prompt.description}
+            </div>
           )}
         </div>
-        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
+        <span className="shrink-0 text-xs text-muted-foreground group-open:hidden">Expand</span>
       </summary>
 
       <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
         {args.length === 0 && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-muted-foreground">
             This prompt takes no arguments. Click <span className="font-medium">Resolve</span> to
             fetch its messages.
           </p>
@@ -184,11 +186,11 @@ function PromptCard({ prompt, tenant, server }: PromptCardProps) {
           <button
             type="submit"
             disabled={submitting}
-            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? 'Resolving…' : 'Resolve'}
           </button>
-          {error && <span className="text-xs text-red-400">{error}</span>}
+          {error && <span className="text-xs text-error">{error}</span>}
         </div>
       </form>
 
@@ -264,9 +266,9 @@ function PromptArgumentField({
 
   return (
     <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-zinc-300">
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-muted-foreground">
         {arg.name}
-        {arg.required && <span className="ml-1 text-red-400">*</span>}
+        {arg.required && <span className="ml-1 text-error">*</span>}
       </label>
       <input
         id={inputId}
@@ -276,7 +278,7 @@ function PromptArgumentField({
         list={suggestions.length > 0 ? listId : undefined}
         required={arg.required}
         autoComplete="off"
-        className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-white placeholder-zinc-500 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
       />
       {suggestions.length > 0 && (
         <datalist id={listId}>
@@ -285,7 +287,9 @@ function PromptArgumentField({
           ))}
         </datalist>
       )}
-      {arg.description && <p className="mt-1 text-[11px] text-zinc-500">{arg.description}</p>}
+      {arg.description && (
+        <p className="mt-1 text-[11px] text-muted-foreground">{arg.description}</p>
+      )}
     </div>
   );
 }
@@ -298,18 +302,20 @@ function PromptResult({ result }: { result: GetPromptResult }) {
   return (
     <div className="mt-4 space-y-3">
       {result.description && (
-        <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3 text-xs text-zinc-400">
+        <div className="rounded-md border border-border bg-card p-3 text-xs text-muted-foreground">
           {result.description}
         </div>
       )}
       {result.messages.map((msg, idx) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: messages have no id
-        <div key={idx} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
-          <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-wide text-zinc-500">
-            <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-zinc-300">{msg.role}</span>
-            <span className="text-zinc-600">{msg.content.type}</span>
+        <div key={idx} className="rounded-md border border-border bg-card p-3">
+          <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+            <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground">
+              {msg.role}
+            </span>
+            <span className="text-muted-foreground">{msg.content.type}</span>
           </div>
-          <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+          <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-foreground">
             {msg.content.type === 'text'
               ? (msg.content.text ?? '')
               : `[${msg.content.type}${msg.content.mimeType ? ` ${msg.content.mimeType}` : ''}]`}

--- a/apps/admin/src/lib/components/mcp/resources-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/resources-panel.tsx
@@ -98,23 +98,23 @@ export function ResourcesPanel({ tenant, server }: ResourcesPanelProps) {
         {message && (
           <div
             role="alert"
-            className="mb-3 rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300"
+            className="mb-3 rounded-lg border border-error/30 bg-error/10 p-3 text-xs text-error"
           >
             {message}
           </div>
         )}
         {state === 'loading' && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+          <div className="rounded-lg border border-dashed border-border bg-card p-4 text-center text-xs text-muted-foreground">
             Loading…
           </div>
         )}
         {state === 'ready' && resources.length === 0 && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-4 text-center text-xs text-zinc-500">
+          <div className="rounded-lg border border-dashed border-border bg-card p-4 text-center text-xs text-muted-foreground">
             No resources advertised.
           </div>
         )}
         {resources.length > 0 && (
-          <ul className="divide-y divide-zinc-800 overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/50">
+          <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card">
             {resources.map((r) => {
               const selected = r.uri === selectedUri;
               return (
@@ -124,12 +124,12 @@ export function ResourcesPanel({ tenant, server }: ResourcesPanelProps) {
                     onClick={() => void handleSelect(r.uri)}
                     className={`block w-full px-3 py-2 text-left transition-colors ${
                       selected
-                        ? 'bg-emerald-900/20 text-emerald-200'
-                        : 'text-zinc-300 hover:bg-zinc-800/60'
+                        ? 'bg-success/10 text-success'
+                        : 'text-muted-foreground hover:bg-muted'
                     }`}
                   >
                     <div className="truncate font-mono text-xs">{r.name || r.uri}</div>
-                    <div className="mt-0.5 truncate text-[10px] text-zinc-500">{r.uri}</div>
+                    <div className="mt-0.5 truncate text-[10px] text-muted-foreground">{r.uri}</div>
                   </button>
                 </li>
               );
@@ -140,44 +140,44 @@ export function ResourcesPanel({ tenant, server }: ResourcesPanelProps) {
 
       <div>
         {!selectedUri && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
+          <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-xs text-muted-foreground">
             Select a resource to preview its contents.
           </div>
         )}
         {selectedUri && previewState === 'loading' && (
-          <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-xs text-zinc-500">
+          <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-xs text-muted-foreground">
             Loading preview…
           </div>
         )}
         {selectedUri && previewState === 'error' && (
-          <div className="rounded-lg border border-red-800 bg-red-900/20 p-3 text-xs text-red-300">
+          <div className="rounded-lg border border-error/30 bg-error/10 p-3 text-xs text-error">
             {previewError}
           </div>
         )}
         {selectedUri && previewState === 'ready' && contents && (
           <div className="space-y-3">
-            <div className="rounded-md border border-zinc-800 bg-zinc-900/50 px-3 py-2 font-mono text-[10px] text-zinc-500">
+            <div className="rounded-md border border-border bg-card px-3 py-2 font-mono text-[10px] text-muted-foreground">
               {selectedUri}
             </div>
             {contents.length === 0 && (
-              <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-900/30 p-3 text-center text-xs text-zinc-500">
+              <div className="rounded-md border border-dashed border-border bg-card p-3 text-center text-xs text-muted-foreground">
                 (empty)
               </div>
             )}
             {contents.map((block, idx) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: content blocks have no id
-              <div key={idx} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
-                <div className="mb-2 text-[10px] text-zinc-500">
+              <div key={idx} className="rounded-md border border-border bg-card p-3">
+                <div className="mb-2 text-[10px] text-muted-foreground">
                   {block.mimeType ??
                     (block.text !== undefined ? 'text/plain' : 'application/octet-stream')}
                   {block.blob && ` · ${block.blob.length} base64 chars`}
                 </div>
                 {block.text !== undefined ? (
-                  <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-200">
+                  <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-foreground">
                     {block.text}
                   </pre>
                 ) : (
-                  <div className="font-mono text-[11px] text-zinc-500">
+                  <div className="font-mono text-[11px] text-muted-foreground">
                     (binary content — not rendered in preview)
                   </div>
                 )}

--- a/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
+++ b/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
@@ -263,20 +263,22 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
   };
 
   return (
-    <details className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <details className="group rounded-lg border border-border bg-card p-4">
       <summary className="flex cursor-pointer items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="font-mono text-sm font-semibold text-white">{tool.name}</div>
+          <div className="font-mono text-sm font-semibold text-foreground">{tool.name}</div>
           {tool.description && (
-            <div className="mt-0.5 line-clamp-1 text-xs text-zinc-400">{tool.description}</div>
+            <div className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+              {tool.description}
+            </div>
           )}
         </div>
-        <span className="shrink-0 text-xs text-zinc-500 group-open:hidden">Expand</span>
+        <span className="shrink-0 text-xs text-muted-foreground group-open:hidden">Expand</span>
       </summary>
 
       <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-3">
         {Object.keys(properties).length === 0 && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-muted-foreground">
             This tool takes no input. Click <span className="font-medium">Invoke</span> to call it.
           </p>
         )}
@@ -295,7 +297,7 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
           <button
             type="submit"
             disabled={invoking}
-            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {invoking ? 'Invoking…' : 'Invoke'}
           </button>
@@ -303,7 +305,7 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
             <button
               type="button"
               onClick={handleCancel}
-              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+              className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted"
             >
               Cancel
             </button>
@@ -322,7 +324,7 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
       {logs.length > 0 && <LogPanel logs={logs} />}
       {result && <ToolResult result={result} />}
       {error && (
-        <div className="mt-4 rounded-md border border-red-800 bg-red-900/20 p-3 text-xs text-red-300">
+        <div className="mt-4 rounded-md border border-error/30 bg-error/10 p-3 text-xs text-error">
           {error}
         </div>
       )}
@@ -344,8 +346,8 @@ function ProgressDisplay({
       ? Math.min(100, Math.round((progress.progress / progress.total) * 100))
       : undefined;
   return (
-    <div className="mt-4 rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
-      <div className="mb-1.5 flex items-center justify-between text-[10px] text-zinc-400">
+    <div className="mt-4 rounded-md border border-border bg-card p-3">
+      <div className="mb-1.5 flex items-center justify-between text-[10px] text-muted-foreground">
         <span>{progress.message ?? 'Progress'}</span>
         <span className="font-mono">
           {pct !== undefined
@@ -353,9 +355,9 @@ function ProgressDisplay({
             : `${progress.progress}${progress.total !== undefined ? ` / ${progress.total}` : ''}`}
         </span>
       </div>
-      <div className="h-1.5 overflow-hidden rounded-full bg-zinc-800">
+      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full bg-emerald-500 transition-all duration-200"
+          className="h-full bg-success transition-all duration-200"
           style={
             pct !== undefined ? { width: `${pct}%` } : { width: '33%', opacity: 0.6 } // indeterminate fallback
           }
@@ -371,18 +373,18 @@ function ProgressDisplay({
 
 function LogPanel({ logs }: { logs: LogEntry[] }) {
   return (
-    <details className="mt-4 rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
-      <summary className="cursor-pointer text-xs text-zinc-400">
-        Logs <span className="text-zinc-500">({logs.length})</span>
+    <details className="mt-4 rounded-md border border-border bg-card p-3">
+      <summary className="cursor-pointer text-xs text-muted-foreground">
+        Logs <span className="text-muted-foreground">({logs.length})</span>
       </summary>
       <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto font-mono text-[11px]">
         {logs.map((entry) => (
-          <li key={entry.at} className="text-zinc-200">
-            <span className="mr-2 text-zinc-500">
+          <li key={entry.at} className="text-foreground">
+            <span className="mr-2 text-muted-foreground">
               [{new Date(entry.at).toISOString().slice(11, 19)}]
             </span>
             <span className={levelColor(entry.level)}>{entry.level}</span>
-            {entry.logger && <span className="ml-1 text-zinc-500">({entry.logger})</span>}{' '}
+            {entry.logger && <span className="ml-1 text-muted-foreground">({entry.logger})</span>}{' '}
             {typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data)}
           </li>
         ))}
@@ -397,14 +399,14 @@ function levelColor(level: string): string {
     case 'critical':
     case 'alert':
     case 'emergency':
-      return 'text-red-400';
+      return 'text-error';
     case 'warning':
-      return 'text-yellow-400';
+      return 'text-warning-foreground';
     case 'notice':
     case 'info':
-      return 'text-emerald-400';
+      return 'text-success';
     default:
-      return 'text-zinc-400';
+      return 'text-muted-foreground';
   }
 }
 
@@ -417,8 +419,8 @@ function ToolResult({ result }: { result: CallToolResult }) {
     <div
       className={`mt-4 rounded-md border p-3 text-xs ${
         result.isError
-          ? 'border-red-800 bg-red-900/20 text-red-300'
-          : 'border-emerald-900 bg-emerald-900/10 text-emerald-200'
+          ? 'border-error/30 bg-error/10 text-error'
+          : 'border-success/30 bg-success/10 text-success'
       }`}
     >
       <div className="mb-2 font-medium">{result.isError ? 'Tool returned an error' : 'Result'}</div>

--- a/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
+++ b/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
@@ -54,7 +54,7 @@ interface StackedBarProps {
 function StackedBar({ successCount, errorCount, unknownCount }: StackedBarProps) {
   const total = successCount + errorCount + unknownCount;
   if (total === 0) {
-    return <div aria-hidden="true" className="h-2 w-full rounded-full bg-zinc-800" />;
+    return <div aria-hidden="true" className="h-2 w-full rounded-full bg-muted" />;
   }
   const successPct = (successCount / total) * 100;
   const errorPct = (errorCount / total) * 100;
@@ -66,13 +66,13 @@ function StackedBar({ successCount, errorCount, unknownCount }: StackedBarProps)
       aria-label={`${successCount} success, ${errorCount} error, ${unknownCount} unknown`}
       viewBox="0 0 100 4"
       preserveAspectRatio="none"
-      className="h-2 w-full overflow-hidden rounded-full bg-zinc-800"
+      className="h-2 w-full overflow-hidden rounded-full bg-muted"
     >
       {successPct > 0 && (
-        <rect x={0} y={0} width={successPct} height={4} className="fill-emerald-500" />
+        <rect x={0} y={0} width={successPct} height={4} className="fill-success" />
       )}
       {errorPct > 0 && (
-        <rect x={successPct} y={0} width={errorPct} height={4} className="fill-red-500" />
+        <rect x={successPct} y={0} width={errorPct} height={4} className="fill-error" />
       )}
       {unknownPct > 0 && (
         <rect
@@ -80,7 +80,7 @@ function StackedBar({ successCount, errorCount, unknownCount }: StackedBarProps)
           y={0}
           width={unknownPct}
           height={4}
-          className="fill-zinc-500"
+          className="fill-muted-foreground"
         />
       )}
     </svg>
@@ -125,13 +125,13 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
     <section aria-label="MCP usage">
       <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-lg font-medium text-white">Usage</h2>
-          <p className="mt-0.5 text-xs text-zinc-500">
+          <h2 className="text-lg font-medium text-foreground">Usage</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
             Per-meter call counts and durations from the events your MCP servers emit.
           </p>
         </div>
         <div
-          className="inline-flex rounded-md border border-zinc-800 bg-zinc-900/50 p-0.5"
+          className="inline-flex rounded-md border border-border bg-card p-0.5"
           role="toolbar"
           aria-label="Time range"
         >
@@ -142,7 +142,9 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
               onClick={() => setRange(r)}
               aria-pressed={range === r}
               className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
-                range === r ? 'bg-zinc-800 text-emerald-300' : 'text-zinc-400 hover:text-zinc-200'
+                range === r
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {r}
@@ -154,60 +156,64 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
       {message && (
         <div
           role="alert"
-          className="mb-4 rounded-lg border border-red-800 bg-red-900/20 p-3 text-sm text-red-300"
+          className="mb-4 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
         >
           {message}
         </div>
       )}
 
       {state === 'loading' && (
-        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+        <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
           Loading usage…
         </div>
       )}
 
       {state === 'ready' && data && data.meters.length === 0 && (
-        <div className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-center text-sm text-zinc-500">
+        <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
           No MCP usage in the {RANGE_LABELS[range].toLowerCase()}. Run an agent that calls an MCP
           tool, or wait for events to accumulate.
         </div>
       )}
 
       {state === 'ready' && data && data.meters.length > 0 && (
-        <div className="overflow-hidden rounded-lg border border-zinc-800">
+        <div className="overflow-hidden rounded-lg border border-border">
           <table className="w-full text-sm">
-            <thead className="bg-zinc-900/50">
+            <thead className="bg-card">
               <tr>
-                <th className="px-4 py-3 text-left font-medium text-zinc-400">Meter</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-400">Calls</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-400">Outcome mix</th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-400">p50</th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-400">p95</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Meter</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Calls</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                  Outcome mix
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">p50</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">p95</th>
               </tr>
             </thead>
             <tbody>
               {data.meters.map((m) => (
-                <tr key={m.meterName} className="border-t border-zinc-800/50 align-middle">
-                  <td className="px-4 py-3 font-mono text-xs text-zinc-300">{m.meterName}</td>
-                  <td className="px-4 py-3 text-zinc-300">{m.total.toLocaleString()}</td>
+                <tr key={m.meterName} className="border-t border-border align-middle">
+                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                    {m.meterName}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{m.total.toLocaleString()}</td>
                   <td className="min-w-48 px-4 py-3">
                     <StackedBar
                       successCount={m.successCount}
                       errorCount={m.errorCount}
                       unknownCount={m.unknownCount}
                     />
-                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-500">
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                       <span>
                         <span
                           aria-hidden="true"
-                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-emerald-500 align-middle"
+                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-success align-middle"
                         />
                         {m.successCount} ok
                       </span>
                       <span>
                         <span
                           aria-hidden="true"
-                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-red-500 align-middle"
+                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-error align-middle"
                         />
                         {m.errorCount} err
                       </span>
@@ -215,17 +221,17 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
                         <span>
                           <span
                             aria-hidden="true"
-                            className="mr-1 inline-block h-2 w-2 rounded-sm bg-zinc-500 align-middle"
+                            className="mr-1 inline-block h-2 w-2 rounded-sm bg-muted-foreground align-middle"
                           />
                           {m.unknownCount} unknown
                         </span>
                       )}
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-right font-mono text-xs text-zinc-300">
+                  <td className="px-4 py-3 text-right font-mono text-xs text-muted-foreground">
                     {formatDuration(m.p50Ms)}
                   </td>
-                  <td className="px-4 py-3 text-right font-mono text-xs text-zinc-300">
+                  <td className="px-4 py-3 text-right font-mono text-xs text-muted-foreground">
                     {formatDuration(m.p95Ms)}
                   </td>
                 </tr>
@@ -236,9 +242,9 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
       )}
 
       {state === 'ready' && data && (
-        <p className="mt-3 text-xs text-zinc-500">
+        <p className="mt-3 text-xs text-muted-foreground">
           {RANGE_LABELS[range]} · since {new Date(data.since).toLocaleString()} · account{' '}
-          <span className="font-mono text-zinc-400">{data.accountId ?? '—'}</span>
+          <span className="font-mono text-muted-foreground">{data.accountId ?? '—'}</span>
         </p>
       )}
     </section>


### PR DESCRIPTION
## Summary

Migrates the admin `(backend)` pages from raw dark-palette Tailwind utilities to cobalt semantic token classes, so the admin renders correctly on both OS-light and OS-dark.

## Why

The `(backend)` pages were authored as a fixed dark theme (raw `zinc`/`gray` backgrounds + light text, no `dark:` variants). Once the cobalt `@theme` bridge landed for the `(backend)` entry, the catalyst shell became theme-adaptive (light on OS-light, dark on OS-dark). On an OS-light machine the pages then rendered as dark islands on a white shell, and pages with bare text on a transparent root showed invisible white-on-white headings. There was no OS-dark contrast bug; the fix targets OS-light coherence and makes both themes correct.

## What changed

- 28 files (27 `(backend)` pages plus the revenue pilot), className-only.
- Surfaces: `bg-zinc/gray-900..950`, `bg-zinc-800/40` to `bg-card` / `bg-muted`; forced-dark page roots drop their bg and inherit the adaptive shell.
- Text: `text-white` to `text-foreground`; `text-zinc/gray-300..600` to `text-muted-foreground`.
- Borders: `border-zinc/gray-*` to `border-border`.
- Status/accent: emerald to `success`, red to `error`, yellow to `warning`, blue to `primary` (cobalt), violet to `accent`; tinted badges use `/10`.
- Solid status buttons use `text-primary-foreground` (white in both themes).
- Grooves and skeletons use `bg-foreground/10`.

## Left as-is

`welcome`, `upgrade`, `chat` already use `dark:` pairs and render correctly on both themes, so they were not touched.

## Design changes worth a review

- Text hierarchy collapses from 4 shades to the 2 bridged text tiers (`foreground` / `muted-foreground`).
- Decorative KPI hues become brand-semantic: blue to cobalt, violet to amber.
- Card elevation unified to `bg-card`.
- Status badges become theme-adaptive (light-tinted chips on OS-light).

## Verification

- className-only, confirmed by diff review and a logic canary (no logic, JSX, props, types, or imports changed).
- Biome clean; no leftover raw palette classes; no invalid token utilities.
- Pending: visual QA on both OS themes via the test preview, plus CI typecheck and build.

Draft until both-theme visual QA passes on the preview.
