### PR TITLE
fix(deps): remove duplicate shell-quote override (lockfile + package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",
       "cross-spawn": ">=7.0.5",
-      "shell-quote": ">=1.8.4",
       "qs": ">=6.15.2",
       "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,6 @@ overrides:
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
   cross-spawn: '>=7.0.5'
-  shell-quote: '>=1.8.4'
   qs: '>=6.15.2'
   axios: '>=1.15.2'
   follow-redirects: '>=1.16.0'


### PR DESCRIPTION
## What

The #1322 / #1323 advisory-override PRs each added a `shell-quote` override and were squash-merged minutes apart. The two independent squashes overlaid the same key, producing a **duplicated `shell-quote` entry in both**:

- `pnpm-lock.yaml` `overrides:` block → `ERR_PNPM_BROKEN_LOCKFILE` (`duplicated mapping key`)
- `package.json` `pnpm.overrides` → Biome `noDuplicateObjectKeys` (hard-fail)

## Impact

`pnpm install --frozen-lockfile` failed on **every** job (Security Gate, CodeQL, Quality, Build, tests…), so `test` was fully red and all open PRs were blocked downstream of it. With the lockfile repaired, the `package.json` duplicate then surfaced as the Biome hard-fail.

## Fix

Removed the redundant `shell-quote` key from both files. Both occurrences had the identical value (`>=1.8.4`) and the override is declared once elsewhere, so this is a no-op for dependency resolution — it only repairs the YAML/JSON.

## Verification (local)

- `pnpm install --frozen-lockfile` — passes ("Lockfile is up to date")
- `pnpm lint` — 0 errors (41 pre-existing warnings unchanged)
- `pnpm audit` — no known vulnerabilities (`shell-quote` + `brace-expansion@5` overrides intact)
- `pnpm validate:claims` — license membership matches package.json (0 mismatches)
