### PR TITLE
feat(marketing): rename primitive copy to People/Offers/Agents vocabulary

### DIFF
--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -10,7 +10,7 @@ import { METRICS, SITE } from '../site';
 // rules the marketing-overhaul lane established. Metric VALUES are enforced
 // separately against the codebase by scripts/validate/claim-drift.ts.
 
-const FIVE_PRIMITIVES = ['Users', 'Content', 'Products', 'Payments', 'Intelligence'];
+const FIVE_PRIMITIVES = ['People', 'Content', 'Offers', 'Payments', 'Agents'];
 
 describe('marketing content contracts', () => {
   describe('primitives', () => {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -47,7 +47,7 @@ export const HOME_HERO = {
       {
         metric: `${METRICS.dbTables} database tables`,
         detail:
-          'Every table maps to a primitive — users, content, products, payments, or intelligence. See the [database reference](https://docs.revealui.com/database).',
+          'Every table maps to a primitive — people, content, offers, payments, or agents. See the [database reference](https://docs.revealui.com/database).',
       },
       {
         metric: `${METRICS.mcpServers} first-party MCP servers`,

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -23,13 +23,13 @@ export interface HomePrimitive {
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login. One audit trail.',
   heading: "Everything a business needs. Nothing you don't.",
-  body: 'Users, content, products, payments, and intelligence — the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
+  body: 'People, content, offers, payments, and agents — the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 
 export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
   {
-    label: 'Users',
+    label: 'People',
     body: 'Auth, sessions, RBAC + ABAC. Same policy governs human and agent access.',
     color: 'emerald',
     iconPath:
@@ -43,7 +43,7 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
   },
   {
-    label: 'Products',
+    label: 'Offers',
     body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
     color: 'amber',
     iconPath:
@@ -57,7 +57,7 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
-    label: 'Intelligence',
+    label: 'Agents',
     body: 'Agents, MCP servers, CRDT memory. Bring-your-own-model; open-weight default.',
     color: 'violet',
     iconPath:
@@ -88,7 +88,7 @@ export interface ProductsPrimitive {
 
 export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
   {
-    name: 'Users',
+    name: 'People',
     icon: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
     color: 'text-blue-600',
     bgColor: 'bg-blue-500/10',
@@ -148,7 +148,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Products',
+    name: 'Offers',
     icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
     color: 'text-purple-600',
     bgColor: 'bg-purple-500/10',
@@ -206,7 +206,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Intelligence',
+    name: 'Agents',
     icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z',
     color: 'text-violet-600',
     bgColor: 'bg-violet-500/10',

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -92,7 +92,7 @@ export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
   status: 'Beta',
   version: 'v0.3.0',
   tagline: 'The agentic business runtime',
-  body: 'Auth, content, products, payments, and intelligence — pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
+  body: 'People, content, offers, payments, and agents — pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
   iconPath: 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5',
   facts: [
     { stat: String(METRICS.packages), label: 'packages' },

--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -79,7 +79,7 @@ const POST_METADATA: PostMeta[] = [
     slug: 'five-primitives',
     title: 'The Five Primitives of Business Software',
     excerpt:
-      'A deep technical walkthrough of Users, Content, Products, Payments, and Intelligence: the building blocks every software company needs.',
+      'A deep technical walkthrough of People, Content, Offers, Payments, and Agents: the building blocks every software company needs.',
     publishedAt: '2026-03-24T12:00:00.000Z',
     author: 'RevealUI Team',
     file: '05-five-primitives.md',


### PR DESCRIPTION
## What

Aligns the customer-facing **five-primitive vocabulary** to the locked 2026-06-07 set — **People / Content / Offers / Payments / Agents** — superseding the old `Users / Content / Products / Payments / Intelligence`. Display copy only; no code identifiers, routes, entitlement keys, DB tables, or package names change.

## Renamed (display copy)

- `apps/marketing/app/content/primitives.ts` — the home + products primitive section labels/names and the section body (`Users→People`, `Products→Offers`, `Intelligence→Agents`).
- Primitive-set enumerations: `home.ts` ("what ships today"), `products.ts` (flagship body), `lib/blog-posts.ts` (five-primitives excerpt).
- `content/__tests__/content.test.ts` — the `FIVE_PRIMITIVES` contract assertion, in lockstep (the suite asserts the labels equal this array in order).

## Deliberately NOT touched (scoped separately)

These match the old words but are not the primitive label:
- the `/products` page nav + `ProductsPage` / `PRODUCTS_*` (that's the RevFleet product roster, not the Products primitive),
- the admin users-list screenshot label,
- the `ai` / `payments` feature-flag **keys** (runtime entitlement, wired into route middleware + license), the `@revealui/ai` package, and the `users` / `products` DB tables.

The deeper code-identifier question (e.g. the source-only `@revealui/engines` `./intelligence` subpath) is captured as a separate proposal.

## Verification

Pure string rename with the content-contract test updated in lockstep (the labels match `FIVE_PRIMITIVES` in order, so `content.test.ts` passes by construction). CI runs the marketing content suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
