### PR TITLE
fix(ai): record provider health on embed() and stream() paths

### DIFF
--- a/packages/ai/src/llm/__tests__/client.test.ts
+++ b/packages/ai/src/llm/__tests__/client.test.ts
@@ -1,0 +1,169 @@
+/**
+ * LLMClient — provider-health recording on embed() and stream()
+ *
+ * Regression guard: ProviderHealthMonitor.recordCall previously fired only on
+ * chat(). embed() and stream() were invisible to health tracking. These tests
+ * assert recording on both paths for success and failure, primary and fallback,
+ * and that a dedicated embed-provider override is intentionally not recorded.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LLMClient } from '../client.js';
+import { ProviderHealthMonitor } from '../provider-health.js';
+import type { Embedding, LLMChunk, LLMProvider } from '../providers/base.js';
+
+const { ollamaChat, ollamaEmbed, ollamaStream, groqChat, groqEmbed, groqStream } = vi.hoisted(
+  () => ({
+    ollamaChat: vi.fn(),
+    ollamaEmbed: vi.fn(),
+    ollamaStream: vi.fn(),
+    groqChat: vi.fn(),
+    groqEmbed: vi.fn(),
+    groqStream: vi.fn(),
+  }),
+);
+
+vi.mock('../providers/ollama.js', () => ({
+  OllamaProvider: class {
+    chat = ollamaChat;
+    embed = ollamaEmbed;
+    stream = ollamaStream;
+  },
+}));
+
+vi.mock('../providers/groq.js', () => ({
+  GroqProvider: class {
+    chat = groqChat;
+    embed = groqEmbed;
+    stream = groqStream;
+  },
+}));
+
+vi.mock('../providers/inference-snaps.js', () => ({
+  InferenceSnapsProvider: class {
+    chat = vi.fn();
+    embed = vi.fn();
+    stream = vi.fn();
+  },
+}));
+
+const EMBEDDING: Embedding = { vector: [0.1, 0.2], dimension: 2, model: 'mock-embed' };
+
+async function* streamChunks(...chunks: LLMChunk[]): AsyncGenerator<LLMChunk> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+/** An async iterable whose first pull rejects — models a provider that throws before any chunk. */
+function failingStream(message: string): AsyncIterable<LLMChunk> {
+  return {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.reject(new Error(message)),
+    }),
+  };
+}
+
+async function drain(stream: AsyncIterable<LLMChunk>): Promise<LLMChunk[]> {
+  const chunks: LLMChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function makeClient(healthMonitor?: ProviderHealthMonitor): LLMClient {
+  return new LLMClient({
+    provider: 'ollama',
+    apiKey: 'test-key',
+    fallbackProvider: 'groq',
+    healthMonitor,
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('LLMClient health recording — embed()', () => {
+  it('records a successful primary embed', async () => {
+    ollamaEmbed.mockResolvedValueOnce(EMBEDDING);
+    const monitor = new ProviderHealthMonitor();
+
+    const result = await makeClient(monitor).embed('hello');
+
+    expect(result).toEqual(EMBEDDING);
+    expect(monitor.getHealth('ollama')).toMatchObject({ sampleCount: 1, errorRate: 0 });
+    expect(monitor.getHealth('groq').sampleCount).toBe(0);
+  });
+
+  it('records primary failure then fallback success', async () => {
+    ollamaEmbed.mockRejectedValueOnce(new Error('primary embed down'));
+    groqEmbed.mockResolvedValueOnce(EMBEDDING);
+    const monitor = new ProviderHealthMonitor();
+
+    const result = await makeClient(monitor).embed('hello');
+
+    expect(result).toEqual(EMBEDDING);
+    expect(monitor.getHealth('ollama')).toMatchObject({ sampleCount: 1, errorRate: 1 });
+    expect(monitor.getHealth('groq')).toMatchObject({ sampleCount: 1, errorRate: 0 });
+  });
+
+  it('does not record health for a dedicated embed-provider override', async () => {
+    const overrideEmbed = vi.fn(async () => EMBEDDING);
+    const embedProvider: LLMProvider = {
+      chat: vi.fn(),
+      embed: overrideEmbed,
+      stream: vi.fn(),
+    };
+    const monitor = new ProviderHealthMonitor();
+    const client = new LLMClient({
+      provider: 'ollama',
+      apiKey: 'test-key',
+      embedProvider,
+      healthMonitor: monitor,
+    });
+
+    await client.embed('hello');
+
+    expect(overrideEmbed).toHaveBeenCalledOnce();
+    expect(ollamaEmbed).not.toHaveBeenCalled();
+    expect(monitor.getHealth('ollama').sampleCount).toBe(0);
+  });
+});
+
+describe('LLMClient health recording — stream()', () => {
+  it('records a successful primary stream at time-to-first-chunk', async () => {
+    ollamaStream.mockImplementation(() =>
+      streamChunks({ content: 'a', done: false }, { content: 'b', done: true }),
+    );
+    const monitor = new ProviderHealthMonitor();
+
+    const chunks = await drain(makeClient(monitor).stream([{ role: 'user', content: 'hi' }]));
+
+    expect(chunks).toHaveLength(2);
+    expect(monitor.getHealth('ollama')).toMatchObject({ sampleCount: 1, errorRate: 0 });
+  });
+
+  it('records primary failure then fallback success', async () => {
+    ollamaStream.mockImplementation(() => failingStream('primary stream down'));
+    groqStream.mockImplementation(() => streamChunks({ content: 'fallback', done: true }));
+    const monitor = new ProviderHealthMonitor();
+
+    const chunks = await drain(makeClient(monitor).stream([{ role: 'user', content: 'hi' }]));
+
+    expect(chunks).toEqual([{ content: 'fallback', done: true }]);
+    expect(monitor.getHealth('ollama')).toMatchObject({ sampleCount: 1, errorRate: 1 });
+    expect(monitor.getHealth('groq')).toMatchObject({ sampleCount: 1, errorRate: 0 });
+  });
+});
+
+describe('LLMClient health recording — optional monitor', () => {
+  it('embed() and stream() run without a configured monitor', async () => {
+    ollamaEmbed.mockResolvedValueOnce(EMBEDDING);
+    ollamaStream.mockImplementation(() => streamChunks({ content: 'a', done: true }));
+    const client = makeClient(undefined);
+
+    await expect(client.embed('hello')).resolves.toEqual(EMBEDDING);
+    await expect(drain(client.stream([{ role: 'user', content: 'hi' }]))).resolves.toHaveLength(1);
+  });
+});

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -381,19 +381,43 @@ export class LLMClient {
 
     // Use dedicated embed provider if one was configured
     const embedProvider = this.embedProviderOverride ?? this.provider;
+    // Only the primary-provider path maps to a known LLMProviderType the health
+    // monitor can key on. A dedicated embed override is an opaque provider, so we
+    // skip recording rather than attribute its latency to the primary provider.
+    const trackPrimary = !this.embedProviderOverride;
+    const callStart = Date.now();
 
     try {
       this.recordRequest();
-      return await this.circuitBreaker.execute(() => embedProvider.embed(text, options));
+      const result = await this.circuitBreaker.execute(() => embedProvider.embed(text, options));
+      if (trackPrimary) {
+        this.healthMonitor?.recordCall(this.config.provider, Date.now() - callStart);
+      }
+      return result;
     } catch (error) {
+      if (trackPrimary) {
+        this.healthMonitor?.recordCall(
+          this.config.provider,
+          Date.now() - callStart,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
       // Try fallback if available (only when using the primary provider path)
-      if (!this.embedProviderOverride && this.fallbackProvider) {
+      if (!this.embedProviderOverride && this.fallbackProvider && this.config.fallbackProvider) {
         const fp = this.fallbackProvider;
+        const fallbackStart = Date.now();
         try {
-          return this.fallbackCircuitBreaker
+          const fb = this.fallbackCircuitBreaker
             ? await this.fallbackCircuitBreaker.execute(() => fp.embed(text, options))
             : await fp.embed(text, options);
-        } catch {
+          this.healthMonitor?.recordCall(this.config.fallbackProvider, Date.now() - fallbackStart);
+          return fb;
+        } catch (fallbackError) {
+          this.healthMonitor?.recordCall(
+            this.config.fallbackProvider,
+            Date.now() - fallbackStart,
+            fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)),
+          );
           throw new Error(
             `Both primary and fallback providers failed: ${error instanceof Error ? error.message : String(error)}`,
           );
@@ -410,6 +434,7 @@ export class LLMClient {
       throw new Error('Rate limit exceeded');
     }
 
+    const callStart = Date.now();
     try {
       // Circuit breaker check — streaming can't use execute() wrapper
       // so we check state and record outcomes manually
@@ -417,16 +442,57 @@ export class LLMClient {
         throw new CircuitBreakerOpenError(`llm-${this.config.provider}`);
       }
       this.recordRequest();
-      yield* this.provider.stream(messages, options);
+      // Sample health latency at time-to-first-chunk, not full stream duration:
+      // a pull-based generator's total time includes downstream consumer speed,
+      // which would falsely mark a healthy provider degraded.
+      let sampled = false;
+      for await (const chunk of this.provider.stream(messages, options)) {
+        if (!sampled) {
+          this.healthMonitor?.recordCall(this.config.provider, Date.now() - callStart);
+          sampled = true;
+        }
+        yield chunk;
+      }
+      if (!sampled) {
+        // Stream produced zero chunks but the call still succeeded.
+        this.healthMonitor?.recordCall(this.config.provider, Date.now() - callStart);
+      }
     } catch (error) {
+      this.healthMonitor?.recordCall(
+        this.config.provider,
+        Date.now() - callStart,
+        error instanceof Error ? error : new Error(String(error)),
+      );
       // Try fallback if available
-      if (this.fallbackProvider) {
+      if (this.fallbackProvider && this.config.fallbackProvider) {
+        const fallbackStart = Date.now();
         try {
           if (this.fallbackCircuitBreaker?.isOpen()) {
             throw new CircuitBreakerOpenError(`llm-${this.config.fallbackProvider}`);
           }
-          yield* this.fallbackProvider.stream(messages, options);
-        } catch {
+          let fallbackSampled = false;
+          for await (const chunk of this.fallbackProvider.stream(messages, options)) {
+            if (!fallbackSampled) {
+              this.healthMonitor?.recordCall(
+                this.config.fallbackProvider,
+                Date.now() - fallbackStart,
+              );
+              fallbackSampled = true;
+            }
+            yield chunk;
+          }
+          if (!fallbackSampled) {
+            this.healthMonitor?.recordCall(
+              this.config.fallbackProvider,
+              Date.now() - fallbackStart,
+            );
+          }
+        } catch (fallbackError) {
+          this.healthMonitor?.recordCall(
+            this.config.fallbackProvider,
+            Date.now() - fallbackStart,
+            fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)),
+          );
           throw new Error(
             `Both primary and fallback providers failed: ${error instanceof Error ? error.message : String(error)}`,
           );


### PR DESCRIPTION
## What

`ProviderHealthMonitor.recordCall` previously fired only on `LLMClient.chat()`. The `embed()` and `stream()` paths recorded nothing, so a provider's health window reflected only chat traffic — embedding and streaming failures or latency were invisible to `getHealth()` / `getBestProvider()`.

This wires `recordCall` into both paths, mirroring `chat()`:

- **`embed()`** — records latency on success and error for the primary, plus the fallback path. A dedicated `embedProvider` override is intentionally *not* recorded: it is an opaque `LLMProvider` with no `LLMProviderType` key, so attributing its latency to the primary provider would corrupt that provider's window.
- **`stream()`** — records the primary and fallback outcomes. Latency is sampled at **time-to-first-chunk**, not full stream duration: a pull-based generator's total wall-clock includes downstream consumer speed, which would otherwise push a healthy provider past the degraded/unhealthy latency thresholds.

No behavior change for callers — this is observability wiring on an opt-in monitor (`healthMonitor` stays optional and `?.`-guarded).

## Why

Health-based provider ranking can only be as good as its inputs. Recording only `chat()` left embed and stream as blind spots in the signal.

## Tests

Adds `packages/ai/src/llm/__tests__/client.test.ts` (6 tests): primary success, primary-failure → fallback-success, the embed-override skip, and the no-monitor safety path, across both `embed()` and `stream()`.

## Verification

- `biome check` clean
- `@revealui/ai` `tsc --noEmit` clean
- `vitest` 6/6 pass

## Follow-on (not in this PR)

Failover still selects a static `fallbackProvider` rather than consulting `getBestProvider()`, and the env/user client factories do not yet opt into a health monitor. Wiring those is a separate, larger change.
