### PR TITLE
fix(core): detoken the admin client to Cobalt semantic tokens (rebrand P1)

### DIFF
--- a/packages/core/src/client/admin/components/AdminDashboard.tsx
+++ b/packages/core/src/client/admin/components/AdminDashboard.tsx
@@ -117,14 +117,18 @@ function reducer(state: DashboardState, action: DashboardAction): DashboardState
 
 function AdminHeader({ title, onBack }: { title: string; onBack: () => void }) {
   return (
-    <header className="bg-white shadow-sm border-b">
+    <header className="bg-card shadow-sm border-b">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-4">
-            <button type="button" onClick={onBack} className="text-gray-400 hover:text-gray-600">
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-muted-foreground hover:text-muted-foreground"
+            >
               ← Back to Dashboard
             </button>
-            <h1 className="text-2xl font-bold text-gray-900 capitalize">{title}</h1>
+            <h1 className="text-2xl font-bold text-foreground capitalize">{title}</h1>
           </div>
           <SignOutButton />
         </div>
@@ -149,7 +153,7 @@ function StatusBanners({
         </div>
       )}
       {successMessage && (
-        <div className="mb-4 bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded">
+        <div className="mb-4 bg-success/10 border border-success/30 text-success px-4 py-3 rounded">
           <p className="font-medium">Success</p>
           <p className="text-sm">{successMessage}</p>
         </div>
@@ -161,8 +165,8 @@ function StatusBanners({
 function LoadingSpinner() {
   return (
     <div className="mb-4 text-center py-8">
-      <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
-      <p className="mt-2 text-sm text-gray-600">Loading...</p>
+      <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
     </div>
   );
 }
@@ -188,7 +192,7 @@ function SignOutButton() {
       type="button"
       onClick={() => void handleSignOut()}
       disabled={loading}
-      className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5 rounded-md hover:bg-gray-100 transition-colors"
+      className="text-sm text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md hover:bg-muted transition-colors"
     >
       {loading ? 'Signing out...' : 'Sign Out'}
     </button>
@@ -211,15 +215,15 @@ function DashboardHome({
   onGlobalClick: (g: RevealGlobalConfig) => void;
 }) {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm border-b">
+    <div className="min-h-screen bg-background">
+      <header className="bg-card shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">RevealUI Admin</h1>
+              <h1 className="text-2xl font-bold text-foreground">RevealUI Admin</h1>
             </div>
             <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-500">v0.1.0</span>
+              <span className="text-sm text-muted-foreground">v0.1.0</span>
               <SignOutButton />
             </div>
           </div>
@@ -230,12 +234,12 @@ function DashboardHome({
         <div className="px-4 py-6 sm:px-0">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {/* Collections */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
                     <svg
-                      className="h-8 w-8 text-gray-400"
+                      className="h-8 w-8 text-muted-foreground"
                       aria-label="Collections"
                       fill="none"
                       stroke="currentColor"
@@ -253,20 +257,22 @@ function DashboardHome({
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">Collections</dt>
-                      <dd className="text-lg font-medium text-gray-900">{collections.length}</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        Collections
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">{collections.length}</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
+              <div className="bg-muted px-5 py-3">
                 <div className="text-sm">
                   {collections.length > 0 ? (
                     <ul className="space-y-1 max-h-48 overflow-y-auto">
                       {collections.map((collection) => (
                         <li
                           key={String(collection.slug)}
-                          className="text-gray-600 hover:text-gray-900"
+                          className="text-muted-foreground hover:text-foreground"
                         >
                           <button
                             type="button"
@@ -279,19 +285,19 @@ function DashboardHome({
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-gray-500">No collections configured</p>
+                    <p className="text-muted-foreground">No collections configured</p>
                   )}
                 </div>
               </div>
             </div>
 
             {/* Globals */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
                     <svg
-                      className="h-8 w-8 text-gray-400"
+                      className="h-8 w-8 text-muted-foreground"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -309,18 +315,23 @@ function DashboardHome({
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">Globals</dt>
-                      <dd className="text-lg font-medium text-gray-900">{globals.length}</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        Globals
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">{globals.length}</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
+              <div className="bg-muted px-5 py-3">
                 <div className="text-sm">
                   {globals.length > 0 ? (
                     <ul className="space-y-1 max-h-32 overflow-y-auto">
                       {globals.map((global) => (
-                        <li key={String(global.slug)} className="text-gray-600 hover:text-gray-900">
+                        <li
+                          key={String(global.slug)}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
                           <button
                             type="button"
                             onClick={() => onGlobalClick(global)}
@@ -332,20 +343,20 @@ function DashboardHome({
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-gray-500">No globals configured</p>
+                    <p className="text-muted-foreground">No globals configured</p>
                   )}
                 </div>
               </div>
             </div>
 
             {/* System Status */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
-                    <div className="h-8 w-8 bg-green-100 rounded-full flex items-center justify-center">
+                    <div className="h-8 w-8 bg-success/15 rounded-full flex items-center justify-center">
                       <svg
-                        className="h-5 w-5 text-green-600"
+                        className="h-5 w-5 text-success"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -364,14 +375,18 @@ function DashboardHome({
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">System Status</dt>
-                      <dd className="text-lg font-medium text-gray-900">Healthy</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        System Status
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">Healthy</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
-                <div className="text-sm text-gray-600">RevealUI admin is running successfully</div>
+              <div className="bg-muted px-5 py-3">
+                <div className="text-sm text-muted-foreground">
+                  RevealUI admin is running successfully
+                </div>
               </div>
             </div>
           </div>
@@ -651,7 +666,7 @@ export function AdminDashboard({ config }: AdminDashboardProps) {
   // ── Collection list view ──────────────────────────────────────────────
   if (state.view.type === 'collection' && state.view.collection) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-background">
         <AdminHeader title={String(state.view.collection.slug)} onBack={goToDashboard} />
         <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
           <StatusBanners error={state.error} successMessage={state.successMessage} />
@@ -681,7 +696,7 @@ export function AdminDashboard({ config }: AdminDashboardProps) {
   // ── Document edit/create view ─────────────────────────────────────────
   if (state.view.type === 'edit' && state.view.collection) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-background">
         <AdminHeader
           title={`${state.view.document ? 'Edit' : 'Create'} ${String(state.view.collection.slug).slice(0, -1)}`}
           onBack={goToDashboard}
@@ -705,7 +720,7 @@ export function AdminDashboard({ config }: AdminDashboardProps) {
   // ── Global edit view ──────────────────────────────────────────────────
   if (state.view.type === 'global' && state.view.global) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-background">
         <AdminHeader
           title={state.view.global.label || String(state.view.global.slug)}
           onBack={goToDashboard}

--- a/packages/core/src/client/admin/components/CollectionList.tsx
+++ b/packages/core/src/client/admin/components/CollectionList.tsx
@@ -120,20 +120,20 @@ export function CollectionList({
   const colCount = displayFields.length + 1 + (hasBulk ? 1 : 0);
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-md">
+    <div className="bg-card shadow overflow-hidden sm:rounded-md">
       <div className="px-4 py-5 sm:px-6 flex justify-between items-center">
         <div>
-          <h3 className="text-lg leading-6 font-medium text-gray-900 capitalize">
+          <h3 className="text-lg leading-6 font-medium text-foreground capitalize">
             {collection.slug}
           </h3>
-          <p className="mt-1 max-w-2xl text-sm text-gray-500">
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
             {totalDocs} {totalDocs === 1 ? 'document' : 'documents'}
           </p>
         </div>
         <button
           type="button"
           onClick={onCreate}
-          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-primary-foreground bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-ring"
         >
           <svg
             className="-ml-1 mr-2 h-5 w-5"
@@ -153,8 +153,8 @@ export function CollectionList({
 
       {/* Bulk action toolbar */}
       {hasBulk && selectedIds.size > 0 && (
-        <div className="bg-indigo-50 border-y border-indigo-100 px-4 py-2 flex items-center gap-3">
-          <span className="text-sm font-medium text-indigo-700">{selectedIds.size} selected</span>
+        <div className="bg-primary/10 border-y border-primary/20 px-4 py-2 flex items-center gap-3">
+          <span className="text-sm font-medium text-primary">{selectedIds.size} selected</span>
           {onBulkDelete && (
             <button
               type="button"
@@ -170,7 +170,7 @@ export function CollectionList({
               type="button"
               onClick={() => void handleBulkAction('publish')}
               disabled={bulkLoading}
-              className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 disabled:opacity-50"
+              className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-md text-success bg-success/15 hover:bg-success/25 disabled:opacity-50"
             >
               Publish
             </button>
@@ -178,7 +178,7 @@ export function CollectionList({
           <button
             type="button"
             onClick={() => setSelectedIds(new Set())}
-            className="ml-auto text-xs text-gray-500 hover:text-gray-700"
+            className="ml-auto text-xs text-muted-foreground hover:text-foreground"
           >
             Clear selection
           </button>
@@ -186,8 +186,8 @@ export function CollectionList({
       )}
 
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-border">
+          <thead className="bg-muted">
             <tr>
               {hasBulk && (
                 <th scope="col" className="w-10 px-3 py-3">
@@ -198,7 +198,7 @@ export function CollectionList({
                       if (el) el.indeterminate = someSelected;
                     }}
                     onChange={toggleAll}
-                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                     aria-label="Select all"
                   />
                 </th>
@@ -207,7 +207,7 @@ export function CollectionList({
                 <th
                   key={field.name}
                   scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
                 >
                   {getFieldLabel(field)}
                 </th>
@@ -217,15 +217,18 @@ export function CollectionList({
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-card divide-y divide-border">
             {documents.length === 0 ? (
               <tr>
-                <td colSpan={colCount} className="px-6 py-4 text-center text-sm text-gray-500">
+                <td
+                  colSpan={colCount}
+                  className="px-6 py-4 text-center text-sm text-muted-foreground"
+                >
                   No documents found.{' '}
                   <button
                     type="button"
                     onClick={onCreate}
-                    className="text-indigo-600 hover:text-indigo-500"
+                    className="text-primary hover:text-primary/80"
                   >
                     Create the first one
                   </button>
@@ -238,7 +241,7 @@ export function CollectionList({
                 return (
                   <tr
                     key={docId}
-                    className={`hover:bg-gray-50 ${selectedIds.has(docId) ? 'bg-indigo-50' : ''}`}
+                    className={`hover:bg-muted ${selectedIds.has(docId) ? 'bg-primary/10' : ''}`}
                   >
                     {hasBulk && (
                       <td className="w-10 px-3 py-4">
@@ -246,7 +249,7 @@ export function CollectionList({
                           type="checkbox"
                           checked={selectedIds.has(docId)}
                           onChange={() => toggleOne(docId)}
-                          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                          className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                           aria-label={`Select ${docId}`}
                         />
                       </td>
@@ -254,7 +257,7 @@ export function CollectionList({
                     {displayFields.map((field: RevealUIField) => (
                       <td
                         key={field.name}
-                        className="px-6 py-4 whitespace-nowrap text-sm text-gray-900"
+                        className="px-6 py-4 whitespace-nowrap text-sm text-foreground"
                       >
                         {renderFieldValue(field.name ? doc[field.name] : undefined, field)}
                       </td>
@@ -263,7 +266,7 @@ export function CollectionList({
                       <button
                         type="button"
                         onClick={() => onEdit(doc)}
-                        className="text-indigo-600 hover:text-indigo-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="text-primary hover:text-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
                         disabled={deleting !== null}
                       >
                         Edit
@@ -287,13 +290,13 @@ export function CollectionList({
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+        <div className="bg-card px-4 py-3 flex items-center justify-between border-t border-border sm:px-6">
           <div className="flex-1 flex justify-between sm:hidden">
             <button
               type="button"
               onClick={() => onPageChange(page - 1)}
               disabled={page <= 1}
-              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="relative inline-flex items-center px-4 py-2 border border-input text-sm font-medium rounded-md text-foreground bg-card hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
             </button>
@@ -301,14 +304,14 @@ export function CollectionList({
               type="button"
               onClick={() => onPageChange(page + 1)}
               disabled={page >= totalPages}
-              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-input text-sm font-medium rounded-md text-foreground bg-card hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next
             </button>
           </div>
           <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm text-gray-700">
+              <p className="text-sm text-foreground">
                 Showing page <span className="font-medium">{page}</span> of{' '}
                 <span className="font-medium">{totalPages}</span>
               </p>
@@ -319,7 +322,7 @@ export function CollectionList({
                   type="button"
                   onClick={() => onPageChange(page - 1)}
                   disabled={page <= 1}
-                  className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-input bg-card text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Previous
                 </button>
@@ -327,7 +330,7 @@ export function CollectionList({
                   type="button"
                   onClick={() => onPageChange(page + 1)}
                   disabled={page >= totalPages}
-                  className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-input bg-card text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next
                 </button>
@@ -342,7 +345,7 @@ export function CollectionList({
 
 function renderFieldValue(value: unknown, field: RevealUIField): React.ReactNode {
   if (value === null || value === undefined) {
-    return <span className="text-gray-400">-</span>;
+    return <span className="text-muted-foreground">-</span>;
   }
 
   switch (field.type) {

--- a/packages/core/src/client/admin/components/DocumentForm.tsx
+++ b/packages/core/src/client/admin/components/DocumentForm.tsx
@@ -100,16 +100,16 @@ export function DocumentForm({
   };
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <div className="bg-card shadow overflow-hidden sm:rounded-lg">
       <div className="px-4 py-5 sm:p-6">
-        <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">
+        <h3 className="text-lg leading-6 font-medium text-foreground mb-4">
           {document ? 'Edit' : 'Create'} {collection.slug.slice(0, -1)}
         </h3>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {visibleFields.map((field: RevealUIField) => (
             <div key={field.name || 'layout'}>
-              <label htmlFor={field.name} className="block text-sm font-medium text-gray-700">
+              <label htmlFor={field.name} className="block text-sm font-medium text-foreground">
                 {getFieldLabel(field)}
                 {field.required && <span className="text-red-500 ml-1">*</span>}
               </label>
@@ -127,14 +127,14 @@ export function DocumentForm({
             <button
               type="button"
               onClick={onCancel}
-              className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="bg-card py-2 px-4 border border-input rounded-md shadow-sm text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-ring"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isLoading}
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-primary-foreground bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Saving...' : 'Save'}
             </button>
@@ -178,7 +178,7 @@ function ArrayFieldRenderer({
       {rows.map((row, idx) => (
         <div
           key={`${field.name}-row-${idx.toString()}`}
-          className="border border-gray-200 rounded-md p-3 space-y-2 relative"
+          className="border border-border rounded-md p-3 space-y-2 relative"
         >
           <button
             type="button"
@@ -191,7 +191,7 @@ function ArrayFieldRenderer({
             <div key={sf.name}>
               <label
                 htmlFor={`${field.name}-${idx}-${sf.name}`}
-                className="block text-xs font-medium text-gray-600"
+                className="block text-xs font-medium text-muted-foreground"
               >
                 {getFieldLabel(sf)}
               </label>
@@ -207,7 +207,7 @@ function ArrayFieldRenderer({
       <button
         type="button"
         onClick={addRow}
-        className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+        className="text-sm text-primary hover:text-primary/80 font-medium"
       >
         + Add item
       </button>
@@ -238,12 +238,12 @@ function GroupFieldRenderer({
   };
 
   return (
-    <div className="border border-gray-200 rounded-md p-3 space-y-3">
+    <div className="border border-border rounded-md p-3 space-y-3">
       {subFields.map((sf) => (
         <div key={sf.name}>
           <label
             htmlFor={`${field.name}-${sf.name}`}
-            className="block text-xs font-medium text-gray-600"
+            className="block text-xs font-medium text-muted-foreground"
           >
             {getFieldLabel(sf)}
             {sf.required && <span className="text-red-500 ml-1">*</span>}
@@ -292,10 +292,10 @@ function BlocksFieldRenderer({
         return (
           <div
             key={`${field.name}-block-${idx.toString()}`}
-            className="border border-gray-200 rounded-md p-3 space-y-2 relative"
+            className="border border-border rounded-md p-3 space-y-2 relative"
           >
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs font-semibold text-gray-500 uppercase">
+              <span className="text-xs font-semibold text-muted-foreground uppercase">
                 {String(block.blockType)}
               </span>
               <button
@@ -310,7 +310,7 @@ function BlocksFieldRenderer({
               <div key={sf.name}>
                 <label
                   htmlFor={`${field.name}-${idx}-${sf.name}`}
-                  className="block text-xs font-medium text-gray-600"
+                  className="block text-xs font-medium text-muted-foreground"
                 >
                   {getFieldLabel(sf)}
                 </label>
@@ -331,7 +331,7 @@ function BlocksFieldRenderer({
               key={bt.slug}
               type="button"
               onClick={() => addBlock(bt.slug)}
-              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+              className="text-sm text-primary hover:text-primary/80 font-medium"
             >
               + {bt.slug}
             </button>
@@ -366,14 +366,14 @@ function CollapsibleFieldRenderer({
   };
 
   return (
-    <div className="border border-gray-200 rounded-md">
+    <div className="border border-border rounded-md">
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="w-full text-left px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 flex items-center justify-between"
+        className="w-full text-left px-3 py-2 text-sm font-medium text-foreground hover:bg-muted flex items-center justify-between"
       >
         {getFieldLabel(field)}
-        <span className="text-gray-400">{open ? '\u25B2' : '\u25BC'}</span>
+        <span className="text-muted-foreground">{open ? '\u25B2' : '\u25BC'}</span>
       </button>
       {open && (
         <div className="px-3 pb-3 space-y-3">
@@ -381,7 +381,7 @@ function CollapsibleFieldRenderer({
             <div key={sf.name}>
               <label
                 htmlFor={`${field.name}-${sf.name}`}
-                className="block text-xs font-medium text-gray-600"
+                className="block text-xs font-medium text-muted-foreground"
               >
                 {getFieldLabel(sf)}
               </label>
@@ -436,7 +436,7 @@ function JsonFieldRenderer({
         value={formatted}
         onChange={handleChange}
         rows={8}
-        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm font-mono text-xs"
+        className="mt-1 block w-full border-input rounded-md shadow-sm focus:ring-ring focus:border-primary sm:text-sm font-mono text-xs"
         spellCheck={false}
       />
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
@@ -461,12 +461,15 @@ function PointFieldRenderer({
     lng: number;
   };
   const baseClasses =
-    'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm';
+    'mt-1 block w-full border-input rounded-md shadow-sm focus:ring-ring focus:border-primary sm:text-sm';
 
   return (
     <div className="grid grid-cols-2 gap-3">
       <div>
-        <label htmlFor={`${field.name}-lat`} className="block text-xs font-medium text-gray-600">
+        <label
+          htmlFor={`${field.name}-lat`}
+          className="block text-xs font-medium text-muted-foreground"
+        >
           Latitude
         </label>
         <input
@@ -481,7 +484,10 @@ function PointFieldRenderer({
         />
       </div>
       <div>
-        <label htmlFor={`${field.name}-lng`} className="block text-xs font-medium text-gray-600">
+        <label
+          htmlFor={`${field.name}-lng`}
+          className="block text-xs font-medium text-muted-foreground"
+        >
           Longitude
         </label>
         <input
@@ -504,7 +510,7 @@ function PointFieldRenderer({
 // ---------------------------------------------------------------------------
 function FieldInput({ field, value, onChange }: FieldInputProps) {
   const baseClasses =
-    'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm';
+    'mt-1 block w-full border-input rounded-md shadow-sm focus:ring-ring focus:border-primary sm:text-sm';
 
   switch (field.type) {
     case 'text':
@@ -591,7 +597,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
           id={field.name}
           checked={Boolean(value)}
           onChange={(e) => onChange(e.target.checked)}
-          className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+          className="h-4 w-4 text-primary focus:ring-ring border-input rounded"
         />
       );
 
@@ -626,7 +632,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
             return (
               <label
                 key={optValue}
-                className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer"
+                className="flex items-center gap-2 text-sm text-foreground cursor-pointer"
               >
                 <input
                   type="radio"
@@ -634,7 +640,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
                   value={optValue}
                   checked={formatTextValue(value) === optValue}
                   onChange={() => onChange(optValue)}
-                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300"
+                  className="h-4 w-4 text-primary focus:ring-ring border-input"
                 />
                 {optLabel}
               </label>
@@ -655,7 +661,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
             required={field.required}
             placeholder={`Enter ${(field as unknown as { relationTo?: string }).relationTo ?? 'related'} ID`}
           />
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-1 text-xs text-muted-foreground">
             Related to: {(field as unknown as { relationTo?: string }).relationTo ?? 'unknown'}
           </p>
         </div>
@@ -671,10 +677,10 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
               const file = e.target.files?.[0];
               if (file) onChange(file);
             }}
-            className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+            className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary/10 file:text-primary hover:file:bg-primary/20"
           />
           {typeof value === 'string' && value !== '' && (
-            <p className="mt-1 text-xs text-gray-500">Current: {value}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Current: {value}</p>
           )}
         </div>
       );
@@ -696,7 +702,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
       return (
         <Suspense
           fallback={
-            <div className="border border-gray-300 rounded-md h-40 flex items-center justify-center text-sm text-gray-400">
+            <div className="border border-input rounded-md h-40 flex items-center justify-center text-sm text-muted-foreground">
               Loading editor…
             </div>
           }
@@ -706,7 +712,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
             editorConfig={editorConfig}
             initialValue={value as string | null | undefined}
             onSerializedChange={(json) => onChange(json)}
-            className="border border-gray-300 rounded-md"
+            className="border border-input rounded-md"
           />
         </Suspense>
       );
@@ -732,7 +738,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
 
     case 'ui':
       return (
-        <div className="border border-dashed border-gray-300 rounded-md p-3 text-sm text-gray-400 text-center">
+        <div className="border border-dashed border-input rounded-md p-3 text-sm text-muted-foreground text-center">
           Custom UI field: {field.name}
         </div>
       );

--- a/packages/core/src/client/admin/components/GlobalForm.tsx
+++ b/packages/core/src/client/admin/components/GlobalForm.tsx
@@ -70,16 +70,16 @@ export function GlobalForm({
   };
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <div className="bg-card shadow overflow-hidden sm:rounded-lg">
       <div className="px-4 py-5 sm:p-6">
-        <h3 className="text-lg leading-6 font-medium text-gray-900 mb-4">
+        <h3 className="text-lg leading-6 font-medium text-foreground mb-4">
           Edit {global.label || global.slug}
         </h3>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {visibleFields.map((field: RevealUIField) => (
             <div key={field.name || 'layout'}>
-              <label htmlFor={field.name} className="block text-sm font-medium text-gray-700">
+              <label htmlFor={field.name} className="block text-sm font-medium text-foreground">
                 {getFieldLabel(field)}
                 {field.required && <span className="text-red-500 ml-1">*</span>}
               </label>
@@ -97,14 +97,14 @@ export function GlobalForm({
             <button
               type="button"
               onClick={onCancel}
-              className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="bg-card py-2 px-4 border border-input rounded-md shadow-sm text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-ring"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isLoading}
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-primary-foreground bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Saving...' : 'Save'}
             </button>
@@ -123,7 +123,7 @@ interface FieldInputProps {
 
 function FieldInput({ field, value, onChange }: FieldInputProps) {
   const baseClasses =
-    'mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm';
+    'mt-1 block w-full border-input rounded-md shadow-sm focus:ring-ring focus:border-primary sm:text-sm';
 
   switch (field.type) {
     case 'text':
@@ -171,7 +171,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
           id={field.name}
           checked={Boolean(value)}
           onChange={(e) => onChange(e.target.checked)}
-          className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+          className="h-4 w-4 text-primary focus:ring-ring border-input rounded"
         />
       );
 

--- a/packages/core/src/client/admin/page.tsx
+++ b/packages/core/src/client/admin/page.tsx
@@ -33,15 +33,15 @@ export function RootPage({ config }: RootPageProps) {
   const globals = (config.globals || []) as AdminCollectionSummary[];
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm border-b">
+    <div className="min-h-screen bg-background">
+      <header className="bg-card shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">RevealUI Admin</h1>
+              <h1 className="text-2xl font-bold text-foreground">RevealUI Admin</h1>
             </div>
             <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-500">v0.1.0</span>
+              <span className="text-sm text-muted-foreground">v0.1.0</span>
             </div>
           </div>
         </div>
@@ -51,12 +51,12 @@ export function RootPage({ config }: RootPageProps) {
         <div className="px-4 py-6 sm:px-0">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {/* Collections */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
                     <svg
-                      className="h-8 w-8 text-gray-400"
+                      className="h-8 w-8 text-muted-foreground"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -73,39 +73,41 @@ export function RootPage({ config }: RootPageProps) {
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">Collections</dt>
-                      <dd className="text-lg font-medium text-gray-900">{collections.length}</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        Collections
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">{collections.length}</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
+              <div className="bg-muted px-5 py-3">
                 <div className="text-sm">
                   {collections.length > 0 ? (
                     <ul className="space-y-1">
                       {collections.map((collection) => (
-                        <li key={collection.slug} className="text-gray-600">
+                        <li key={collection.slug} className="text-muted-foreground">
                           <span className="font-medium">{collection.slug}</span>
-                          <span className="ml-2 text-xs text-gray-400">
+                          <span className="ml-2 text-xs text-muted-foreground">
                             ({collection.fields?.length || 0} fields)
                           </span>
                         </li>
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-gray-500">No collections configured</p>
+                    <p className="text-muted-foreground">No collections configured</p>
                   )}
                 </div>
               </div>
             </div>
 
             {/* Globals */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
                     <svg
-                      className="h-8 w-8 text-gray-400"
+                      className="h-8 w-8 text-muted-foreground"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -122,40 +124,42 @@ export function RootPage({ config }: RootPageProps) {
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">Globals</dt>
-                      <dd className="text-lg font-medium text-gray-900">{globals.length}</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        Globals
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">{globals.length}</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
+              <div className="bg-muted px-5 py-3">
                 <div className="text-sm">
                   {globals.length > 0 ? (
                     <ul className="space-y-1">
                       {globals.map((global) => (
-                        <li key={global.slug} className="text-gray-600">
+                        <li key={global.slug} className="text-muted-foreground">
                           <span className="font-medium">{global.slug}</span>
-                          <span className="ml-2 text-xs text-gray-400">
+                          <span className="ml-2 text-xs text-muted-foreground">
                             ({global.fields?.length || 0} fields)
                           </span>
                         </li>
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-gray-500">No globals configured</p>
+                    <p className="text-muted-foreground">No globals configured</p>
                   )}
                 </div>
               </div>
             </div>
 
             {/* System Status */}
-            <div className="bg-white overflow-hidden shadow rounded-lg">
+            <div className="bg-card overflow-hidden shadow rounded-lg">
               <div className="p-5">
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
-                    <div className="h-8 w-8 bg-green-100 rounded-full flex items-center justify-center">
+                    <div className="h-8 w-8 bg-success/15 rounded-full flex items-center justify-center">
                       <svg
-                        className="h-5 w-5 text-green-600"
+                        className="h-5 w-5 text-success"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -173,14 +177,16 @@ export function RootPage({ config }: RootPageProps) {
                   </div>
                   <div className="ml-5 w-0 flex-1">
                     <dl>
-                      <dt className="text-sm font-medium text-gray-500 truncate">System Status</dt>
-                      <dd className="text-lg font-medium text-gray-900">Operational</dd>
+                      <dt className="text-sm font-medium text-muted-foreground truncate">
+                        System Status
+                      </dt>
+                      <dd className="text-lg font-medium text-foreground">Operational</dd>
                     </dl>
                   </div>
                 </div>
               </div>
-              <div className="bg-gray-50 px-5 py-3">
-                <div className="text-sm text-gray-600">
+              <div className="bg-muted px-5 py-3">
+                <div className="text-sm text-muted-foreground">
                   RevealUI admin is running successfully with {collections.length} collections and{' '}
                   {globals.length} globals configured.
                 </div>


### PR DESCRIPTION
## Rebrand P1 — detoken the `@revealui/core` admin client

The `@revealui/core` admin client (the shipped OSS admin UI) rendered entirely in **off-brand indigo + neutral gray** with zero design tokens, so every RevealUI install showed an indigo admin instead of Cobalt. This maps the palette to the shadcn-bridge semantic tokens, following the convention `apps/admin` already migrated to.

### Mapping

- **indigo → primary:** `bg-primary`, `text-primary`, `hover:bg-primary/90`, `ring-ring`, `text-primary-foreground`, `bg-primary/10` tints, `focus:ring-offset-background`
- **gray → surfaces + text:** `bg-background` / `bg-card` / `bg-muted`, `text-foreground`, `text-muted-foreground`, `border-border` / `border-input`, `divide-border`
- **green → success:** `bg-success/15`, `text-success`, `border-success/30`

198 className-string swaps across `page.tsx`, `AdminDashboard`, `CollectionList`, `DocumentForm`, and `GlobalForm`. **className-only** — no logic or markup change.

### Verification

- `@revealui/core` typecheck clean, biome clean, pre-push gate green.
- `apps/admin` already `@source`-scans `packages/core/src/**`, so the new token utilities are generated.
- No tests assert the old classes.
- Both-theme (OS light/dark) visual QA on the admin preview is **owner-gated**, matching the `apps/admin` token-migration convention (#1198).

Base: `test`. Part of the Cobalt rebrand: P0 identity shipped in #1286; P2 (colour sweep), P3 (icon-system consolidation), P4 (docs type → Inter) still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
