### PR TITLE
fix(server): pinpoint wrong-public-key at boot license validation

### DIFF
--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -420,20 +420,25 @@ describe('validateLicenseAtStartup', () => {
     ).rejects.toThrow(/REVEALUI_LICENSE_KEY is invalid/);
   });
 
-  it('throws when the JWT was signed with a different key', async () => {
+  it('throws a precise wrong-public-key error when the JWT was signed with a different key', async () => {
     const jwt = await generateLicenseKey(
       { tier: 'enterprise', customerId: 'acme' },
       testPrivateKey,
       30 * 24 * 60 * 60,
       testPublicKey,
     );
-    // Verify against a DIFFERENT public key — must fail.
-    await expect(
-      validateLicenseAtStartup({
-        REVEALUI_LICENSE_KEY: jwt,
-        REVEALUI_LICENSE_PUBLIC_KEY: mismatchedPublicKey,
-      }),
-    ).rejects.toThrow(/REVEALUI_LICENSE_KEY is invalid/);
+    // Verify against a DIFFERENT public key: the kit baked the wrong key. The
+    // boot check should name this specific cause (public-key id mismatch), not
+    // the generic invalid/expired/customerId message.
+    const err = await validateLicenseAtStartup({
+      REVEALUI_LICENSE_KEY: jwt,
+      REVEALUI_LICENSE_PUBLIC_KEY: mismatchedPublicKey,
+    }).then(
+      () => null,
+      (e: unknown) => (e instanceof Error ? e.message : String(e)),
+    );
+    expect(err).toContain('does not match the key that signed');
+    expect(err).toContain('baked the wrong public key');
   });
 
   it('throws when the JWT is expired beyond the grace window', async () => {

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -1,4 +1,8 @@
-import { hostMatchesLicensedDomains, validateLicenseKey } from '@revealui/core/license';
+import {
+  computeKeyId,
+  hostMatchesLicensedDomains,
+  validateLicenseKey,
+} from '@revealui/core/license';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
 
@@ -440,6 +444,30 @@ export function validateStartup(
 }
 
 /**
+ * Extracts the `kid` (key id) from a JWT's protected header WITHOUT verifying
+ * the signature. Returns undefined when the token is malformed or carries no
+ * `kid` (older tokens issued before the issuer paired a public key). Uses only
+ * built-in parsers (base64url decode + JSON.parse): no authored regex and no
+ * jose import at the boot layer. Used purely to sharpen the error message once
+ * cryptographic verification has ALREADY failed; never as a verification step.
+ */
+function decodeJwtKid(jwt: string): string | undefined {
+  const headerSegment = jwt.split('.')[0];
+  if (!headerSegment) return undefined;
+  try {
+    const header: unknown = JSON.parse(Buffer.from(headerSegment, 'base64url').toString('utf8'));
+    if (header && typeof header === 'object' && 'kid' in header) {
+      const { kid } = header as { kid?: unknown };
+      return typeof kid === 'string' ? kid : undefined;
+    }
+  } catch {
+    // Malformed header segment. Fall through; the caller's generic
+    // "invalid license" path surfaces the real failure.
+  }
+  return undefined;
+}
+
+/**
  * Boot-time license enforcement for self-hosted (Forge) deployments.
  *
  * The hosted SaaS deployment (apps/server on Vercel for revealui.com) signs
@@ -504,6 +532,28 @@ export async function validateLicenseAtStartup(env: EnvMap = process.env as EnvM
   const expectedCustomerId = env.REVEALUI_LICENSED_CUSTOMER_ID || undefined;
   const payload = await validateLicenseKey(env.REVEALUI_LICENSE_KEY, publicKey, expectedCustomerId);
   if (!payload) {
+    // Sharpen the most common (and most confusing) stamping failure: the kit
+    // baked a REVEALUI_LICENSE_PUBLIC_KEY that is not the verification key for
+    // the issued JWT. Our issuer embeds a `kid` (a short digest of the paired
+    // public key) in every token, so a token whose kid does not match the
+    // configured public key's id was provably signed by a different key. We
+    // consult the kid only HERE, after cryptographic verification has already
+    // failed, so a public key that is correct but merely formatted differently
+    // (validateLicenseKey verifies key material, not PEM bytes) can never reach
+    // this branch and produce a false "wrong key" message.
+    const tokenKid = decodeJwtKid(env.REVEALUI_LICENSE_KEY);
+    if (tokenKid !== undefined) {
+      const expectedKid = await computeKeyId(publicKey);
+      if (tokenKid !== expectedKid) {
+        throw new Error(
+          'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_PUBLIC_KEY does not match the key that ' +
+            `signed REVEALUI_LICENSE_KEY (license key id "${tokenKid}", configured public key id ` +
+            `"${expectedKid}"). The stamped kit baked the wrong public key. Re-issue the license ` +
+            'with the matching keypair, or bake the public key that pairs with the signing key, ' +
+            'then re-run bin/revvault-bootstrap.sh. Contact the operator who stamped this kit.',
+        );
+      }
+    }
     throw new Error(
       'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_KEY is invalid, expired beyond grace, ' +
         'signed with a key that does not match REVEALUI_LICENSE_PUBLIC_KEY, or its ' +


### PR DESCRIPTION
## Problem

When a self-hosted (Forge) kit boots with a `REVEALUI_LICENSE_PUBLIC_KEY` that does not match the key that signed its `REVEALUI_LICENSE_KEY`, `validateLicenseAtStartup` failed with a single generic message that lumped four distinct causes together (invalid / expired-beyond-grace / wrong-key / customerId-mismatch). An operator debugging a crash-looping kit had to guess which one applied, and the wrong-public-key case (a kit baking a mismatched key) is both the most common and the least obvious.

## Fix

After cryptographic verification fails, consult the JWT's `kid` (a short digest of the public key the issuer paired with) and compare it to the configured public key's id. When they differ, the token was provably signed by a different key, so throw a precise message that names both ids and the remedy (re-issue with the matching keypair, or bake the correct public key, then re-bootstrap).

Key safety property: the `kid` is consulted **only on the failure path**, after `validateLicenseKey` has already returned null. `validateLicenseKey` verifies key *material* cryptographically, so a public key that is correct but merely formatted differently (e.g. a `\n`-encoded PEM) passes verification and never reaches the diagnostic. That guarantees the precise message can never be a false positive. The existing expired-key and single-line-PEM tests lock this in.

`decodeJwtKid` uses built-in parsers only (`base64url` + `JSON.parse`): no authored regex, no jose import at the boot layer.

## Verification

- Updated the existing "different key" test to assert the precise message (it previously asserted the generic one).
- The `decodeJwtKid` parser was proven standalone across valid / malformed / no-kid / non-object / non-string headers.
- Biome clean; pre-push quality gate passed; CI runs the full apps/server unit suite.

## Scope

Diagnostic-only: the boot already failed on a mismatched key (the kit could never validate its license), so this changes the message, not the gate. No behavior change for valid licenses. It is the boot-side complement to the issuance-time pair-match guard in #1241.
