### PR TITLE
fix(presentation): emit doc-system frontmatter from the design-context generator

### DIFF
--- a/packages/presentation/scripts/build-design-context.ts
+++ b/packages/presentation/scripts/build-design-context.ts
@@ -40,9 +40,28 @@ writeFileSync(join(OUT_DIR, 'tokens.css'), tokensSrc);
 
 writeFileSync(join(OUT_DIR, 'MANIFEST.sha256'), `${digest}  tokens.css\n`);
 
+// Frontmatter for the generated .md packs. The doc-system
+// (scripts/docs/apply-frontmatter.ts) classifies design-context/** as internal
+// docs and stamps this block; emitting it from the generator keeps regeneration
+// idempotent, so the "generated types in sync" CI gate stays green on rebuild.
+const frontmatter = (title: string, description: string): string[] => [
+  '---',
+  `title: ${JSON.stringify(title)}`,
+  `description: ${JSON.stringify(description)}`,
+  'visibility: internal',
+  'status: generated',
+  'audience: maintainer',
+  '---',
+  '',
+];
+
 writeFileSync(
   join(OUT_DIR, 'brand.md'),
   [
+    ...frontmatter(
+      `${meta.brand.name} — ${meta.brand['formal-name']}`,
+      'Voice/headline rules consolidation deferred to lane Phase 3 (DS-V1). Canonical voice corpus: .jv messaging-funnel-audit/voice-and-headline-rules.md',
+    ),
     `<!-- ${BANNER} -->`,
     '',
     `# ${meta.brand.name} — ${meta.brand['formal-name']}`,
@@ -80,6 +99,10 @@ writeFileSync(
 writeFileSync(
   join(OUT_DIR, 'README.md'),
   [
+    ...frontmatter(
+      'RevealUI Design Context — Claude Design Pack',
+      'Drop this folder into a Claude Design session.',
+    ),
     `<!-- ${BANNER} -->`,
     '',
     '# RevealUI Design Context — Claude Design Pack',


### PR DESCRIPTION
## Summary

Fixes a pre-existing drift from #1293 that blocks any PR which rebuilds `packages/presentation`.

#1293's `scripts/docs/apply-frontmatter.ts` classifies `design-context/**` as internal docs and stamps YAML frontmatter (`title`/`description`/`visibility`/`status`/`audience`) onto the **generated** `design-context/README.md` + `brand.md`. But `build-design-context.ts` emitted those files **without** frontmatter — so every `gen:design-context` (run during the presentation build) stripped it, failing the **"Validate generated types are in sync"** Build gate.

#1296 didn't hit it (its React-catalog change didn't rebuild presentation); [#1295](https://github.com/RevealUIStudio/revealui/pull/1295) did, surfacing it.

## Fix

The generator now emits the same frontmatter via a small typed `frontmatter()` helper, so regeneration is **idempotent**.

**Verified:** after `pnpm --filter @revealui/presentation gen:design-context`, `git diff packages/presentation/design-context/` is **empty** — the generator reproduces the committed files byte-for-byte. Biome clean.

Brand title is templated from `brand-meta.json` (stays in sync with the H1); README title/description mirror the existing body copy.

## Scope

One file (`packages/presentation/scripts/build-design-context.ts`, +23). No generated-file content change. Unblocks #1295 once merged (then I'll rebase #1295 onto test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
