### PR TITLE
fix(admin): externalize @revealui/config so its lazy Proxy survives the prod build

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -91,11 +91,18 @@ const nextConfig = {
     // via @revealui/auth (transpilePackages). Externalize so it loads from
     // node_modules at runtime. Fixes the prod passkey-options 500 (GAP-220).
     '@simplewebauthn/server',
+    // @revealui/config exports a lazy-Proxy default (read as config.reveal.secret
+    // etc.). When transpiled by Turbopack into the standalone server bundle the
+    // Proxy default export is mangled, so config.reveal resolves to `undefined`
+    // at runtime — fine in `next dev`, but throws "Cannot read properties of
+    // undefined (reading 'secret')" in the prod build, 500ing passkey + every
+    // config.reveal route. It ships built ESM dist (./dist/index.js), so
+    // externalize it to load the working Proxy from node_modules un-transformed.
+    '@revealui/config',
   ],
   // Transpile workspace packages - all now use bundler module resolution with extensionless imports
   // This works with Turbopack since we changed from NodeNext to bundler resolution
   transpilePackages: [
-    '@revealui/config',
     '@revealui/db',
     '@revealui/contracts',
     '@revealui/auth',


### PR DESCRIPTION
## Problem

The admin passkey sign-in path 500s in production. `POST /api/auth/passkey/authenticate-options` returns 500; the runtime error (Vercel logs) is:

```
TypeError: Cannot read properties of undefined (reading 'secret')
```

The throw is `config.reveal.secret` — `config.reveal` is `undefined` at runtime. This affects every route that reads `config.reveal.*` on the production build (passkey, mfa, sign-in, etc.).

## Root cause

`@revealui/config`'s default export is a lazy `Proxy` (`packages/config/src/index.ts`). It is currently in `transpilePackages`, so Turbopack compiles it into the admin standalone server bundle, and the Proxy default export is mangled by that transform — `config.reveal` resolves to `undefined` at runtime. It works in `next dev` (no standalone transform) but throws in the prod build, which is why it was latent until prod auth was exercised.

## Fix

Move `@revealui/config` from `transpilePackages` to `serverExternalPackages` in `apps/admin/next.config.mjs`. The package ships built ESM dist (`./dist/index.js`), so it loads the working Proxy from `node_modules` un-transformed. This mirrors the `@simplewebauthn/server` externalization from #1102 (GAP-220), directly above it in the same array.

## Verify

- CI build (this PR) confirms the externalize does not break the admin build.
- `deploy-test` preview → `POST /api/auth/passkey/authenticate-options` should return **200** with options (was **500**), and admin passkey sign-in + dashboard data load.
