### PR TITLE
fix(docs): cobalt success/warning tokens in showcase usage panels

### DIFF
--- a/apps/docs/app/components/showcase/ShowcaseShell.tsx
+++ b/apps/docs/app/components/showcase/ShowcaseShell.tsx
@@ -94,7 +94,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {story.usage.when && (
             <div className="rounded-xl border border-border bg-surface p-4">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-success">
                 When to use
               </h3>
               <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.when)}</div>
@@ -102,7 +102,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
           )}
           {story.usage.avoid && (
             <div className="rounded-xl border border-border bg-surface p-4">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-amber-700">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-warning-foreground">
                 When to avoid
               </h3>
               <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.avoid)}</div>
@@ -195,7 +195,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
                   {a11y.conformance.map((item) => (
                     <span
                       key={item}
-                      className="rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200"
+                      className="rounded-md bg-success/15 px-2 py-1 text-xs font-medium text-success ring-1 ring-success/30"
                     >
                       {item}
                     </span>


### PR DESCRIPTION
## What

The docs showcase usage panels (`ShowcaseShell.tsx`) hardcoded `emerald`/`amber` Tailwind palette colors for their "When to use" / "When to avoid" headers and the accessibility-conformance badges. The cobalt bridge in [#1203](https://github.com/RevealUIStudio/revealui/pull/1203) themed the *rendered* `@revealui/presentation` components but left this showcase **chrome** on raw palette colors, so the status colors did not track the cobalt design system (or the showcase light/dark toggle).

## Change

Map to the cobalt semantic tokens already defined in `apps/docs/app/index.css`'s `@theme inline` bridge:

| Before | After | Why |
|---|---|---|
| `text-emerald-700` (when-to-use) | `text-success` | `--rvui-success` |
| `text-amber-700` (when-to-avoid) | `text-warning-foreground` | `--rvui-warning-text` — AA-safe (~5:1); bare `--rvui-warning` fails text contrast at 2.39:1 |
| badge `bg-emerald-50 text-emerald-700 ring-emerald-200` | `bg-success/15 text-success ring-success/30` | matches the `pricing-table.tsx` success pattern |

3-line change, one file. Colors now cascade with the active theme.

## Test plan
- [x] no `(text\|bg\|ring\|border)-(emerald\|amber)` left in `ShowcaseShell.tsx`
- [x] `biome check` clean
- [x] tokens verified defined + bridged (`tokens.css` + `index.css`)
- [ ] CI / preview deploy (visual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
