### PR TITLE
release: promote test -> main (docs #1203 + admin cobalt shell, email boot-hardening, marketing)

### DIFF
--- a/apps/docs/__tests__/lib/search-index.test.ts
+++ b/apps/docs/__tests__/lib/search-index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { extractExcerpt, extractTitle, listSearchDocPaths } from '../../app/lib/search-index';
+
+describe('extractTitle', () => {
+  it('returns the first ATX H1', () => {
+    expect(extractTitle('# Hello World\n\nbody text')).toBe('Hello World');
+  });
+
+  it('ignores h2+ and bare hashes, finding the real H1', () => {
+    expect(extractTitle('## Subhead\n\n# Real Title')).toBe('Real Title');
+  });
+
+  it('returns an empty string when there is no H1', () => {
+    expect(extractTitle('no heading here\njust prose')).toBe('');
+  });
+});
+
+describe('extractExcerpt', () => {
+  it('uses the first substantive paragraph, stripping links and emphasis', () => {
+    const md = '# Title\n\nSee the [admin guide](./ADMIN_GUIDE.md) for **bold** `code`.';
+    expect(extractExcerpt(md)).toBe('See the admin guide for bold code.');
+  });
+
+  it('skips headings, rules, tables, and fenced code blocks', () => {
+    const md = [
+      '# T',
+      '',
+      '---',
+      '',
+      '```',
+      'this is a long line of code that should be skipped entirely',
+      '```',
+      '',
+      'The real paragraph text.',
+    ].join('\n');
+    expect(extractExcerpt(md)).toBe('The real paragraph text.');
+  });
+
+  it('truncates to maxLength with an ellipsis', () => {
+    const out = extractExcerpt(`# T\n\n${'x'.repeat(200)}`, 50);
+    expect(out.endsWith('...')).toBe(true);
+    expect(out.length).toBe(53);
+  });
+});
+
+describe('listSearchDocPaths (H2 coverage regression lock)', () => {
+  const slugs = new Set(listSearchDocPaths().map(([slug]) => slug));
+
+  it('includes nested-section and hyphenated docs the old INDEX.md regex dropped', () => {
+    // The previous `[A-Z_]+.md` INDEX.md scrape matched neither of these.
+    expect(slugs.has('guides/deployment')).toBe(true);
+    expect(slugs.has('environment-variables-guide')).toBe(true);
+  });
+
+  it('covers far more than the ~26 uppercase INDEX.md entries', () => {
+    expect(listSearchDocPaths().length).toBeGreaterThan(40);
+  });
+});

--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from '@revealui/router';
 import { lazy, Suspense, useEffect, useState } from 'react';
+import { buildDocNavSections, type NavItem, type NavSection } from '../lib/nav';
 import { showcaseEntries } from './showcase/registry.js';
 
 const SearchBar = lazy(async () =>
@@ -7,118 +8,21 @@ const SearchBar = lazy(async () =>
 );
 
 /**
- * Build the Showcase nav items from the registry. Two stable anchors
- * (Overview + Design Tokens) followed by every entry sorted by display name.
- * Adding a new showcase to `showcase/registry.ts` automatically surfaces
- * it here — no hand-maintained list to drift.
+ * Per-component Showcase nav items, derived from the registry and sorted by
+ * display name. Adding a showcase to `showcase/registry.ts` automatically
+ * surfaces it here — no hand-maintained list to drift. The static doc sections
+ * + the two stable Showcase anchors live in `../lib/nav` (React-free so the
+ * link guard in `scripts/check-links.ts` can validate every doc link).
  */
-const showcaseNavItems = [
-  { label: 'Overview', path: '/showcase' },
-  { label: 'Design Tokens', path: '/showcase/tokens' },
-  ...[...showcaseEntries]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map((entry) => ({ label: entry.name, path: `/showcase/${entry.slug}` })),
-];
+const showcaseComponentItems: NavItem[] = [...showcaseEntries]
+  .sort((a, b) => a.name.localeCompare(b.name))
+  .map((entry) => ({ label: entry.name, path: `/showcase/${entry.slug}` }));
 
 interface DocLayoutProps {
   children?: React.ReactNode;
 }
 
-interface NavItem {
-  label: string;
-  path: string;
-  children?: NavItem[];
-}
-
-interface NavSection {
-  title: string;
-  items: NavItem[];
-}
-
-const sections: NavSection[] = [
-  {
-    title: 'Getting Started',
-    items: [
-      { label: 'Quick Start', path: '/quick-start' },
-      { label: 'Build Your Business', path: '/build-your-business' },
-      { label: 'Examples', path: '/examples' },
-    ],
-  },
-  {
-    title: 'Tutorials',
-    items: [
-      { label: 'Quick Start', path: '/guides/quick-start' },
-      { label: 'Authentication', path: '/guides/authentication' },
-      { label: 'Collections', path: '/guides/collections' },
-      { label: 'Billing', path: '/guides/billing' },
-      { label: 'Deployment', path: '/guides/deployment' },
-    ],
-  },
-  {
-    title: 'Core Guides',
-    items: [
-      { label: 'Admin Guide', path: '/admin-guide' },
-      { label: 'Authentication', path: '/auth' },
-      { label: 'Database', path: '/database' },
-      { label: 'CI/CD & Deployment', path: '/ci-cd-guide' },
-      { label: 'Environment Variables', path: '/environment-variables-guide' },
-      { label: 'Testing', path: '/testing' },
-      { label: 'Troubleshooting', path: '/troubleshooting' },
-    ],
-  },
-  {
-    title: 'Architecture',
-    items: [
-      { label: 'System Architecture', path: '/architecture' },
-      { label: 'Performance', path: '/performance' },
-      { label: 'Standards', path: '/standards' },
-      { label: 'Core Stability', path: '/core-stability' },
-    ],
-  },
-  {
-    title: 'Reference',
-    items: [
-      { label: 'Package Reference', path: '/reference' },
-      { label: 'REST API', path: '/api/rest-api' },
-      { label: 'Component Catalog', path: '/component-catalog' },
-      { label: 'AI', path: '/ai' },
-      { label: 'Marketplace', path: '/marketplace' },
-    ],
-  },
-  {
-    title: 'Showcase',
-    items: showcaseNavItems,
-  },
-  {
-    title: 'Pro & Enterprise',
-    items: [
-      { label: 'Pro (AI, MCP, Inference)', path: '/pro' },
-      { label: 'Enterprise', path: '/forge' },
-      { label: 'Local-First Setup', path: '/local-first' },
-    ],
-  },
-  {
-    title: 'RevFleet (companion products)',
-    items: [{ label: 'Other RevealUI Studio products →', path: '/revfleet' }],
-  },
-  {
-    title: 'Blog',
-    items: [
-      { label: 'Why We Built RevealUI', path: '/blog/01-why-we-built-revealui' },
-      { label: 'HTTP 402 Payments', path: '/blog/02-http-402-payments' },
-      { label: 'Multi-Agent Coordination', path: '/blog/03-multi-agent-coordination' },
-      { label: 'The Air-Gap Capable Stack', path: '/blog/04-local-first-ai-stack' },
-      { label: 'The Five Primitives', path: '/blog/05-five-primitives' },
-      { label: 'Open Source & Pro', path: '/blog/06-open-source-and-pro' },
-      { label: 'Agent-First Future', path: '/blog/07-agent-first-future' },
-      { label: 'Getting Started in About 30 Minutes', path: '/blog/08-getting-started' },
-    ],
-  },
-  {
-    title: 'Legal',
-    items: [{ label: 'Third-Party Licenses', path: '/third-party-licenses' }],
-  },
-];
+const sections: NavSection[] = buildDocNavSections(showcaseComponentItems);
 
 function NavLink({
   item,

--- a/apps/docs/app/index.css
+++ b/apps/docs/app/index.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 @import "@revealui/presentation/tokens.css";
 
+/*
+ * Scan @revealui/presentation source so Tailwind generates the utility classes
+ * those components use (bg-primary, bg-card, text-foreground, ring-ring, …).
+ * Without this, showcase components reference classes Tailwind never emitted
+ * and render unstyled regardless of the token bridge below.
+ */
+@source "../../../packages/presentation/src/**/*.{ts,tsx}";
+
 /* ──────────────────────────────────────────────
    Theme — design tokens as Tailwind v4 @theme
    ────────────────────────────────────────────── */
@@ -26,6 +34,43 @@
 
   --width-sidebar: 272px;
   --width-content: 820px;
+}
+
+/* ──────────────────────────────────────────────
+   Cobalt semantic bridge — maps the shadcn-style utility names used by
+   @revealui/presentation components (rendered under /showcase) onto the
+   canonical --rvui-* tokens from tokens.css. Values cascade with the active
+   theme, so the showcase Preview's Dark/Light toggle (which sets data-theme)
+   actually re-themes the components.
+
+   Intentionally NOT bridged: --color-accent and --color-border are owned by
+   the docs palette above (accent = cobalt brand; border = #e8eaed). Leaving
+   them out keeps the docs chrome unchanged. Presentation's `accent` hover
+   surfaces therefore reuse the docs cobalt accent, paired with the on-brand
+   foreground below for contrast.
+   ────────────────────────────────────────────── */
+@theme inline {
+  --color-background: var(--rvui-surface-0);
+  --color-foreground: var(--rvui-text-0);
+  --color-card: var(--rvui-surface-1);
+  --color-card-foreground: var(--rvui-text-0);
+  --color-popover: var(--rvui-surface-1);
+  --color-popover-foreground: var(--rvui-text-0);
+  --color-primary: var(--rvui-brand);
+  --color-primary-foreground: var(--rvui-text-on-brand);
+  --color-secondary: var(--rvui-surface-2);
+  --color-secondary-foreground: var(--rvui-text-0);
+  --color-muted: var(--rvui-surface-2);
+  --color-muted-foreground: var(--rvui-text-2);
+  --color-accent-foreground: var(--rvui-text-on-brand);
+  --color-destructive: var(--rvui-error);
+  --color-destructive-foreground: var(--rvui-text-0);
+  --color-input: var(--rvui-border);
+  --color-ring: var(--rvui-brand);
+  --color-success: var(--rvui-success);
+  --color-warning: var(--rvui-warning);
+  --color-warning-foreground: var(--rvui-warning-text);
+  --color-error: var(--rvui-error);
 }
 
 /* ──────────────────────────────────────────────

--- a/apps/docs/app/lib/nav.ts
+++ b/apps/docs/app/lib/nav.ts
@@ -1,0 +1,118 @@
+/**
+ * Static documentation navigation — plain data, no React imports.
+ *
+ * Kept React-free on purpose so it can be consumed by BOTH the rendered
+ * sidebar (`components/DocLayout.tsx`) and the build-time link guard
+ * (`scripts/check-links.ts`). The guard resolves every doc link here against
+ * the served set, so a nav entry pointing at an internal-excluded or missing
+ * doc fails CI instead of silently 404ing in production.
+ *
+ * Per-component Showcase links are derived from the showcase registry at
+ * render time and injected via `buildDocNavSections`; only the two stable
+ * Showcase anchors live here.
+ */
+
+export interface NavItem {
+  label: string;
+  path: string;
+  children?: NavItem[];
+}
+
+export interface NavSection {
+  title: string;
+  items: NavItem[];
+}
+
+/**
+ * Build the full sidebar navigation. `showcaseItems` are the registry-derived
+ * per-component entries appended after the two stable Showcase anchors;
+ * callers that only need the static doc links (e.g. the link guard) pass an
+ * empty array.
+ */
+export function buildDocNavSections(showcaseItems: NavItem[]): NavSection[] {
+  return [
+    {
+      title: 'Getting Started',
+      items: [
+        { label: 'Quick Start', path: '/quick-start' },
+        { label: 'Build Your Business', path: '/build-your-business' },
+        { label: 'Examples', path: '/examples' },
+      ],
+    },
+    {
+      title: 'Tutorials',
+      items: [
+        { label: 'Quick Start', path: '/guides/quick-start' },
+        { label: 'Authentication', path: '/guides/authentication' },
+        { label: 'Collections', path: '/guides/collections' },
+        { label: 'Billing', path: '/guides/billing' },
+        { label: 'Deployment', path: '/guides/deployment' },
+      ],
+    },
+    {
+      title: 'Core Guides',
+      items: [
+        { label: 'Admin Guide', path: '/admin-guide' },
+        { label: 'Authentication', path: '/auth' },
+        { label: 'Database', path: '/database' },
+        { label: 'Environment Variables', path: '/environment-variables-guide' },
+        { label: 'Testing', path: '/testing' },
+        { label: 'Troubleshooting', path: '/troubleshooting' },
+      ],
+    },
+    {
+      title: 'Architecture',
+      items: [
+        { label: 'System Architecture', path: '/architecture' },
+        { label: 'Core Stability', path: '/core-stability' },
+      ],
+    },
+    {
+      title: 'Reference',
+      items: [
+        { label: 'Package Reference', path: '/reference' },
+        { label: 'REST API', path: '/api/rest-api' },
+        { label: 'Component Catalog', path: '/component-catalog' },
+        { label: 'AI', path: '/ai' },
+        { label: 'Marketplace', path: '/marketplace' },
+      ],
+    },
+    {
+      title: 'Showcase',
+      items: [
+        { label: 'Overview', path: '/showcase' },
+        { label: 'Design Tokens', path: '/showcase/tokens' },
+        ...showcaseItems,
+      ],
+    },
+    {
+      title: 'Pro & Enterprise',
+      items: [
+        { label: 'Pro (AI, MCP, Inference)', path: '/pro' },
+        { label: 'Enterprise', path: '/forge' },
+        { label: 'Local-First Setup', path: '/local-first' },
+      ],
+    },
+    {
+      title: 'RevFleet (companion products)',
+      items: [{ label: 'Other RevealUI Studio products →', path: '/revfleet' }],
+    },
+    {
+      title: 'Blog',
+      items: [
+        { label: 'Why We Built RevealUI', path: '/blog/01-why-we-built-revealui' },
+        { label: 'HTTP 402 Payments', path: '/blog/02-http-402-payments' },
+        { label: 'Multi-Agent Coordination', path: '/blog/03-multi-agent-coordination' },
+        { label: 'The Air-Gap Capable Stack', path: '/blog/04-local-first-ai-stack' },
+        { label: 'The Five Primitives', path: '/blog/05-five-primitives' },
+        { label: 'Open Source & Pro', path: '/blog/06-open-source-and-pro' },
+        { label: 'Agent-First Future', path: '/blog/07-agent-first-future' },
+        { label: 'Getting Started in About 30 Minutes', path: '/blog/08-getting-started' },
+      ],
+    },
+    {
+      title: 'Legal',
+      items: [{ label: 'Third-Party Licenses', path: '/third-party-licenses' }],
+    },
+  ];
+}

--- a/apps/docs/app/lib/search-index.ts
+++ b/apps/docs/app/lib/search-index.ts
@@ -1,12 +1,21 @@
 /**
  * Client-side full-text search index for documentation.
  *
- * Fetches all markdown docs listed in INDEX.md, extracts titles and
- * excerpts, and indexes them with FlexSearch for instant search.
+ * Indexes EVERY served doc enumerated in the slug manifest — the same
+ * build-time enumeration the route resolver uses — not just the handful of
+ * uppercase top-level files linked from INDEX.md. That is what makes nested
+ * sections (guides/, blog/, fleet/, api/), pro docs, and hyphenated or
+ * lowercase filenames searchable; the previous INDEX.md `[A-Z_]+.md` scrape
+ * silently dropped all of them. Internal-only docs are absent from the served
+ * set, so their fetch 404s and they are skipped automatically (never indexed,
+ * never leaked into results).
+ *
+ * No authored regex (fleet hardline, matching scripts/check-links.ts): title
+ * and excerpt extraction are indexOf / character scans.
  */
 
 import FlexSearch from 'flexsearch';
-import { filenameToSlug } from './slug';
+import { SLUG_TO_PATH } from './slug-manifest';
 
 const { Document } = FlexSearch;
 
@@ -38,37 +47,94 @@ let docs: DocEntry[] = [];
 let buildPromise: Promise<void> | null = null;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers (no authored regex)
 // ---------------------------------------------------------------------------
 
-/** Extract the first H1 heading from markdown content. */
-function extractTitle(markdown: string): string {
-  const match = /^#\s+(.+)$/m.exec(markdown);
-  return match?.[1]?.trim() ?? '';
+/** Inline emphasis markers stripped from excerpts (bold, italic, code, strikethrough). */
+const EXCERPT_EMPHASIS = new Set(['*', '_', '`', '~']);
+
+/** Extract the first ATX H1 (`# Title`) from markdown content. */
+export function extractTitle(markdown: string): string {
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith('#')) {
+      continue;
+    }
+    const rest = line.slice(1);
+    // A single `#` followed by whitespace is an H1. `##`/`###` (rest starts
+    // with another `#`) and a bare `#` fall through.
+    if (rest.length > 0 && (rest[0] === ' ' || rest[0] === '\t')) {
+      return rest.trim();
+    }
+  }
+  return '';
 }
 
-/** Extract the first non-heading, non-empty paragraph as an excerpt. */
-function extractExcerpt(markdown: string, maxLength = 160): string {
-  const lines = markdown.split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    // Skip empty lines, headings, links-only lines, and horizontal rules
+/** Replace `[label](target)` spans with just their label (indexOf scan). */
+function stripMarkdownLinks(text: string): string {
+  if (!text.includes('](')) {
+    return text;
+  }
+  let out = '';
+  let cursor = 0;
+  while (cursor < text.length) {
+    const open = text.indexOf('[', cursor);
+    if (open === -1) {
+      out += text.slice(cursor);
+      break;
+    }
+    const mid = text.indexOf('](', open);
+    if (mid === -1) {
+      out += text.slice(cursor);
+      break;
+    }
+    const close = text.indexOf(')', mid + 2);
+    if (close === -1) {
+      out += text.slice(cursor);
+      break;
+    }
+    out += text.slice(cursor, open); // text before the link
+    out += text.slice(open + 1, mid); // the link label
+    cursor = close + 1; // skip past the (target)
+  }
+  return out;
+}
+
+/** Remove inline emphasis markers (`*`, `_`, `` ` ``, `~`). */
+function stripEmphasis(text: string): string {
+  let out = '';
+  for (const ch of text) {
+    if (!EXCERPT_EMPHASIS.has(ch)) {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+/** Extract the first substantive paragraph as a plain-text excerpt. */
+export function extractExcerpt(markdown: string, maxLength = 160): string {
+  let inFence = false;
+  for (const rawLine of markdown.split('\n')) {
+    const trimmed = rawLine.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      continue;
+    }
+    // Skip empty lines, headings, horizontal rules, tables, link-only list items.
     if (
       !trimmed ||
       trimmed.startsWith('#') ||
       trimmed.startsWith('---') ||
       trimmed.startsWith('|') ||
       trimmed.startsWith('- [') ||
-      trimmed.startsWith('* [') ||
-      trimmed.startsWith('```')
+      trimmed.startsWith('* [')
     ) {
       continue;
     }
-    // Strip inline markdown formatting
-    const plain = trimmed
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
-      .replace(/[*_`~]+/g, '') // bold, italic, code, strikethrough
-      .trim();
+    const plain = stripEmphasis(stripMarkdownLinks(trimmed)).trim();
     if (plain.length > 10) {
       return plain.length > maxLength ? `${plain.slice(0, maxLength)}...` : plain;
     }
@@ -76,20 +142,13 @@ function extractExcerpt(markdown: string, maxLength = 160): string {
   return '';
 }
 
-/** Parse INDEX.md to extract markdown filenames. */
-function parseIndex(indexContent: string): string[] {
-  const files: string[] = [];
-  // Match lines like: - [Title](./FILENAME.md)
-  const linkRegex = /\[.*?\]\(\.\/([A-Z_]+\.md)\)/g;
-  let match: RegExpExecArray | null = null;
-  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop pattern
-  while ((match = linkRegex.exec(indexContent)) !== null) {
-    const filename = match[1];
-    if (filename) {
-      files.push(filename);
-    }
-  }
-  return files;
+/**
+ * The full set of searchable docs as `[slug, file]` pairs, sourced from the
+ * slug manifest. The slug doubles as the result path (flat URL space); the
+ * file is fetched from the served root.
+ */
+export function listSearchDocPaths(): Array<readonly [string, string]> {
+  return Object.entries(SLUG_TO_PATH);
 }
 
 // ---------------------------------------------------------------------------
@@ -97,7 +156,7 @@ function parseIndex(indexContent: string): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the search index by fetching INDEX.md and all referenced docs.
+ * Build the search index by fetching every served doc and indexing it.
  * Safe to call multiple times  -  subsequent calls return the same promise.
  */
 export async function buildSearchIndex(): Promise<void> {
@@ -107,29 +166,17 @@ export async function buildSearchIndex(): Promise<void> {
 
   buildPromise = (async () => {
     try {
-      // Fetch and parse the index (CHIP-3 D5a: docs serve from root)
-      const indexResponse = await fetch('/INDEX.md');
-      if (!indexResponse.ok) {
-        return;
-      }
-      const indexContent = await indexResponse.text();
-      const filenames = parseIndex(indexContent);
-
-      // Fetch all docs in parallel (CHIP-3 D5a: docs serve from root)
+      // Fetch all enumerated docs in parallel. Internal-only docs are not in
+      // the served set, so their fetch 404s and they fall out via the !ok
+      // guard — they are never indexed.
       const fetchResults = await Promise.allSettled(
-        filenames.map(async (filename) => {
-          const response = await fetch(`/${filename}`);
+        listSearchDocPaths().map(async ([slug, file]) => {
+          const response = await fetch(`/${file}`);
           if (!response.ok) {
             return null;
           }
           const content = await response.text();
-          // CHIP-3 D2b: use the lowercase-kebab slug so result.path matches
-          // the new flat URL space (e.g. ADMIN_GUIDE.md → admin-guide).
-          const slug = filenameToSlug(filename);
-          return {
-            filename: slug,
-            content,
-          };
+          return { slug, content };
         }),
       );
 
@@ -140,15 +187,15 @@ export async function buildSearchIndex(): Promise<void> {
         if (result.status !== 'fulfilled' || !result.value) {
           continue;
         }
-        const { filename, content } = result.value;
-        const title = extractTitle(content) || filename.replace(/_/g, ' ');
+        const { slug, content } = result.value;
+        const title = extractTitle(content) || slug;
         const excerpt = extractExcerpt(content);
 
         docs.push({
           id,
           title,
           content,
-          path: filename,
+          path: slug,
           excerpt,
         });
         id++;

--- a/apps/docs/scripts/check-links.ts
+++ b/apps/docs/scripts/check-links.ts
@@ -29,6 +29,8 @@
 import { execFileSync } from 'node:child_process';
 import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { buildDocNavSections } from '../app/lib/nav';
+import { type DocSection, resolveDocPath } from '../app/utils/paths';
 
 const scriptDir = import.meta.dirname;
 const docsApp = path.resolve(scriptDir, '..'); // apps/docs
@@ -209,6 +211,68 @@ function describe(link: BrokenLink): string {
   }
 }
 
+/**
+ * Validate the hardcoded sidebar navigation. `DocLayout.tsx` renders these
+ * entries from `app/lib/nav.ts`; here each doc link is resolved with the SAME
+ * resolver the app uses at runtime (`resolveDocPath` + the slug manifest), and
+ * a target that isn't in the served set would 404 in production. Showcase
+ * (`/showcase…`) and Pro (`/pro…`) paths are component-rendered routes, not
+ * direct markdown fetches, so they are out of scope. This closes the gap that
+ * let `/ci-cd-guide`, `/performance`, `/standards` (all internal-excluded)
+ * ship as dead nav links — the markdown `](…)` scan never saw the React nav.
+ */
+function checkNavLinks(served: Set<string>, source: Set<string>): BrokenLink[] {
+  const broken: BrokenLink[] = [];
+  const navSource = '(sidebar nav — app/lib/nav.ts)';
+
+  const links: string[] = [];
+  for (const section of buildDocNavSections([])) {
+    for (const item of section.items) {
+      links.push(item.path);
+      for (const child of item.children ?? []) {
+        links.push(child.path);
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  for (const navPath of links) {
+    if (seen.has(navPath)) {
+      continue;
+    }
+    seen.add(navPath);
+
+    if (isExternal(navPath) || navPath === '/') {
+      continue; // home → INDEX.md (always served)
+    }
+    const segments = navPath.split('/').filter(Boolean);
+    const first = segments[0] ?? '';
+    if (first === 'showcase' || first === 'pro') {
+      continue; // component-rendered routes, not direct .md fetches
+    }
+
+    let section: DocSection = 'docs';
+    let routePath = segments.join('/');
+    if (first === 'guides' || first === 'api') {
+      section = first;
+      routePath = segments.slice(1).join('/');
+    }
+
+    const { markdownPath } = resolveDocPath({ section, routePath: routePath || null });
+    const resolved = markdownPath.startsWith('/') ? markdownPath.slice(1) : markdownPath;
+    if (served.has(resolved)) {
+      continue;
+    }
+    broken.push({
+      source: navSource,
+      raw: navPath,
+      resolved,
+      kind: source.has(resolved) ? 'internal-excluded' : 'missing',
+    });
+  }
+  return broken;
+}
+
 function main(): void {
   // Refresh the served set exactly as the build does — copy-docs.sh is the
   // single authority for what ships to the public site.
@@ -222,10 +286,13 @@ function main(): void {
 
   const served = collectMarkdownFiles(servedRoot);
   const source = collectMarkdownFiles(sourceDocs);
-  const broken = checkLinks(served, source);
+  const broken = [...checkLinks(served, source), ...checkNavLinks(served, source)];
 
   if (broken.length === 0) {
-    write(`✓ docs link check: ${served.size} served pages, 0 broken relative .md links.`);
+    write(
+      `✓ docs link check: ${served.size} served pages, 0 broken relative .md links, ` +
+        'sidebar nav links all resolve.',
+    );
     return;
   }
 
@@ -238,7 +305,7 @@ function main(): void {
 
   write('');
   write(
-    `✗ docs link check: ${broken.length} broken relative .md link(s) across ${bySource.size} served page(s).`,
+    `✗ docs link check: ${broken.length} broken link(s) across ${bySource.size} source(s) (served pages + sidebar nav).`,
   );
   write('');
   for (const src of [...bySource.keys()].sort()) {


### PR DESCRIPTION
## Promote `test` → `main`

Production release via merge commit (preserves per-PR history). Pushing to `main` triggers `deploy.yml`, so this deploys the **8 commits currently on `test`** to production — not only the docs change.

### Included
- **#1203** fix(docs): remove dead sidebar nav links + add CI nav guard; index the full served doc set for search; cobalt showcase theme bridge
- **#1202** refactor(presentation): native cobalt-token admin shell (Phase 1)
- **#1198** fix(admin): make (backend) pages theme-adaptive via cobalt tokens
- **#1201** fix(marketing): align index.html title/meta with the reframed hero
- **#1188** fix(server,admin): require Gmail email transport at boot in hosted prod
- **#1187** fix(admin): let non-admin subscribers reach /welcome after checkout
- main→test backflow (#1200) + a merge-main-into-test commit

### Deploy heads-up
- **#1188 hardens prod boot** to require the Gmail email transport — the production email environment must be configured or the server will refuse to boot.
- Admin backend pages + shell get the native cobalt re-skin (#1198 / #1202); browser visual QA on the admin preview is recommended.

### Gate
All 16 `main`-required checks must pass (`enforce_admins: true`, no bypass). The non-required `Integration Tests (extended)` TRIAGE suite (`continue-on-error`) is excluded from the gate — it currently fails on pre-existing server / CORS / Postgres / DB-concurrency tests unrelated to these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
