### PR TITLE
chore: drop unused open collective funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
 github: RevealUIStudio
-open_collective: revealui
 custom: ["https://revealui.com/sponsor"]


### PR DESCRIPTION
## What
Removes the `open_collective: revealui` entry from `.github/FUNDING.yml`.

## Why
The project does not maintain an Open Collective, so that sponsor button
linked to an empty page. The GitHub Sponsors (`github: RevealUIStudio`) and
custom sponsor-page (`custom`) entries remain and are unaffected.

## Risk
None. Funding metadata only; no code or build impact.
