### PR TITLE
release: promote test to main (marketing repositioning + env cleanup)

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -89,16 +89,6 @@ NEXT_PRIVATE_STRIPE_PUBLISHABLE_KEY=pk_test_...
 # Expose live/test mode to the client (used for the test-mode banner):
 NEXT_PUBLIC_IS_LIVE=false
 
-# -----------------------------------------------------------------------------
-# Draft / Preview
-# -----------------------------------------------------------------------------
-REVEALUI_PUBLIC_DRAFT_SECRET=your-draft-secret-min-32-chars
-NEXT_PRIVATE_REVEALUI_DRAFT_SECRET=your-draft-secret-min-32-chars
-
-# Revalidation key for on-demand ISR
-REVEALUI_REVALIDATION_KEY=your-revalidation-key-min-32-chars
-NEXT_PRIVATE_REVEALUI_REVALIDATION_KEY=your-revalidation-key-min-32-chars
-
 # Public seed flag (controls whether DB seed runs in this env)
 # REVEALUI_PUBLIC_SEED=false
 

--- a/apps/marketing/app/components/landing/Actors.tsx
+++ b/apps/marketing/app/components/landing/Actors.tsx
@@ -1,0 +1,41 @@
+// Three-actors explainer. Defines developer / operator / agent before the
+// audience fork uses those roles. Rendered between <Hero /> and <Fork /> in
+// HomePage.tsx so the hero's "agents" is defined within one scroll.
+
+import { HOME_ACTORS } from '../../content/home';
+
+export function Actors() {
+  return (
+    <section aria-label="Who does what in RevealUI" className="bg-background py-12 sm:py-16">
+      <div className="mx-auto max-w-5xl px-6 lg:px-8">
+        <div className="text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {HOME_ACTORS.eyebrow}
+          </p>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            {HOME_ACTORS.heading}
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            {HOME_ACTORS.body}
+          </p>
+        </div>
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {HOME_ACTORS.actors.map((actor) => (
+            <div
+              key={actor.role}
+              className="rounded-2xl border border-border bg-card p-6 text-left shadow-sm"
+            >
+              <h3 className="text-lg font-semibold leading-7 text-foreground">
+                <span className="text-primary">{actor.role}</span> {actor.action}
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{actor.body}</p>
+            </div>
+          ))}
+        </div>
+        <p className="mt-8 text-center text-base font-medium text-foreground">
+          {HOME_ACTORS.tagline}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
-import { HOME_FORK } from '../home';
+import { HOME_ACTORS, HOME_FORK } from '../home';
 import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
 import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
 import { METRICS, SITE } from '../site';
@@ -112,6 +112,24 @@ describe('marketing content contracts', () => {
     it('the navigating branches each carry an href', () => {
       expect(HOME_FORK.branchB.href.length).toBeGreaterThan(0);
       expect(HOME_FORK.branchC.href.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('three actors', () => {
+    it('defines exactly three actors, each fully populated', () => {
+      expect(HOME_ACTORS.actors).toHaveLength(3);
+      for (const actor of HOME_ACTORS.actors) {
+        expect(actor.role.length, 'empty role').toBeGreaterThan(0);
+        expect(actor.action.length, 'empty action').toBeGreaterThan(0);
+        expect(actor.body.length, 'empty body').toBeGreaterThan(0);
+      }
+    });
+
+    it('names developer, operator, and agent', () => {
+      const roles = HOME_ACTORS.actors.map((a) => a.role.toLowerCase());
+      expect(roles.some((r) => r.includes('develop'))).toBe(true);
+      expect(roles.some((r) => r.includes('operator'))).toBe(true);
+      expect(roles.some((r) => r.includes('agent'))).toBe(true);
     });
   });
 });

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -241,6 +241,44 @@ export const HOME_GET_STARTED = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Three actors (cast explainer)
+// Defines the three roles the rest of the copy assumes: developer, operator,
+// agent. Two human roles (build, run) plus the AI role (work inside). Sits
+// between the hero and the audience fork so "agents" in the hero h1 is defined
+// within one scroll, before the visitor self-identifies in the fork below.
+// ---------------------------------------------------------------------------
+
+export interface Actor {
+  readonly role: string;
+  readonly action: string;
+  readonly body: string;
+}
+
+export const HOME_ACTORS = {
+  eyebrow: 'Who does what',
+  heading: 'Three actors, one runtime.',
+  body: 'RevealUI runs people and AI under one set of rules: the same permissions and the same tamper-evident audit trail.',
+  actors: [
+    {
+      role: 'Developers',
+      action: 'build it.',
+      body: 'Install RevealUI, write the code, own the stack.',
+    },
+    {
+      role: 'Operators',
+      action: 'run it.',
+      body: 'Log into the admin to manage customers, content, and billing. No code required.',
+    },
+    {
+      role: 'Agents',
+      action: 'work inside it.',
+      body: 'An agent is an AI that works through the same APIs you do: read and update your data, send notifications, look up customers and billing. Every action runs under the same permissions and the same audit trail as a person.',
+    },
+  ] as readonly Actor[],
+  tagline: 'Developers build it. Operators run it. Agents work in it.',
+} as const;
+
+// ---------------------------------------------------------------------------
 // Homepage audience fork
 // Per spec-2026-05-14-non-technical-lane.md §4.3 (Phase 2 of the spec sequence).
 // Three equal-weight branches; visitor self-identifies before the technical-lane

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -17,10 +17,11 @@ import type { Cta, FaqItem } from './types';
 
 export const HOME_HERO = {
   eyebrow: 'Open source. Self-hostable. Audit-ready.',
-  h1: 'Five primitives. One runtime for humans and agents.',
+  h1: 'Run your whole business on one runtime you own.',
   subtitle: {
-    strong: 'An open-source framework. The business logic every product needs, pre-wired.',
-    body: 'Spin up a working app — users, Stripe payments, an admin dashboard, and an AI agent layer, all sharing one login and one audit trail. Build it yourself',
+    strong:
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
+    body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
     agencyHref: SITE.urls.agency,
@@ -63,7 +64,7 @@ export const HOME_HERO = {
         detail: 'Source-visible, non-compete. Auto-converts to MIT 2 years after each release.',
       },
       {
-        metric: 'Same login. Same audit chain. Same API.',
+        metric: 'Same permissions. Same audit chain. Same API.',
         detail:
           'One permission model and one tamper-evident chain — for your team and your agents alike. See the [architecture](https://docs.revealui.com/architecture).',
       },

--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -53,7 +53,7 @@ export const MARKETPLACE_DISCOVERY_STEPS: readonly DiscoveryStep[] = [
     step: '2',
     title: 'Authenticate',
     description:
-      'The agent authenticates using the same RBAC system that governs human users. Permissions are scoped per tenant and per role.',
+      'The agent authenticates using the same RBAC system that governs your users. Permissions are scoped per tenant and per role.',
   },
   {
     step: '3',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -101,7 +101,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     forAgents: {
       headline: 'RBAC governs agent access per tenant',
       description:
-        'Every agent action is scoped by the same role and permission system that governs human users. Audit logs track every agent operation with full attribution.',
+        'Every agent action is scoped by the same role and permission system that governs your users. Audit logs track every agent operation with full attribution.',
     },
     together: {
       headline: 'Set permissions once. Agents respect them automatically.',
@@ -196,7 +196,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     together: {
       headline: 'Humans monetize. Agents transact. One billing infrastructure.',
       description:
-        'Human customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
+        'Your customers pay through Stripe. Agent payments via x402 are in development. Both flows are designed to settle into the same revenue system.',
     },
     features: [
       'Stripe checkout and subscriptions',

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '../components/Footer';
 import { GetStarted } from '../components/GetStarted';
+import { Actors } from '../components/landing/Actors';
 import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
 import { Fork } from '../components/landing/Fork';
@@ -15,6 +16,7 @@ export function HomePage() {
   return (
     <div className="min-h-screen bg-background">
       <Hero />
+      <Actors />
       <Fork />
       <Problem />
       <Demo />

--- a/docs/CREDENTIAL-ROTATION-RUNBOOK.md
+++ b/docs/CREDENTIAL-ROTATION-RUNBOOK.md
@@ -9,7 +9,7 @@ Cross-reference `docs/ENVIRONMENT-VARIABLES-GUIDE.md` for env var details.
 
 | Cadence | Credentials |
 |---------|------------|
-| **90 days** | REVEALUI_SECRET, REVEALUI_KEK*, REVEALUI_LICENSE_ENCRYPTION_KEY*, REVEALUI_CRON_SECRET, REVEALUI_PUBLIC_DRAFT_SECRET, REVEALUI_REVALIDATION_KEY, REVEALUI_ADMIN_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, TAVILY_API_KEY, HF_TOKEN, VERCEL_API_KEY, RESEND_API_KEY, NEON_API_KEY, MCP_API_KEY |
+| **90 days** | REVEALUI_SECRET, REVEALUI_KEK*, REVEALUI_LICENSE_ENCRYPTION_KEY*, REVEALUI_CRON_SECRET, REVEALUI_ADMIN_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, TAVILY_API_KEY, HF_TOKEN, VERCEL_API_KEY, RESEND_API_KEY, NEON_API_KEY, MCP_API_KEY |
 | **Quarterly** | STRIPE_SECRET_KEY, GOOGLE_CLIENT_SECRET, GOOGLE_PRIVATE_KEY, GITHUB_CLIENT_SECRET, REVEALUI_GITHUB_TOKEN, SENTRY_AUTH_TOKEN, SUPABASE_SERVICE_ROLE_KEY, ELECTRIC_API_KEY, ELECTRIC_DATABASE_URL (password) |
 | **Annually** | REVEALUI_LICENSE_PRIVATE_KEY (Ed25519 pair), GOOGLE_CLIENT_ID, GITHUB_CLIENT_ID, VERCEL_CLIENT_ID, YOUTUBE_API_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY |
 | **As-needed** | STRIPE_WEBHOOK_SECRET (endpoint change), REVFORGE_LICENSE_KEY (renewal), X402_RECEIVING_ADDRESS (wallet change), POSTGRES_URL (provider migration) |
@@ -74,18 +74,14 @@ revvault set revealui/env/core REVEALUI_SECRET "$NEW_SECRET"
 
 **Impact:** Every logged-in user is signed out. Schedule during low-traffic window and communicate.
 
-#### REVEALUI_CRON_SECRET / REVEALUI_PUBLIC_DRAFT_SECRET / REVEALUI_REVALIDATION_KEY
+#### REVEALUI_CRON_SECRET
 
 ```bash
-# All follow the same pattern: generate, update, redeploy
 openssl rand -hex 32  # → new value
 revvault set revealui/env/cron REVEALUI_CRON_SECRET "$(openssl rand -hex 32)"
-revvault set revealui/env/core REVEALUI_PUBLIC_DRAFT_SECRET "$(openssl rand -hex 32)"
-revvault set revealui/env/core REVEALUI_REVALIDATION_KEY "$(openssl rand -hex 32)"
-# Update paired NEXT_PRIVATE_ variants in Vercel too
 ```
 
-**Impact:** DRAFT_SECRET invalidates existing preview links. CRON_SECRET requires updating cron job headers.
+**Impact:** CRON_SECRET requires updating cron job headers.
 
 #### REVEALUI_ADMIN_API_KEY (inter-service auth)
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -80,8 +80,6 @@ revealui/prod/marketplace-connect-return-url  # MARKETPLACE_CONNECT_RETURN_URL
 revealui/prod/admin/api-key          # REVEALUI_ADMIN_API_KEY
 revealui/prod/admin/email            # REVEALUI_ADMIN_EMAIL
 revealui/prod/admin/password         # REVEALUI_ADMIN_PASSWORD
-revealui/prod/admin/revalidation-key # REVEALUI_REVALIDATION_KEY
-revealui/prod/admin/draft-secret     # REVEALUI_PUBLIC_DRAFT_SECRET
 ```
 
 **Database**
@@ -145,13 +143,6 @@ revealui/prod/license/public-key    # REVEALUI_LICENSE_PUBLIC_KEY — rotating i
 revealui/prod/passkey/origin    # PASSKEY_ORIGIN
 revealui/prod/passkey/rp-id     # PASSKEY_RP_ID
 revealui/prod/passkey/rp-name   # PASSKEY_RP_NAME
-```
-
-**CMS**
-
-```
-revealui/prod/cms/admin-email     # CMS_ADMIN_EMAIL
-revealui/prod/cms/admin-password  # CMS_ADMIN_PASSWORD
 ```
 
 **Observability (Sentry)**

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -82,9 +82,7 @@ Safe to loop (effect on redeploy only; `revealui/prod/secret` also invalidates a
 for p in \
   revealui/prod/secret \
   revealui/prod/cron-secret \
-  revealui/prod/admin/api-key \
-  revealui/prod/admin/revalidation-key \
-  revealui/prod/admin/draft-secret ; do
+  revealui/prod/admin/api-key ; do
   revvault generate "$p" --force --length 48 --no-symbols --no-ambiguous && echo "rotated $p"
 done
 ```
@@ -93,7 +91,6 @@ Rotate **individually, with awareness** (each has a side effect):
 revvault generate revealui/prod/audit-hmac-secret --force --length 48 --no-symbols --no-ambiguous
 #   ↑ pre-rotation audit-log HMACs stop verifying
 revvault generate revealui/prod/admin/password     --force --length 32 --no-ambiguous
-revvault generate revealui/prod/cms/admin-password --force --length 32 --no-ambiguous
 #   ↑ admin login changes — retrieve the new value from revvault to log in
 revvault generate revealui/prod/electric/secret    --force --length 48 --no-symbols --no-ambiguous
 #   ↑ ALSO set the Electric service to the same value, or realtime sync breaks
@@ -146,8 +143,8 @@ Stripe price IDs (`*-price-id`) + `agent-meter-event-name` · passkey `origin`/`
 all `NEXT_PUBLIC_*` + `public/server-url` + `public/api-url` + `public/is-live` ·
 `session-cookie-domain` · `cors-origin` · `email/from` + `email/reply-to` · `alert-email` ·
 `marketplace-connect-return-url` · `electric/service-url` · `sentry/org` + `sentry/project*` +
-`sentry/dsn*` (DSNs are embeddable) · `google/service-account-email` · `admin/email` +
-`cms/admin-email` · `VERCEL_ORG_ID`.
+`sentry/dsn*` (DSNs are embeddable) · `google/service-account-email` · `admin/email` ·
+`VERCEL_ORG_ID`.
 
 ## See also
 - [`vercel-env-sync.md`](./vercel-env-sync.md) — day-to-day single-secret sync workflow

--- a/scripts/secrets/rotate.ts
+++ b/scripts/secrets/rotate.ts
@@ -6,7 +6,7 @@
  * Prints a rotation checklist for the given secret name and generates a new value.
  *
  * Usage:
- *   pnpm secrets:rotate CMS_ADMIN_PASSWORD
+ *   pnpm secrets:rotate REVEALUI_ADMIN_PASSWORD
  *   pnpm secrets:rotate STRIPE_SECRET_KEY
  */
 
@@ -26,7 +26,7 @@ const secretName = process.argv[2];
 
 if (!secretName) {
   console.error('Usage: pnpm secrets:rotate <SECRET_NAME>');
-  console.error('Example: pnpm secrets:rotate CMS_ADMIN_PASSWORD');
+  console.error('Example: pnpm secrets:rotate REVEALUI_ADMIN_PASSWORD');
   process.exit(1);
 }
 

--- a/scripts/setup/environment.ts
+++ b/scripts/setup/environment.ts
@@ -54,8 +54,6 @@ function parseArgs(): SetupOptions {
 // Variables that can be generated automatically from crypto
 const AUTO_GENERATE: Record<string, () => string> = {
   REVEALUI_SECRET: () => generateSecret(32),
-  REVEALUI_PUBLIC_DRAFT_SECRET: () => generateSecret(32),
-  REVEALUI_REVALIDATION_KEY: () => generateSecret(32),
   REVEALUI_ADMIN_PASSWORD: () => generatePassword(16),
 };
 

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -212,10 +212,6 @@ REVEALUI_API_URL           = "revealui/prod/public/api-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
 REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 
-# CMS bootstrap creds (canonical paths under cms/)
-CMS_ADMIN_EMAIL    = "revealui/prod/cms/admin-email"
-CMS_ADMIN_PASSWORD = "revealui/prod/cms/admin-password"
-
 # Observability — Sentry (Next.js admin; DSN is client-bundled via NEXT_PUBLIC_,
 # auth-token + org + project are build-time for source-map upload via withSentryConfig)
 NEXT_PUBLIC_SENTRY_DSN = "revealui/prod/sentry/dsn-admin"
@@ -227,8 +223,6 @@ SENTRY_PROJECT         = "revealui/prod/sentry/project-admin"
 REVEALUI_ADMIN_EMAIL         = "revealui/prod/admin/email"
 REVEALUI_ADMIN_PASSWORD      = "revealui/prod/admin/password"
 REVEALUI_ADMIN_API_KEY       = "revealui/prod/admin/api-key"
-REVEALUI_REVALIDATION_KEY    = "revealui/prod/admin/revalidation-key"
-REVEALUI_PUBLIC_DRAFT_SECRET = "revealui/prod/admin/draft-secret"
 
 
 # ── revealui-marketing ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Promote `test` -> `main` (production release)

Ships the 4 commits on `test` not yet on `main`:

| PR | Change |
| --- | --- |
| #1197 | Marketing hero reframe: lead with the commerce + white-label + self-host runtime (the uncontested differentiator from the 20-vendor scan); humans+agents demoted to a supporting clause on the tamper-evident audit chain |
| #1194 | Homepage "three actors" band defining developer / operator / agent, with code-verified (truthful) agent capabilities |
| #1192 | Warmth pass: "human users/customers" -> "your users/customers" |
| #1191 | Retire 4 unconsumed env vars from the sync manifest + docs (config/docs cleanup; the vars were unread and the Vercel deletion already applied) |

## Production impact

- **Marketing (revealui.com)** redeploys with the new hero, the three-actors band, and the warmer copy.
- No database migrations, no auth or security behavior changes, no breaking API changes.
- #1191 has no runtime impact (removes dead references to already-deleted, unconsumed env vars).

Merge with a merge commit to preserve each PR's history on `main`.
