### PR TITLE
fix(auth): grant owner/super-admin full access across signup, server gates, and first-user hook

### DIFF
--- a/apps/admin/src/__tests__/auth/password-reset-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/password-reset-routes.test.ts
@@ -204,6 +204,26 @@ describe('POST /api/auth/password-reset', () => {
     expect(body.message).toContain('password reset link has been sent');
   });
 
+  it('returns success even when sendPasswordResetEmail throws (transport down)', async () => {
+    vi.mocked(generatePasswordResetToken).mockResolvedValue({
+      success: true,
+      token: 'raw-token',
+      tokenId: 'tid-throw',
+    } as never);
+    vi.mocked(sendPasswordResetEmail).mockRejectedValue(
+      new Error('Gmail transport not configured'),
+    );
+
+    const req = makeRequest('/api/auth/password-reset', 'POST', {
+      email: 'alice@test.com',
+    });
+    const res = await POST(req);
+    // A thrown email send is swallowed like a returned failure, not a 500.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain('password reset link has been sent');
+  });
+
   it('returns 400 for missing email', async () => {
     const req = makeRequest('/api/auth/password-reset', 'POST', {});
     const res = await POST(req);

--- a/apps/admin/src/app/api/auth/password-reset/route.ts
+++ b/apps/admin/src/app/api/auth/password-reset/route.ts
@@ -67,22 +67,36 @@ async function passwordResetRequestHandler(request: NextRequest): Promise<NextRe
       );
     }
 
-    // Send email with reset link (tokenId is included in the URL for O(1) lookup)
+    // Send email with reset link (tokenId is included in the URL for O(1) lookup).
+    // Email transport failure must never 500 the request or reveal whether the
+    // account exists. A thrown send (e.g. an unconfigured or throwing mail
+    // provider) is logged and swallowed exactly like a returned { success:false },
+    // so the handler always falls through to the generic success response below.
     if (result.token && result.tokenId) {
-      const emailResult = await sendPasswordResetEmail(
-        sanitizedEmail,
-        result.tokenId,
-        result.token,
-      );
+      try {
+        const emailResult = await sendPasswordResetEmail(
+          sanitizedEmail,
+          result.tokenId,
+          result.token,
+        );
 
-      if (!emailResult.success) {
-        // Log error but don't reveal to user (security)
+        if (!emailResult.success) {
+          // Log error but don't reveal to user (security)
+          logger.error(
+            'Failed to send password reset email',
+            new Error(emailResult.error || 'Unknown email error'),
+            { email: sanitizedEmail },
+          );
+          // Still return success to prevent user enumeration
+        }
+      } catch (emailError) {
+        // A thrown send (transport misconfig, network) is non-fatal: log and
+        // fall through to the generic success response, matching the !success path.
         logger.error(
-          'Failed to send password reset email',
-          new Error(emailResult.error || 'Unknown email error'),
+          'Password reset email send threw',
+          emailError instanceof Error ? emailError : new Error(String(emailError)),
           { email: sanitizedEmail },
         );
-        // Still return success to prevent user enumeration
       }
     }
 

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -15,6 +15,7 @@ import { users } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
 import { count, eq, sql } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
+import { grantSuperAdminRoleById } from '@/lib/auth/roles';
 import { getTosAcceptance } from '@/lib/auth/tos';
 import { sendVerificationEmail } from '@/lib/email/verification';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -193,6 +194,14 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
           emailVerified: true,
           emailVerifiedAt: new Date(),
         });
+        // Grant the app-layer super-admin role in `_json.roles`. The DB `role`
+        // column above is read by the proxy/cookie gate, but the engine's
+        // access gates (isSuperAdmin / isAdmin via hasRole) read `_json.roles`
+        // — without this the first user is an admin the engine still denies.
+        // signUp() creates users via a typed insert that never populates
+        // `_json`, so the grant must be a typed update afterward. Canonical
+        // owner shape per #1219: DB role + _json.roles=['super-admin'].
+        await grantSuperAdminRoleById(db, result.user.id);
         if (updatedUser) {
           resolvedUser = {
             ...updatedUser,
@@ -200,8 +209,11 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
           };
         }
       } catch (upgradeError) {
-        // Non-fatal  -  user was created, couldn't promote to admin
-        logger.warn('Failed to promote first user to admin', {
+        // Non-fatal  -  user was created, but couldn't be promoted (DB `role`
+        // and/or the `_json.roles` super-admin grant). Loud: a half-promoted
+        // first user can't reach the engine-gated admin surface and needs a
+        // manual backfill.
+        logger.error('Failed to promote first user to admin/super-admin', {
           userId: result.user.id,
           error: upgradeError instanceof Error ? upgradeError.message : String(upgradeError),
         });
@@ -239,7 +251,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
     if (result.sessionToken && isVerified) {
       // Set role hint cookie for proxy.ts admin gate (defense-in-depth).
       const userRole = resolvedUser?.role ?? 'user';
-      const isAdminRole = ['admin', 'super-admin', 'admin', 'super-admin'].includes(userRole);
+      const isAdminRole = ['owner', 'admin', 'super-admin'].includes(userRole);
       response.cookies.set('revealui-role', isAdminRole ? 'admin' : 'user', {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/apps/admin/src/lib/access/__tests__/roles.test.ts
+++ b/apps/admin/src/lib/access/__tests__/roles.test.ts
@@ -32,6 +32,15 @@ const admin: UserWithRoles = {
   roles: [Role.UserAdmin],
 };
 
+// Canonical owner per #1219: DB role='owner' + app-layer roles ['super-admin'].
+// The engine gates operate on the app-layer roles array, so the owner is
+// recognized through its 'super-admin' app role (NOT the DB 'owner' value).
+const owner: UserWithRoles = {
+  id: 'u7',
+  role: 'owner',
+  roles: [Role.UserSuperAdmin],
+};
+
 const tenantAdmin: UserWithRoles = {
   id: 'u3',
   roles: [Role.TenantAdmin],
@@ -133,6 +142,10 @@ describe('isAdmin', () => {
     expect(isAdmin({ req: makeReq(superAdmin) })).toBe(true);
   });
 
+  it('allows the canonical owner (super-admin app role)', () => {
+    expect(isAdmin({ req: makeReq(owner) })).toBe(true);
+  });
+
   it('denies Viewer', () => {
     expect(isAdmin({ req: makeReq(viewer) })).toBe(false);
   });
@@ -155,6 +168,10 @@ describe('isAdmin', () => {
 describe('isSuperAdmin', () => {
   it('allows UserSuperAdmin', async () => {
     expect(await isSuperAdmin({ req: makeReq(superAdmin) })).toBe(true);
+  });
+
+  it('allows the canonical owner (super-admin app role)', async () => {
+    expect(await isSuperAdmin({ req: makeReq(owner) })).toBe(true);
   });
 
   it('denies UserAdmin', async () => {

--- a/apps/admin/src/lib/auth/roles.test.ts
+++ b/apps/admin/src/lib/auth/roles.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { grantSuperAdminRoleById, SUPER_ADMIN_ROLES } from './roles';
+
+/**
+ * Builds a minimal Drizzle-shaped stub exercising the
+ * select().from().where().limit() read and the update().set().where() write
+ * that grantSuperAdminRoleById performs. `existingJson` seeds the row the read
+ * returns (undefined → no row / null _json).
+ */
+function makeDb(existingJson: unknown) {
+  const set = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+  const update = vi.fn(() => ({ set }));
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(existingJson === undefined ? [] : [{ json: existingJson }]),
+      }),
+    }),
+  }));
+  const db = { select, update } as unknown as Parameters<typeof grantSuperAdminRoleById>[0];
+  return { db, set, update };
+}
+
+describe('grantSuperAdminRoleById', () => {
+  it('writes _json.roles=[super-admin] for a freshly-created user (empty _json)', async () => {
+    // Mirrors the /sign-up first-user path: signUp() inserts with _json='{}',
+    // so the grant must populate roles from scratch. This is the founder's bug —
+    // the engine gates read _json.roles, which was never set.
+    const { db, set } = makeDb({});
+
+    await grantSuperAdminRoleById(db, 'user-1');
+
+    expect(set).toHaveBeenCalledWith({ _json: { roles: ['super-admin'] } });
+    expect([...SUPER_ADMIN_ROLES]).toEqual(['super-admin']);
+  });
+
+  it('treats a null/absent _json row as empty and still grants the role', async () => {
+    const { db, set } = makeDb(undefined);
+
+    await grantSuperAdminRoleById(db, 'user-1');
+
+    expect(set).toHaveBeenCalledWith({ _json: { roles: ['super-admin'] } });
+  });
+
+  it('preserves other _json keys when merging the role grant', async () => {
+    const { db, set } = makeDb({ preference: 'dark', roles: ['editor'] });
+
+    await grantSuperAdminRoleById(db, 'user-1');
+
+    expect(set).toHaveBeenCalledWith({
+      _json: { preference: 'dark', roles: ['editor', 'super-admin'] },
+    });
+  });
+
+  it('is idempotent — does not duplicate an existing super-admin role', async () => {
+    const { db, set } = makeDb({ roles: ['super-admin'] });
+
+    await grantSuperAdminRoleById(db, 'user-1');
+
+    expect(set).toHaveBeenCalledWith({ _json: { roles: ['super-admin'] } });
+  });
+});

--- a/apps/admin/src/lib/auth/roles.ts
+++ b/apps/admin/src/lib/auth/roles.ts
@@ -1,0 +1,58 @@
+/**
+ * App-layer role grants for account bootstrap.
+ *
+ * Companion to ./tos.ts: where that file stamps the typed TOS columns, this one
+ * stamps the app-layer `roles` array into the `_json` blob via a typed Drizzle
+ * write. The two are separate because they protect different surfaces — TOS is
+ * legal-compliance metadata; `_json.roles` is what the engine's access gates
+ * (isSuperAdmin / isAdmin via hasRole) actually read.
+ *
+ * Why this exists: the DB `role` column is CHECK-constrained to
+ * owner/admin/editor/viewer/agent/contributor, so the app-level 'super-admin'
+ * CANNOT live there — it lives in `_json.roles`. A first user promoted to DB
+ * role 'admin'/'owner' but with no `_json.roles` is denied by every engine gate
+ * (the founder's bug). Canonical owner shape (per #1219): DB role='owner' +
+ * _json.roles=['super-admin'].
+ *
+ * A typed Drizzle write is required for the same reason ./tos.ts documents: the
+ * engine's dynamic-SQL create path can write `roles` into `_json`, but the
+ * /sign-up route creates users via a typed insert that never populates it, so
+ * the grant has to be applied as a typed update afterward.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { eq } from '@revealui/db/orm';
+import { users } from '@revealui/db/schema';
+
+/**
+ * App-layer roles granted to the first user / an owner account. Stored in
+ * `_json.roles` (NOT the DB `role` column). Single source for the value so the
+ * sign-up route and tests don't re-inline the string.
+ */
+export const SUPER_ADMIN_ROLES = ['super-admin'] as const;
+
+/**
+ * Grant the super-admin app-layer role to a user via a typed Drizzle write,
+ * mirroring {@link import('./tos').stampTosAcceptanceByEmail}. Merges into any
+ * existing `_json`, preserving other keys and de-duplicating roles, so it is
+ * idempotent and safe to call on a user that already has roles.
+ */
+export async function grantSuperAdminRoleById(db: Database, id: string): Promise<void> {
+  const [existing] = await db
+    .select({ json: users._json })
+    .from(users)
+    .where(eq(users.id, id))
+    .limit(1);
+
+  const currentJson =
+    existing?.json && typeof existing.json === 'object' && !Array.isArray(existing.json)
+      ? (existing.json as Record<string, unknown>)
+      : {};
+  const currentRoles = Array.isArray(currentJson.roles) ? (currentJson.roles as string[]) : [];
+  const mergedRoles = Array.from(new Set([...currentRoles, ...SUPER_ADMIN_ROLES]));
+
+  await db
+    .update(users)
+    .set({ _json: { ...currentJson, roles: mergedRoles } })
+    .where(eq(users.id, id));
+}

--- a/apps/admin/src/lib/hooks/__tests__/admin-hooks-critical.test.ts
+++ b/apps/admin/src/lib/hooks/__tests__/admin-hooks-critical.test.ts
@@ -43,7 +43,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
       value: [],
     });
 
-    expect(result).toContain(Role.TenantSuperAdmin);
+    expect(result).toContain(Role.UserSuperAdmin);
     expect(mockFind).toHaveBeenCalledWith({
       collection: 'users',
       limit: 1,
@@ -63,7 +63,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
 
     expect(result).toContain('editor');
     expect(result).toContain('viewer');
-    expect(result).toContain(Role.TenantSuperAdmin);
+    expect(result).toContain(Role.UserSuperAdmin);
   });
 
   it('does NOT promote second user when users already exist', async () => {
@@ -80,7 +80,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
     });
 
     expect(result).toEqual(['editor']);
-    expect(result).not.toContain(Role.TenantSuperAdmin);
+    expect(result).not.toContain(Role.UserSuperAdmin);
   });
 
   it('does not duplicate super-admin role if already present', async () => {
@@ -90,12 +90,12 @@ describe('ensureFirstUserIsSuperAdmin', () => {
     const result = await hook({
       req: makeReq(),
       operation: 'create',
-      value: [Role.TenantSuperAdmin],
+      value: [Role.UserSuperAdmin],
     });
 
-    expect(result).toEqual([Role.TenantSuperAdmin]);
+    expect(result).toEqual([Role.UserSuperAdmin]);
     // Should not have duplicated it
-    const superAdminCount = result?.filter((r: string) => r === Role.TenantSuperAdmin).length;
+    const superAdminCount = result?.filter((r: string) => r === Role.UserSuperAdmin).length;
     expect(superAdminCount).toBe(1);
   });
 
@@ -134,7 +134,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
       value: undefined,
     });
 
-    expect(result).toEqual([Role.TenantSuperAdmin]);
+    expect(result).toEqual([Role.UserSuperAdmin]);
   });
 
   it('queries users collection with minimal depth and limit', async () => {

--- a/apps/admin/src/lib/hooks/__tests__/admin-hooks.test.ts
+++ b/apps/admin/src/lib/hooks/__tests__/admin-hooks.test.ts
@@ -260,7 +260,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
     const hook = await loadHook();
     mockFind.mockResolvedValue({ totalDocs: 0, docs: [] });
     const result = await hook({ req: makeReq(), operation: 'create', value: ['user'] });
-    expect(result).toContain('tenant-super-admin');
+    expect(result).toContain('super-admin');
     expect(result).toContain('user');
   });
 
@@ -270,9 +270,9 @@ describe('ensureFirstUserIsSuperAdmin', () => {
     const result = await hook({
       req: makeReq(),
       operation: 'create',
-      value: ['tenant-super-admin', 'user'],
+      value: ['super-admin', 'user'],
     });
-    expect(result).toEqual(['tenant-super-admin', 'user']);
+    expect(result).toEqual(['super-admin', 'user']);
   });
 
   it('returns value unchanged when users already exist', async () => {
@@ -286,7 +286,7 @@ describe('ensureFirstUserIsSuperAdmin', () => {
     const hook = await loadHook();
     mockFind.mockResolvedValue({ totalDocs: 0, docs: [] });
     const result = await hook({ req: makeReq(), operation: 'create', value: undefined });
-    expect(result).toEqual(['tenant-super-admin']);
+    expect(result).toEqual(['super-admin']);
   });
 });
 

--- a/apps/admin/src/lib/hooks/ensureFirstUserIsSuperAdmin.ts
+++ b/apps/admin/src/lib/hooks/ensureFirstUserIsSuperAdmin.ts
@@ -38,10 +38,14 @@ export async function ensureFirstUserIsSuperAdmin({
 
     // If no users found, this is the first user
     if (users.totalDocs === 0) {
-      // Ensure 'super-admin' is added to the roles if not already included
+      // Ensure the app-layer 'super-admin' role is present. This must be
+      // Role.UserSuperAdmin ('super-admin') — the value the engine gates check
+      // via isSuperAdmin/isAdmin. The previous Role.TenantSuperAdmin
+      // ('tenant-super-admin') granted a role no gate reads, so the first user
+      // was left without engine-level super-admin access.
       const currentRoles = value || [];
-      if (!currentRoles.includes(Role.TenantSuperAdmin)) {
-        return [...currentRoles, Role.TenantSuperAdmin];
+      if (!currentRoles.includes(Role.UserSuperAdmin)) {
+        return [...currentRoles, Role.UserSuperAdmin];
       }
     }
   }

--- a/apps/server/src/lib/__tests__/access.test.ts
+++ b/apps/server/src/lib/__tests__/access.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { ADMIN_ROLES, isAdminRole } from '../access.js';
+
+// ---------------------------------------------------------------------------
+// isAdminRole — server-side admin/owner gate for admin-gated REST routes.
+// ---------------------------------------------------------------------------
+describe('isAdminRole', () => {
+  it('grants the canonical owner DB role', () => {
+    // Per #1219 an owner account carries DB role='owner'. This is the gap the
+    // pre-consolidation per-route Sets (['admin','super-admin']) missed.
+    expect(isAdminRole('owner')).toBe(true);
+  });
+
+  it('grants the legacy admin role', () => {
+    expect(isAdminRole('admin')).toBe(true);
+  });
+
+  it('grants the app-layer super-admin value (kept for parity)', () => {
+    expect(isAdminRole('super-admin')).toBe(true);
+  });
+
+  it('denies non-admin DB roles', () => {
+    expect(isAdminRole('editor')).toBe(false);
+    expect(isAdminRole('viewer')).toBe(false);
+    expect(isAdminRole('contributor')).toBe(false);
+    expect(isAdminRole('agent')).toBe(false);
+  });
+
+  it('denies null / undefined / empty role', () => {
+    expect(isAdminRole(null)).toBe(false);
+    expect(isAdminRole(undefined)).toBe(false);
+    expect(isAdminRole('')).toBe(false);
+  });
+
+  it('exposes the underlying role set', () => {
+    expect(ADMIN_ROLES.has('owner')).toBe(true);
+    expect(ADMIN_ROLES.has('editor')).toBe(false);
+  });
+});

--- a/apps/server/src/lib/access.ts
+++ b/apps/server/src/lib/access.ts
@@ -1,0 +1,28 @@
+/**
+ * Server-side admin/owner role gate.
+ *
+ * Single source of truth for "does this DB role grant admin-level access to
+ * admin/owner-gated REST routes". Consolidates the per-route
+ * `ADMIN_ROLES = new Set(['admin', 'super-admin'])` guards that previously
+ * lived inline in content/users, admin/coordination, and admin/inference-config.
+ *
+ * The gate input is the DB `role` column (users_role_check:
+ * owner/admin/editor/viewer/agent/contributor). An owner account carries DB
+ * role='owner' (canonical per #1219), so 'owner' MUST grant admin-level access
+ * alongside the legacy 'admin'.
+ *
+ * 'super-admin' is an app-layer role — it lives in `_json.roles`, not the DB
+ * `role` column, so it never appears as a DB `role` value in practice. It is
+ * kept in the set for parity with the pre-existing route guards this
+ * consolidates (harmless: no real DB row carries it).
+ *
+ * Mirrors apps/admin/src/lib/access/roles/isAdminRole.ts on the admin side.
+ */
+
+/** DB roles that grant admin-level access to admin/owner-gated server routes. */
+export const ADMIN_ROLES: ReadonlySet<string> = new Set(['owner', 'admin', 'super-admin']);
+
+/** True when the given DB role grants admin-level access. */
+export function isAdminRole(role: string | null | undefined): boolean {
+  return role != null && ADMIN_ROLES.has(role);
+}

--- a/apps/server/src/routes/admin/__tests__/coordination.test.ts
+++ b/apps/server/src/routes/admin/__tests__/coordination.test.ts
@@ -63,6 +63,14 @@ describe('GET /admin/coordination/sessions', () => {
     expect(res.status).toBe(403);
   });
 
+  it('grants access to the canonical owner role', async () => {
+    // Per #1219 an owner account carries DB role='owner'; the admin gate must
+    // admit it alongside 'admin'.
+    const { app } = createApp({ id: 'u1', role: 'owner' }, [[], [{ total: 0 }]]);
+    const res = await app.fetch(new Request('http://localhost/sessions'));
+    expect(res.status).toBe(200);
+  });
+
   it('returns 200 with empty data when no rows exist', async () => {
     const { app } = createApp({ id: 'u1', role: 'admin' }, [[], [{ total: 0 }]]);
     const res = await app.fetch(new Request('http://localhost/sessions'));

--- a/apps/server/src/routes/admin/coordination.ts
+++ b/apps/server/src/routes/admin/coordination.ts
@@ -20,6 +20,7 @@ import { coordinationAgents, coordinationSessions } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { isAdminRole } from '../../lib/access.js';
 import { nullableDateToString } from '../_helpers/serialize.js';
 
 type AdminVariables = {
@@ -27,13 +28,11 @@ type AdminVariables = {
   user?: { id: string; role: string };
 };
 
-const ADMIN_ROLES = new Set(['admin', 'super-admin']);
-
 const STALE_THRESHOLD_SECONDS = 7 * 24 * 60 * 60;
 
 function requireAdmin(user: { id: string; role: string } | undefined): void {
   if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-  if (!ADMIN_ROLES.has(user.role)) {
+  if (!isAdminRole(user.role)) {
     throw new HTTPException(403, { message: 'Admin access required' });
   }
 }

--- a/apps/server/src/routes/admin/inference-config.ts
+++ b/apps/server/src/routes/admin/inference-config.ts
@@ -27,6 +27,7 @@ import { workspaceInferenceConfigs } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { isAdminRole } from '../../lib/access.js';
 
 // LLMProviderType narrowed to the post-vultr-removal set.
 const ALLOWED_PROVIDERS = ['groq', 'huggingface', 'inference-snaps', 'ollama'] as const;
@@ -49,11 +50,9 @@ type AdminVariables = {
   user?: { id: string; role: string };
 };
 
-const ADMIN_ROLES = new Set(['admin', 'super-admin']);
-
 function requireAdmin(user: { id: string; role: string } | undefined): void {
   if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-  if (!ADMIN_ROLES.has(user.role)) {
+  if (!isAdminRole(user.role)) {
     throw new HTTPException(403, { message: 'Admin access required' });
   }
 }

--- a/apps/server/src/routes/content/users.ts
+++ b/apps/server/src/routes/content/users.ts
@@ -15,6 +15,7 @@
 import * as userQueries from '@revealui/db/queries/users';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { isAdminRole } from '../../lib/access.js';
 import { ErrorSchema, IdParam } from '../_helpers/content-schemas.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
@@ -24,13 +25,6 @@ const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 // =============================================================================
 // Constants
 // =============================================================================
-
-/** Roles that grant admin-level access to user management */
-const ADMIN_ROLES = new Set(['admin', 'super-admin']);
-
-function isAdminRole(role: string): boolean {
-  return ADMIN_ROLES.has(role);
-}
 
 /**
  * Fields that must NEVER be returned in API responses.


### PR DESCRIPTION
## Summary

Completes owner-access + RBAC so an `owner` user has full access everywhere. Canonical model (per #1219): `role='owner'` (DB column) + `_json.roles=['super-admin']` (app layer). DB-role gates must admit `'owner'`; engine gates read the app-layer `_json.roles` array.

Builds on #1216 (proxy/cookie gate accepting `'owner'`), #1219 / #1221 (typed-write first-admin TOS pattern this mirrors).

## Changes

**1 — Sign-up first-user grants the app-layer super-admin role (the founder's bug)**
`signUp()` inserts users via a typed insert that never populates `_json`, so the first-user promotion set DB `role='admin'` but left `_json.roles` empty — every engine gate (`isSuperAdmin`/`isAdmin` via `hasRole`) then denied the admin. New helper `apps/admin/src/lib/auth/roles.ts` (`grantSuperAdminRoleById`, mirroring `stampTosAcceptanceByEmail`) applies a merge-aware, idempotent typed Drizzle write; the sign-up route calls it after the role promotion. Also de-duplicated the cookie-hint role array (`['admin','super-admin','admin','super-admin']`) and added `'owner'`.

**2 — Server API gates admit `'owner'`**
New shared `apps/server/src/lib/access.ts` (`isAdminRole` + `ADMIN_ROLES={owner,admin,super-admin}`) replaces the inline `Set(['admin','super-admin'])` guards in `content/users`, `admin/coordination`, and `admin/inference-config`. Mirrors the admin-side `isAdminRole` from #1216.

**3 — `ensureFirstUserIsSuperAdmin` value corrected**
The hook granted `Role.TenantSuperAdmin` (`'tenant-super-admin'`) — a value no gate reads — leaving the first user without engine-level super-admin. Corrected to `Role.UserSuperAdmin` (`'super-admin'`). Kept as a safety net rather than retired.

**4 — Tests**
- `server/src/lib/__tests__/access.test.ts` — `isAdminRole` admits owner/admin/super-admin, denies others/null.
- `coordination.test.ts` — owner gets `200` end-to-end.
- `admin/.../access/__tests__/roles.test.ts` — engine `isAdmin`/`isSuperAdmin` recognize the canonical owner.
- `auth/roles.test.ts` — proves the first-user mechanism ends with `_json.roles=['super-admin']` (fresh / null / merge / idempotent cases).
- Both hook test files updated to the corrected role value.

## Notes

- Sign-up keeps DB `role='admin'` (works with the current cookie/proxy gate). Owner-alignment of new sign-ups is deferred until #1216 lands; the founder prod row (`role='admin'` + `_json.roles=['super-admin','admin']`) can be aligned to canonical `role='owner'` after this merges.
- `'super-admin'` is an app-layer role (lives in `_json.roles`, not the DB `role` column), so it never appears as a DB `role` value; kept in the server `ADMIN_ROLES` set for parity with the guards this consolidates.

## Verification
- `pnpm --filter admin typecheck` + `pnpm --filter server typecheck` clean
- Affected suites: 116 tests pass
- Pre-push gate: PASS (all hard-fail checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
