### PR TITLE
feat(docs): strip redundant body H1 across all 75 served docs

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Admin Guide"
+title: "RevealUI Admin Guide"
 description: "Collections, access control, hooks, rich text, media, and admin dashboard"
 category: guide
 audience: developer
 ---
-
-# RevealUI Admin Guide
 
 **Purpose**: Complete guide to using the RevealUI admin dashboard and content engine
 **Last Updated**: 2026-02-01

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -7,8 +7,6 @@ category: package-guide
 audience: developer
 ---
 
-# @revealui/ai
-
 AI agents, LLM providers, CRDT memory, and the A2A protocol for RevealUI Pro.
 
 ## Overview

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "System Architecture"
+title: "RevealUI System Architecture"
 description: "RevealUI system architecture reference  -  apps, packages, data flow, and deployment"
 category: architecture
 audience: developer
 ---
-
-# RevealUI System Architecture
 
 **Last Updated:** 2026-05-26
 **Status:** Working draft (architectural target — not all systems are live in default deployments)

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Authentication System"
+title: "RevealUI Authentication System"
 description: "Session-based auth, OAuth, password reset, rate limiting, and brute force protection"
 category: guide
 audience: developer
 ---
-
-# RevealUI Authentication System
 
 **Last Updated:** 2026-03-05
 **Package:** `@revealui/auth`

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Build Your First Business"
+title: "Build Your First Business with RevealUI"
 description: "Step-by-step tutorial for building a software product with RevealUI"
 category: tutorial
 audience: developer
 ---
-
-# Build Your First Business with RevealUI
 
 This tutorial walks you from zero to a deployed product in under an hour. You'll build a simple product catalog with user accounts, billing, and an admin dashboard  -  the same foundation you'd use for any software business.
 

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Component Catalog"
+title: "RevealUI Component Catalog"
 description: "Complete reference for @revealui/presentation UI components"
 category: reference
 audience: developer
 ---
-
-# RevealUI Component Catalog
 
 **Last Updated:** 2026-05-02
 **Packages:** `@revealui/presentation`, `@revealui/core`

--- a/docs/CORE_STABILITY.md
+++ b/docs/CORE_STABILITY.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Core API Stability"
+title: "@revealui/core  -  API Stability Reference"
 description: "API stability guarantees, versioning policy, and breaking change process for @revealui/core"
 category: reference
 audience: developer
 ---
-
-# @revealui/core  -  API Stability Reference
 
 **Version:** 0.6.x
 **Last Updated:** 2026-04-26

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Database Management"
+title: "Database Management Guide"
 description: "Drizzle ORM schema, migrations, NeonDB setup (with optional legacy Supabase RAG sidecar), and seeding"
 category: guide
 audience: developer
 ---
-
-# Database Management Guide
 
 This guide describes the RevealUI database workflow and the underlying database scripts it orchestrates across different development environments.
 

--- a/docs/ENVIRONMENT-VARIABLES-GUIDE.md
+++ b/docs/ENVIRONMENT-VARIABLES-GUIDE.md
@@ -8,8 +8,6 @@ category: reference
 audience: developer
 ---
 
-# Environment Variables Guide
-
 This guide is the single reference for every environment variable used across the RevealUI monorepo. It covers setup, validation, secret management, and per-environment configuration.
 
 For initial project setup, see [Quick Start](./QUICK_START.md). For deployment, see the [Deployment Guide](./guides/deployment.md).

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -7,8 +7,6 @@ category: tutorial
 audience: developer
 ---
 
-# Example Projects
-
 Three complete examples showing how to build real products with RevealUI. Each example includes the full collection definitions, config, and API usage patterns.
 
 ---

--- a/docs/FAIR_SOURCE.md
+++ b/docs/FAIR_SOURCE.md
@@ -7,8 +7,6 @@ category: reference
 audience: developer
 ---
 
-# Fair Source
-
 The narrative version of this page lives at [revealui.com/fair-source](https://revealui.com/fair-source). This document is the engineer-targeted reference: license text, package status, runtime enforcement, and how to verify everything yourself.
 
 ## What's licensed how

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -7,8 +7,6 @@ category: guide
 audience: enterprise
 ---
 
-# RevealUI Fleet — Self-Hosted Deployment
-
 Customers buy the Enterprise tier of RevealUI; the Fleet kit (produced by RevForge) is what they deploy. Instead of running on `revealui.com`, you deploy the entire stack on your own infrastructure with full domain lock and unlimited users.
 
 RevealUI Fleet is a deployment-level commercial product, distinct from the hosted account-level subscription and metered usage model used for SaaS.

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -2,12 +2,10 @@
 visibility: public
 status: verified
 audience: user
-title: "FORGE — Moved"
+title: "FORGE — Page moved"
 description: "This page has been split. See FLEET.md for the runtime kit; see PRO.md §Enterprise tier for billing."
 category: redirect
 ---
-
-# FORGE — Page moved
 
 This page has been split into two distinct guides per the 7-tier rename (ADR `RevealUIStudio/revealui-jv/docs/decisions/2026-05-03-revfleet-rename.md`):
 

--- a/docs/HARNESS_PROTOCOL.md
+++ b/docs/HARNESS_PROTOCOL.md
@@ -7,8 +7,6 @@ category: protocol
 audience: developer
 ---
 
-# Harness Protocol
-
 > **Version:** 0.1.0  (Active — Phase 1 + 2 shipped; multi-tool adapters and full coordinator surface remain on the roadmap.)
 > **Package:** [`@revealui/harnesses`](../packages/harnesses) at v0.5.0+
 > **Renamed:** 2026-05-18, from the original "VAUGHN" backronym. See [§Why "Harness Protocol"](#why-harness-protocol) at the end.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Documentation Index"
+title: "RevealUI Documentation"
 description: "Entry point and navigation hub for all RevealUI documentation"
 category: index
 audience: developer
 ---
-
-# RevealUI Documentation
 
 Agentic business runtime. Five primitives for humans and agents: users, content, products, payments, and intelligence.
 

--- a/docs/JOSHUA.md
+++ b/docs/JOSHUA.md
@@ -7,8 +7,6 @@ category: philosophy
 audience: developer
 ---
 
-# Design Principles
-
 Six engineering principles that govern every architectural decision in RevealUI.
 
 **Justifiable. Orthogonal. Sovereign. Hermetic. Unified. Adaptive.**

--- a/docs/LINTING_RULES.md
+++ b/docs/LINTING_RULES.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# Custom Linting Rules
-
 This document describes custom code quality rules enforced in the RevealUI project.
 
 ## no-hardcoded-exit

--- a/docs/LOCAL_FIRST.md
+++ b/docs/LOCAL_FIRST.md
@@ -7,8 +7,6 @@ category: guide
 audience: developer
 ---
 
-# Local-First Setup
-
 Run RevealUI's AI inference and secrets layer entirely on your own hardware. Local-first is an **optional path** that swaps cloud LLM providers for Snaps/Ollama and remote secret managers for RevVault — the default RevealUI deployment still uses cloud services (Neon Postgres, Stripe, Cloudflare R2 object storage). Cloud-compatible LLM providers (Groq, HuggingFace, OpenAI-compatible, Anthropic) are pluggable but opt-in via env vars.
 
 ## Overview

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Logging Guide
-
 **Last Updated:** 2026-02-04
 
 ## Overview

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -7,8 +7,6 @@ category: guide
 audience: developer
 ---
 
-# MCP Marketplace
-
 > **Preview status.** The publish/list/invoke/onboard endpoints are wired; live payouts are gated on the internal billing-readiness audit (Stripe runs in TEST mode in production today). The 80/20 revenue split is the planned launch policy.
 
 The RevealUI MCP Marketplace lets developers publish Model Context Protocol (MCP) servers with a per-call price. Callers pay in USDC on Base via the x402 protocol. The planned revenue split is 80% developer / 20% platform; live payouts open once the billing-readiness audit closes.

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Pro Guide"
+title: "RevealUI Pro Guide"
 description: "RevealUI Pro tier  -  AI agents, MCP servers, editor integrations, and licensing"
 category: guide
 audience: developer
 ---
-
-# RevealUI Pro Guide
 
 Commercial guide to RevealUI Pro: packaging, MCP integrations, open-model inference, editors, harnesses, services, x402 payments, marketplace flows, and licensing.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Quick Start"
+title: "Quick Start Guide"
 description: "Get RevealUI running locally in 15-30 minutes"
 category: tutorial
 audience: developer
 ---
-
-# Quick Start Guide
 
 Get RevealUI up and running locally. Budget 15–30 minutes if you're creating accounts for the first time.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "API Reference"
+title: "@revealui/core"
 description: "Complete API reference for @revealui/core exports and subpath modules"
 category: reference
 audience: developer
 ---
-
-# @revealui/core
 
 The runtime engine. Provides config building, collections, access control, REST API handlers, entitlement and feature gating primitives, rich text, admin UI components, logging, and plugins.
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -7,8 +7,6 @@ category: index
 audience: developer
 ---
 
-# RevFleet — Architecture & Integration Guide
-
 > RevFleet is the umbrella for all RevealUI Studio software. This guide covers the 7-tier product model: what each piece is, who it's for, and how they integrate.
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Roadmap"
+title: "RevealUI Roadmap"
 description: "Product roadmap with planned features, timelines, and priorities"
 category: planning
 audience: developer
 ---
-
-# RevealUI Roadmap
 
 > Agentic business runtime. Build your business, not your boilerplate.
 

--- a/docs/SCRIPT_MANAGEMENT.md
+++ b/docs/SCRIPT_MANAGEMENT.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# Script Management System
-
 Complete guide to the RevealUI Script Management Enhancement System - infrastructure for managing 203 TypeScript scripts with visibility, type safety, verification, and rollback capabilities.
 
 ## Status

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -7,8 +7,6 @@ category: guide
 audience: contributor
 ---
 
-# Testing Guide
-
 Reference guide to testing in the RevealUI monorepo.
 
 ## Overview

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -7,8 +7,6 @@ category: legal
 audience: legal
 ---
 
-# Third-Party Licenses
-
 This document lists all third-party dependencies used in the RevealUI Framework and their respective licenses.
 
 ## License Summary

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,13 +1,11 @@
 ---
 visibility: public
 status: verified
-title: "Troubleshooting"
+title: "Troubleshooting Guide"
 description: "Common issues, error messages, and solutions for RevealUI development"
 category: guide
 audience: developer
 ---
-
-# Troubleshooting Guide
 
 **Last Updated**: 2026-02-01
 

--- a/docs/TYPE-SYSTEM-RULES.md
+++ b/docs/TYPE-SYSTEM-RULES.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# Type System Rules & Enforcement
-
 **Status**: 🔒 **CRITICAL RULE** - Must be followed by all developers and AI agents
 **Created**: 2026-02-04
 **Applies To**: All TypeScript code in RevealUI monorepo

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# What Works Today
-
 > Last verified: 2026-05-26
 
 This page is an honest account of what RevealUI can and can't do right now.

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Agent Rules
-
 Tool-agnostic convention files for AI-assisted development in the RevealUI monorepo.
 
 ## What This Is

--- a/docs/agent-rules/biome.md
+++ b/docs/agent-rules/biome.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Biome Conventions
-
 ## Overview
 
 Biome 2 is the sole linter and formatter for this monorepo.

--- a/docs/agent-rules/conventions.md
+++ b/docs/agent-rules/conventions.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Coding Conventions
-
 Standards for TypeScript, git, and configuration in the RevealUI monorepo.
 
 ## TypeScript

--- a/docs/agent-rules/database-boundaries.md
+++ b/docs/agent-rules/database-boundaries.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Database Conventions
-
 ## Database Architecture (NeonDB primary; Supabase being retired)
 
 > **Status:** per ADR [`2026-05-01-supabase-removal`](../decisions/2026-05-01-supabase-removal.md), the canonical stack is **NeonDB primary + ElectricSQL sync, no Supabase**. NeonDB holds everything, including vector embeddings and `agent_memories` (via `pgvector`). Supabase is a legacy, optional sidecar being phased out (Phase 7). The import boundary below remains **enforced during the phase-out** so no new code couples to Supabase.

--- a/docs/agent-rules/evaluation-log.md
+++ b/docs/agent-rules/evaluation-log.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# AI Tool Evaluation Log
-
 Track pass/fail results when running test prompts from `test-prompts.md` across different AI tools.
 
 ## Claude Code (Opus 4.6)  -  2026-03-13

--- a/docs/agent-rules/feature-gating.md
+++ b/docs/agent-rules/feature-gating.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Feature Gating Conventions
-
 Rules for managing Pro/OSS tier boundaries in the RevealUI monorepo.
 
 ## Tier Model

--- a/docs/agent-rules/monorepo.md
+++ b/docs/agent-rules/monorepo.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Monorepo Conventions
-
 ## Structure
 - Apps live in `apps/`  -  deployable services (Next.js, Hono, Vite)
 - Packages live in `packages/`  -  shared libraries consumed by apps

--- a/docs/agent-rules/safety.md
+++ b/docs/agent-rules/safety.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Safety Conventions
-
 Rules for protecting sensitive files, credentials, and system paths in the RevealUI monorepo.
 
 ## Protected Files  -  Never Edit Without Explicit Ask

--- a/docs/agent-rules/tailwind-v4.md
+++ b/docs/agent-rules/tailwind-v4.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Tailwind CSS v4 Conventions
-
 ## Version
 
 RevealUI uses **Tailwind CSS v4** (`^4.1.18`). All new code must use v4 patterns.

--- a/docs/agent-rules/test-prompts.md
+++ b/docs/agent-rules/test-prompts.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Cross-Tool Validation Prompts
-
 Test these prompts in any AI coding tool to verify it follows RevealUI conventions. Each prompt has an expected behavior  -  the tool should match it without being told the rule explicitly.
 
 ## How to Use

--- a/docs/agent-rules/testing.md
+++ b/docs/agent-rules/testing.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Testing Conventions
-
 Rules for testing in the RevealUI monorepo. Covers Vitest, React Testing Library, Pro/OSS test boundaries, and CI gate triage.
 
 ## Repo Rules

--- a/docs/agent-rules/unused-declarations.md
+++ b/docs/agent-rules/unused-declarations.md
@@ -6,8 +6,6 @@ status: verified
 audience: agent
 ---
 
-# Unused Declarations Policy
-
 ## Core Rule
 
 **NEVER suppress an unused variable/import warning without first determining if the code is incomplete.**

--- a/docs/ai/PROMPT_CACHING.md
+++ b/docs/ai/PROMPT_CACHING.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Prompt Caching
-
 RevealUI's AI layer is provider-agnostic: open-weight models (Gemma, Phi, etc. via Ollama or Inference Snaps) are the default runtime path, and cloud providers are opt-in adapters. Prompt caching is one such provider capability — when you opt into a cloud provider that supports it (e.g. Anthropic), you can get up to **90% cost reduction** on repeated context. This guide uses Anthropic as the worked example because its caching API is the most mature; the same `@revealui/ai` client interface applies to any provider, and caching is a no-op on providers that don't support it.
 
 ## Quick Start

--- a/docs/ai/RESPONSE_CACHING.md
+++ b/docs/ai/RESPONSE_CACHING.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Response Caching for All LLM Providers
-
 Cache **complete LLM responses** at the application level — works with any provider. A cache HIT costs zero (no provider call); real-world dollar savings depend on your duplicate rate × hit rate.
 
 > **Note on dollar figures.** Every dollar amount in this guide is illustrative arithmetic against assumed traffic patterns and assumed provider pricing — not measured RevealUI traffic (RevealUI is pre-launch with 0 paying customers). Use the calculator below to estimate against your own stats.

--- a/docs/ai/SEMANTIC_CACHING.md
+++ b/docs/ai/SEMANTIC_CACHING.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Semantic Caching for LLM Responses
-
 Up to **73% cost reduction** in published industry benchmarks (Redis blog, FAQ-style traffic) through meaning-based caching.
 
 > **Note on benchmarks.** Every percentage and dollar figure in this guide is from Redis's published benchmarks and similar industry references — they are not measured RevealUI traffic (RevealUI is pre-launch with 0 paying customers). RevealUI ships the implementation; your real savings depend on your query distribution.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# API Reference
-
 RevealUI exposes a REST API built with [Hono](https://hono.dev/) and documented with OpenAPI. The API runs at `apps/server/` (default port 3004) and serves content, billing, auth, and agent endpoints.
 
 ---

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -6,8 +6,6 @@ status: generated
 audience: user
 ---
 
-# REST API Reference
-
 **Version:** 0.1.0
 
 **Base URL (production):** `https://api.revealui.com/api`

--- a/docs/architecture/ADR-001-agent-first.md
+++ b/docs/architecture/ADR-001-agent-first.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR-001: Agent-First, Human-Readable
-
 **Date:** 2026-03-11
 **Status:** Accepted
 

--- a/docs/architecture/ADR-002-dual-database.md
+++ b/docs/architecture/ADR-002-dual-database.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR-002: Dual-Database Architecture (NeonDB + Supabase)
-
 **Date:** 2026-04-08
 **Status:** Superseded by [2026-05-01-supabase-removal](../decisions/2026-05-01-supabase-removal.md) on 2026-05-01
 

--- a/docs/architecture/ADR-003-fair-source-licensing.md
+++ b/docs/architecture/ADR-003-fair-source-licensing.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR-003: Fair Source Licensing (FSL-1.1-MIT)
-
 **Date:** 2026-04-08
 **Status:** Accepted
 

--- a/docs/architecture/ADR-004-session-only-auth.md
+++ b/docs/architecture/ADR-004-session-only-auth.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR-004: Session-Only Authentication (No JWT)
-
 **Date:** 2026-04-08
 **Status:** Accepted
 

--- a/docs/architecture/ADR-005-two-repo-model.md
+++ b/docs/architecture/ADR-005-two-repo-model.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR-005: Two-Repo Model (Public + Private Coordination Hub)
-
 **Date:** 2026-04-08
 **Status:** Superseded by the four-repo model (2026-05-18) — see note below
 

--- a/docs/architecture/ai-stack.md
+++ b/docs/architecture/ai-stack.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# AI Stack Architecture
-
 RevealUI's AI subsystem lives in `@revealui/ai` (Pro, Fair Source FSL-1.1-MIT). It provides open-model inference, agent orchestration, CRDT-based memory, RAG ingestion, and streaming runtime  -  all gated by tier. The default and recommended path is open-model inference (Ollama, Canonical Inference Snaps); cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible, Anthropic for prompt caching) are pluggable but opt-in via environment variables.
 
 ## Inference Abstraction

--- a/docs/architecture/x402.md
+++ b/docs/architecture/x402.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# x402 Native Payment Architecture
-
 RevealUI implements [x402](https://x402.org) — HTTP-native micropayments — for monetizing per-call API access (agent tasks, marketplace MCP servers, A2A interactions). Settlement is in **USDC on Base** (EVM), verified via the Coinbase facilitator.
 
 ## Status

--- a/docs/decisions/2026-05-01-supabase-removal.md
+++ b/docs/decisions/2026-05-01-supabase-removal.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR: Supabase Removal — Single Neon-Primary Database
-
 **Note**: This ADR is a backfill written 2026-05-16 to document a migration that
 completed incrementally between 2026-04-15 and 2026-05-16.
 

--- a/docs/decisions/2026-05-08-deployment-target-vercel-not-k8s.md
+++ b/docs/decisions/2026-05-08-deployment-target-vercel-not-k8s.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# ADR: Deployment Target — Vercel + Forge Docker, not Kubernetes
-
 **Date:** 2026-05-08
 **Status:** Decided — final
 **Phase:** 5 — Agent-First Infrastructure

--- a/docs/decisions/licensing-platform-evaluation.md
+++ b/docs/decisions/licensing-platform-evaluation.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Decision: Licensing Platform Evaluation
-
 > **SUPERSEDED 2026-05-04 by the private-repo spec `docs/specs/cr8-p0-01-api-ed25519-migration.md` (Ed25519 migration).** The platform-evaluation decision recorded below selected RS256 at the time of writing. The 2026-05-04 charge-readiness re-audit surfaced an issuer/daemon-verifier format mismatch that required revisiting the algorithm choice; Owner approved migration to Ed25519 (Option α — preserve rich JWT payload, swap algorithm). The original decision-record is preserved verbatim below for SOC2-audit decision lineage.
 
 **Date:** 2026-03-31

--- a/docs/fleet/revcon.md
+++ b/docs/fleet/revcon.md
@@ -7,8 +7,6 @@ category: fleet
 audience: developer
 ---
 
-# RevCon
-
 **Centralized editor configurations for RevealUI projects.**
 
 > RevCon is a separate fleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revcon](https://github.com/RevealUIStudio/revcon) (its package historically shipped under the name `editor-configs`). This page summarises what RevCon is; the canonical product README lives in the RevCon repo.

--- a/docs/fleet/revdev.md
+++ b/docs/fleet/revdev.md
@@ -7,8 +7,6 @@ category: fleet
 audience: developer
 ---
 
-# RevDev
-
 **Native developer tools for [RevealUI](https://github.com/RevealUIStudio/revealui). One product, two interfaces.**
 
 > RevDev is a separate RevFleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev). This page summarises what RevDev is and how it composes with RevealUI; the canonical product README lives in the RevDev repo.

--- a/docs/fleet/revkit.md
+++ b/docs/fleet/revkit.md
@@ -7,8 +7,6 @@ category: fleet
 audience: developer
 ---
 
-# RevKit
-
 **Portable WSL development environment toolkit for RevealUI projects.**
 
 > RevKit is a separate fleet product. The repo is at [RevealUIStudio/revkit](https://github.com/RevealUIStudio/revkit) (product name: RevealUI DevKit). This page summarises what RevKit is; the canonical product README lives in the RevKit repo.

--- a/docs/fleet/revskills.md
+++ b/docs/fleet/revskills.md
@@ -7,8 +7,6 @@ category: fleet
 audience: developer
 ---
 
-# RevSkills
-
 **Curated [Agent Skills](https://agentskills.io) for modern web development. Built by RevealUI Studio.**
 
 > RevSkills is a separate fleet product. The repo is at [RevealUIStudio/revskills](https://github.com/RevealUIStudio/revskills). This page summarises what RevSkills is; the canonical product README lives in the RevSkills repo.

--- a/docs/fleet/revvault.md
+++ b/docs/fleet/revvault.md
@@ -7,8 +7,6 @@ category: fleet
 audience: developer
 ---
 
-# RevVault
-
 **Age-encrypted secret vault with CLI and Tauri desktop app. 100% [passage](https://github.com/FiloSottile/passage)-compatible.**
 
 > RevVault is a separate RevFleet product, not part of the RevealUI monorepo. The repo is at [RevealUIStudio/revvault](https://github.com/RevealUIStudio/revvault). This page summarises what RevVault is and how it composes with RevealUI; the canonical product README lives in the RevVault repo.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# RevealUI Glossary
-
 Canonical vocabulary across [RevFleet](#revfleet). This page is the single source of truth for cross-cutting terminology — agent, runtime, tier, harness, license, and the rest. When the same concept shows up across two products with different names, this page picks the one canonical name and points the others at it.
 
 > **Audience:** technical humans, non-technical operators, and AI agents working in or on a RevealUI deployment. Each entry leads with a one-sentence framing then expands. Internal-only codenames (Kingdom taxonomy) are listed at the end so they don't appear customer-facing.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Guides
-
 Practical, step-by-step guides for building with RevealUI.
 
 ---

--- a/docs/guides/audit-chain.md
+++ b/docs/guides/audit-chain.md
@@ -7,8 +7,6 @@ category: security
 audience: developer
 ---
 
-# Audit Chain
-
 Every action by every human and every agent signs into an append-only `audit_log` table with an HMAC-SHA256 hash chain. Tampering with any row breaks the chain. This page documents the schema, the signing semantics, and how to verify the chain.
 
 ## Schema

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Authentication
-
 RevealUI uses session-based authentication backed by database-stored sessions. There are no JWTs. The sole authentication mechanism is a `revealui-session` cookie containing a hashed token that maps to a row in the `sessions` table.
 
 **Package:** `@revealui/auth`

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Billing
-
 RevealUI integrates with Stripe for checkout, subscriptions, and billing portal. The billing system uses account-level subscriptions with metered usage for AI and agent features.
 
 **API routes:** `apps/server/src/routes/billing.ts`, `apps/server/src/routes/webhooks.ts`

--- a/docs/guides/collections.md
+++ b/docs/guides/collections.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Collections
-
 Collections are the core content abstraction in RevealUI. A collection defines a schema, access control rules, and lifecycle hooks for a type of content (posts, products, users, pages, etc.). Collections are stored in NeonDB via Drizzle ORM and exposed through the REST API.
 
 **Package:** `@revealui/core`

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -6,8 +6,6 @@ status: verified
 audience: user
 ---
 
-# Deployment
-
 RevealUI supports several deployment targets: Vercel (recommended for the HTTP apps), Fly (for long-running services like the ElectricSQL sync layer), Docker Compose, and self-hosted Node.js. This guide covers each option and the environment configuration required for production.
 
 > RevealUI Studio's own production runs on **Vercel (HTTP) + Fly (long-running `apps/server` subset + ElectricSQL) + Neon (Postgres)** — three vendors (Railway was dropped; Kubernetes is not a target). A `fly.toml` ships at `apps/server/fly.toml`.

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -2,12 +2,10 @@
 visibility: public
 status: verified
 audience: user
-title: "Quick Start — Moved"
+title: "Quick Start — Page moved"
 description: "The quick-start guide is now maintained as a single canonical doc at docs/QUICK_START.md."
 category: redirect
 ---
-
-# Quick Start — Page moved
 
 The quick-start guide is now maintained as a single canonical doc, to keep one source of truth:
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -7,8 +7,6 @@ category: guide
 audience: developer
 ---
 
-# Technology Stack
-
 RevealUI is a framework, not a stack. The five primitives (users, content, products, payments, intelligence) are the contract; `@revealui/*` packages are one implementation of that contract. This page documents the libraries that implementation uses today, with one-line rationale for each choice. Future implementations could carry the same primitives on different code.
 
 ## Apps

--- a/docs/internal/documentation-system.md
+++ b/docs/internal/documentation-system.md
@@ -8,8 +8,6 @@ owner: RevealUI Studio
 last_verified: 2026-06-08
 ---
 
-# RevealUI Documentation System
-
 This is the canonical specification for how documentation works in the RevealUI
 monorepo. It supersedes the stale `scripts/validate/README.md`.
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# RevealUI Methodology
-
 The engineering postures and coordination primitives that govern how RevFleet is built. This document is the canonical in-repo reference. Canonical rule definitions live in private repos and `~/.claude/rules/`; cross-references are provided at the end.
 
 ---

--- a/docs/submodules/POLICY.md
+++ b/docs/submodules/POLICY.md
@@ -6,8 +6,6 @@ status: verified
 audience: maintainer
 ---
 
-# No Git Submodules Policy
-
 ## Rule
 
 **No git submodules are permitted in any RevFleet repository.** This policy is permanent and applies to all repos under the `RevealUIStudio` GitHub org.


### PR DESCRIPTION
## Summary

Completes the fleet-wide body-H1 dedup on top of #1315 (frontmatter title chrome, merged). Removes the redundant leading body `# H1` from all 75 served non-blog docs so the gated SectionPage chrome renders the title. Two commits:

1. **60 exact-match docs** — body H1 was byte-identical to the frontmatter title; removed it. Zero displayed-title change.
2. **15 mismatch docs** — body H1 differed from the frontmatter title (e.g. ARCHITECTURE `System Architecture` vs `RevealUI System Architecture`; REFERENCE `API Reference` vs `@revealui/core`). Set the frontmatter `title` to the H1 text (preserving the displayed title exactly), then removed the H1. This also aligns search — which prefers the frontmatter title — with the page title; previously these showed the short title in search but the longer H1 on the page.

## Result

All 75 non-blog served docs now render their title via frontmatter chrome, consistently. No displayed-title changes.

## Verification

Dev-server DOM inspection: a deduped no-author doc (`/testing`) renders one H1 (chrome title), no byline, no frontmatter text in the UI, body clean. Full pre-push gate green on both commits.

## Note

`docs/architecture/x402.md` is `visibility: internal` but currently served (the copy step doesn't yet enforce `visibility`); it was deduped consistently. The `visibility` boundary is flagged for the docs-system lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
