### PR TITLE
ci(deploy): single-source Vercel project IDs

### DIFF
--- a/.github/vercel-projects.json
+++ b/.github/vercel-projects.json
@@ -1,0 +1,6 @@
+{
+  "api": "prj_zk6EQijYXwd9L7BccuBssi436ktM",
+  "admin": "prj_7sEFDg4MH6C26nJPjrukK86QdwfG",
+  "marketing": "prj_frTIYlnONVPLNIjKnQpINiGb5lm0",
+  "docs": "prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1"
+}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -71,20 +71,18 @@ jobs:
           echo "has-apps=true" >> "$GITHUB_OUTPUT"
           echo "app-list=$AFFECTED" >> "$GITHUB_OUTPUT"
 
-          MATRIX="["
-          FIRST=true
+          # Build matrix JSON from the single-source project-id map
+          # (.github/vercel-projects.json); unknown apps dropped + warned.
+          MATRIX=$(jq -cn --slurpfile map .github/vercel-projects.json --arg apps "$AFFECTED" '
+            [ ($apps | split(" ") | .[] | select(length > 0))
+              | select($map[0][.] != null)
+              | {app: ., "project-id": $map[0][.]} ]
+          ')
           for app in $AFFECTED; do
-            case "$app" in
-              api)        PID="prj_zk6EQijYXwd9L7BccuBssi436ktM" ;;
-              admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
-              marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
-              docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              *) echo "::warning::Unknown app: $app"; continue ;;
-            esac
-            if [ "$FIRST" = true ]; then FIRST=false; else MATRIX="$MATRIX,"; fi
-            MATRIX="$MATRIX{\"app\":\"$app\",\"project-id\":\"$PID\"}"
+            if [ "$(jq -r --arg a "$app" '.[$a] // "null"' .github/vercel-projects.json)" = "null" ]; then
+              echo "::warning::Unknown app: $app"
+            fi
           done
-          MATRIX="$MATRIX]"
 
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "::notice::Preview deploy: $AFFECTED"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest
 
+      - name: Resolve api project id from .github/vercel-projects.json
+        run: echo "API_PROJECT_ID=$(jq -r '.api' .github/vercel-projects.json)" >> "$GITHUB_ENV"
+
       - name: Pull production env from Vercel (api project)
         run: |
           rm -rf .vercel
@@ -102,7 +105,7 @@ jobs:
           fi
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: prj_zk6EQijYXwd9L7BccuBssi436ktM # api
+          VERCEL_PROJECT_ID: ${{ env.API_PROJECT_ID }} # api (from .github/vercel-projects.json)
 
       - name: Build @revealui/core (transitive dep of validate-startup)
         # validateStartup imports validateLicenseKey from @revealui/core/license
@@ -276,21 +279,19 @@ jobs:
           echo "has-apps=true" >> "$GITHUB_OUTPUT"
           echo "app-list=$AFFECTED" >> "$GITHUB_OUTPUT"
 
-          # Build matrix JSON with project IDs
-          MATRIX="["
-          FIRST=true
+          # Build matrix JSON from the single-source project-id map
+          # (.github/vercel-projects.json). Unknown apps are dropped from the
+          # matrix (and warned below), matching the prior case-statement.
+          MATRIX=$(jq -cn --slurpfile map .github/vercel-projects.json --arg apps "$AFFECTED" '
+            [ ($apps | split(" ") | .[] | select(length > 0))
+              | select($map[0][.] != null)
+              | {app: ., "project-id": $map[0][.]} ]
+          ')
           for app in $AFFECTED; do
-            case "$app" in
-              api)        PID="prj_zk6EQijYXwd9L7BccuBssi436ktM" ;;
-              admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
-              marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
-              docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              *) echo "::warning::Unknown app: $app"; continue ;;
-            esac
-            if [ "$FIRST" = true ]; then FIRST=false; else MATRIX="$MATRIX,"; fi
-            MATRIX="$MATRIX{\"app\":\"$app\",\"project-id\":\"$PID\"}"
+            if [ "$(jq -r --arg a "$app" '.[$a] // "null"' .github/vercel-projects.json)" = "null" ]; then
+              echo "::warning::Unknown app: $app"
+            fi
           done
-          MATRIX="$MATRIX]"
 
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "::notice::Deploying: $AFFECTED"
@@ -444,13 +445,11 @@ jobs:
           ROLLBACK_FAILED=0
           ROLLBACK_NO_HISTORY=0
           for app in $APP_LIST; do
-            case "$app" in
-              api)        PID="prj_zk6EQijYXwd9L7BccuBssi436ktM" ;;
-              admin)      PID="prj_7sEFDg4MH6C26nJPjrukK86QdwfG" ;;
-              marketing)  PID="prj_frTIYlnONVPLNIjKnQpINiGb5lm0" ;;
-              docs)       PID="prj_OPwr0FrgcK17AOBCyoj4JIilJ9S1" ;;
-              *) continue ;;
-            esac
+            # Look the project id up from the detect job's matrix (built from the
+            # single-source .github/vercel-projects.json). This job has no checkout,
+            # so it reuses the matrix via env rather than reading the file. Unknown -> skip.
+            PID=$(printf '%s' "$DETECT_MATRIX" | jq -r --arg a "$app" '.[] | select(.app == $a) | .["project-id"]')
+            if [ -z "$PID" ]; then continue; fi
 
             echo ""
             echo "=== Rolling back $app ($PID) ==="
@@ -515,6 +514,9 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ""
           VERCEL_TEAM_SLUG: ${{ vars.TURBO_TEAM || 'revealuistudio' }}
+          # Reuse the matrix the detect job built from .github/vercel-projects.json
+          # (this job has no checkout, so it can't read the file directly).
+          DETECT_MATRIX: ${{ needs.detect.outputs.matrix }}
 
   # ---------------------------------------------------------------------------
   # Summary

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,6 +21,16 @@ useDefault = true
 [allowlist]
 description = "Test fixtures, CLI templates, documentation examples, and CI placeholder secrets"
 
+# Vercel project IDs (prj_ + base62) are non-secret identifiers, not credentials.
+# They are committed by design in .github/vercel-projects.json (the app -> project-id
+# map that single-sources deploy targets). The generic-api-key rule trips on their
+# entropy; allowlist the identifier shape so the exemption is durable across line /
+# commit drift (a fingerprint in .gitleaksignore would break on squash-merge).
+# REGEX-CONFIG-BOUNDARY (gitleaks TOML; minimal, anchored to the Vercel prj_ prefix).
+regexes = [
+  '''prj_[A-Za-z0-9]{20,}''',
+]
+
 paths = [
   # Tests — any file under a __tests__ directory
   '''(^|.*/)__tests__/.*''',


### PR DESCRIPTION
## Single-source the Vercel project-ID map (#6)

The `app → project-id` map was duplicated in **4 places**: `deploy.yml` detect-matrix + rollback, `deploy-test.yml` detect-matrix, and the `deploy.yml` validate api hardcode. Adding / renaming / rotating an app meant editing all four, which can drift.

Extracted to a single `.github/vercel-projects.json`:
- **detect** (`deploy.yml` + `deploy-test.yml`) — build the matrix with `jq` from the file (both jobs check out the repo).
- **validate** — a resolve step reads `.api` into `$GITHUB_ENV`.
- **rollback** — the `smoke-test` job has no checkout, so it reuses the `detect` job's `matrix` output via env (`DETECT_MATRIX`) rather than re-reading the file. Truly single-source.

Behaviour preserved: the `jq` matrix-build + lookup were validated locally to produce **byte-identical** output to the prior case-statements (app order preserved, unknown apps dropped + warned). YAML parsed clean.

Follow-up in its own PR: #9 (`persist-credentials: false` on read-only checkouts).
