### PR TITLE
fix(pricing): re-space subscription + perpetual ladder to canonical

### DIFF
--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/lib/providers/LicenseProvider', () => ({
 vi.mock('@revealui/contracts/pricing', () => ({
   getTiersFromCurrent: vi.fn(() => [
     { id: 'pro', name: 'Pro', price: '$49/mo' },
-    { id: 'max', name: 'Max', price: '$149/mo' },
+    { id: 'max', name: 'Max', price: '$299/mo' },
   ]),
 }));
 

--- a/apps/admin/src/lib/middleware/ai-feature-gate.ts
+++ b/apps/admin/src/lib/middleware/ai-feature-gate.ts
@@ -30,7 +30,7 @@ export function checkAIFeatureGate(): NextResponse | null {
 
 /**
  * Returns a 403 NextResponse if AI Memory features are not enabled (no Max license).
- * AI Memory routes (episodic, working, context, vector search) require Max ($149/mo),
+ * AI Memory routes (episodic, working, context, vector search) require Max ($299/mo),
  * not Pro ($49/mo).
  * Bypassed in development mode.
  */

--- a/apps/docs/app/showcase/radio.showcase.tsx
+++ b/apps/docs/app/showcase/radio.showcase.tsx
@@ -74,7 +74,7 @@ const story: ShowcaseStory = {
           {[
             { value: 'free', label: 'Free', desc: 'Basic features' },
             { value: 'pro', label: 'Pro', desc: '$49/mo' },
-            { value: 'max', label: 'Max', desc: '$149/mo' },
+            { value: 'max', label: 'Max', desc: '$299/mo' },
           ].map((plan) => (
             <RadioField key={plan.value}>
               <Radio color="blue" value={plan.value} />

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -14,8 +14,8 @@ import {
 const TEASER_FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> = {
   free: { price: '$0' },
   pro: { price: '$49', period: '/month' },
-  max: { price: '$149', period: '/month' },
-  enterprise: { price: '$299', period: '/month' },
+  max: { price: '$299', period: '/month' },
+  enterprise: { price: '$1,499', period: '/month' },
 };
 
 const API_URL =

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -40,8 +40,8 @@ const API_URL =
 const FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> = {
   free: { price: '$0' },
   pro: { price: '$49', period: '/month' },
-  max: { price: '$149', period: '/month' },
-  enterprise: { price: '$299', period: '/month' },
+  max: { price: '$299', period: '/month' },
+  enterprise: { price: '$1,499', period: '/month' },
 };
 
 function CheckIcon({ className }: { className?: string }) {

--- a/apps/server/src/lib/tier-pricing.ts
+++ b/apps/server/src/lib/tier-pricing.ts
@@ -24,8 +24,8 @@ export type SubscriptionTierId = 'pro' | 'max' | 'enterprise';
  */
 export const MRR_TIER_PRICE_FALLBACK_USD: Record<SubscriptionTierId, number> = {
   pro: 49,
-  max: 149,
-  enterprise: 299,
+  max: 299,
+  enterprise: 1499,
 };
 
 /** Same values in cents — convenience for Stripe comparisons. */

--- a/apps/server/src/routes/__tests__/billing-metrics.test.ts
+++ b/apps/server/src/routes/__tests__/billing-metrics.test.ts
@@ -524,7 +524,7 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
         ],
         catalogRows: [
           { tier: 'pro', metadata: { unitAmountCents: 4900 } },
-          { tier: 'max', metadata: { unitAmountCents: 14900 } },
+          { tier: 'max', metadata: { unitAmountCents: 29900 } },
         ],
       });
 
@@ -533,12 +533,12 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      // MRR = (10 * 4900) + (5 * 14900) = 49000 + 74500 = 123500
-      expect(body.mrr).toBe(123_500);
+      // MRR = (10 * 4900) + (5 * 29900) = 49000 + 149500 = 198500
+      expect(body.mrr).toBe(198_500);
     });
 
     it('uses fallback tier prices when catalog is empty', async () => {
-      // Fallback: pro=4900, max=14900, enterprise=29900
+      // Fallback: pro=4900, max=29900, enterprise=149900
       queueMetricsResults({
         tierRows: [
           { tier: 'pro', tierCount: 3 },
@@ -553,8 +553,8 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      // MRR = (3 * 4900) + (1 * 14900) + (1 * 29900) = 14700 + 14900 + 29900 = 59500
-      expect(body.mrr).toBe(59_500);
+      // MRR = (3 * 4900) + (1 * 29900) + (1 * 149900) = 14700 + 29900 + 149900 = 194500
+      expect(body.mrr).toBe(194_500);
     });
 
     it('returns recent events with type mapping', async () => {
@@ -610,7 +610,7 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
         ],
         catalogRows: [
           { tier: 'pro', metadata: { unitAmountCents: 3900 } }, // custom price
-          // enterprise not in catalog  -  falls back to 29900
+          // enterprise not in catalog  -  falls back to 149900
         ],
       });
 
@@ -620,8 +620,8 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.tierBreakdown).toEqual({ pro: 5, max: 0, enterprise: 2 });
-      // MRR = (5 * 3900) + (0 * anything) + (2 * 29900) = 19500 + 0 + 59800 = 79300
-      expect(body.mrr).toBe(79_300);
+      // MRR = (5 * 3900) + (0 * anything) + (2 * 149900) = 19500 + 0 + 299800 = 319300
+      expect(body.mrr).toBe(319_300);
     });
 
     it('ignores unknown tiers in breakdown', async () => {

--- a/apps/server/src/routes/__tests__/pricing-edge.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-edge.test.ts
@@ -263,7 +263,7 @@ describe('GET /api/pricing  -  missing metadata fields', () => {
     const data = await res.json();
 
     const max = data.subscriptions.find((t: { id: string }) => t.id === 'max');
-    expect(max.price).toBe('$149'); // static fallback
+    expect(max.price).toBe('$299'); // static fallback
   });
 
   it('ignores products with an unknown revealui_track value', async () => {
@@ -277,7 +277,7 @@ describe('GET /api/pricing  -  missing metadata fields', () => {
         {
           name: 'Enterprise',
           metadata: { revealui_track: 'subscription', revealui_tier: 'enterprise' },
-          default_price: { unit_amount: 29900, recurring: { interval: 'month' } },
+          default_price: { unit_amount: 149900, recurring: { interval: 'month' } },
         },
       ],
     });
@@ -287,7 +287,7 @@ describe('GET /api/pricing  -  missing metadata fields', () => {
 
     // Enterprise should be enriched; Widget (unknown track) silently ignored
     const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
-    expect(enterprise.price).toBe('$299');
+    expect(enterprise.price).toBe('$1499');
     // Subscriptions should still return 4 tiers
     expect(data.subscriptions).toHaveLength(4);
   });
@@ -332,13 +332,13 @@ describe('GET /api/pricing  -  logger call verification', () => {
 });
 
 describe('GET /api/pricing  -  formatPrice edge values', () => {
-  it('formats large unit amounts correctly ($29900 → $299)', async () => {
+  it('formats large unit amounts correctly ($149900 → $1499)', async () => {
     mockProductsList.mockResolvedValue({
       data: [
         {
           name: 'Enterprise',
           metadata: { revealui_track: 'subscription', revealui_tier: 'enterprise' },
-          default_price: { unit_amount: 29900, recurring: { interval: 'month' } },
+          default_price: { unit_amount: 149900, recurring: { interval: 'month' } },
         },
       ],
     });
@@ -347,7 +347,7 @@ describe('GET /api/pricing  -  formatPrice edge values', () => {
     const data = await res.json();
 
     const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
-    expect(enterprise.price).toBe('$299');
+    expect(enterprise.price).toBe('$1499');
     expect(enterprise.period).toBe('/month');
   });
 

--- a/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
@@ -54,8 +54,8 @@ import app from '../pricing.js';
 const CANONICAL_SUBSCRIPTION_PRICES = {
   free: { price: '$0', period: undefined },
   pro: { price: '$49', period: '/month' },
-  max: { price: '$149', period: '/month' },
-  enterprise: { price: '$299', period: '/month' },
+  max: { price: '$299', period: '/month' },
+  enterprise: { price: '$1,499', period: '/month' },
 } as const;
 
 const CANONICAL_CREDIT_PRICES = {
@@ -66,19 +66,19 @@ const CANONICAL_CREDIT_PRICES = {
 
 const CANONICAL_PERPETUAL_PRICES = {
   'Pro Perpetual': {
-    price: '$299',
+    price: '$1,499',
     priceNote: 'one-time',
-    renewal: '$99/yr for continued support',
+    renewal: '$149/yr for continued support',
   },
   'Agency Perpetual': {
-    price: '$799',
+    price: '$8,499',
     priceNote: 'one-time',
-    renewal: '$199/yr for continued support',
+    renewal: '$799/yr for continued support',
   },
   'Enterprise Perpetual': {
-    price: '$1,999',
+    price: '$42,999',
     priceNote: 'one-time',
-    renewal: '$499/yr for continued support',
+    renewal: '$3,999/yr for continued support',
   },
 } as const;
 

--- a/apps/server/src/routes/__tests__/pricing.test.ts
+++ b/apps/server/src/routes/__tests__/pricing.test.ts
@@ -176,16 +176,16 @@ describe('GET /api/pricing  -  Stripe active path', () => {
     expect(standard.costPer).toBe('$0.00065/task');
   });
 
-  it('formats unit_amount in cents correctly ($4900 → $49)', async () => {
+  it('formats unit_amount in cents correctly ($29900 → $299)', async () => {
     mockProductsList.mockResolvedValue({
-      data: [makeStripeProduct('Max', 'subscription', 'max', 14900, 'month')],
+      data: [makeStripeProduct('Max', 'subscription', 'max', 29900, 'month')],
     });
 
     const res = await app.request('/');
     const data = await res.json();
 
     const max = data.subscriptions.find((t: { id: string }) => t.id === 'max');
-    expect(max.price).toBe('$149');
+    expect(max.price).toBe('$299');
   });
 });
 
@@ -251,8 +251,8 @@ describe('GET /api/pricing', () => {
     const data = await res.json();
 
     const proPerpetual = data.perpetual.find((t: { name: string }) => t.name === 'Pro Perpetual');
-    expect(proPerpetual.price).toBe('$299');
-    expect(proPerpetual.renewal).toBe('$99/yr for continued support');
+    expect(proPerpetual.price).toBe('$1,499');
+    expect(proPerpetual.renewal).toBe('$149/yr for continued support');
   });
 
   it('response matches expected shape', async () => {
@@ -352,7 +352,7 @@ describe('GET /api/pricing  -  Stripe integration', () => {
         {
           name: 'Max',
           metadata: { revealui_track: 'subscription', revealui_tier: 'max' },
-          default_price: { unit_amount: 14900, recurring: { interval: 'month' } },
+          default_price: { unit_amount: 29900, recurring: { interval: 'month' } },
         },
       ],
     });
@@ -366,7 +366,7 @@ describe('GET /api/pricing  -  Stripe integration', () => {
     expect(pro.period).toBe('/month');
 
     const max = data.subscriptions.find((t: { id: string }) => t.id === 'max');
-    expect(max.price).toBe('$149');
+    expect(max.price).toBe('$299');
     expect(max.period).toBe('/month');
   });
 
@@ -418,9 +418,9 @@ describe('GET /api/pricing  -  Stripe integration', () => {
             revealui_track: 'perpetual',
             revealui_tier: 'pro_perpetual',
             revealui_price_note: 'one-time',
-            revealui_renewal: '$99/yr for continued support',
+            revealui_renewal: '$149/yr for continued support',
           },
-          default_price: { unit_amount: 29900 },
+          default_price: { unit_amount: 149900 },
         },
       ],
     });
@@ -430,9 +430,9 @@ describe('GET /api/pricing  -  Stripe integration', () => {
     const data = await res.json();
 
     const proPerpetual = data.perpetual.find((t: { name: string }) => t.name === 'Pro Perpetual');
-    expect(proPerpetual.price).toBe('$299');
+    expect(proPerpetual.price).toBe('$1499');
     expect(proPerpetual.priceNote).toBe('one-time');
-    expect(proPerpetual.renewal).toBe('$99/yr for continued support');
+    expect(proPerpetual.renewal).toBe('$149/yr for continued support');
   });
 
   it('falls back to defaults when Stripe throws a generic error', async () => {
@@ -507,7 +507,7 @@ describe('GET /api/pricing  -  Stripe integration', () => {
     expect(pro.price).toBe('$49');
 
     const max = data.subscriptions.find((t: { id: string }) => t.id === 'max');
-    expect(max.price).toBe('$149');
+    expect(max.price).toBe('$299');
   });
 
   it('formats yearly subscription interval as /year', async () => {
@@ -516,7 +516,7 @@ describe('GET /api/pricing  -  Stripe integration', () => {
         {
           name: 'Enterprise Annual',
           metadata: { revealui_track: 'subscription', revealui_tier: 'enterprise' },
-          default_price: { unit_amount: 29900, recurring: { interval: 'year' } },
+          default_price: { unit_amount: 1439000, recurring: { interval: 'year' } },
         },
       ],
     });
@@ -526,7 +526,7 @@ describe('GET /api/pricing  -  Stripe integration', () => {
     const data = await res.json();
 
     const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
-    expect(enterprise.price).toBe('$299');
+    expect(enterprise.price).toBe('$14390');
     expect(enterprise.period).toBe('/year');
   });
 
@@ -639,14 +639,14 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
 
   it('defaults perpetual priceNote to "one-time" and renewal to empty string when metadata is absent', async () => {
     mockProductsList.mockResolvedValue({
-      data: [makeStripeProduct('Pro Perpetual', 'perpetual', 'pro_perpetual', 29900)],
+      data: [makeStripeProduct('Pro Perpetual', 'perpetual', 'pro_perpetual', 149900)],
     });
 
     const res = await app.request('/');
     const data = await res.json();
 
     const proPerpetual = data.perpetual.find((t: { name: string }) => t.name === 'Pro Perpetual');
-    expect(proPerpetual.price).toBe('$299');
+    expect(proPerpetual.price).toBe('$1499');
     expect(proPerpetual.priceNote).toBe('one-time');
     expect(proPerpetual.renewal).toBe('');
   });
@@ -731,8 +731,8 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
       data: [
         makeStripeProduct('Free', 'subscription', 'free', 0),
         makeStripeProduct('Pro', 'subscription', 'pro', 4900, 'month'),
-        makeStripeProduct('Max', 'subscription', 'max', 14900, 'month'),
-        makeStripeProduct('Enterprise', 'subscription', 'enterprise', 29900, 'month'),
+        makeStripeProduct('Max', 'subscription', 'max', 29900, 'month'),
+        makeStripeProduct('Enterprise', 'subscription', 'enterprise', 149900, 'month'),
       ],
     });
 
@@ -746,9 +746,9 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
     const pro = data.subscriptions.find((t: { id: string }) => t.id === 'pro');
     expect(pro.price).toBe('$49');
     const max = data.subscriptions.find((t: { id: string }) => t.id === 'max');
-    expect(max.price).toBe('$149');
+    expect(max.price).toBe('$299');
     const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
-    expect(enterprise.price).toBe('$299');
+    expect(enterprise.price).toBe('$1499');
   });
 
   it('enriches all three credit bundles simultaneously from Stripe', async () => {
@@ -784,23 +784,23 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
   it('enriches all three perpetual tiers simultaneously from Stripe', async () => {
     mockProductsList.mockResolvedValue({
       data: [
-        makeStripeProduct('Pro Perpetual', 'perpetual', 'pro_perpetual', 29900, undefined, {
+        makeStripeProduct('Pro Perpetual', 'perpetual', 'pro_perpetual', 149900, undefined, {
           revealui_price_note: 'one-time',
-          revealui_renewal: '$99/yr',
+          revealui_renewal: '$149/yr',
         }),
-        makeStripeProduct('Agency Perpetual', 'perpetual', 'agency_perpetual', 79900, undefined, {
+        makeStripeProduct('Agency Perpetual', 'perpetual', 'agency_perpetual', 849900, undefined, {
           revealui_price_note: 'one-time',
-          revealui_renewal: '$199/yr',
+          revealui_renewal: '$799/yr',
         }),
         makeStripeProduct(
           'Enterprise Perpetual',
           'perpetual',
           'enterprise_perpetual',
-          199900,
+          4299900,
           undefined,
           {
             revealui_price_note: 'one-time',
-            revealui_renewal: '$499/yr',
+            revealui_renewal: '$3,999/yr',
           },
         ),
       ],
@@ -811,13 +811,13 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
 
     expect(data.perpetual).toHaveLength(3);
     const pro = data.perpetual.find((t: { name: string }) => t.name === 'Pro Perpetual');
-    expect(pro.price).toBe('$299');
+    expect(pro.price).toBe('$1499');
     const agency = data.perpetual.find((t: { name: string }) => t.name === 'Agency Perpetual');
-    expect(agency.price).toBe('$799');
+    expect(agency.price).toBe('$8499');
     const enterprise = data.perpetual.find(
       (t: { name: string }) => t.name === 'Enterprise Perpetual',
     );
-    expect(enterprise.price).toBe('$1999');
+    expect(enterprise.price).toBe('$42999');
   });
 
   it('mixes Stripe enrichment with fallback across tracks', async () => {
@@ -837,6 +837,6 @@ describe('GET /api/pricing  -  metadata defaults and edge cases', () => {
     expect(standard.price).toBe('$50');
     // Perpetual: fallback
     const proPerpetual = data.perpetual.find((t: { name: string }) => t.name === 'Pro Perpetual');
-    expect(proPerpetual.price).toBe('$299');
+    expect(proPerpetual.price).toBe('$1,499');
   });
 });

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -304,8 +304,8 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     const event = makeChargeRefundedEvent({
       customerId: 'cus_perpetual',
       paymentIntentId: 'pi_perpetual',
-      amount: 199900,
-      amountRefunded: 199900,
+      amount: 4299900,
+      amountRefunded: 4299900,
       billingEmail: 'buyer@example.com',
     });
 
@@ -330,8 +330,8 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     const event = makeChargeRefundedEvent({
       customerId: 'cus_perpetual_email',
       paymentIntentId: 'pi_perpetual_email',
-      amount: 199900,
-      amountRefunded: 199900,
+      amount: 4299900,
+      amountRefunded: 4299900,
       billingEmail: 'enterprise@example.com',
     });
 
@@ -358,7 +358,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     const event = makeChargeRefundedEvent({
       customerId: 'cus_partial',
       paymentIntentId: 'pi_partial',
-      amount: 199900,
+      amount: 4299900,
       amountRefunded: 5000,
       billingEmail: null,
     });

--- a/apps/server/src/routes/pricing.ts
+++ b/apps/server/src/routes/pricing.ts
@@ -50,8 +50,8 @@ function isStripeConfigured(): boolean {
 const HARDCODED_SUBSCRIPTION_PRICES: Record<string, { price: string; period?: string }> = {
   free: { price: '$0' },
   pro: { price: '$49', period: '/month' },
-  max: { price: '$149', period: '/month' },
-  enterprise: { price: '$299', period: '/month' },
+  max: { price: '$299', period: '/month' },
+  enterprise: { price: '$1,499', period: '/month' },
 };
 
 const HARDCODED_CREDIT_PRICES: [string, { price: string; priceNote: string; costPer: string }][] = [
@@ -65,14 +65,14 @@ const HARDCODED_PERPETUAL_PRICES: Record<
   { price: string; priceNote: string; renewal: string }
 > = {
   'Pro Perpetual': {
-    price: '$299',
+    price: '$1,499',
     priceNote: 'one-time',
-    renewal: '$99/yr for continued support',
+    renewal: '$149/yr for continued support',
   },
   'Agency Perpetual': {
-    price: '$799',
+    price: '$8,499',
     priceNote: 'one-time',
-    renewal: '$199/yr for continued support',
+    renewal: '$799/yr for continued support',
   },
   // 'Enterprise Perpetual' is the post-rename canonical name per
   // brand-naming ADR (2026-05-03-revfleet-rename.md). The contracts file
@@ -80,9 +80,9 @@ const HARDCODED_PERPETUAL_PRICES: Record<
   // Phase 2.6 (2026-05-18) closed the pre-rename "Forge Perpetual" drift
   // surfaced by pricing-marketing-drift.test.ts.
   'Enterprise Perpetual': {
-    price: '$1,999',
+    price: '$42,999',
     priceNote: 'one-time',
-    renewal: '$499/yr for continued support',
+    renewal: '$3,999/yr for continued support',
   },
 };
 

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -48,8 +48,8 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 |---|---|---|---|---|---|
 | Free | $0 | 1 | 3 | 1,000 | 200 |
 | Pro | $49 | 5 | 25 | 10,000 | 300 |
-| Max | $149 | 15 | 100 | 50,000 | 600 |
-| Enterprise | $299 | unlimited | unlimited | unlimited | 1,000 |
+| Max | $299 | 15 | 100 | 50,000 | 600 |
+| Enterprise | $1,499 | unlimited | unlimited | unlimited | 1,000 |
 
 ### Track B — Agent task credits (one-time)
 
@@ -63,9 +63,9 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 
 | Tier | Price | Annual support renewal |
 |---|---|---|
-| Pro Perpetual | $299 | $99/yr |
-| Agency Perpetual | $799 | $199/yr |
-| Enterprise Perpetual | $1,999 | $499/yr |
+| Pro Perpetual | $1,499 | $149/yr |
+| Agency Perpetual | $8,499 | $799/yr |
+| Enterprise Perpetual | $42,999 | $3,999/yr |
 
 **Status:** marked `comingSoon: true` in `packages/contracts/src/pricing.ts`. Marketing must label Track C "Coming soon" at H2 weight (no corner badges).
 

--- a/packages/presentation/src/__tests__/pricing-table.test.tsx
+++ b/packages/presentation/src/__tests__/pricing-table.test.tsx
@@ -32,7 +32,7 @@ const mockTiers: PricingTier[] = [
   {
     id: 'enterprise',
     name: 'Enterprise',
-    price: '$299',
+    price: '$1,499',
     period: '/month',
     description: 'For large teams.',
     features: ['Everything in Pro', 'Feature E'],
@@ -58,7 +58,7 @@ describe('PricingTable  -  full layout', () => {
     render(<PricingTable tiers={mockTiers} />);
     expect(screen.getByText('$0')).toBeInTheDocument();
     expect(screen.getByText('$49')).toBeInTheDocument();
-    expect(screen.getByText('$299')).toBeInTheDocument();
+    expect(screen.getByText('$1,499')).toBeInTheDocument();
   });
 
   it('renders period for paid tiers', () => {

--- a/packages/test/src/e2e/smoke-production.spec.ts
+++ b/packages/test/src/e2e/smoke-production.spec.ts
@@ -64,7 +64,7 @@ test.describe('Production Smoke Tests', () => {
     // Verify dollar amounts are rendered on the page
     expect(pageText).toContain('$0');
     expect(pageText).toContain('$49');
-    expect(pageText).toContain('$149');
+    expect(pageText).toContain('$299');
   });
 
   test('signup redirect flow and login page @smoke', async ({ page }) => {

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -116,7 +116,7 @@ const CATALOG: ProductDefinition[] = [
     prices: [
       {
         key: 'revealui_max_monthly',
-        unitAmount: 14900,
+        unitAmount: 29900,
         currency: 'usd',
         mode: 'subscription',
         interval: 'month',
@@ -124,7 +124,7 @@ const CATALOG: ProductDefinition[] = [
       },
       {
         key: 'revealui_max_yearly',
-        unitAmount: 142800,
+        unitAmount: 287000,
         currency: 'usd',
         mode: 'subscription',
         interval: 'year',
@@ -143,14 +143,14 @@ const CATALOG: ProductDefinition[] = [
     prices: [
       {
         key: 'revealui_enterprise_monthly',
-        unitAmount: 29900,
+        unitAmount: 149900,
         currency: 'usd',
         mode: 'subscription',
         interval: 'month',
       },
       {
         key: 'revealui_enterprise_yearly',
-        unitAmount: 287000,
+        unitAmount: 1439000,
         currency: 'usd',
         mode: 'subscription',
         interval: 'year',
@@ -164,12 +164,12 @@ const CATALOG: ProductDefinition[] = [
     tier: 'pro',
     billingModel: 'perpetual',
     priceNote: 'one-time',
-    renewal: '$99/yr for continued support',
+    renewal: '$149/yr for continued support',
     defaultPriceKey: 'revealui_pro_perpetual',
     prices: [
       {
         key: 'revealui_pro_perpetual',
-        unitAmount: 29900,
+        unitAmount: 149900,
         currency: 'usd',
         mode: 'payment',
       },
@@ -182,12 +182,12 @@ const CATALOG: ProductDefinition[] = [
     tier: 'max',
     billingModel: 'perpetual',
     priceNote: 'one-time',
-    renewal: '$199/yr for continued support',
+    renewal: '$799/yr for continued support',
     defaultPriceKey: 'revealui_max_perpetual',
     prices: [
       {
         key: 'revealui_max_perpetual',
-        unitAmount: 79900,
+        unitAmount: 849900,
         currency: 'usd',
         mode: 'payment',
       },
@@ -200,12 +200,12 @@ const CATALOG: ProductDefinition[] = [
     tier: 'enterprise',
     billingModel: 'perpetual',
     priceNote: 'one-time',
-    renewal: '$499/yr for continued support',
+    renewal: '$3,999/yr for continued support',
     defaultPriceKey: 'revealui_enterprise_perpetual',
     prices: [
       {
         key: 'revealui_enterprise_perpetual',
-        unitAmount: 199900,
+        unitAmount: 4299900,
         currency: 'usd',
         mode: 'payment',
       },
@@ -223,7 +223,7 @@ const CATALOG: ProductDefinition[] = [
     prices: [
       {
         key: 'revealui_renewal_pro',
-        unitAmount: 9900,
+        unitAmount: 14900,
         currency: 'usd',
         mode: 'payment',
       },
@@ -240,7 +240,7 @@ const CATALOG: ProductDefinition[] = [
     prices: [
       {
         key: 'revealui_renewal_max',
-        unitAmount: 19900,
+        unitAmount: 79900,
         currency: 'usd',
         mode: 'payment',
       },
@@ -257,7 +257,7 @@ const CATALOG: ProductDefinition[] = [
     prices: [
       {
         key: 'revealui_renewal_enterprise',
-        unitAmount: 49900,
+        unitAmount: 399900,
         currency: 'usd',
         mode: 'payment',
       },


### PR DESCRIPTION
## What

Propagates the updated (2026-06-07) pricing across every code, test, and canonical-doc surface so the displayed prices, the Stripe seed, and the fallback drift gate all agree. No old prices remain in the pricing surfaces.

Stripe live-mode is not flipped, so there is **no billing impact** — this updates displayed / fallback / seed values and keeps the drift gate green.

## Price changes

**Subscriptions (monthly / annual)**
- Free $0 — unchanged
- Pro $49 / $470 — unchanged
- Max $149 → **$299** / $2,870
- Enterprise $299 → **$1,499** / $14,390

**Perpetual licenses (one-time / annual support)**
- Pro Perpetual $299 → **$1,499** · renewal $99 → **$149/yr**
- Agency Perpetual $799 → **$8,499** · renewal $199 → **$799/yr**
- Enterprise Perpetual $1,999 → **$42,999** · renewal $499 → **$3,999/yr**

**Credit bundles** — unchanged ($10 / $50 / $250).

## Surfaces (lockstep)

Server fallback (`apps/server/src/routes/pricing.ts`), MRR fallback (`apps/server/src/lib/tier-pricing.ts`), Stripe seed cents (`scripts/setup/seed-stripe.ts`), marketing fallbacks (`PricingTeaser`, `PricingPage`), the `MARKETING_METRICS.md` §2 canonical table, admin/docs fixtures, and the `pricing` / `pricing-edge` / `pricing-marketing-drift` / `webhooks-perpetual-refund` test suites (including the drift gate's `CANONICAL_*` maps).

Note on formatting: the hand-written fallback strings keep comma formatting (`$1,499`); the Stripe-derived `formatPrice` path stays comma-free (`$1499`). Both are covered by the updated tests.

## Verification

87 tests pass locally — `pricing` (34), `pricing-edge` (14), `pricing-marketing-drift` (3, the lockstep gate), `webhooks-perpetual-refund` (4), `PricingTable` (22), `UpgradeDialog` (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
