### PR TITLE
fix(admin): gate AdminBar Exit Preview on draft/preview mode

### DIFF
--- a/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
+++ b/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
@@ -62,12 +62,29 @@ describe('AdminBar', () => {
     mockUsePathname.mockReturnValue('/posts/some-post');
     render(<AdminBar />);
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Exit Preview')).toBeInTheDocument();
   });
 
   it('renders the bar on the dashboard root', () => {
     mockUsePathname.mockReturnValue('/');
     render(<AdminBar />);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('hides "Exit Preview" on a content route when preview mode is not enabled', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar />);
+    expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
+  });
+
+  it('hides "Exit Preview" when preview is explicitly false', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar adminBarProps={{ preview: false }} />);
+    expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
+  });
+
+  it('shows "Exit Preview" only when preview mode is enabled', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar adminBarProps={{ preview: true }} />);
     expect(screen.getByText('Exit Preview')).toBeInTheDocument();
   });
 

--- a/apps/admin/src/lib/components/AdminBar/index.tsx
+++ b/apps/admin/src/lib/components/AdminBar/index.tsx
@@ -32,7 +32,7 @@ export interface RevealUIMeUser {
 
 // RevealUI Admin Bar component
 const RevealUIAdminBar = (props: RevealUIAdminBarProps) => {
-  const { className, logo, onAuthChange, onPreviewExit, style } = props;
+  const { className, logo, onAuthChange, onPreviewExit, preview, style } = props;
 
   // Fetch user on mount
   React.useEffect(() => {
@@ -57,9 +57,11 @@ const RevealUIAdminBar = (props: RevealUIAdminBarProps) => {
       <div className="flex items-center justify-between">
         <div>{logo}</div>
         <div className="flex items-center gap-4">
-          <button type="button" onClick={onPreviewExit} className="text-sm underline">
-            Exit Preview
-          </button>
+          {preview ? (
+            <button type="button" onClick={onPreviewExit} className="text-sm underline">
+              Exit Preview
+            </button>
+          ) : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes the dead `preview` prop on the admin bar. `RevealUIAdminBar` declared `preview?: boolean` but never destructured it, so the **"Exit Preview"** button rendered unconditionally — any authenticated admin saw a misleading "Exit Preview" control on content pages outside draft/preview mode.

## Change

- Destructure `preview` in `RevealUIAdminBar` and render the "Exit Preview" button only when preview mode is enabled (the prop already flows from `apps/admin/src/app/(frontend)/layout.tsx` via `draftMode().isEnabled`).
- Coexists with the existing `AUTH_ROUTES` early-return (#1098) — no change to bar suppression on `/login` / `/signup` / etc.

## Tests

`apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx` — kept the content-route / dashboard-root cases (bar still renders the "Dashboard" label) and added coverage for the three preview states: unset → hidden, `false` → hidden, `true` → shown. **14/14 passing locally** (`vitest run src/lib/components/AdminBar`); Biome clean on the changed files.

Closes #1108
