### PR TITLE
feat(scripts): write seeded Stripe price IDs to revvault (--sync-revvault)

### DIFF
--- a/scripts/setup/__tests__/stripe-revvault-sync.test.ts
+++ b/scripts/setup/__tests__/stripe-revvault-sync.test.ts
@@ -1,0 +1,110 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  loadManifestEnvKeyToVaultPath,
+  parseManifestEnvKeyToVaultPath,
+  syncToRevvault,
+} from '../stripe-revvault-sync.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = resolve(here, '..', '..', 'sync', 'revvault-vercel.toml');
+
+const noop = (): void => undefined;
+const silentLog = { info: noop, success: noop, warn: noop, error: noop };
+
+describe('parseManifestEnvKeyToVaultPath', () => {
+  it('maps KEY = "revealui/..." lines; ignores comments, sections, arrays, non-vault values', () => {
+    const text = [
+      '# a comment',
+      '[projects.revealui-api]',
+      'project_id = "prj_123"', // value is not a revealui/ path -> ignored
+      '',
+      '[projects.revealui-api.vars]',
+      'STRIPE_PRO_PRICE_ID                  = "revealui/prod/stripe/pro-price-id"', // aligned
+      'STRIPE_MAX_PRICE_ID = "revealui/prod/stripe/max-price-id"', // tight
+      'skip = ["STRIPE_LIVE_MODE"]', // array value -> ignored
+    ].join('\n');
+
+    const map = parseManifestEnvKeyToVaultPath(text);
+
+    expect(map.get('STRIPE_PRO_PRICE_ID')).toBe('revealui/prod/stripe/pro-price-id');
+    expect(map.get('STRIPE_MAX_PRICE_ID')).toBe('revealui/prod/stripe/max-price-id');
+    expect(map.has('project_id')).toBe(false);
+    expect(map.has('skip')).toBe(false);
+  });
+});
+
+describe('drift guard: seeded price env keys must have a manifest vault path', () => {
+  it('maps every STRIPE_*_PRICE_ID the seeder emits to a revealui/prod/stripe/ path', () => {
+    const map = loadManifestEnvKeyToVaultPath(MANIFEST_PATH);
+    // Mirrors PRICE_SERVER_ENV_KEYS in seed-stripe.ts (the vaulted price keys).
+    // Adding a new price env key without a manifest entry fails this test ->
+    // add the revvault-vercel.toml mapping before merging.
+    const requiredKeys = [
+      'STRIPE_PRO_PRICE_ID',
+      'STRIPE_MAX_PRICE_ID',
+      'STRIPE_ENTERPRISE_PRICE_ID',
+      'STRIPE_PERPETUAL_PRO_PRICE_ID',
+      'STRIPE_PERPETUAL_MAX_PRICE_ID',
+      'STRIPE_PERPETUAL_ENTERPRISE_PRICE_ID',
+      'STRIPE_CREDITS_STARTER_PRICE_ID',
+      'STRIPE_CREDITS_STANDARD_PRICE_ID',
+      'STRIPE_CREDITS_SCALE_PRICE_ID',
+    ];
+    for (const key of requiredKeys) {
+      const vaultPath = map.get(key);
+      expect(vaultPath, `${key} is missing from scripts/sync/revvault-vercel.toml`).toBeDefined();
+      expect(vaultPath?.startsWith('revealui/prod/stripe/')).toBe(true);
+    }
+  });
+});
+
+describe('syncToRevvault', () => {
+  it('writes mapped keys, skips unmapped keys, reports results', () => {
+    const calls: Array<{ path: string; value: string }> = [];
+    const result = syncToRevvault(
+      {
+        STRIPE_PRO_PRICE_ID: 'price_pro',
+        STRIPE_RENEWAL_PRO_PRICE_ID: 'price_renewal_not_vaulted', // no manifest path
+      },
+      {
+        manifestPath: MANIFEST_PATH,
+        setter: (path, value) => calls.push({ path, value }),
+        log: silentLog,
+      },
+    );
+
+    expect(calls).toEqual([{ path: 'revealui/prod/stripe/pro-price-id', value: 'price_pro' }]);
+    expect(result.written).toEqual(['revealui/prod/stripe/pro-price-id']);
+    expect(result.skipped).toEqual(['STRIPE_RENEWAL_PRO_PRICE_ID']);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('does not call the setter in dry-run', () => {
+    const setter = vi.fn();
+    const result = syncToRevvault(
+      { STRIPE_PRO_PRICE_ID: 'price_pro' },
+      { manifestPath: MANIFEST_PATH, dryRun: true, setter, log: silentLog },
+    );
+
+    expect(setter).not.toHaveBeenCalled();
+    expect(result.written).toEqual(['revealui/prod/stripe/pro-price-id']);
+  });
+
+  it('collects per-key failures without throwing', () => {
+    const result = syncToRevvault(
+      { STRIPE_PRO_PRICE_ID: 'price_pro' },
+      {
+        manifestPath: MANIFEST_PATH,
+        setter: () => {
+          throw new Error('revvault unavailable');
+        },
+        log: silentLog,
+      },
+    );
+
+    expect(result.written).toEqual([]);
+    expect(result.failed).toEqual(['revealui/prod/stripe/pro-price-id']);
+  });
+});

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -17,7 +17,8 @@
  *   pnpm stripe:seed -- --skip-portal        # skip billing portal setup
  *   pnpm stripe:seed -- --skip-catalog-sync  # skip local billing_catalog sync
  *   pnpm stripe:seed -- --webhook-url URL    # override webhook URL
- *   pnpm stripe:seed -- --sync-vercel        # push price IDs to Vercel env
+ *   pnpm stripe:seed -- --sync-revvault      # write IDs to revvault (source of truth), then `revvault sync vercel`
+ *   pnpm stripe:seed -- --sync-vercel        # DEPRECATED: writes Vercel directly; prefer --sync-revvault
  */
 
 import { execFileSync } from 'node:child_process';
@@ -30,6 +31,7 @@ import type Stripe from 'stripe';
 // @revealui/contracts as a root-level dep. Script only; not bundled.
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '../../packages/contracts/src/stripe-webhook-events.js';
 import { LOCAL_STRIPE_ENV_CACHE_PATH } from './stripe-env-cache-path.js';
+import { syncToRevvault } from './stripe-revvault-sync.js';
 
 // Load env from root .env
 config({ path: resolve(import.meta.dirname, '../../.env') });
@@ -926,6 +928,7 @@ async function main(): Promise<void> {
   const skipPortal = args.includes('--skip-portal');
   const skipCatalogSync = args.includes('--skip-catalog-sync');
   const syncVercel = args.includes('--sync-vercel');
+  const syncRevvault = args.includes('--sync-revvault');
   const webhookUrlFlag = (() => {
     const idx = args.indexOf('--webhook-url');
     return idx !== -1 ? args[idx + 1] : undefined;
@@ -1015,8 +1018,28 @@ async function main(): Promise<void> {
       await syncBillingCatalog(envVars, dryRun);
     }
 
+    if (syncRevvault) {
+      log.header('Revvault Sync (source of truth)');
+      const revvaultResult = syncToRevvault(envVars, {
+        manifestPath: resolve(import.meta.dirname, '../sync/revvault-vercel.toml'),
+        dryRun,
+        log,
+      });
+      log.info(
+        `revvault: ${revvaultResult.written.length} written, ${revvaultResult.skipped.length} skipped (no manifest path), ${revvaultResult.failed.length} failed`,
+      );
+      if (revvaultResult.failed.length > 0) {
+        process.exitCode = 1;
+      } else if (!dryRun) {
+        log.info('Next: review + commit the passage-store, then `revvault sync vercel --apply`');
+      }
+    }
+
     if (syncVercel) {
       log.header('Vercel Sync');
+      log.warn(
+        '--sync-vercel is DEPRECATED (writes Vercel behind revvault). Prefer --sync-revvault, then `revvault sync vercel --apply`.',
+      );
       await syncToVercel(envVars);
     }
   }

--- a/scripts/setup/stripe-revvault-sync.ts
+++ b/scripts/setup/stripe-revvault-sync.ts
@@ -1,0 +1,140 @@
+/**
+ * stripe-revvault-sync — write seeded Stripe IDs into revvault (source of truth).
+ *
+ * `seed-stripe.ts` provisions Stripe products/prices/webhook idempotently and
+ * produces an env-var map (`STRIPE_*_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, the
+ * meter event name, ...). This module writes those values into revvault via
+ * `revvault set --force <path>`, using the revvault → Vercel manifest as the
+ * single source of truth for the env-key → vault-path mapping. The canonical
+ * flow becomes:
+ *
+ *   seed-stripe (Stripe IaC) → revvault (encrypted source of truth)
+ *     → `revvault sync vercel --apply` (vault → Vercel) → billing_catalog
+ *
+ * so no secret is written to Vercel behind revvault's back (revvault-first, M4).
+ *
+ * `revvault set` writes `.age` files into the passage-store working tree;
+ * committing the passage-store git history (the audit trail) stays an OWNER
+ * step, exactly as in the secret-rotation workflow. This module never touches
+ * git and never echoes a secret value (logs reference paths only).
+ *
+ * No regex (M2): the manifest is parsed with string operations only.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+export interface SyncLog {
+  info: (message: string) => void;
+  success: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+}
+
+const defaultLog: SyncLog = {
+  info: (message) => process.stdout.write(`${message}\n`),
+  success: (message) => process.stdout.write(`${message}\n`),
+  warn: (message) => process.stdout.write(`${message}\n`),
+  error: (message) => process.stderr.write(`${message}\n`),
+};
+
+/** Pipe a single value into `revvault set --force <path>` via stdin. */
+export type RevvaultSetter = (vaultPath: string, value: string) => void;
+
+const defaultSetter: RevvaultSetter = (vaultPath, value) => {
+  execFileSync('revvault', ['set', '--force', vaultPath], {
+    input: value,
+    encoding: 'utf-8',
+  });
+};
+
+/**
+ * Parse `KEY = "revealui/..."` lines from a revvault-vercel manifest into an
+ * env-key → vault-path map. Section headers (`[...]`), comments (`#`), arrays,
+ * and any value that is not a `revealui/` vault path are ignored. The same key
+ * appears under multiple `[projects.*]` blocks mapping to the same path, so a
+ * later occurrence simply re-sets the identical value. String ops only.
+ */
+export function parseManifestEnvKeyToVaultPath(manifestText: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const rawLine of manifestText.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#') || line.startsWith('[')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+    if (key.length > 0 && value.startsWith('revealui/')) {
+      map.set(key, value);
+    }
+  }
+  return map;
+}
+
+export function loadManifestEnvKeyToVaultPath(manifestPath: string): Map<string, string> {
+  return parseManifestEnvKeyToVaultPath(readFileSync(manifestPath, 'utf-8'));
+}
+
+export interface SyncToRevvaultOptions {
+  /** Path to scripts/sync/revvault-vercel.toml */
+  manifestPath: string;
+  dryRun?: boolean;
+  /** Injectable for tests; defaults to a real `revvault set` over stdin. */
+  setter?: RevvaultSetter;
+  log?: SyncLog;
+}
+
+export interface SyncToRevvaultResult {
+  /** Vault paths written (or, in dry-run, that would be written). */
+  written: string[];
+  /** Env keys produced by the seeder that the manifest does not map. */
+  skipped: string[];
+  /** Vault paths whose write threw. */
+  failed: string[];
+}
+
+/**
+ * Write each produced env var that the manifest maps to a vault path into
+ * revvault. Env vars with no manifest path are skipped (for example
+ * renewal-tier keys that are not vaulted yet). Per-key failures are collected,
+ * not thrown, so one bad write does not abort the rest — the caller inspects
+ * `failed` and decides the exit code.
+ */
+export function syncToRevvault(
+  envVars: Record<string, string>,
+  options: SyncToRevvaultOptions,
+): SyncToRevvaultResult {
+  const { manifestPath, dryRun = false, setter = defaultSetter } = options;
+  const log = options.log ?? defaultLog;
+  const pathByEnvKey = loadManifestEnvKeyToVaultPath(manifestPath);
+  const result: SyncToRevvaultResult = { written: [], skipped: [], failed: [] };
+
+  for (const [envKey, value] of Object.entries(envVars)) {
+    const vaultPath = pathByEnvKey.get(envKey);
+    if (vaultPath === undefined) {
+      result.skipped.push(envKey);
+      log.warn(`  ${envKey}: no manifest vault path -> skipping revvault write`);
+      continue;
+    }
+    if (dryRun) {
+      log.info(`  [dry-run] would write revvault ${vaultPath}`);
+      result.written.push(vaultPath);
+      continue;
+    }
+    try {
+      setter(vaultPath, value);
+      result.written.push(vaultPath);
+      log.success(`  Wrote revvault ${vaultPath}`);
+    } catch (err) {
+      result.failed.push(vaultPath);
+      log.error(
+        `  Failed revvault ${vaultPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## What

`seed-stripe.ts` already declares the Stripe catalog as code and provisions products/prices idempotently, but it wrote the resulting IDs to Vercel directly, bypassing revvault. This adds a revvault write-back so revvault stays the single source of truth.

## Changes

- New `scripts/setup/stripe-revvault-sync.ts`: reads the env-key to vault-path map from `scripts/sync/revvault-vercel.toml` (no duplicated list; string-ops parse, no regex) and writes each produced Stripe env var into revvault via `revvault set --force` (dependency-injected for tests; per-key failures collected, not thrown).
- `seed-stripe.ts`: new `--sync-revvault` flag. The direct `--sync-vercel` is deprecated in favor of `--sync-revvault` then `revvault sync vercel --apply`.
- Tests: manifest parse, a drift guard asserting every seeded `STRIPE_*_PRICE_ID` has a manifest vault path, and `syncToRevvault` behavior.

## Flow

`seed-stripe` → revvault (source of truth) → `revvault sync vercel` → Vercel. No secret is written to Vercel behind revvault. `revvault set` writes `.age` files into the passage-store working tree; committing that history stays an operator step.

## Verification

Unit tests cover the parser, the drift guard, and the sync behavior. The live seed run remains an operator action (needs the live Stripe key).
