### PR TITLE
refactor(core): replace @aws-sdk/client-s3 with a native R2 client

### DIFF
--- a/.changeset/native-r2-client.md
+++ b/.changeset/native-r2-client.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": minor
+---
+
+Replace the `@aws-sdk/client-s3` dependency with a native, dependency-free Cloudflare R2 storage client. The R2 `StorageProvider` now signs requests with AWS Signature V4 (`node:crypto`) over global `fetch` and reads `ListObjectsV2`/error responses with a small no-regex XML parser, instead of routing through the AWS SDK. The provider contract and all behavior are unchanged; this drops the entire `@aws-sdk` / `@aws-crypto` / `@smithy` transitive dependency tree.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,6 @@
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1064.0",
     "@electric-sql/pglite": "catalog:",
     "@lexical/clipboard": "^0.45.0",
     "@lexical/code": "^0.45.0",

--- a/packages/core/src/storage/__tests__/_sigv4.test.ts
+++ b/packages/core/src/storage/__tests__/_sigv4.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { awsUriEncode, computeSigV4, EMPTY_SHA256, signS3Request } from '../_sigv4.js';
+
+describe('computeSigV4', () => {
+  // AWS SigV4 test-suite, `get-vanilla` — the canonical known-answer vector.
+  // https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
+  it('matches the published AWS get-vanilla signature', () => {
+    const result = computeSigV4({
+      method: 'GET',
+      canonicalPath: '/',
+      query: [],
+      headersToSign: { Host: 'example.amazonaws.com', 'X-Amz-Date': '20150830T123600Z' },
+      payloadHash: EMPTY_SHA256,
+      amzDate: '20150830T123600Z',
+      region: 'us-east-1',
+      service: 'service',
+      accessKeyId: 'AKIDEXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+    });
+    expect(result.signature).toBe(
+      '5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31',
+    );
+    expect(result.signedHeaders).toBe('host;x-amz-date');
+  });
+});
+
+describe('awsUriEncode', () => {
+  it('preserves slashes in paths and encodes spaces + reserved chars', () => {
+    expect(awsUriEncode('media/a b.jpg', false)).toBe('media/a%20b.jpg');
+    expect(awsUriEncode('uploads/(x)+y&z', false)).toBe('uploads/%28x%29%2By%26z');
+  });
+
+  it('leaves unreserved chars (~) untouched', () => {
+    expect(awsUriEncode('tilde~ok.txt', false)).toBe('tilde~ok.txt');
+  });
+
+  it('encodes slashes when encodeSlash=true (query values)', () => {
+    expect(awsUriEncode('media/x', true)).toBe('media%2Fx');
+  });
+});
+
+describe('signS3Request', () => {
+  const creds = {
+    accountId: 'acct-123',
+    accessKeyId: 'AKIA-TEST',
+    secretAccessKey: 'secret',
+    region: 'auto',
+  } as const;
+
+  it('builds a path-style R2 URL with an auto/s3-scoped AWS4 Authorization', () => {
+    const { url, headers } = signS3Request({
+      method: 'PUT',
+      bucket: 'media',
+      key: 'uploads/a.bin',
+      payloadHash: EMPTY_SHA256,
+      now: new Date('2026-05-18T10:00:00.000Z'),
+      ...creds,
+    });
+    expect(url).toBe('https://acct-123.r2.cloudflarestorage.com/media/uploads/a.bin');
+    expect(headers.authorization).toContain(
+      'AWS4-HMAC-SHA256 Credential=AKIA-TEST/20260518/auto/s3/aws4_request',
+    );
+    expect(headers['x-amz-date']).toBe('20260518T100000Z');
+    expect(headers['x-amz-content-sha256']).toBe(EMPTY_SHA256);
+  });
+
+  it('sorts query params and drops undefined values', () => {
+    const { url } = signS3Request({
+      method: 'GET',
+      bucket: 'media',
+      query: {
+        'list-type': '2',
+        prefix: 'media/',
+        'max-keys': '2',
+        'continuation-token': undefined,
+      },
+      payloadHash: EMPTY_SHA256,
+      now: new Date('2026-05-18T10:00:00.000Z'),
+      ...creds,
+    });
+    expect(url).toBe(
+      'https://acct-123.r2.cloudflarestorage.com/media?list-type=2&max-keys=2&prefix=media%2F',
+    );
+  });
+});

--- a/packages/core/src/storage/__tests__/_xml.test.ts
+++ b/packages/core/src/storage/__tests__/_xml.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { parseListObjectsV2, s3ErrorFields } from '../_xml.js';
+
+const LIST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Name>media</Name>
+  <Prefix>media/</Prefix>
+  <IsTruncated>true</IsTruncated>
+  <NextContinuationToken>next-cursor</NextContinuationToken>
+  <Contents><Key>media/a.jpg</Key><LastModified>2026-05-18T10:00:00.000Z</LastModified><Size>1024</Size></Contents>
+  <Contents><Key>media/b.jpg</Key><LastModified>2026-05-18T11:00:00.000Z</LastModified><Size>2048</Size></Contents>
+</ListBucketResult>`;
+
+describe('parseListObjectsV2', () => {
+  it('maps objects + truncation flag + continuation token', () => {
+    const result = parseListObjectsV2(LIST_XML);
+    expect(result.isTruncated).toBe(true);
+    expect(result.nextContinuationToken).toBe('next-cursor');
+    expect(result.objects).toEqual([
+      { key: 'media/a.jpg', size: 1024, lastModified: new Date('2026-05-18T10:00:00.000Z') },
+      { key: 'media/b.jpg', size: 2048, lastModified: new Date('2026-05-18T11:00:00.000Z') },
+    ]);
+  });
+
+  it('handles an empty result', () => {
+    const result = parseListObjectsV2(
+      '<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>',
+    );
+    expect(result.objects).toEqual([]);
+    expect(result.isTruncated).toBe(false);
+    expect(result.nextContinuationToken).toBeUndefined();
+  });
+
+  it('defaults a missing Size to 0 and a missing LastModified to the epoch', () => {
+    const result = parseListObjectsV2(
+      '<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>a</Key></Contents></ListBucketResult>',
+    );
+    expect(result.objects[0]).toEqual({ key: 'a', size: 0, lastModified: new Date(0) });
+  });
+
+  it('omits Contents rows without a Key', () => {
+    const result = parseListObjectsV2(
+      '<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Size>5</Size></Contents></ListBucketResult>',
+    );
+    expect(result.objects).toEqual([]);
+  });
+
+  it('decodes XML entities in keys', () => {
+    const result = parseListObjectsV2(
+      '<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>a&amp;b/c.jpg</Key><Size>1</Size></Contents></ListBucketResult>',
+    );
+    expect(result.objects[0].key).toBe('a&b/c.jpg');
+  });
+});
+
+describe('s3ErrorFields', () => {
+  it('extracts Code + Message from an Error body', () => {
+    const { code, message } = s3ErrorFields(
+      '<Error><Code>NoSuchKey</Code><Message>The key does not exist.</Message></Error>',
+    );
+    expect(code).toBe('NoSuchKey');
+    expect(message).toBe('The key does not exist.');
+  });
+
+  it('returns undefined fields for a non-error body', () => {
+    expect(s3ErrorFields('<ok/>')).toEqual({ code: undefined, message: undefined });
+  });
+});

--- a/packages/core/src/storage/__tests__/factory.test.ts
+++ b/packages/core/src/storage/__tests__/factory.test.ts
@@ -1,21 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
-
-// Stub @aws-sdk/client-s3 so createR2Provider can construct the S3Client
-// without touching network / requiring real creds.
-vi.mock('@aws-sdk/client-s3', () => ({
-  S3Client: class {
-    constructor(_args: unknown) {}
-  },
-  PutObjectCommand: class {
-    constructor(public input: unknown) {}
-  },
-  DeleteObjectCommand: class {
-    constructor(public input: unknown) {}
-  },
-  ListObjectsV2Command: class {
-    constructor(public input: unknown) {}
-  },
-}));
+import { describe, expect, it } from 'vitest';
 
 import { createStorage } from '../index.js';
 import type { StorageConfig } from '../types.js';

--- a/packages/core/src/storage/__tests__/r2.test.ts
+++ b/packages/core/src/storage/__tests__/r2.test.ts
@@ -1,46 +1,43 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// ---------------------------------------------------------------------------
-// Mock @aws-sdk/client-s3 — capture S3Client constructor args + every command
-// sent, return canned responses from a queue per command type.
-// ---------------------------------------------------------------------------
-const s3ConstructorArgs: unknown[] = [];
-const sendCalls: Array<{ command: string; input: unknown }> = [];
-const listResponses: unknown[] = [];
-
-vi.mock('@aws-sdk/client-s3', () => {
-  class FakeS3Client {
-    constructor(args: unknown) {
-      s3ConstructorArgs.push(args);
-    }
-    async send(command: { __command: string; input: unknown }): Promise<unknown> {
-      sendCalls.push({ command: command.__command, input: command.input });
-      if (command.__command === 'ListObjectsV2Command') {
-        return listResponses.shift() ?? { Contents: [], IsTruncated: false };
-      }
-      return {};
-    }
-  }
-  const wrap = (name: string) => {
-    return class {
-      readonly __command = name;
-      constructor(public input: unknown) {}
-    };
-  };
-  return {
-    S3Client: FakeS3Client,
-    PutObjectCommand: wrap('PutObjectCommand'),
-    DeleteObjectCommand: wrap('DeleteObjectCommand'),
-    ListObjectsV2Command: wrap('ListObjectsV2Command'),
-  };
-});
-
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createR2Provider } from '../r2.js';
 import type { R2Config } from '../types.js';
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Mock global fetch — capture every request (url + method + lowercased headers
+// + body) and return canned Responses from a queue.
 // ---------------------------------------------------------------------------
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let requests: CapturedRequest[];
+let responseQueue: Response[];
+
+beforeEach(() => {
+  requests = [];
+  responseQueue = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const raw = init?.headers;
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      for (const [k, v] of Object.entries(raw as Record<string, string>)) {
+        headers[k.toLowerCase()] = v;
+      }
+    }
+    requests.push({ url, method: init?.method ?? 'GET', headers, body: init?.body });
+    return Promise.resolve(responseQueue.shift() ?? new Response('', { status: 200 }));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 function baseConfig(overrides: Partial<R2Config> = {}): R2Config {
   return {
     accountId: 'acct-123',
@@ -52,16 +49,11 @@ function baseConfig(overrides: Partial<R2Config> = {}): R2Config {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-describe('createR2Provider', () => {
-  beforeEach(() => {
-    s3ConstructorArgs.length = 0;
-    sendCalls.length = 0;
-    listResponses.length = 0;
-  });
+function queueResponse(body: string, status = 200): void {
+  responseQueue.push(new Response(body, { status }));
+}
 
+describe('createR2Provider', () => {
   describe('construction', () => {
     it('throws if publicBaseUrl is missing', () => {
       expect(() => createR2Provider(baseConfig({ publicBaseUrl: undefined }))).toThrow(
@@ -69,40 +61,32 @@ describe('createR2Provider', () => {
       );
     });
 
-    it('configures S3Client with R2 endpoint + region="auto" + credentials', () => {
-      createR2Provider(baseConfig());
-      expect(s3ConstructorArgs).toHaveLength(1);
-      expect(s3ConstructorArgs[0]).toEqual({
-        region: 'auto',
-        endpoint: 'https://acct-123.r2.cloudflarestorage.com',
-        credentials: {
-          accessKeyId: 'AKIA-TEST',
-          secretAccessKey: 'secret-test',
-        },
-      });
+    it('exposes provider="r2"', () => {
+      expect(createR2Provider(baseConfig()).provider).toBe('r2');
     });
 
-    it('exposes provider="r2"', () => {
+    it('signs requests for the R2 path-style endpoint with region=auto + service=s3', async () => {
       const provider = createR2Provider(baseConfig());
-      expect(provider.provider).toBe('r2');
+      await provider.put('k', new Uint8Array([1]));
+      expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/k');
+      expect(requests[0].headers.authorization).toContain('AWS4-HMAC-SHA256 Credential=AKIA-TEST/');
+      expect(requests[0].headers.authorization).toContain('/auto/s3/aws4_request');
+      expect(requests[0].headers.authorization).toContain('Signature=');
+      expect(requests[0].headers['x-amz-content-sha256']).toBeDefined();
     });
   });
 
   describe('put', () => {
-    it('sends PutObjectCommand with bucket + key + body + content-type', async () => {
+    it('PUTs to the object URL with body + content-type and returns the public URL', async () => {
       const provider = createR2Provider(baseConfig());
       const body = new Uint8Array([1, 2, 3, 4, 5]);
       const result = await provider.put('uploads/a.bin', body, { contentType: 'image/png' });
 
-      expect(sendCalls).toHaveLength(1);
-      expect(sendCalls[0].command).toBe('PutObjectCommand');
-      expect(sendCalls[0].input).toMatchObject({
-        Bucket: 'media',
-        Key: 'uploads/a.bin',
-        Body: body,
-        ContentType: 'image/png',
-        ContentLength: 5,
-      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0].method).toBe('PUT');
+      expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/uploads/a.bin');
+      expect(requests[0].headers['content-type']).toBe('image/png');
+      expect(requests[0].body).toBe(body);
 
       expect(result).toEqual({
         key: 'uploads/a.bin',
@@ -115,19 +99,17 @@ describe('createR2Provider', () => {
     it('defaults contentType to application/octet-stream', async () => {
       const provider = createR2Provider(baseConfig());
       await provider.put('blob', new Uint8Array([1]));
-      expect(sendCalls[0].input).toMatchObject({ ContentType: 'application/octet-stream' });
+      expect(requests[0].headers['content-type']).toBe('application/octet-stream');
     });
 
-    it('passes cacheControl + metadata when provided', async () => {
+    it('sends cacheControl + metadata as signed headers when provided', async () => {
       const provider = createR2Provider(baseConfig());
       await provider.put('cached', new Uint8Array([1]), {
         cacheControl: 'public, max-age=3600',
         metadata: { owner: 'tester' },
       });
-      expect(sendCalls[0].input).toMatchObject({
-        CacheControl: 'public, max-age=3600',
-        Metadata: { owner: 'tester' },
-      });
+      expect(requests[0].headers['cache-control']).toBe('public, max-age=3600');
+      expect(requests[0].headers['x-amz-meta-owner']).toBe('tester');
     });
 
     it('strips trailing slash from publicBaseUrl when building result url', async () => {
@@ -136,11 +118,18 @@ describe('createR2Provider', () => {
       expect(result.url).toBe('https://cdn.example/a/b.txt');
     });
 
-    it('throws when access="private" is requested (Phase 2a limit)', async () => {
+    it('throws when access="private" is requested (Phase 2a limit) without sending a request', async () => {
       const provider = createR2Provider(baseConfig());
       await expect(provider.put('p', new Uint8Array([1]), { access: 'private' })).rejects.toThrow(
         /Phase 2a does not support access: 'private'/,
       );
+      expect(requests).toHaveLength(0);
+    });
+
+    it('throws with the S3 error code on a non-2xx response', async () => {
+      queueResponse('<Error><Code>AccessDenied</Code><Message>nope</Message></Error>', 403);
+      const provider = createR2Provider(baseConfig());
+      await expect(provider.put('p', new Uint8Array([1]))).rejects.toThrow(/AccessDenied/);
     });
 
     it('normalizes ArrayBuffer input', async () => {
@@ -153,8 +142,7 @@ describe('createR2Provider', () => {
 
     it('normalizes Blob input', async () => {
       const provider = createR2Provider(baseConfig());
-      const blob = new Blob(['hi']);
-      const result = await provider.put('b', blob);
+      const result = await provider.put('b', new Blob(['hi']));
       expect(result.size).toBe(2);
     });
 
@@ -173,63 +161,57 @@ describe('createR2Provider', () => {
   });
 
   describe('del', () => {
-    it('sends DeleteObjectCommand with the key when given a bare key', async () => {
+    it('DELETEs the key when given a bare key', async () => {
       const provider = createR2Provider(baseConfig());
       await provider.del('uploads/a.bin');
-      expect(sendCalls[0]).toEqual({
-        command: 'DeleteObjectCommand',
-        input: { Bucket: 'media', Key: 'uploads/a.bin' },
-      });
+      expect(requests[0].method).toBe('DELETE');
+      expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/uploads/a.bin');
     });
 
-    it('extracts key from a full URL', async () => {
+    it('extracts the key from a full URL', async () => {
       const provider = createR2Provider(baseConfig());
       await provider.del('https://media.revealui.com/uploads/b.png');
-      expect(sendCalls[0].input).toEqual({ Bucket: 'media', Key: 'uploads/b.png' });
+      expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/uploads/b.png');
     });
 
-    it('handles URL with no path beyond root', async () => {
+    it('treats a 404 as success (best-effort delete)', async () => {
+      queueResponse('<Error><Code>NoSuchKey</Code></Error>', 404);
       const provider = createR2Provider(baseConfig());
-      await provider.del('https://media.revealui.com/');
-      expect(sendCalls[0].input).toEqual({ Bucket: 'media', Key: '' });
+      await expect(provider.del('missing')).resolves.toBeUndefined();
     });
   });
 
   describe('list', () => {
-    it('returns mapped items + cursor + hasMore from ListObjectsV2 response', async () => {
-      listResponses.push({
-        Contents: [
-          { Key: 'media/a.jpg', Size: 1024, LastModified: new Date('2026-05-18T10:00:00Z') },
-          { Key: 'media/b.jpg', Size: 2048, LastModified: new Date('2026-05-18T11:00:00Z') },
-        ],
-        IsTruncated: true,
-        NextContinuationToken: 'next-cursor',
-      });
+    const LIST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <IsTruncated>true</IsTruncated>
+  <NextContinuationToken>next-cursor</NextContinuationToken>
+  <Contents><Key>media/a.jpg</Key><LastModified>2026-05-18T10:00:00.000Z</LastModified><Size>1024</Size></Contents>
+  <Contents><Key>media/b.jpg</Key><LastModified>2026-05-18T11:00:00.000Z</LastModified><Size>2048</Size></Contents>
+</ListBucketResult>`;
+
+    it('maps items + cursor + hasMore and sends list-type=2 + prefix + max-keys', async () => {
+      queueResponse(LIST_XML);
       const provider = createR2Provider(baseConfig());
       const result = await provider.list({ prefix: 'media/', limit: 2 });
 
-      expect(sendCalls[0]).toEqual({
-        command: 'ListObjectsV2Command',
-        input: {
-          Bucket: 'media',
-          Prefix: 'media/',
-          MaxKeys: 2,
-          ContinuationToken: undefined,
-        },
-      });
+      expect(requests[0].method).toBe('GET');
+      expect(requests[0].url).toBe(
+        'https://acct-123.r2.cloudflarestorage.com/media?list-type=2&max-keys=2&prefix=media%2F',
+      );
       expect(result).toEqual({
         items: [
           {
             key: 'media/a.jpg',
             url: 'https://media.revealui.com/media/a.jpg',
             size: 1024,
-            uploadedAt: new Date('2026-05-18T10:00:00Z'),
+            uploadedAt: new Date('2026-05-18T10:00:00.000Z'),
           },
           {
             key: 'media/b.jpg',
             url: 'https://media.revealui.com/media/b.jpg',
             size: 2048,
-            uploadedAt: new Date('2026-05-18T11:00:00Z'),
+            uploadedAt: new Date('2026-05-18T11:00:00.000Z'),
           },
         ],
         cursor: 'next-cursor',
@@ -237,59 +219,25 @@ describe('createR2Provider', () => {
       });
     });
 
-    it('defaults to maxKeys=1000 when no limit given', async () => {
-      listResponses.push({ Contents: [], IsTruncated: false });
+    it('defaults to max-keys=1000 when no limit is given', async () => {
+      queueResponse('<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>');
       const provider = createR2Provider(baseConfig());
       await provider.list();
-      expect(sendCalls[0].input).toMatchObject({ MaxKeys: 1000 });
+      expect(requests[0].url).toContain('max-keys=1000');
     });
 
-    it('handles empty Contents response', async () => {
-      listResponses.push({ Contents: [], IsTruncated: false });
+    it('handles an empty result', async () => {
+      queueResponse('<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>');
       const provider = createR2Provider(baseConfig());
       const result = await provider.list();
       expect(result).toEqual({ items: [], cursor: undefined, hasMore: false });
     });
 
-    it('omits entries without a Key', async () => {
-      listResponses.push({
-        Contents: [
-          { Key: 'a', Size: 1, LastModified: new Date('2026-01-01') },
-          { Size: 5, LastModified: new Date('2026-01-02') }, // bogus row
-        ],
-        IsTruncated: false,
-      });
-      const provider = createR2Provider(baseConfig());
-      const result = await provider.list();
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0].key).toBe('a');
-    });
-
-    it('falls back to epoch when LastModified is missing', async () => {
-      listResponses.push({
-        Contents: [{ Key: 'a', Size: 1 }],
-        IsTruncated: false,
-      });
-      const provider = createR2Provider(baseConfig());
-      const result = await provider.list();
-      expect(result.items[0].uploadedAt).toEqual(new Date(0));
-    });
-
-    it('falls back to size=0 when Size is missing', async () => {
-      listResponses.push({
-        Contents: [{ Key: 'a', LastModified: new Date('2026-01-01') }],
-        IsTruncated: false,
-      });
-      const provider = createR2Provider(baseConfig());
-      const result = await provider.list();
-      expect(result.items[0].size).toBe(0);
-    });
-
-    it('passes cursor through as ContinuationToken', async () => {
-      listResponses.push({ Contents: [], IsTruncated: false });
+    it('passes the cursor through as continuation-token', async () => {
+      queueResponse('<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>');
       const provider = createR2Provider(baseConfig());
       await provider.list({ cursor: 'resume-from' });
-      expect(sendCalls[0].input).toMatchObject({ ContinuationToken: 'resume-from' });
+      expect(requests[0].url).toContain('continuation-token=resume-from');
     });
   });
 });

--- a/packages/core/src/storage/_sigv4.ts
+++ b/packages/core/src/storage/_sigv4.ts
@@ -1,0 +1,201 @@
+/**
+ * AWS Signature Version 4 signer for the Cloudflare R2 (S3-compatible) API.
+ *
+ * Replaces the request signing that @aws-sdk/client-s3 used to do for us.
+ * Uses only node:crypto — no external dependencies, no regex.
+ *
+ * The core (`computeSigV4`) is verified byte-for-byte against the official AWS
+ * SigV4 test-suite `get-vanilla` vector in __tests__/_sigv4.test.ts.
+ *
+ * Server-only. Do NOT import from client-side code or edge runtime.
+ */
+
+import { createHash, createHmac } from 'node:crypto';
+
+const ALGORITHM = 'AWS4-HMAC-SHA256';
+const S3_SERVICE = 's3';
+
+/** Hex SHA-256 of the empty string — the payload hash for body-less requests. */
+export const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+/** Hex SHA-256 of arbitrary bytes (request payload hashing). */
+export function sha256Hex(data: string | Uint8Array): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function hmac(key: Uint8Array | string, data: string): Buffer {
+  return createHmac('sha256', key).update(data, 'utf8').digest();
+}
+
+const UNRESERVED = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~';
+
+/**
+ * RFC 3986 percent-encoding per the AWS SigV4 spec. `encodeSlash` is false for
+ * path segments (slashes are separators) and true for query keys/values.
+ */
+export function awsUriEncode(input: string, encodeSlash: boolean): string {
+  let out = '';
+  for (const byte of new TextEncoder().encode(input)) {
+    const ch = String.fromCharCode(byte);
+    if (UNRESERVED.includes(ch)) {
+      out += ch;
+    } else if (ch === '/' && !encodeSlash) {
+      out += '/';
+    } else {
+      out += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+  return out;
+}
+
+function toAmzDate(now: Date): { amzDate: string; dateStamp: string } {
+  const iso = now.toISOString(); // e.g. 2026-05-18T10:00:00.000Z
+  const amzDate = `${iso.slice(0, 4)}${iso.slice(5, 7)}${iso.slice(8, 10)}T${iso.slice(11, 13)}${iso.slice(14, 16)}${iso.slice(17, 19)}Z`;
+  return { amzDate, dateStamp: amzDate.slice(0, 8) };
+}
+
+/** Inputs to the verified SigV4 core. All path/header values must be final. */
+export interface CanonicalInput {
+  method: string;
+  /** Already AWS-URI-encoded path (slashes preserved). */
+  canonicalPath: string;
+  /** Raw (unencoded) query pairs; encoded + sorted by the signer. */
+  query: [string, string][];
+  /** Exact header set to sign (any case; lowercased + trimmed internally). */
+  headersToSign: Record<string, string>;
+  payloadHash: string;
+  amzDate: string;
+  region: string;
+  service: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+export interface SigV4Result {
+  signature: string;
+  signedHeaders: string;
+  scope: string;
+  canonicalQuery: string;
+}
+
+/**
+ * The verified SigV4 computation: canonical request → string-to-sign → signing
+ * key → signature. Verified against AWS's official `get-vanilla` test vector.
+ */
+export function computeSigV4(input: CanonicalInput): SigV4Result {
+  const lowered = new Map<string, string>();
+  for (const [name, value] of Object.entries(input.headersToSign)) {
+    lowered.set(name.toLowerCase(), value.trim());
+  }
+  const names = [...lowered.keys()].sort();
+  const canonicalHeaders = names.map((n) => `${n}:${lowered.get(n)}\n`).join('');
+  const signedHeaders = names.join(';');
+
+  const canonicalQuery = [...input.query]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${awsUriEncode(k, true)}=${awsUriEncode(v, true)}`)
+    .join('&');
+
+  const canonicalRequest = [
+    input.method,
+    input.canonicalPath,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    input.payloadHash,
+  ].join('\n');
+
+  const dateStamp = input.amzDate.slice(0, 8);
+  const scope = `${dateStamp}/${input.region}/${input.service}/aws4_request`;
+  const stringToSign = [ALGORITHM, input.amzDate, scope, sha256Hex(canonicalRequest)].join('\n');
+
+  const kDate = hmac(`AWS4${input.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, input.region);
+  const kService = hmac(kRegion, input.service);
+  const kSigning = hmac(kService, 'aws4_request');
+  const signature = createHmac('sha256', kSigning).update(stringToSign, 'utf8').digest('hex');
+
+  return { signature, signedHeaders, scope, canonicalQuery };
+}
+
+/** Inputs for an R2/S3 request signature. */
+export interface SignS3Input {
+  method: 'GET' | 'PUT' | 'DELETE';
+  accountId: string;
+  bucket: string;
+  /** Object key; omit for bucket-level operations (e.g. ListObjectsV2). */
+  key?: string;
+  /** Query params; `undefined` values are dropped before signing. */
+  query?: Record<string, string | undefined>;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Hex SHA-256 of the body, or EMPTY_SHA256 for body-less requests. */
+  payloadHash: string;
+  /** Extra headers to send + sign (content-type, cache-control, x-amz-meta-*). */
+  extraHeaders?: Record<string, string>;
+  now: Date;
+}
+
+export interface SignedS3Request {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Build a signed R2 request: a path-style URL + AWS4-HMAC-SHA256 Authorization
+ * header. The `host` header is signed but not returned — fetch/undici sets it
+ * from the URL (same value), and `Host` is a forbidden header to set manually.
+ */
+export function signS3Request(input: SignS3Input): SignedS3Request {
+  const host = `${input.accountId}.r2.cloudflarestorage.com`;
+  const { amzDate } = toAmzDate(input.now);
+
+  const encodedKey = (input.key ?? '')
+    .split('/')
+    .map((segment) => awsUriEncode(segment, false))
+    .join('/');
+  const canonicalPath =
+    input.key !== undefined
+      ? `/${awsUriEncode(input.bucket, false)}/${encodedKey}`
+      : `/${awsUriEncode(input.bucket, false)}`;
+
+  const query: [string, string][] = [];
+  for (const [k, v] of Object.entries(input.query ?? {})) {
+    if (v !== undefined) query.push([k, v]);
+  }
+
+  const headersToSign: Record<string, string> = {
+    host,
+    'x-amz-date': amzDate,
+    'x-amz-content-sha256': input.payloadHash,
+  };
+  for (const [k, v] of Object.entries(input.extraHeaders ?? {})) {
+    headersToSign[k.toLowerCase()] = v;
+  }
+
+  const { signature, signedHeaders, scope, canonicalQuery } = computeSigV4({
+    method: input.method,
+    canonicalPath,
+    query,
+    headersToSign,
+    payloadHash: input.payloadHash,
+    amzDate,
+    region: input.region,
+    service: S3_SERVICE,
+    accessKeyId: input.accessKeyId,
+    secretAccessKey: input.secretAccessKey,
+  });
+
+  const headers: Record<string, string> = {
+    'x-amz-date': amzDate,
+    'x-amz-content-sha256': input.payloadHash,
+    authorization: `${ALGORITHM} Credential=${input.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+  for (const [k, v] of Object.entries(input.extraHeaders ?? {})) {
+    headers[k.toLowerCase()] = v;
+  }
+
+  const url = `https://${host}${canonicalPath}${canonicalQuery ? `?${canonicalQuery}` : ''}`;
+  return { url, headers };
+}

--- a/packages/core/src/storage/_xml.ts
+++ b/packages/core/src/storage/_xml.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal, dependency-free readers for the two S3/R2 XML responses we consume:
+ * ListObjectsV2 results and `<Error>` bodies. Replaces the XML codec that
+ * @aws-sdk/client-s3 used to run for us.
+ *
+ * No regex (M2): a tag's text can never contain a raw `<` (XML escapes it to
+ * `&lt;`), so `indexOf`-based tag scanning is unambiguous.
+ */
+
+/** First `<tag>…</tag>` text content at or after `from`, or undefined. */
+function firstTagValue(xml: string, tag: string, from = 0): string | undefined {
+  const open = `<${tag}>`;
+  const start = xml.indexOf(open, from);
+  if (start === -1) return undefined;
+  const contentStart = start + open.length;
+  const end = xml.indexOf(`</${tag}>`, contentStart);
+  if (end === -1) return undefined;
+  return xml.slice(contentStart, end);
+}
+
+/** Decode the five predefined XML entities (no regex). `&amp;` is decoded last. */
+function decodeXmlEntities(value: string): string {
+  if (!value.includes('&')) return value;
+  return value
+    .split('&lt;')
+    .join('<')
+    .split('&gt;')
+    .join('>')
+    .split('&quot;')
+    .join('"')
+    .split('&apos;')
+    .join("'")
+    .split('&amp;')
+    .join('&');
+}
+
+export interface ListedObject {
+  key: string;
+  size: number;
+  lastModified: Date;
+}
+
+export interface ParsedList {
+  objects: ListedObject[];
+  isTruncated: boolean;
+  nextContinuationToken?: string;
+}
+
+/** Parse an S3 ListObjectsV2 XML response into the fields the R2 provider needs. */
+export function parseListObjectsV2(xml: string): ParsedList {
+  const objects: ListedObject[] = [];
+  const contentsOpen = '<Contents>';
+  const contentsClose = '</Contents>';
+  let cursor = 0;
+  for (;;) {
+    const start = xml.indexOf(contentsOpen, cursor);
+    if (start === -1) break;
+    const end = xml.indexOf(contentsClose, start);
+    if (end === -1) break;
+    const block = xml.slice(start + contentsOpen.length, end);
+    const key = firstTagValue(block, 'Key');
+    if (key !== undefined) {
+      const lastModified = firstTagValue(block, 'LastModified');
+      objects.push({
+        key: decodeXmlEntities(key),
+        size: Number(firstTagValue(block, 'Size') ?? '0') || 0,
+        lastModified: lastModified ? new Date(lastModified) : new Date(0),
+      });
+    }
+    cursor = end + contentsClose.length;
+  }
+
+  const token = firstTagValue(xml, 'NextContinuationToken');
+  return {
+    objects,
+    isTruncated: firstTagValue(xml, 'IsTruncated') === 'true',
+    nextContinuationToken: token !== undefined ? decodeXmlEntities(token) : undefined,
+  };
+}
+
+/** Extract `<Code>`/`<Message>` from an S3 `<Error>` response for diagnostics. */
+export function s3ErrorFields(xml: string): { code?: string; message?: string } {
+  return {
+    code: firstTagValue(xml, 'Code'),
+    message: firstTagValue(xml, 'Message'),
+  };
+}

--- a/packages/core/src/storage/r2.ts
+++ b/packages/core/src/storage/r2.ts
@@ -1,21 +1,29 @@
 /**
  * Cloudflare R2 implementation of StorageProvider.
  *
- * R2 is S3-compatible — uses @aws-sdk/client-s3 with a custom endpoint and
- * region='auto'. See https://developers.cloudflare.com/r2/api/s3/api/.
+ * R2 is S3-compatible. This is a native client: AWS SigV4 request signing
+ * (./_sigv4.ts, verified against AWS's official test vector) over global
+ * `fetch`, plus a small XML reader for ListObjectsV2 (./_xml.ts). No SDK
+ * dependency — only node:crypto + fetch.
+ *
+ * Path-style addressing is used for the S3 API calls
+ * (https://<account>.r2.cloudflarestorage.com/<bucket>/<key>); this has no
+ * effect on the public object URLs, which are built from `publicBaseUrl`.
  *
  * GAP-208 Phase 2a (2026-05-18). Phase 1 (interface + types) shipped in #959.
+ * Native client (dropping @aws-sdk/client-s3) landed 2026-06-09.
  *
  * Server-only. Do NOT import from client-side code or edge runtime.
+ *
+ * Known limitation (unchanged from the SDK version): request bodies are
+ * buffered fully in memory (see toUint8Array) so the payload can be hashed for
+ * SigV4. Streaming uploads (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) are a future
+ * enhancement; presigned/private URLs remain Phase 2b.
  */
 
-import {
-  DeleteObjectCommand,
-  ListObjectsV2Command,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3';
 import { toUint8Array } from './_helpers.js';
+import { EMPTY_SHA256, sha256Hex, signS3Request } from './_sigv4.js';
+import { parseListObjectsV2, s3ErrorFields } from './_xml.js';
 import type {
   ListItem,
   ListOptions,
@@ -29,10 +37,13 @@ import type {
 const PROVIDER_TAG = 'r2';
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 const DEFAULT_LIST_LIMIT = 1000;
+const REGION = 'auto';
 
 class R2Provider implements StorageProvider {
   readonly provider = PROVIDER_TAG;
-  private readonly client: S3Client;
+  private readonly accountId: string;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
   private readonly bucket: string;
   private readonly publicBaseUrl: string;
 
@@ -46,16 +57,11 @@ class R2Provider implements StorageProvider {
       );
     }
 
+    this.accountId = config.accountId;
+    this.accessKeyId = config.accessKeyId;
+    this.secretAccessKey = config.secretAccessKey;
     this.bucket = config.bucket;
     this.publicBaseUrl = stripTrailingSlash(config.publicBaseUrl);
-    this.client = new S3Client({
-      region: 'auto',
-      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
-      },
-    });
   }
 
   async put(
@@ -73,17 +79,39 @@ class R2Provider implements StorageProvider {
 
     const body = await toUint8Array(data);
 
-    await this.client.send(
-      new PutObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-        Body: body,
-        ContentType: opts?.contentType ?? DEFAULT_CONTENT_TYPE,
-        ContentLength: body.byteLength,
-        CacheControl: opts?.cacheControl,
-        Metadata: opts?.metadata,
-      }),
-    );
+    const extraHeaders: Record<string, string> = {
+      'content-type': opts?.contentType ?? DEFAULT_CONTENT_TYPE,
+    };
+    if (opts?.cacheControl) {
+      extraHeaders['cache-control'] = opts.cacheControl;
+    }
+    for (const [name, value] of Object.entries(opts?.metadata ?? {})) {
+      extraHeaders[`x-amz-meta-${name.toLowerCase()}`] = value;
+    }
+
+    const { url, headers } = signS3Request({
+      method: 'PUT',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      key,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      payloadHash: sha256Hex(body),
+      extraHeaders,
+      now: new Date(),
+    });
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: { ...headers, 'content-length': String(body.byteLength) },
+      // `as BodyInit`: bridge the TS lib's ArrayBufferLike/ArrayBuffer typed-array
+      // variance for fetch bodies — same pattern as src/api/compression.ts.
+      body: body as BodyInit,
+    });
+    if (!response.ok) {
+      throw await storageError('PUT', key, response);
+    }
 
     return {
       key,
@@ -95,40 +123,61 @@ class R2Provider implements StorageProvider {
 
   async del(keyOrUrl: string): Promise<void> {
     const key = this.extractKey(keyOrUrl);
-    await this.client.send(
-      new DeleteObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-      }),
-    );
+    const { url, headers } = signS3Request({
+      method: 'DELETE',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      key,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      payloadHash: EMPTY_SHA256,
+      now: new Date(),
+    });
+
+    // Best-effort: a missing key is not an error. S3/R2 returns 204 regardless;
+    // tolerate 404 defensively.
+    const response = await fetch(url, { method: 'DELETE', headers });
+    if (!response.ok && response.status !== 404) {
+      throw await storageError('DELETE', key, response);
+    }
   }
 
   async list(opts?: ListOptions): Promise<ListResult> {
-    const response = await this.client.send(
-      new ListObjectsV2Command({
-        Bucket: this.bucket,
-        Prefix: opts?.prefix,
-        MaxKeys: opts?.limit ?? DEFAULT_LIST_LIMIT,
-        ContinuationToken: opts?.cursor,
-      }),
-    );
-
-    const items: ListItem[] = (response.Contents ?? []).flatMap((entry) => {
-      if (!entry.Key) return [];
-      return [
-        {
-          key: entry.Key,
-          url: `${this.publicBaseUrl}/${entry.Key}`,
-          size: entry.Size ?? 0,
-          uploadedAt: entry.LastModified ?? new Date(0),
-        },
-      ];
+    const { url, headers } = signS3Request({
+      method: 'GET',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      payloadHash: EMPTY_SHA256,
+      query: {
+        'list-type': '2',
+        prefix: opts?.prefix,
+        'max-keys': String(opts?.limit ?? DEFAULT_LIST_LIMIT),
+        'continuation-token': opts?.cursor,
+      },
+      now: new Date(),
     });
+
+    const response = await fetch(url, { method: 'GET', headers });
+    if (!response.ok) {
+      throw await storageError('LIST', this.bucket, response);
+    }
+
+    const parsed = parseListObjectsV2(await response.text());
+    const items: ListItem[] = parsed.objects.map((entry) => ({
+      key: entry.key,
+      url: `${this.publicBaseUrl}/${entry.key}`,
+      size: entry.size,
+      uploadedAt: entry.lastModified,
+    }));
 
     return {
       items,
-      cursor: response.NextContinuationToken,
-      hasMore: response.IsTruncated === true,
+      cursor: parsed.nextContinuationToken,
+      hasMore: parsed.isTruncated,
     };
   }
 
@@ -147,6 +196,14 @@ export function createR2Provider(config: R2Config): StorageProvider {
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────
+
+async function storageError(operation: string, key: string, response: Response): Promise<Error> {
+  const body = await response.text().catch(() => '');
+  const { code, message } = s3ErrorFields(body);
+  return new Error(
+    `R2 ${operation} failed for "${key}": ${code ?? response.status} ${message ?? response.statusText}`,
+  );
+}
 
 function tryParseUrl(value: string): URL | null {
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,6 @@ importers:
 
   packages/core:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.1064.0
-        version: 3.1064.0
       '@electric-sql/pglite':
         specifier: 'catalog:'
         version: 0.5.1
@@ -1727,109 +1724,6 @@ packages:
 
   '@assemblyscript/loader@0.19.23':
     resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
-
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/crc32c@5.2.0':
-    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/checksums@3.1000.3':
-    resolution: {integrity: sha512-vkPd3NMJf6Gw4QjBBdiUdu2uo4P0HfHrx5+1hqjDYZhZAF4HWkMHXoQtxHQmDi/LyysUgTU5uNhcZLCkpF9LKg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/client-s3@3.1064.0':
-    resolution: {integrity: sha512-6OQhE4Qpt94oTw7ruBHE2E6/PS57alsCSdemMf4c3gBSUM0emoXRRykYffFSL56oluL49AZh/DLWRnQafynbLg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.974.19':
-    resolution: {integrity: sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.45':
-    resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.47':
-    resolution: {integrity: sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.51':
-    resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.50':
-    resolution: {integrity: sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.53':
-    resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.45':
-    resolution: {integrity: sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.50':
-    resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.50':
-    resolution: {integrity: sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.974.28':
-    resolution: {integrity: sha512-XkHArJreL8hnpKrBTlnwrIcynZT4kDiAF6BF/z7AVxV7VUvojrjL2RzeK8QLVNyfzkEJGIYBKoufOIOSSpd6nQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.972.49':
-    resolution: {integrity: sha512-9CQoJfMZMqGJVBqFO/C8Gwke6WM7CLskQBiAjGU5LyXsVtqhymAATfqFnIa87Dw23ssfgGzqBHpSSwSchldFXw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/nested-clients@3.997.18':
-    resolution: {integrity: sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.33':
-    resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1064.0':
-    resolution: {integrity: sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.12':
-    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-locate-window@3.965.7':
-    resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.29':
-    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
-    engines: {node: '>=18.0.0'}
 
   '@axe-core/playwright@4.11.3':
     resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
@@ -2903,9 +2797,6 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@nodable/entities@2.1.1':
-    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3723,42 +3614,6 @@ packages:
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       size-limit: 12.1.0
-
-  '@smithy/core@3.24.6':
-    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.3.8':
-    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.4.6':
-    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/node-http-handler@4.7.7':
-    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.4.6':
-    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.3':
-    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
 
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
@@ -5115,9 +4970,6 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  bowser@2.14.1:
-    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -5905,13 +5757,6 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
-
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
-  fast-xml-parser@5.7.3:
-    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
-    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -7226,10 +7071,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -7923,9 +7764,6 @@ packages:
       '@types/node':
         optional: true
 
-  strnum@2.3.0:
-    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
-
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -8589,10 +8427,6 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
-
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -8708,236 +8542,6 @@ snapshots:
   '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@assemblyscript/loader@0.19.23': {}
-
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      tslib: 2.8.1
-
-  '@aws-crypto/crc32c@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      tslib: 2.8.1
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/util-locate-window': 3.965.7
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/util-locate-window': 3.965.7
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      tslib: 2.8.1
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/checksums@3.1000.3':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@aws-crypto/crc32c': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.1064.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 5.2.0
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-node': 3.972.53
-      '@aws-sdk/middleware-flexible-checksums': 3.974.28
-      '@aws-sdk/middleware-sdk-s3': 3.972.49
-      '@aws-sdk/signature-v4-multi-region': 3.996.33
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.974.19':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.45':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.47':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.51':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-env': 3.972.45
-      '@aws-sdk/credential-provider-http': 3.972.47
-      '@aws-sdk/credential-provider-login': 3.972.50
-      '@aws-sdk/credential-provider-process': 3.972.45
-      '@aws-sdk/credential-provider-sso': 3.972.50
-      '@aws-sdk/credential-provider-web-identity': 3.972.50
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.53':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.45
-      '@aws-sdk/credential-provider-http': 3.972.47
-      '@aws-sdk/credential-provider-ini': 3.972.51
-      '@aws-sdk/credential-provider-process': 3.972.45
-      '@aws-sdk/credential-provider-sso': 3.972.50
-      '@aws-sdk/credential-provider-web-identity': 3.972.50
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.45':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/token-providers': 3.1064.0
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.974.28':
-    dependencies:
-      '@aws-sdk/checksums': 3.1000.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/signature-v4-multi-region': 3.996.33
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.18':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/signature-v4-multi-region': 3.996.33
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.33':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1064.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.12':
-    dependencies:
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/util-locate-window@3.965.7':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.29':
-    dependencies:
-      '@smithy/types': 4.14.3
-      fast-xml-parser: 5.7.3
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
     dependencies:
@@ -10125,8 +9729,6 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@nodable/entities@2.1.1': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10824,54 +10426,6 @@ snapshots:
       - esbuild
       - uglify-js
       - webpack-cli
-
-  '@smithy/core@3.24.6':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.3.8':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.7.7':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
 
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -12526,8 +12080,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bowser@2.14.1: {}
-
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -13209,18 +12761,6 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.7.3:
-    dependencies:
-      '@nodable/entities': 2.1.1
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -14715,8 +14255,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -15514,8 +15052,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
-  strnum@2.3.0: {}
-
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -16219,8 +15755,6 @@ snapshots:
       os-paths: 4.4.0
 
   xml-name-validator@5.0.0: {}
-
-  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

Replaces the `@aws-sdk/client-s3` dependency in `@revealui/core` with a native, dependency-free Cloudflare R2 client. R2 is S3-compatible and the provider only needs a handful of operations, so the AWS SDK (plus its `@aws-crypto` / `@smithy` transitive tree) is swapped for ~440 lines of owned code — squarely "framework, not stack".

## What changed

- **`packages/core/src/storage/_sigv4.ts`** (new) — AWS Signature V4 request signing on `node:crypto`. The `computeSigV4` core is verified byte-for-byte against AWS's official `get-vanilla` SigV4 test vector (locked by a unit test).
- **`packages/core/src/storage/_xml.ts`** (new) — no-regex (`indexOf`-based) reader for `ListObjectsV2` results and `<Error>` bodies (replaces the SDK's XML codec).
- **`packages/core/src/storage/r2.ts`** — rewritten on global `fetch` + the two helpers. Path-style addressing; signed-payload `PUT`; best-effort `DELETE` (tolerates 404); surfaces the S3 `<Error>` code/message. The `createR2Provider` / `StorageProvider` contract and all behavior are unchanged.
- **Tests** — `r2.test.ts` migrated from mocking `@aws-sdk/client-s3` to spying on `fetch` (every behavioral assertion preserved); `ListObjectsV2` parsing edge cases moved to `_xml.test.ts`; `factory.test.ts` SDK mock removed.
- **Dependency** — `@aws-sdk/client-s3` dropped from `packages/core/package.json`; `pnpm-lock.yaml` shrinks by 466 lines (the entire `@aws-sdk` / `@aws-crypto` / `@smithy` tree).

## Verification

- Biome clean
- `tsc --noEmit` (core) clean
- **81/81** storage tests pass (SigV4 known-answer test, XML parser, 19 `fetch`-based provider tests, de-mocked factory)
- `tsc` build clean

## Not yet done — pre-merge gate

- :warning: **Live R2 round-trip** (`PUT` → `GET` → `LIST` → `DELETE` against a real bucket) is **not** run here — it needs real credentials and is owner-gated. This is the production-readiness check; it should pass before merge.

## Notes

- Path-style addressing is used for the S3 API calls; it has no effect on public object URLs, which are built from `publicBaseUrl`.
- Known limitation, unchanged from the SDK version: request bodies are buffered in memory to hash the payload for SigV4. Streaming uploads and presigned/private URLs remain future work (Phase 2b).
