### PR TITLE
fix(billing): set session metadata.tier on subscription checkout

### DIFF
--- a/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
+++ b/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
@@ -326,3 +326,52 @@ describe('POST /checkout — metered overage price attachment', () => {
     expect(lineItems[0]).toEqual({ price: 'price_pro_test', quantity: 1 });
   });
 });
+
+describe('POST /checkout — session metadata (license-issuance contract)', () => {
+  // The webhook resolves the paid tier via resolveTier(session.metadata) in
+  // webhooks.ts. Stripe does NOT copy subscription_data.metadata onto the
+  // Checkout Session, so the subscription checkout MUST set metadata.tier at the
+  // TOP level or every completed checkout 500s and no license is issued.
+  // Regression guard for the P0 found in the 2026-06-07 checkout audit — the
+  // metered tests above inspect the same create args but only checked line_items.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChains();
+    process.env.STRIPE_SECRET_KEY = 'stripe_test_placeholder';
+    process.env.ADMIN_URL = 'https://app.example.com';
+  });
+
+  it('sets top-level session metadata.tier + revealui_user_id (P0 regression)', async () => {
+    queueSelectResults([{ stripePriceId: 'price_pro_test' }], [{ stripeCustomerId: 'cus_pro' }]);
+    mockCheckoutSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/pro' });
+
+    const app = createApp();
+    const res = await app.request(post('/checkout', { tier: 'pro' }));
+    expect(res.status).toBe(200);
+
+    const sessionArgs = mockCheckoutSessionsCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    // Top-level metadata is what webhooks.ts resolveTier(session.metadata) reads.
+    expect(sessionArgs.metadata).toEqual({ tier: 'pro', revealui_user_id: 'user-metered' });
+    // subscription_data.metadata must stay in lockstep (durable fallback source).
+    const subData = sessionArgs.subscription_data as Record<string, unknown>;
+    expect(subData.metadata).toEqual({ tier: 'pro', revealui_user_id: 'user-metered' });
+  });
+
+  it('top-level metadata.tier reflects the requested tier, not a hardcoded default', async () => {
+    queueSelectResults(
+      [{ stripePriceId: 'price_enterprise_test' }],
+      [{ stripeCustomerId: 'cus_ent' }],
+    );
+    mockCheckoutSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/ent' });
+
+    const app = createApp();
+    const res = await app.request(post('/checkout', { tier: 'enterprise' }));
+    expect(res.status).toBe(200);
+
+    const sessionArgs = mockCheckoutSessionsCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(sessionArgs.metadata).toEqual({
+      tier: 'enterprise',
+      revealui_user_id: 'user-metered',
+    });
+  });
+});

--- a/apps/server/src/routes/__tests__/webhook-lifecycle-complete.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-lifecycle-complete.test.ts
@@ -390,6 +390,42 @@ describe('Webhook Lifecycle Complete', () => {
       expect(mockAuditAppend).toHaveBeenCalled();
     });
 
+    it('falls back to subscription metadata.tier when the session lacks it', async () => {
+      // Defense-in-depth (2026-06-07 audit P0 hardening): Stripe does not copy
+      // subscription_data.metadata onto the Checkout Session. If a session is
+      // ever created without top-level metadata.tier, the handler must still
+      // issue a license by reading the tier from the retrieved subscription.
+      const event = {
+        id: 'evt_checkout_sub_meta_fallback',
+        livemode: false,
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            mode: 'subscription',
+            subscription: 'sub_checkout',
+            customer: 'cus_checkout',
+            metadata: { revealui_user_id: 'user_checkout' }, // no tier on the session
+          },
+        },
+      };
+      mockConstructEvent.mockReturnValueOnce(event);
+      mockSubscriptionsRetrieve.mockResolvedValueOnce({
+        status: 'active',
+        trial_end: null,
+        metadata: { tier: 'max' }, // tier lives only on the subscription
+      });
+      mockDbSelectChain.limit.mockResolvedValueOnce([{ email: 'buyer@test.com' }]);
+
+      const app = createApp();
+      const res = await app.request(postStripe(event));
+
+      expect(res.status).toBe(200);
+      expect(licenseModule.generateLicenseKey).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: 'max' }),
+        expect.anything(),
+      );
+    });
+
     it('is idempotent  -  duplicate event returns 200 with duplicate:true', async () => {
       const event = makeCheckoutEvent('evt_checkout_idempotent');
       mockConstructEvent.mockReturnValue(event);

--- a/apps/server/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-pglite.test.ts
@@ -306,6 +306,63 @@ describe('webhook integration  -  checkout.session.completed (subscription)', ()
     expect(licenseRows[0].perpetual).toBe(false);
     expect(licenseRows[0].licenseKey).toBe('test-jwt-license-key');
   });
+
+  it('issues a real license when tier is only on the subscription (session lacks tier)', async () => {
+    // Production-fidelity proof of the 2026-06-07 audit P0 hardening: Stripe does
+    // not copy subscription_data.metadata onto the Checkout Session. Even when the
+    // session carries no tier, the handler must read it from the retrieved
+    // subscription and write a real licenses row at the correct tier.
+    await seedTestUser(testDb.drizzle, {
+      id: 'user-sub-fallback',
+      email: 'fallback@example.com',
+    });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_sub_fallback' })
+      .where(eq(users.id, 'user-sub-fallback'));
+
+    // The subscription carries the tier; the session (below) does not.
+    mockSubscriptionsRetrieve.mockResolvedValueOnce({
+      id: 'sub_checkout_fallback',
+      status: 'active',
+      trial_end: null,
+      items: {
+        data: [
+          {
+            id: 'si_fallback',
+            current_period_start: Math.floor(Date.now() / 1000),
+            current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+          },
+        ],
+      },
+      metadata: { tier: 'max', revealui_user_id: 'user-sub-fallback' },
+    });
+
+    const event = makeStripeEvent('checkout.session.completed', {
+      id: 'cs_test_sub_fallback',
+      mode: 'subscription',
+      customer: 'cus_sub_fallback',
+      subscription: 'sub_checkout_fallback',
+      customer_email: 'fallback@example.com',
+      metadata: { revealui_user_id: 'user-sub-fallback' }, // no tier on the session
+    });
+
+    const res = await postWebhook(event);
+    if (res.status !== 200) {
+      const errBody = await res.clone().text();
+      throw new Error(`Expected 200, got ${res.status}: ${errBody}`);
+    }
+
+    const licenseRows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.customerId, 'cus_sub_fallback'));
+
+    expect(licenseRows).toHaveLength(1);
+    expect(licenseRows[0].tier).toBe('max');
+    expect(licenseRows[0].status).toBe('active');
+    expect(licenseRows[0].subscriptionId).toBe('sub_checkout_fallback');
+  });
 });
 
 describe('webhook integration  -  checkout.session.completed (perpetual)', () => {

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -633,6 +633,13 @@ app.openapi(checkoutRoute, async (c) => {
       {
         customer: customerId,
         mode: 'subscription',
+        // Top-level session metadata is REQUIRED: the webhook reads
+        // resolveTier(session.metadata), and Stripe does NOT copy
+        // subscription_data.metadata onto the Checkout Session. Without this,
+        // checkout.session.completed throws in resolveTier -> 500 -> the paid
+        // customer never gets a license. Keep in lockstep with the
+        // subscription_data.metadata below.
+        metadata: { tier: resolvedTier, revealui_user_id: user.id },
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -1326,7 +1326,35 @@ app.openapi(stripeWebhookRoute, async (c) => {
           );
         }
 
-        const tier = resolveTier(session.metadata);
+        // Retrieve the subscription up front: it is both the trialing-state
+        // source (below) and the authoritative fallback for the paid tier.
+        // All new checkouts start as trialing (7-day trial configured in billing.ts).
+        let checkoutSubscription: Stripe.Subscription;
+        try {
+          checkoutSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+        } catch (err) {
+          // Throw so Stripe retries the webhook  -  a payment was captured but we
+          // cannot determine trialing vs active without the subscription object.
+          logger.error(
+            'Failed to retrieve subscription at checkout  -  returning 500 for retry',
+            undefined,
+            {
+              subscriptionId,
+              detail: err instanceof Error ? err.message : 'unknown',
+            },
+          );
+          throw new Error(`Failed to retrieve subscription ${subscriptionId} at checkout`);
+        }
+
+        // Resolve the paid tier. Prefer the top-level session metadata set at
+        // checkout creation; fall back to the subscription's own metadata
+        // (subscription_data.metadata.tier). Stripe does NOT mirror one bag onto
+        // the other, so consulting both keeps license issuance working even if a
+        // session is ever created without top-level metadata. resolveTier throws
+        // (-> 500 -> Stripe retry) only when BOTH bags lack a valid tier.
+        const tier = resolveTier(
+          session.metadata?.tier ? session.metadata : checkoutSubscription.metadata,
+        );
         const userId = session.metadata?.revealui_user_id ?? null;
 
         // Resolve userId from Stripe customer if not in metadata
@@ -1371,25 +1399,6 @@ app.openapi(stripeWebhookRoute, async (c) => {
         // with \n escaped in the .env format; the runtime preserves the literal
         // \n chars, so we must convert them to real newlines for jose/importPKCS8.
         const normalizedKey = privateKey.replaceAll('\\n', '\n');
-
-        // Retrieve subscription to detect trialing state and trial_end date.
-        // All new checkouts start as trialing (7-day trial configured in billing.ts).
-        let checkoutSubscription: Stripe.Subscription;
-        try {
-          checkoutSubscription = await stripe.subscriptions.retrieve(subscriptionId);
-        } catch (err) {
-          // Throw so Stripe retries the webhook  -  a payment was captured but we
-          // cannot determine trialing vs active without the subscription object.
-          logger.error(
-            'Failed to retrieve subscription at checkout  -  returning 500 for retry',
-            undefined,
-            {
-              subscriptionId,
-              detail: err instanceof Error ? err.message : 'unknown',
-            },
-          );
-          throw new Error(`Failed to retrieve subscription ${subscriptionId} at checkout`);
-        }
 
         const isTrialing = checkoutSubscription.status === 'trialing';
         const licenseStatus = isTrialing ? 'trialing' : 'active';


### PR DESCRIPTION
## Summary

P0 from the 2026-06-07 checkout-flow audit. The subscription checkout (`POST /api/billing/checkout`) set the paid tier **only** in `subscription_data.metadata`, never in the top-level Checkout Session `metadata`. The webhook resolves the tier via `resolveTier(session.metadata)` on `checkout.session.completed`, and Stripe does **not** copy `subscription_data.metadata` onto the session — so every completed subscription checkout would throw in `resolveTier` → 500 → Stripe retries exhaust → **the paid customer never receives a license.**

The `payment`-mode flows (perpetual / credits / renewal) already set top-level `metadata`, so only the primary subscription flow was affected. Confirmed on both `test` and `main`.

The production smoke runbook (`docs/runbooks/checkout-smoke-production.md`) flagged this exact metadata bag as **"Failure Mode #4 (most-likely-to-bite)"** with a manual pre-flight checkbox — this replaces that soft mitigation with a code fix plus regression tests.

## Changes

- **`billing.ts`** (the fix): add top-level `metadata: { tier, revealui_user_id }` to the subscription checkout, in lockstep with `subscription_data.metadata`.
- **`webhooks.ts`** (defense-in-depth): retrieve the subscription up front and resolve the tier from session metadata **with a fallback to the subscription's own metadata**, so license issuance is robust to either bag.
- **`billing-metered-checkout.test.ts`**: assert the create call sets top-level `metadata.tier` + `revealui_user_id` (the harness already inspected create args but only checked `line_items` — how this slipped through).
- **`webhook-lifecycle-complete.test.ts`**: unit test for the fallback path.
- **`webhook-pglite.test.ts`**: real-Postgres (PGlite) integration test proving a `licenses` row is written at the correct tier via the fallback.

## Verification

- `tsc --noEmit` clean
- Biome clean on changed files
- 77 mock unit tests pass
- PGlite fallback test writes a real `licenses` row at `tier=max`

## Risk

Low. Additive metadata field mirroring three existing flows; the webhook change is a reorder plus fallback that preserves the existing "reject when tier truly absent" behavior (the existing "missing tier → 500" tests stay green because the subscription mock carries no metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
