### PR TITLE
chore(marketing): retire AI-native from the brand tagline

### DIFF
--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -53,7 +53,7 @@ export type Metrics = typeof METRICS;
 
 export const SITE = {
   brand: 'RevealUI',
-  brandTagline: 'The open runtime for AI-native businesses.',
+  brandTagline: 'The open runtime for businesses that run their own AI.',
   urls: {
     signup: 'https://admin.revealui.com/signup',
     admin: 'https://admin.revealui.com',


### PR DESCRIPTION
## What

Retire "AI-native" from the homepage brand tagline.

- Before: `The open runtime for AI-native businesses.`
- After: `The open runtime for businesses that run their own AI.`

## Why

"AI-native" is being retired from customer-facing copy in favor of the self-hosted / own-your-runtime positioning. This is the single homepage tagline. The marketing-voice validator currently allows "AI-native" as a context-caveated term, so this is a copy change, not a gate change.

## Scope

- One string: `apps/marketing/app/content/site.ts` `brandTagline`.
- The new tagline avoids the marketing-voice gate's banned hype words/sequences.
- **Out of scope (separate follow-up):** the "AI-native" byline still used across the blog corpus, and the validator's allow-list stance on the term. Those are a coordinated change (validator + corpus + baseline), not this single-string fix.

## Test plan

CI: quality (incl. the marketing-voice gate), typecheck, build.
