### PR TITLE
chore(release): promote test -> main (pglite-0.5 + admin fixes + docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Claim drift validation (hard fail)
         run: pnpm validate:claims
 
+      - name: Marketing voice validation (hard fail)
+        run: pnpm validate:marketing-voice
+
       - name: Migration journal validation (hard fail)
         run: pnpm validate:migrations
 

--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Admin proxy — authenticated-user redirect off /login + /signup (#1107).
+ *
+ * An admin holding a valid `revealui-session` has no reason to see the
+ * login/signup screens. Verifies `src/proxy.ts` redirects such a user to '/',
+ * scoped to /login + /signup only, and leaves the other public auth-flow pages
+ * (forgot/reset/rotate-password, mfa, setup) reachable. The `revealui-role`
+ * cookie is normalized to 'admin' | 'user' at sign-in, so the redirect predicate
+ * matches the auth gate's admit check — no redirect loop.
+ *
+ * No regex authored (fleet posture): assertions use URL parsing + equality.
+ */
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import proxy from '../proxy';
+
+// The setup-redirect probe (fires on '/' and '/login' for UNAUTHENTICATED
+// requests) calls fetch(`${origin}/api/setup`). Stub it to report setup-not-needed
+// so the unauthenticated cases fall through to the normal page passthrough.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function req(path: string, cookie?: string): NextRequest {
+  return new NextRequest(`https://admin.example.com${path}`, {
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+/** Location header's pathname, or null when there is no redirect. */
+function redirectPath(res: Response): string | null {
+  const location = res.headers.get('location');
+  return location ? new URL(location).pathname : null;
+}
+
+const ADMIN_COOKIES = 'revealui-session=sess-abc; revealui-role=admin';
+const USER_COOKIES = 'revealui-session=sess-abc; revealui-role=user';
+
+describe('admin proxy — authenticated redirect off /login + /signup (#1107)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+  });
+
+  it('redirects an authenticated admin off /login to /', async () => {
+    const res = await proxy(req('/login', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('redirects an authenticated admin off /signup to /', async () => {
+    const res = await proxy(req('/signup', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('does not redirect an unauthenticated visitor off /login', async () => {
+    const res = await proxy(req('/login'));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated non-admin (role=user) off /login', async () => {
+    const res = await proxy(req('/login', USER_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated admin off /forgot-password', async () => {
+    const res = await proxy(req('/forgot-password', ADMIN_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+
+  it('does not redirect an authenticated admin off /rotate-password', async () => {
+    const res = await proxy(req('/rotate-password', ADMIN_COOKIES));
+    expect(redirectPath(res)).not.toBe('/');
+  });
+});

--- a/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
+++ b/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
@@ -62,12 +62,29 @@ describe('AdminBar', () => {
     mockUsePathname.mockReturnValue('/posts/some-post');
     render(<AdminBar />);
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Exit Preview')).toBeInTheDocument();
   });
 
   it('renders the bar on the dashboard root', () => {
     mockUsePathname.mockReturnValue('/');
     render(<AdminBar />);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('hides "Exit Preview" on a content route when preview mode is not enabled', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar />);
+    expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
+  });
+
+  it('hides "Exit Preview" when preview is explicitly false', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar adminBarProps={{ preview: false }} />);
+    expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
+  });
+
+  it('shows "Exit Preview" only when preview mode is enabled', () => {
+    mockUsePathname.mockReturnValue('/posts/some-post');
+    render(<AdminBar adminBarProps={{ preview: true }} />);
     expect(screen.getByText('Exit Preview')).toBeInTheDocument();
   });
 

--- a/apps/admin/src/lib/components/AdminBar/index.tsx
+++ b/apps/admin/src/lib/components/AdminBar/index.tsx
@@ -32,7 +32,7 @@ export interface RevealUIMeUser {
 
 // RevealUI Admin Bar component
 const RevealUIAdminBar = (props: RevealUIAdminBarProps) => {
-  const { className, logo, onAuthChange, onPreviewExit, style } = props;
+  const { className, logo, onAuthChange, onPreviewExit, preview, style } = props;
 
   // Fetch user on mount
   React.useEffect(() => {
@@ -57,9 +57,11 @@ const RevealUIAdminBar = (props: RevealUIAdminBarProps) => {
       <div className="flex items-center justify-between">
         <div>{logo}</div>
         <div className="flex items-center gap-4">
-          <button type="button" onClick={onPreviewExit} className="text-sm underline">
-            Exit Preview
-          </button>
+          {preview ? (
+            <button type="button" onClick={onPreviewExit} className="text-sm underline">
+              Exit Preview
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -145,6 +145,24 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
+  // Already-authenticated admins have no reason to see the login/signup screens.
+  // Redirect them to the dashboard. Scoped to /login + /signup ONLY — /setup,
+  // /rotate-password, /forgot-password, /reset-password, /mfa stay reachable for an
+  // authenticated or partially-authenticated user (forced rotation, MFA enrollment,
+  // etc.). The `revealui-role` cookie is normalized to 'admin' | 'user' at sign-in
+  // (defense-in-depth UI hint), and this predicate matches the auth gate's admit
+  // check below, so an admin sent to '/' always passes that gate — no redirect loop.
+  if (pathname === '/login' || pathname === '/signup') {
+    const session = request.cookies.get('revealui-session')?.value;
+    const role = request.cookies.get('revealui-role')?.value;
+    if (session && role === 'admin') {
+      const homeUrl = request.nextUrl.clone();
+      homeUrl.pathname = '/';
+      homeUrl.search = '';
+      return NextResponse.redirect(homeUrl);
+    }
+  }
+
   // Auth gate: protect (backend) pages — every path that isn't public and
   // isn't internal needs a session + admin role. The role cookie is a
   // defense-in-depth UI hint (set at login). Real enforcement is at the API

--- a/apps/docs/app/components/showcase/ShowcaseShell.tsx
+++ b/apps/docs/app/components/showcase/ShowcaseShell.tsx
@@ -94,7 +94,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {story.usage.when && (
             <div className="rounded-xl border border-border bg-surface p-4">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-success">
                 When to use
               </h3>
               <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.when)}</div>
@@ -102,7 +102,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
           )}
           {story.usage.avoid && (
             <div className="rounded-xl border border-border bg-surface p-4">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-amber-700">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-warning-foreground">
                 When to avoid
               </h3>
               <div className="text-sm text-text-secondary">{renderMarkdown(story.usage.avoid)}</div>
@@ -195,7 +195,7 @@ export function ShowcaseShell({ story }: ShowcaseShellProps) {
                   {a11y.conformance.map((item) => (
                     <span
                       key={item}
-                      className="rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200"
+                      className="rounded-md bg-success/15 px-2 py-1 text-xs font-medium text-success ring-1 ring-success/30"
                     >
                       {item}
                     </span>

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -57,7 +57,7 @@ export const HOME_HERO = {
       {
         metric: 'Pro license enforcement, signed and verified',
         detail:
-          'Pro features unlock against your license, server-checked — no manual install gates. See the [Pro reference](https://docs.revealui.com/pro).',
+          'Pro features check against your license server-side — no manual install gates. See the [Pro reference](https://docs.revealui.com/pro).',
       },
       {
         metric: `FSL-1.1-MIT on ${METRICS.licenseSplit.fsl} Fair Source packages`,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@biomejs/biome": "catalog:",
     "@changesets/cli": "^2.31.0",
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "catalog:",
     "@size-limit/file": "^12.1.0",
@@ -56,7 +56,6 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
-      "@electric-sql/pglite": "^0.4.5",
       "form-data": ">=4.0.4",
       "path-to-regexp": ">=6.3.0",
       "tar-fs": ">=2.1.4",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
+    "validate:marketing-voice": "tsx scripts/validate/marketing-voice.ts",
     "validate:client-safety": "tsx scripts/validate/client-safety.ts",
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",
     "validate:brand-bridge": "tsx scripts/validate/brand-bridge.ts",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.8",
     "@revealui/dev": "workspace:*",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,7 +7,7 @@
     "@revealui/security": "workspace:*"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@types/node": "catalog:",
     "@revealui/dev": "workspace:*",
     "tsup": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@lexical/clipboard": "^0.45.0",
     "@lexical/code": "^0.45.0",
     "@lexical/html": "^0.45.0",

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -12,7 +12,7 @@
     "revealui-harnesses": "./dist/cli.js"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@revealui/core": "workspace:*",
     "zod": "catalog:"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "pg": "catalog:",
     "typescript": "catalog:",
     "vitest": "^4.1.8"

--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -4,7 +4,7 @@
   "description": "Circuit breaker, retry, bulkhead, and timeout patterns for resilient services. Database-backed circuit state. Ships with RevealUI.",
   "license": "MIT",
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
     "@types/node": "catalog:",
     "@revealui/dev": "workspace:*",
     "tsup": "catalog:",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,7 +9,7 @@
     "ret": "^0.5.0"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5"
+    "@electric-sql/pglite": "^0.5.1"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -17,7 +17,8 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.5",
+    "@electric-sql/pglite": "^0.5.1",
+    "@electric-sql/pglite-pgvector": "^0.0.2",
     "@playwright/test": "catalog:",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/test/src/utils/drizzle-test-db.ts
+++ b/packages/test/src/utils/drizzle-test-db.ts
@@ -44,7 +44,7 @@ export interface CreateTestDbOptions {
   logger?: boolean;
   /**
    * Enable the PGlite pgvector extension. When true, the harness loads
-   * `@electric-sql/pglite/vector`, enables the `vector` type, and keeps
+   * `@electric-sql/pglite-pgvector`, enables the `vector` type, and keeps
    * (rather than skips) tables + statements that reference vector columns.
    * Required for tests that query tables like `agent_contexts`, `agent_memories`,
    * or `rag_chunks` which have pgvector-typed embedding columns.
@@ -111,7 +111,7 @@ export async function createTestDb(options?: CreateTestDbOptions): Promise<TestD
   const enableVector = options?.enableVector === true;
   let pglite: PGlite;
   if (enableVector) {
-    const { vector } = await import('@electric-sql/pglite/vector');
+    const { vector } = await import('@electric-sql/pglite-pgvector');
     pglite = new PGlite({ extensions: { vector } });
   } else {
     pglite = new PGlite();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,6 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  '@electric-sql/pglite': ^0.4.5
   form-data: '>=4.0.4'
   path-to-regexp: '>=6.3.0'
   tar-fs: '>=2.1.4'
@@ -135,8 +134,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.9.2)
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
         version: 1.29.0(zod@4.4.3)
@@ -310,7 +309,7 @@ importers:
         version: 10.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -601,7 +600,7 @@ importers:
         version: 10.56.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       hono:
         specifier: 4.12.23
         version: 4.12.23
@@ -668,7 +667,7 @@ importers:
         version: link:../resilience
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       lru-cache:
         specifier: ^11.5.1
         version: 11.5.1
@@ -677,8 +676,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -729,7 +728,7 @@ importers:
         version: 3.0.3
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -772,8 +771,8 @@ importers:
         version: link:../security
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -876,7 +875,7 @@ importers:
         version: 25.9.2
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -890,8 +889,8 @@ importers:
         specifier: ^3.1063.0
         version: 3.1063.0
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@lexical/clipboard':
         specifier: ^0.45.0
         version: 0.45.0
@@ -1018,7 +1017,7 @@ importers:
         version: link:../utils
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -1034,7 +1033,7 @@ importers:
         version: 0.31.10
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -1110,8 +1109,8 @@ importers:
   packages/harnesses:
     dependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
@@ -1160,8 +1159,8 @@ importers:
         version: 6.2.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -1299,8 +1298,8 @@ importers:
   packages/resilience:
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
@@ -1376,8 +1375,8 @@ importers:
         version: 6.0.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
 
   packages/security:
     dependencies:
@@ -1432,7 +1431,7 @@ importers:
         version: 5.8.4(rollup@4.60.3)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -1594,7 +1593,7 @@ importers:
         version: link:../utils
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       hono:
         specifier: 4.12.23
         version: 4.12.23
@@ -1606,8 +1605,11 @@ importers:
         version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
-        specifier: ^0.4.5
-        version: 0.4.6
+        specifier: ^0.5.1
+        version: 0.5.1
+      '@electric-sql/pglite-pgvector':
+        specifier: ^0.0.2
+        version: 0.0.2(@electric-sql/pglite@0.5.1)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -2086,8 +2088,13 @@ packages:
     resolution: {integrity: sha512-Ftf+ze/rZK9dBzvZqW7wrS74aQBToUlhQeUFm7KCTfOCkNJZ+7iZMm9JW/NjyIQjPOz4ApXg3VWOpeCbzsU3IQ==}
     hasBin: true
 
-  '@electric-sql/pglite@0.4.6':
-    resolution: {integrity: sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w==}
+  '@electric-sql/pglite-pgvector@0.0.2':
+    resolution: {integrity: sha512-Gu9Nv7JHlg6BgOLqPCR6lCjI+3xlb7ej5qUtHWmzEYA0ZKzuNgeDK16nRO0ELInwzhLptLqX7VdWyYRElSXjdQ==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1':
+    resolution: {integrity: sha512-h2Vc+qkQqsEL5kvyN5nBAxn3Vbyvka7QfDW7Io+CdcwU1+X8JbCAN2og+5dI11S3eJuDfroUCxzJaap6k+ezEw==}
 
   '@electric-sql/react@1.0.49':
     resolution: {integrity: sha512-lpEmF5rD7VMHJAeov/3SWa0ctqkzZJPZyf8sQnIVJdIUBSgniIYCCNXUzJ1fIeXJwvxNsBj4QX1zUbhntVR/Mw==}
@@ -5516,7 +5523,7 @@ packages:
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': ^0.4.5
+      '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
       '@neondatabase/serverless': '>=0.10.0'
@@ -9271,7 +9278,11 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.60.4
 
-  '@electric-sql/pglite@0.4.6': {}
+  '@electric-sql/pglite-pgvector@0.0.2(@electric-sql/pglite@0.5.1)':
+    dependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1': {}
 
   '@electric-sql/react@1.0.49(react@19.2.6)':
     dependencies:
@@ -12775,17 +12786,17 @@ snapshots:
       esbuild: 0.28.0
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0):
     optionalDependencies:
-      '@electric-sql/pglite': 0.4.6
+      '@electric-sql/pglite': 0.5.1
       '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       pg: 8.21.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0))(zod@4.4.3):
     dependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       zod: 4.4.3
 
   dunder-proto@1.0.1:

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -295,6 +295,11 @@ async function gate(): Promise<void> {
         args: ['validate:claims'],
       },
       {
+        name: 'Marketing voice (hard fail)',
+        command: 'pnpm',
+        args: ['validate:marketing-voice'],
+      },
+      {
         name: 'Design-context drift (hard fail)',
         command: 'pnpm',
         args: ['validate:design-context'],

--- a/scripts/validate/__tests__/marketing-voice.test.ts
+++ b/scripts/validate/__tests__/marketing-voice.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  baselineKey,
+  hasEmoji,
+  hasSentenceExclamation,
+  isContentFile,
+  isVoiceExempt,
+  type LineScanOptions,
+  matchesSequence,
+  scanLine,
+  tokenize,
+} from '../marketing-voice.js';
+
+const CONTENT: LineScanOptions = { scanHype: true, scanPunctuation: true, scanVoice: true };
+const TSX: LineScanOptions = { scanHype: false, scanPunctuation: false, scanVoice: true };
+const EXEMPT: LineScanOptions = { scanHype: true, scanPunctuation: true, scanVoice: false };
+
+function ruleIds(line: string, opts: LineScanOptions): string[] {
+  return scanLine(line, opts).map((f) => f.ruleId);
+}
+function hits(line: string, opts: LineScanOptions): string[] {
+  return scanLine(line, opts).map((f) => `${f.ruleId}:${f.token}`);
+}
+
+describe('tokenize', () => {
+  it('splits hyphenated words but keeps contractions whole', () => {
+    expect(
+      tokenize('cutting-edge')
+        .filter((t) => t.kind === 'word')
+        .map((t) => t.text),
+    ).toEqual(['cutting', 'edge']);
+    expect(
+      tokenize("we're")
+        .filter((t) => t.kind === 'word')
+        .map((t) => t.text),
+    ).toEqual(["we're"]);
+  });
+});
+
+describe('matchesSequence', () => {
+  it('matches a contiguous run, order-sensitive', () => {
+    expect(matchesSequence(['the', 'future', 'of', 'ai'], ['the', 'future', 'of'])).toBe(true);
+    expect(matchesSequence(['future', 'the', 'of'], ['the', 'future', 'of'])).toBe(false);
+    expect(matchesSequence(['x'], [])).toBe(false);
+  });
+});
+
+describe('scanLine — hype', () => {
+  it('flags a single hype word in content scope', () => {
+    expect(hits("  metric: 'A powerful runtime',", CONTENT)).toContain('hype-word:powerful');
+  });
+  it('flags a hyphenated hype phrase', () => {
+    expect(hits("  tagline: 'cutting-edge tooling',", CONTENT)).toContain(
+      'hype-phrase:cutting edge',
+    );
+  });
+  it('does NOT scan hype outside content scope (Tailwind className collision guard)', () => {
+    // "transition-transform" tokenizes to ["transition","transform"]; "transform"
+    // is a hype word but must not fire on a route/component className.
+    expect(ruleIds('<div className="transition-transform" />', TSX)).not.toContain('hype-word');
+  });
+});
+
+describe('scanLine — codename', () => {
+  it('flags bare RVUI and bare Forge but never RevForge', () => {
+    expect(hits("  body: 'pay with RVUI tokens',", CONTENT)).toContain('codename:rvui');
+    expect(hits("  body: 'the Forge tier',", CONTENT)).toContain('codename:forge');
+    expect(ruleIds("  body: 'RevForge trial kits',", CONTENT)).not.toContain('codename');
+  });
+  it('flags the forge-stamp sequence', () => {
+    expect(hits("  value: 'forge-stamp',", CONTENT)).toContain('codename:forge stamp');
+  });
+  it('scans codenames even in tsx scope (no className collision)', () => {
+    expect(ruleIds("  const t = 'RevealCoin';", TSX)).toContain('codename');
+  });
+});
+
+describe('scanLine — fleet voice register', () => {
+  it('flags the agency engagement-verb construction "we build"', () => {
+    expect(hits("  headline: 'We build your platform',", CONTENT)).toContain(
+      'fleet-voice:we build',
+    );
+  });
+  it('does NOT flag legitimate company voice ("we collect", "we process")', () => {
+    expect(ruleIds("  body: 'We collect your email to reply.',", CONTENT)).not.toContain(
+      'fleet-voice',
+    );
+  });
+  it('does not scan voice on exempt (for-operators / blog) files', () => {
+    expect(ruleIds("  headline: 'We build and deploy for you',", EXEMPT)).not.toContain(
+      'fleet-voice',
+    );
+  });
+});
+
+describe('scanLine — punctuation (content only)', () => {
+  it('flags a sentence-ending exclamation', () => {
+    expect(ruleIds("  cta: 'Start today!',", CONTENT)).toContain('punctuation');
+  });
+  it('does not flag code negation', () => {
+    expect(ruleIds('  if (!ready) return null;', CONTENT)).not.toContain('punctuation');
+  });
+  it('flags an emoji but not an arrow', () => {
+    expect(ruleIds("  note: 'Launch 🚀',", CONTENT)).toContain('punctuation');
+    expect(ruleIds("  cta: 'View services →',", CONTENT)).not.toContain('punctuation');
+  });
+});
+
+describe('scanLine — skips imports and comments', () => {
+  it('skips import lines even when they contain banned tokens', () => {
+    expect(scanLine("import { powerful } from './x';", CONTENT)).toEqual([]);
+  });
+  it('skips comment lines', () => {
+    expect(scanLine('  // a powerful, cutting-edge comment', CONTENT)).toEqual([]);
+    expect(scanLine('   * jsdoc powerful line', CONTENT)).toEqual([]);
+  });
+});
+
+describe('helpers', () => {
+  it('hasEmoji distinguishes emoji from BMP symbols', () => {
+    expect(hasEmoji('🚀')).toBe(true);
+    expect(hasEmoji('→')).toBe(false);
+    expect(hasEmoji('x')).toBe(false);
+  });
+  it('hasSentenceExclamation distinguishes copy from code', () => {
+    expect(hasSentenceExclamation('Ship today!')).toBe(true);
+    expect(hasSentenceExclamation('return !ready')).toBe(false);
+  });
+  it('isVoiceExempt covers for-operators and blog', () => {
+    expect(isVoiceExempt('apps/marketing/app/content/for-operators.ts')).toBe(true);
+    expect(isVoiceExempt('apps/marketing/app/routes/BlogPostPage.tsx')).toBe(true);
+    expect(isVoiceExempt('apps/marketing/app/content/home.ts')).toBe(false);
+  });
+  it('isContentFile detects the content data modules', () => {
+    expect(isContentFile('apps/marketing/app/content/home.ts')).toBe(true);
+    expect(isContentFile('apps/marketing/app/routes/HomePage.tsx')).toBe(false);
+  });
+  it('baselineKey is a stable triple', () => {
+    expect(baselineKey({ file: 'a.ts', ruleId: 'hype-word', token: 'powerful' })).toBe(
+      'a.ts::hype-word::powerful',
+    );
+  });
+});

--- a/scripts/validate/marketing-voice-baseline.json
+++ b/scripts/validate/marketing-voice-baseline.json
@@ -1,0 +1,5 @@
+{
+  "note": "Grandfathered marketing-voice occurrences. Regenerate via `pnpm validate:marketing-voice --update-baseline`. Each key is a (file::ruleId::token) triple known to exist as of generation; CI fails only on NEW triples. Shrinking this list = progress.",
+  "count": 0,
+  "keys": []
+}

--- a/scripts/validate/marketing-voice.ts
+++ b/scripts/validate/marketing-voice.ts
@@ -1,0 +1,473 @@
+// console-allowed
+/**
+ * Marketing Voice Validator — banned-word + voice-register CI gate.
+ *
+ * Enforces the voice-and-headline-rules corpus on customer-facing
+ * marketing copy in `apps/marketing/app`:
+ *
+ *   - §4.1 banned hype words / phrases   → `hype-word`, `hype-phrase`
+ *   - §4.1 punctuation bans (emoji, `!`) → `punctuation`
+ *   - §4.2 internal-codename leaks       → `codename`
+ *   - §2 / §4.3 / §5 fleet voice register → `fleet-voice`
+ *     (no first-person-plural studio voice on fleet pages; `for-operators/*`
+ *      and `blog` surfaces are exempt per corpus §2.1)
+ *
+ * Implements the banned-word scan + fleet/agency voice-register split the
+ * corpus §5 maintenance note calls for. Self-contained like its sibling
+ * validators (`claim-drift.ts`, the fleet doc-currency scanner): node built-ins
+ * + `Intl.Segmenter` only, zero authored regex (the fleet no-regex hardline).
+ * The shared `@revealui/contracts/marketing-voice` engine is the eventual
+ * consolidation home once GAP-192 retires the regex detectors in
+ * `claim-drift.ts`; this gate stays dependency-light by design.
+ *
+ * Scope split (false-positive control on a hard-fail gate):
+ *   - hype + punctuation: `content/*.ts` data modules only. Route/component
+ *     `.tsx` carry Tailwind classNames ("transition-transform") that collide
+ *     with hype tokens, so they are out of scope for those rules.
+ *   - codename + voice: every marketing file — those tokens never collide
+ *     with class names.
+ *
+ * A baseline (`marketing-voice-baseline.json`) grandfathers the current
+ * corpus; CI fails only on NEW `(file::ruleId::token)` triples. Shrinking the
+ * baseline = progress (the gitleaks / doc-currency pattern).
+ *
+ * Usage:
+ *   pnpm validate:marketing-voice                    # CI mode (exit 1 on new)
+ *   pnpm validate:marketing-voice --update-baseline  # regenerate the baseline
+ *
+ * Exit codes: 0 = no new violations; 1 = new violations found.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const BASELINE_PATH = path.join(ROOT, 'scripts/validate/marketing-voice-baseline.json');
+const UPDATE_BASELINE = process.argv.includes('--update-baseline');
+
+// ---------------------------------------------------------------------------
+// Tokenizer — Intl.Segmenter word granularity (mirrors the shared
+// @revealui/contracts/marketing-voice tokenizer, inlined to stay self-
+// contained). No authored regex.
+// ---------------------------------------------------------------------------
+
+export interface Token {
+  text: string;
+  kind: 'word' | 'symbol' | 'whitespace';
+  offset: number;
+}
+
+const SEGMENTER = new Intl.Segmenter('en', { granularity: 'word' });
+
+export function tokenize(text: string): Token[] {
+  const out: Token[] = [];
+  for (const part of SEGMENTER.segment(text)) {
+    const isWord = (part as Intl.SegmentData & { isWordLike?: boolean }).isWordLike === true;
+    out.push({
+      text: part.segment,
+      kind: isWord ? 'word' : part.segment.trim() === '' ? 'whitespace' : 'symbol',
+      offset: part.index,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rule data — derived verbatim from the corpus §4.1 / §4.2.
+//
+// Context-caveated words the corpus explicitly allows in technical prose
+// (`optimize`, `leverage`, `AI-native`, `AI-first`, `smart`) are intentionally
+// NOT banned — a blanket ban would be wrong per the corpus's own caveat.
+// Generic connectives (`the only`, `the leading`) are omitted: too common in
+// honest prose to hard-fail on (claim-drift's "prefer false-negatives on a
+// hard-fail gate" philosophy).
+// ---------------------------------------------------------------------------
+
+/** §4.1 single-word hype adjectives + verbs (case-insensitive). */
+export const HYPE_WORDS: ReadonlySet<string> = new Set([
+  'revolutionary',
+  'groundbreaking',
+  'seamless',
+  'frictionless',
+  'effortless',
+  'intuitive',
+  'powerful',
+  'robust',
+  'comprehensive',
+  'extensive',
+  'empower',
+  'unlock',
+  'elevate',
+  'transform',
+  'revolutionize',
+  'supercharge',
+  'accelerate',
+  'amplify',
+  'streamline',
+  'intelligent',
+]);
+
+/** §4.1 multi-word / hyphenated hype phrases (lowercased token sequences). */
+export const HYPE_SEQUENCES: ReadonlyArray<readonly string[]> = [
+  ['game', 'changing'],
+  ['cutting', 'edge'],
+  ['next', 'generation'],
+  ['world', 'class'],
+  ['best', 'in', 'class'],
+  ['industry', 'leading'],
+  ['state', 'of', 'the', 'art'],
+  ['enterprise', 'grade'],
+  ['battle', 'tested'],
+  ['production', 'grade'],
+  ['mission', 'critical'],
+  ['blazingly', 'fast'],
+  ['lightning', 'fast'],
+  ['ai', 'powered'],
+  ['the', 'future', 'of'],
+  ["world's", 'most'],
+  ['built', 'for', 'the', 'modern'],
+  ['designed', 'for', 'ambitious'],
+  ['the', 'premier'],
+];
+
+/**
+ * §4.2 internal-codename leaks (case-SENSITIVE — proper-noun codenames).
+ * `Forge` bare only: "RevForge" tokenizes as one word and never matches.
+ */
+export const CODENAME_WORDS: ReadonlySet<string> = new Set(['RevealCoin', 'RVUI', 'RVC', 'Forge']);
+
+/** §4.2 codename token sequences (case-insensitive). */
+export const CODENAME_SEQUENCES: ReadonlyArray<readonly string[]> = [
+  ['forge', 'stamp'],
+  ['token', '2022'],
+];
+
+/**
+ * §4.3 fleet voice register — the agency's first-person engagement-verb voice
+ * ("we build", "we ship", …) leaking onto fleet pages. Encoded as verb
+ * SEQUENCES, not bare `we`/`us`/`our`: bare first-person is legitimate company
+ * voice on legal, contact, and FAQ pages (S3's author-attribution exception),
+ * so flagging it floods false positives. The construction the corpus actually
+ * targets (§2 "We build…", §4.3 leak) is the studio engagement verb after
+ * "we". Allowed on `for-operators/*` + `blog` surfaces (studio voice by
+ * design, corpus §2.1).
+ */
+export const VOICE_SEQUENCES: ReadonlyArray<readonly string[]> = [
+  ['we', 'build'],
+  ['we', 'ship'],
+  ['we', 'design'],
+  ['we', 'deliver'],
+  ['we', 'maintain'],
+  ['we', 'integrate'],
+  ['we', 'productionize'],
+  ['we', 'scope'],
+  ['we', 'start'],
+];
+
+// ---------------------------------------------------------------------------
+// Matchers (pure)
+// ---------------------------------------------------------------------------
+
+export interface RawFinding {
+  ruleId: string;
+  /** Lowercased offending token or phrase — stable baseline key component. */
+  token: string;
+}
+
+function isLetter(ch: string): boolean {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+}
+
+/** True when an emoji codepoint (Supplementary Multilingual Plane emoji blocks)
+ *  appears in `text`. Arrows (→) and ✅/❌ iconography (BMP) are intentionally
+ *  excluded — the corpus uses arrows in CTAs and renders check marks as SVG. */
+export function hasEmoji(text: string): boolean {
+  for (const ch of text) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined && cp >= 0x1f000 && cp <= 0x1faff) return true;
+  }
+  return false;
+}
+
+/** True when `line` contains a sentence-ending `!` (preceded by a letter or a
+ *  quote) — distinguishes copy ("Ship today!") from code negation ("!ready"). */
+export function hasSentenceExclamation(line: string): boolean {
+  for (let i = 1; i < line.length; i++) {
+    if (line[i] !== '!') continue;
+    const prev = line[i - 1] ?? '';
+    if (isLetter(prev) || prev === '"' || prev === "'" || prev === '`' || prev === '’') return true;
+  }
+  return false;
+}
+
+/** Find a lowercased token `sequence` as a contiguous run within `lowerWords`. */
+export function matchesSequence(
+  lowerWords: readonly string[],
+  sequence: readonly string[],
+): boolean {
+  if (sequence.length === 0) return false;
+  for (let i = 0; i + sequence.length <= lowerWords.length; i++) {
+    let hit = true;
+    for (let j = 0; j < sequence.length; j++) {
+      if (lowerWords[i + j] !== sequence[j]) {
+        hit = false;
+        break;
+      }
+    }
+    if (hit) return true;
+  }
+  return false;
+}
+
+export interface LineScanOptions {
+  /** Scan hype words/phrases (content files only — className collision). */
+  scanHype: boolean;
+  /** Scan punctuation bans (content files only). */
+  scanPunctuation: boolean;
+  /** Scan fleet voice register (non-exempt fleet files). */
+  scanVoice: boolean;
+}
+
+/** Collect rule findings for one source line. Pure + exported for tests. */
+export function scanLine(line: string, opts: LineScanOptions): RawFinding[] {
+  const trimmed = line.trimStart();
+  if (
+    trimmed.startsWith('import ') ||
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('/*') ||
+    trimmed.startsWith('*')
+  ) {
+    return [];
+  }
+
+  const findings: RawFinding[] = [];
+  const tokens = tokenize(line);
+  const words = tokens.filter((t) => t.kind === 'word');
+  const lowerWords = words.map((w) => w.text.toLowerCase());
+
+  // Codenames — every marketing file.
+  for (const w of words) {
+    if (CODENAME_WORDS.has(w.text)) {
+      findings.push({ ruleId: 'codename', token: w.text.toLowerCase() });
+    }
+  }
+  for (const seq of CODENAME_SEQUENCES) {
+    if (matchesSequence(lowerWords, seq)) {
+      findings.push({ ruleId: 'codename', token: seq.join(' ') });
+    }
+  }
+
+  // Fleet voice register — non-exempt fleet files.
+  if (opts.scanVoice) {
+    for (const seq of VOICE_SEQUENCES) {
+      if (matchesSequence(lowerWords, seq)) {
+        findings.push({ ruleId: 'fleet-voice', token: seq.join(' ') });
+      }
+    }
+  }
+
+  // Hype — content data modules only.
+  if (opts.scanHype) {
+    for (const lw of lowerWords) {
+      if (HYPE_WORDS.has(lw)) findings.push({ ruleId: 'hype-word', token: lw });
+    }
+    for (const seq of HYPE_SEQUENCES) {
+      if (matchesSequence(lowerWords, seq)) {
+        findings.push({ ruleId: 'hype-phrase', token: seq.join(' ') });
+      }
+    }
+  }
+
+  // Punctuation — content data modules only.
+  if (opts.scanPunctuation) {
+    if (hasSentenceExclamation(line))
+      findings.push({ ruleId: 'punctuation', token: 'exclamation' });
+    for (const t of tokens) {
+      if (t.kind === 'symbol' && hasEmoji(t.text)) {
+        findings.push({ ruleId: 'punctuation', token: 'emoji' });
+        break;
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// File scoping
+// ---------------------------------------------------------------------------
+
+const MARKETING_APP = 'apps/marketing/app';
+const SCAN_SUBDIRS = ['content', 'components', 'routes', 'layouts'];
+
+/** `for-operators/*` + blog surfaces speak in the studio's first-person voice
+ *  by design (corpus §2.1) — exempt from the fleet-voice register rule. */
+export function isVoiceExempt(rel: string): boolean {
+  const lower = rel.toLowerCase();
+  return lower.includes('for-operators') || lower.includes('blog');
+}
+
+/** Content data modules carry prose as string constants and no classNames. */
+export function isContentFile(rel: string): boolean {
+  return rel.includes('/content/');
+}
+
+function isScannable(name: string): boolean {
+  if (name.endsWith('.d.ts')) return false;
+  if (name.endsWith('.test.ts') || name.endsWith('.test.tsx')) return false;
+  if (name === 'types.ts') return false;
+  return name.endsWith('.ts') || name.endsWith('.tsx');
+}
+
+function walkFiles(dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.name === '__tests__' || e.name === 'node_modules') continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walkFiles(full, out);
+    else if (isScannable(e.name)) out.push(full);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+export interface Finding {
+  file: string;
+  line: number;
+  ruleId: string;
+  token: string;
+  text: string;
+}
+
+export function baselineKey(f: Pick<Finding, 'file' | 'ruleId' | 'token'>): string {
+  return `${f.file}::${f.ruleId}::${f.token}`;
+}
+
+function scanFile(absPath: string): Finding[] {
+  const rel = path.relative(ROOT, absPath).split(path.sep).join('/');
+  const content = fs.readFileSync(absPath, 'utf8');
+  const lines = content.split('\n');
+  const content_ = isContentFile(rel);
+  const opts: LineScanOptions = {
+    scanHype: content_,
+    scanPunctuation: content_,
+    scanVoice: !isVoiceExempt(rel),
+  };
+  const findings: Finding[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    for (const raw of scanLine(line, opts)) {
+      findings.push({
+        file: rel,
+        line: i + 1,
+        ruleId: raw.ruleId,
+        token: raw.token,
+        text: line.trim(),
+      });
+    }
+  }
+  return findings;
+}
+
+export function scanAll(): Finding[] {
+  const files: string[] = [];
+  for (const sub of SCAN_SUBDIRS) {
+    walkFiles(path.join(ROOT, MARKETING_APP, sub), files);
+  }
+  files.sort();
+  const findings: Finding[] = [];
+  for (const f of files) findings.push(...scanFile(f));
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline
+// ---------------------------------------------------------------------------
+
+interface BaselineFile {
+  note: string;
+  count: number;
+  keys: string[];
+}
+
+function loadBaseline(): Set<string> {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')) as BaselineFile;
+    return new Set(parsed.keys);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeBaseline(findings: Finding[]): number {
+  const keys = [...new Set(findings.map(baselineKey))].sort();
+  const body: BaselineFile = {
+    note: 'Grandfathered marketing-voice occurrences. Regenerate via `pnpm validate:marketing-voice --update-baseline`. Each key is a (file::ruleId::token) triple known to exist as of generation; CI fails only on NEW triples. Shrinking this list = progress.',
+    count: keys.length,
+    keys,
+  };
+  fs.writeFileSync(BASELINE_PATH, `${JSON.stringify(body, null, 2)}\n`);
+  return keys.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function run(): void {
+  console.log('Marketing Voice Validator');
+  console.log('=========================\n');
+
+  const findings = scanAll();
+
+  if (UPDATE_BASELINE) {
+    const n = writeBaseline(findings);
+    console.log(`Baseline regenerated: ${n} grandfathered (file::ruleId::token) keys.`);
+    return;
+  }
+
+  const baseline = loadBaseline();
+  const seen = new Set<string>();
+  const fresh: Finding[] = [];
+  for (const f of findings) {
+    const key = baselineKey(f);
+    if (baseline.has(key)) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    fresh.push(f);
+  }
+
+  const distinct = new Set(findings.map(baselineKey)).size;
+  console.log(
+    `Scanned ${MARKETING_APP}: ${findings.length} occurrences, ${distinct} distinct, ${baseline.size} grandfathered, ${fresh.length} new.\n`,
+  );
+
+  if (fresh.length === 0) {
+    console.log('No new marketing-voice violations. ✓');
+    return;
+  }
+
+  console.error(
+    'New marketing-voice violations (fix the copy, or justify + run --update-baseline):\n',
+  );
+  for (const f of fresh) {
+    console.error(`  ${f.file}:${f.line}  [${f.ruleId}] ${f.token}`);
+    console.error(`    ${f.text}`);
+  }
+  console.error(
+    `\n${fresh.length} new violation(s). See the voice-and-headline-rules corpus (§4.1 banned words, §4.2 codenames, §2/§4.3 fleet voice).`,
+  );
+  process.exitCode = 1;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) run();


### PR DESCRIPTION
## Promote `test` → `main`

Carries these merged-to-`test` PRs to `main` (prod):

- #1254 — chore(deps): upgrade `@electric-sql/pglite` 0.4.x → 0.5.x (clears the pglite-on-main hold)
- #1253 — feat(scripts): marketing-voice CI gate (banned words + fleet voice)
- #1255 — fix(docs): cobalt success/warning tokens in showcase usage panels
- #1256 — fix(admin): gate AdminBar "Exit Preview" on draft/preview mode (fixes #1108)
- #1257 — fix(admin): redirect already-authenticated admins off `/login` + `/signup` (fixes #1107)

`test` already contains `main` (via the #1252 backflow merge), so this is a clean merge — no conflicts expected.

### Merge instructions
- **Use a merge commit, not squash.** Squashing diverges `main` from `test` and breaks the next `main` → `test` backflow.
- Merging to `main` triggers the prod deploy (`deploy.yml`).
- Manual merge only (no auto-merge), after required checks are green.
