### PR TITLE
fix(ci): repair webhook-reconciliation workflow startup failure

### DIFF
--- a/.github/workflows/webhook-reconciliation.yml
+++ b/.github/workflows/webhook-reconciliation.yml
@@ -79,7 +79,7 @@ jobs:
           # Build the body from the captured JSON file into a file, then post via
           # --body-file. Nothing attacker-influenced or multi-line is interpolated
           # into the shell: COUNT is a numeric step output passed through env, and
-          # the rows come from the file, not a re-interpolated ${{ }} expression.
+          # the rows come from the file, not a re-interpolated GitHub Actions expression.
           ROWS=$(jq '.rows' /tmp/unrecon.json)
           {
             echo "## Unreconciled Webhook Events"


### PR DESCRIPTION
## Problem

`.github/workflows/webhook-reconciliation.yml` produced a `startup_failure` on
every push (e.g. run `27254660579`): a phantom run with `event: push`, zero
jobs, 0s duration, and a display name of the file path rather than the
workflow's `name:` ("Webhook Reconciliation Check"). That is the signature of
GitHub failing to compile the workflow.

The file has no `push` trigger (only `schedule` + `workflow_dispatch`), so it
should never produce push runs at all. GitHub validates every workflow file on
each push regardless of its triggers, so an invalid file surfaces as a push
`startup_failure`. It is not a required check, so it never blocked merges, but
it left a persistent red X on every push.

## Root cause

The "Create or update issue" step's `run:` block contained an empty `${{ }}`
token inside a *shell comment*:

```
# the rows come from the file, not a re-interpolated ${{ }} expression.
```

GitHub Actions interpolates `${{ }}` expressions across the entire `run:`
string *before* the shell executes it, and does not honor shell `#` comments at
that stage. The empty `${{ }}` was therefore parsed as an expression with no
body and failed to compile. `actionlint` reproduces the exact error:

```
webhook-reconciliation.yml:78:289: unexpected end of input while parsing
variable access, function call, null, bool, int, float or string.
expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
```

The file is otherwise valid YAML with SHA-pinned actions and a valid cron,
which is why it passed visual review and plain YAML linting.

## Fix

Reword the comment to drop the literal `${{ }}` token. The security intent it
documented (the issue rows come from a file via `jq`, never re-interpolated
through a GitHub expression) is unchanged. No behavior change to the workflow.

## Verification

- `actionlint` 1.7.12 now reports zero errors on the file (was one).
- Remaining expression openers: 5 (all real), down from 6.
- This workflow has no `push` / `pull_request` trigger, so after this fix
  neither pushing the branch nor opening this PR creates a
  `webhook-reconciliation` run, confirming the `startup_failure` is gone.
