### PR TITLE
feat(docs): frontmatter title chrome + blog migration

### DIFF
--- a/apps/docs/app/lib/__tests__/search-index.test.ts
+++ b/apps/docs/app/lib/__tests__/search-index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDocMeta, extractExcerpt, extractTitle } from '../search-index';
+
+describe('deriveDocMeta (frontmatter-aware)', () => {
+  it('prefers the frontmatter title over a body H1', () => {
+    const content = '---\ntitle: Front Title\n---\n\n# Body Heading\n\nBody text here.';
+    expect(deriveDocMeta(content, 'some-slug').title).toBe('Front Title');
+  });
+
+  it('excerpts from the body, never the frontmatter block', () => {
+    const content =
+      '---\ntitle: My Post\ndescription: "*By Someone*"\n---\n\nThe first real paragraph of the post body.';
+    const { excerpt } = deriveDocMeta(content, 'my-post');
+    expect(excerpt).toBe('The first real paragraph of the post body.');
+    expect(excerpt).not.toContain('title:');
+    expect(excerpt).not.toContain('description');
+  });
+
+  it('falls back to the body H1 when there is no frontmatter title', () => {
+    const content = '# Just an H1\n\nSome body text that is long enough.';
+    expect(deriveDocMeta(content, 'slug').title).toBe('Just an H1');
+  });
+
+  it('falls back to the slug when there is neither', () => {
+    const content = 'No heading, no frontmatter, just prose long enough to be an excerpt.';
+    expect(deriveDocMeta(content, 'fallback-slug').title).toBe('fallback-slug');
+  });
+
+  it('keeps extractTitle/extractExcerpt working on plain markdown', () => {
+    expect(extractTitle('# Hello\n\nWorld')).toBe('Hello');
+    expect(extractExcerpt('# Hello\n\nThis is the body paragraph.')).toBe(
+      'This is the body paragraph.',
+    );
+  });
+});

--- a/apps/docs/app/lib/search-index.ts
+++ b/apps/docs/app/lib/search-index.ts
@@ -15,6 +15,7 @@
  */
 
 import FlexSearch from 'flexsearch';
+import { parseFrontmatter } from '../utils/frontmatter';
 import { SLUG_TO_PATH } from './slug-manifest';
 
 const { Document } = FlexSearch;
@@ -143,6 +144,20 @@ export function extractExcerpt(markdown: string, maxLength = 160): string {
 }
 
 /**
+ * Derive a doc's search title and excerpt, frontmatter-aware. Prefers the
+ * frontmatter `title`, and reads both the title fallback and the excerpt from
+ * the body so a leading frontmatter block is never indexed as content. Falls
+ * back to the first body H1, then the slug.
+ */
+export function deriveDocMeta(content: string, slug: string): { title: string; excerpt: string } {
+  const { data, body } = parseFrontmatter(content);
+  const fmTitle = typeof data.title === 'string' ? data.title.trim() : '';
+  const title = fmTitle || extractTitle(body) || slug;
+  const excerpt = extractExcerpt(body);
+  return { title, excerpt };
+}
+
+/**
  * The full set of searchable docs as `[slug, file]` pairs, sourced from the
  * slug manifest. The slug doubles as the result path (flat URL space); the
  * file is fetched from the served root.
@@ -188,8 +203,7 @@ export async function buildSearchIndex(): Promise<void> {
           continue;
         }
         const { slug, content } = result.value;
-        const title = extractTitle(content) || slug;
-        const excerpt = extractExcerpt(content);
+        const { title, excerpt } = deriveDocMeta(content, slug);
 
         docs.push({
           id,

--- a/apps/docs/app/routes/SectionPage.tsx
+++ b/apps/docs/app/routes/SectionPage.tsx
@@ -4,9 +4,38 @@ import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { useWildcardPath } from '../hooks/useWildcardPath';
 import { slugToPath } from '../lib/slug-manifest';
-import { loadMarkdownFile, renderMarkdown } from '../utils/markdown';
+import { loadMarkdownFile, parseFrontmatter, renderMarkdown } from '../utils/markdown';
 import type { DocSection } from '../utils/paths';
 import { resolveDocPath, stripDocExtension } from '../utils/paths';
+
+/** True when the first non-blank line of `markdown` is an ATX H1 (`# `). */
+function startsWithH1(markdown: string): boolean {
+  for (const raw of markdown.split('\n')) {
+    const line = raw.trim();
+    if (line === '') {
+      continue;
+    }
+    return line.startsWith('# ');
+  }
+  return false;
+}
+
+/** Format an ISO date for display, or '' when absent / unparseable. */
+function formatPostDate(iso: string): string {
+  if (iso === '') {
+    return '';
+  }
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    return iso;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(ms));
+}
 
 interface SectionPageProps {
   section: DocSection;
@@ -80,8 +109,27 @@ Document not found at \`${resolved.markdownPath}\`.
   const sourceFile = slugToPath(slugKey) ?? (slugKey ? `${slugKey}.md` : 'INDEX.md');
   const githubUrl = `https://github.com/RevealUIStudio/revealui/blob/main/docs/${sourceFile}`;
 
+  // Frontmatter-driven page chrome: when a doc carries a frontmatter `title`
+  // and its body no longer opens with an H1 (e.g. migrated blog posts), render
+  // the title + byline as chrome. Docs that still lead with their own H1 are
+  // left untouched, so the title is never rendered twice.
+  const { data, body } = parseFrontmatter(content);
+  const fmTitle = typeof data.title === 'string' ? data.title.trim() : '';
+  const fmAuthor = typeof data.author === 'string' ? data.author.trim() : '';
+  const fmDate = typeof data.date === 'string' ? data.date.trim() : '';
+  const showHeader = fmTitle !== '' && !startsWithH1(body);
+  const byline = [fmAuthor ? `By ${fmAuthor}` : '', formatPostDate(fmDate)]
+    .filter((part) => part !== '')
+    .join(' · ');
+
   return (
     <ErrorBoundary>
+      {showHeader ? (
+        <header className="mx-auto mb-8 max-w-[var(--width-content)] px-8">
+          <h1 className="font-bold text-3xl text-text-primary tracking-tight">{fmTitle}</h1>
+          {byline !== '' ? <p className="mt-2 text-[0.9375rem] text-text-muted">{byline}</p> : null}
+        </header>
+      ) : null}
       <div>{renderMarkdown(content)}</div>
       <div className="mx-auto mt-12 flex max-w-[var(--width-content)] items-center justify-between border-t border-border px-8 pt-6 text-[0.8125rem] text-text-muted">
         <a

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -4,12 +4,7 @@ description: "*By Joshua Vaughn — RevealUI Studio*"
 visibility: public
 status: narrative
 audience: user
----
-
-# Why I Built RevealUI (and Open-Sourced It)
-
-*By Joshua Vaughn — RevealUI Studio*
-
+author: Joshua Vaughn
 ---
 
 I've started three software companies. Each time, I spent the first three to six months building the same thing: user authentication, a content management system, billing integration, an admin dashboard, role-based access control. The actual product — the thing that made the company worth existing — didn't get serious development time until month four at the earliest.

--- a/docs/blog/02-http-402-payments.md
+++ b/docs/blog/02-http-402-payments.md
@@ -4,12 +4,7 @@ description: "_By Joshua Vaughn - RevealUI Studio_"
 visibility: public
 status: narrative
 audience: user
----
-
-# Paying for AI API Calls with HTTP 402 and USDC
-
-_By Joshua Vaughn  -  RevealUI Studio_
-
+author: Joshua Vaughn
 ---
 
 > **Status note (updated 2026-05-26):** The x402 integration in RevealUI is **designed and code-complete but dormant** today. The feature flag `X402_ENABLED=false` is the default; the endpoints exist but won't transact. Live agent payments are gated on the Stripe live-keys flip and the billing-readiness audit — see [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status). This post explains the design and how to wire it; it does not claim x402 payments are currently transactable through RevealUI in production.

--- a/docs/blog/03-multi-agent-coordination.md
+++ b/docs/blog/03-multi-agent-coordination.md
@@ -4,12 +4,7 @@ description: "*By Joshua Vaughn - RevealUI Studio*"
 visibility: public
 status: narrative
 audience: user
----
-
-# Three AI Agents, One Codebase, No Conflicts
-
-*By Joshua Vaughn  -  RevealUI Studio*
-
+author: Joshua Vaughn
 ---
 
 I built most of RevealUI with three Claude Code instances running simultaneously.

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -4,12 +4,7 @@ description: "*By Joshua Vaughn - RevealUI Studio*"
 visibility: public
 status: narrative
 audience: user
----
-
-# The Air-Gap-Capable Business Runtime
-
-*By Joshua Vaughn  -  RevealUI Studio*
-
+author: Joshua Vaughn
 ---
 
 Most software companies accept a particular bargain without thinking about it: your secrets live in someone else's vault, your AI calls someone else's API, and your dev environment is a pile of global installs that one `npm install -g` can break.

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -4,9 +4,8 @@ description: "Every software company ships the same five things: a way to manage
 visibility: public
 status: narrative
 audience: user
+author: Joshua Vaughn
 ---
-
-# The Five Primitives of Business Software
 
 > **Status note (updated 2026-05-26):** One forward-looking system mentioned in this post is not transactable in production today: **x402 agent-to-agent payments** (designed and code-complete behind `X402_ENABLED=false`). Everything else described — auth, content, Stripe billing, MCP wiring, agent primitives — runs today. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current per-feature shipping status.
 

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -4,9 +4,8 @@ description: "RevealUI is open source today; the commercial side is pre-launch. 
 visibility: public
 status: narrative
 audience: user
+author: Joshua Vaughn
 ---
-
-# Open Source + Pro: How We Think About Monetization
 
 RevealUI is open source today; the commercial side is pre-launch. Before we talk about features or roadmaps, I want to be completely transparent about how we plan to make money, what's free, what's paid, and why.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -4,9 +4,8 @@ description: "*The web was built for browsers. The next web is being built for a
 visibility: public
 status: narrative
 audience: user
+author: Joshua Vaughn
 ---
-
-# Building for the Agent-First Internet
 
 *The web was built for browsers. The next web is being built for agents.*
 

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -4,9 +4,8 @@ description: "**Build a complete business application with auth, content, and pa
 visibility: public
 status: narrative
 audience: user
+author: Joshua Vaughn
 ---
-
-# From Zero to Production in About 30 Minutes
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 

--- a/docs/blog/09-component-library.md
+++ b/docs/blog/09-component-library.md
@@ -4,12 +4,7 @@ description: "*By Joshua Vaughn, RevealUI Studio*"
 visibility: public
 status: narrative
 audience: user
----
-
-# 60 Components, One Dependency
-
-*By Joshua Vaughn, RevealUI Studio*
-
+author: Joshua Vaughn
 ---
 
 Open the `package.json` of a typical React app and trace the dependency tree under your UI. A component library. The headless-primitive library it sits on. An icon set. A class-merging utility. A variants helper. A few polyfills the library pulls in. Every one of those is a version you have to track, a breaking change you have to absorb on someone else's schedule, and a styling opinion you have to work around.

--- a/docs/blog/10-own-your-data.md
+++ b/docs/blog/10-own-your-data.md
@@ -4,12 +4,7 @@ description: "*By Joshua Vaughn, RevealUI Studio*"
 visibility: public
 status: narrative
 audience: user
----
-
-# Your Database, Your Storage, Your Sync
-
-*By Joshua Vaughn, RevealUI Studio*
-
+author: Joshua Vaughn
 ---
 
 Most "modern data stacks" charge a quiet tax: lock-in. The database speaks a proprietary dialect, so your queries do not move. The file storage is a vendor blob API with no standard underneath, so your uploads do not move. Real-time sync is a separate SaaS you wire in by hand, so your live data lives somewhere you do not control. Each choice is reasonable on its own. Together they mean that the day you want to leave, you cannot.


### PR DESCRIPTION
## Summary

Follow-on to #1311 (native frontmatter parser, now merged). Makes the docs app fully frontmatter-safe, renders the metadata as page chrome, and migrates the blog posts to use it.

The blog source already carried frontmatter (`title`/`description`/`visibility`/`status`/`audience`), but the bodies redundantly repeated the title and byline — and once the public copies regenerate from that source, the frontmatter would otherwise leak into search excerpts.

## Changes

- **search-index**: derive title + excerpt from the frontmatter-stripped body and prefer the frontmatter `title` (`deriveDocMeta`), so a leading block is never indexed as an excerpt. +5 tests.
- **SectionPage**: render the frontmatter `title` + `author` as page chrome when a doc's body no longer opens with an H1. Docs that still lead with their own H1 are left untouched, so the title is never rendered twice — gated and fleet-safe.
- **blog (10 posts)**: add `author`, and remove the now-redundant body H1, byline, and `---` divider. Status-note callouts and taglines are preserved.

## Verification

Ran the docs dev server and inspected the rendered DOM:
- Blog post: exactly one H1 (the chrome title), byline renders, **no frontmatter text in the UI**, body starts at the content.
- Non-blog doc (architecture): keeps its body H1, gets no chrome, frontmatter also stripped — no regression.
- tests 19/19, biome + tsc clean, full pre-push gate green.

## Coordination note

The `visibility`/`status`/`audience` frontmatter belongs to an in-flight internal docs-classification effort, and the title-vs-H1 duplication exists fleet-wide (every doc carries a frontmatter `title`). This PR migrates the **blog** subset and adds a generic, gated chrome renderer that a future fleet-wide body-dedup will light up automatically. Flagged for that effort to reconcile the remaining docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
