### PR TITLE
fix(ci): least-privilege permissions + pin-comment + doc corrections

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,7 @@ Mirrors the local `pnpm gate` — same hard-fail/warn policy:
 | Build                       | all (affected on PRs)             | Hard fail   |
 | Unit tests                  | all                               | Hard fail   |
 | Integration tests           | PRs + push to main                | Hard fail   |
-| Integration tests (extended)| PRs + push to main (advisory)     | Hard fail   |
+| Integration tests (extended)| PRs + push to main                | Advisory    |
 | Coverage                    | main and PRs targeting main       | Hard fail   |
 | E2E smoke                   | main and PRs targeting main       | Hard fail   |
 | Accessibility (E2E)         | main and PRs targeting main       | Hard fail   |

--- a/.github/workflows/electric-e2e.yml
+++ b/.github/workflows/electric-e2e.yml
@@ -65,9 +65,11 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Probe Electric health before running E2E
+        env:
+          ADMIN_URL: ${{ secrets.ELECTRIC_E2E_ADMIN_URL }}
         run: |
           STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-            "${{ secrets.ELECTRIC_E2E_ADMIN_URL }}/api/health/electric" || echo "000")
+            "$ADMIN_URL/api/health/electric" || echo "000")
           if [ "$STATUS" != "200" ]; then
             echo "::error::Electric health probe returned HTTP $STATUS — skipping E2E to avoid false failures"
             exit 1

--- a/.github/workflows/issue-leak-scan.yml
+++ b/.github/workflows/issue-leak-scan.yml
@@ -51,7 +51,7 @@ jobs:
           gitleaks version
 
       - name: Scan + comment + label on findings
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('node:fs/promises');

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4 (resolved 2026-05-19)
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/reconciliation-crons.yml
+++ b/.github/workflows/reconciliation-crons.yml
@@ -30,6 +30,10 @@ on:
         required: false
         default: 'manual ops trigger'
 
+# These jobs only POST to an external API with a bearer secret; they never use
+# GITHUB_TOKEN. Grant it nothing (previously inherited the repo-default scope).
+permissions: {}
+
 jobs:
   drain-unreconciled:
     name: drain-unreconciled


### PR DESCRIPTION
## CI hygiene batch (workflow audit)

Five small, low-risk fixes from an audit of `.github/workflows/`. No change to CI gating behavior except the permissions tightening (the affected jobs don't use `GITHUB_TOKEN`).

- **`reconciliation-crons.yml`** — add `permissions: {}`. It was the only workflow without a `permissions:` block, so its `GITHUB_TOKEN` inherited the repo-default scope despite the jobs only POSTing to an external endpoint with a bearer secret. Least-privilege.
- **`electric-e2e.yml`** — route `ELECTRIC_E2E_ADMIN_URL` through `env:` rather than interpolating the secret directly into the `run` script.
- **`issue-leak-scan.yml`** — correct the `actions/github-script` pin comment `v8.0.0` → `v9.0.0` (SHA `3a2844b` is v9.0.0; the pin itself is unchanged).
- **`promotion-gate.yml`** — correct the `actions/checkout` pin comment `v4` → `v6` (SHA `df4cb1c` is v6; pin unchanged).
- **`README.md`** — mark *Integration tests (extended)* as **Advisory** instead of *Hard fail*; it isn't a branch-protection required check (matches the `ci.yml` job comment).

### Verification
- `git diff` reviewed; the four changed workflow YAMLs parse cleanly.
- Pin comments verified against the GitHub tags API (`3a2844b` = v9.0.0, `df4cb1c` = v6).
