### PR TITLE
fix(core): stop aliasing @revealui/config to the app config file

### DIFF
--- a/.changeset/withrevealui-config-alias-shadow.md
+++ b/.changeset/withrevealui-config-alias-shadow.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': patch
+---
+
+withRevealUI no longer aliases the `@revealui/config` package specifier to the app's `revealui.config.ts` (webpack + Turbopack). The alias shadowed the real env-config package inside Next.js server bundles, so `config.reveal` / `config.database` reads resolved against the CMS instance config and returned `undefined` at runtime (prod admin passkey/MFA/sign-in 500s). CMS config loading is unaffected: apps import `revealui.config.ts` relatively or via their own `@reveal-config` alias. The webpack-only "config file not found" build validation tied to the alias is removed with it; a missing config file still fails the build at the app's own import site.

--- a/packages/core/src/__tests__/nextjs/withRevealUI.test.ts
+++ b/packages/core/src/__tests__/nextjs/withRevealUI.test.ts
@@ -1,24 +1,13 @@
 /**
  * withRevealUI tests  -  validates Next.js config wrapper including
- * config merging, webpack alias setup, turbopack aliases, headers,
- * environment variables, and config file resolution.
+ * config merging, webpack alias setup, turbopack passthrough, headers,
+ * and environment variables. Locks the regression that the `@revealui/config`
+ * package specifier is never aliased: the alias shadowed the env-config
+ * package in server bundles (prod admin passkey/MFA 500s, 2026-06-10).
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type WithRevealUIOptions, withRevealUI } from '../../nextjs/withRevealUI.js';
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-vi.mock('node:fs', () => ({
-  default: {
-    existsSync: vi.fn(),
-  },
-  existsSync: vi.fn(),
-}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,10 +50,6 @@ function callWebpack(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-beforeEach(() => {
-  vi.mocked(fs.existsSync).mockReturnValue(true);
-});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -173,12 +158,12 @@ describe('withRevealUI  -  config merging', () => {
 // =============================================================================
 
 describe('withRevealUI  -  webpack', () => {
-  it('sets @revealui/config alias to resolved config path', () => {
+  it('does not alias @revealui/config (must resolve to the real env-config package)', () => {
     const result = withRevealUI();
     const webpackResult = callWebpack(result);
 
     const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/project', './revealui.config.ts'));
+    expect(alias['@revealui/config']).toBeUndefined();
   });
 
   it('sets @revealui/core alias', () => {
@@ -200,7 +185,7 @@ describe('withRevealUI  -  webpack', () => {
 
     const alias = webpackResult.resolve?.alias ?? {};
     expect(alias['my-alias']).toBe('/some/path');
-    expect(alias['@revealui/config']).toBeDefined();
+    expect(alias['@revealui/config']).toBeUndefined();
   });
 
   it('initializes resolve.modules if missing', () => {
@@ -229,101 +214,6 @@ describe('withRevealUI  -  webpack', () => {
 
     expect(existingWebpack).toHaveBeenCalledOnce();
   });
-
-  it('uses context.dir as project root', () => {
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result, {}, { dir: '/custom/project' });
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/custom/project', './revealui.config.ts'));
-  });
-});
-
-// =============================================================================
-// Config file resolution
-// =============================================================================
-
-describe('withRevealUI  -  config file resolution', () => {
-  it('uses exact path when file exists', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/project', './revealui.config.ts'));
-  });
-
-  it('tries alternative extensions when exact path not found', () => {
-    // First call (exact path) returns false, second (.ts ext) returns true
-    vi.mocked(fs.existsSync)
-      .mockReturnValueOnce(false) // exact path
-      .mockReturnValueOnce(true); // .ts extension
-
-    const result = withRevealUI({}, { configPath: './revealui.config' });
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBeDefined();
-  });
-
-  it('throws in production when config file not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    expect(() => {
-      callWebpack(result, {}, { dev: false });
-    }).toThrow(/RevealUI config file not found/);
-  });
-
-  it('warns in development when config file not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    // Should not throw in dev mode
-    expect(() => {
-      callWebpack(result, {}, { dev: true });
-    }).not.toThrow();
-  });
-
-  it('uses fallback path in dev when config not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result, {}, { dev: true, dir: '/my/project' });
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    // Falls back to resolved configPath
-    expect(alias['@revealui/config']).toBe(path.resolve('/my/project', './revealui.config.ts'));
-  });
-
-  it('handles absolute configPath', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    const result = withRevealUI({}, { configPath: '/absolute/path/config.ts' });
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe('/absolute/path/config.ts');
-  });
-
-  it('error message includes searched paths', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    try {
-      callWebpack(result, {}, { dev: false });
-      expect.unreachable('should have thrown');
-    } catch (error) {
-      const message = (error as Error).message;
-      expect(message).toContain('RevealUI config file not found');
-      expect(message).toContain('Searched for');
-      expect(message).toContain('Please ensure the config file exists');
-    }
-  });
 });
 
 // =============================================================================
@@ -331,12 +221,12 @@ describe('withRevealUI  -  config file resolution', () => {
 // =============================================================================
 
 describe('withRevealUI  -  turbopack', () => {
-  it('sets turbopack resolveAlias for @revealui/config', () => {
+  it('injects no turbopack config when the app provides none', () => {
     const result = withRevealUI();
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeDefined();
+    expect(result.turbopack).toBeUndefined();
   });
 
-  it('preserves existing turbopack config', () => {
+  it('passes through existing turbopack config without injecting @revealui/config', () => {
     const result = withRevealUI({
       turbopack: {
         resolveAlias: { 'my-pkg': './src/my-pkg' },
@@ -344,10 +234,10 @@ describe('withRevealUI  -  turbopack', () => {
     });
 
     expect(result.turbopack?.resolveAlias?.['my-pkg']).toBe('./src/my-pkg');
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeDefined();
+    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeUndefined();
   });
 
-  it('prefers existing @revealui/config alias from nextConfig', () => {
+  it('passes through a consumer-set @revealui/config alias untouched', () => {
     const result = withRevealUI({
       turbopack: {
         resolveAlias: { '@revealui/config': './custom-config.ts' },
@@ -355,12 +245,6 @@ describe('withRevealUI  -  turbopack', () => {
     });
 
     expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBe('./custom-config.ts');
-  });
-
-  it('uses relative configPath for turbopack when not absolute', () => {
-    const result = withRevealUI({}, { configPath: './my-config.ts' });
-    // When configPath is relative and no existing turbopack alias, it should use configPath
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBe('./my-config.ts');
   });
 });
 

--- a/packages/core/src/nextjs/withRevealUI.ts
+++ b/packages/core/src/nextjs/withRevealUI.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -41,8 +40,13 @@ export interface WithRevealUIOptions {
  * Next.js configuration wrapper for RevealUI
  * Provides webpack aliases, environment variables, and build configuration
  *
- * Sets up `@revealui/config` alias to import the RevealUI config file.
- * The alias works with both Webpack (Next.js < 15) and Turbopack (Next.js 16+).
+ * MUST NOT alias the `@revealui/config` package specifier: that is a real
+ * workspace package (type-safe env config). Aliasing it to the app's
+ * revealui.config.ts shadows the package in every server bundle, so
+ * `config.reveal` / `config.database` reads resolve against the CMS instance
+ * config and come back undefined at runtime (prod admin passkey/MFA 500s,
+ * 2026-06-10). Apps load their CMS config via relative imports or their own
+ * `@reveal-config` alias instead.
  */
 export function withRevealUI(
   nextConfig: NextConfig = {},
@@ -54,41 +58,6 @@ export function withRevealUI(
     adminRoute = '/admin',
     apiRoute = '/api',
   } = options;
-
-  /**
-   * Resolve config file path with validation
-   * Attempts multiple extensions (.ts, .js, .mjs) if base path doesn't exist
-   */
-  const resolveConfigPath = (baseDir: string): string => {
-    const basePath = path.isAbsolute(configPath) ? configPath : path.resolve(baseDir, configPath);
-
-    // Try exact path first
-    if (fs.existsSync(basePath)) {
-      return basePath;
-    }
-
-    // Try with extensions if no extension provided
-    const extensions = ['.ts', '', '.mjs'];
-    const baseWithoutExt = path.parse(basePath);
-
-    for (const ext of extensions) {
-      const candidate = path.format({
-        ...baseWithoutExt,
-        base: undefined,
-        ext: ext,
-      });
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    // If not found, throw helpful error
-    throw new Error(
-      `RevealUI config file not found: ${basePath}\n` +
-        `Searched for: ${basePath}, ${extensions.map((ext) => path.format({ ...baseWithoutExt, base: undefined, ext })).join(', ')}\n` +
-        `Please ensure the config file exists or provide a valid configPath option.`,
-    );
-  };
 
   return {
     ...nextConfig,
@@ -113,34 +82,6 @@ export function withRevealUI(
         config = nextConfig.webpack(config, context);
       }
 
-      // Resolve config path at execution time (when webpack runs)
-      // This ensures we're using the correct cwd for the Next.js project
-      const projectRoot = context.dir || process.cwd();
-      let resolvedConfigPath: string;
-
-      try {
-        resolvedConfigPath = resolveConfigPath(projectRoot);
-      } catch (error) {
-        // In development, warn but don't fail - allow for dynamic config creation
-        if (dev) {
-          // Lazy import logger to avoid ESM resolution issues at module load time
-          import('../instance/logger.js')
-            .then(({ defaultLogger }) => {
-              defaultLogger.warn(error instanceof Error ? error.message : String(error));
-            })
-            .catch(() => {
-              // Logger failed to load - silently continue (already falling back to default config path)
-            });
-          // Use fallback path
-          resolvedConfigPath = path.isAbsolute(configPath)
-            ? configPath
-            : path.resolve(projectRoot, configPath);
-        } else {
-          // In production, fail fast
-          throw error;
-        }
-      }
-
       // Add RevealUI-specific webpack aliases
       const resolve = (config.resolve || {}) as {
         alias?: Record<string, string>;
@@ -151,9 +92,6 @@ export function withRevealUI(
         ...resolve.alias,
         // RevealUI core aliases - resolve to source index file
         '@revealui/core': path.resolve(__dirname, '../index'),
-        // Config alias - resolves to the actual config file path in the Next.js project
-        // Use absolute path for reliable resolution
-        '@revealui/config': resolvedConfigPath,
       };
 
       // Also ensure it's in resolve.modules if needed (for some edge cases)
@@ -164,43 +102,8 @@ export function withRevealUI(
       return config;
     },
 
-    // Turbopack configuration (Next.js 16+)
-    // IMPORTANT: Turbopack's resolveAlias must be resolved at config evaluation time
-    // Turbopack should read tsconfig.json paths, but we also set it explicitly here for reliability
-    // If next.config.mjs already set @revealui/config, we respect it (it uses __dirname which is reliable).
-    turbopack: {
-      ...nextConfig.turbopack,
-      resolveAlias: {
-        // Start with existing aliases from next.config.mjs (which includes @revealui/config)
-        ...nextConfig.turbopack?.resolveAlias,
-        // RevealUI core aliases - use relative path for Turbopack compatibility
-        // Don't set @revealui/core here - let next.config.mjs handle it via the @revealui alias
-        // Ensure @revealui/config is set (next.config.mjs should have it, but ensure it's there)
-        // Use the existing one if present (prefer relative path for Turbopack)
-        // Otherwise resolve it to relative path from project root
-        '@revealui/config':
-          nextConfig.turbopack?.resolveAlias?.['@revealui/config'] ||
-          (() => {
-            // Prefer relative path for Turbopack (matches tsconfig.json format)
-            if (!path.isAbsolute(configPath)) {
-              return configPath;
-            }
-            // If absolute, convert to relative from project root
-            try {
-              const projectRoot = process.cwd();
-              const resolved = resolveConfigPath(projectRoot);
-              if (fs.existsSync(resolved)) {
-                // Return relative path from project root
-                return path.relative(projectRoot, resolved);
-              }
-            } catch {
-              // Fall through to fallback
-            }
-            // Fallback: use configPath as-is (should be relative)
-            return configPath;
-          })(),
-      },
-    },
+    // Turbopack config passes through verbatim via the `...nextConfig` spread —
+    // withRevealUI injects no resolveAlias entries (see the docstring constraint).
 
     // Headers for RevealUI
     async headers() {


### PR DESCRIPTION
## Summary

Removes the `@revealui/config` → `revealui.config.ts` alias that `withRevealUI()` injected into both the webpack and Turbopack resolve config.

That alias shadowed the real `@revealui/config` workspace package (the type-safe env config) inside every Next.js server bundle built through `withRevealUI`: any `import config from '@revealui/config'` resolved to the app's CMS instance config instead, so reads like `config.reveal.secret` / `config.database` returned `undefined` at runtime.

**Observed impact (prod admin):** `POST /api/auth/passkey/authenticate-options` 500s with `TypeError: Cannot read properties of undefined (reading 'secret')` thrown from the route's bundled chunk. The same class affects every admin route importing `@revealui/config` (passkey, MFA, sign-in, email lib) plus `@revealui/auth` / `@revealui/db` reads inside the admin bundle.

#1332 (externalizing `@revealui/config` via `serverExternalPackages`) could not fix this: `resolveAlias` rewrites the specifier to a relative file before externals are consulted. The post-#1333 prod runtime stack shows the identical chunk + offset still throwing.

This also explains a long-standing footgun: named imports (`import { getConfig } from '@revealui/config'`) failed the admin Turbopack build, because the aliased module (`revealui.config.ts`) has no such export. Default imports built but delivered the wrong object.

## Why removing the alias is safe

- No consumer depends on the shadowing: the CMS config is loaded via relative imports (e.g. `apps/admin/src/app/(backend)/layout.tsx`) and the app-level `@reveal-config` alias (`apps/admin/next.config.mjs`); `packages/core/src` contains no `from '@revealui/config'` import.
- `REVEALUI_CONFIG_PATH` (still set by `withRevealUI`) has no runtime consumer.
- All current `@revealui/config` importers (admin routes, `@revealui/auth`, `@revealui/db`) expect the env package — the same resolution `apps/server` already gets, which is why the Hono API was unaffected.
- The webpack-only "config file not found" validation existed solely to feed the alias; a missing `revealui.config.ts` still fails the build at the app's own import site. (Turbopack builds — what admin actually uses — never executed that validation.)

## Changes

- `packages/core/src/nextjs/withRevealUI.ts` — drop the alias + `resolveConfigPath` machinery from both branches; Turbopack config now passes through verbatim via the `...nextConfig` spread; docstring documents the do-not-realias constraint.
- `packages/core/src/__tests__/nextjs/withRevealUI.test.ts` — regression locks: `@revealui/config` is never aliased (webpack + turbopack), consumer-set aliases pass through untouched; removed the dead config-file-resolution suite. 30/30 green.
- Changeset: patch `@revealui/core`.

## Verification (ran against the built artifact, not just source)

- Vitest `packages/core` withRevealUI suite 30/30; Biome clean; `tsc --noEmit` clean.
- Built the admin Turbopack **standalone** output from this branch and booted it locally (`node server.js`, schema-valid dummy env). `POST /api/revalidate` exercises the exact poisoned read (`config.reveal.secret`, no middleware/DB in the way):
  - no secret header → **401 Unauthorized** (was: TypeError 500 — prod today returns 500 on this same probe)
  - wrong secret → **401**
  - correct secret + `{"tag":"smoke-test"}` → **200 `{"revalidated":true}`**
  - i.e. the bundled real `@revealui/config` Proxy resolves through Turbopack; with deliberately incomplete env it throws the package's own named `ConfigValidationError` from the Proxy get-trap (previously unreachable code).
- Note: `serverExternalPackages` does NOT externalize this workspace package under Turbopack (no `@revealui/config` in standalone `node_modules`; code is bundled) — which is why #1332 could never have fixed this. The bundled package works correctly once the alias stops hijacking the specifier.
- Local passkey route probe stops at the DB-backed rate limiter (no local Postgres) — its `pg` connection attempt itself shows `@revealui/db`'s config read now working.
- Definitive post-promotion check: cold `POST https://admin.revealui.com/api/auth/passkey/authenticate-options` → 200, and `POST https://admin.revealui.com/api/revalidate` (no header) → 401 instead of 500.
