### PR TITLE
fix(marketing): align index.html title/meta with the reframed hero

### DIFF
--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -9,28 +9,28 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RevealUI | Build a business your agents can run.</title>
-    <meta name="description" content="Auth, billing, content, and AI primitives wired into one runtime — so the same APIs your users hit, your agents hit too." />
-    <meta name="keywords" content="open source, agent-native, AI agents, business runtime, auth, billing, CMS, admin dashboard, MCP, Stripe, self-hostable, RevealUI, RevVault, RevKit" />
+    <title>RevealUI | Run your whole business on one runtime you own.</title>
+    <meta name="description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
+    <meta name="keywords" content="open source, self-hostable, multi-tenant, white-label, business runtime, auth, content, products, payments, billing, admin dashboard, AI agents, MCP, Stripe, RevealUI, RevVault, RevKit" />
     <meta name="author" content="RevealUI Studio" />
     <link rel="canonical" href="https://revealui.com" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="RevealUI | Build a business your agents can run." />
-    <meta property="og:description" content="Auth, billing, content, and AI primitives wired into one runtime — so the same APIs your users hit, your agents hit too." />
+    <meta property="og:title" content="RevealUI | Run your whole business on one runtime you own." />
+    <meta property="og:description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
     <meta property="og:url" content="https://revealui.com" />
     <meta property="og:site_name" content="RevealUI" />
-    <meta property="og:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Build%20a%20business%20your%20agents%20can%20run." />
+    <meta property="og:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own." />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="RevealUI | Build a business your agents can run." />
+    <meta property="og:image:alt" content="RevealUI | Run your whole business on one runtime you own." />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="RevealUI | Build a business your agents can run." />
-    <meta name="twitter:description" content="Auth, billing, content, and AI primitives wired into one runtime — so the same APIs your users hit, your agents hit too." />
-    <meta name="twitter:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Build%20a%20business%20your%20agents%20can%20run." />
+    <meta name="twitter:title" content="RevealUI | Run your whole business on one runtime you own." />
+    <meta name="twitter:description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
+    <meta name="twitter:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own." />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## What

Aligns the static SEO/social meta in `apps/marketing/index.html` with the reframed hero (#1197, now live on revealui.com). The `<title>`, meta description, keywords, Open Graph, and Twitter tags still led with the old agent-first positioning, so the browser tab, Google snippet, and every shared-link preview contradicted the page.

## Before -> after

| Tag | Before | After |
| --- | --- | --- |
| title / og:title / twitter:title / og:image:alt | "RevealUI \| Build a business your agents can run." | "RevealUI \| Run your whole business on one runtime you own." |
| description / og / twitter | "...wired into one runtime, so the same APIs your users hit, your agents hit too." | "Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." |
| og:image / twitter:image | `...description=Build%20a%20business%20your%20agents%20can%20run.` | `...description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.` |
| keywords | leads with "agent-native, AI agents" | leads with "self-hostable, multi-tenant, white-label, ... payments"; AI agents kept |

## Why

The hero now leads with the commerce + white-label + self-host runtime (the uncontested differentiator from the 20-vendor scan). The social card image, search snippet, and tab title are the first impression for shared links and SEO; they should not still say "build a business your agents can run."

## Scope

- `apps/marketing/index.html` only. Grep confirmed no other surface (llms.txt, content config) carries the old tagline.
- Static HTML, no logic. Truthful: every claim is shipped (self-host, the four primitives including payments, per-client white-label stamping).
- Note: this fixes the mismatch on `test`. The live mismatch on revealui.com clears when this rides a `test -> main` promotion.
