### PR TITLE
feat(scripts): seed STRIPE_MAX_ANNUAL_PRICE_ID from max-yearly price

### DIFF
--- a/scripts/setup/__tests__/stripe-revvault-sync.test.ts
+++ b/scripts/setup/__tests__/stripe-revvault-sync.test.ts
@@ -44,6 +44,7 @@ describe('drift guard: seeded price env keys must have a manifest vault path', (
     const requiredKeys = [
       'STRIPE_PRO_PRICE_ID',
       'STRIPE_MAX_PRICE_ID',
+      'STRIPE_MAX_ANNUAL_PRICE_ID',
       'STRIPE_ENTERPRISE_PRICE_ID',
       'STRIPE_PERPETUAL_PRO_PRICE_ID',
       'STRIPE_PERPETUAL_MAX_PRICE_ID',

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -334,6 +334,7 @@ const WEBHOOK_EVENTS = [
 const PRICE_ENV_KEYS: Record<string, string> = {
   revealui_pro_monthly: 'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
   revealui_max_monthly: 'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+  revealui_max_yearly: 'NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID',
   revealui_enterprise_monthly: 'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
   revealui_pro_perpetual: 'NEXT_PUBLIC_STRIPE_PRO_PERPETUAL_PRICE_ID',
   revealui_max_perpetual: 'NEXT_PUBLIC_STRIPE_MAX_PERPETUAL_PRICE_ID',
@@ -342,6 +343,7 @@ const PRICE_ENV_KEYS: Record<string, string> = {
 const PRICE_SERVER_ENV_KEYS: Record<string, string> = {
   revealui_pro_monthly: 'STRIPE_PRO_PRICE_ID',
   revealui_max_monthly: 'STRIPE_MAX_PRICE_ID',
+  revealui_max_yearly: 'STRIPE_MAX_ANNUAL_PRICE_ID',
   revealui_enterprise_monthly: 'STRIPE_ENTERPRISE_PRICE_ID',
   revealui_pro_perpetual: 'STRIPE_PERPETUAL_PRO_PRICE_ID',
   revealui_max_perpetual: 'STRIPE_PERPETUAL_MAX_PRICE_ID',


### PR DESCRIPTION
## What
The Stripe seeder defines the `revealui_max_yearly` price (annual Max) and
creates it in Stripe, but never mapped it to an env var, so the already-declared
`STRIPE_MAX_ANNUAL_PRICE_ID` (in `scripts/sync/revvault-vercel.toml` +
`revvault-fly.toml`) was never populated by `pnpm stripe:seed`. This wires it.

## Changes
- `scripts/setup/seed-stripe.ts`: map `revealui_max_yearly` to
  `STRIPE_MAX_ANNUAL_PRICE_ID` (server) and `NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID`
  (public), mirroring the existing monthly / perpetual entries.
- `scripts/setup/__tests__/stripe-revvault-sync.test.ts`: add the new key to the
  drift-guard list so it asserts the manifest has a vault path for it.

## Verify
`vitest run` on the seed-stripe tests passes 17/17, including the drift guard
(the new key resolves to `revealui/prod/stripe/max-annual-price-id`). Biome clean
on the changed lines. Full typecheck runs in CI; the change is type-trivial (two
`Record<string, string>` entries plus one array string).

## Scope / deferred
This is the reproducible-seeding half only. Two follow-ups are intentionally not
included, each needing its own decision: modeling annual as a `billing_catalog`
plan (the catalog planId model is `{model}:{tier}`, so an annual plan needs a
billing-interval design choice, not a drop-in), and wiring an annual-Max checkout
selection (a separate UI change; no annual selection exists in pricing yet). The
live seed run remains operator-gated.
