### PR TITLE
feat(marketing): Foundation hero A/B + published from-anchors

### DIFF
--- a/apps/marketing/app/__tests__/hero-variant.test.ts
+++ b/apps/marketing/app/__tests__/hero-variant.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { HOME_HERO, HOME_HERO_FOUNDATION } from '../content/home';
+import { selectHomeHero } from '../lib/hero-variant';
+
+describe('selectHomeHero', () => {
+  it('serves the Foundation variant for ?hero=foundation', () => {
+    expect(selectHomeHero('?hero=foundation')).toBe(HOME_HERO_FOUNDATION);
+  });
+
+  it('serves the canonical hero by default (no query)', () => {
+    expect(selectHomeHero('')).toBe(HOME_HERO);
+  });
+
+  it('serves the canonical hero for any non-foundation value', () => {
+    expect(selectHomeHero('?hero=runtime')).toBe(HOME_HERO);
+    expect(selectHomeHero('?other=1')).toBe(HOME_HERO);
+  });
+
+  it('isolates the noun: only h1 + subtitle.strong differ from HOME_HERO', () => {
+    expect(HOME_HERO_FOUNDATION.h1).not.toBe(HOME_HERO.h1);
+    expect(HOME_HERO_FOUNDATION.subtitle.strong).not.toBe(HOME_HERO.subtitle.strong);
+    expect(HOME_HERO_FOUNDATION.eyebrow).toBe(HOME_HERO.eyebrow);
+    expect(HOME_HERO_FOUNDATION.subtitle.body).toBe(HOME_HERO.subtitle.body);
+    expect(HOME_HERO_FOUNDATION.cta).toEqual(HOME_HERO.cta);
+    expect(HOME_HERO_FOUNDATION.shipsToday).toEqual(HOME_HERO.shipsToday);
+  });
+});

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -30,9 +30,7 @@ export function EngagementPricing() {
                 <ButtonCVA asChild variant="outline" className="w-full">
                   <a
                     href={rung.cta.href}
-                    {...(rung.cta.external
-                      ? { target: '_blank', rel: 'noopener noreferrer' }
-                      : {})}
+                    {...(rung.cta.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
                   >
                     {rung.cta.label}
                   </a>

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -1,0 +1,47 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { FOR_OPERATORS_PRICING } from '../../content/for-operators';
+
+export function EngagementPricing() {
+  const { eyebrow, heading, body, rungs } = FOR_OPERATORS_PRICING;
+
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {heading}
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{body}</p>
+        </div>
+
+        <ul className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3 list-none p-0">
+          {rungs.map((rung) => (
+            <li
+              key={rung.title}
+              className="flex flex-col rounded-2xl border border-border bg-card p-8 shadow-sm"
+            >
+              <h3 className="text-lg font-semibold leading-7 text-foreground">{rung.title}</h3>
+              <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
+              <p className="mt-4 flex-1 text-base leading-7 text-muted-foreground">{rung.body}</p>
+              <div className="mt-8">
+                <ButtonCVA asChild variant="outline" className="w-full">
+                  <a
+                    href={rung.cta.href}
+                    {...(rung.cta.external
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
+                  >
+                    {rung.cta.label}
+                  </a>
+                </ButtonCVA>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -87,8 +87,8 @@ export function Hero() {
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-            <strong className="text-foreground">{hero.subtitle.strong}</strong>{' '}
-            {hero.subtitle.body} &mdash;{' '}
+            <strong className="text-foreground">{hero.subtitle.strong}</strong> {hero.subtitle.body}{' '}
+            &mdash;{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
               {SITE.cli.create}
             </code>{' '}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -1,6 +1,7 @@
 import { ButtonCVA } from '@revealui/presentation';
-import { HOME_HERO } from '../../content/home';
+import { useLocation } from '@revealui/router';
 import { SITE } from '../../content/site';
+import { selectHomeHero } from '../../lib/hero-variant';
 
 const backgroundPrimitives = [
   {
@@ -49,6 +50,9 @@ const backgroundPrimitives = [
 ];
 
 export function Hero() {
+  const { search } = useLocation();
+  const hero = selectHomeHero(search);
+
   return (
     <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
       {/* Brand background: warm wash + radial spotlight + faint primitive symbols */}
@@ -75,35 +79,35 @@ export function Hero() {
         <div className="mx-auto max-w-3xl text-center">
           <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle mr-2 animate-pulse" />
-            {HOME_HERO.eyebrow}
+            {hero.eyebrow}
           </p>
 
           <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-            {HOME_HERO.h1}
+            {hero.h1}
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-            <strong className="text-foreground">{HOME_HERO.subtitle.strong}</strong>{' '}
-            {HOME_HERO.subtitle.body} &mdash;{' '}
+            <strong className="text-foreground">{hero.subtitle.strong}</strong>{' '}
+            {hero.subtitle.body} &mdash;{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
               {SITE.cli.create}
             </code>{' '}
-            {HOME_HERO.subtitle.cliSuffix}{' '}
+            {hero.subtitle.cliSuffix}{' '}
             <a
-              href={HOME_HERO.subtitle.agencyHref}
+              href={hero.subtitle.agencyHref}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-primary hover:underline"
             >
-              {HOME_HERO.subtitle.agencyLabel}
+              {hero.subtitle.agencyLabel}
             </a>{' '}
-            {HOME_HERO.subtitle.agencySuffix}
+            {hero.subtitle.agencySuffix}
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" className="w-full sm:w-auto gap-2">
-              <a href={HOME_HERO.cta.primary.href}>
-                {HOME_HERO.cta.primary.label}
+              <a href={hero.cta.primary.href}>
+                {hero.cta.primary.label}
                 <svg
                   className="h-4 w-4"
                   fill="none"
@@ -122,25 +126,25 @@ export function Hero() {
               </a>
             </ButtonCVA>
             <ButtonCVA asChild variant="outline" size="lg" className="w-full sm:w-auto gap-2">
-              <a href={HOME_HERO.cta.secondary.href} target="_blank" rel="noopener noreferrer">
+              <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <title>GitHub</title>
                   <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
                 </svg>
-                {HOME_HERO.cta.secondary.label}
+                {hero.cta.secondary.label}
               </a>
             </ButtonCVA>
           </div>
 
           <p className="mt-6 text-sm text-muted-foreground">
-            {HOME_HERO.agencyCta.prefix}{' '}
+            {hero.agencyCta.prefix}{' '}
             <a
-              href={HOME_HERO.agencyCta.href}
+              href={hero.agencyCta.href}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-primary hover:underline"
             >
-              {HOME_HERO.agencyCta.label}
+              {hero.agencyCta.label}
             </a>
           </p>
 
@@ -151,14 +155,14 @@ export function Hero() {
             <span className="text-blue-300">my-app</span>
           </div>
 
-          <p className="mt-4 text-sm text-muted-foreground">{HOME_HERO.cliCaption}</p>
+          <p className="mt-4 text-sm text-muted-foreground">{hero.cliCaption}</p>
 
           <div className="mt-16 border-t border-border pt-10">
             <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-6">
-              {HOME_HERO.shipsToday.heading}
+              {hero.shipsToday.heading}
             </h2>
             <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
-              {HOME_HERO.shipsToday.items.map((item) => (
+              {hero.shipsToday.items.map((item) => (
                 <li key={item.metric} className="flex gap-3">
                   <svg
                     className="mt-0.5 h-4 w-4 shrink-0 text-primary"

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -89,6 +89,47 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
     'If "I want it automatic and instant" is the requirement, this is not yet the right time to engage. If "I want it built, scoped, and delivered by people who maintain the runtime it runs on" is the requirement, that is what we ship.',
 } as const;
 
+// ---------------------------------------------------------------------------
+// Engagement pricing — published "from" anchors (Architecture Review, Fleet
+// deployment, Custom Build), shown as "from" minimums. Every engagement is
+// still scoped in a discovery call; the numbers are starting points, not quotes.
+// WIRE-UP-PENDING: render as a section component (components/for-operators/
+// EngagementPricing.tsx) on ForOperatorsPage, placed after <HowWeDeliver />.
+// ---------------------------------------------------------------------------
+
+export interface PricingRung {
+  readonly title: string;
+  readonly price: string;
+  readonly body: string;
+  readonly cta: Cta;
+}
+
+export const FOR_OPERATORS_PRICING = {
+  eyebrow: 'What it costs',
+  heading: 'What an engagement costs.',
+  body: 'Every engagement is fixed-bid and starts with a discovery call that scopes the work. The numbers below are starting points, not final quotes.',
+  rungs: [
+    {
+      title: 'Architecture Review',
+      price: '$3,500',
+      body: 'A two-week, fixed-bid plan for a self-hosted, audited product your clients own: a reference architecture, a data-flow and audit map, a model plan, and a priced path to launch. Credited toward a Fleet deployment if you start one within 30 days.',
+      cta: { label: 'Book the scoping call', href: AGENCY_CONTACT, external: true },
+    },
+    {
+      title: 'Fleet deployment',
+      price: 'from $25,000',
+      body: 'A branded, self-hosted runtime your clients use under your name, on your cloud, white-labeled per client. Built and delivered as a fixed-scope engagement, scoped in the Architecture Review. Ongoing support runs as a separate monthly plan.',
+      cta: { label: 'Book a build call', href: AGENCY_CONTACT, external: true },
+    },
+    {
+      title: 'Custom Build',
+      price: 'from $50,000',
+      body: 'A bespoke product on the same runtime, scoped to what your business needs beyond a standard Fleet deployment. A four-to-twelve-week statement of work, fixed-bid, scoped in discovery.',
+      cta: { label: 'Book a build call', href: AGENCY_CONTACT, external: true },
+    },
+  ] as readonly PricingRung[],
+} as const;
+
 export const FOR_OPERATORS_DISCOVERY = {
   eyebrow: 'How the engagement works',
   heading: 'Discovery, scope, ship.',
@@ -140,7 +181,7 @@ export const FOR_OPERATORS_FAQ = {
     {
       question: 'How much does it cost?',
       answer:
-        'The discovery call scopes the engagement. A $3,500 fixed-bid Architecture Review is available as a written-assessment starting point if you want an outside-eye look before committing to a full engagement. Full-scope engagement prices are scoped per project in discovery.',
+        'The discovery call scopes the engagement. A $3,500 fixed-bid Architecture Review is the written-assessment starting point, and it credits toward what you build next. From there, Fleet deployments start at $25,000 and Custom Builds at $50,000; the discovery call scopes the final number.',
     },
     {
       question: 'How long does it take?',

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -93,8 +93,8 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
 // Engagement pricing — published "from" anchors (Architecture Review, Fleet
 // deployment, Custom Build), shown as "from" minimums. Every engagement is
 // still scoped in a discovery call; the numbers are starting points, not quotes.
-// WIRE-UP-PENDING: render as a section component (components/for-operators/
-// EngagementPricing.tsx) on ForOperatorsPage, placed after <HowWeDeliver />.
+// Rendered by components/for-operators/EngagementPricing.tsx, placed after
+// <HowWeDeliver /> on ForOperatorsPage.
 // ---------------------------------------------------------------------------
 
 export interface PricingRung {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -77,8 +77,10 @@ export const HOME_HERO = {
 // Tests the noun "foundation" against the canonical "runtime" in HOME_HERO.
 // The two strings below (h1 + subtitle.strong) are the only difference, so the
 // A/B isolates the noun; "runtime" stays the canonical noun on every other
-// surface. WIRE-UP-PENDING: the hero component selects HOME_HERO (default) vs
-// this variant; the A/B serving + measurement wiring is a follow-up.
+// surface. Served via selectHomeHero() (app/lib/hero-variant.ts): the homepage
+// hero renders this variant when the URL carries ?hero=foundation, else
+// HOME_HERO. An automatic traffic split + conversion measurement is separate
+// (the marketing app has no analytics sink yet).
 // ---------------------------------------------------------------------------
 
 export const HOME_HERO_FOUNDATION = {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -73,6 +73,25 @@ export const HOME_HERO = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Hero — "Foundation" A/B variant.
+// Tests the noun "foundation" against the canonical "runtime" in HOME_HERO.
+// The two strings below (h1 + subtitle.strong) are the only difference, so the
+// A/B isolates the noun; "runtime" stays the canonical noun on every other
+// surface. WIRE-UP-PENDING: the hero component selects HOME_HERO (default) vs
+// this variant; the A/B serving + measurement wiring is a follow-up.
+// ---------------------------------------------------------------------------
+
+export const HOME_HERO_FOUNDATION = {
+  ...HOME_HERO,
+  h1: 'Run your whole business on a foundation you own.',
+  subtitle: {
+    ...HOME_HERO.subtitle,
+    strong:
+      'Auth, content, products, and payments, pre-wired into one open-source foundation you self-host.',
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
 // Problem (comparison table)
 // ---------------------------------------------------------------------------
 

--- a/apps/marketing/app/lib/hero-variant.ts
+++ b/apps/marketing/app/lib/hero-variant.ts
@@ -1,0 +1,20 @@
+import { HOME_HERO, HOME_HERO_FOUNDATION } from '../content/home';
+
+/**
+ * Homepage-hero A/B variant selector.
+ *
+ * Serves the "Foundation" hero variant when the URL carries `?hero=foundation`,
+ * else the canonical `HOME_HERO`. This is the manual / preview serving seam for
+ * the hero-noun A/B: visit `/?hero=foundation` to see the variant. "runtime"
+ * stays the canonical noun on every other surface.
+ *
+ * An automatic traffic split + conversion measurement is deliberately out of
+ * scope here: the marketing app has no analytics sink yet, so a real experiment
+ * (cohort assignment + event logging + a winner readout) is its own piece of
+ * work. This selector is the seam that work plugs into.
+ */
+export function selectHomeHero(search: string): typeof HOME_HERO | typeof HOME_HERO_FOUNDATION {
+  return new URLSearchParams(search).get('hero') === 'foundation'
+    ? HOME_HERO_FOUNDATION
+    : HOME_HERO;
+}

--- a/apps/marketing/app/routes/ForOperatorsPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsPage.tsx
@@ -11,6 +11,7 @@
 import { Footer } from '../components/Footer';
 import { ClosingCta } from '../components/for-operators/ClosingCta';
 import { DiscoveryScopeShip } from '../components/for-operators/DiscoveryScopeShip';
+import { EngagementPricing } from '../components/for-operators/EngagementPricing';
 import { Faq } from '../components/for-operators/Faq';
 import { Hero } from '../components/for-operators/Hero';
 import { HowWeDeliver } from '../components/for-operators/HowWeDeliver';
@@ -23,6 +24,7 @@ export function ForOperatorsPage() {
       <Hero />
       <WhatYouGet />
       <HowWeDeliver />
+      <EngagementPricing />
       <DiscoveryScopeShip />
       <Proof />
       <Faq />


### PR DESCRIPTION
## What

Draft copy for two public-surface consequences of the recent offerings/pricing realignment, scoped to copy only (no rendering wiring yet):

- **Foundation hero A/B variant** — `HOME_HERO_FOUNDATION` in `apps/marketing/app/content/home.ts`. Tests the noun "foundation" against the canonical "runtime" in `HOME_HERO`. Exactly two strings differ (h1 + subtitle.strong), so the A/B isolates the noun. "runtime" stays canonical on every other surface.
- **Published "from" anchors** — `FOR_OPERATORS_PRICING` in `apps/marketing/app/content/for-operators.ts`: Architecture Review ($3,500), Fleet deployment (from $25,000), Custom Build (from $50,000), shown as "from" minimums with a discovery call still scoping each engagement. Plus a "How much does it cost?" FAQ update to match.

## Why content-only

This is a draft for owner sign-off on numbers + wording, so the diff is intentionally pure content — the words and numbers are the whole review surface. Both consts are marked `WIRE-UP-PENDING`.

## Follow-ups (not in this PR)

1. Render `FOR_OPERATORS_PRICING` as a `components/for-operators/EngagementPricing.tsx` section, placed after `<HowWeDeliver />` on `ForOperatorsPage`.
2. Wire the hero A/B: a selector between `HOME_HERO` (default) and `HOME_HERO_FOUNDATION`, plus the serving + measurement mechanism.

## Checks

- Marketing-voice validator: clean (0 new violations).
- Content-only; no product-price surfaces touched — the gated subscription / perpetual ladder and the `pricing-marketing-drift` test are untouched (these are services figures, not product prices).

Draft PR — do not mark ready / merge until the owner signs off the numbers + wording.
