### PR TITLE
fix(billing): scope refund/chargeback revoke to affected subscription

### DIFF
--- a/apps/server/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-pglite.test.ts
@@ -24,12 +24,14 @@ const {
   mockSubscriptionsCancel,
   mockInvoicesRetrieve,
   mockPaymentIntentsRetrieve,
+  mockChargesRetrieve,
 } = vi.hoisted(() => ({
   mockConstructEvent: vi.fn(),
   mockSubscriptionsRetrieve: vi.fn(),
   mockSubscriptionsCancel: vi.fn(),
   mockInvoicesRetrieve: vi.fn(),
   mockPaymentIntentsRetrieve: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
 }));
 
 vi.mock('stripe', () => ({
@@ -44,6 +46,9 @@ vi.mock('stripe', () => ({
       };
       invoices = {
         retrieve: mockInvoicesRetrieve,
+      };
+      charges = {
+        retrieve: mockChargesRetrieve,
       };
       paymentIntents = {
         retrieve: mockPaymentIntentsRetrieve,
@@ -64,7 +69,7 @@ vi.mock('@revealui/services', () => ({
       list: vi.fn().mockResolvedValue({ data: [] }),
     },
     customers: { update: vi.fn() },
-    charges: { retrieve: vi.fn() },
+    charges: { retrieve: mockChargesRetrieve },
     invoices: { retrieve: mockInvoicesRetrieve },
     paymentIntents: { retrieve: mockPaymentIntentsRetrieve },
   },
@@ -969,5 +974,287 @@ describe('webhook integration  -  claim/complete idempotency (PR3)', () => {
       .from(agentCreditBalance)
       .where(eq(agentCreditBalance.userId, 'user-credit-idem'));
     expect(bal[0].balance).toBe(500); // not 1000
+  });
+});
+
+// S2: refund + chargeback revocation must be scoped to the affected
+// subscription, not every license the customer holds. Falls back to the prior
+// (broader) behavior only when the charge cannot be traced to a subscription.
+describe('webhook integration  -  refund/dispute revoke scoping (S2)', () => {
+  it('charge.refunded revokes ONLY the refunded subscription, not the customer other subscriptions', async () => {
+    await seedTestUser(testDb.drizzle, { id: 'user-s2-refund', email: 's2refund@example.com' });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_s2_refund' })
+      .where(eq(users.id, 'user-s2-refund'));
+
+    // Two active subscription licenses for the SAME customer + one perpetual.
+    await testDb.drizzle.insert(licenses).values([
+      {
+        id: 'lic-s2-subA',
+        userId: 'user-s2-refund',
+        licenseKey: 'subA-key',
+        tier: 'pro',
+        customerId: 'cus_s2_refund',
+        subscriptionId: 'sub_A',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2-subB',
+        userId: 'user-s2-refund',
+        licenseKey: 'subB-key',
+        tier: 'max',
+        customerId: 'cus_s2_refund',
+        subscriptionId: 'sub_B',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2-perp',
+        userId: 'user-s2-refund',
+        licenseKey: 'perp-key',
+        tier: 'pro',
+        customerId: 'cus_s2_refund',
+        subscriptionId: null,
+        status: 'active',
+        perpetual: true,
+      },
+    ]);
+
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({ id: 'pi_s2_refund', metadata: {} });
+    // Charge → Invoice → Subscription resolves to sub_A only.
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: 'in_s2_refund',
+      parent: { subscription_details: { subscription: 'sub_A' } },
+    });
+    mockSubscriptionsCancel.mockResolvedValueOnce({ id: 'sub_A', status: 'canceled' });
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_s2_refund',
+      customer: 'cus_s2_refund',
+      payment_intent: 'pi_s2_refund',
+      invoice: 'in_s2_refund',
+      amount: 4900,
+      amount_refunded: 4900,
+      currency: 'usd',
+      billing_details: { email: 's2refund@example.com' },
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.customerId, 'cus_s2_refund'));
+    const byId = new Map(rows.map((r) => [r.id, r.status]));
+    expect(byId.get('lic-s2-subA')).toBe('revoked'); // the refunded subscription
+    expect(byId.get('lic-s2-subB')).toBe('active'); // the OTHER subscription — preserved
+    expect(byId.get('lic-s2-perp')).toBe('active'); // perpetual — preserved
+    // Only the resolved subscription is canceled in Stripe.
+    expect(mockSubscriptionsCancel).toHaveBeenCalledWith('sub_A', {
+      invoice_now: false,
+      prorate: false,
+    });
+  });
+
+  it('charge.refunded falls back to all non-perpetual licenses when the subscription is unresolvable', async () => {
+    await seedTestUser(testDb.drizzle, { id: 'user-s2-fb', email: 's2fb@example.com' });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_s2_fb' })
+      .where(eq(users.id, 'user-s2-fb'));
+
+    await testDb.drizzle.insert(licenses).values([
+      {
+        id: 'lic-s2fb-subA',
+        userId: 'user-s2-fb',
+        licenseKey: 'fa-key',
+        tier: 'pro',
+        customerId: 'cus_s2_fb',
+        subscriptionId: 'sub_FA',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2fb-subB',
+        userId: 'user-s2-fb',
+        licenseKey: 'fb-key',
+        tier: 'pro',
+        customerId: 'cus_s2_fb',
+        subscriptionId: 'sub_FB',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2fb-perp',
+        userId: 'user-s2-fb',
+        licenseKey: 'fp-key',
+        tier: 'pro',
+        customerId: 'cus_s2_fb',
+        subscriptionId: null,
+        status: 'active',
+        perpetual: true,
+      },
+    ]);
+
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({ id: 'pi_s2_fb', metadata: {} });
+    // No invoice on the charge → subscription unresolvable → fallback.
+
+    const event = makeStripeEvent('charge.refunded', {
+      id: 'ch_s2_fb',
+      customer: 'cus_s2_fb',
+      payment_intent: 'pi_s2_fb',
+      invoice: null,
+      amount: 4900,
+      amount_refunded: 4900,
+      currency: 'usd',
+      billing_details: { email: 's2fb@example.com' },
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.customerId, 'cus_s2_fb'));
+    const byId = new Map(rows.map((r) => [r.id, r.status]));
+    // Fallback: ALL non-perpetual revoked, perpetual preserved.
+    expect(byId.get('lic-s2fb-subA')).toBe('revoked');
+    expect(byId.get('lic-s2fb-subB')).toBe('revoked');
+    expect(byId.get('lic-s2fb-perp')).toBe('active');
+    // No subscription resolved → no Stripe invoice lookup / cancel.
+    expect(mockInvoicesRetrieve).not.toHaveBeenCalled();
+    expect(mockSubscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it('charge.dispute.closed (lost) revokes ONLY the disputed subscription when resolvable', async () => {
+    await seedTestUser(testDb.drizzle, { id: 'user-s2-dispute', email: 's2dispute@example.com' });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_s2_dispute' })
+      .where(eq(users.id, 'user-s2-dispute'));
+
+    await testDb.drizzle.insert(licenses).values([
+      {
+        id: 'lic-s2d-subA',
+        userId: 'user-s2-dispute',
+        licenseKey: 'da-key',
+        tier: 'pro',
+        customerId: 'cus_s2_dispute',
+        subscriptionId: 'sub_DA',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2d-subB',
+        userId: 'user-s2-dispute',
+        licenseKey: 'db-key',
+        tier: 'pro',
+        customerId: 'cus_s2_dispute',
+        subscriptionId: 'sub_DB',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2d-perp',
+        userId: 'user-s2-dispute',
+        licenseKey: 'dp-key',
+        tier: 'pro',
+        customerId: 'cus_s2_dispute',
+        subscriptionId: null,
+        status: 'active',
+        perpetual: true,
+      },
+    ]);
+
+    // Charge → customer + invoice; invoice → sub_DA.
+    mockChargesRetrieve.mockResolvedValueOnce({
+      id: 'ch_s2_dispute',
+      customer: 'cus_s2_dispute',
+      invoice: 'in_s2_dispute',
+    });
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: 'in_s2_dispute',
+      parent: { subscription_details: { subscription: 'sub_DA' } },
+    });
+
+    const event = makeStripeEvent('charge.dispute.closed', {
+      id: 'dp_s2_dispute',
+      status: 'lost',
+      charge: 'ch_s2_dispute',
+      amount: 4900,
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.customerId, 'cus_s2_dispute'));
+    const byId = new Map(rows.map((r) => [r.id, r.status]));
+    expect(byId.get('lic-s2d-subA')).toBe('revoked'); // the disputed subscription
+    expect(byId.get('lic-s2d-subB')).toBe('active'); // the OTHER subscription — preserved
+    expect(byId.get('lic-s2d-perp')).toBe('active'); // perpetual — preserved
+  });
+
+  it('charge.dispute.closed (lost) falls back to all licenses when the subscription is unresolvable', async () => {
+    await seedTestUser(testDb.drizzle, { id: 'user-s2-dfb', email: 's2dfb@example.com' });
+    await testDb.drizzle
+      .update(users)
+      .set({ stripeCustomerId: 'cus_s2_dfb' })
+      .where(eq(users.id, 'user-s2-dfb'));
+
+    await testDb.drizzle.insert(licenses).values([
+      {
+        id: 'lic-s2dfb-subA',
+        userId: 'user-s2-dfb',
+        licenseKey: 'dfa-key',
+        tier: 'pro',
+        customerId: 'cus_s2_dfb',
+        subscriptionId: 'sub_DFA',
+        status: 'active',
+        perpetual: false,
+      },
+      {
+        id: 'lic-s2dfb-perp',
+        userId: 'user-s2-dfb',
+        licenseKey: 'dfp-key',
+        tier: 'pro',
+        customerId: 'cus_s2_dfb',
+        subscriptionId: null,
+        status: 'active',
+        perpetual: true,
+      },
+    ]);
+
+    // Charge has a customer but no invoice → subscription unresolvable → fallback.
+    mockChargesRetrieve.mockResolvedValueOnce({
+      id: 'ch_s2_dfb',
+      customer: 'cus_s2_dfb',
+      invoice: null,
+    });
+
+    const event = makeStripeEvent('charge.dispute.closed', {
+      id: 'dp_s2_dfb',
+      status: 'lost',
+      charge: 'ch_s2_dfb',
+      amount: 4900,
+    });
+
+    const res = await postWebhook(event);
+    expect(res.status).toBe(200);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(licenses)
+      .where(eq(licenses.customerId, 'cus_s2_dfb'));
+    const byId = new Map(rows.map((r) => [r.id, r.status]));
+    // Conservative fallback for a chargeback: ALL licenses revoked, incl. perpetual.
+    expect(byId.get('lic-s2dfb-subA')).toBe('revoked');
+    expect(byId.get('lic-s2dfb-perp')).toBe('revoked');
   });
 });

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -757,6 +757,40 @@ async function findHostedStatusByCustomerId(
   return entitlement?.status ?? null;
 }
 
+/**
+ * Resolve the Stripe subscription ID backing a charge, via the
+ * Charge → Invoice → Subscription chain. Returns null when the charge is not
+ * invoice-backed (a one-time perpetual or credit-bundle purchase) or the chain
+ * cannot be resolved. Used to scope refund / chargeback license revocation to
+ * the affected subscription instead of revoking every license the customer
+ * holds.
+ *
+ * charge.invoice exists at runtime for invoice-backed charges but is not in the
+ * SDK type — cast through unknown to read it (same SDK-typing gap as elsewhere
+ * in this file). Stripe SDK v20 moved the subscription field to
+ * invoice.parent.subscription_details.subscription.
+ */
+async function resolveSubscriptionIdFromCharge(
+  stripe: ProtectedStripe,
+  charge: Stripe.Charge,
+): Promise<string | null> {
+  const chargeInvoice = (charge as unknown as { invoice?: string | { id: string } | null }).invoice;
+  const invoiceId = typeof chargeInvoice === 'string' ? chargeInvoice : (chargeInvoice?.id ?? null);
+  if (!invoiceId) return null;
+  try {
+    const invoice = await stripe.invoices.retrieve(invoiceId);
+    const field = invoice.parent?.subscription_details?.subscription;
+    return typeof field === 'string' ? field : (field?.id ?? null);
+  } catch (err) {
+    logger.warn('Failed to resolve subscription from charge invoice', {
+      chargeId: charge.id,
+      invoiceId,
+      detail: err instanceof Error ? err.message : 'unknown',
+    });
+    return null;
+  }
+}
+
 // ─── Webhook Endpoint ────────────────────────────────────────────────────────
 
 // Canonical list lives in `@revealui/contracts` so seed-stripe.ts and this
@@ -2950,11 +2984,13 @@ app.openapi(stripeWebhookRoute, async (c) => {
         // is returned to the cardholder.
         const chargeId = typeof dispute.charge === 'string' ? dispute.charge : dispute.charge.id;
 
-        // Retrieve the charge to resolve the customer ID
+        // Retrieve the charge to resolve the customer ID (and, below, the
+        // disputed subscription).
         let disputeCustomerId: string | null = null;
+        let disputeCharge: Stripe.Charge | null = null;
         try {
-          const charge = await stripe.charges.retrieve(chargeId);
-          disputeCustomerId = resolveCustomerId(charge.customer);
+          disputeCharge = await stripe.charges.retrieve(chargeId);
+          disputeCustomerId = resolveCustomerId(disputeCharge.customer);
         } catch (err) {
           logger.error('Failed to retrieve charge for lost dispute', undefined, {
             chargeId,
@@ -2973,11 +3009,27 @@ app.openapi(stripeWebhookRoute, async (c) => {
           break;
         }
 
-        // Revoke all licenses for this customer
+        // S2: scope the chargeback revoke to the disputed subscription when the
+        // charge can be traced to one. A customer with multiple subscriptions
+        // must lose only the disputed one's license. When the charge is not
+        // invoice-backed or the chain is unresolvable, fall back to revoking ALL
+        // of the customer's licenses — the conservative posture for a chargeback
+        // (money was returned; never under-revoke), preserving prior behavior.
+        const disputeSubscriptionId = disputeCharge
+          ? await resolveSubscriptionIdFromCharge(stripe, disputeCharge)
+          : null;
+        const disputeRevokeWhere = disputeSubscriptionId
+          ? and(
+              eq(licenses.customerId, disputeCustomerId),
+              eq(licenses.perpetual, false),
+              eq(licenses.subscriptionId, disputeSubscriptionId),
+              isNull(licenses.deletedAt),
+            )
+          : and(eq(licenses.customerId, disputeCustomerId), isNull(licenses.deletedAt));
         await db
           .update(licenses)
           .set({ status: 'revoked', updatedAt: new Date() })
-          .where(and(eq(licenses.customerId, disputeCustomerId), isNull(licenses.deletedAt)));
+          .where(disputeRevokeWhere);
 
         await syncHostedSubscriptionState(db, {
           customerId: disputeCustomerId,
@@ -3272,6 +3324,13 @@ app.openapi(stripeWebhookRoute, async (c) => {
         }
 
         if (isFullRefund) {
+          // S2: resolve the subscription this charge backs ONCE (Charge →
+          // Invoice → Subscription) so we can both scope the license revoke to
+          // that subscription and cancel it below. Resolving once keeps a single
+          // Stripe invoices.retrieve call (a second call would break the
+          // single-mock refund-cancel test and double the Stripe round-trip).
+          const refundSubscriptionId = await resolveSubscriptionIdFromCharge(stripe, charge);
+
           // B-1 fix: Revoke perpetual licenses when the originating charge is
           // fully refunded. Identify the perpetual purchase via the PaymentIntent
           // metadata set at checkout (payment_intent_data.metadata.perpetual='true').
@@ -3335,18 +3394,28 @@ app.openapi(stripeWebhookRoute, async (c) => {
             }
           }
 
-          // Only revoke NON-PERPETUAL licenses. Perpetual licenses represent
-          // a separate one-time purchase handled above.
-          await db
-            .update(licenses)
-            .set({ status: 'revoked', updatedAt: new Date() })
-            .where(
-              and(
+          // S2: scope the revoke to the subscription this refunded charge backs.
+          // A customer with multiple active subscriptions must lose only the
+          // refunded one's license, not all of them. When the charge cannot be
+          // traced to a subscription (non-invoice charge or broken chain) fall
+          // back to the prior all-non-perpetual revoke — strictly safer, never
+          // under-revokes. Perpetual licenses are handled above.
+          const refundRevokeWhere = refundSubscriptionId
+            ? and(
+                eq(licenses.customerId, customerId),
+                eq(licenses.perpetual, false),
+                eq(licenses.subscriptionId, refundSubscriptionId),
+                isNull(licenses.deletedAt),
+              )
+            : and(
                 eq(licenses.customerId, customerId),
                 eq(licenses.perpetual, false),
                 isNull(licenses.deletedAt),
-              ),
-            );
+              );
+          await db
+            .update(licenses)
+            .set({ status: 'revoked', updatedAt: new Date() })
+            .where(refundRevokeWhere);
 
           await syncHostedSubscriptionState(db, {
             customerId,
@@ -3375,101 +3444,65 @@ app.openapi(stripeWebhookRoute, async (c) => {
           // Without this, Stripe continues invoicing the customer at the next
           // cycle while our entitlement is 'revoked' — producing immediate
           // "I got a refund and you charged me again" confusion + likely
-          // chargebacks.
-          //
-          // Detect via Charge → Invoice → Subscription chain. Idempotent:
-          // if the subscription is already canceled, Stripe returns
-          // resource_missing / "No such subscription" or "subscription is
-          // already canceled"; we log info and continue.
-          // charge.invoice exists at runtime (Stripe sends it for invoice-
-          // backed charges) but is not in the SDK type. Same SDK-typing gap
-          // as elsewhere in this file (see line ~2235 comment). Cast through
-          // unknown to read it.
-          const chargeInvoice = (charge as unknown as { invoice?: string | { id: string } | null })
-            .invoice;
-          const invoiceId =
-            typeof chargeInvoice === 'string' ? chargeInvoice : (chargeInvoice?.id ?? null);
-          if (invoiceId) {
+          // chargebacks. Uses the subscription resolved at the top of this
+          // block. Idempotent: if the subscription is already canceled, Stripe
+          // returns resource_missing / "No such subscription" / "already
+          // canceled"; we log info and continue.
+          if (refundSubscriptionId) {
             try {
-              const invoice = await stripe.invoices.retrieve(invoiceId);
-              // Stripe SDK v20 moved subscription from invoice.subscription to
-              // invoice.parent.subscription_details.subscription (matches the
-              // fix at line ~2451 in this file).
-              const invoiceSubscriptionField = invoice.parent?.subscription_details?.subscription;
-              const subscriptionId =
-                typeof invoiceSubscriptionField === 'string'
-                  ? invoiceSubscriptionField
-                  : (invoiceSubscriptionField?.id ?? null);
-              if (subscriptionId) {
-                try {
-                  await stripe.subscriptions.cancel(subscriptionId, {
-                    invoice_now: false,
-                    prorate: false,
-                  });
-                  logger.warn('Stripe subscription canceled after full refund', {
-                    customerId,
-                    chargeId: charge.id,
-                    invoiceId,
-                    subscriptionId,
-                  });
-                  auditLicenseEvent(db, 'subscription.canceled.refund', 'warn', {
-                    customerId,
-                    chargeId: charge.id,
-                    invoiceId,
-                    subscriptionId,
-                  });
-                } catch (cancelErr) {
-                  // Already-canceled is the common idempotent case. Stripe
-                  // surfaces it as a StripeInvalidRequestError with
-                  // code='resource_missing' (deleted) or a message containing
-                  // 'already canceled' / 'already been canceled'. Treat all
-                  // of these as a no-op success.
-                  const msg = cancelErr instanceof Error ? cancelErr.message : 'unknown';
-                  const code = (cancelErr as { code?: string }).code;
-                  // M2 no-regex: detect Stripe's idempotent "already canceled"
-                  // outcomes via case-insensitive substring checks. Covers
-                  // "already canceled" / "already cancelled" / "already been
-                  // cancel(l)ed" and "no such subscription".
-                  const lowerMsg = msg.toLowerCase();
-                  const isAlreadyCanceled =
-                    code === 'resource_missing' ||
-                    (lowerMsg.includes('already') && lowerMsg.includes('cancel')) ||
-                    lowerMsg.includes('no such subscription');
-                  if (isAlreadyCanceled) {
-                    logger.info(
-                      'Stripe subscription already canceled — refund cancel is no-op (idempotent)',
-                      {
-                        customerId,
-                        chargeId: charge.id,
-                        subscriptionId,
-                        detail: msg,
-                      },
-                    );
-                  } else {
-                    // Unexpected error — log loudly but don't crash the
-                    // webhook (email + audit-log already wrote; subscription
-                    // cancel can be retried by admin).
-                    logger.error(
-                      'Failed to cancel Stripe subscription after full refund',
-                      undefined,
-                      {
-                        customerId,
-                        chargeId: charge.id,
-                        subscriptionId,
-                        detail: msg,
-                        code,
-                      },
-                    );
-                  }
-                }
-              }
-            } catch (invoiceErr) {
-              logger.warn('Failed to retrieve invoice for refund — skipping subscription cancel', {
+              await stripe.subscriptions.cancel(refundSubscriptionId, {
+                invoice_now: false,
+                prorate: false,
+              });
+              logger.warn('Stripe subscription canceled after full refund', {
                 customerId,
                 chargeId: charge.id,
-                invoiceId,
-                detail: invoiceErr instanceof Error ? invoiceErr.message : 'unknown',
+                subscriptionId: refundSubscriptionId,
               });
+              auditLicenseEvent(db, 'subscription.canceled.refund', 'warn', {
+                customerId,
+                chargeId: charge.id,
+                subscriptionId: refundSubscriptionId,
+              });
+            } catch (cancelErr) {
+              // Already-canceled is the common idempotent case. Stripe
+              // surfaces it as a StripeInvalidRequestError with
+              // code='resource_missing' (deleted) or a message containing
+              // 'already canceled' / 'already been canceled'. Treat all
+              // of these as a no-op success.
+              const msg = cancelErr instanceof Error ? cancelErr.message : 'unknown';
+              const code = (cancelErr as { code?: string }).code;
+              // M2 no-regex: detect Stripe's idempotent "already canceled"
+              // outcomes via case-insensitive substring checks. Covers
+              // "already canceled" / "already cancelled" / "already been
+              // cancel(l)ed" and "no such subscription".
+              const lowerMsg = msg.toLowerCase();
+              const isAlreadyCanceled =
+                code === 'resource_missing' ||
+                (lowerMsg.includes('already') && lowerMsg.includes('cancel')) ||
+                lowerMsg.includes('no such subscription');
+              if (isAlreadyCanceled) {
+                logger.info(
+                  'Stripe subscription already canceled — refund cancel is no-op (idempotent)',
+                  {
+                    customerId,
+                    chargeId: charge.id,
+                    subscriptionId: refundSubscriptionId,
+                    detail: msg,
+                  },
+                );
+              } else {
+                // Unexpected error — log loudly but don't crash the
+                // webhook (email + audit-log already wrote; subscription
+                // cancel can be retried by admin).
+                logger.error('Failed to cancel Stripe subscription after full refund', undefined, {
+                  customerId,
+                  chargeId: charge.id,
+                  subscriptionId: refundSubscriptionId,
+                  detail: msg,
+                  code,
+                });
+              }
             }
           }
         } else {


### PR DESCRIPTION
## What

S2 — the last open finding from the 2026-06-07 checkout-flow audit. The refund and chargeback webhook handlers over-revoked licenses:

- `charge.refunded` (full refund) revoked **every** non-perpetual license the customer held.
- `charge.dispute.closed` (status `lost`) revoked **every** license the customer held, including perpetual.

So a customer with more than one active subscription lost **all** of them on a single refund or chargeback — and a perpetual purchase could be revoked by an unrelated subscription chargeback.

## Fix

Scope both revokes to the subscription the refunded/disputed charge actually backs, resolved via the Charge → Invoice → Subscription chain. A new shared `resolveSubscriptionIdFromCharge` helper centralizes that chain — the existing refund-cancel path is refactored to reuse it, so the subscription is resolved **once** and used for both the scoped revoke and the Stripe cancel (a single `invoices.retrieve`).

When the charge can't be traced to a subscription (non-invoice charge or a broken chain), fall back to the prior, broader behavior — strictly safer, never under-revokes:
- refund → all non-perpetual licenses;
- chargeback → all licenses (conservative; the money was returned).

## Tests

4 new PGlite integration tests in `webhook-pglite.test.ts`:
- refund of one subscription's charge revokes only that subscription's license (the other subscription + a perpetual are preserved);
- refund with an unresolvable subscription falls back to all non-perpetual;
- lost dispute on one subscription's charge revokes only that subscription's license;
- lost dispute with an unresolvable subscription falls back to all licenses.

The existing refund-cancel + idempotent-cancel tests are unchanged and still pass (the single `invoices.retrieve` mock is honored by the resolve-once refactor).
