### PR TITLE
fix(admin): stamp first-admin TOS in onInit env-bootstrap path

### DIFF
--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -328,6 +328,28 @@ export default buildConfig({
         });
 
         revealui.logger.info(`First admin user created: ${adminEmail}`);
+
+        // Stamp TOS acceptance on the typed tos_accepted_at / tos_version
+        // columns: revealui.create() above can't persist them (the engine's
+        // dynamic-SQL adapter rejects camelCase column identifiers), so an
+        // onInit-created owner would otherwise have a NULL tos_accepted_at.
+        // Record them via a typed Drizzle write, mirroring the web setup route
+        // (api/setup) and the CLI (scripts/admin/bootstrap). Non-fatal — a
+        // failure here is a backfillable gap, not a reason to abort startup.
+        // Imports are lazy because pulling @revealui/db/client into the
+        // top-level module graph causes Turbopack async-module-init issues
+        // (see the poolFactory note near the top of this file).
+        try {
+          const { getClient } = await import('@revealui/db/client');
+          const { stampTosAcceptanceByEmail } = await import('@/lib/auth/tos');
+          const db = getClient('rest');
+          await stampTosAcceptanceByEmail(db, adminEmail);
+        } catch (tosError) {
+          const message = tosError instanceof Error ? tosError.message : String(tosError);
+          revealui.logger.error(
+            `Failed to record TOS acceptance for bootstrap admin ${adminEmail}: ${message}`,
+          );
+        }
       } catch (error) {
         // 23505 = unique_violation  -  user already exists, not a fatal error
         const pgCode = (error as { code?: string }).code;


### PR DESCRIPTION
## What

The env-driven first-admin auto-bootstrap in `apps/admin/revealui.config.ts` (the `onInit` callback) creates the first owner via `revealui.create(...)` when `REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD` are set and no users exist — but it never recorded TOS acceptance, leaving `onInit`-created owners with `tos_accepted_at = NULL`.

This stamps TOS acceptance immediately after the successful create, via the shared `stampTosAcceptanceByEmail(db, email)` helper (a typed Drizzle write on the `tos_accepted_at` / `tos_version` columns), with a db client from `getClient('rest')`.

## Why

Same legal-defensibility gap #1219 closed for the web setup route (`apps/admin/src/app/api/setup/route.ts`) and the CLI (`scripts/admin/bootstrap.ts`). `onInit` was deliberately left out of that focused bugfix because — unlike `bootstrap()` — it never passed `tos` through the engine `create()`, so it never hit the universal-postgres camelCase-column rejection and didn't crash. The gap was **latent, not loud**: `onInit`-created owners are exactly the rows the backfill script `scripts/setup/backfill-tos-pre-458-bootstrap.ts` hunts (`role='owner' AND email_verified=true AND tos_accepted_at IS NULL`).

## How

Mirrors the post-create block from #1219's `api/setup` change:

- The TOS write is **non-fatal** — wrapped in its own try/catch and logged via `revealui.logger.error`. A failure is a backfillable gap, not a startup blocker. The create is already inside a try/catch; the dedicated inner catch also stops a TOS failure from being misreported as a create failure by the outer `23505` handler.
- Both imports (`getClient`, `stampTosAcceptanceByEmail`) are **dynamic/lazy** to keep `@revealui/db/client` out of the config's top-level module graph — the Turbopack async-module-init constraint already documented on the `poolFactory` near the top of the file.

## Testing

- `pnpm --filter admin typecheck` — pass
- `pnpm exec biome check apps/admin/revealui.config.ts` — pass

`onInit` is skipped under test (`apps/admin/vitest.config.ts` sets `SKIP_ONINIT=true` / `NODE_ENV=test`), so it isn't unit-testable here. Correctness rests on the typecheck plus the already-tested `api/setup` route pattern this mirrors.

## ⚠️ Stacked on #1219

Based on `fix/bootstrap-admin-tos-columns` (the head branch of #1219), because the shared `stampTosAcceptanceByEmail` helper only lands on `test` when #1219 merges. **Will be retargeted to `test` once #1219 merges.** Review #1219 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
