### PR TITLE
fix(cli): use revealui db init in starter scaffolds

### DIFF
--- a/packages/cli/templates/starter-native/package.json
+++ b/packages/cli/templates/starter-native/package.json
@@ -11,7 +11,7 @@
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "db:init": "revealui cms",
+    "db:init": "revealui db init",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/seed.ts"
   },

--- a/packages/cli/templates/starter/package.json
+++ b/packages/cli/templates/starter/package.json
@@ -10,7 +10,7 @@
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "db:init": "revealui cms",
+    "db:init": "revealui db init",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/seed.ts"
   },


### PR DESCRIPTION
## What
Fix the `db:init` script in two scaffolding templates
(`packages/cli/templates/starter` + `starter-native`):
`"revealui cms"` -> `"revealui db init"`.

## Why
`revealui cms` is not a valid CLI command (the `cms` surface was renamed to
`admin`), so a freshly scaffolded starter project failed immediately on
`pnpm db:init`. The CLI registers `db init` (`packages/cli/src/cli.ts`), and
the e-commerce / basic-blog / portfolio templates already use
`revealui db init`. This aligns the two outliers.

## Verify
`pnpm db:init` in a fresh `create-revealui` starter now resolves to the real
command. No test changes needed: the CLI tests assert the `db:init` script
key, not its value.

## Risk
Low. Scaffolding-template metadata only; no runtime or build impact.
