### PR TITLE
fix(marketing): purge copy em dashes + gate them in marketing-voice

### DIFF
--- a/apps/marketing/app/components/ProductMockup.tsx
+++ b/apps/marketing/app/components/ProductMockup.tsx
@@ -134,7 +134,7 @@ export function ProductMockup() {
           {/* biome-ignore lint/performance/noImgElement: Vite SPA, no Next image optimizer available */}
           <img
             src={SCREENSHOTS[activeTab]?.src ?? ''}
-            alt={`RevealUI Admin — ${SCREENSHOTS[activeTab]?.label ?? ''}`}
+            alt={`RevealUI Admin: ${SCREENSHOTS[activeTab]?.label ?? ''}`}
             className="absolute inset-0 h-full w-full object-cover object-top"
           />
         </div>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -184,8 +184,8 @@ export function ProductsPage() {
               And the rest of the fleet
             </h2>
             <p className="mt-4 text-lg leading-7 text-muted-foreground">
-              Sister products that extend the runtime — secrets, dev tooling, white-labeling,
-              skills, and the agent tool catalog.
+              Sister products that extend the runtime: secrets, dev tooling, white-labeling, skills,
+              and the agent tool catalog.
             </p>
           </div>
 

--- a/scripts/validate/__tests__/marketing-voice.test.ts
+++ b/scripts/validate/__tests__/marketing-voice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   baselineKey,
+  hasEmDash,
   hasEmoji,
   hasSentenceExclamation,
   isContentFile,
@@ -106,6 +107,23 @@ describe('scanLine — punctuation (content only)', () => {
   });
 });
 
+describe('scanLine — em-dash (all scopes)', () => {
+  it('flags an em dash in content scope', () => {
+    expect(hits("  body: 'one runtime — five primitives',", CONTENT)).toContain('em-dash:em-dash');
+  });
+  it('flags an em dash in tsx scope (JSX copy)', () => {
+    expect(hits('  <p>Sister products — secrets, tooling</p>', TSX)).toContain('em-dash:em-dash');
+  });
+  it('does not flag hyphens or en dashes', () => {
+    expect(ruleIds("  body: 'self-hosted - your data, 4–12 weeks',", CONTENT)).not.toContain(
+      'em-dash',
+    );
+  });
+  it('skips JSX comment lines', () => {
+    expect(scanLine('  {/* Value band — you own the runtime */}', TSX)).toEqual([]);
+  });
+});
+
 describe('scanLine — skips imports and comments', () => {
   it('skips import lines even when they contain banned tokens', () => {
     expect(scanLine("import { powerful } from './x';", CONTENT)).toEqual([]);
@@ -113,6 +131,7 @@ describe('scanLine — skips imports and comments', () => {
   it('skips comment lines', () => {
     expect(scanLine('  // a powerful, cutting-edge comment', CONTENT)).toEqual([]);
     expect(scanLine('   * jsdoc powerful line', CONTENT)).toEqual([]);
+    expect(scanLine('  // product roster — em dashes fine in comments', CONTENT)).toEqual([]);
   });
 });
 
@@ -121,6 +140,11 @@ describe('helpers', () => {
     expect(hasEmoji('🚀')).toBe(true);
     expect(hasEmoji('→')).toBe(false);
     expect(hasEmoji('x')).toBe(false);
+  });
+  it('hasEmDash matches only the em dash character', () => {
+    expect(hasEmDash('runtime — primitives')).toBe(true);
+    expect(hasEmDash('runtime - primitives')).toBe(false);
+    expect(hasEmDash('4–12 weeks')).toBe(false);
   });
   it('hasSentenceExclamation distinguishes copy from code', () => {
     expect(hasSentenceExclamation('Ship today!')).toBe(true);

--- a/scripts/validate/marketing-voice.ts
+++ b/scripts/validate/marketing-voice.ts
@@ -7,6 +7,7 @@
  *
  *   - §4.1 banned hype words / phrases   → `hype-word`, `hype-phrase`
  *   - §4.1 punctuation bans (emoji, `!`) → `punctuation`
+ *   - owner style: no em dashes in copy  → `em-dash`
  *   - §4.2 internal-codename leaks       → `codename`
  *   - §2 / §4.3 / §5 fleet voice register → `fleet-voice`
  *     (no first-person-plural studio voice on fleet pages; `for-operators/*`
@@ -26,6 +27,8 @@
  *     with hype tokens, so they are out of scope for those rules.
  *   - codename + voice: every marketing file — those tokens never collide
  *     with class names.
+ *   - em-dash: every marketing file — the character never appears in class
+ *     names, and comment lines (including JSX comments) are skipped.
  *
  * A baseline (`marketing-voice-baseline.json`) grandfathers the current
  * corpus; CI fails only on NEW `(file::ruleId::token)` triples. Shrinking the
@@ -201,6 +204,15 @@ export function hasSentenceExclamation(line: string): boolean {
   return false;
 }
 
+/** U+2014 em dash, constructed from its code point so this validator's own
+ *  source never carries the raw character. Banned in customer copy (owner
+ *  writing style: use a comma, colon, or period instead). */
+const EM_DASH = String.fromCodePoint(0x2014);
+
+export function hasEmDash(text: string): boolean {
+  return text.includes(EM_DASH);
+}
+
 /** Find a lowercased token `sequence` as a contiguous run within `lowerWords`. */
 export function matchesSequence(
   lowerWords: readonly string[],
@@ -236,6 +248,7 @@ export function scanLine(line: string, opts: LineScanOptions): RawFinding[] {
     trimmed.startsWith('import ') ||
     trimmed.startsWith('//') ||
     trimmed.startsWith('/*') ||
+    trimmed.startsWith('{/*') ||
     trimmed.startsWith('*')
   ) {
     return [];
@@ -256,6 +269,12 @@ export function scanLine(line: string, opts: LineScanOptions): RawFinding[] {
     if (matchesSequence(lowerWords, seq)) {
       findings.push({ ruleId: 'codename', token: seq.join(' ') });
     }
+  }
+
+  // Em dashes — every marketing file (owner style: comma/colon/period in copy).
+  // Comment lines, including JSX comments, are already skipped above.
+  if (hasEmDash(line)) {
+    findings.push({ ruleId: 'em-dash', token: 'em-dash' });
   }
 
   // Fleet voice register — non-exempt fleet files.
@@ -463,7 +482,7 @@ function run(): void {
     console.error(`    ${f.text}`);
   }
   console.error(
-    `\n${fresh.length} new violation(s). See the voice-and-headline-rules corpus (§4.1 banned words, §4.2 codenames, §2/§4.3 fleet voice).`,
+    `\n${fresh.length} new violation(s). See the voice-and-headline-rules corpus (§4.1 banned words, §4.2 codenames, §2/§4.3 fleet voice) and the no-em-dash style rule (use a comma, colon, or period).`,
   );
   process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary

- Purges the two remaining em dashes in rendered marketing copy (the landing conversion pass had already cleared the homepage): the sister-products intro on `/products` and the admin screenshot alt text in `ProductMockup`, both replaced with colons.
- Extends the marketing-voice CI gate with an `em-dash` rule so the ban is enforced rather than remembered:
  - scanned across every marketing file like `codename` (the character cannot collide with Tailwind class names)
  - the comment-skip heuristic now also skips JSX comments (`{/* ... */}`), which hardens the existing rules too; code comments stay out of scope by design (they are developer-facing, not copy)
  - `EM_DASH` constructed from its code point (`String.fromCodePoint(0x2014)`) so the validator's own source never carries the raw character
  - unit tests for fire / comment-skip / hyphen + en-dash non-matches

Follow-up from the 2026-06-10 public-surfaces assessment (internal audit): em-dash debt in marketing copy was down to exactly these two instances; the durable fix is the gate rule.

## Verification

- `pnpm validate:marketing-voice`: scanned clean, 0 new, baseline stays empty
- Validator unit tests: 26/26 pass
- `pnpm --filter marketing test`: 31/31 pass (after building workspace deps in the fresh worktree)
- Biome clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
