### PR TITLE
chore(ci): drop dependabot docker entry for apps/marketing (no Dockerfile)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -136,16 +136,3 @@ updates:
     ignore:
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "docker"
-    directory: "/apps/marketing"
-    schedule:
-      interval: "monthly"
-      timezone: "UTC"
-    labels:
-      - "dependencies"
-      - "docker"
-      - "automated"
-    ignore:
-      - dependency-name: "node"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Removes the docker dependabot ecosystem entry for apps/marketing, which has no Dockerfile (it is a Vite SPA). That entry failed dependency_file_not_found on every Dependabot run. The apps/admin and apps/docs docker entries are valid (both have Dockerfiles, both pass) and are unchanged. Squash-merge is fine here (config chore, not a test/main sync).