### PR TITLE
chore(billing): rename seed Forge perpetual products to Enterprise

### DIFF
--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -195,8 +195,8 @@ const CATALOG: ProductDefinition[] = [
   },
   {
     key: 'revealui_enterprise_perpetual',
-    name: 'Forge Perpetual',
-    description: 'Full self-hosted Forge with unlimited deployments.',
+    name: 'Enterprise Perpetual',
+    description: 'Full self-hosted Enterprise with unlimited deployments.',
     tier: 'enterprise',
     billingModel: 'perpetual',
     priceNote: 'one-time',
@@ -248,8 +248,8 @@ const CATALOG: ProductDefinition[] = [
   },
   {
     key: 'revealui_renewal_enterprise',
-    name: 'Forge Support Renewal',
-    description: 'Renew your Forge perpetual license support contract for 1 year.',
+    name: 'Enterprise Support Renewal',
+    description: 'Renew your Enterprise perpetual license support contract for 1 year.',
     tier: 'enterprise',
     billingModel: 'renewal',
     priceNote: 'annual',


### PR DESCRIPTION
## What

Rename the Stripe seed's enterprise-tier perpetual products from the pre-rename "Forge" labels to "Enterprise":

- `Forge Perpetual` -> `Enterprise Perpetual`
- `Forge Support Renewal` -> `Enterprise Support Renewal`

(plus the matching product descriptions). Naming only.

## Why

The `enterprise` tier was renamed from "Forge" earlier. The `/api/pricing` fallback (`apps/server/src/routes/pricing.ts`) already ships "Enterprise Perpetual"; the seed (`scripts/setup/seed-stripe.ts`) was the last place still using the old labels.

## Scope / safety

- **Naming only.** No price (`unitAmount`), no product `key`, no `defaultPriceKey`, no behavior change. Stripe lookup keys are unchanged, so re-seeding maps to the same products.
- Verified the old strings appear nowhere else in code (only this seed, plus a historical MASTER_PLAN checklist line and a historical comment in `pricing.ts`, both left as-is as accurate records). No test asserts the old names.

## Test plan

CI (quality + typecheck + tests + build). No runtime or price impact.
