### PR TITLE
fix(core): drop manual Content-Length from the R2 PUT request

### DIFF
--- a/.changeset/fix-r2-put-content-length.md
+++ b/.changeset/fix-r2-put-content-length.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+Fix the R2 storage provider's `PUT`, which set a manual `Content-Length` header. `Content-Length` is a forbidden `fetch` header that undici computes from the body itself; setting it threw `UND_ERR_INVALID_ARG` ("invalid content-length header") and failed every upload before the request left the process. The header is removed — undici derives the correct length from the body. (Unit tests mock `fetch`, so this only surfaced against a live R2 endpoint.)

--- a/packages/core/src/storage/__tests__/r2.test.ts
+++ b/packages/core/src/storage/__tests__/r2.test.ts
@@ -86,6 +86,9 @@ describe('createR2Provider', () => {
       expect(requests[0].method).toBe('PUT');
       expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/uploads/a.bin');
       expect(requests[0].headers['content-type']).toBe('image/png');
+      // No manual content-length: it is a forbidden fetch header (undici computes
+      // it from the body) and setting it throws UND_ERR_INVALID_ARG on a live R2 PUT.
+      expect(requests[0].headers['content-length']).toBeUndefined();
       expect(requests[0].body).toBe(body);
 
       expect(result).toEqual({

--- a/packages/core/src/storage/r2.ts
+++ b/packages/core/src/storage/r2.ts
@@ -102,11 +102,14 @@ class R2Provider implements StorageProvider {
       now: new Date(),
     });
 
+    // No manual content-length: it is a forbidden fetch header that undici
+    // computes from the body itself, and setting it throws UND_ERR_INVALID_ARG
+    // ("invalid content-length header") on the R2 PUT. `headers` already carries
+    // the signed set. `as BodyInit` bridges the TS lib's ArrayBufferLike vs
+    // ArrayBuffer typed-array variance for fetch bodies (cf. src/api/compression.ts).
     const response = await fetch(url, {
       method: 'PUT',
-      headers: { ...headers, 'content-length': String(body.byteLength) },
-      // `as BodyInit`: bridge the TS lib's ArrayBufferLike/ArrayBuffer typed-array
-      // variance for fetch bodies — same pattern as src/api/compression.ts.
+      headers,
       body: body as BodyInit,
     });
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Fixes a real bug in the native R2 storage provider (follow-up to the native-R2 client): the `PUT` set a manual `Content-Length` header. `Content-Length` is a forbidden `fetch` header that undici computes from the body itself — setting it throws `UND_ERR_INVALID_ARG` ("invalid content-length header"), so **every R2 upload failed before the request was even sent**.

The mocked unit tests recorded the header but never exercised real `fetch`, so this only surfaced against a live R2 endpoint.

## Fix

- Remove the manual `content-length` from the `PUT` in `packages/core/src/storage/r2.ts`; undici derives the correct length from the `Uint8Array` body.
- Add a regression assertion in `r2.test.ts` that the `PUT` carries no `content-length` header.

## Verification

- Biome clean, `tsc --noEmit` clean, 81/81 storage tests pass, build clean.
- Live R2 round-trip: with this fix the request now reaches R2 and gets a proper HTTP response (previously it failed inside undici before sending).
- Signing independently confirmed correct — boto3 (reference AWS SigV4) produces an identical response for the same request, so the signing path is sound.

## Note (infra, out of scope)

The live round-trip is currently blocked one step later by an **invalid R2 credential** in the environment — a reference signer (boto3) hits the same `401 Unauthorized`, so it is not related to this code. Regenerating the R2 API token is an operational fix tracked separately.
