### PR TITLE
chore(security): pin shell-quote to 1.8.4 (patches critical dev-dep advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
+      "shell-quote": ">=1.8.4",
       "form-data": ">=4.0.4",
       "path-to-regexp": ">=6.3.0",
       "tar-fs": ">=2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  shell-quote: '>=1.8.4'
   form-data: '>=4.0.4'
   path-to-regexp: '>=6.3.0'
   tar-fs: '>=2.1.4'
@@ -7555,8 +7556,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -12263,7 +12264,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -14852,7 +14853,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Pins `shell-quote` to `>=1.8.4` via `pnpm.overrides` to patch a **critical** advisory ("quote() does not escape newlines in object .op values"; vulnerable `>= 1.1.0, <= 1.8.3`, patched in `1.8.4`). It is a transitive **dev-scope** dependency, but `pnpm audit` (the Security Gate) hard-fails on it — which currently blocks the Security Gate on every open PR.

## Change

- `package.json` `pnpm.overrides`: add `"shell-quote": ">=1.8.4"` (follows the existing minimum-safe-version override pattern in the same block).
- `pnpm-lock.yaml`: regenerated via `pnpm install --lockfile-only` — `shell-quote@1.8.3` → `1.8.4`, the only change.

## Why now

The advisory went active after several open PRs had already passed their Security Gate, so it now blocks the merge train. This is the minimal unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
