### PR TITLE
feat(scripts): no-regex leak-scan tool (consolidates the bash check-no-private-leaks gates)

### DIFF
--- a/scripts/leak-scan/README.md
+++ b/scripts/leak-scan/README.md
@@ -2,29 +2,58 @@
 
 No-regex leak scanner. Single source of truth for the fleet's
 `check-no-private-leaks` gate, consolidating 8 drifting bash copies into one
-TypeScript tool. Tracked by the `leak-scanner-consolidation` lane in the internal coordination repo.
+TypeScript tool. Tracked by the `leak-scanner-consolidation` lane in the internal
+coordination repo.
 
-## Status — increment 1
+## Usage
 
-- `predicates.ts` — no-regex matching primitives: literal substring + a typed
-  segment matcher (`lit` / `run` over `CharClass` predicates). No `RegExp`.
-- `rules.ts` — `BASE_RULES` (generic, public-safe) + `SENSITIVE_TAGS` (repo-local).
-- `__tests__/` — Vitest. Run: `vitest run --config scripts/leak-scan/vitest.config.ts`.
+```
+node scripts/leak-scan/leak-scan.mjs [path...] [--json] [--leakignore=FILE] [--local-rules=FILE]
+```
+
+Scans the given paths (default: cwd). Exit `0` clean, `1` violations found, `2`
+setup error. Reads `<root>/.leakignore` (allowlist) and `<root>/.leakrules.json`
+(repo-local sensitive rules) by default. The bundle imports only `node:` builtins,
+so consuming repos run it with plain `node` — no install, no `tsx`.
+
+## Build
+
+`node scripts/leak-scan/build.mjs` bundles the TS source to the committed
+`leak-scan.mjs` via esbuild. `--check` mode fails if the committed bundle is
+stale (drift gate). The `.mjs` lives at the tool root (not `dist/`, which is
+git-ignored) and is skipped by Biome (`.mjs` is not in its `includes`) and by the
+scanner's own self-exclude list.
+
+## Modules
+
+- `predicates.ts` — no-regex primitives: literal substring + a typed segment
+  matcher (`lit` / `run` over `CharClass`). No `RegExp` anywhere in the tool.
+- `rules.ts` — `BASE_RULES` (22 generic, public-safe) + `SENSITIVE_TAGS`.
+- `glob.ts` — no-regex wildcard matcher for excludes + `.leakignore` globs.
+- `scan.ts` — `scanContent` + `walkFiles` (excludes, symlink/binary skip) + `scanPaths`.
+- `leakignore.ts` — allowlist parser + `makeIsIgnored` (revvault#45 `./` norm,
+  revdev#55 non-exclusions).
+- `config.ts` — `loadLocalRules` (repo-local sensitive rules: `literal` | `anyOf`).
+- `report.ts` — text + JSON (`{violations,entries}`) output.
+- `cli.ts` — `runCli` (pure, testable) + a `VITEST`-guarded launcher.
+- `build.mjs` — esbuild bundle + drift-check.
+- `__tests__/` — Vitest (92 tests). Run: `vitest run --config scripts/leak-scan/vitest.config.ts`.
 
 ## Trust boundary
 
-This canonical source lives in the public `revealui` repo, so `BASE_RULES`
-carry only shapes and non-secret names (mount paths, ID formats, internal doc
-names). Sensitive literal values — internal hostname, customer / prospect /
-person names, operator bank, partnership reference, personal email (see
-`SENSITIVE_TAGS`) — are **never** hard-coded here. Each consuming repo supplies
-them via local config. This fixes, rather than cements, today's bash scanners,
-several of which embed those literals directly.
+This canonical source lives in the public `revealui` repo, so `BASE_RULES` carry
+only shapes and non-secret names (mount paths, ID formats, internal doc names).
+Sensitive literal values — internal hostname, customer / prospect / person names,
+operator bank, partnership reference, personal email (see `SENSITIVE_TAGS`) — are
+**never** hard-coded here. Each consuming repo supplies them via local config
+(`.leakrules.json`, self-excluded from scanning). This fixes, rather than
+cements, today's bash scanners, several of which embed those literals directly.
 
 ## Remaining (lane §6)
 
-file-walk + exclude-dirs/files, `.leakignore` allowlist parser (path-glob +
-tag, with the revvault#45 `./` normalization and the revdev#55 non-exclusions),
-repo-local sensitive-rule loader, JSON output mode, exit-code CLI entry,
-dependency-free `.mjs` bundle, revkit propagation + drift gate, per-repo cutover
-(base = test, one PR each), and the old-vs-new parity harness.
+- **PR-time hardening**: pin `esbuild` as a direct devDep (reproducible bundle),
+  wire `build.mjs --check` into CI, confirm gitleaks + check-client-leaks pass on
+  the committed `.mjs`.
+- revkit propagation of `leak-scan.mjs` into each repo + a render drift gate.
+- per-repo cutover (base = test, one PR each, behind an old-vs-new parity harness).
+- delete revealcoin's scanner (cancelled repo).

--- a/scripts/leak-scan/README.md
+++ b/scripts/leak-scan/README.md
@@ -1,0 +1,30 @@
+# leak-scan (canonical source)
+
+No-regex leak scanner. Single source of truth for the fleet's
+`check-no-private-leaks` gate, consolidating 8 drifting bash copies into one
+TypeScript tool. Tracked by the `leak-scanner-consolidation` lane in the internal coordination repo.
+
+## Status — increment 1
+
+- `predicates.ts` — no-regex matching primitives: literal substring + a typed
+  segment matcher (`lit` / `run` over `CharClass` predicates). No `RegExp`.
+- `rules.ts` — `BASE_RULES` (generic, public-safe) + `SENSITIVE_TAGS` (repo-local).
+- `__tests__/` — Vitest. Run: `vitest run --config scripts/leak-scan/vitest.config.ts`.
+
+## Trust boundary
+
+This canonical source lives in the public `revealui` repo, so `BASE_RULES`
+carry only shapes and non-secret names (mount paths, ID formats, internal doc
+names). Sensitive literal values — internal hostname, customer / prospect /
+person names, operator bank, partnership reference, personal email (see
+`SENSITIVE_TAGS`) — are **never** hard-coded here. Each consuming repo supplies
+them via local config. This fixes, rather than cements, today's bash scanners,
+several of which embed those literals directly.
+
+## Remaining (lane §6)
+
+file-walk + exclude-dirs/files, `.leakignore` allowlist parser (path-glob +
+tag, with the revvault#45 `./` normalization and the revdev#55 non-exclusions),
+repo-local sensitive-rule loader, JSON output mode, exit-code CLI entry,
+dependency-free `.mjs` bundle, revkit propagation + drift gate, per-repo cutover
+(base = test, one PR each), and the old-vs-new parity harness.

--- a/scripts/leak-scan/__tests__/cli.test.ts
+++ b/scripts/leak-scan/__tests__/cli.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runCli } from '../cli';
+
+describe('runCli', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'leakcli-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns 0 + OK for a clean tree', () => {
+    writeFileSync(join(dir, 'src', 'ok.ts'), 'all clean here\n');
+    const r = runCli([dir], dir);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('OK');
+  });
+
+  it('returns 1 and reports a leak (text mode)', () => {
+    writeFileSync(join(dir, 'src', 'bad.ts'), "const h = '/home/alice/x';\n");
+    const r = runCli([dir], dir);
+    expect(r.code).toBe(1);
+    expect(r.stdout).toContain('abs-home-path');
+    expect(r.stderr).toContain('FAIL');
+  });
+
+  it('returns 2 for a missing scan path', () => {
+    const r = runCli([join(dir, 'does-not-exist')], dir);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('not found');
+  });
+
+  it('--json emits parseable output', () => {
+    writeFileSync(join(dir, 'bad.ts'), 'team_ABCDEFGHIJKLMNOP12\n');
+    const r = runCli([dir, '--json'], dir);
+    expect(r.code).toBe(1);
+    expect(JSON.parse(r.stdout).violations).toBeGreaterThan(0);
+  });
+
+  it('loads repo-local rules and flags a custom literal', () => {
+    writeFileSync(
+      join(dir, '.leakrules.json'),
+      JSON.stringify([{ tag: 'cust', reason: 'customer', literal: 'Acme' }]),
+    );
+    writeFileSync(join(dir, 'doc.md'), 'we work with Acme\n');
+    const r = runCli([dir], dir);
+    expect(r.code).toBe(1);
+    expect(r.stdout).toContain('cust');
+  });
+
+  it('returns 2 on malformed repo-local rules', () => {
+    writeFileSync(join(dir, '.leakrules.json'), '{not valid');
+    const r = runCli([dir], dir);
+    expect(r.code).toBe(2);
+  });
+
+  it('honors .leakignore (path-glob + tag)', () => {
+    writeFileSync(join(dir, 'bad.ts'), "const h = '/home/alice/x';\n");
+    writeFileSync(join(dir, '.leakignore'), 'bad.ts abs-home-path\n');
+    const r = runCli([dir], dir);
+    expect(r.code).toBe(0);
+  });
+
+  it('--help returns 0 with usage', () => {
+    const r = runCli(['--help'], dir);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Usage:');
+  });
+});

--- a/scripts/leak-scan/__tests__/config.test.ts
+++ b/scripts/leak-scan/__tests__/config.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigError, loadLocalRules } from '../config';
+
+describe('loadLocalRules', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'leakcfg-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (obj: unknown): string => {
+    const p = join(dir, '.leakrules.json');
+    writeFileSync(p, typeof obj === 'string' ? obj : JSON.stringify(obj));
+    return p;
+  };
+
+  it('returns [] when the file is missing', () => {
+    expect(loadLocalRules(join(dir, 'nope.json'))).toEqual([]);
+  });
+  it('loads a literal rule that matches as a substring', () => {
+    const rules = loadLocalRules(write([{ tag: 'cust', reason: 'customer', literal: 'Acme' }]));
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.matches('we partner with Acme Inc')).toBe(true);
+    expect(rules[0]?.matches('nothing here')).toBe(false);
+  });
+  it('loads an anyOf rule (case variants)', () => {
+    const rules = loadLocalRules(
+      write([{ tag: 'v', reason: 'venture', anyOf: ['Biotix', 'biotix'] }]),
+    );
+    expect(rules[0]?.matches('the biotix project')).toBe(true);
+    expect(rules[0]?.matches('BIOTIX')).toBe(false);
+  });
+  it('throws ConfigError on non-array JSON', () => {
+    expect(() => loadLocalRules(write({ not: 'an array' }))).toThrow(ConfigError);
+  });
+  it('throws ConfigError when neither literal nor anyOf is provided', () => {
+    expect(() => loadLocalRules(write([{ tag: 'x', reason: 'y' }]))).toThrow(ConfigError);
+  });
+  it('throws ConfigError when both literal and anyOf are provided', () => {
+    expect(() =>
+      loadLocalRules(write([{ tag: 'x', reason: 'y', literal: 'a', anyOf: ['b'] }])),
+    ).toThrow(ConfigError);
+  });
+  it('throws ConfigError on invalid JSON', () => {
+    expect(() => loadLocalRules(write('{not valid'))).toThrow(ConfigError);
+  });
+});

--- a/scripts/leak-scan/__tests__/config.test.ts
+++ b/scripts/leak-scan/__tests__/config.test.ts
@@ -30,10 +30,10 @@ describe('loadLocalRules', () => {
   });
   it('loads an anyOf rule (case variants)', () => {
     const rules = loadLocalRules(
-      write([{ tag: 'v', reason: 'venture', anyOf: ['Biotix', 'biotix'] }]),
+      write([{ tag: 'v', reason: 'venture', anyOf: ['Globex', 'globex'] }]),
     );
-    expect(rules[0]?.matches('the biotix project')).toBe(true);
-    expect(rules[0]?.matches('BIOTIX')).toBe(false);
+    expect(rules[0]?.matches('the globex project')).toBe(true);
+    expect(rules[0]?.matches('GLOBEX')).toBe(false);
   });
   it('throws ConfigError on non-array JSON', () => {
     expect(() => loadLocalRules(write({ not: 'an array' }))).toThrow(ConfigError);

--- a/scripts/leak-scan/__tests__/glob.test.ts
+++ b/scripts/leak-scan/__tests__/glob.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { matchGlob } from '../glob';
+
+describe('matchGlob', () => {
+  it('matches an exact literal path', () => {
+    expect(
+      matchGlob('wsl/bashrc.d/70-revcon-personal.sh', 'wsl/bashrc.d/70-revcon-personal.sh'),
+    ).toBe(true);
+  });
+  it('matches a basename suffix glob', () => {
+    expect(matchGlob('logo.png', '*.png')).toBe(true);
+    expect(matchGlob('logo.svg', '*.png')).toBe(false);
+  });
+  it('lets `*` cross path separators (bash [[ == ]] semantics)', () => {
+    expect(matchGlob('a/b/c.ts', 'a/*.ts')).toBe(true);
+    expect(matchGlob('a/b/c.ts', '*.ts')).toBe(true);
+  });
+  it('matches `?` as exactly one character', () => {
+    expect(matchGlob('ab', 'a?')).toBe(true);
+    expect(matchGlob('abc', 'a?')).toBe(false);
+  });
+  it('rejects a non-match', () => {
+    expect(matchGlob('foo/bar', 'baz/*')).toBe(false);
+  });
+  it('trailing star matches the empty remainder', () => {
+    expect(matchGlob('abc', 'abc*')).toBe(true);
+  });
+});

--- a/scripts/leak-scan/__tests__/leakignore.test.ts
+++ b/scripts/leak-scan/__tests__/leakignore.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { makeIsIgnored, parseLeakignore } from '../leakignore';
+
+describe('parseLeakignore', () => {
+  it('parses glob + tags and strips comments + blank lines', () => {
+    const entries = parseLeakignore(
+      [
+        '# a comment',
+        '',
+        'wsl/bashrc.d/70-revcon-personal.sh   private-jv-repo',
+        'docs/x.md   abs-windows-user   # reason',
+      ].join('\n'),
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.glob).toBe('wsl/bashrc.d/70-revcon-personal.sh');
+    expect(entries[0]?.tags.has('private-jv-repo')).toBe(true);
+  });
+  it('skips a glob-only line that lists no tags', () => {
+    expect(parseLeakignore('just/a/path\n')).toEqual([]);
+  });
+  it('parses multiple comma-separated tags', () => {
+    const entries = parseLeakignore('a.ts  lts-drive,forge-drive\n');
+    expect(entries[0]?.tags.has('lts-drive')).toBe(true);
+    expect(entries[0]?.tags.has('forge-drive')).toBe(true);
+  });
+});
+
+describe('makeIsIgnored', () => {
+  const ignored = makeIsIgnored(parseLeakignore('frontend/src/foo.ts  abs-home-path\n'));
+
+  it('suppresses only when BOTH the path-glob and the tag match', () => {
+    expect(ignored('frontend/src/foo.ts', 'abs-home-path')).toBe(true);
+    expect(ignored('frontend/src/foo.ts', 'lts-drive')).toBe(false);
+    expect(ignored('other.ts', 'abs-home-path')).toBe(false);
+  });
+  it('normalizes a leading ./ (revvault#45 parity)', () => {
+    expect(ignored('./frontend/src/foo.ts', 'abs-home-path')).toBe(true);
+  });
+});

--- a/scripts/leak-scan/__tests__/predicates.test.ts
+++ b/scripts/leak-scan/__tests__/predicates.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  containsPattern,
+  isAlnum,
+  isDigit,
+  isHexLower,
+  isLower,
+  lit,
+  literalIncludes,
+  run,
+} from '../predicates';
+
+describe('literalIncludes', () => {
+  it('matches a substring', () => {
+    expect(literalIncludes('cd /mnt/e/backups', '/mnt/e/')).toBe(true);
+  });
+  it('rejects when absent', () => {
+    expect(literalIncludes('cd /mnt/d/backups', '/mnt/e/')).toBe(false);
+  });
+});
+
+describe('containsPattern', () => {
+  const teamId = [lit('team_'), run(isAlnum, 16)];
+
+  it('matches prefix + class run at the required min length', () => {
+    expect(containsPattern('id team_ABCdef0123456789 here', teamId)).toBe(true);
+  });
+  it('rejects when the class run is too short', () => {
+    expect(containsPattern('team_ABCdef0123', teamId)).toBe(false);
+  });
+  it('advances the start index (match not at position 0)', () => {
+    expect(containsPattern('zzzteam_ABCDEFGHIJKLMNOP', teamId)).toBe(true);
+  });
+  it('honors an exact max on a bounded run', () => {
+    const handoff = [
+      lit('/HANDOFF-'),
+      run(isDigit, 4, 4),
+      lit('-'),
+      run(isDigit, 2, 2),
+      lit('-'),
+      run(isDigit, 2, 2),
+    ];
+    expect(containsPattern('docs/HANDOFF-2026-06-08-x', handoff)).toBe(true);
+    expect(containsPattern('docs/HANDOFF-202-06-08', handoff)).toBe(false);
+  });
+  it('matches a multi-part token (license key)', () => {
+    const license = [lit('RVUI-'), run(isLower, 1), lit('-'), run(isHexLower, 16)];
+    expect(containsPattern('key RVUI-pro-0123456789abcdef', license)).toBe(true);
+    expect(containsPattern('key RVUI-pro-0123', license)).toBe(false);
+  });
+});

--- a/scripts/leak-scan/__tests__/report.test.ts
+++ b/scripts/leak-scan/__tests__/report.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatJson, formatText } from '../report';
+import type { Finding } from '../scan';
+
+const findings: Finding[] = [
+  { tag: 'abs-home-path', file: 'a.ts', line: 3, reason: 'home path', content: '/home/alice/x' },
+];
+
+describe('formatText', () => {
+  it('renders a [LEAK:tag] file:line header and the content', () => {
+    const out = formatText(findings);
+    expect(out).toContain('[LEAK:abs-home-path] a.ts:3');
+    expect(out).toContain('/home/alice/x');
+  });
+  it('is empty for no findings', () => {
+    expect(formatText([])).toBe('');
+  });
+});
+
+describe('formatJson', () => {
+  it('emits a parseable violations count + entries', () => {
+    const parsed = JSON.parse(formatJson(findings));
+    expect(parsed.violations).toBe(1);
+    expect(parsed.entries[0].tag).toBe('abs-home-path');
+  });
+  it('reports zero for no findings', () => {
+    expect(JSON.parse(formatJson([])).violations).toBe(0);
+  });
+});

--- a/scripts/leak-scan/__tests__/rules.test.ts
+++ b/scripts/leak-scan/__tests__/rules.test.ts
@@ -9,8 +9,8 @@ const byTag = (tag: string): Rule => {
 
 // One positive + one negative per BASE rule, mirroring the legacy ERE semantics.
 const cases: ReadonlyArray<{ tag: string; hit: string; miss: string }> = [
-  { tag: 'abs-home-path', hit: 'see /home/joshua-v-dev/x', miss: 'see /home//x' },
-  { tag: 'abs-windows-user', hit: 'C:\\Users\\joshu\\x', miss: 'C:\\Programs\\x' },
+  { tag: 'abs-home-path', hit: 'see /home/alice/x', miss: 'see /home//x' },
+  { tag: 'abs-windows-user', hit: 'C:\\Users\\alice\\x', miss: 'C:\\Programs\\x' },
   { tag: 'private-jv-repo', hit: '~/revfleet/.jv/docs', miss: '~/revfleet/revealui' },
   { tag: 'private-jv-name', hit: 'RevealUIStudio/revealui-jv', miss: 'RevealUIStudio/revealui' },
   { tag: 'lts-drive', hit: 'cd /mnt/e/backups', miss: 'cd /mnt/d/backups' },

--- a/scripts/leak-scan/__tests__/rules.test.ts
+++ b/scripts/leak-scan/__tests__/rules.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { BASE_RULES, type Rule, SENSITIVE_TAGS } from '../rules';
+
+const byTag = (tag: string): Rule => {
+  const r = BASE_RULES.find((x) => x.tag === tag);
+  if (!r) throw new Error(`no BASE rule with tag ${tag}`);
+  return r;
+};
+
+// One positive + one negative per BASE rule, mirroring the legacy ERE semantics.
+const cases: ReadonlyArray<{ tag: string; hit: string; miss: string }> = [
+  { tag: 'abs-home-path', hit: 'see /home/joshua-v-dev/x', miss: 'see /home//x' },
+  { tag: 'abs-windows-user', hit: 'C:\\Users\\joshu\\x', miss: 'C:\\Programs\\x' },
+  { tag: 'private-jv-repo', hit: '~/revfleet/.jv/docs', miss: '~/revfleet/revealui' },
+  { tag: 'private-jv-name', hit: 'RevealUIStudio/revealui-jv', miss: 'RevealUIStudio/revealui' },
+  { tag: 'lts-drive', hit: 'cd /mnt/e/backups', miss: 'cd /mnt/d/backups' },
+  { tag: 'forge-drive', hit: '/mnt/forge/x', miss: '/mnt/sand/x' },
+  { tag: 'sandbox-drive', hit: '/mnt/sandbox/x', miss: '/mnt/box/x' },
+  { tag: 'license-key', hit: 'RVUI-pro-0123456789abcdef00', miss: 'RVUI-pro-0123' },
+  { tag: 'vercel-org-id', hit: 'team_ABCDEFGHIJKLMNOP12', miss: 'team_short' },
+  { tag: 'vercel-project-id', hit: 'prj_ABCDEFGHIJKLMNOP12', miss: 'prj_tiny' },
+  { tag: 'stripe-account', hit: 'acct_ABCDEFGHIJKLMN', miss: 'acct_short' },
+  { tag: 'stripe-product', hit: 'prod_ABCDEFGHIJKLMN', miss: 'prod_x' },
+  { tag: 'stripe-portal-config', hit: 'bpc_ABCDEFGHIJKLMN', miss: 'bpc_x' },
+  { tag: 'revvault-path-prod', hit: 'revvault/prod/stripe', miss: 'revvault/staging/x' },
+  { tag: 'revvault-path-dev', hit: 'revvault/dev/x', miss: 'revvault/d/x' },
+  { tag: 'revvault-path-forge', hit: 'revvault/forge/x', miss: 'revvault/f/x' },
+  { tag: 'age-identity', hit: '~/.age-identity/keys.txt', miss: '~/.ssh/id' },
+  { tag: 'coord-paths', hit: '.claude/coordination/branches.json', miss: '.claude/rules/x' },
+  { tag: 'coord-workboard', hit: 'x/.claude/workboard.md', miss: '.claude/workboard' },
+  { tag: 'coord-beacon', hit: 'context-beacon.json', miss: 'beacon.json' },
+  { tag: 'internal-handoff', hit: 'docs/HANDOFF-2026-06-08-x', miss: 'docs/HANDOFF-x' },
+  { tag: 'internal-gap-id', hit: 'GAP-194 blah', miss: 'GAP-7' },
+  { tag: 'internal-master-plan', hit: 'docs/MASTER_PLAN.md', miss: 'docs/PLAN.md' },
+];
+
+describe('BASE_RULES parity', () => {
+  for (const c of cases) {
+    it(`${c.tag} hits its positive sample`, () => {
+      expect(byTag(c.tag).matches(c.hit)).toBe(true);
+    });
+    it(`${c.tag} rejects its negative sample`, () => {
+      expect(byTag(c.tag).matches(c.miss)).toBe(false);
+    });
+  }
+});
+
+describe('BASE_RULES coverage + trust boundary', () => {
+  it('covers every BASE rule with a parity case', () => {
+    const tagged = new Set(cases.map((c) => c.tag));
+    const uncovered = BASE_RULES.filter((r) => !tagged.has(r.tag)).map((r) => r.tag);
+    expect(uncovered).toEqual([]);
+  });
+
+  it('ships no sensitive-literal rule in the public bundle', () => {
+    const baseTags = new Set(BASE_RULES.map((r) => r.tag));
+    const leaked = SENSITIVE_TAGS.filter((t) => baseTags.has(t));
+    expect(leaked).toEqual([]);
+  });
+
+  it('uses unique tags', () => {
+    const tags = BASE_RULES.map((r) => r.tag);
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+});

--- a/scripts/leak-scan/__tests__/scan.test.ts
+++ b/scripts/leak-scan/__tests__/scan.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { makeIsIgnored, parseLeakignore } from '../leakignore';
+import { BASE_RULES } from '../rules';
+import {
+  DEFAULT_EXCLUDE_DIRS,
+  DEFAULT_EXCLUDE_FILE_GLOBS,
+  scanContent,
+  scanPaths,
+  walkFiles,
+} from '../scan';
+
+describe('scanContent', () => {
+  it('reports tag, 1-based line number, file, and content for a hit', () => {
+    const content = 'clean line\nteam_ABCDEFGHIJKLMNOP12 here\nclean';
+    const findings = scanContent(BASE_RULES, content, 'x.ts');
+    const hit = findings.find((f) => f.tag === 'vercel-org-id');
+    expect(hit?.line).toBe(2);
+    expect(hit?.file).toBe('x.ts');
+  });
+  it('returns nothing for clean content', () => {
+    expect(scanContent(BASE_RULES, 'totally clean\nlines here', 'x.ts')).toEqual([]);
+  });
+});
+
+describe('walkFiles + scanPaths (filesystem)', () => {
+  let root: string;
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'leakscan-'));
+    writeFileSync(join(root, 'a.ts'), "const home = '/home/alice/project';\n");
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+    writeFileSync(join(root, 'node_modules', 'pkg', 'b.ts'), 'team_ABCDEFGHIJKLMNOP12\n');
+    writeFileSync(join(root, 'logo.png'), 'team_ABCDEFGHIJKLMNOP12\n');
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'ok.ts'), 'nothing to see\n');
+  });
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('excludes node_modules and image files, keeps real source', () => {
+    const files = walkFiles(root, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_FILE_GLOBS);
+    expect(files.some((f) => f.includes('node_modules'))).toBe(false);
+    expect(files.some((f) => f.endsWith('.png'))).toBe(false);
+    expect(files.some((f) => f.endsWith('a.ts'))).toBe(true);
+  });
+
+  it('finds the home-path leak in a.ts and nothing under node_modules', () => {
+    const { findings, violations } = scanPaths(BASE_RULES, [root]);
+    expect(violations).toBeGreaterThan(0);
+    expect(findings.every((f) => !f.file.includes('node_modules'))).toBe(true);
+    expect(findings.some((f) => f.tag === 'abs-home-path')).toBe(true);
+  });
+
+  it('suppresses a finding via .leakignore (path-glob + tag)', () => {
+    const isIgnored = makeIsIgnored(parseLeakignore('a.ts  abs-home-path\n'));
+    const { findings } = scanPaths(BASE_RULES, [root], { isIgnored });
+    expect(findings.some((f) => f.tag === 'abs-home-path')).toBe(false);
+  });
+
+  it('skips symlinks (no recursion into linked dirs)', () => {
+    let linked = false;
+    try {
+      symlinkSync(join(root, 'src'), join(root, 'linkdir'), 'dir');
+      linked = true;
+    } catch {
+      // some sandboxes block symlink creation; fall through
+    }
+    const files = walkFiles(root, DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_FILE_GLOBS);
+    if (linked) {
+      expect(files.some((f) => f.includes('linkdir'))).toBe(false);
+    } else {
+      expect(files.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/scripts/leak-scan/build.mjs
+++ b/scripts/leak-scan/build.mjs
@@ -1,0 +1,39 @@
+// Build the dependency-free single-file scanner bundle from the TS source.
+//
+//   node scripts/leak-scan/build.mjs           write scripts/leak-scan/leak-scan.mjs
+//   node scripts/leak-scan/build.mjs --check    exit 1 if the committed bundle is stale
+//
+// Uses the workspace esbuild binary. The bundle imports only node: builtins, so
+// consuming repos run it with plain `node leak-scan.mjs` — no install, no tsx.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const esbuild = join(repoRoot, "node_modules", ".bin", "esbuild");
+const entry = join(here, "cli.ts");
+const committed = join(here, "leak-scan.mjs");
+const check = process.argv.includes("--check");
+
+const outfile = check ? join(mkdtempSync(join(tmpdir(), "leakbuild-")), "leak-scan.mjs") : committed;
+
+execFileSync(
+  esbuild,
+  [entry, "--bundle", "--platform=node", "--format=esm", "--target=node20", `--outfile=${outfile}`],
+  { stdio: ["ignore", "ignore", "inherit"] },
+);
+
+if (check) {
+  const fresh = readFileSync(outfile, "utf8");
+  rmSync(dirname(outfile), { recursive: true, force: true });
+  if (fresh !== readFileSync(committed, "utf8")) {
+    process.stderr.write("leak-scan: leak-scan.mjs is stale - run `node scripts/leak-scan/build.mjs`\n");
+    process.exit(1);
+  }
+  process.stdout.write("leak-scan: bundle up to date\n");
+} else {
+  process.stdout.write(`leak-scan: built ${committed}\n`);
+}

--- a/scripts/leak-scan/cli.ts
+++ b/scripts/leak-scan/cli.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ConfigError, loadLocalRules } from './config';
+import { makeIsIgnored, parseLeakignore } from './leakignore';
+import { formatJson, formatText } from './report';
+import { BASE_RULES } from './rules';
+import { DEFAULT_EXCLUDE_FILE_GLOBS, scanPaths } from './scan';
+
+export interface CliResult {
+  readonly code: 0 | 1 | 2;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const HELP = [
+  'leak-scan - detect private paths, IDs, and credentials that must not ship.',
+  '',
+  'Usage: leak-scan [path...] [--json] [--leakignore=FILE] [--local-rules=FILE]',
+  '',
+  '  path...           directories/files to scan (default: current directory)',
+  '  --json            machine-readable output',
+  '  --leakignore=F    allowlist file (default: <root>/.leakignore)',
+  '  --local-rules=F   repo-local sensitive rules (default: <root>/.leakrules.json)',
+  '',
+  'Exit codes: 0 clean, 1 violations found, 2 setup error.',
+  '',
+].join('\n');
+
+// The scanner's own artifacts are self-excluded so they never flag their own
+// rule patterns (analogous to the bash scanner excluding its own filename).
+const SELF_EXCLUDE_GLOBS = ['leak-scan.mjs', 'check-no-private-leaks.sh', '.leakrules.json'];
+
+/** Pure CLI core: no process.exit, returns code + streams, so it is unit-testable. */
+export function runCli(argv: readonly string[], cwd: string): CliResult {
+  let json = false;
+  let leakignorePath: string | undefined;
+  let localRulesPath: string | undefined;
+  const paths: string[] = [];
+  for (const arg of argv) {
+    if (arg === '--json') json = true;
+    else if (arg === '--help' || arg === '-h') return { code: 0, stdout: HELP, stderr: '' };
+    else if (arg.startsWith('--leakignore=')) leakignorePath = arg.slice('--leakignore='.length);
+    else if (arg.startsWith('--local-rules=')) localRulesPath = arg.slice('--local-rules='.length);
+    else if (arg.startsWith('-'))
+      return { code: 2, stdout: '', stderr: `leak-scan: unknown option ${arg}\n` };
+    else paths.push(arg);
+  }
+
+  const roots = paths.length > 0 ? paths : [cwd];
+  const primaryRoot = roots[0] ?? cwd;
+
+  for (const p of roots) {
+    if (!existsSync(p))
+      return { code: 2, stdout: '', stderr: `leak-scan: scan path not found: ${p}\n` };
+  }
+
+  let rules = BASE_RULES;
+  try {
+    const local = loadLocalRules(localRulesPath ?? join(primaryRoot, '.leakrules.json'));
+    if (local.length > 0) rules = [...BASE_RULES, ...local];
+  } catch (err) {
+    if (err instanceof ConfigError) return { code: 2, stdout: '', stderr: `${err.message}\n` };
+    throw err;
+  }
+
+  const leakignoreFile = leakignorePath ?? join(primaryRoot, '.leakignore');
+  const isIgnored = existsSync(leakignoreFile)
+    ? makeIsIgnored(parseLeakignore(readFileSync(leakignoreFile, 'utf8')))
+    : undefined;
+
+  const excludeFileGlobs = [...DEFAULT_EXCLUDE_FILE_GLOBS, ...SELF_EXCLUDE_GLOBS];
+  const { findings, violations } = scanPaths(rules, roots, { isIgnored, excludeFileGlobs });
+
+  if (json) {
+    return { code: violations > 0 ? 1 : 0, stdout: `${formatJson(findings)}\n`, stderr: '' };
+  }
+  if (violations > 0) {
+    return {
+      code: 1,
+      stdout: `${formatText(findings)}\n`,
+      stderr: `leak-scan: FAIL - ${violations} violation(s)\n`,
+    };
+  }
+  return { code: 0, stdout: `leak-scan: OK - no leaks across ${roots.join(', ')}\n`, stderr: '' };
+}
+
+// Thin launcher. Guarded so importing runCli under Vitest does not exit the runner.
+if (!process.env.VITEST) {
+  const result = runCli(process.argv.slice(2), process.cwd());
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.code);
+}

--- a/scripts/leak-scan/config.ts
+++ b/scripts/leak-scan/config.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { literalIncludes } from './predicates';
+import type { Rule } from './rules';
+
+/** Thrown on a malformed repo-local rules file so the CLI can exit 2 (setup error). */
+export class ConfigError extends Error {}
+
+interface RawRule {
+  readonly tag?: unknown;
+  readonly reason?: unknown;
+  readonly literal?: unknown;
+  readonly anyOf?: unknown;
+}
+
+/**
+ * Load repo-local SENSITIVE rules from a JSON file (default `.leakrules.json`).
+ * These are the literal values that must NOT live in the shipped bundle —
+ * internal hostname, customer / prospect / person names, operator bank, etc.
+ *
+ * Format: a JSON array of `{ tag, reason, (literal | anyOf) }`. `literal` is a
+ * single substring; `anyOf` is a list of substrings (match any) — e.g. the two
+ * case forms of a name. Structured-token rules are all generic and live in
+ * BASE; repo-local rules are literal-only, which keeps them JSON-expressible.
+ *
+ * Missing file => no local rules. Malformed file => ConfigError (fail loud).
+ */
+export function loadLocalRules(path: string): Rule[] {
+  if (!existsSync(path)) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new ConfigError(`leak-scan: invalid JSON in ${path}: ${(err as Error).message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new ConfigError(`leak-scan: ${path} must be a JSON array of rules`);
+  }
+  return parsed.map((raw, index) => toRule(raw as RawRule, index, path));
+}
+
+function toRule(raw: RawRule, index: number, path: string): Rule {
+  const where = `${path}[${index}]`;
+  if (typeof raw.tag !== 'string' || raw.tag === '') {
+    throw new ConfigError(`${where}: "tag" must be a non-empty string`);
+  }
+  if (typeof raw.reason !== 'string' || raw.reason === '') {
+    throw new ConfigError(`${where}: "reason" must be a non-empty string`);
+  }
+  const hasLiteral = typeof raw.literal === 'string';
+  const hasAnyOf = Array.isArray(raw.anyOf);
+  if (hasLiteral === hasAnyOf) {
+    throw new ConfigError(
+      `${where}: provide exactly one of "literal" (string) or "anyOf" (string[])`,
+    );
+  }
+  const { tag, reason } = raw;
+  if (hasLiteral) {
+    const value = raw.literal as string;
+    if (value === '') throw new ConfigError(`${where}: "literal" must be non-empty`);
+    return { tag, reason, matches: (line) => literalIncludes(line, value) };
+  }
+  const values = (raw.anyOf as unknown[]).map((v, j) => {
+    if (typeof v !== 'string' || v === '') {
+      throw new ConfigError(`${where}.anyOf[${j}]: each entry must be a non-empty string`);
+    }
+    return v;
+  });
+  if (values.length === 0) throw new ConfigError(`${where}: "anyOf" must list at least one string`);
+  return { tag, reason, matches: (line) => values.some((v) => literalIncludes(line, v)) };
+}

--- a/scripts/leak-scan/glob.ts
+++ b/scripts/leak-scan/glob.ts
@@ -1,0 +1,31 @@
+// No-regex glob matching for path excludes and `.leakignore` path-globs.
+//
+// Classic iterative wildcard matcher: `*` matches any run of characters
+// (including `/`, matching the legacy bash `[[ path == glob ]]` semantics) and
+// `?` matches exactly one character. No RegExp (M2 hardline).
+export function matchGlob(text: string, pattern: string): boolean {
+  let t = 0;
+  let p = 0;
+  let star = -1;
+  let mark = 0;
+  while (t < text.length) {
+    if (p < pattern.length && (pattern[p] === '?' || pattern[p] === text[t])) {
+      t += 1;
+      p += 1;
+    } else if (p < pattern.length && pattern[p] === '*') {
+      star = p;
+      mark = t;
+      p += 1;
+    } else if (star !== -1) {
+      p = star + 1;
+      mark += 1;
+      t = mark;
+    } else {
+      return false;
+    }
+  }
+  while (p < pattern.length && pattern[p] === '*') {
+    p += 1;
+  }
+  return p === pattern.length;
+}

--- a/scripts/leak-scan/leak-scan.mjs
+++ b/scripts/leak-scan/leak-scan.mjs
@@ -1,0 +1,439 @@
+// scripts/leak-scan/cli.ts
+import { existsSync as existsSync2, readFileSync as readFileSync3 } from "node:fs";
+import { join as join2 } from "node:path";
+
+// scripts/leak-scan/config.ts
+import { existsSync, readFileSync } from "node:fs";
+
+// scripts/leak-scan/predicates.ts
+var isLower = (c) => c >= "a" && c <= "z";
+var isUpper = (c) => c >= "A" && c <= "Z";
+var isDigit = (c) => c >= "0" && c <= "9";
+var isHexLower = (c) => isDigit(c) || c >= "a" && c <= "f";
+var isAlnum = (c) => isLower(c) || isUpper(c) || isDigit(c);
+var isLowerNameChar = (c) => isLower(c) || isDigit(c) || c === "_" || c === "-";
+var isNameChar = (c) => isAlnum(c) || c === "_" || c === "-";
+var isPathSep = (c) => c === "\\" || c === "/";
+var lit = (value) => ({ kind: "literal", value });
+var run = (cls, min, max) => ({
+  kind: "class",
+  cls,
+  min,
+  max
+});
+function matchAt(s, start, segments) {
+  let i = start;
+  for (const seg of segments) {
+    if (seg.kind === "literal") {
+      if (!s.startsWith(seg.value, i)) return -1;
+      i += seg.value.length;
+    } else {
+      const cap = seg.max ?? Number.POSITIVE_INFINITY;
+      let count = 0;
+      while (i < s.length && count < cap && seg.cls(s[i])) {
+        i += 1;
+        count += 1;
+      }
+      if (count < seg.min) return -1;
+    }
+  }
+  return i;
+}
+function containsPattern(s, segments) {
+  for (let i = 0; i < s.length; i += 1) {
+    if (matchAt(s, i, segments) !== -1) return true;
+  }
+  return false;
+}
+function literalIncludes(s, value) {
+  return s.includes(value);
+}
+
+// scripts/leak-scan/config.ts
+var ConfigError = class extends Error {
+};
+function loadLocalRules(path) {
+  if (!existsSync(path)) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new ConfigError(`leak-scan: invalid JSON in ${path}: ${err.message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new ConfigError(`leak-scan: ${path} must be a JSON array of rules`);
+  }
+  return parsed.map((raw, index) => toRule(raw, index, path));
+}
+function toRule(raw, index, path) {
+  const where = `${path}[${index}]`;
+  if (typeof raw.tag !== "string" || raw.tag === "") {
+    throw new ConfigError(`${where}: "tag" must be a non-empty string`);
+  }
+  if (typeof raw.reason !== "string" || raw.reason === "") {
+    throw new ConfigError(`${where}: "reason" must be a non-empty string`);
+  }
+  const hasLiteral = typeof raw.literal === "string";
+  const hasAnyOf = Array.isArray(raw.anyOf);
+  if (hasLiteral === hasAnyOf) {
+    throw new ConfigError(
+      `${where}: provide exactly one of "literal" (string) or "anyOf" (string[])`
+    );
+  }
+  const { tag, reason } = raw;
+  if (hasLiteral) {
+    const value = raw.literal;
+    if (value === "") throw new ConfigError(`${where}: "literal" must be non-empty`);
+    return { tag, reason, matches: (line) => literalIncludes(line, value) };
+  }
+  const values = raw.anyOf.map((v, j) => {
+    if (typeof v !== "string" || v === "") {
+      throw new ConfigError(`${where}.anyOf[${j}]: each entry must be a non-empty string`);
+    }
+    return v;
+  });
+  if (values.length === 0) throw new ConfigError(`${where}: "anyOf" must list at least one string`);
+  return { tag, reason, matches: (line) => values.some((v) => literalIncludes(line, v)) };
+}
+
+// scripts/leak-scan/glob.ts
+function matchGlob(text, pattern) {
+  let t = 0;
+  let p = 0;
+  let star = -1;
+  let mark = 0;
+  while (t < text.length) {
+    if (p < pattern.length && (pattern[p] === "?" || pattern[p] === text[t])) {
+      t += 1;
+      p += 1;
+    } else if (p < pattern.length && pattern[p] === "*") {
+      star = p;
+      mark = t;
+      p += 1;
+    } else if (star !== -1) {
+      p = star + 1;
+      mark += 1;
+      t = mark;
+    } else {
+      return false;
+    }
+  }
+  while (p < pattern.length && pattern[p] === "*") {
+    p += 1;
+  }
+  return p === pattern.length;
+}
+
+// scripts/leak-scan/leakignore.ts
+function parseLeakignore(text) {
+  const entries = [];
+  for (const raw of text.split("\n")) {
+    const hash = raw.indexOf("#");
+    const line = (hash === -1 ? raw : raw.slice(0, hash)).trim();
+    if (line === "") continue;
+    const ws = firstWhitespace(line);
+    if (ws === -1) continue;
+    const glob = line.slice(0, ws);
+    const tagSpec = line.slice(ws).trim();
+    if (tagSpec === "") continue;
+    const tags = new Set(
+      tagSpec.split(",").map((tag) => tag.trim()).filter((tag) => tag !== "")
+    );
+    if (tags.size === 0) continue;
+    entries.push({ glob, tags });
+  }
+  return entries;
+}
+function firstWhitespace(s) {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s[i];
+    if (c === " " || c === "	") return i;
+  }
+  return -1;
+}
+function makeIsIgnored(entries) {
+  return (relPath, tag) => {
+    const rel = relPath.startsWith("./") ? relPath.slice(2) : relPath;
+    for (const entry of entries) {
+      if (entry.tags.has(tag) && matchGlob(rel, entry.glob)) return true;
+    }
+    return false;
+  };
+}
+
+// scripts/leak-scan/report.ts
+function formatText(findings) {
+  const out = [];
+  for (const f of findings) {
+    out.push(`[LEAK:${f.tag}] ${f.file}:${f.line} - ${f.reason}`);
+    out.push(`  -> ${f.content}`);
+  }
+  return out.join("\n");
+}
+function formatJson(findings) {
+  return JSON.stringify({ violations: findings.length, entries: findings });
+}
+
+// scripts/leak-scan/rules.ts
+var literalRule = (tag, value, reason) => ({
+  tag,
+  reason,
+  matches: (line) => literalIncludes(line, value)
+});
+var patternRule = (tag, segments, reason) => ({
+  tag,
+  reason,
+  matches: (line) => containsPattern(line, segments)
+});
+var isCDrive = (c) => c === "c" || c === "C";
+var BASE_RULES = [
+  patternRule(
+    "abs-home-path",
+    [lit("/home/"), run(isLower, 1, 1), run(isLowerNameChar, 1)],
+    "absolute user home path (/home/<username>/...)"
+  ),
+  patternRule(
+    "abs-windows-user",
+    [
+      run(isCDrive, 1, 1),
+      lit(":"),
+      run(isPathSep, 1, 1),
+      lit("Users"),
+      run(isPathSep, 1, 1),
+      run(isNameChar, 1)
+    ],
+    "absolute Windows user path (C:\\Users\\<name>)"
+  ),
+  literalRule("private-jv-repo", "revfleet/.jv", "private repo path (~/revfleet/.jv/...)"),
+  literalRule("private-jv-name", "revealui-jv", "private repo name (revealui-jv)"),
+  literalRule("lts-drive", "/mnt/e/", "LTS drive mount path"),
+  literalRule("forge-drive", "/mnt/forge/", "Forge drive mount path"),
+  literalRule("sandbox-drive", "/mnt/sandbox/", "Sandbox drive mount path"),
+  patternRule(
+    "license-key",
+    [lit("RVUI-"), run(isLower, 1), lit("-"), run(isHexLower, 16)],
+    "RevealUI license key (looks like a real issued key)"
+  ),
+  patternRule("vercel-org-id", [lit("team_"), run(isAlnum, 16)], "Vercel org/team identifier"),
+  patternRule("vercel-project-id", [lit("prj_"), run(isAlnum, 16)], "Vercel project identifier"),
+  patternRule("stripe-account", [lit("acct_"), run(isAlnum, 14)], "Stripe account identifier"),
+  patternRule("stripe-product", [lit("prod_"), run(isAlnum, 14)], "Stripe product identifier"),
+  patternRule(
+    "stripe-portal-config",
+    [lit("bpc_"), run(isAlnum, 14)],
+    "Stripe billing portal config identifier"
+  ),
+  literalRule("revvault-path-prod", "revvault/prod/", "revvault prod credential path"),
+  literalRule("revvault-path-dev", "revvault/dev/", "revvault dev credential path"),
+  literalRule("revvault-path-forge", "revvault/forge/", "revvault forge credential path"),
+  literalRule("age-identity", ".age-identity", "age identity key reference"),
+  literalRule("coord-paths", ".claude/coordination/", "coordination directory path"),
+  literalRule("coord-workboard", "/.claude/workboard.md", "workboard.md path reference"),
+  literalRule("coord-beacon", "context-beacon.json", "context-beacon.json path reference"),
+  patternRule(
+    "internal-handoff",
+    [
+      lit("/HANDOFF-"),
+      run(isDigit, 4, 4),
+      lit("-"),
+      run(isDigit, 2, 2),
+      lit("-"),
+      run(isDigit, 2, 2)
+    ],
+    "internal handoff doc reference"
+  ),
+  patternRule(
+    "internal-gap-id",
+    [lit("GAP-"), run(isDigit, 3)],
+    "internal gap/work-item identifier (private surface)"
+  ),
+  literalRule("internal-master-plan", "MASTER_PLAN.md", "master plan doc reference")
+];
+
+// scripts/leak-scan/scan.ts
+import { lstatSync, readdirSync, readFileSync as readFileSync2 } from "node:fs";
+import { join, relative } from "node:path";
+var DEFAULT_EXCLUDE_DIRS = /* @__PURE__ */ new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".pnpm",
+  "coverage",
+  "target",
+  ".direnv",
+  ".nyc_output"
+]);
+var DEFAULT_EXCLUDE_FILE_GLOBS = [
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "Cargo.lock",
+  "*.png",
+  "*.jpg",
+  "*.jpeg",
+  "*.gif",
+  "*.webp",
+  "*.pdf",
+  "*.zip",
+  "*.tar.gz",
+  "*.tgz",
+  "*.ico",
+  "*.woff",
+  "*.woff2",
+  "*.ttf",
+  "*.otf"
+];
+function isExcludedFile(name, globs) {
+  for (const glob of globs) {
+    if (matchGlob(name, glob)) return true;
+  }
+  return false;
+}
+function scanContent(rules, content, file) {
+  const findings = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    for (const rule of rules) {
+      if (rule.matches(line)) {
+        findings.push({ tag: rule.tag, file, line: i + 1, reason: rule.reason, content: line });
+      }
+    }
+  }
+  return findings;
+}
+function walkFiles(root, excludeDirs, excludeFileGlobs) {
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      let isSymlink = false;
+      try {
+        isSymlink = lstatSync(full).isSymbolicLink();
+      } catch {
+        continue;
+      }
+      if (isSymlink) continue;
+      if (entry.isDirectory()) {
+        if (!excludeDirs.has(entry.name)) stack.push(full);
+      } else if (entry.isFile()) {
+        if (!isExcludedFile(entry.name, excludeFileGlobs)) out.push(full);
+      }
+    }
+  }
+  return out;
+}
+function toForwardSlashes(p) {
+  return p.split("\\").join("/");
+}
+function scanPaths(rules, roots, opts = {}) {
+  const excludeDirs = opts.excludeDirs ?? DEFAULT_EXCLUDE_DIRS;
+  const excludeFileGlobs = opts.excludeFileGlobs ?? DEFAULT_EXCLUDE_FILE_GLOBS;
+  const isIgnored = opts.isIgnored ?? (() => false);
+  const maxBytes = opts.maxBytes ?? 5e6;
+  const findings = [];
+  for (const root of roots) {
+    for (const file of walkFiles(root, excludeDirs, excludeFileGlobs)) {
+      let content;
+      try {
+        const buf = readFileSync2(file);
+        if (buf.length > maxBytes || buf.includes(0)) continue;
+        content = buf.toString("utf8");
+      } catch {
+        continue;
+      }
+      const rel = toForwardSlashes(relative(root, file));
+      for (const finding of scanContent(rules, content, file)) {
+        if (!isIgnored(rel, finding.tag)) findings.push(finding);
+      }
+    }
+  }
+  return { findings, violations: findings.length };
+}
+
+// scripts/leak-scan/cli.ts
+var HELP = [
+  "leak-scan - detect private paths, IDs, and credentials that must not ship.",
+  "",
+  "Usage: leak-scan [path...] [--json] [--leakignore=FILE] [--local-rules=FILE]",
+  "",
+  "  path...           directories/files to scan (default: current directory)",
+  "  --json            machine-readable output",
+  "  --leakignore=F    allowlist file (default: <root>/.leakignore)",
+  "  --local-rules=F   repo-local sensitive rules (default: <root>/.leakrules.json)",
+  "",
+  "Exit codes: 0 clean, 1 violations found, 2 setup error.",
+  ""
+].join("\n");
+var SELF_EXCLUDE_GLOBS = ["leak-scan.mjs", "check-no-private-leaks.sh", ".leakrules.json"];
+function runCli(argv, cwd) {
+  let json = false;
+  let leakignorePath;
+  let localRulesPath;
+  const paths = [];
+  for (const arg of argv) {
+    if (arg === "--json") json = true;
+    else if (arg === "--help" || arg === "-h") return { code: 0, stdout: HELP, stderr: "" };
+    else if (arg.startsWith("--leakignore=")) leakignorePath = arg.slice("--leakignore=".length);
+    else if (arg.startsWith("--local-rules=")) localRulesPath = arg.slice("--local-rules=".length);
+    else if (arg.startsWith("-"))
+      return { code: 2, stdout: "", stderr: `leak-scan: unknown option ${arg}
+` };
+    else paths.push(arg);
+  }
+  const roots = paths.length > 0 ? paths : [cwd];
+  const primaryRoot = roots[0] ?? cwd;
+  for (const p of roots) {
+    if (!existsSync2(p))
+      return { code: 2, stdout: "", stderr: `leak-scan: scan path not found: ${p}
+` };
+  }
+  let rules = BASE_RULES;
+  try {
+    const local = loadLocalRules(localRulesPath ?? join2(primaryRoot, ".leakrules.json"));
+    if (local.length > 0) rules = [...BASE_RULES, ...local];
+  } catch (err) {
+    if (err instanceof ConfigError) return { code: 2, stdout: "", stderr: `${err.message}
+` };
+    throw err;
+  }
+  const leakignoreFile = leakignorePath ?? join2(primaryRoot, ".leakignore");
+  const isIgnored = existsSync2(leakignoreFile) ? makeIsIgnored(parseLeakignore(readFileSync3(leakignoreFile, "utf8"))) : void 0;
+  const excludeFileGlobs = [...DEFAULT_EXCLUDE_FILE_GLOBS, ...SELF_EXCLUDE_GLOBS];
+  const { findings, violations } = scanPaths(rules, roots, { isIgnored, excludeFileGlobs });
+  if (json) {
+    return { code: violations > 0 ? 1 : 0, stdout: `${formatJson(findings)}
+`, stderr: "" };
+  }
+  if (violations > 0) {
+    return {
+      code: 1,
+      stdout: `${formatText(findings)}
+`,
+      stderr: `leak-scan: FAIL - ${violations} violation(s)
+`
+    };
+  }
+  return { code: 0, stdout: `leak-scan: OK - no leaks across ${roots.join(", ")}
+`, stderr: "" };
+}
+if (!process.env.VITEST) {
+  const result = runCli(process.argv.slice(2), process.cwd());
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.code);
+}
+export {
+  runCli
+};

--- a/scripts/leak-scan/leakignore.ts
+++ b/scripts/leak-scan/leakignore.ts
@@ -1,0 +1,61 @@
+import { matchGlob } from './glob';
+
+export interface IgnoreEntry {
+  readonly glob: string;
+  readonly tags: ReadonlySet<string>;
+}
+
+/**
+ * Parse a `.leakignore` allowlist. Format per line:
+ *   `<path-glob> <tag[,tag...]>  # reason`
+ * Blank lines, comment lines, and glob-only lines (no tags) are skipped, exactly
+ * matching the legacy bash parser.
+ */
+export function parseLeakignore(text: string): IgnoreEntry[] {
+  const entries: IgnoreEntry[] = [];
+  for (const raw of text.split('\n')) {
+    const hash = raw.indexOf('#');
+    const line = (hash === -1 ? raw : raw.slice(0, hash)).trim();
+    if (line === '') continue;
+    const ws = firstWhitespace(line);
+    if (ws === -1) continue; // glob with no tags
+    const glob = line.slice(0, ws);
+    const tagSpec = line.slice(ws).trim();
+    if (tagSpec === '') continue;
+    const tags = new Set(
+      tagSpec
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== ''),
+    );
+    if (tags.size === 0) continue;
+    entries.push({ glob, tags });
+  }
+  return entries;
+}
+
+function firstWhitespace(s: string): number {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s[i];
+    if (c === ' ' || c === '\t') return i;
+  }
+  return -1;
+}
+
+/**
+ * Build the allowlist predicate. A finding is suppressed only when BOTH the
+ * relative path matches an entry's glob AND the finding's tag is in that entry's
+ * tag set. A leading `./` on the path is normalized away (revvault#45 parity:
+ * `frontend/src/foo.ts` and `./frontend/src/foo.ts` must match the same glob).
+ */
+export function makeIsIgnored(
+  entries: readonly IgnoreEntry[],
+): (relPath: string, tag: string) => boolean {
+  return (relPath, tag) => {
+    const rel = relPath.startsWith('./') ? relPath.slice(2) : relPath;
+    for (const entry of entries) {
+      if (entry.tags.has(tag) && matchGlob(rel, entry.glob)) return true;
+    }
+    return false;
+  };
+}

--- a/scripts/leak-scan/predicates.ts
+++ b/scripts/leak-scan/predicates.ts
@@ -1,0 +1,80 @@
+// No-regex matching primitives for the leak scanner.
+//
+// Per the fleet zero-regex hardline (M2 / feedback_no_regex_ast_only): every
+// rule is expressed with a literal substring check or a small typed segment
+// matcher over code points. No RegExp is constructed anywhere in this tool.
+
+/** A character-class predicate over a single character. */
+export type CharClass = (ch: string) => boolean;
+
+export const isLower: CharClass = (c) => c >= 'a' && c <= 'z';
+export const isUpper: CharClass = (c) => c >= 'A' && c <= 'Z';
+export const isDigit: CharClass = (c) => c >= '0' && c <= '9';
+export const isHexLower: CharClass = (c) => isDigit(c) || (c >= 'a' && c <= 'f');
+export const isAlnum: CharClass = (c) => isLower(c) || isUpper(c) || isDigit(c);
+/** [a-z0-9_-] — unix username body. */
+export const isLowerNameChar: CharClass = (c) => isLower(c) || isDigit(c) || c === '_' || c === '-';
+/** [A-Za-z0-9_-] — Windows username body. */
+export const isNameChar: CharClass = (c) => isAlnum(c) || c === '_' || c === '-';
+/** Path separator: backslash or forward slash. */
+export const isPathSep: CharClass = (c) => c === '\\' || c === '/';
+
+/**
+ * A pattern segment: either a fixed literal, or a run of `min`..`max`
+ * (max omitted = unbounded) consecutive characters all satisfying `cls`.
+ */
+export type Segment =
+  | { readonly kind: 'literal'; readonly value: string }
+  | {
+      readonly kind: 'class';
+      readonly cls: CharClass;
+      readonly min: number;
+      readonly max?: number;
+    };
+
+export const lit = (value: string): Segment => ({ kind: 'literal', value });
+export const run = (cls: CharClass, min: number, max?: number): Segment => ({
+  kind: 'class',
+  cls,
+  min,
+  max,
+});
+
+/**
+ * Try to match `segments` in order, anchored at index `start`. Class runs are
+ * greedy with no backtracking — sufficient and intentional, because every rule
+ * keeps each class run either terminal or followed by a literal whose first
+ * character is OUTSIDE the run's class, so greedy never over-eats a character a
+ * later literal needs. Returns the end index, or -1 on no match.
+ */
+function matchAt(s: string, start: number, segments: readonly Segment[]): number {
+  let i = start;
+  for (const seg of segments) {
+    if (seg.kind === 'literal') {
+      if (!s.startsWith(seg.value, i)) return -1;
+      i += seg.value.length;
+    } else {
+      const cap = seg.max ?? Number.POSITIVE_INFINITY;
+      let count = 0;
+      while (i < s.length && count < cap && seg.cls(s[i] as string)) {
+        i += 1;
+        count += 1;
+      }
+      if (count < seg.min) return -1;
+    }
+  }
+  return i;
+}
+
+/** True if `segments` match starting at some index in `s`. */
+export function containsPattern(s: string, segments: readonly Segment[]): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    if (matchAt(s, i, segments) !== -1) return true;
+  }
+  return false;
+}
+
+/** True if `s` contains `value` as a literal substring. */
+export function literalIncludes(s: string, value: string): boolean {
+  return s.includes(value);
+}

--- a/scripts/leak-scan/report.ts
+++ b/scripts/leak-scan/report.ts
@@ -1,0 +1,16 @@
+import type { Finding } from './scan';
+
+/** Human-readable: a `[LEAK:tag] file:line` header + an indented content line per finding. */
+export function formatText(findings: readonly Finding[]): string {
+  const out: string[] = [];
+  for (const f of findings) {
+    out.push(`[LEAK:${f.tag}] ${f.file}:${f.line} - ${f.reason}`);
+    out.push(`  -> ${f.content}`);
+  }
+  return out.join('\n');
+}
+
+/** Machine-readable: `{ violations, entries }` — mirrors the legacy LEAK_JSON shape. */
+export function formatJson(findings: readonly Finding[]): string {
+  return JSON.stringify({ violations: findings.length, entries: findings });
+}

--- a/scripts/leak-scan/rules.ts
+++ b/scripts/leak-scan/rules.ts
@@ -114,20 +114,22 @@ export const BASE_RULES: readonly Rule[] = [
 ];
 
 /**
- * Tags whose patterns are SENSITIVE literal values. Intentionally absent from
- * BASE_RULES; each repo supplies them via local config (the cutover moves them
- * out of that repo's bash scanner). Listed so the migration knows the exact set
- * to relocate, and so a test can assert none of them leaked into BASE_RULES.
+ * Generic CATEGORY tags for SENSITIVE literal rules. Intentionally absent from
+ * BASE_RULES; each repo supplies the actual values via local config. The tags
+ * are kept generic (no real customer / prospect / host values) because this
+ * source is public — the per-repo cutover maps each bash scanner's specific tag
+ * onto the matching category here and into that repo's .leakrules.json (and
+ * updates its .leakignore keys to match). A test asserts none appear in BASE.
  */
 export const SENSITIVE_TAGS: readonly string[] = [
-  'devbox-host',
+  'internal-hostname',
   'personal-email',
-  'customer-allevia',
-  'customer-alleviafleet',
-  'prospect-stefan',
-  'prospect-djones-name',
-  'prospect-djones-email',
-  'venture-biotix',
-  'bank-mercury',
-  'anthropic-partner',
+  'customer-name',
+  'customer-brand',
+  'prospect-name',
+  'prospect-contact',
+  'prospect-email',
+  'internal-venture',
+  'operator-bank',
+  'partner-reference',
 ];

--- a/scripts/leak-scan/rules.ts
+++ b/scripts/leak-scan/rules.ts
@@ -1,0 +1,133 @@
+import {
+  type CharClass,
+  containsPattern,
+  isAlnum,
+  isDigit,
+  isHexLower,
+  isLower,
+  isLowerNameChar,
+  isNameChar,
+  isPathSep,
+  lit,
+  literalIncludes,
+  run,
+  type Segment,
+} from './predicates';
+
+export interface Rule {
+  /** Stable tag, kept 1:1 with the legacy bash scanner so `.leakignore` entries keep resolving. */
+  readonly tag: string;
+  /** Human-readable reason shown on a hit. */
+  readonly reason: string;
+  /** True if `line` contains the disallowed pattern. No regex. */
+  readonly matches: (line: string) => boolean;
+}
+
+const literalRule = (tag: string, value: string, reason: string): Rule => ({
+  tag,
+  reason,
+  matches: (line) => literalIncludes(line, value),
+});
+
+const patternRule = (tag: string, segments: readonly Segment[], reason: string): Rule => ({
+  tag,
+  reason,
+  matches: (line) => containsPattern(line, segments),
+});
+
+/** 'c' or 'C' — the drive-letter head of the abs-windows-user rule. */
+const isCDrive: CharClass = (c) => c === 'c' || c === 'C';
+
+/**
+ * BASE ruleset — generic, structural patterns only, kept tag-for-tag with the
+ * legacy bash scanner so existing `.leakignore` allowlists keep resolving.
+ *
+ * Public-safe by construction: every entry describes a SHAPE or a well-known
+ * non-secret NAME (mount path, ID format, internal doc name), never a secret
+ * VALUE. Sensitive literals (internal hostname, customer / prospect / person
+ * names, operator bank, partnership, personal email) are NOT here — see
+ * SENSITIVE_TAGS. They are supplied per-repo via local config so this shipped
+ * bundle never carries a private value into a public repo.
+ */
+export const BASE_RULES: readonly Rule[] = [
+  patternRule(
+    'abs-home-path',
+    [lit('/home/'), run(isLower, 1, 1), run(isLowerNameChar, 1)],
+    'absolute user home path (/home/<username>/...)',
+  ),
+  patternRule(
+    'abs-windows-user',
+    [
+      run(isCDrive, 1, 1),
+      lit(':'),
+      run(isPathSep, 1, 1),
+      lit('Users'),
+      run(isPathSep, 1, 1),
+      run(isNameChar, 1),
+    ],
+    'absolute Windows user path (C:\\Users\\<name>)',
+  ),
+  literalRule('private-jv-repo', 'revfleet/.jv', 'private repo path (~/revfleet/.jv/...)'),
+  literalRule('private-jv-name', 'revealui-jv', 'private repo name (revealui-jv)'),
+  literalRule('lts-drive', '/mnt/e/', 'LTS drive mount path'),
+  literalRule('forge-drive', '/mnt/forge/', 'Forge drive mount path'),
+  literalRule('sandbox-drive', '/mnt/sandbox/', 'Sandbox drive mount path'),
+  patternRule(
+    'license-key',
+    [lit('RVUI-'), run(isLower, 1), lit('-'), run(isHexLower, 16)],
+    'RevealUI license key (looks like a real issued key)',
+  ),
+  patternRule('vercel-org-id', [lit('team_'), run(isAlnum, 16)], 'Vercel org/team identifier'),
+  patternRule('vercel-project-id', [lit('prj_'), run(isAlnum, 16)], 'Vercel project identifier'),
+  patternRule('stripe-account', [lit('acct_'), run(isAlnum, 14)], 'Stripe account identifier'),
+  patternRule('stripe-product', [lit('prod_'), run(isAlnum, 14)], 'Stripe product identifier'),
+  patternRule(
+    'stripe-portal-config',
+    [lit('bpc_'), run(isAlnum, 14)],
+    'Stripe billing portal config identifier',
+  ),
+  literalRule('revvault-path-prod', 'revvault/prod/', 'revvault prod credential path'),
+  literalRule('revvault-path-dev', 'revvault/dev/', 'revvault dev credential path'),
+  literalRule('revvault-path-forge', 'revvault/forge/', 'revvault forge credential path'),
+  literalRule('age-identity', '.age-identity', 'age identity key reference'),
+  literalRule('coord-paths', '.claude/coordination/', 'coordination directory path'),
+  literalRule('coord-workboard', '/.claude/workboard.md', 'workboard.md path reference'),
+  literalRule('coord-beacon', 'context-beacon.json', 'context-beacon.json path reference'),
+  patternRule(
+    'internal-handoff',
+    [
+      lit('/HANDOFF-'),
+      run(isDigit, 4, 4),
+      lit('-'),
+      run(isDigit, 2, 2),
+      lit('-'),
+      run(isDigit, 2, 2),
+    ],
+    'internal handoff doc reference',
+  ),
+  patternRule(
+    'internal-gap-id',
+    [lit('GAP-'), run(isDigit, 3)],
+    'internal gap/work-item identifier (private surface)',
+  ),
+  literalRule('internal-master-plan', 'MASTER_PLAN.md', 'master plan doc reference'),
+];
+
+/**
+ * Tags whose patterns are SENSITIVE literal values. Intentionally absent from
+ * BASE_RULES; each repo supplies them via local config (the cutover moves them
+ * out of that repo's bash scanner). Listed so the migration knows the exact set
+ * to relocate, and so a test can assert none of them leaked into BASE_RULES.
+ */
+export const SENSITIVE_TAGS: readonly string[] = [
+  'devbox-host',
+  'personal-email',
+  'customer-allevia',
+  'customer-alleviafleet',
+  'prospect-stefan',
+  'prospect-djones-name',
+  'prospect-djones-email',
+  'venture-biotix',
+  'bank-mercury',
+  'anthropic-partner',
+];

--- a/scripts/leak-scan/scan.ts
+++ b/scripts/leak-scan/scan.ts
@@ -1,0 +1,162 @@
+import { type Dirent, lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { matchGlob } from './glob';
+import type { Rule } from './rules';
+
+export interface Finding {
+  readonly tag: string;
+  readonly file: string;
+  readonly line: number;
+  readonly reason: string;
+  readonly content: string;
+}
+
+export interface ScanOptions {
+  readonly excludeDirs?: ReadonlySet<string>;
+  readonly excludeFileGlobs?: readonly string[];
+  /** `(relPath, tag) => true` suppresses a finding. Defaults to never-ignore. */
+  readonly isIgnored?: (relPath: string, tag: string) => boolean;
+  /** Files larger than this many bytes are skipped (binary/asset guard). */
+  readonly maxBytes?: number;
+}
+
+/** Build/dev-artifact dirs skipped by default — mirrors the bash EXCLUDE_DIRS. */
+export const DEFAULT_EXCLUDE_DIRS: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.pnpm',
+  'coverage',
+  'target',
+  '.direnv',
+  '.nyc_output',
+]);
+
+/**
+ * Lockfiles + binary assets skipped by default — mirrors the bash EXCLUDE_FILES,
+ * MINUS the scanner's own filename, `.leakignore`, and `settings.local.json`:
+ * those are deliberately scanned (revdev#55 — excluding the allowlist or a
+ * stray local settings file would let a real leak bypass the gate).
+ */
+export const DEFAULT_EXCLUDE_FILE_GLOBS: readonly string[] = [
+  'pnpm-lock.yaml',
+  'package-lock.json',
+  'yarn.lock',
+  'Cargo.lock',
+  '*.png',
+  '*.jpg',
+  '*.jpeg',
+  '*.gif',
+  '*.webp',
+  '*.pdf',
+  '*.zip',
+  '*.tar.gz',
+  '*.tgz',
+  '*.ico',
+  '*.woff',
+  '*.woff2',
+  '*.ttf',
+  '*.otf',
+];
+
+function isExcludedFile(name: string, globs: readonly string[]): boolean {
+  for (const glob of globs) {
+    if (matchGlob(name, glob)) return true;
+  }
+  return false;
+}
+
+/** Apply every rule to every line of `content`. Pure; performs no I/O. */
+export function scanContent(rules: readonly Rule[], content: string, file: string): Finding[] {
+  const findings: Finding[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] as string;
+    for (const rule of rules) {
+      if (rule.matches(line)) {
+        findings.push({ tag: rule.tag, file, line: i + 1, reason: rule.reason, content: line });
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Recursively collect scannable file paths under `root`, honoring the dir +
+ * file excludes. Symlinks are skipped (avoids cycles and the worktree's
+ * `node_modules` symlink). Unreadable dirs are skipped, not fatal.
+ */
+export function walkFiles(
+  root: string,
+  excludeDirs: ReadonlySet<string>,
+  excludeFileGlobs: readonly string[],
+): string[] {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      let isSymlink = false;
+      try {
+        isSymlink = lstatSync(full).isSymbolicLink();
+      } catch {
+        continue;
+      }
+      if (isSymlink) continue;
+      if (entry.isDirectory()) {
+        if (!excludeDirs.has(entry.name)) stack.push(full);
+      } else if (entry.isFile()) {
+        if (!isExcludedFile(entry.name, excludeFileGlobs)) out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function toForwardSlashes(p: string): string {
+  return p.split('\\').join('/');
+}
+
+/**
+ * Scan one or more roots. Returns allowlist-filtered findings plus a violation
+ * count. Binary files (containing a NUL byte) and oversized files are skipped,
+ * mirroring `grep -I`.
+ */
+export function scanPaths(
+  rules: readonly Rule[],
+  roots: readonly string[],
+  opts: ScanOptions = {},
+): { findings: Finding[]; violations: number } {
+  const excludeDirs = opts.excludeDirs ?? DEFAULT_EXCLUDE_DIRS;
+  const excludeFileGlobs = opts.excludeFileGlobs ?? DEFAULT_EXCLUDE_FILE_GLOBS;
+  const isIgnored = opts.isIgnored ?? (() => false);
+  const maxBytes = opts.maxBytes ?? 5_000_000;
+  const findings: Finding[] = [];
+  for (const root of roots) {
+    for (const file of walkFiles(root, excludeDirs, excludeFileGlobs)) {
+      let content: string;
+      try {
+        const buf = readFileSync(file);
+        if (buf.length > maxBytes || buf.includes(0)) continue;
+        content = buf.toString('utf8');
+      } catch {
+        continue;
+      }
+      const rel = toForwardSlashes(relative(root, file));
+      for (const finding of scanContent(rules, content, file)) {
+        if (!isIgnored(rel, finding.tag)) findings.push(finding);
+      }
+    }
+  }
+  return { findings, violations: findings.length };
+}

--- a/scripts/leak-scan/vitest.config.ts
+++ b/scripts/leak-scan/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Self-contained so the tool's tests run independently of the monorepo root
+// config: `vitest run --config scripts/leak-scan/vitest.config.ts`.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    root: fileURLToPath(new URL('.', import.meta.url)),
+    include: ['**/*.test.ts'],
+    exclude: ['**/node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary

A no-regex TypeScript leak scanner that consolidates the fleet's `check-no-private-leaks.sh` gates (8 hand-maintained bash copies, 7 byte-identical plus one superset) into a single, tested tool. It lives at `scripts/leak-scan/` as the canonical source and ships as a dependency-free `leak-scan.mjs` that any repo runs with plain `node`.

Motivation: the bash scanners are built on `grep -rEIn` over authored ERE patterns, which is the largest remaining pocket of authored regex in the tooling layer (the fleet's zero-regex / M2 hardline). They are also duplicated across many repos and have already drifted. Tracked by an internal coordination-repo lane.

## What's here

- `predicates.ts` / `rules.ts` — no-regex matching engine (literal substring + a typed segment matcher) and 22 generic BASE rules, tagged 1:1 with the bash scanner so existing `.leakignore` allowlists keep resolving. Plus `SENSITIVE_TAGS` (see Trust boundary).
- `glob.ts` / `scan.ts` / `leakignore.ts` — wildcard matcher, file-walk with excludes + symlink/binary skip, and the `.leakignore` allowlist with the parity quirks from prior review findings (the `./`-prefix normalization; the allowlist + a stray local settings file stay scanned).
- `config.ts` / `report.ts` / `cli.ts` — repo-local rule loader, text + JSON output, and the CLI (`runCli` is pure and testable; a guarded launcher does `process.exit`). Exit `0` clean / `1` violations / `2` setup error.
- `build.mjs` / `leak-scan.mjs` — esbuild bundle (dependency-free, imports only `node:` builtins) plus a `--check` drift gate.

## Verification

- 92 Vitest tests (engine, rules positive+negative, scan over a temp fixture, allowlist, config, CLI, formatters).
- Biome clean; `tsc --strict` clean on all library files.
- The bundle runs standalone on plain `node` in a directory with no `node_modules` (leak → exit 1, clean → exit 0); the drift-check reports up to date.

## Trust boundary

The canonical source lives in this public repo, so the BASE rules carry only shapes and non-secret names (mount paths, ID formats, internal doc names), never a secret value. Sensitive literals (internal hostname, customer / prospect names, operator bank, partnership, personal email) are kept out of the shipped bundle and supplied per-repo via a self-excluded local config. This fixes, rather than cements, today's bash scanners, several of which embed those literals directly.

## Not in this PR (follow-ups)

- Pin `esbuild` as a direct devDep (reproducible bundle) and wire `build.mjs --check` into CI as a drift gate.
- Propagate `leak-scan.mjs` into each consuming repo, then cut each over from its bash scanner one PR at a time, behind an old-vs-new parity harness (identical violation sets before any bash copy is deleted).

## Review / merge

Draft until CI is green and the follow-up hardening lands. Manual merge only (no auto-merge), base `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
