### PR TITLE
fix(presentation,admin): cobalt-token first-run pages + re-skin the kit they use

### DIFF
--- a/apps/admin/src/app/(backend)/error.tsx
+++ b/apps/admin/src/app/(backend)/error.tsx
@@ -25,9 +25,9 @@ export default function BackendError({
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-5 p-8">
       {/* Icon */}
-      <div className="flex size-14 items-center justify-center rounded-full bg-red-900/20">
+      <div className="flex size-14 items-center justify-center rounded-full bg-destructive/10">
         <svg
-          className="size-7 text-red-400"
+          className="size-7 text-destructive"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -42,47 +42,49 @@ export default function BackendError({
         </svg>
       </div>
 
-      <h2 className="text-lg font-semibold text-white">
+      <h2 className="text-lg font-semibold text-foreground">
         {isDatabaseError ? 'Database connection failed' : 'Something went wrong'}
       </h2>
 
       {isDatabaseError ? (
-        <div className="flex max-w-lg flex-col gap-3 text-center text-sm text-zinc-400">
+        <div className="flex max-w-lg flex-col gap-3 text-center text-sm text-muted-foreground">
           <p>The admin dashboard cannot reach the database. To fix this:</p>
-          <ol className="list-inside list-decimal text-left text-xs text-zinc-500">
+          <ol className="list-inside list-decimal text-left text-xs text-muted-foreground">
             <li>
-              Set <code className="text-zinc-300">POSTGRES_URL</code> or{' '}
-              <code className="text-zinc-300">DATABASE_URL</code> in your environment
+              Set <code className="text-foreground">POSTGRES_URL</code> or{' '}
+              <code className="text-foreground">DATABASE_URL</code> in your environment
             </li>
             <li>
-              Run <code className="text-zinc-300">pnpm db:migrate</code> to create tables
+              Run <code className="text-foreground">pnpm db:migrate</code> to create tables
             </li>
             <li>
-              Run <code className="text-zinc-300">pnpm db:seed</code> for sample content
+              Run <code className="text-foreground">pnpm db:seed</code> for sample content
             </li>
           </ol>
         </div>
       ) : (
-        <p className="max-w-md text-center text-sm text-zinc-400">
+        <p className="max-w-md text-center text-sm text-muted-foreground">
           {isNetworkError
             ? 'Unable to reach the server. Check your connection and try again.'
             : 'An unexpected error occurred while loading this page.'}
         </p>
       )}
 
-      {error.digest && <p className="font-mono text-xs text-zinc-600">Error ID: {error.digest}</p>}
+      {error.digest && (
+        <p className="font-mono text-xs text-muted-foreground">Error ID: {error.digest}</p>
+      )}
 
       <div className="flex items-center gap-3">
         <button
           type="button"
           onClick={() => reset()}
-          className="rounded-lg bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-200"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Try again
         </button>
         <Link
           href="/"
-          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
         >
           Go to dashboard
         </Link>

--- a/apps/admin/src/app/(backend)/loading.tsx
+++ b/apps/admin/src/app/(backend)/loading.tsx
@@ -4,17 +4,17 @@ export default function BackendLoading() {
   return (
     <div className="min-h-screen">
       {/* Header skeleton */}
-      <div className="border-b border-zinc-800 bg-zinc-900 px-6 py-4">
-        <Skeleton className="h-6 w-40 bg-zinc-800" />
-        <Skeleton className="mt-2 h-4 w-64 bg-zinc-800" />
+      <div className="border-b border-border bg-card px-6 py-4">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="mt-2 h-4 w-64" />
       </div>
 
       {/* Content skeleton */}
       <div className="p-6">
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <SkeletonCard className="border-zinc-800 bg-zinc-800/40" />
-          <SkeletonCard className="border-zinc-800 bg-zinc-800/40" />
-          <SkeletonCard className="border-zinc-800 bg-zinc-800/40" />
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
         </div>
       </div>
     </div>

--- a/apps/admin/src/app/(backend)/welcome/page.tsx
+++ b/apps/admin/src/app/(backend)/welcome/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { TIER_LABELS } from '@revealui/contracts/pricing';
+import { Badge } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { useLicense } from '@/lib/providers/LicenseProvider';
 
@@ -49,17 +50,19 @@ export default function WelcomePage() {
       {/* Hero */}
       <div className="text-center mb-12">
         {isPostPurchase && isPaidTier && (
-          <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5 text-sm font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-            <span role="img" aria-label="Checkmark">
-              &#10003;
-            </span>
-            Your {tierLabel} subscription is active
+          <div className="mb-6 flex justify-center">
+            <Badge color="success">
+              <span role="img" aria-label="Checkmark">
+                &#10003;
+              </span>
+              Your {tierLabel} subscription is active
+            </Badge>
           </div>
         )}
-        <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-5xl">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
           {isPostPurchase ? 'Welcome to RevealUI' : 'Get started with RevealUI'}
         </h1>
-        <p className="mx-auto mt-4 max-w-2xl text-lg text-zinc-600 dark:text-zinc-400">
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
           {isPostPurchase
             ? 'Three concrete first actions to put your subscription to work.'
             : 'New here? Start with one of these three tracks.'}
@@ -69,20 +72,20 @@ export default function WelcomePage() {
       {/* Three CTAs */}
       <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-3">
         {/* CTA 1: Install the CLI */}
-        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+        <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
             <span className="text-lg font-semibold">1</span>
           </div>
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Install the CLI</h2>
-          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          <h2 className="text-lg font-semibold text-foreground">Install the CLI</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             Scaffold a new RevealUI project locally. Fastest path to a running stack.
           </p>
-          <div className="mt-4 flex items-center gap-2 rounded-md bg-zinc-100 px-3 py-2 font-mono text-xs text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+          <div className="mt-4 flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs text-foreground">
             <code className="flex-1 truncate">{CLI_INSTALL_COMMAND}</code>
             <button
               type="button"
               onClick={() => void handleCopyCli()}
-              className="rounded bg-white px-2 py-1 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-700 dark:text-zinc-100 dark:ring-zinc-600 dark:hover:bg-zinc-600"
+              className="rounded bg-card px-2 py-1 text-xs font-medium text-foreground ring-1 ring-border transition-colors hover:bg-muted"
               aria-label="Copy command to clipboard"
             >
               {cliCopied ? 'Copied' : 'Copy'}
@@ -91,12 +94,12 @@ export default function WelcomePage() {
         </div>
 
         {/* CTA 2: Clone the starter */}
-        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+        <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
             <span className="text-lg font-semibold">2</span>
           </div>
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Clone the source</h2>
-          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          <h2 className="text-lg font-semibold text-foreground">Clone the source</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             Inspect the full monorepo — apps, packages, contracts, schemas. Full source-code access
             is part of every paid tier.
           </p>
@@ -104,7 +107,7 @@ export default function WelcomePage() {
             href={STARTER_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-indigo-700 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
+            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
           >
             Open on GitHub
             <span aria-hidden="true">&rarr;</span>
@@ -112,14 +115,12 @@ export default function WelcomePage() {
         </div>
 
         {/* CTA 3: Read the first guide */}
-        <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+        <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+          <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
             <span className="text-lg font-semibold">3</span>
           </div>
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">
-            Read the quick-start
-          </h2>
-          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          <h2 className="text-lg font-semibold text-foreground">Read the quick-start</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             5-minute walk-through: define a collection, get a REST API + admin UI + MCP tool
             automatically.
           </p>
@@ -127,7 +128,7 @@ export default function WelcomePage() {
             href={`${DOCS_URL}/quick-start`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-emerald-700 hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-300"
+            className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
           >
             Open the guide
             <span aria-hidden="true">&rarr;</span>
@@ -136,21 +137,21 @@ export default function WelcomePage() {
       </div>
 
       {/* Account-management footer */}
-      <div className="mt-12 rounded-2xl border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-800 dark:bg-zinc-900/50">
-        <h2 className="text-sm font-semibold text-zinc-900 dark:text-white">Manage your account</h2>
-        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+      <div className="mt-12 rounded-2xl border border-border bg-muted/40 p-6">
+        <h2 className="text-sm font-semibold text-foreground">Manage your account</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
           Update billing details, view invoices, or change your plan in account settings.
         </p>
         <div className="mt-4 flex flex-wrap gap-3 text-sm font-medium">
           <a
             href="/account/billing"
-            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+            className="rounded-md bg-card px-3 py-1.5 text-foreground ring-1 ring-border transition-colors hover:bg-muted"
           >
             Billing portal
           </a>
           <a
             href="/admin"
-            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+            className="rounded-md bg-card px-3 py-1.5 text-foreground ring-1 ring-border transition-colors hover:bg-muted"
           >
             Admin dashboard
           </a>
@@ -158,7 +159,7 @@ export default function WelcomePage() {
             href={DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-md bg-white px-3 py-1.5 text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700 dark:hover:bg-zinc-700"
+            className="rounded-md bg-card px-3 py-1.5 text-foreground ring-1 ring-border transition-colors hover:bg-muted"
           >
             Full documentation
           </a>

--- a/packages/presentation/src/__tests__/components/table.test.tsx
+++ b/packages/presentation/src/__tests__/components/table.test.tsx
@@ -100,7 +100,9 @@ describe('Table with striped prop', () => {
     const rows = screen.getAllByRole('row');
     // Body rows (index 1 and 2) get striped classes
     const bodyRow = rows[1];
-    expect(bodyRow.className).toContain('even:bg-zinc-950/2.5');
+    // Cobalt re-skin: striped rows now use the token-driven foreground overlay
+    // (was even:bg-zinc-950/2.5) so they adapt to light/dark via --rvui-* tokens.
+    expect(bodyRow.className).toContain('even:bg-foreground/2.5');
   });
 
   it('should omit bottom border on cells when striped', () => {

--- a/packages/presentation/src/components/Card.tsx
+++ b/packages/presentation/src/components/Card.tsx
@@ -9,9 +9,10 @@ function Card({
   return (
     <div
       className={cn(
-        // Bare `border` previously fell through to currentColor — visible bug.
-        // Lighter than field borders (cards sit one tier behind interactive fields).
-        'rounded-lg border border-zinc-200 dark:border-zinc-700 bg-card text-card-foreground shadow-sm hover:shadow-md',
+        // Token-driven card border (was a zinc-200/700 Catalyst holdover). `border-border`
+        // resolves via --rvui-border and auto-adapts to light/dark; cards sit one tier
+        // behind interactive fields, which the border token already accounts for.
+        'rounded-lg border border-border bg-card text-card-foreground shadow-sm hover:shadow-md',
         className,
       )}
       style={{

--- a/packages/presentation/src/components/badge.tsx
+++ b/packages/presentation/src/components/badge.tsx
@@ -32,6 +32,15 @@ const colors = {
   pink: 'bg-pink-400/15 text-pink-700 group-data-hover:bg-pink-400/25 dark:bg-pink-400/10 dark:text-pink-400 dark:group-data-hover:bg-pink-400/20',
   rose: 'bg-rose-400/15 text-rose-700 group-data-hover:bg-rose-400/25 dark:bg-rose-400/10 dark:text-rose-400 dark:group-data-hover:bg-rose-400/20',
   zinc: 'bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10',
+  // Cobalt semantic variants (token-driven; auto-adapt to light/dark via the --rvui-*
+  // bridge, so no `dark:` pair is needed). Added so admin/dashboard status badges can
+  // track the semantic token system instead of the raw-palette swatches above. The raw
+  // palette stays intact (it is the allowlisted product surface per ds-catalyst-reskin).
+  brand: 'bg-primary/10 text-primary group-data-hover:bg-primary/20',
+  success: 'bg-success/10 text-success group-data-hover:bg-success/20',
+  warning: 'bg-warning/10 text-warning-foreground group-data-hover:bg-warning/20',
+  danger: 'bg-destructive/10 text-destructive group-data-hover:bg-destructive/20',
+  muted: 'bg-muted text-muted-foreground group-data-hover:bg-muted/80',
 };
 
 type BadgeProps = { color?: keyof typeof colors };

--- a/packages/presentation/src/components/empty-state.tsx
+++ b/packages/presentation/src/components/empty-state.tsx
@@ -17,19 +17,17 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 px-6 py-16 text-center dark:border-zinc-700',
+        'flex flex-col items-center justify-center rounded-xl border border-dashed border-border px-6 py-16 text-center',
         className,
       )}
     >
       {icon && (
-        <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+        <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
           {icon}
         </div>
       )}
-      <h3 className="text-sm font-semibold text-zinc-950 dark:text-white">{title}</h3>
-      {description && (
-        <p className="mt-1 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">{description}</p>
-      )}
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      {description && <p className="mt-1 max-w-sm text-sm text-muted-foreground">{description}</p>}
       {action && <div className="mt-6">{action}</div>}
     </div>
   );

--- a/packages/presentation/src/components/skeleton.tsx
+++ b/packages/presentation/src/components/skeleton.tsx
@@ -6,7 +6,7 @@ export function Skeleton({ className, ...props }: React.ComponentPropsWithoutRef
     <div
       aria-hidden="true"
       {...props}
-      className={cn('animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-700', className)}
+      className={cn('animate-pulse rounded-md bg-foreground/10', className)}
     />
   );
 }
@@ -29,7 +29,7 @@ export function SkeletonText({ lines = 3, className }: { lines?: number; classNa
 
 export function SkeletonCard({ className }: { className?: string }) {
   return (
-    <div className={cn('rounded-xl border border-zinc-200 p-4 dark:border-zinc-700', className)}>
+    <div className={cn('rounded-xl border border-border p-4', className)}>
       <div className="flex items-center gap-3">
         <Skeleton className="size-10 rounded-full" />
         <div className="flex-1 space-y-2">

--- a/packages/presentation/src/components/table.tsx
+++ b/packages/presentation/src/components/table.tsx
@@ -41,9 +41,7 @@ export function Table({
           className={cn(className, '-mx-(--gutter) overflow-x-auto whitespace-nowrap')}
         >
           <div className={cn('inline-block min-w-full align-middle', !bleed && 'sm:px-(--gutter)')}>
-            <table className="min-w-full text-left text-sm/6 text-zinc-950 dark:text-white">
-              {children}
-            </table>
+            <table className="min-w-full text-left text-sm/6 text-foreground">{children}</table>
           </div>
         </div>
       </div>
@@ -52,7 +50,7 @@ export function Table({
 }
 
 export function TableHead({ className, ...props }: React.ComponentPropsWithoutRef<'thead'>) {
-  return <thead {...props} className={cn(className, 'text-zinc-500 dark:text-zinc-400')} />;
+  return <thead {...props} className={cn(className, 'text-muted-foreground')} />;
 }
 
 export function TableBody(props: React.ComponentPropsWithoutRef<'tbody'>) {
@@ -91,10 +89,10 @@ export function TableRow({
         className={cn(
           className,
           href &&
-            'has-[[data-row-link][data-focus]]:outline-2 has-[[data-row-link][data-focus]]:-outline-offset-2 has-[[data-row-link][data-focus]]:outline-blue-500 dark:focus-within:bg-white/2.5',
-          striped && 'even:bg-zinc-950/2.5 dark:even:bg-white/2.5',
-          href && striped && 'hover:bg-zinc-950/5 dark:hover:bg-white/5',
-          href && !striped && 'hover:bg-zinc-950/2.5 dark:hover:bg-white/2.5',
+            'has-[[data-row-link][data-focus]]:outline-2 has-[[data-row-link][data-focus]]:-outline-offset-2 has-[[data-row-link][data-focus]]:outline-ring focus-within:bg-foreground/2.5',
+          striped && 'even:bg-foreground/2.5',
+          href && striped && 'hover:bg-foreground/5',
+          href && !striped && 'hover:bg-foreground/2.5',
         )}
       />
     </TableRowContext.Provider>
@@ -109,8 +107,8 @@ export function TableHeader({ className, ...props }: React.ComponentPropsWithout
       {...props}
       className={cn(
         className,
-        'border-b border-b-zinc-950/10 px-4 py-2 font-medium first:pl-(--gutter,--spacing(2)) last:pr-(--gutter,--spacing(2)) dark:border-b-white/10',
-        grid && 'border-l border-l-zinc-950/5 first:border-l-0 dark:border-l-white/5',
+        'border-b border-b-foreground/10 px-4 py-2 font-medium first:pl-(--gutter,--spacing(2)) last:pr-(--gutter,--spacing(2))',
+        grid && 'border-l border-l-foreground/5 first:border-l-0',
         !bleed && 'sm:first:pl-1 sm:last:pr-1',
       )}
     />
@@ -129,8 +127,8 @@ export function TableCell({ className, children, ...props }: React.ComponentProp
       className={cn(
         className,
         'relative px-4 first:pl-(--gutter,--spacing(2)) last:pr-(--gutter,--spacing(2))',
-        !striped && 'border-b border-zinc-950/5 dark:border-white/5',
-        grid && 'border-l border-l-zinc-950/5 first:border-l-0 dark:border-l-white/5',
+        !striped && 'border-b border-foreground/5',
+        grid && 'border-l border-l-foreground/5 first:border-l-0',
         dense ? 'py-2.5' : 'py-4',
         !bleed && 'sm:first:pl-1 sm:last:pr-1',
       )}


### PR DESCRIPTION
## What

Fixes the off-brand, hardcoded first-run admin pages and re-skins the design-system components they rely on, continuing the Catalyst-zinc → cobalt (`--rvui-*`) re-skin of `@revealui/presentation`.

### Kit (`packages/presentation`)
- **badge.tsx** — adds `brand`/`success`/`warning`/`danger`/`muted` cobalt semantic variants. Purely additive: the existing raw-palette swatches stay (allowlisted product surface), so no existing `<Badge>` usage changes.
- **empty-state.tsx**, **skeleton.tsx** — zinc → `border-border` / `bg-muted` / `bg-foreground/10`. Also fixes the zinc-on-cobalt rendering these already had in agent-tasks / jobs / coordination.
- **Card.tsx** — `border-zinc-200/700` holdover → `border-border`.
- **table.tsx** — Catalyst `zinc-950/X dark:white/X` → token-driven `foreground/X` (one class, both modes); `outline-blue-500` → `outline-ring`.

### Pages (`apps/admin` `(backend)`)
- **welcome** — the post-Stripe-checkout landing. Was 80 hardcoded color classes (bright `bg-white` cards, three unrelated blue/indigo/emerald accents, hand-rolled `dark:` variants). Now fully token-driven; success pill is `<Badge color="success">`; step accents unified to cobalt.
- **loading** — adopts the re-skinned `Skeleton`/`SkeletonCard`, drops its `bg-zinc-800` overrides.
- **error** — `bg-red-900` + zinc → `bg-destructive/10` + semantic text tokens.

## Why

These are the first surfaces a paying customer sees (post-checkout, loading flashes, error states), and they rendered off-brand zinc/white on the cobalt shell. The kit components were stuck on the stock Catalyst zinc palette, which is why pages hand-rolled inline styles instead of adopting them. Re-skinning the components the admin actually uses makes them adoptable.

## Scope / coordination

- Deliberately **excludes** `Button.tsx`'s `outline` zinc leak to avoid colliding with the in-flight button-polish refactor.
- Net: 62 raw-palette lines removed; the single retained one is the allowlisted Badge default.

## Verification

- ✅ Biome clean
- ✅ `@revealui/presentation` build + typecheck
- ✅ admin typecheck (`tsc --noEmit`)
- ✅ pre-push gate PASS (incl. design-context drift, brand bridge, claim-drift hard-fail gates)
- ⏳ Visual regression deferred to CI / a test deploy (kit visual-baseline infra not yet wired). The token classes used already ship on the revenue / agents / monitoring pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
