### PR TITLE
fix(admin): redirect authenticated admins off /login + /signup

### DIFF
--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Admin proxy — authenticated-user redirect off /login + /signup (#1107).
+ *
+ * An admin holding a valid `revealui-session` has no reason to see the
+ * login/signup screens. Verifies `src/proxy.ts` redirects such a user to '/',
+ * scoped to /login + /signup only, and leaves the other public auth-flow pages
+ * (forgot/reset/rotate-password, mfa, setup) reachable. The `revealui-role`
+ * cookie is normalized to 'admin' | 'user' at sign-in, so the redirect predicate
+ * matches the auth gate's admit check — no redirect loop.
+ *
+ * No regex authored (fleet posture): assertions use URL parsing + equality.
+ */
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import proxy from '../proxy';
+
+// The setup-redirect probe (fires on '/' and '/login' for UNAUTHENTICATED
+// requests) calls fetch(`${origin}/api/setup`). Stub it to report setup-not-needed
+// so the unauthenticated cases fall through to the normal page passthrough.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function req(path: string, cookie?: string): NextRequest {
+  return new NextRequest(`https://admin.example.com${path}`, {
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+/** Location header's pathname, or null when there is no redirect. */
+function redirectPath(res: Response): string | null {
+  const location = res.headers.get('location');
+  return location ? new URL(location).pathname : null;
+}
+
+const ADMIN_COOKIES = 'revealui-session=sess-abc; revealui-role=admin';
+const USER_COOKIES = 'revealui-session=sess-abc; revealui-role=user';
+
+describe('admin proxy — authenticated redirect off /login + /signup (#1107)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+  });
+
+  it('redirects an authenticated admin off /login to /', async () => {
+    const res = await proxy(req('/login', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('redirects an authenticated admin off /signup to /', async () => {
+    const res = await proxy(req('/signup', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('does not redirect an unauthenticated visitor off /login', async () => {
+    const res = await proxy(req('/login'));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated non-admin (role=user) off /login', async () => {
+    const res = await proxy(req('/login', USER_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated admin off /forgot-password', async () => {
+    const res = await proxy(req('/forgot-password', ADMIN_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated admin off /rotate-password', async () => {
+    const res = await proxy(req('/rotate-password', ADMIN_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+});

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -145,6 +145,24 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
+  // Already-authenticated admins have no reason to see the login/signup screens.
+  // Redirect them to the dashboard. Scoped to /login + /signup ONLY — /setup,
+  // /rotate-password, /forgot-password, /reset-password, /mfa stay reachable for an
+  // authenticated or partially-authenticated user (forced rotation, MFA enrollment,
+  // etc.). The `revealui-role` cookie is normalized to 'admin' | 'user' at sign-in
+  // (defense-in-depth UI hint), and this predicate matches the auth gate's admit
+  // check below, so an admin sent to '/' always passes that gate — no redirect loop.
+  if (pathname === '/login' || pathname === '/signup') {
+    const session = request.cookies.get('revealui-session')?.value;
+    const role = request.cookies.get('revealui-role')?.value;
+    if (session && role === 'admin') {
+      const homeUrl = request.nextUrl.clone();
+      homeUrl.pathname = '/';
+      homeUrl.search = '';
+      return NextResponse.redirect(homeUrl);
+    }
+  }
+
   // Auth gate: protect (backend) pages — every path that isn't public and
   // isn't internal needs a session + admin role. The role cookie is a
   // defense-in-depth UI hint (set at login). Real enforcement is at the API


### PR DESCRIPTION
## Summary

`apps/admin/src/proxy.ts` lists `/login` and `/signup` in `PUBLIC_PATHS`, and the auth gate only *adds* protection for non-public pages — it never redirects an **already-authenticated** admin *away* from the auth screens. So an admin with a valid `revealui-session` could sit on `/signup` (or `/login`) while effectively logged in. This is the root condition behind the production "CSRF token missing on account creation" report (symptom-level mitigations already merged: #1086 CSRF-exempt pre-auth endpoints, #1098 AdminBar suppression on auth routes).

## Change

In `proxy.ts`, before the auth gate: if a `revealui-session` is present **and** `revealui-role === 'admin'` **and** the path is exactly `/login` or `/signup`, redirect to `/`.

- Scoped to `/login` + `/signup` only — `/setup`, `/rotate-password`, `/forgot-password`, `/reset-password`, `/mfa` remain reachable (forced rotation, MFA enrollment, etc.).
- The `revealui-role` cookie is normalized to `'admin' | 'user'` at sign-in (all four auth routes set `isAdminRole(userRole) ? 'admin' : 'user'`), so the redirect predicate matches the gate's existing `role === 'admin'` admit check — an admin sent to `/` always passes it, **no redirect loop**.
- UX/hardening change; the role cookie is defense-in-depth, not the security boundary (real enforcement is API-level collection access).

## Tests

New `apps/admin/src/__tests__/proxy-auth-redirect.test.ts` drives `proxy()` directly: authed admin off `/login` / `/signup` → 307 → `/`; unauthenticated `/login`, authed non-admin `/login`, and authed admin on `/forgot-password` / `/rotate-password` → not redirected. **6/6 pass**, and the existing `proxy-csp.test.ts` stays green (8/8). Biome clean.

Closes #1107
