### PR TITLE
fix(admin): read passkey cookie secret via getConfig()

### DIFF
--- a/apps/admin/src/app/api/auth/passkey/authenticate-options/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-options/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { generateAuthenticationChallenge, signCookiePayload } from '@revealui/auth/server';
-import config from '@revealui/config';
+import { getConfig } from '@revealui/config';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -28,7 +28,7 @@ async function authenticateOptionsHandler(_request: NextRequest): Promise<NextRe
         challenge: options.challenge,
         expiresAt: Date.now() + 5 * 60 * 1000,
       },
-      config.reveal.secret,
+      getConfig().reveal.secret,
     );
 
     const response = NextResponse.json({ options });

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { rotateSession, verifyAuthentication, verifyCookiePayload } from '@revealui/auth/server';
-import config from '@revealui/config';
+import { getConfig } from '@revealui/config';
 import { PasskeyAuthenticateVerifyRequestSchema } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
 import { getPasskeyByCredentialId } from '@revealui/db/queries/passkeys';
@@ -41,7 +41,7 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
 
     const challengePayload = verifyCookiePayload<{ challenge: string; expiresAt: number }>(
       challengeCookie,
-      config.reveal.secret,
+      getConfig().reveal.secret,
     );
 
     if (!challengePayload) {

--- a/apps/admin/src/app/api/auth/passkey/register-options/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-options/route.ts
@@ -15,7 +15,7 @@ import {
   listPasskeys,
   signCookiePayload,
 } from '@revealui/auth/server';
-import config from '@revealui/config';
+import { getConfig } from '@revealui/config';
 import { PasskeyRegisterOptionsRequestSchema } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
 import { getUserByEmail } from '@revealui/db/queries/users';
@@ -131,7 +131,7 @@ async function registerOptionsHandler(request: NextRequest): Promise<NextRespons
           expiresAt: Date.now() + 5 * 60 * 1000,
         };
 
-    const signed = signCookiePayload(challengePayload, config.reveal.secret);
+    const signed = signCookiePayload(challengePayload, getConfig().reveal.secret);
 
     const response = NextResponse.json({ options });
 

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -17,7 +17,7 @@ import {
   verifyCookiePayload,
   verifyRegistration,
 } from '@revealui/auth/server';
-import config from '@revealui/config';
+import { getConfig } from '@revealui/config';
 import { PasskeyRegisterVerifyRequestSchema } from '@revealui/contracts';
 import { getMaxUsers, initializeLicense } from '@revealui/core/license';
 import { getClient } from '@revealui/db';
@@ -61,7 +61,7 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
 
     const challengePayload = verifyCookiePayload<ChallengePayload>(
       challengeCookie,
-      config.reveal.secret,
+      getConfig().reveal.secret,
     );
 
     if (!challengePayload) {


### PR DESCRIPTION
## Summary

The four passkey API routes signed/verified the challenge cookie using the eager default `config` export from `@revealui/config` (a lazy Proxy). This reads the cookie secret via the explicit `getConfig()` accessor instead, matching how the secret is resolved elsewhere and avoiding reliance on the default-Proxy binding for a security-sensitive value.

## Changes

- `apps/admin/src/app/api/auth/passkey/authenticate-options/route.ts`
- `apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts`
- `apps/admin/src/app/api/auth/passkey/register-options/route.ts`
- `apps/admin/src/app/api/auth/passkey/register-verify/route.ts`

Each: `config.reveal.secret` -> `getConfig().reveal.secret` (+ import). Same secret, explicit accessor; no behavior change to the passkey flow.
