### PR TITLE
fix(deps): remove duplicate shell-quote override breaking the lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",
       "cross-spawn": ">=7.0.5",
-      "shell-quote": ">=1.8.4",
       "qs": ">=6.15.2",
       "axios": ">=1.15.2",
       "follow-redirects": ">=1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,6 @@ overrides:
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
   cross-spawn: '>=7.0.5'
-  shell-quote: '>=1.8.4'
   qs: '>=6.15.2'
   axios: '>=1.15.2'
   follow-redirects: '>=1.16.0'


### PR DESCRIPTION
## What

Removes a duplicate `shell-quote` override that broke the test lockfile.

## Why

#1322 and #1323 each independently added `"shell-quote": ">=1.8.4"` to `pnpm.overrides`, so test ended up with the key twice in both `package.json` (lines 59 and 68) and `pnpm-lock.yaml` (overrides block). A duplicate YAML mapping key makes `pnpm install --frozen-lockfile` fail with `ERR_PNPM_BROKEN_LOCKFILE`, which fails the Security Gate and every other install-dependent job. That currently blocks all open PRs to test (#1318, #1319, #1320, #1321, #1324, #1306) and test deploys.

## The fix

Removes the second occurrence from both files only. Two deletions, no resolution changes:
- `pnpm install --frozen-lockfile` installs clean (verified locally).
- `pnpm audit` reports no known vulnerabilities (shell-quote stays pinned to 1.8.4 via the remaining override).

The lockfile was de-duped surgically (the single duplicate line removed), not regenerated, so no transitive versions move.
