### PR TITLE
chore(deps): upgrade @electric-sql/pglite 0.4.x to 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@biomejs/biome": "catalog:",
     "@changesets/cli": "^2.31.0",
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "catalog:",
     "@size-limit/file": "^12.1.0",
@@ -56,7 +56,6 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
-      "@electric-sql/pglite": "^0.4.5",
       "form-data": ">=4.0.4",
       "path-to-regexp": ">=6.3.0",
       "tar-fs": ">=2.1.4",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.8",
     "@revealui/dev": "workspace:*",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,7 +7,7 @@
     "@revealui/security": "workspace:*"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@types/node": "catalog:",
     "@revealui/dev": "workspace:*",
     "tsup": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@lexical/clipboard": "^0.45.0",
     "@lexical/code": "^0.45.0",
     "@lexical/html": "^0.45.0",

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -12,7 +12,7 @@
     "revealui-harnesses": "./dist/cli.js"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@revealui/core": "workspace:*",
     "zod": "catalog:"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "pg": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.8"

--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -4,7 +4,7 @@
   "description": "Circuit breaker, retry, bulkhead, and timeout patterns for resilient services. Database-backed circuit state. Ships with RevealUI.",
   "license": "MIT",
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@types/node": "catalog:",
     "@revealui/dev": "workspace:*",
     "tsup": "catalog:",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,7 +9,7 @@
     "ret": "^0.5.0"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5"
+    "@electric-sql/pglite": "^0.5.1"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -17,7 +17,8 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
+    "@electric-sql/pglite-pgvector": "^0.0.2",
     "@playwright/test": "catalog:",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/test/src/utils/drizzle-test-db.ts
+++ b/packages/test/src/utils/drizzle-test-db.ts
@@ -44,7 +44,7 @@ export interface CreateTestDbOptions {
   logger?: boolean;
   /**
    * Enable the PGlite pgvector extension. When true, the harness loads
-   * `@electric-sql/pglite/vector`, enables the `vector` type, and keeps
+   * `@electric-sql/pglite-pgvector`, enables the `vector` type, and keeps
    * (rather than skips) tables + statements that reference vector columns.
    * Required for tests that query tables like `agent_contexts`, `agent_memories`,
    * or `rag_chunks` which have pgvector-typed embedding columns.
@@ -111,7 +111,7 @@ export async function createTestDb(options?: CreateTestDbOptions): Promise<TestD
   const enableVector = options?.enableVector === true;
   let pglite: PGlite;
   if (enableVector) {
-    const { vector } = await import('@electric-sql/pglite/vector');
+    const { vector } = await import('@electric-sql/pglite-pgvector');
     pglite = new PGlite({ extensions: { vector } });
   } else {
     pglite = new PGlite();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,6 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  '@electric-sql/pglite': ^0.4.5
   form-data: '>=4.0.4'
   path-to-regexp: '>=6.3.0'
   tar-fs: '>=2.1.4'
@@ -135,8 +134,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.9.2)
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
         version: 1.29.0(zod@4.4.3)
@@ -310,7 +309,7 @@ importers:
         version: 10.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -601,7 +600,7 @@ importers:
         version: 10.56.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       hono:
         specifier: 4.12.23
         version: 4.12.23
@@ -668,7 +667,7 @@ importers:
         version: link:../resilience
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       lru-cache:
         specifier: ^11.5.1
         version: 11.5.1
@@ -677,8 +676,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -729,7 +728,7 @@ importers:
         version: 3.0.3
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -772,8 +771,8 @@ importers:
         version: link:../security
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -876,7 +875,7 @@ importers:
         version: 25.9.2
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -890,8 +889,8 @@ importers:
         specifier: ^3.1063.0
         version: 3.1063.0
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@lexical/clipboard':
         specifier: ^0.45.0
         version: 0.45.0
@@ -1018,7 +1017,7 @@ importers:
         version: link:../utils
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -1034,7 +1033,7 @@ importers:
         version: 0.31.10
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -1110,8 +1109,8 @@ importers:
   packages/harnesses:
     dependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
@@ -1160,8 +1159,8 @@ importers:
         version: 6.2.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -1299,8 +1298,8 @@ importers:
   packages/resilience:
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -1376,8 +1375,8 @@ importers:
         version: 6.0.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
 
   packages/security:
     dependencies:
@@ -1432,7 +1431,7 @@ importers:
         version: 5.8.4(rollup@4.60.3)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -1594,7 +1593,7 @@ importers:
         version: link:../utils
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       hono:
         specifier: 4.12.23
         version: 4.12.23
@@ -1606,8 +1605,11 @@ importers:
         version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
+      '@electric-sql/pglite-pgvector':
+        specifier: ^0.0.2
+        version: 0.0.2(@electric-sql/pglite@0.5.1)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -2086,8 +2088,13 @@ packages:
     resolution: {integrity: sha512-Ftf+ze/rZK9dBzvZqW7wrS74aQBToUlhQeUFm7KCTfOCkNJZ+7iZMm9JW/NjyIQjPOz4ApXg3VWOpeCbzsU3IQ==}
     hasBin: true
 
-  '@electric-sql/pglite@0.4.6':
-    resolution: {integrity: sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w==}
+  '@electric-sql/pglite-pgvector@0.0.2':
+    resolution: {integrity: sha512-Gu9Nv7JHlg6BgOLqPCR6lCjI+3xlb7ej5qUtHWmzEYA0ZKzuNgeDK16nRO0ELInwzhLptLqX7VdWyYRElSXjdQ==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1':
+    resolution: {integrity: sha512-h2Vc+qkQqsEL5kvyN5nBAxn3Vbyvka7QfDW7Io+CdcwU1+X8JbCAN2og+5dI11S3eJuDfroUCxzJaap6k+ezEw==}
 
   '@electric-sql/react@1.0.49':
     resolution: {integrity: sha512-lpEmF5rD7VMHJAeov/3SWa0ctqkzZJPZyf8sQnIVJdIUBSgniIYCCNXUzJ1fIeXJwvxNsBj4QX1zUbhntVR/Mw==}
@@ -5516,7 +5523,7 @@ packages:
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': ^0.4.5
+      '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
       '@neondatabase/serverless': '>=0.10.0'
@@ -9271,7 +9278,11 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.60.4
 
-  '@electric-sql/pglite@0.4.6': {}
+  '@electric-sql/pglite-pgvector@0.0.2(@electric-sql/pglite@0.5.1)':
+    dependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1': {}
 
   '@electric-sql/react@1.0.49(react@19.2.6)':
     dependencies:
@@ -12775,17 +12786,17 @@ snapshots:
       esbuild: 0.28.0
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0):
     optionalDependencies:
-      '@electric-sql/pglite': 0.4.6
+      '@electric-sql/pglite': 0.5.1
       '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       pg: 8.21.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3):
     dependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       zod: 4.4.3
 
   dunder-proto@1.0.1:


### PR DESCRIPTION
## Summary

Completes the deferred `@electric-sql/pglite` 0.4.x to 0.5.x upgrade and reverts the temporary `^0.4.5` hold the dependabot consolidation (#1249, commit `825a08391`) had to add. PGlite 0.5 dropped the bundled `./vector` subpath export. The pgvector extension now ships as the standalone [`@electric-sql/pglite-pgvector`](https://www.npmjs.com/package/@electric-sql/pglite-pgvector) package, which peer-depends on pglite `0.5.1`.

## Audit

The hold was enforced in two places, both at `^0.4.5`:

1. A temporary `@electric-sql/pglite` entry in root `pnpm.overrides`, which forces every instance (direct and transitive) to `<0.5.0`.
2. Nine direct `@electric-sql/pglite` declarations across the workspace (root plus `ai`, `cache`, `core`, `harnesses`, `mcp`, `resilience`, `scripts`, `test`).

Both had to change for a clean single-version resolution; removing the override alone would leave the nine carets capping pglite at `<0.5.0`. Only one site used the removed `/vector` subpath: `packages/test/src/utils/drizzle-test-db.ts`. Every other usage is the core `PGlite` class (constructor, `.exec`, `.close`), whose API is unchanged in 0.5. The 0.5.0 changelog reads: "Upgrade to Postgres 18.3; move other extensions to their own npm packages."

## Changes

- Remove the temporary `@electric-sql/pglite` pin from root `pnpm.overrides`.
- Bump all 9 direct `@electric-sql/pglite` declarations from `^0.4.5` to `^0.5.1`.
- Add `@electric-sql/pglite-pgvector@^0.0.2` to the `test` package, its only consumer.
- Swap the vector import in `packages/test/src/utils/drizzle-test-db.ts` from `@electric-sql/pglite/vector` to `@electric-sql/pglite-pgvector`. The usage (`new PGlite({ extensions: { vector } })`) is identical.

The lockfile resolves a single `pglite@0.5.1` (no 0.4/0.5 split) and `pglite-pgvector@0.0.2`. drizzle-orm 0.45.2's pglite peer (`>=0.2.0`) is satisfied. Removing the override also restored that real peer range in the lockfile, where it had been rewritten to `^0.4.5`.

Versions follow the repo's caret convention. The committed lockfile is the concrete pin to 0.5.1, and `pglite-pgvector@0.0.2`'s exact `0.5.1` peer acts as a tripwire if a future bump tries to move pglite without pgvector.

## Verification

Run locally on PGlite 0.5.1 plus pgvector 0.0.2:

- Single pglite version confirmed in `pnpm-lock.yaml` (no 0.4/0.5 split). The drizzle-orm `>=0.2.0` peer otherwise permits a 0.4.6/0.5.1 split, which would break the pglite-to-drizzle type bridge in `drizzle-test-db.ts`.
- `pnpm --filter ./packages/test typecheck`: clean. The new import and `extensions: { vector }` typecheck under 0.5.1.
- Vector-enabled `createTestDb({ enableVector: true })` path, exercised by `packages/ai/src/__tests__/agent-context-manager.test.ts`: 25 of 25 pass. This loads `@electric-sql/pglite-pgvector`, applies the full migration set (including `CREATE EXTENSION vector` and the `vector(768)` `agent_contexts` column) under Postgres 18.3, and runs against the live extension.
- In-memory PGlite integration suite: 100 tests pass.

The real-Postgres integration tests (`connection-recovery`, `integration-pro/memory/*`) require a provisioned `test_revealui` database via `pnpm db:setup-test`. They could not run in my local environment due to a host port conflict with pre-existing containers, and they are orthogonal to this change (real node-postgres, not the in-memory PGlite path or the vector import). They exercise in CI, where the test database is provisioned.

## Context

Reverts/obsoletes the temporary hold from #1249 (commit `825a08391`), which is also live on `main`/production via the promotion #1251. Removing the override here completes the proper fix; the hold on `main` is undone when this reaches `main` through the normal test-to-main promotion. The branch is rebased onto current `test` (post-#1252 backflow). No dedicated tracking issue.
