### PR TITLE
docs(blog): align with code, gate the enforcement-test count, and add 2 posts

### DIFF
--- a/apps/docs/app/lib/nav.ts
+++ b/apps/docs/app/lib/nav.ts
@@ -107,6 +107,8 @@ export function buildDocNavSections(showcaseItems: NavItem[]): NavSection[] {
         { label: 'Open Source & Pro', path: '/blog/06-open-source-and-pro' },
         { label: 'Agent-First Future', path: '/blog/07-agent-first-future' },
         { label: 'Getting Started in About 30 Minutes', path: '/blog/08-getting-started' },
+        { label: '59 Components, One Dependency', path: '/blog/09-component-library' },
+        { label: 'Your Database, Your Storage, Your Sync', path: '/blog/10-own-your-data' },
       ],
     },
     {

--- a/apps/docs/app/lib/slug-manifest.ts
+++ b/apps/docs/app/lib/slug-manifest.ts
@@ -6,7 +6,7 @@
  * Used by the markdown resolver to translate flat URLs
  * (docs.revealui.com/admin-guide) into file fetches
  * (/admin-guide.md served from public/).
- * Generated: 112 entries.
+ * Generated: 116 entries.
  */
 
 export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
@@ -47,6 +47,8 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'blog/06-open-source-and-pro': 'blog/06-open-source-and-pro.md',
   'blog/07-agent-first-future': 'blog/07-agent-first-future.md',
   'blog/08-getting-started': 'blog/08-getting-started.md',
+  'blog/09-component-library': 'blog/09-component-library.md',
+  'blog/10-own-your-data': 'blog/10-own-your-data.md',
   'build-your-business': 'BUILD_YOUR_BUSINESS.md',
   'checklists/stripe-checkout-verification': 'checklists/stripe-checkout-verification.md',
   'ci-cd-guide': 'CI_CD_GUIDE.md',
@@ -72,12 +74,14 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'fleet/revvault': 'fleet/revvault.md',
   forge: 'FORGE.md',
   glossary: 'glossary.md',
+  'guides/audit-chain': 'guides/audit-chain.md',
   'guides/authentication': 'guides/authentication.md',
   'guides/billing': 'guides/billing.md',
   'guides/collections': 'guides/collections.md',
   'guides/deployment': 'guides/deployment.md',
   'guides/quick-start': 'guides/quick-start.md',
   'guides/readme': 'guides/README.md',
+  'guides/technology-stack': 'guides/technology-stack.md',
   'harness-protocol': 'HARNESS_PROTOCOL.md',
   index: 'INDEX.md',
   joshua: 'JOSHUA.md',

--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -62,6 +62,8 @@ See the [Quick Start guide](/quick-start) for the full walkthrough, or browse th
 - [Open Source & Pro](/blog/06-open-source-and-pro)  -  Our monetization philosophy
 - [Agent-First Future](/blog/07-agent-first-future)  -  Building for the agent economy
 - [Getting Started in About 30 Minutes](/blog/08-getting-started)  -  From zero to deployed
+- [59 Components, One Dependency](/blog/09-component-library)  -  The UI layer you own
+- [Your Database, Your Storage, Your Sync](/blog/10-own-your-data)  -  Standard Postgres, S3 storage, built-in sync
 
 ---
 

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -96,7 +96,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     forYou: {
       headline: 'Auth, roles, and compliance, handled',
       description:
-        'Session-based auth, RBAC with 58 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
+        'Session-based auth, RBAC with 59 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
     },
     forAgents: {
       headline: 'RBAC governs agent access per tenant',

--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -31,6 +31,24 @@ interface PostMeta {
 
 const POST_METADATA: PostMeta[] = [
   {
+    slug: 'component-library',
+    title: '59 Components, One Dependency',
+    excerpt:
+      'A native React component library with 59 components and a single runtime dependency. No Radix, no MUI, no lock-in, just components you own.',
+    publishedAt: '2026-06-08T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '09-component-library.md',
+  },
+  {
+    slug: 'own-your-data',
+    title: 'Your Database, Your Storage, Your Sync',
+    excerpt:
+      'Standard Postgres, S3-compatible storage, and real-time sync, all built in and all portable. The data layer you can actually leave.',
+    publishedAt: '2026-06-07T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '10-own-your-data.md',
+  },
+  {
     slug: 'getting-started',
     title: 'From Zero to Production in About 30 Minutes',
     excerpt:

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -46,7 +46,7 @@ All gates must pass on the `main` branch before deploy.
 - [ ] Bcrypt cost factor is 12 rounds **(blocking)**
 - [ ] AES-256-GCM encryption keys are non-extractable by default **(blocking)**
 - [ ] Rate limiting active on auth endpoints and `/api/webhooks` (100 req/min) **(blocking)**
-- [ ] RBAC + ABAC policy engine tests pass (58 enforcement tests) **(blocking)**
+- [ ] RBAC + ABAC policy engine tests pass (59 enforcement tests) **(blocking)**
 - [ ] `SECURITY.md` exists at repository root **(blocking)**
 - [ ] Incident response plan reviewed: `docs/security/INCIDENT_RESPONSE.md` **(advisory)**
 - [ ] `docs/security/INFORMATION_SECURITY_POLICY.md` reviewed and current **(advisory)**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -30,6 +30,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-05-18 (
 | UI components in `packages/presentation/` | **59** | `countUIComponents()` | Marketing copy says "59 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |
+| Access-control enforcement tests | **59** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
 | License: MIT packages | **20** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
 | License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |

--- a/docs/blog/03-multi-agent-coordination.md
+++ b/docs/blog/03-multi-agent-coordination.md
@@ -208,7 +208,7 @@ if (!clean) {
 wb.releaseFiles('my-agent')
 ```
 
-The package also includes adapters for Claude Code, Cursor, and Aider  -  so you can coordinate across different AI tools on the same codebase.
+The package also includes adapters for Claude Code, Cursor, and GitHub Copilot  -  so you can coordinate across different AI tools on the same codebase.
 
 ---
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -17,7 +17,7 @@ RevealUI's local-first story comes from four independent pieces that happen to c
 | Layer | Technology | What it does |
 |-------|-----------|-------------|
 | **Secrets** | RevVault (age encryption) | Credentials stay on your machine, encrypted at rest |
-| **AI inference (default)** | Inference snaps / Ollama (open models) | Local LLM inference. Cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible, Anthropic) are pluggable via env vars but opt-in. |
+| **AI inference (default)** | Inference snaps / Ollama (open models) | Local LLM inference. Cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible) are pluggable via env vars but opt-in. |
 | **Dev environment** | Nix flakes + direnv | Reproducible environment, zero manual tool installs |
 | **Business logic** | RevealUI | Auth, content, payments, AI agents  -  all wired |
 
@@ -108,7 +108,7 @@ The entire AI-powered business stack  -  auth, content, products, payments, agen
 
 ## Who this is for
 
-The "local-first" configuration is one of several inference paths. RevealUI supports Ubuntu Inference Snaps (Canonical's managed runtime, planned recommended) and Ollama (any open source GGUF model, default local). Cloud-compatible providers — Groq, HuggingFace, OpenAI-compatible endpoints, and Anthropic for prompt caching — are pluggable but opt-in via env vars. Pick the path that fits your trust + cost profile; there is no vendor lock-in.
+The "local-first" configuration is one of several inference paths. RevealUI supports Ubuntu Inference Snaps (Canonical's managed runtime, planned recommended) and Ollama (any open source GGUF model, default local). Cloud-compatible providers — Groq, HuggingFace, and OpenAI-compatible endpoints — are pluggable but opt-in via env vars. Pick the path that fits your trust + cost profile; there is no vendor lock-in.
 
 But there's a real and growing audience for whom those concerns matter:
 

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -120,7 +120,7 @@ export const hasAnyRole = (roles: string[]) => ({ req }) =>
   !!req.user && roles.some((role) => req.user?.roles?.includes(role));
 ```
 
-These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 58 enforcement tests proving role isolation.
+These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 59 enforcement tests proving role isolation.
 
 ### How Users connects to everything else
 
@@ -424,7 +424,7 @@ The `@revealui/ai` package is loaded dynamically. If the license is free, the im
 
 ### Open-Model Inference
 
-RevealUI defaults to open-weight models — no API key, no cloud bill, no vendor lock-in. Cloud providers (Groq, HuggingFace, OpenAI-compatible, and Anthropic for prompt caching) are opt-in via environment variables. The inference path is auto-detected:
+RevealUI defaults to open-weight models — no API key, no cloud bill, no vendor lock-in. Cloud providers (Groq, HuggingFace, and OpenAI-compatible endpoints) are opt-in via environment variables. The inference path is auto-detected:
 
 1. **Ubuntu Inference Snaps** (recommended)  -  Canonical snap runtime (Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano)
 2. **Ollama** (fallback)  -  Any open source GGUF model (chat: `gemma4:e2b`, embeddings: `nomic-embed-text`)

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -37,7 +37,7 @@ RevealUI Pro includes:
 - **AI agents** -- task execution, multi-step workflows, autonomous operations
 - **CRDT memory** -- working memory, episodic memory, and vector storage that persists across agent sessions
 - **LLM orchestration** -- open-model inference via Ubuntu Inference Snaps and Ollama
-- **Editor integrations** -- daemon adapters for Zed, VS Code, and Neovim
+- **Editor integrations** -- config sync for Zed and VS Code
 - **Harness coordination** -- workboard-based agent orchestration, JSON-RPC communication, daemon management
 - **MCP framework** -- the hypervisor, 14 first-party servers, and the adapter base class that connect agents to tools
 

--- a/docs/blog/09-component-library.md
+++ b/docs/blog/09-component-library.md
@@ -1,0 +1,102 @@
+# 59 Components, One Dependency
+
+*By Joshua Vaughn, RevealUI Studio*
+
+---
+
+Open the `package.json` of a typical React app and trace the dependency tree under your UI. A component library. The headless-primitive library it sits on. An icon set. A class-merging utility. A variants helper. A few polyfills the library pulls in. Every one of those is a version you have to track, a breaking change you have to absorb on someone else's schedule, and a styling opinion you have to work around.
+
+RevealUI's UI layer, `@revealui/presentation`, has exactly one runtime dependency. Not one UI framework. One package: `tailwind-merge`. Everything else, the 59 components and the machinery that powers them, is in the box and MIT licensed.
+
+This post is about why a component library should be something you own outright, and how this one is built.
+
+## The cost of "just use a component library"
+
+Component libraries are a good trade right up until they aren't. You move fast for six months. Then the library ships a major version that rewrites its theming API, and your design tokens stop resolving. Or the headless primitive it depends on changes its focus-management behavior and your dialog starts trapping keyboard focus in the wrong place. Or you need a component the library does not have, so you bolt on a second library, and now two different abstractions own your markup.
+
+The deeper problem is that the most important layer of your product, the part your users actually touch, is code you did not write and cannot change without forking. When something renders wrong at 11pm before a launch, you are reading someone else's source in `node_modules` hoping you can monkey-patch your way out.
+
+I have done that enough times to want a different deal.
+
+## What ships in the box
+
+`@revealui/presentation` is 59 native React components. Not wrappers around another library. Components, built directly on Tailwind v4 and React.
+
+The set is meant to cover real business software, not just a demo: `accordion`, `alert`, `avatar`, `badge`, `breadcrumb`, `callout`, `card`, `checkbox`, `code-block`, `combobox`, `dialog`, `drawer`, `divider`, `description-list`, and on through the list. Form controls, overlays, navigation, data display. The pieces you reach for on day one and the ones you need in month three.
+
+The dependency story is the headline:
+
+- **One runtime dependency:** `tailwind-merge`, for safely merging Tailwind class lists.
+- **React is a peer dependency**, not a bundled copy. The package works on React 18 or 19; RevealUI runs it on 19.
+- **Tailwind v4** for styling.
+
+That is the whole external surface. There is no component framework underneath.
+
+## No library underneath
+
+It is worth being specific, because "zero dependencies" is a claim people make loosely. Search the source of `@revealui/presentation` for Radix, MUI, Headless UI, Chakra, or React Aria and you will find nothing. There is no `class-variance-authority` either, which is the one most projects keep even after they drop the rest.
+
+The three things those libraries usually provide are all in-package:
+
+- The **variant system** (`cva`) and the **class-merge helper** (`cn`) live in `packages/presentation/src/utils/cn.ts`.
+- The **polymorphic `Slot`** that powers the `asChild` pattern lives in `packages/presentation/src/primitives/Slot.ts`.
+
+So a component imports its tooling from inside the package, not from npm:
+
+```tsx
+// packages/presentation/src/components/Button.tsx
+import { cn, cva, type VariantProps } from '../utils/cn.js';
+import { Slot } from '../primitives/Slot.js';
+
+const buttonVariants = cva('inline-flex items-center justify-center …', {
+  variants: {
+    variant: { primary: '…', outline: '…', ghost: '…' },
+    size: { sm: '…', md: '…', lg: '…' },
+  },
+  defaultVariants: { variant: 'primary', size: 'md' },
+});
+```
+
+If a variant behaves wrong, the fix is in your tree, not in a dependency you are pinned to.
+
+## Variants without the dependency
+
+The API will feel familiar if you have used `class-variance-authority`, because that is the shape worth keeping. You define variants, you get a typed `VariantProps`, and the merge helper makes sure a caller-supplied `className` wins cleanly over the defaults instead of producing two conflicting Tailwind classes.
+
+The `asChild` pattern works the same way it does in the libraries that popularized it. Pass `asChild` and the component renders its child instead of its own element, forwarding props and merging classes through the in-house `Slot`. A `Button` becomes a link without losing its styling or its keyboard behavior:
+
+```tsx
+<Button asChild variant="primary">
+  <a href="/signup">Start free</a>
+</Button>
+```
+
+You get the ergonomics. You do not get the dependency.
+
+## Headless when you want behavior, not styling
+
+Some components ship in two forms. Alongside `Button` and `Checkbox` there is `button-headless` and `checkbox-headless`: the behavior, state, and accessibility wiring with none of the visual opinion. When the default styling is not what you want, you drop down a level and bring your own classes, without giving up focus management, ARIA attributes, and keyboard handling.
+
+That split matters for a framework. The styled components get you to a working product fast. The headless ones mean you never hit a wall where the only way forward is to rip the library out.
+
+## Theming is tokens, not hardcoded colors
+
+Colors are not baked into the components. They resolve through a semantic design-token layer in `tokens.css`: `bg-background`, `text-foreground`, `border-border`, `text-primary`, and so on. The tokens carry RevealUI's cobalt palette and adapt to light and dark. Retheme the whole system by changing the token values in one place; you do not touch 59 component files to change your brand color.
+
+Because the tokens are semantic rather than literal, a component never says "blue." It says "primary," and the token decides what primary means in the current theme.
+
+## The trade-off
+
+Here is the honest version. A from-scratch component layer trades away two real things: the ecosystem breadth of a Radix or an MUI, and the millions of hours of edge-case hardening that a widely used library accumulates. If you need an exotic widget that is not among the 59, you build it, on the same primitives, rather than `npm install`-ing it in an afternoon.
+
+What you get back is ownership. No major-version migrations dictated by someone else's roadmap. No dependency that can change behavior under you. No styling you cannot reach. For business software, where the component needs are broad but not exotic, that is the trade I want, and it is the one RevealUI makes by default.
+
+## Own every line
+
+The component layer is MIT licensed, like the rest of RevealUI's core. It ships with every `npx create-revealui`, it renders RevealUI's own apps, and you can fork any component in it without asking anyone. The UI your users touch should be code you control. This is that code.
+
+Build your business, not your boilerplate.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. The component layer is MIT licensed and ships with every install. Get started with `npx create-revealui`, or read the [docs](https://docs.revealui.com).*

--- a/docs/blog/10-own-your-data.md
+++ b/docs/blog/10-own-your-data.md
@@ -1,0 +1,59 @@
+# Your Database, Your Storage, Your Sync
+
+*By Joshua Vaughn, RevealUI Studio*
+
+---
+
+Most "modern data stacks" charge a quiet tax: lock-in. The database speaks a proprietary dialect, so your queries do not move. The file storage is a vendor blob API with no standard underneath, so your uploads do not move. Real-time sync is a separate SaaS you wire in by hand, so your live data lives somewhere you do not control. Each choice is reasonable on its own. Together they mean that the day you want to leave, you cannot.
+
+RevealUI takes the opposite position on every one of those. The database is standard Postgres. The object storage speaks the S3 API. Sync ships in the box. None of it is proprietary, and all of it is portable. This post walks the data layer and the one test that matters: can you leave?
+
+## Standard Postgres, not a proprietary database
+
+RevealUI runs on Postgres. Specifically NeonDB, which is Postgres, the real thing, with the standard wire protocol and `pg_dump` that does exactly what you expect. The schema is 85 tables defined with Drizzle ORM, typed end to end, and it is not hiding any vendor-only behavior in the hot path.
+
+That choice has a few consequences worth naming:
+
+- Your queries are SQL. They run on Neon today and on any other Postgres tomorrow, managed or self-hosted, without a rewrite.
+- Your data is a `pg_dump` away from being somewhere else. There is no export API to beg for and no proprietary format to reverse-engineer.
+- The schema is in your repo, in TypeScript, versioned with migrations. You can read it, diff it, and own it.
+
+New features are built to stay portable on purpose: the project is mid-migration off an earlier Supabase dependency, and the rule for new code is that it must not depend on any one provider's Postgres extensions. Standard first.
+
+## Object storage you can move
+
+Files, images, and uploads go to Cloudflare R2, which is S3-compatible. That hyphenated word is the whole point. R2 is the canonical backend (the older Vercel Blob integration is legacy and being retired), but the code talks to it through the S3 API, the same API that AWS S3, MinIO, and a dozen other stores speak.
+
+So the storage layer passes the same test the database does. Point the S3 credentials at a different provider and your application does not notice. Your media is not trapped behind a vendor SDK with no standard under it. It is objects in a bucket, addressable the way object storage has been addressable for fifteen years.
+
+## Real-time sync, in the box
+
+This is the piece most stacks bolt on later, and the one RevealUI ships with: `@revealui/sync`. It is a real-time sync layer that wraps ElectricSQL for syncing Postgres data to clients and Yjs CRDTs for collaborative editing. Out of that you get an offline queue, a shape cache, conflict resolution, and collaborative documents, without standing up a separate real-time service.
+
+The model is worth understanding because it is not websockets-and-hope. ElectricSQL syncs defined "shapes" of your Postgres data to the client and keeps them live, so the client reads from a local copy that stays current. Yjs handles the case where two people edit the same thing at once, merging changes with conflict-free data types instead of last-write-wins. The offline queue means a client that loses its connection keeps working and reconciles when it comes back.
+
+It is the same Postgres from the first section. Sync is a layer over data you already own, not a second source of truth you have to keep in step by hand.
+
+## Rich text is data, not markup
+
+Content in RevealUI is stored as structured Lexical JSON, not as a blob of HTML. That keeps the door open the same way the rest of the stack does. Because the content is data, it renders on the server without a browser, it can be queried and transformed, and it is not married to one front end. The server-side renderer also sanitizes every URL before it emits anything, so stored content cannot smuggle a `javascript:` link into a page.
+
+Structured content is portable content. You can move it, re-render it somewhere else, or feed it to something that is not a browser at all, which matters more every month that agents read your data instead of people.
+
+## The portability test
+
+Here is the test I apply to any stack I am asked to trust: if I wanted to leave, what would it take? For most "modern" stacks the honest answer is a rewrite, a data-export project, and a few weeks of praying the proprietary features have equivalents.
+
+For this one the answer is `pg_dump`, an S3 bucket copy, and standard protocols on both ends. That is not an accident or a side effect. It is the design goal. Portability is not a feature you add later; it is a property you either build in from the schema up or you do not have at all.
+
+## The trade-off
+
+The honest cost: you are running a Postgres database and an object store, not a single magic box that hides both behind one bill and one dashboard. There is a little more surface area than an all-in-one platform, and you are responsible for the credentials to each piece (RevealUI keeps those in an encrypted local vault rather than scattered across `.env` files, which helps).
+
+What you get back is the thing the all-in-one platforms cannot sell you: the ability to walk away. Standard Postgres, S3-compatible storage, sync built on open protocols, content stored as data. Every layer is one you could re-host yourself. For software you intend to run for years, that is the trade worth making.
+
+Build your business, not your boilerplate.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. The data layer is MIT licensed and ships with every install. Get started with `npx create-revealui`, or read the [docs](https://docs.revealui.com).*

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -155,7 +155,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 
 | ID | Control | Package | Purpose |
 |----|---------|---------|---------|
-| SEC-017 | RBAC + ABAC Policy Engine | @revealui/core | Role-based and attribute-based access control (58 enforcement tests) |
+| SEC-017 | RBAC + ABAC Policy Engine | @revealui/core | Role-based and attribute-based access control (59 enforcement tests) |
 | SEC-018 | Rate Limiting | @revealui/auth | Brute force protection, webhook rate limiting (100 req/min) |
 | SEC-019 | Session Auth | @revealui/auth | httpOnly, secure, sameSite=lax cookies; no JWTs |
 | SEC-020 | CSP/CORS/HSTS Headers | @revealui/security | Transport and browser security headers |

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -62,7 +62,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 
 ### Authorization
 
-- **RBAC + ABAC**: Role-based access control combined with attribute-based policies. 58 enforcement tests verify role isolation.
+- **RBAC + ABAC**: Role-based access control combined with attribute-based policies. 59 enforcement tests verify role isolation.
 - **Collection-level access**: Every database operation enforces `access.read`, `access.update`, and `access.delete` policies.
 - **Admin gate**: Proxy middleware checks role cookies for /admin routes (defense-in-depth).
 - **Feature gating**: Pro features require valid license checks via `isLicensed('pro')` and `isFeatureEnabled()`.

--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -2,7 +2,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { countDirs, extractRevealuiPackages, findIncompleteProList } from '../claim-drift.ts';
+import {
+  countDirs,
+  countEnforcementTests,
+  extractRevealuiPackages,
+  findIncompleteProList,
+} from '../claim-drift.ts';
 
 describe('countDirs', () => {
   let tmp: string;
@@ -31,6 +36,45 @@ describe('countDirs', () => {
   it('returns 0 when base contains only files', () => {
     fs.writeFileSync(path.join(tmp, 'file.txt'), '');
     expect(countDirs(tmp)).toBe(0);
+  });
+});
+
+describe('countEnforcementTests', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-drift-enf-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('counts it()/test() cases across a directory of suites and a single file', () => {
+    const dir = path.join(tmp, 'auth');
+    fs.mkdirSync(dir);
+    // Only *.test.ts files in a directory count; a stray .ts is ignored.
+    fs.writeFileSync(
+      path.join(dir, 'access.test.ts'),
+      "describe('x', () => {\n  it('a', () => {});\n  test('b', () => {});\n});\n",
+    );
+    fs.writeFileSync(path.join(dir, 'helpers.ts'), "export const it = 'not a test';\n");
+    const file = path.join(tmp, 'access-enforcement.test.ts');
+    fs.writeFileSync(file, "it('one', () => {});\n  it('two', () => {});\n");
+    expect(countEnforcementTests([dir, file])).toBe(4);
+  });
+
+  it('does not count it.skip()/it.each() as plain cases', () => {
+    const file = path.join(tmp, 'x.test.ts');
+    fs.writeFileSync(
+      file,
+      "it('a', () => {});\nit.skip('b', () => {});\nit.each([1])('c', () => {});\n",
+    );
+    expect(countEnforcementTests([file])).toBe(1);
+  });
+
+  it('returns 0 for missing roots', () => {
+    expect(countEnforcementTests([path.join(tmp, 'nope')])).toBe(0);
   });
 });
 

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -152,6 +152,64 @@ function countDbTables(): number {
 }
 
 // ---------------------------------------------------------------------------
+// Enforcement-test collector
+//
+// The access-control story is quoted fleet-wide as "N enforcement tests": the
+// blog, both security attestations (INFORMATION_SECURITY_POLICY,
+// ASSET_INVENTORY), LAUNCH-CHECKLIST, and marketing primitives all cite it.
+// Canonical scope (per the Security section of CLAUDE.md) is the two suites
+// that prove RBAC/ABAC role isolation. Counting it here makes a drift in any
+// one of those surfaces fail CI, the same way the mcp / component / table
+// counts already do.
+// ---------------------------------------------------------------------------
+
+const ENFORCEMENT_TEST_ROOTS = [
+  path.join(ROOT, 'packages/core/src/__tests__/auth'),
+  path.join(ROOT, 'packages/core/src/collections/operations/__tests__/access-enforcement.test.ts'),
+];
+
+/**
+ * Count `it(` / `test(` cases across the canonical enforcement suites. No
+ * authored regex (fleet no-regex rule) — a trimmed-line `startsWith` scan.
+ * Modifier forms (disabled cases, or table-driven `each` cases) are
+ * intentionally excluded: none exist in these suites today, and a disabled
+ * case should not inflate an attestation that the tests verify role isolation.
+ * Path-injectable + exported for tests.
+ */
+export function countEnforcementTests(roots: string[] = ENFORCEMENT_TEST_ROOTS): number {
+  const files: string[] = [];
+  for (const root of roots) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(root);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(root)) {
+        if (entry.endsWith('.test.ts')) files.push(path.join(root, entry));
+      }
+    } else if (stat.isFile()) {
+      files.push(root);
+    }
+  }
+  let count = 0;
+  for (const file of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of content.split('\n')) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('it(') || trimmed.startsWith('test(')) count++;
+    }
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
 // License-split collector (added 2026-05-14 — closes a fleet drift class)
 //
 // Walks `packages/*/package.json` and groups by the `license` field. The
@@ -1369,6 +1427,7 @@ function run(): void {
   const uiComponents = countUIComponents();
   const mcpServers = countMCPServers();
   const dbTables = countDbTables();
+  const enforcementTests = countEnforcementTests();
   const licenseSplit = countLicenseSplit();
 
   console.log('Actual metrics:');
@@ -1379,6 +1438,7 @@ function run(): void {
   console.log(`  UI components: ${uiComponents}`);
   console.log(`  MCP servers:   ${mcpServers}`);
   console.log(`  DB tables:     ${dbTables}`);
+  console.log(`  Enforcement:   ${enforcementTests}`);
   console.log(
     `  License split: ${licenseSplit.mit} MIT | ${licenseSplit.fsl} FSL-1.1-MIT | ${licenseSplit.internal} internal/none`,
   );
@@ -1432,6 +1492,13 @@ function run(): void {
         // "Schema (85 tables)" parenthetical
         /\(\s*([1-9]\d{1,2})\s+tables?\s*\)/i,
       ],
+    },
+    {
+      name: 'enforcement tests',
+      actual: enforcementTests,
+      // REGEX-CONFIG-BOUNDARY — claim pattern only (pre-existing convention in
+      // this file); countEnforcementTests computes the count with no authored regex.
+      claimPatterns: [/\b(\d+)\s+enforcement\s+tests?\b/i],
     },
     // License-split metrics (REGEX-CONFIG-BOUNDARY — pre-existing convention
     // in this file; AST-refactor pending GAP-192). Patterns target the


### PR DESCRIPTION
## What & why

Bring all blog content to current codebase state. Three commits: fix the drifted claims, close the drift class durably, and add posts for current capabilities that had no post.

### Commit 1 — blog AI-tooling accuracy (4 fixes)
Audited every factual claim across all 8 existing posts against live code. Confirmed already-accurate: 30 workspaces, 14 MCP servers (matches the 14 server files), 85 tables, `featureTierMap`, pricing tiers/quotas, EdDSA licenses, OAuth trio, marketplace 80/20 + Stripe Connect, credit bundles, CLI templates, snaps catalog. Fixed only the genuinely-drifted AI-tooling specifics:

- **03**: harness adapters `Aider` → `GitHub Copilot` (live registry: `claude-code`/`cursor`/`copilot`)
- **04, 05**: dropped **Anthropic** from the pluggable inference-provider lists — live `LLMProviderType = groq | ollama | huggingface | inference-snaps`; no Anthropic provider (matches the no-Anthropic-in-runtime posture). MARKETING_METRICS §6 still permits an out-of-band Anthropic mention if wanted.
- **06**: editor integrations `daemon adapters for Zed, VS Code, and Neovim` → `config sync for Zed and VS Code` (`ALL_EDITORS = ['vscode','zed']`)

### Commit 2 — enforcement-test count: correct to 59 + gate it
The "58 enforcement tests" claim had drifted. The suites now hold **59** passing `it()/test()` cases (`vitest run` confirms). The number was propagated to 5 surfaces, 4 stale at 58 — **including two security attestations and marketing copy**. Fixed all to 59 and made the claim-drift gate own it (`countEnforcementTests()`, code-derived, no authored regex) so it can never re-drift across files again.

### Commit 3 — two new posts (09, 10)
Net-new posts for current capabilities the existing 8 don't cover. Every claim verified against live code first:

- **09 — `59 Components, One Dependency`**: `@revealui/presentation` has 59 components and one runtime dependency (`tailwind-merge`); `cva`/`cn`/`Slot` are in-package; no Radix/MUI/Headless/CVA.
- **10 — `Your Database, Your Storage, Your Sync`**: standard Postgres (Neon, 85 tables/Drizzle) + S3-compatible R2 (Blob retiring) + ElectricSQL/Yjs sync (`@revealui/sync`).

Wired both render surfaces: marketing manifest (`blog-posts.ts`), docs nav + `DocsIndexPage`, and the regenerated auto-built `slug-manifest`.

## Verification
- `pnpm validate:claims` → green (`Enforcement: 59`, UI components 59, DB tables 85, 0 mismatches) — the new posts pass the gate.
- `docs check:links` → green (94 pages, nav resolves).
- Pre-push quality gate → PASS on every push.
- 35 claim-drift unit tests pass · Biome + code-validator clean · all commits hook-verified (no `--no-verify`).

## Reviewer notes — do not auto-merge
- Touches **2 security attestations** (`INFORMATION_SECURITY_POLICY.md`, `ASSET_INVENTORY.md`) — factual accuracy only (58 → 59).
- Adds a **hard-fail CI metric** (enforcement-test count) — future additions to those suites require bumping the pinned number (intended durability).
- Two new customer-facing posts — worth a copy read before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
