### PR TITLE
chore: point community links at GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: GitHub Discussions
     url: https://github.com/RevealUIStudio/revealui/discussions
     about: Ask questions and share ideas with the community
-  - name: Discourse Community
-    url: https://revnation.discourse.group
-    about: Ask questions and get help from the community

--- a/README.md
+++ b/README.md
@@ -308,7 +308,6 @@ pnpm gate       # full CI gate (runs before push)
 ## Community
 
 - [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions)
-- [Discourse Community](https://revnation.discourse.group)
 - [GitHub Issues](https://github.com/RevealUIStudio/revealui/issues)
 
 ## Sponsors

--- a/apps/marketing/README.md
+++ b/apps/marketing/README.md
@@ -1,6 +1,6 @@
 # marketing
 
-Public marketing site for RevealUI — homepage, blog, pricing, fair-source, contact, etc. Lives at `revealui.com` (and the `community.revealui.com` host redirects to the Discourse forum via `vercel.json`).
+Public marketing site for RevealUI — homepage, blog, pricing, fair-source, contact, etc. Lives at `revealui.com` (and the `community.revealui.com` host redirects to GitHub Discussions via `vercel.json`).
 
 ## Stack
 

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -74,7 +74,7 @@ export const SITE = {
     adminLogin: 'https://admin.revealui.com/login',
     x: 'https://x.com/revealui',
     linkedin: 'https://www.linkedin.com/company/revealui',
-    forum: 'https://revnation.discourse.group',
+    forum: 'https://github.com/RevealUIStudio/revealui/discussions',
     repoChangelog: 'https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md',
     repoLicense: 'https://github.com/RevealUIStudio/revealui/blob/main/LICENSE',
   },

--- a/apps/marketing/app/content/sponsor.ts
+++ b/apps/marketing/app/content/sponsor.ts
@@ -88,7 +88,7 @@ export const SPONSOR_TIERS: readonly SponsorTier[] = [
     benefits: [
       'All Gold Sponsor benefits',
       'Logo with link on landing page',
-      'Dedicated Discourse channel',
+      'Dedicated community channel',
       'Direct line to the founder for prioritized feature requests — implementation scoped separately via RevealUI Studio engagements',
     ],
   },
@@ -107,7 +107,7 @@ export const SPONSOR_SUPPORT_AREAS: readonly SupportArea[] = [
   },
   {
     title: 'Community',
-    description: 'Discourse forums, issue triage, code reviews, and mentorship.',
+    description: 'Community forums, issue triage, code reviews, and mentorship.',
     iconKey: 'community',
   },
 ];

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -52,13 +52,13 @@
     { "source": "/marketplace", "destination": "/roadmap", "permanent": true },
     {
       "source": "/community",
-      "destination": "https://revnation.discourse.group",
+      "destination": "https://github.com/RevealUIStudio/revealui/discussions",
       "permanent": false
     },
     {
       "source": "/:path*",
       "has": [{ "type": "host", "value": "community.revealui.com" }],
-      "destination": "https://revnation.discourse.group",
+      "destination": "https://github.com/RevealUIStudio/revealui/discussions",
       "permanent": true
     }
   ],

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,7 +178,6 @@ See [revealui.com/pricing](https://revealui.com/pricing) for details.
 
 - **GitHub Issues**  -  [Request features or report bugs](https://github.com/RevealUIStudio/revealui/issues)
 - **Discussions**  -  [Join the conversation](https://github.com/RevealUIStudio/revealui/discussions)
-- **Community**  -  [revnation.discourse.group](https://revnation.discourse.group)
 - **Email**  -  support@revealui.com
 
 We prioritize based on: customer impact, charge readiness, and community demand.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -458,11 +458,6 @@ Comprehensive troubleshooting guide for common RevealUI issues.
    - Request features
    - Track progress
 
-3. **Discourse Community** - [Join here](https://revnation.discourse.group)
-   - Discussion forums
-   - Quick questions
-   - Community help
-
 4. **Email Support** - support@revealui.com
    - Technical issues
    - Account problems

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -252,7 +252,7 @@ The repository is public on GitHub. The docs site is live at [docs.revealui.com]
 
 RevDev Studio (Tauri + React) is the native AI experience — agent coordination, local inference management, and a visual dashboard. A terminal client (Go + Bubble Tea) gives you a TUI for API access and license lookups.
 
-The near-term roadmap includes MCP server registry listings, A2A agent discovery for RevealUI-to-RevealUI communication, a broader template library, and a template marketplace where developers can publish project starters. The community forum is at [revnation.discourse.group](https://revnation.discourse.group) — join early and help shape what gets built next.
+The near-term roadmap includes MCP server registry listings, A2A agent discovery for RevealUI-to-RevealUI communication, a broader template library, and a template marketplace where developers can publish project starters. The community lives on [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions), so join early and help shape what gets built next.
 
 But the core thesis won't change: **every software company needs users, content, products, payments, and intelligence. You shouldn't have to build them from scratch.**
 

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -138,7 +138,7 @@ RevealUI isn't just a framework you install. It's an open runtime for AI-native 
 
 **Template marketplace.** Starter projects on Vercel that showcase RevealUI for specific use cases -- SaaS boilerplates, e-commerce setups, documentation sites, internal tools. These lower the barrier to getting started and demonstrate what's possible.
 
-**Community on Discourse.** Free support for everyone through community forums. Pro and above get priority support with SLA-backed response times. The community is where we build trust, gather feedback, and help people succeed -- regardless of what tier they're on.
+**Community discussions.** Free support for everyone through community forums. Pro and above get priority support with SLA-backed response times. The community is where we build trust, gather feedback, and help people succeed -- regardless of what tier they're on.
 
 **The flywheel.** More developers using RevealUI means more MCP servers published to the marketplace. More MCP servers means agents can do more things. More capable agents means more demand for agent tasks. More demand means more developers building servers. Each layer reinforces the others.
 

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -621,7 +621,7 @@ The pattern scales. Add products, orders, tickets, knowledge bases  -  each coll
 
 - [Documentation](https://docs.revealui.com)  -  full reference for every package and API
 - [GitHub](https://github.com/RevealUIStudio/revealui)  -  star the repo, report issues, contribute
-- [Community Forum](https://revnation.discourse.group)  -  ask questions, share what you are building
+- [Community Forum](https://github.com/RevealUIStudio/revealui/discussions)  -  ask questions, share what you are building
 
 ---
 


### PR DESCRIPTION
## What
Repoints community links from the retiring Discourse forum
(`revnation.discourse.group`) to GitHub Discussions
(`https://github.com/RevealUIStudio/revealui/discussions`).

## Changes
- **Removed redundant Discourse entries** where GitHub Discussions was already
  listed beside them: `.github/ISSUE_TEMPLATE/config.yml`, root `README.md`,
  `docs/ROADMAP.md`, `docs/TROUBLESHOOTING.md`.
- **Repointed redirects** in `apps/marketing/vercel.json`: the `/community`
  redirect and the `community.revealui.com` host redirect now resolve to GitHub
  Discussions.
- **Repointed the marketing forum link** (`apps/marketing/app/content/site.ts`
  `forum`) and updated the `apps/marketing` README description.
- **De-Discourse'd copy** in `apps/marketing/app/content/sponsor.ts` (sponsor
  perk + support-area wording) and three blog posts (`01`, `06`, `08`).

## Left as-is (intentional)
`docs/MASTER_PLAN.md` internal status and `docs/archive/...` historical record
correctly reference Discourse as past/internal state.

## Verify
`biome check` clean on changed TS/JSON; `vercel.json` valid JSON; claim-drift
validator reports 0 mismatches. GitHub Discussions is enabled on the repo.

## Risk
Low. Community links plus two marketing redirects. Destinations change from
Discourse to GitHub Discussions; the `community.revealui.com` vanity host keeps
resolving via the same Vercel rule, now pointing at Discussions.
