### PR TITLE
feat(marketing): motivation-first hero, objections section, homepage copy polish

### DIFF
--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -2,7 +2,7 @@ import { HOME_FAQ } from '../../content/home';
 
 export function Faq() {
   return (
-    <section className="bg-background py-24 sm:py-32">
+    <section id="faq" className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -87,8 +87,10 @@ export function Hero() {
           </h1>
 
           <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-            <strong className="text-foreground">{hero.subtitle.strong}</strong> {hero.subtitle.body}{' '}
-            &mdash;{' '}
+            <strong className="text-foreground">
+              {hero.subtitle.lead} {hero.subtitle.strong}
+            </strong>{' '}
+            {hero.subtitle.body}{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
               {SITE.cli.create}
             </code>{' '}

--- a/apps/marketing/app/components/landing/Objections.tsx
+++ b/apps/marketing/app/components/landing/Objections.tsx
@@ -1,0 +1,42 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { HOME_OBJECTIONS } from '../../content/home';
+
+export function Objections() {
+  return (
+    <section className="bg-secondary py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {HOME_OBJECTIONS.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {HOME_OBJECTIONS.heading}
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 sm:grid-cols-2">
+          {HOME_OBJECTIONS.cards.map((card) => (
+            <div
+              key={card.heading}
+              className="rounded-2xl bg-card p-8 ring-1 ring-border shadow-sm"
+            >
+              <h3 className="text-lg font-semibold text-foreground">{card.heading}</h3>
+              <p className="mt-3 text-base leading-7 text-muted-foreground">{card.body}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 text-center">
+          <ButtonCVA
+            asChild
+            variant="link"
+            size="default"
+            className="items-center justify-center text-sm font-medium"
+          >
+            <a href={HOME_OBJECTIONS.cta.href}>{HOME_OBJECTIONS.cta.label}</a>
+          </ButtonCVA>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAPABILITIES, CAPABILITIES_SECTION } from '../capabilities';
-import { HOME_ACTORS, HOME_FORK } from '../home';
+import { HOME_ACTORS, HOME_FORK, HOME_OBJECTIONS } from '../home';
 import { HOME_PRIMITIVES, PRODUCTS_PRIMITIVES } from '../primitives';
 import { ROADMAP_SHIPPED, ROADMAP_UPCOMING } from '../roadmap';
 import { METRICS, SITE } from '../site';
@@ -130,6 +130,21 @@ describe('marketing content contracts', () => {
       expect(roles.some((r) => r.includes('develop'))).toBe(true);
       expect(roles.some((r) => r.includes('operator'))).toBe(true);
       expect(roles.some((r) => r.includes('agent'))).toBe(true);
+    });
+  });
+
+  describe('objections', () => {
+    it('surfaces exactly two objection cards, each fully populated', () => {
+      expect(HOME_OBJECTIONS.cards).toHaveLength(2);
+      for (const card of HOME_OBJECTIONS.cards) {
+        expect(card.heading.length, 'empty heading').toBeGreaterThan(0);
+        expect(card.body.length, 'empty body').toBeGreaterThan(0);
+      }
+    });
+
+    it('links onward to the full FAQ', () => {
+      expect(HOME_OBJECTIONS.cta.href).toBe('#faq');
+      expect(HOME_OBJECTIONS.cta.label.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/marketing/app/content/capabilities.ts
+++ b/apps/marketing/app/content/capabilities.ts
@@ -16,15 +16,15 @@ const REPO_TREE = `${SITE.urls.repo}/tree/main`;
 export const CAPABILITIES_SECTION = {
   eyebrow: 'Capabilities, file by file',
   heading: "What's actually shipped.",
-  body: 'Nine load-bearing primitives most platforms ship as separate products — or never ship at all. Each card links to the actual file.',
+  body: 'Nine load-bearing primitives most platforms ship as separate products, or never ship at all. Each card links to the actual file.',
   footnote:
-    "Trust through specificity. Buyers comparing to Convex, Supabase, or Payload see depth competitors don't ship.",
+    "Trust through specificity. Compare RevealUI to Convex, Supabase, or Payload and you'll see depth those competitors don't ship.",
 } as const;
 
 export const CAPABILITIES: readonly Capability[] = [
   {
     title: 'Tamper-evident audit chain',
-    body: 'Every mutation across every primitive — by humans or agents — signs into an HMAC-SHA256 hash chain. Tampering breaks the chain.',
+    body: 'Every mutation across every primitive, by humans or agents, signs into an HMAC-SHA256 hash chain. Tampering breaks the chain.',
     path: 'packages/db/src/schema/audit-log.ts',
     href: `${REPO_ROOT}/packages/db/src/schema/audit-log.ts`,
   },
@@ -42,19 +42,19 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     title: 'CRDT operation replay',
-    body: 'Most platforms snapshot-merge. RevealUI replays operations — collaborative editing across humans and agents stays correct after concurrent edits.',
+    body: 'Most platforms snapshot-merge. RevealUI replays operations, so collaborative editing across humans and agents stays correct after concurrent edits.',
     path: 'packages/db/src/schema/crdt-operations.ts',
     href: `${REPO_ROOT}/packages/db/src/schema/crdt-operations.ts`,
   },
   {
     title: 'Circuit breakers + retry + bulkhead',
-    body: 'Production resilience patterns wired into the runtime — adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
+    body: 'Production resilience patterns wired into the runtime: adaptive timeouts, retry budgets, and bulkhead isolation that early-stage SaaS usually skips.',
     path: 'packages/resilience/src/circuit-breaker.ts',
     href: `${REPO_ROOT}/packages/resilience/src/circuit-breaker.ts`,
   },
   {
     title: 'Multi-agent harness',
-    body: 'Claude, Cursor, and Copilot coordinate on the same project through a shared workboard — its own product category, ships in the runtime.',
+    body: 'Claude, Cursor, and Copilot coordinate on the same project through a shared workboard, a product category of its own that ships in the runtime.',
     path: 'packages/harnesses',
     href: `${REPO_TREE}/packages/harnesses`,
   },
@@ -66,13 +66,13 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     title: 'Envelope encryption + key rotation',
-    body: 'Sensitive fields wrapped in per-record DEKs encrypted by a KEK. Rotation is online — no downtime, no re-encrypt-the-world batch job.',
+    body: 'Sensitive fields wrapped in per-record DEKs encrypted by a KEK. Rotation is online, with no downtime and no re-encrypt-the-world batch job.',
     path: 'packages/security/src/encryption.ts',
     href: `${REPO_ROOT}/packages/security/src/encryption.ts`,
   },
   {
     title: 'Code provenance tracking',
-    body: 'Every commit attributed to human, agent, or model. A real supply-chain primitive baked into the data model — not bolted on after the fact.',
+    body: 'Every commit attributed to human, agent, or model. A real supply-chain primitive baked into the data model, not bolted on after the fact.',
     path: 'packages/db/src/schema/code-provenance.ts',
     href: `${REPO_ROOT}/packages/db/src/schema/code-provenance.ts`,
   },

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -19,9 +19,10 @@ export const HOME_HERO = {
   eyebrow: 'Open source. Self-hostable. Audit-ready.',
   h1: 'Run your whole business on one runtime you own.',
   subtitle: {
+    lead: 'Stop renting your stack from a half-dozen vendors.',
     strong:
       'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
-    body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself',
+    body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself with',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
     agencyHref: SITE.urls.agency,
@@ -47,7 +48,7 @@ export const HOME_HERO = {
       {
         metric: `${METRICS.dbTables} database tables`,
         detail:
-          'Every table maps to a primitive — people, content, offers, payments, or agents. See the [database reference](https://docs.revealui.com/database).',
+          'Every table maps to a primitive: people, content, offers, payments, or agents. See the [database reference](https://docs.revealui.com/database).',
       },
       {
         metric: `${METRICS.mcpServers} first-party MCP servers`,
@@ -57,7 +58,7 @@ export const HOME_HERO = {
       {
         metric: 'Pro license enforcement, signed and verified',
         detail:
-          'Pro features check against your license server-side — no manual install gates. See the [Pro reference](https://docs.revealui.com/pro).',
+          'Pro features check against your license server-side, with no manual install gates. See the [Pro reference](https://docs.revealui.com/pro).',
       },
       {
         metric: `FSL-1.1-MIT on ${METRICS.licenseSplit.fsl} Fair Source packages`,
@@ -66,7 +67,7 @@ export const HOME_HERO = {
       {
         metric: 'Same permissions. Same audit chain. Same API.',
         detail:
-          'One permission model and one tamper-evident chain — for your team and your agents alike. See the [architecture](https://docs.revealui.com/architecture).',
+          'One permission model and one tamper-evident chain, for your team and your agents alike. See the [architecture](https://docs.revealui.com/architecture).',
       },
     ],
   },
@@ -154,7 +155,30 @@ export const HOME_PROBLEM = {
     },
   ] as readonly ProblemRow[],
   footnote:
-    'Sprawl prices reflect typical mid-startup invoices. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors — RevealUI runs on all three.',
+    'Sprawl prices reflect typical mid-startup invoices. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Objections (surfaced high: the two questions skeptical engineers ask first)
+// Concise answers to the two hardest objections (lock-in, production-readiness),
+// promoted above the FAQ so a skeptic gets them without scrolling. Full detail
+// lives in HOME_FAQ + PROOF_*; the cards link onward to #faq.
+// ---------------------------------------------------------------------------
+
+export const HOME_OBJECTIONS = {
+  eyebrow: 'Before you ask',
+  heading: 'The two questions every engineer asks first.',
+  cards: [
+    {
+      heading: 'Will I get locked in?',
+      body: 'No. Open standards end-to-end: OAuth, JWT, Stripe webhooks, MCP, OpenAPI, and plain Postgres. Deploy anywhere Node runs, and take your data, your code, and your infra with you. RevealUI is the runtime, not the prison.',
+    },
+    {
+      heading: 'Is it production-ready?',
+      body: 'Every PR clears a 3-phase gate before it lands: Biome, Vitest unit and integration, Playwright E2E, CodeQL, and Gitleaks. This site and the agency site at revealuistudio.com both run on RevealUI in production.',
+    },
+  ],
+  cta: { label: 'See all the questions →', href: '#faq' },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -206,22 +230,22 @@ export const HOME_FAQ = {
     {
       question: 'How is this different from Supabase, Convex, Clerk, or Trigger?',
       answer:
-        'Convex gives you real-time DB + functions. Supabase gives you Postgres + auth. Clerk gives you sessions. Trigger runs background jobs. Each one is a slice. RevealUI is the whole runtime — auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors — RevealUI runs on all three.)',
+        'Convex gives you real-time DB + functions. Supabase gives you Postgres + auth. Clerk gives you sessions. Trigger runs background jobs. Each one is a slice. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
     },
     {
       question: 'Can I self-host?',
       answer:
-        'Yes. 20 of 26 packages are MIT and stay MIT — forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infra at any tier — no vendor-specific edge runtimes, no proprietary database.',
+        'Yes. 20 of 26 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infra at any tier, with no vendor-specific edge runtimes and no proprietary database.',
     },
     {
       question: 'What does "agent-native" actually mean in code?',
       answer:
-        'Every collection is an MCP tool AND a REST endpoint AND a typed SDK call — gated by the same RBAC + ABAC policy. Agents are first-class principals: scope one to a collection, give it a budget, watch every action sign into the audit chain, revoke when done. The runtime is the contract, not a glue layer.',
+        'Every collection is an MCP tool AND a REST endpoint AND a typed SDK call, gated by the same RBAC + ABAC policy. Agents are first-class principals: scope one to a collection, give it a budget, watch every action sign into the audit chain, revoke when done. The runtime is the contract, not a glue layer.',
     },
     {
       question: "What's the lock-in story?",
       answer:
-        'Open standards, end-to-end. OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Postgres for data. Deploy anywhere Node runs — Vercel, Cloudflare, Fly, Hetzner, your own metal. Your data, your code, your infra. RevealUI is the runtime, not the prison.',
+        'Open standards, end-to-end. OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Postgres for data. Deploy anywhere Node runs: Vercel, Cloudflare, Fly, Hetzner, your own metal. Your data, your code, your infra. RevealUI is the runtime, not the prison.',
     },
     {
       question: 'Production-ready?',
@@ -236,12 +260,12 @@ export const HOME_FAQ = {
     {
       question: 'How does AI inference work?',
       answer:
-        'Pair RevealUI with Ollama or Ubuntu Inference Snaps. Bring Gemma 3/4, DeepSeek R1, Qwen VL, or Nemotron locally — your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
+        'Pair RevealUI with Ollama or Ubuntu Inference Snaps. Bring Gemma 3/4, DeepSeek R1, Qwen VL, or Nemotron locally, so your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
     },
     {
       question: 'How do agent payments work?',
       answer:
-        "x402-native. RevealUI implements the HTTP 402 payment protocol — compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare's x402 Foundation. Agents pay agents over standard HTTP. The protocol is the load-bearing piece; the agent-payment rails are in development.",
+        "x402-native. RevealUI implements the HTTP 402 payment protocol, compatible with Amazon Bedrock AgentCore Payments, Coinbase, and Cloudflare's x402 Foundation. Agents pay agents over standard HTTP. The protocol is the load-bearing piece; the agent-payment rails are in development.",
     },
   ] as readonly FaqItem[],
 } as const;
@@ -313,7 +337,7 @@ export const HOME_ACTORS = {
 export const HOME_FORK = {
   branchA: {
     title: "I'm building this myself.",
-    body: 'Source, packages, the CLI, and docs — read on.',
+    body: 'Source, packages, the CLI, and docs. Read on.',
     cta: 'Keep reading →',
   },
   branchB: {

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -6,15 +6,15 @@
 
 export const PERSONA_SECTION = {
   eyebrow: "Who it's for",
-  heading: 'For founders who need to ship fast — and still pass a security review.',
+  heading: 'For founders who need to ship fast, and still pass a security review.',
 } as const;
 
 export const PERSONA_CARD = {
   label: 'What this team needs before they can charge customers',
   quote:
-    'You’ve got a working AI demo. Then your first serious customer asks the hard questions — who can see this data, who can shut an agent down at 3am, and can you prove everything it did? You need answers before you can charge them, and you shouldn’t have to rebuild what you’ve already shipped to get there.',
+    'You’ve got a working AI demo. Then your first serious customer asks the hard questions: who can see this data, who can shut an agent down at 3am, and can you prove everything it did? You need answers before you can charge them, and you shouldn’t have to rebuild what you’ve already shipped to get there.',
   checklist: [
-    'An audit trail of every action — by people and by agents — that you can prove was not edited after the fact',
+    'An audit trail of every action, by people and by agents, that you can prove was not edited after the fact',
     'One set of permission rules covering your team, your agents, and your service accounts',
     'GDPR consent, deletion, and anonymization built into the data model',
     'Stripe billing that catches the payment events most apps quietly drop',

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -18,7 +18,7 @@ export interface TeaserTier {
 export const PRICING_TEASER_SECTION = {
   eyebrow: 'Pricing',
   heading: 'Start free. Pay when you scale.',
-  body: 'Self-host the open-source stack at no cost. Paid tiers (Pro, Enterprise) are previews — subscription billing opens when we flip Stripe live mode.',
+  body: 'Self-host the open-source stack at no cost. Paid tiers (Pro, Enterprise) are previews. Subscription billing opens when we flip Stripe live mode.',
 } as const;
 
 export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
@@ -26,7 +26,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     id: 'free',
     name: 'Free',
     description:
-      '20 of 26 packages MIT — forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. No telemetry.',
+      '20 of 26 packages MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. No telemetry.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',
@@ -44,7 +44,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     features: [
       'Everything in Free',
       '10,000 agent tasks / month included',
-      'Pro AI features (agents, MCP, memory) — beta in production',
+      'Pro AI features (agents, MCP, memory), beta in production',
       'Priority support',
     ],
     cta: 'See Pro pricing',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -23,7 +23,7 @@ export interface HomePrimitive {
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login. One audit trail.',
   heading: "Everything a business needs. Nothing you don't.",
-  body: 'People, content, offers, payments, and agents — the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
+  body: 'People, content, offers, payments, and agents: the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -47,7 +47,7 @@ export const PROOF_STACK: readonly StackItem[] = [
 export const PROOF_STACK_PANEL = {
   eyebrow: 'No proprietary lock-in',
   heading: 'Standards your team already knows',
-  body: 'Open standards end-to-end — OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Deploys to Vercel, Cloudflare, Fly, Hetzner, or your own infra. Take your data with you.',
+  body: 'Open standards end-to-end: OAuth, JWT, Stripe webhooks, MCP, OpenAPI. Deploys to Vercel, Cloudflare, Fly, Hetzner, or your own infra. Take your data with you.',
 } as const;
 
 export const PROOF_TRUST = {
@@ -56,7 +56,7 @@ export const PROOF_TRUST = {
   cards: [
     {
       eyebrow: 'In the repo',
-      heading: `${METRICS.licenseSplit.mit} of ${METRICS.packages} packages MIT — forever.`,
+      heading: `${METRICS.licenseSplit.mit} of ${METRICS.packages} packages MIT, forever.`,
       body: {
         prefix: `The ${METRICS.licenseSplit.fsl} Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. View the`,
         licenseLabel: 'LICENSE',
@@ -76,7 +76,7 @@ signature:         text('signature'),
 previousSignature: text('previous_signature'),`,
       fileLabel: 'packages/db/src/schema/audit-log.ts',
       fileHref: `${SITE.urls.repo}/blob/main/packages/db/src/schema/audit-log.ts`,
-      caption: '— tampering breaks the chain.',
+      caption: '(tampering breaks the chain).',
     },
     {
       eyebrow: 'In production',

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -5,6 +5,7 @@ import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
 import { Fork } from '../components/landing/Fork';
 import { Hero } from '../components/landing/Hero';
+import { Objections } from '../components/landing/Objections';
 import { Persona } from '../components/landing/Persona';
 import { PricingTeaser } from '../components/landing/PricingTeaser';
 import { Primitives } from '../components/landing/Primitives';
@@ -20,6 +21,7 @@ export function HomePage() {
       <Fork />
       <Problem />
       <Demo />
+      <Objections />
       <Primitives />
       <WhatsShipped />
       <Persona />


### PR DESCRIPTION
## What

Landing-page conversion-copy pass on the marketing homepage, from a landing-page best-practices review. Three improvements plus a copy-style cleanup.

## Changes

- **Motivation-first hero.** Lead with a bold hook ("Stop renting your stack from a half-dozen vendors.") before the feature sentence, so the emotional driver lands before the mechanics. Implemented as a new `subtitle.lead`; the Foundation A/B hero variant inherits it, so the runtime-vs-foundation noun test stays isolated.
- **New Objections section.** A compact two-card band ("Will I get locked in?" / "Is it production-ready?") between the Demo and Primitives, surfacing the two hardest objections high on the page and linking to a new `#faq` anchor on the FAQ.
- **Em-dash cleanup.** Removed em dashes from all homepage rendered copy (hero, FAQ, problem footnote, fork, primitives, capabilities, proof, persona, pricing teaser) per house style. Hyphenated compounds untouched; the `/products` page strings are a deferred follow-up.
- **You-voice fix** on the capabilities footnote.
- **Tests.** Added content-contract tests asserting the new section's shape and its `#faq` link.

## Verification

`tsc --noEmit`, `biome check`, `vitest` (31 passed), and `vite build` all green, plus the marketing content gates (claim-drift, marketing-voice, client-safety). The rendered hero, objections section, and pricing teaser were verified in a local dev server.

## Notes

- No new product claims or metrics; claim-drift is clean.
- The A/B Foundation hero variant is preserved and inherits the new lead line.
- A site-wide em-dash sweep (other marketing pages + the `Title — Brand` page-title separators) is a separate follow-up.
