### PR TITLE
docs(blog): reword AI-native byline to the self-host positioning

### DIFF
--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -8,7 +8,7 @@ I've started three software companies. Each time, I spent the first three to six
 
 That's not a skills problem. That's an infrastructure problem. And after the third time, I decided to solve it.
 
-RevealUI is the open runtime for AI-native businesses. Users, content, products, payments, and intelligence — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
+RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
 
 ## The problem nobody talks about
 

--- a/docs/blog/02-http-402-payments.md
+++ b/docs/blog/02-http-402-payments.md
@@ -260,4 +260,4 @@ The important constraint is ethical billing: failed or replayed calls should not
 
 ---
 
-_RevealUI is the open runtime for AI-native businesses. [revealui.com](https://revealui.com)_
+_RevealUI is the open runtime for businesses that run their own AI. [revealui.com](https://revealui.com)_

--- a/docs/blog/03-multi-agent-coordination.md
+++ b/docs/blog/03-multi-agent-coordination.md
@@ -222,4 +222,4 @@ The `@revealui/harnesses` package is part of RevealUI Pro. The protocol itself  
 
 ---
 
-*RevealUI is the open runtime for AI-native businesses. [revealui.com](https://revealui.com)*
+*RevealUI is the open runtime for businesses that run their own AI. [revealui.com](https://revealui.com)*

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -6,7 +6,7 @@
 
 Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell products, a way to collect payments, and increasingly, a way to run AI. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
 
-RevealUI is the open runtime for AI-native businesses. Its thesis is simple: these five primitives should be pre-wired, open source, and ready to deploy. You bring your business logic. We bring the infrastructure.
+RevealUI is the open runtime for businesses that run their own AI. Its thesis is simple: these five primitives should be pre-wired, open source, and ready to deploy. You bring your business logic. We bring the infrastructure.
 
 This post is a deep technical walkthrough of all five. Not marketing copy. Real code, real architecture decisions, real trade-offs.
 
@@ -512,4 +512,4 @@ Build your business, not your boilerplate.
 
 ---
 
-*RevealUI is the open runtime for AI-native businesses. The core — Users, Content, Products, and Payments — is MIT licensed and free forever. Intelligence (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. The core — Users, Content, Products, and Payments — is MIT licensed and free forever. Intelligence (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -18,7 +18,7 @@ This wasn't a naive decision. I'm aware of the arguments for more restrictive li
 
 I understand that risk. I accept it. Here's why.
 
-RevealUI is an open runtime for AI-native businesses. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
+RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
 The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 14 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
@@ -45,7 +45,7 @@ These features are commercially licensed. The source code is available (you can 
 
 Why AI specifically? Three reasons.
 
-**It's the highest-value part of the stack.** AI agents that can manage your content, process payments, handle support tickets, and coordinate across services are genuinely transformative. This is where RevealUI stops being "another framework" and starts being an open runtime for AI-native businesses.
+**It's the highest-value part of the stack.** AI agents that can manage your content, process payments, handle support tickets, and coordinate across services are genuinely transformative. This is where RevealUI stops being "another framework" and starts being an open runtime for businesses that run their own AI.
 
 **It's the most expensive to maintain.** Open-model inference evolves rapidly. Model formats change, quantization techniques improve, context windows expand, and new inference backends emerge. Maintaining reliable integrations across inference paths -- with memory systems, CRDT synchronization, and multi-agent coordination -- is a full-time job. Pro revenue funds this work directly.
 
@@ -130,7 +130,7 @@ I'm not going to share revenue projections here. That's not the point. The point
 
 ## The Ecosystem Play
 
-RevealUI isn't just a framework you install. It's an open runtime for AI-native businesses with an ecosystem strategy.
+RevealUI isn't just a framework you install. It's an open runtime for businesses that run their own AI, with an ecosystem strategy.
 
 **MCP Marketplace (in preview).** Developers will be able to publish MCP servers -- tools that AI agents use to interact with external services -- with per-call pricing via the x402 payment protocol. Server authors earn 80% of revenue. The publish/list/invoke/onboard endpoints are wired today; payouts open with the billing-readiness audit. We handle discovery, billing, and the agent routing infrastructure. The goal is a self-sustaining marketplace where developers build specialized integrations and get paid for their work.
 
@@ -178,4 +178,4 @@ Build something.
 
 ---
 
-*RevealUI is the open runtime for AI-native businesses. Learn more at [revealui.com](https://revealui.com) or read the [docs](https://docs.revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. Learn more at [revealui.com](https://revealui.com) or read the [docs](https://docs.revealui.com).*

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -8,7 +8,7 @@
 
 ---
 
-I have been building RevealUI for the past year as the open runtime for AI-native businesses -- the kind of thing where you get users, content, products, payments, and intelligence pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
+I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get users, content, products, payments, and intelligence pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
 
 But somewhere around the third month of building, I realized something that changed the architecture fundamentally: **the next wave of customers for software platforms are not human.**
 
@@ -299,6 +299,6 @@ The user interface for the future has yet to reveal itself. But we know one thin
 
 ---
 
-*RevealUI is the open runtime for AI-native businesses. Users, content, products, payments, and intelligence -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
 
 *Follow the project on [GitHub](https://github.com/RevealUIStudio/revealui).*

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -2,7 +2,7 @@
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 
-RevealUI is the open runtime for AI-native businesses. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get users, content, products, payments, and intelligence pre-wired and ready to deploy.
+RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get users, content, products, payments, and intelligence pre-wired and ready to deploy.
 
 This tutorial walks you through creating a real business application from scratch. By the end, you will have a working admin with typed collections, session-based authentication, a REST API with Swagger documentation, Stripe billing, license enforcement, and an admin dashboard  -  deployed to production on Vercel.
 
@@ -625,4 +625,4 @@ The pattern scales. Add products, orders, tickets, knowledge bases  -  each coll
 
 ---
 
-*RevealUI is the open runtime for AI-native businesses. Users, content, products, payments, and intelligence  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*


### PR DESCRIPTION
## What

Reword the recurring marketing byline across the blog from "the open runtime for AI-native businesses" to "the open runtime for businesses that run their own AI" (matching the homepage tagline retired in #1272).

- 13 occurrences across 7 posts (01, 02, 03, 05, 06, 07, 08).
- Pure 1:1 line swaps (13 insertions / 13 deletions).

## Scope

- **Marketing byline only.** The two technical-prose mentions in `02-http-402-payments` ("AI-native APIs", "AI-native infrastructure") are intentionally preserved — they are context-caveated technical usage, which the marketing-voice validator deliberately allows.
- The validator's allow-list and baseline are unchanged (no policy flip).

## Test plan

CI. `docs/blog` is not scanned by the marketing-voice gate (it targets `apps/marketing/app`); this is markdown content only.
