### PR TITLE
fix(core): verify RevForge license keypair matches before issuing

### DIFF
--- a/.changeset/revforge-license-keypair-guard.md
+++ b/.changeset/revforge-license-keypair-guard.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+Fail closed when a RevForge license is issued with a private/public pair that is not a matching Ed25519 keypair. `issueRevForgeLicense` now verifies the freshly-signed JWT against the supplied public key (reusing the runtime verifier) and throws `REVFORGE_LICENSE_KEYPAIR_MISMATCH` on failure, so a stamped kit can no longer bake a public key that cannot verify its own license and crash-loop at boot.

--- a/packages/core/src/__tests__/revforge-license.test.ts
+++ b/packages/core/src/__tests__/revforge-license.test.ts
@@ -53,6 +53,23 @@ describe('issueRevForgeLicense', () => {
     expect(verified?.domains).toEqual(['bigcorp.example', 'admin.bigcorp.example']);
   });
 
+  it('fails closed when the public key does not match the signing private key', async () => {
+    // A second, unrelated Ed25519 keypair: its public half cannot verify a JWT
+    // signed by the first keypair's private half. Issuing must abort rather than
+    // hand back a license a stamped kit would crash-loop on at boot.
+    const other = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    await expect(
+      issueRevForgeLicense(
+        { slug: 'mismatch', tier: 'enterprise', perpetual: true },
+        { privateKey, publicKey: other.publicKey },
+      ),
+    ).rejects.toThrow('REVFORGE_LICENSE_KEYPAIR_MISMATCH');
+  });
+
   it('omits exp claim for perpetual licenses', async () => {
     const result = await issueRevForgeLicense(
       { slug: 'forever', tier: 'enterprise', perpetual: true },

--- a/packages/core/src/revforge-license.ts
+++ b/packages/core/src/revforge-license.ts
@@ -11,7 +11,7 @@
  * handles argv parsing and reading keys from the environment.
  */
 
-import { generateLicenseKey, type LicensePayload } from './license.js';
+import { generateLicenseKey, type LicensePayload, validateLicenseKey } from './license.js';
 
 export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -56,8 +56,10 @@ export interface IssueRevForgeLicenseResult {
  * Issue a signed RevForge license JWT for a paying customer.
  *
  * @throws Error on invalid slug, invalid tier, mutually-exclusive flag combos,
- * or non-positive numeric overrides. The error message names the offending
- * field so callers can surface it directly to the operator.
+ * non-positive numeric overrides, or a private/public pair that is not a
+ * matching Ed25519 keypair. The error message names the offending field (or, for
+ * the keypair case, carries the `REVFORGE_LICENSE_KEYPAIR_MISMATCH` prefix) so
+ * callers can surface it directly to the operator.
  */
 export async function issueRevForgeLicense(
   opts: IssueRevForgeLicenseOptions,
@@ -117,6 +119,25 @@ export async function issueRevForgeLicense(
     expiresInSeconds,
     keys.publicKey,
   );
+
+  // Pair-match guard: prove the supplied public key can verify the JWT we just
+  // signed with the supplied private key. If it cannot, the two are not a
+  // matching Ed25519 keypair, and issuing anyway would hand back a license whose
+  // baked REVEALUI_LICENSE_PUBLIC_KEY crash-loops the kit at boot with
+  // "LICENSE VALIDATION FAILED" (apps/server validateLicenseAtStartup). Reusing
+  // the runtime verifier (validateLicenseKey) guarantees this check agrees
+  // exactly with the deployment-time check, so a mismatched pair can never reach
+  // a stamped customer kit.
+  const keypairSelfCheck = await validateLicenseKey(licenseKey, keys.publicKey);
+  if (keypairSelfCheck === null) {
+    throw new Error(
+      'REVFORGE_LICENSE_KEYPAIR_MISMATCH: the supplied public key cannot verify a ' +
+        'license JWT signed by the supplied private key, so they are not a matching ' +
+        'Ed25519 keypair. A kit issued with this pair would crash at boot with ' +
+        'LICENSE VALIDATION FAILED. Source REVEALUI_LICENSE_PRIVATE_KEY and ' +
+        'REVEALUI_LICENSE_PUBLIC_KEY from the same keypair in revvault and retry.',
+    );
+  }
 
   const expiresAt =
     expiresInSeconds === null ? null : new Date(issuedAtMs + expiresInSeconds * 1000).toISOString();


### PR DESCRIPTION
## Problem

`issueRevForgeLicense` signs the customer license JWT with the supplied private key and returns it without ever checking that the supplied public key can verify it. When the private and public keys come from different Ed25519 keypairs, issuance still succeeds, a stamped self-hosted kit bakes the mismatched `REVEALUI_LICENSE_PUBLIC_KEY`, and the kit's `api` + `admin` then crash-loop at boot on `LICENSE VALIDATION FAILED` (the baked key cannot verify the signature). It is a channel-readiness bug: a fresh kit can be produced that cannot boot, with no signal at issuance time.

The runtime `kid` check in `validateLicenseKey` is warn-only, so it does not prevent this.

## Fix

After signing, run the freshly-issued JWT back through the runtime verifier (`validateLicenseKey`) with the supplied public key. If it cannot verify, the keys are not a matching pair, so fail closed with a `REVFORGE_LICENSE_KEYPAIR_MISMATCH` error that names the cause and the remedy.

- Reuses the exact runtime verifier, so the issuance-time check and the deployment-time check are guaranteed to agree.
- Scoped to the RevForge issuance path (`issueRevForgeLicense`). The SaaS webhook path (which calls `generateLicenseKey` directly) is untouched.
- The CLI wrapper (`scripts/setup/issue-revforge-license.ts`) and `stamp.sh` inherit the guard transitively, since both issue through this function.
- Edge-safe (jose only, no `node:crypto`), no authored regex.

## Verification

- `pnpm --filter @revealui/core test src/__tests__/revforge-license.test.ts` — 11/11 pass, including a new test that issues with a deliberately mismatched keypair and asserts the abort.
- Biome clean on the changed files; pre-push quality gate passed.

## Scope

This is the issuance-time guard only. The broader consolidation of the studio's license signing keypairs to a single canonical pair is tracked internally and is owner-gated (it involves re-issuing outstanding licenses and rotating vault keys).

A patch changeset is included for `@revealui/core`.
