### PR TITLE
fix(docs): de-regex path/slug/breadcrumb utilities (no authored regex)

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -220,9 +220,25 @@ function Breadcrumbs({ sections: navSections }: { sections: NavSection[] }) {
       }
     }
 
-    // Format last segment as page title
+    // Format last segment as page title: dashes/underscores become spaces and
+    // the first character of each word is upper-cased (no authored regex).
     const lastSegment = segments[segments.length - 1] ?? '';
-    const pageTitle = lastSegment.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    const isWordChar = (c: string): boolean =>
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c === '_';
+    let pageTitle = '';
+    let atWordBoundary = true;
+    for (const ch of lastSegment) {
+      if (ch === '-' || ch === '_') {
+        pageTitle += ' ';
+        atWordBoundary = true;
+      } else if (isWordChar(ch)) {
+        pageTitle += atWordBoundary ? ch.toUpperCase() : ch;
+        atWordBoundary = false;
+      } else {
+        pageTitle += ch;
+        atWordBoundary = true;
+      }
+    }
     if (pageTitle) {
       crumbs.push({ label: pageTitle });
     }

--- a/apps/docs/app/lib/slug.ts
+++ b/apps/docs/app/lib/slug.ts
@@ -5,7 +5,7 @@
  * Filenames in fleet-root `docs/` use a mix of conventions:
  *   - SCREAMING_SNAKE: ADMIN_GUIDE.md, QUICK_START.md
  *   - kebab-case: 02-x402-payments.md, agent-rules/test-prompts.md
- *   - mixed (rare): RevealUIDocs.md (none today, but the regex handles it)
+ *   - mixed (rare): RevealUIDocs.md (none today, but the slug algorithm handles it)
  *
  * The slug derivation produces a single canonical lowercase-kebab form
  * for every filename, preserving directory structure for nested files.
@@ -14,7 +14,7 @@
  *
  * Round-trip is one-way: filename → slug is deterministic; slug → filename
  * requires the manifest lookup (information loss in the lowercase + dash
- * collapse means we cannot reverse the regex).
+ * collapse means we cannot reverse the derivation).
  */
 
 /**
@@ -27,15 +27,54 @@
  *   02-x402-payments.md    → 02-x402-payments
  *   RevealUIDocs.md        → reveal-ui-docs
  */
+const isAsciiUpper = (ch: string | undefined): boolean =>
+  ch !== undefined && ch >= 'A' && ch <= 'Z';
+const isAsciiLower = (ch: string | undefined): boolean =>
+  ch !== undefined && ch >= 'a' && ch <= 'z';
+
 export function filenameToSlug(filename: string): string {
-  return filename
-    .replace(/\.md$/, '')
-    .replace(/_/g, '-')
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-    .toLowerCase()
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
+  // Drop a trailing `.md` extension (only `.md`, matching the prior behavior).
+  const base = filename.endsWith('.md') ? filename.slice(0, -3) : filename;
+
+  // Single pass: map `_` to `-` and insert `-` at word boundaries —
+  //   lower->Upper ("aB" -> "a-B") and acronym->word ("HTMLParser" -> "HTML-Parser").
+  let dashed = '';
+  for (let i = 0; i < base.length; i++) {
+    const ch = base[i];
+    if (ch === '_') {
+      dashed += '-';
+      continue;
+    }
+    const prev = i > 0 ? base[i - 1] : '';
+    const next = i + 1 < base.length ? base[i + 1] : '';
+    const lowerToUpper = isAsciiUpper(ch) && isAsciiLower(prev);
+    const acronymToWord = isAsciiUpper(ch) && isAsciiUpper(prev) && isAsciiLower(next);
+    if (lowerToUpper || acronymToWord) {
+      dashed += '-';
+    }
+    dashed += ch;
+  }
+
+  // Lowercase, collapse runs of `-`, and trim a leading/trailing `-`.
+  const lowered = dashed.toLowerCase();
+  let collapsed = '';
+  let prevDash = false;
+  for (const ch of lowered) {
+    if (ch === '-') {
+      if (!prevDash) {
+        collapsed += '-';
+      }
+      prevDash = true;
+    } else {
+      collapsed += ch;
+      prevDash = false;
+    }
+  }
+  let start = 0;
+  let end = collapsed.length;
+  if (start < end && collapsed[start] === '-') start++;
+  if (end > start && collapsed[end - 1] === '-') end--;
+  return collapsed.slice(start, end);
 }
 
 /**

--- a/apps/docs/app/routes/SectionPage.tsx
+++ b/apps/docs/app/routes/SectionPage.tsx
@@ -6,7 +6,7 @@ import { useWildcardPath } from '../hooks/useWildcardPath';
 import { slugToPath } from '../lib/slug-manifest';
 import { loadMarkdownFile, renderMarkdown } from '../utils/markdown';
 import type { DocSection } from '../utils/paths';
-import { resolveDocPath } from '../utils/paths';
+import { resolveDocPath, stripDocExtension } from '../utils/paths';
 
 interface SectionPageProps {
   section: DocSection;
@@ -76,7 +76,7 @@ Document not found at \`${resolved.markdownPath}\`.
   // CHIP-3 D2b: path is a lowercase-kebab slug for the 'docs' section.
   // Resolve it back to the original filename via the manifest so the
   // GitHub edit link points at the real source file (e.g. ADMIN_GUIDE.md).
-  const slugKey = (path ?? '').replace(/\.(md|mdx)$/, '');
+  const slugKey = stripDocExtension(path ?? '');
   const sourceFile = slugToPath(slugKey) ?? (slugKey ? `${slugKey}.md` : 'INDEX.md');
   const githubUrl = `https://github.com/RevealUIStudio/revealui/blob/main/docs/${sourceFile}`;
 

--- a/apps/docs/app/utils/file-discovery.ts
+++ b/apps/docs/app/utils/file-discovery.ts
@@ -2,6 +2,8 @@
  * File discovery utilities for auto-generating documentation indexes
  */
 
+import { stripDocExtension } from './paths';
+
 /**
  * Discovered file information
  */
@@ -95,7 +97,7 @@ export async function discoverFiles(
  */
 function formatDisplayName(filename: string): string {
   // Remove extension
-  const withoutExt = filename.replace(/\.(md|mdx)$/, '');
+  const withoutExt = stripDocExtension(filename);
 
   // Convert kebab-case to Title Case
   return withoutExt

--- a/apps/docs/app/utils/paths.ts
+++ b/apps/docs/app/utils/paths.ts
@@ -68,6 +68,47 @@ const stripControlChars = (value: string): string => {
   return result;
 };
 
+/** Strip a trailing `.md` or `.mdx` extension (no authored regex). */
+export const stripDocExtension = (value: string): string => {
+  if (value.endsWith('.mdx')) return value.slice(0, -4);
+  if (value.endsWith('.md')) return value.slice(0, -3);
+  return value;
+};
+
+/** Remove leading and trailing forward slashes (no authored regex). */
+const trimSlashes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') {
+    start++;
+  }
+  while (end > start && value[end - 1] === '/') {
+    end--;
+  }
+  return value.slice(start, end);
+};
+
+/** True when a segment is non-empty and consists only of '.' characters. */
+const isAllDots = (segment: string): boolean => {
+  if (segment.length === 0) return false;
+  for (const ch of segment) {
+    if (ch !== '.') {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** True for an absolute path: a leading '/' or a Windows drive letter like "C:". */
+const isAbsolutePath = (value: string): boolean => {
+  if (value.startsWith('/')) return true;
+  if (value.length >= 2 && value[1] === ':') {
+    const code = value.charCodeAt(0);
+    return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+  }
+  return false;
+};
+
 /**
  * Sanitize a file path to prevent directory traversal and other security issues
  */
@@ -80,10 +121,10 @@ export function sanitizePath(input: string): string {
   let sanitized = stripControlChars(input);
 
   // Normalize path separators
-  sanitized = sanitized.replace(/\\/g, '/');
+  sanitized = sanitized.replaceAll('\\', '/');
 
   // Remove leading/trailing slashes and whitespace
-  sanitized = sanitized.trim().replace(/^\/+|\/+$/g, '');
+  sanitized = trimSlashes(sanitized.trim());
 
   // Split into segments and filter
   const segments = sanitized.split('/').filter((segment) => {
@@ -97,7 +138,7 @@ export function sanitizePath(input: string): string {
     if (segment === '..') return false;
 
     // Remove segments containing only dots (security: "....")
-    if (/^\.+$/.test(segment)) return false;
+    if (isAllDots(segment)) return false;
 
     // Remove segments with control characters
     if (hasControlChars(segment)) return false;
@@ -144,7 +185,7 @@ export function resolveDocPath(options: ResolveDocPathOptions): ResolvedDocPath 
   // CHIP-3 D2b: 'docs' section route paths are lowercase-kebab slugs.
   // Resolve via the slug manifest to recover the original filename.
   if (section === 'docs') {
-    const slugKey = sanitized.replace(/\.(md|mdx)$/, '');
+    const slugKey = stripDocExtension(sanitized);
     const original = slugToPath(slugKey);
     if (original) {
       return {
@@ -173,7 +214,7 @@ export function resolveDocPath(options: ResolveDocPathOptions): ResolvedDocPath 
       // Keep as is
     } else {
       // Remove extension if not required
-      resolvedPath = resolvedPath.replace(/\.(md|mdx)$/, '');
+      resolvedPath = stripDocExtension(resolvedPath);
     }
   } else {
     // No extension - add it if required
@@ -218,7 +259,7 @@ export function isPathSafe(input: string): boolean {
   }
 
   // Check for absolute paths (on Windows or Unix)
-  if (/^([a-zA-Z]:|\/)/.test(input)) {
+  if (isAbsolutePath(input)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

De-regex the `apps/docs` path-resolution, slug-derivation, and breadcrumb
utilities so they carry **no authored regex**, per the fleet no-regex posture.
All replacements are behavior-preserving char-scanners / `endsWith` / indexOf-style
helpers.

## Changes

- **`app/utils/paths.ts`** (security-sensitive): replace 6 regexes with
  `stripDocExtension`, `trimSlashes`, `isAllDots`, and `isAbsolutePath` helpers —
  covering separator normalization, leading/trailing-slash trim, the `"...."`
  all-dots traversal guard, the absolute-path / drive-letter check, and `.md`/`.mdx`
  extension stripping.
- **`app/lib/slug.ts`**: replace the 6-regex `filenameToSlug` chain with a single
  pass that maps `_`→`-`, inserts `-` at camelCase / acronym word boundaries, then
  lowercases, collapses dash runs, and trims edges.
- **`app/components/DocLayout.tsx`**: breadcrumb title-casing via a character scan.
- **`app/utils/file-discovery.ts`** and **`app/routes/SectionPage.tsx`**: reuse the
  shared `stripDocExtension` helper (the `.md`/`.mdx` strip was previously a regex
  duplicated in four places).

## Verification (local)

- `pnpm typecheck` — clean
- `pnpm lint` (Biome) — clean
- `pnpm test` — **125/125** pass, including `paths.test.ts` (24 security tests),
  `slug.test.ts` (29), and `file-discovery.test.ts` (13)
- `pnpm check:links` — 87 served pages, **0 broken** relative links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
