### PR TITLE
fix(setup): persist first-admin TOS via typed write, not engine create

### DIFF
--- a/apps/admin/src/__tests__/api/setup-routes.test.ts
+++ b/apps/admin/src/__tests__/api/setup-routes.test.ts
@@ -22,6 +22,19 @@ vi.mock('@/lib/utilities/revealui-singleton', () => ({
     }),
 }));
 
+// Capture the typed Drizzle writes the route performs after a successful create:
+// stampTosAcceptanceByEmail() (TOS columns) + the audit-log insert. The route
+// dynamically imports @revealui/db/client for both.
+const mockTosWhere = vi.fn().mockResolvedValue(undefined);
+const mockTosSet = vi.fn(() => ({ where: mockTosWhere }));
+const mockUpdate = vi.fn(() => ({ set: mockTosSet }));
+const mockAuditValues = vi.fn().mockResolvedValue(undefined);
+const mockInsert = vi.fn(() => ({ values: mockAuditValues }));
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: () => ({ update: mockUpdate, insert: mockInsert }),
+}));
+
 // ---------------------------------------------------------------------------
 // Route imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -65,6 +78,46 @@ describe('POST /api/setup', () => {
     expect(body.status).toBe('created');
     expect(body.user?.email).toBe('admin@test.com');
     expect(body.seeded).toBe(true);
+  });
+
+  it('stamps TOS acceptance via a typed write after creating the admin', async () => {
+    await POST(
+      makePostRequest({
+        email: 'admin@test.com',
+        password: 'securepassword12',
+      }),
+    );
+
+    // bootstrap() must NOT push TOS through the engine create (the dynamic-SQL
+    // adapter rejects camelCase column identifiers)...
+    const createData = mockCreate.mock.calls[0]?.[0]?.data as Record<string, unknown> | undefined;
+    expect(createData).not.toHaveProperty('tosAcceptedAt');
+    expect(createData).not.toHaveProperty('tosVersion');
+
+    // ...the route stamps it via a typed Drizzle update instead.
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockTosSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tosAcceptedAt: expect.any(Date),
+        tosVersion: expect.any(String),
+      }),
+    );
+    expect(mockTosWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns 201 when the TOS write fails (non-fatal)', async () => {
+    mockTosWhere.mockRejectedValueOnce(new Error('db unavailable'));
+
+    const res = await POST(
+      makePostRequest({
+        email: 'admin@test.com',
+        password: 'securepassword12',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe('created');
   });
 
   it('returns 403 when users already exist', async () => {

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -15,6 +15,7 @@ import { users } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
 import { count, eq, sql } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
+import { getTosAcceptance } from '@/lib/auth/tos';
 import { sendVerificationEmail } from '@/lib/email/verification';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import {
@@ -89,8 +90,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
 
     // Contract automatically sanitizes email (lowercase, trim) and name (trim, normalize spaces)
     const { email: sanitizedEmail, password, name: sanitizedName } = validationResult.data;
-    const tosAcceptedAt = new Date();
-    const tosVersion = process.env.TOS_VERSION ?? '2026-03-01';
+    const { tosAcceptedAt, tosVersion } = getTosAcceptance();
 
     // Check signup whitelist before proceeding
     if (!isSignupAllowed(sanitizedEmail)) {

--- a/apps/admin/src/app/api/setup/route.ts
+++ b/apps/admin/src/app/api/setup/route.ts
@@ -1,6 +1,8 @@
 import { type BootstrapResult, bootstrap, type RevealUILike } from '@revealui/setup/bootstrap';
+import { logger } from '@revealui/utils/logger';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { stampTosAcceptanceByEmail } from '@/lib/auth/tos';
 import { getRevealUIInstance } from '@/lib/utilities/revealui-singleton';
 
 export const runtime = 'nodejs';
@@ -72,23 +74,49 @@ export async function POST(request: Request): Promise<NextResponse<BootstrapResu
 
   if (result.status === 'created') {
     try {
-      const { hostname } = await import('node:os');
       const { getClient } = await import('@revealui/db/client');
-      const { auditLog } = await import('@revealui/db/schema');
       const db = getClient('rest');
-      await db.insert(auditLog).values({
-        event: 'admin.bootstrap.completed',
-        actor: 'web',
-        severity: 'info',
-        meta: {
+
+      // Stamp TOS acceptance on the typed columns. bootstrap() creates the admin
+      // through the engine's create(), which can't persist tos_accepted_at /
+      // tos_version (its dynamic-SQL adapter rejects camelCase column
+      // identifiers), so the caller records them via a typed Drizzle write —
+      // mirrors the CLI (scripts/admin/bootstrap.ts) and the sign-up route.
+      try {
+        await stampTosAcceptanceByEmail(db, parsed.data.email);
+      } catch (tosError) {
+        logger.error('Failed to record TOS acceptance for bootstrap admin', {
           email: parsed.data.email,
-          source: 'web',
-          hostname: hostname(),
-          seeded: parsed.data.seed ?? true,
-        },
-      } as never);
-    } catch {
-      // Non-fatal — audit log may not be available in all environments
+          error: tosError instanceof Error ? tosError.message : String(tosError),
+        });
+      }
+
+      // Audit log — non-fatal.
+      try {
+        const { hostname } = await import('node:os');
+        const { auditLog } = await import('@revealui/db/schema');
+        await db.insert(auditLog).values({
+          event: 'admin.bootstrap.completed',
+          actor: 'web',
+          severity: 'info',
+          meta: {
+            email: parsed.data.email,
+            source: 'web',
+            hostname: hostname(),
+            seeded: parsed.data.seed ?? true,
+          },
+        } as never);
+      } catch {
+        // Non-fatal — audit log may not be available in all environments
+      }
+    } catch (dbError) {
+      // DB client unavailable — the admin was still created by bootstrap(), but
+      // the TOS record and audit entry couldn't be written. Surface loudly so the
+      // gap (a backfillable NULL tos_accepted_at) is visible, not silent.
+      logger.error('Post-create steps skipped: database client unavailable', {
+        email: parsed.data.email,
+        error: dbError instanceof Error ? dbError.message : String(dbError),
+      });
     }
   }
 

--- a/apps/admin/src/lib/auth/tos.test.ts
+++ b/apps/admin/src/lib/auth/tos.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_TOS_VERSION, getTosAcceptance, stampTosAcceptanceByEmail } from './tos';
+
+describe('getTosAcceptance', () => {
+  const prevTosVersion = process.env.TOS_VERSION;
+
+  afterEach(() => {
+    if (prevTosVersion === undefined) delete process.env.TOS_VERSION;
+    else process.env.TOS_VERSION = prevTosVersion;
+  });
+
+  it('returns the default version and a fresh acceptance timestamp', () => {
+    delete process.env.TOS_VERSION;
+
+    const before = Date.now();
+    const { tosAcceptedAt, tosVersion } = getTosAcceptance();
+    const after = Date.now();
+
+    expect(tosVersion).toBe(DEFAULT_TOS_VERSION);
+    expect(tosAcceptedAt).toBeInstanceOf(Date);
+    expect(tosAcceptedAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(tosAcceptedAt.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it('honors the TOS_VERSION env override when present', () => {
+    process.env.TOS_VERSION = '2099-01-01';
+    expect(getTosAcceptance().tosVersion).toBe('2099-01-01');
+  });
+});
+
+describe('stampTosAcceptanceByEmail', () => {
+  it('issues a typed update setting tosAcceptedAt + tosVersion for the email', async () => {
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn(() => ({ where }));
+    const update = vi.fn(() => ({ set }));
+    // Minimal Drizzle-shaped stub; we only exercise update().set().where().
+    const db = { update } as unknown as Parameters<typeof stampTosAcceptanceByEmail>[0];
+
+    await stampTosAcceptanceByEmail(db, 'admin@test.com');
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tosAcceptedAt: expect.any(Date),
+        tosVersion: expect.any(String),
+      }),
+    );
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin/src/lib/auth/tos.ts
+++ b/apps/admin/src/lib/auth/tos.ts
@@ -1,0 +1,54 @@
+/**
+ * Terms-of-Service acceptance capture for account creation.
+ *
+ * Single source for the default TOS version and the typed write that stamps
+ * acceptance onto a user row. Used by every programmatic first-admin path that
+ * goes through the engine's create() (web setup route, CLI `admin:bootstrap`)
+ * plus the regular sign-up route, so the `TOS_VERSION` default lives in one
+ * place instead of being re-inlined per call site.
+ *
+ * Why a typed Drizzle write rather than the engine's create(): `tos_accepted_at`
+ * and `tos_version` are typed Postgres columns, but the engine's dynamic-SQL
+ * create path writes the literal (camelCase) data keys as column identifiers and
+ * rejects them via its snake_case identifier guard — and would JSON-stringify a
+ * Date into an invalid timestamp literal besides. Drizzle maps camelCase fields
+ * to their snake_case columns, so the typed path is the only one that persists
+ * these columns correctly. See packages/setup/src/bootstrap/index.ts for the
+ * matching engine-side note.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { eq } from '@revealui/db/orm';
+import { users } from '@revealui/db/schema';
+
+/** Default Terms-of-Service version stamped when `TOS_VERSION` is unset. */
+export const DEFAULT_TOS_VERSION = '2026-03-01';
+
+export interface TosAcceptance {
+  /** When acceptance was recorded (account-creation time). */
+  tosAcceptedAt: Date;
+  /** The TOS version the account accepted. */
+  tosVersion: string;
+}
+
+/**
+ * Resolve the Terms-of-Service acceptance record for an account created now.
+ * `tosAcceptedAt` is the current time; `tosVersion` is the `TOS_VERSION` env
+ * value or the {@link DEFAULT_TOS_VERSION} fallback.
+ */
+export function getTosAcceptance(): TosAcceptance {
+  return {
+    tosAcceptedAt: new Date(),
+    tosVersion: process.env.TOS_VERSION ?? DEFAULT_TOS_VERSION,
+  };
+}
+
+/**
+ * Stamp TOS acceptance onto the user with the given email via a typed Drizzle
+ * update. For creation-time use: sets both columns unconditionally. A no-op if
+ * no row matches the email (e.g. the create was rolled back upstream).
+ */
+export async function stampTosAcceptanceByEmail(db: Database, email: string): Promise<void> {
+  const { tosAcceptedAt, tosVersion } = getTosAcceptance();
+  await db.update(users).set({ tosAcceptedAt, tosVersion }).where(eq(users.email, email));
+}

--- a/packages/setup/src/__tests__/bootstrap.test.ts
+++ b/packages/setup/src/__tests__/bootstrap.test.ts
@@ -142,44 +142,27 @@ describe('bootstrap', () => {
     );
   });
 
-  it('records tosAcceptedAt and tosVersion on the bootstrap admin', async () => {
-    // Regression guard for revealui#431 — web signup records TOS acceptance;
-    // bootstrap must match so the first admin has the same legal record.
-    const before = new Date();
+  it('does not send TOS fields through the engine create (callers persist them via typed write)', async () => {
+    // Regression guard for the PR #458 breakage: tos_accepted_at / tos_version
+    // are typed columns the injected engine's dynamic-SQL create() cannot
+    // persist — it writes the literal camelCase keys as column names and the
+    // universal-postgres identifier guard rejects `tosAcceptedAt`, failing the
+    // whole admin creation. bootstrap() must keep these OUT of the engine create;
+    // the callers stamp them via a typed Drizzle write
+    // (apps/admin/src/lib/auth/tos.ts → stampTosAcceptanceByEmail).
     await bootstrap({
       revealui: mockRevealUI,
       admin: VALID_ADMIN,
     });
-    const after = new Date();
 
     const createCall = (mockRevealUI.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     const data = createCall?.data as Record<string, unknown>;
 
-    expect(data.tosAcceptedAt).toBeInstanceOf(Date);
-    const acceptedAt = data.tosAcceptedAt as Date;
-    expect(acceptedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
-    expect(acceptedAt.getTime()).toBeLessThanOrEqual(after.getTime());
-
-    expect(typeof data.tosVersion).toBe('string');
-    expect((data.tosVersion as string).length).toBeGreaterThan(0);
-  });
-
-  it('honors TOS_VERSION env override when present', async () => {
-    const prev = process.env.TOS_VERSION;
-    process.env.TOS_VERSION = '2099-01-01';
-    try {
-      await bootstrap({
-        revealui: mockRevealUI,
-        admin: VALID_ADMIN,
-      });
-
-      const createCall = (mockRevealUI.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-      const data = createCall?.data as Record<string, unknown>;
-      expect(data.tosVersion).toBe('2099-01-01');
-    } finally {
-      if (prev === undefined) delete process.env.TOS_VERSION;
-      else process.env.TOS_VERSION = prev;
-    }
+    expect(data).not.toHaveProperty('tosAcceptedAt');
+    expect(data).not.toHaveProperty('tosVersion');
+    // The role/roles dual-write must still be present.
+    expect(data.role).toBe('owner');
+    expect(data.roles).toEqual(['super-admin']);
   });
 
   it('continues even if seed fails (non-fatal)', async () => {

--- a/packages/setup/src/bootstrap/index.ts
+++ b/packages/setup/src/bootstrap/index.ts
@@ -187,11 +187,16 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
   // (super-admin/admin). Both layers consume different fields;
   // first user is 'owner' at the DB layer and 'super-admin' at the app layer.
   //
-  // TOS capture: record acceptance at bootstrap time so the bootstrap admin has
-  // the same legal-defensibility record as web-signup users. Web signup sets
-  // these fields in apps/admin/src/app/api/auth/sign-up/route.ts:61-62;
-  // matching the pattern (including the same env-var default) keeps the two
-  // code paths in sync.
+  // TOS capture is intentionally NOT done here. tos_accepted_at / tos_version
+  // are typed Postgres columns, but the injected engine's create() routes
+  // through a dynamic-SQL adapter that writes the literal (camelCase) data keys
+  // as column identifiers and rejects them via a snake_case identifier guard
+  // (a Date would also be JSON-stringified into an invalid timestamp literal).
+  // Keeping @revealui/setup engine-agnostic, the bootstrap CALLERS stamp TOS via
+  // a typed Drizzle write right after this returns — see
+  // apps/admin/src/lib/auth/tos.ts (stampTosAcceptanceByEmail), used by the web
+  // setup route (apps/admin/src/app/api/setup/route.ts) and the CLI
+  // (scripts/admin/bootstrap.ts).
   try {
     await revealui.create({
       collection: 'users',
@@ -201,8 +206,6 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
         password: admin.password,
         role: 'owner',
         roles: ['super-admin'],
-        tosAcceptedAt: new Date(),
-        tosVersion: process.env.TOS_VERSION ?? '2026-03-01',
       },
       overrideAccess: true,
     });

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -165,6 +165,23 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Record TOS acceptance on the typed columns. bootstrap() creates the admin
+  // through the engine's create(), which can't persist tos_accepted_at /
+  // tos_version (its dynamic-SQL adapter rejects camelCase column identifiers),
+  // so the caller stamps them via a typed Drizzle write — mirrors the web setup
+  // route (apps/admin/src/app/api/setup/route.ts).
+  if (result.user) {
+    try {
+      const { stampTosAcceptanceByEmail } = await import('../../apps/admin/src/lib/auth/tos.js');
+      await stampTosAcceptanceByEmail(db, email);
+      console.log('[bootstrap] recorded TOS acceptance');
+    } catch (err) {
+      console.warn(
+        `[bootstrap] failed to record TOS acceptance: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   // Set mustRotatePassword flag if requested
   if (forceRotate && result.user) {
     try {


### PR DESCRIPTION
## Summary

First-admin creation via `bootstrap()` — both the web **POST `/api/setup`** flow and the **`pnpm admin:bootstrap`** CLI — was completely broken. The universal-postgres adapter rejected the create with:

> Invalid column name: `"tosAcceptedAt"`. Column names must start with a lowercase letter or underscore and contain only lowercase alphanumeric characters and underscores.

So `bootstrap()` returned `Failed to create admin user.` and **no admin was created**. Only the regular `/sign-up` route worked, leaving fresh deployments unable to create their first admin programmatically.

## Root cause

#458 added `tosAcceptedAt` / `tosVersion` to the engine `revealui.create()` data in `@revealui/setup` `bootstrap()`. But the engine's dynamic-SQL create path writes the **literal (camelCase) data keys as column identifiers** and validates them against a snake_case-only guard, so `tosAcceptedAt` is rejected outright (and a `Date` would additionally be `JSON.stringify`'d into an invalid timestamp literal).

The change only ever ran against **mocked** unit tests, which is why it shipped — the mock never exercises the adapter that enforces the identifier guard. `tos_accepted_at` / `tos_version` are real typed columns, writable only via the typed Drizzle path (the same path `/sign-up` already uses).

## Fix

Caller-side typed write, keeping `@revealui/setup` engine-agnostic (it has no dependency on `@revealui/core` / `@revealui/db` by design):

- **`bootstrap()`** no longer pushes TOS through the engine create; its create now matches the known-working env-driven `onInit` shape (`name` / `email` / `password` / `role` / `roles`).
- The **bootstrap callers** stamp TOS via a typed Drizzle update immediately after create — mirroring the CLI's existing `mustRotatePassword` write:
  - **web setup route**: `stampTosAcceptanceByEmail()` on a `created` result (logs loudly on failure; audit-log path unchanged / non-fatal).
  - **CLI `admin:bootstrap`**: stamps TOS for every created admin.
- New shared helper **`apps/admin/src/lib/auth/tos.ts`** — `DEFAULT_TOS_VERSION`, `getTosAcceptance()`, `stampTosAcceptanceByEmail()` — de-duplicating the `TOS_VERSION` default that `/sign-up` also inlined (third inliner removed).

## Files

- `packages/setup/src/bootstrap/index.ts` — drop TOS from the engine create + explain why.
- `apps/admin/src/lib/auth/tos.ts` *(new)* — shared TOS helper.
- `apps/admin/src/app/api/setup/route.ts` — stamp TOS after create.
- `scripts/admin/bootstrap.ts` — stamp TOS after create.
- `apps/admin/src/app/api/auth/sign-up/route.ts` — use the shared helper (de-drift).
- Tests: `packages/setup/src/__tests__/bootstrap.test.ts`, `apps/admin/src/__tests__/api/setup-routes.test.ts`, `apps/admin/src/lib/auth/tos.test.ts`.

## Testing

Run locally (all green):
- `biome check` on changed files
- `@revealui/setup` typecheck + full test suite
- `admin` typecheck
- affected admin suites: `tos.test.ts`, `setup-routes.test.ts`, auth `integration.test.ts` + passkey `routes.test.ts`

Test changes of note:
- The `@revealui/setup` bootstrap test's TOS assertion is **inverted**: it now guards that `bootstrap()` does **not** send TOS through the engine create (the camelCase column that was rejected).
- The setup-route test asserts TOS is stamped via the typed write on success, and that a failed TOS write is **non-fatal** (still `201`).

**Not run:** a live `POST /api/setup` against a migrated Postgres. The typed write type-checks against the real `users` schema (whose columns are `tos_accepted_at` / `tos_version`) and is structurally identical to the proven-live CLI `mustRotatePassword` write. Recommended acceptance check: from a fresh migrated DB, `POST /api/setup` (and `pnpm admin:bootstrap`) → an `owner` user with `tos_accepted_at` + `tos_version` populated.

## Out of scope (follow-up)

The env-driven `onInit` auto-bootstrap path in `apps/admin/revealui.config.ts` creates its admin via the engine **without** TOS — a pre-existing latent gap (it doesn't crash because it never passed TOS). Left out of this focused bugfix; it can adopt the same `stampTosAcceptanceByEmail()` helper in a follow-up so the central engine-boot file isn't entangled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
