### PR TITLE
fix(billing): checkout-audit hardening (regex, pause/resume, webhook)

### DIFF
--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -1227,7 +1227,18 @@ app.openapi(pauseRoute, async (c) => {
   }
   assertAccountOwner(c);
 
-  const stripeCustomerId = await ensureStripeCustomer(user.id, user.email ?? '');
+  // Read-only resolution: pause/resume require an existing active subscription,
+  // so there is never a reason to create a Stripe customer here (the create-
+  // capable ensureStripeCustomer with an empty-email fallback could mint a
+  // customer for someone who never checked out). Mirror upgrade/downgrade/portal.
+  const requestEntitlements = c.get('entitlements') as RequestEntitlements | undefined;
+  const stripeCustomerId = await resolveHostedStripeCustomerId(
+    user.id,
+    requestEntitlements?.accountId,
+  );
+  if (!stripeCustomerId) {
+    throw new HTTPException(400, { message: 'No active subscription found.' });
+  }
 
   const subscriptionList = await withStripe((stripe) =>
     stripe.subscriptions.list({ customer: stripeCustomerId, status: 'active', limit: 1 }),
@@ -1287,7 +1298,18 @@ app.openapi(resumeRoute, async (c) => {
   }
   assertAccountOwner(c);
 
-  const stripeCustomerId = await ensureStripeCustomer(user.id, user.email ?? '');
+  // Read-only resolution: pause/resume require an existing active subscription,
+  // so there is never a reason to create a Stripe customer here (the create-
+  // capable ensureStripeCustomer with an empty-email fallback could mint a
+  // customer for someone who never checked out). Mirror upgrade/downgrade/portal.
+  const requestEntitlements = c.get('entitlements') as RequestEntitlements | undefined;
+  const stripeCustomerId = await resolveHostedStripeCustomerId(
+    user.id,
+    requestEntitlements?.accountId,
+  );
+  if (!stripeCustomerId) {
+    throw new HTTPException(400, { message: 'No active subscription found.' });
+  }
 
   const subscriptionList = await withStripe((stripe) =>
     stripe.subscriptions.list({ customer: stripeCustomerId, status: 'active', limit: 1 }),

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -855,6 +855,13 @@ app.openapi(stripeWebhookRoute, async (c) => {
     return c.json({ error: 'Webhook service unavailable' }, 503);
   }
 
+  // CONTRACT: Stripe signature verification REQUIRES the raw request bytes.
+  // Always read the body via c.req.text() here and verify with
+  // constructEventAsync below. Do NOT switch the event source to
+  // c.req.valid('json') / c.req.json() — a re-serialized body changes the bytes
+  // and breaks HMAC verification. The OpenAPI route declares a JSON body schema
+  // for documentation only; Hono buffers the raw body so this text() read and
+  // the schema coexist.
   const body = await c.req.text();
   const sig = c.req.header('Stripe-Signature');
 
@@ -3410,10 +3417,15 @@ app.openapi(stripeWebhookRoute, async (c) => {
                   // of these as a no-op success.
                   const msg = cancelErr instanceof Error ? cancelErr.message : 'unknown';
                   const code = (cancelErr as { code?: string }).code;
+                  // M2 no-regex: detect Stripe's idempotent "already canceled"
+                  // outcomes via case-insensitive substring checks. Covers
+                  // "already canceled" / "already cancelled" / "already been
+                  // cancel(l)ed" and "no such subscription".
+                  const lowerMsg = msg.toLowerCase();
                   const isAlreadyCanceled =
                     code === 'resource_missing' ||
-                    /already\s+(been\s+)?cance(l|ll)ed/i.test(msg) ||
-                    /no such subscription/i.test(msg);
+                    (lowerMsg.includes('already') && lowerMsg.includes('cancel')) ||
+                    lowerMsg.includes('no such subscription');
                   if (isAlreadyCanceled) {
                     logger.info(
                       'Stripe subscription already canceled — refund cancel is no-op (idempotent)',


### PR DESCRIPTION
## Summary

Secondary findings (S1, S3, S4) from the 2026-06-07 checkout-flow audit, batched as low-risk hardening. No behavior change to the happy paths. The P0 — subscription `session.metadata.tier` — shipped separately in #1269. S2 (refund/dispute revoke scoping) is intentionally held for its own focused PR, since it changes when a paying customer's access is revoked.

## Changes

- **S1 — no-regex (M2):** `charge.refunded` → subscription-cancel detected Stripe's idempotent "already canceled" outcome with two inline regex literals. Replaced with case-insensitive substring checks (`already`+`cancel`, `no such subscription`) plus the existing `resource_missing` code check. Strictly a superset of the prior match.
- **S3 — pause/resume:** both called the create-capable `ensureStripeCustomer` with a `user.email ?? ''` fallback, which could mint a Stripe customer (blank email) for a user who never checked out. They require an existing active subscription, so they now resolve read-only via `resolveHostedStripeCustomerId` (mirroring upgrade/downgrade/portal) and 400 when none resolves — same outcome for the no-subscription case, minus the spurious customer.
- **S4 — webhook raw-body contract:** added a contract comment pinning `c.req.text()` as the signature-verification source so a future switch to `c.req.valid('json')` can't silently break HMAC verification.

## Verification

- `tsc --noEmit` clean
- Biome clean on changed files (the one remaining `noNonNullAssertion` warning at `billing.ts:863` is pre-existing, in the invoices route)
- 73 mocked webhook tests pass
- PGlite already-canceled idempotent test passes (exercises the S1 path against real Postgres)

## Note

`/pause` and `/resume` have no route-level tests (pre-existing gap); S3 preserves the existing 400-on-no-subscription outcome via a near-verbatim copy of the tested upgrade/downgrade resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
