### PR TITLE
refactor(engines): rename the intelligence primitive subpath to agents

### DIFF
--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -2,7 +2,7 @@
   "name": "@revealui/engines",
   "version": "0.4.2",
   "private": true,
-  "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, intelligence.",
+  "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, agents.",
   "license": "FSL-1.1-MIT",
   "type": "module",
   "dependencies": {
@@ -24,7 +24,7 @@
     "./content": "./src/content/index.ts",
     "./products": "./src/products/index.ts",
     "./payments": "./src/payments/index.ts",
-    "./intelligence": "./src/intelligence/index.ts"
+    "./agents": "./src/agents/index.ts"
   },
   "scripts": {
     "build": "echo 'Source-only package — consumed via tsconfig paths, no build needed'",

--- a/packages/engines/src/__tests__/engines.test.ts
+++ b/packages/engines/src/__tests__/engines.test.ts
@@ -8,7 +8,7 @@ describe('@revealui/engines', () => {
     expect(engines.content).toBeDefined();
     expect(engines.products).toBeDefined();
     expect(engines.payments).toBeDefined();
-    expect(engines.intelligence).toBeDefined();
+    expect(engines.agents).toBeDefined();
   }, 15_000);
 
   describe('users', () => {
@@ -382,72 +382,72 @@ describe('@revealui/engines', () => {
     });
   });
 
-  describe('intelligence', () => {
+  describe('agents', () => {
     it('exports all agent db tables', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.agentContexts).toBeDefined();
-      expect(intelligence.agentMemories).toBeDefined();
-      expect(intelligence.conversations).toBeDefined();
-      expect(intelligence.agentActions).toBeDefined();
-      expect(intelligence.ragDocuments).toBeDefined();
-      expect(intelligence.ragChunks).toBeDefined();
-      expect(intelligence.codeProvenance).toBeDefined();
-      expect(intelligence.codeReviews).toBeDefined();
+      expect(agents.agentContexts).toBeDefined();
+      expect(agents.agentMemories).toBeDefined();
+      expect(agents.conversations).toBeDefined();
+      expect(agents.agentActions).toBeDefined();
+      expect(agents.ragDocuments).toBeDefined();
+      expect(agents.ragChunks).toBeDefined();
+      expect(agents.codeProvenance).toBeDefined();
+      expect(agents.codeReviews).toBeDefined();
     });
 
     it('exports agent definition schema with validation', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.AgentDefinitionSchema).toBeDefined();
-      expect(typeof intelligence.AgentDefinitionSchema.parse).toBe('function');
-      expect(intelligence.AGENT_SCHEMA_VERSION).toBeDefined();
+      expect(agents.AgentDefinitionSchema).toBeDefined();
+      expect(typeof agents.AgentDefinitionSchema.parse).toBe('function');
+      expect(agents.AGENT_SCHEMA_VERSION).toBeDefined();
     });
 
     it('exports agent state and context schemas', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.AgentStateSchema).toBeDefined();
-      expect(intelligence.AgentContextSchema).toBeDefined();
-      expect(intelligence.AgentActionRecordSchema).toBeDefined();
-      expect(intelligence.AgentMemorySchema).toBeDefined();
-      expect(typeof intelligence.createAgentContext).toBe('function');
-      expect(typeof intelligence.createAgentMemory).toBe('function');
+      expect(agents.AgentStateSchema).toBeDefined();
+      expect(agents.AgentContextSchema).toBeDefined();
+      expect(agents.AgentActionRecordSchema).toBeDefined();
+      expect(agents.AgentMemorySchema).toBeDefined();
+      expect(typeof agents.createAgentContext).toBe('function');
+      expect(typeof agents.createAgentMemory).toBe('function');
     });
 
     it('exports A2A protocol schemas', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.A2AAgentCardSchema).toBeDefined();
-      expect(typeof intelligence.A2AAgentCardSchema.parse).toBe('function');
-      expect(typeof intelligence.agentDefinitionToCard).toBe('function');
+      expect(agents.A2AAgentCardSchema).toBeDefined();
+      expect(typeof agents.A2AAgentCardSchema.parse).toBe('function');
+      expect(typeof agents.agentDefinitionToCard).toBe('function');
     });
 
     it('exports conversation schemas and factories', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.ConversationSchema).toBeDefined();
-      expect(intelligence.ConversationMessageSchema).toBeDefined();
-      expect(typeof intelligence.createConversation).toBe('function');
-      expect(typeof intelligence.createMessage).toBe('function');
+      expect(agents.ConversationSchema).toBeDefined();
+      expect(agents.ConversationMessageSchema).toBeDefined();
+      expect(typeof agents.createConversation).toBe('function');
+      expect(typeof agents.createMessage).toBe('function');
     });
 
     it('exports embedding utilities', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.EmbeddingSchema).toBeDefined();
-      expect(typeof intelligence.createEmbedding).toBe('function');
-      expect(intelligence.DEFAULT_EMBEDDING_MODEL).toBeDefined();
-      expect(intelligence.DEFAULT_EMBEDDING_DIMENSION).toBeDefined();
-      expect(intelligence.EMBEDDING_DIMENSIONS).toBeDefined();
+      expect(agents.EmbeddingSchema).toBeDefined();
+      expect(typeof agents.createEmbedding).toBe('function');
+      expect(agents.DEFAULT_EMBEDDING_MODEL).toBeDefined();
+      expect(agents.DEFAULT_EMBEDDING_DIMENSION).toBeDefined();
+      expect(agents.EMBEDDING_DIMENSIONS).toBeDefined();
     });
 
     it('exports tool and intent schemas', async () => {
-      const { intelligence } = await import('../index.js');
+      const { agents } = await import('../index.js');
 
-      expect(intelligence.ToolDefinitionSchema).toBeDefined();
-      expect(typeof intelligence.toolDefinitionToSkill).toBe('function');
-      expect(intelligence.IntentSchema).toBeDefined();
+      expect(agents.ToolDefinitionSchema).toBeDefined();
+      expect(typeof agents.toolDefinitionToSkill).toBe('function');
+      expect(agents.IntentSchema).toBeDefined();
     });
   });
 
@@ -501,19 +501,19 @@ describe('@revealui/engines', () => {
       }
     });
 
-    it('intelligence db tables are Drizzle table objects', async () => {
-      const { intelligence } = await import('../index.js');
+    it('agents db tables are Drizzle table objects', async () => {
+      const { agents } = await import('../index.js');
 
       const drizzleName = Symbol.for('drizzle:Name');
       for (const table of [
-        intelligence.agentContexts,
-        intelligence.agentMemories,
-        intelligence.conversations,
-        intelligence.agentActions,
-        intelligence.ragDocuments,
-        intelligence.ragChunks,
-        intelligence.codeProvenance,
-        intelligence.codeReviews,
+        agents.agentContexts,
+        agents.agentMemories,
+        agents.conversations,
+        agents.agentActions,
+        agents.ragDocuments,
+        agents.ragChunks,
+        agents.codeProvenance,
+        agents.codeReviews,
       ]) {
         expect(drizzleName in (table as object)).toBe(true);
       }
@@ -527,7 +527,7 @@ describe('@revealui/engines', () => {
         engines.content,
         engines.products,
         engines.payments,
-        engines.intelligence,
+        engines.agents,
       ];
 
       for (let i = 0; i < namespaces.length; i++) {

--- a/packages/engines/src/agents/index.ts
+++ b/packages/engines/src/agents/index.ts
@@ -1,5 +1,5 @@
 /**
- * Intelligence primitive — AI agents, memory, LLM providers, RAG, and tools.
+ * Agents primitive — AI agents, memory, LLM providers, RAG, and tools.
  *
  * Re-exports from @revealui/ai, @revealui/db, and @revealui/contracts.
  */
@@ -55,7 +55,7 @@ export {
   ToolDefinitionSchema,
   toolDefinitionToSkill,
 } from '@revealui/contracts';
-// ── DB: intelligence tables ─────────────────────────────────────────────────
+// ── DB: agent tables ─────────────────────────────────────────────────
 export {
   agentActions,
   agentContexts,

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -4,7 +4,7 @@
  * Each primitive is available as a namespace import:
  *
  * ```ts
- * import { users, content, products, payments, intelligence } from '@revealui/engines';
+ * import { users, content, products, payments, agents } from '@revealui/engines';
  * ```
  *
  * Or import a specific primitive directly:
@@ -14,8 +14,8 @@
  * ```
  */
 
+export * as agents from './agents/index.js';
 export * as content from './content/index.js';
-export * as intelligence from './intelligence/index.js';
 export * as payments from './payments/index.js';
 export * as products from './products/index.js';
 export * as users from './users/index.js';


### PR DESCRIPTION
## What

Renames the `@revealui/engines` **`./intelligence` subpath → `./agents`** to align the engines facade with the locked 2026-06-07 primitive vocabulary (Intelligence → Agents). This is the one code-identifier rename the realignment scope flagged as safe to do now.

## Why it's safe

`@revealui/engines` is `private: true`, source-only (no build, never published to npm), and a repo-wide search found **zero external importers** of the `./intelligence` subpath or the `intelligence` namespace. So this is an internal-facade rename: no DB migration, no npm republish, no consumer break.

## Changes

- `git mv src/intelligence → src/agents` (the dir is pure re-exports from `@revealui/ai` + `@revealui/db`, already agent-named).
- `package.json`: `"./intelligence"` export → `"./agents"`; description updated.
- `src/index.ts`: `export * as intelligence` → `export * as agents` (reordered alphabetically).
- `src/__tests__/engines.test.ts`: the `intelligence` namespace assertions → `agents` (52 refs, lockstep).
- Two stale comments in the moved file.

## Explicitly left alone

- `./users` and `./products` subpaths — they front the `users`/`products` tables and `User` types; renaming would misname what they wrap (all-or-none, owner call).
- The `ai` / `payments` FeatureFlag keys, the `@revealui/ai` package, and DB tables — runtime/structural, out of scope.

## Verification

Mechanical namespace rename with the test updated in lockstep; the underlying re-exports are unchanged. The isolated worktree has no `node_modules`, so CI runs the engines suite + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
