### PR TITLE
chore(release): promote test to main (config-alias passkey fix)

### DIFF
--- a/.changeset/withrevealui-config-alias-shadow.md
+++ b/.changeset/withrevealui-config-alias-shadow.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': patch
+---
+
+withRevealUI no longer aliases the `@revealui/config` package specifier to the app's `revealui.config.ts` (webpack + Turbopack). The alias shadowed the real env-config package inside Next.js server bundles, so `config.reveal` / `config.database` reads resolved against the CMS instance config and returned `undefined` at runtime (prod admin passkey/MFA/sign-in 500s). CMS config loading is unaffected: apps import `revealui.config.ts` relatively or via their own `@reveal-config` alias. The webpack-only "config file not found" build validation tied to the alias is removed with it; a missing config file still fails the build at the app's own import site.

--- a/packages/core/src/__tests__/nextjs/withRevealUI.test.ts
+++ b/packages/core/src/__tests__/nextjs/withRevealUI.test.ts
@@ -1,24 +1,13 @@
 /**
  * withRevealUI tests  -  validates Next.js config wrapper including
- * config merging, webpack alias setup, turbopack aliases, headers,
- * environment variables, and config file resolution.
+ * config merging, webpack alias setup, turbopack passthrough, headers,
+ * and environment variables. Locks the regression that the `@revealui/config`
+ * package specifier is never aliased: the alias shadowed the env-config
+ * package in server bundles (prod admin passkey/MFA 500s, 2026-06-10).
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type WithRevealUIOptions, withRevealUI } from '../../nextjs/withRevealUI.js';
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-vi.mock('node:fs', () => ({
-  default: {
-    existsSync: vi.fn(),
-  },
-  existsSync: vi.fn(),
-}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,10 +50,6 @@ function callWebpack(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-beforeEach(() => {
-  vi.mocked(fs.existsSync).mockReturnValue(true);
-});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -173,12 +158,12 @@ describe('withRevealUI  -  config merging', () => {
 // =============================================================================
 
 describe('withRevealUI  -  webpack', () => {
-  it('sets @revealui/config alias to resolved config path', () => {
+  it('does not alias @revealui/config (must resolve to the real env-config package)', () => {
     const result = withRevealUI();
     const webpackResult = callWebpack(result);
 
     const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/project', './revealui.config.ts'));
+    expect(alias['@revealui/config']).toBeUndefined();
   });
 
   it('sets @revealui/core alias', () => {
@@ -200,7 +185,7 @@ describe('withRevealUI  -  webpack', () => {
 
     const alias = webpackResult.resolve?.alias ?? {};
     expect(alias['my-alias']).toBe('/some/path');
-    expect(alias['@revealui/config']).toBeDefined();
+    expect(alias['@revealui/config']).toBeUndefined();
   });
 
   it('initializes resolve.modules if missing', () => {
@@ -229,101 +214,6 @@ describe('withRevealUI  -  webpack', () => {
 
     expect(existingWebpack).toHaveBeenCalledOnce();
   });
-
-  it('uses context.dir as project root', () => {
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result, {}, { dir: '/custom/project' });
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/custom/project', './revealui.config.ts'));
-  });
-});
-
-// =============================================================================
-// Config file resolution
-// =============================================================================
-
-describe('withRevealUI  -  config file resolution', () => {
-  it('uses exact path when file exists', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe(path.resolve('/project', './revealui.config.ts'));
-  });
-
-  it('tries alternative extensions when exact path not found', () => {
-    // First call (exact path) returns false, second (.ts ext) returns true
-    vi.mocked(fs.existsSync)
-      .mockReturnValueOnce(false) // exact path
-      .mockReturnValueOnce(true); // .ts extension
-
-    const result = withRevealUI({}, { configPath: './revealui.config' });
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBeDefined();
-  });
-
-  it('throws in production when config file not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    expect(() => {
-      callWebpack(result, {}, { dev: false });
-    }).toThrow(/RevealUI config file not found/);
-  });
-
-  it('warns in development when config file not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    // Should not throw in dev mode
-    expect(() => {
-      callWebpack(result, {}, { dev: true });
-    }).not.toThrow();
-  });
-
-  it('uses fallback path in dev when config not found', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-    const webpackResult = callWebpack(result, {}, { dev: true, dir: '/my/project' });
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    // Falls back to resolved configPath
-    expect(alias['@revealui/config']).toBe(path.resolve('/my/project', './revealui.config.ts'));
-  });
-
-  it('handles absolute configPath', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    const result = withRevealUI({}, { configPath: '/absolute/path/config.ts' });
-    const webpackResult = callWebpack(result);
-
-    const alias = webpackResult.resolve?.alias ?? {};
-    expect(alias['@revealui/config']).toBe('/absolute/path/config.ts');
-  });
-
-  it('error message includes searched paths', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = withRevealUI();
-
-    try {
-      callWebpack(result, {}, { dev: false });
-      expect.unreachable('should have thrown');
-    } catch (error) {
-      const message = (error as Error).message;
-      expect(message).toContain('RevealUI config file not found');
-      expect(message).toContain('Searched for');
-      expect(message).toContain('Please ensure the config file exists');
-    }
-  });
 });
 
 // =============================================================================
@@ -331,12 +221,12 @@ describe('withRevealUI  -  config file resolution', () => {
 // =============================================================================
 
 describe('withRevealUI  -  turbopack', () => {
-  it('sets turbopack resolveAlias for @revealui/config', () => {
+  it('injects no turbopack config when the app provides none', () => {
     const result = withRevealUI();
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeDefined();
+    expect(result.turbopack).toBeUndefined();
   });
 
-  it('preserves existing turbopack config', () => {
+  it('passes through existing turbopack config without injecting @revealui/config', () => {
     const result = withRevealUI({
       turbopack: {
         resolveAlias: { 'my-pkg': './src/my-pkg' },
@@ -344,10 +234,10 @@ describe('withRevealUI  -  turbopack', () => {
     });
 
     expect(result.turbopack?.resolveAlias?.['my-pkg']).toBe('./src/my-pkg');
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeDefined();
+    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBeUndefined();
   });
 
-  it('prefers existing @revealui/config alias from nextConfig', () => {
+  it('passes through a consumer-set @revealui/config alias untouched', () => {
     const result = withRevealUI({
       turbopack: {
         resolveAlias: { '@revealui/config': './custom-config.ts' },
@@ -355,12 +245,6 @@ describe('withRevealUI  -  turbopack', () => {
     });
 
     expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBe('./custom-config.ts');
-  });
-
-  it('uses relative configPath for turbopack when not absolute', () => {
-    const result = withRevealUI({}, { configPath: './my-config.ts' });
-    // When configPath is relative and no existing turbopack alias, it should use configPath
-    expect(result.turbopack?.resolveAlias?.['@revealui/config']).toBe('./my-config.ts');
   });
 });
 

--- a/packages/core/src/nextjs/withRevealUI.ts
+++ b/packages/core/src/nextjs/withRevealUI.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -41,8 +40,13 @@ export interface WithRevealUIOptions {
  * Next.js configuration wrapper for RevealUI
  * Provides webpack aliases, environment variables, and build configuration
  *
- * Sets up `@revealui/config` alias to import the RevealUI config file.
- * The alias works with both Webpack (Next.js < 15) and Turbopack (Next.js 16+).
+ * MUST NOT alias the `@revealui/config` package specifier: that is a real
+ * workspace package (type-safe env config). Aliasing it to the app's
+ * revealui.config.ts shadows the package in every server bundle, so
+ * `config.reveal` / `config.database` reads resolve against the CMS instance
+ * config and come back undefined at runtime (prod admin passkey/MFA 500s,
+ * 2026-06-10). Apps load their CMS config via relative imports or their own
+ * `@reveal-config` alias instead.
  */
 export function withRevealUI(
   nextConfig: NextConfig = {},
@@ -54,41 +58,6 @@ export function withRevealUI(
     adminRoute = '/admin',
     apiRoute = '/api',
   } = options;
-
-  /**
-   * Resolve config file path with validation
-   * Attempts multiple extensions (.ts, .js, .mjs) if base path doesn't exist
-   */
-  const resolveConfigPath = (baseDir: string): string => {
-    const basePath = path.isAbsolute(configPath) ? configPath : path.resolve(baseDir, configPath);
-
-    // Try exact path first
-    if (fs.existsSync(basePath)) {
-      return basePath;
-    }
-
-    // Try with extensions if no extension provided
-    const extensions = ['.ts', '', '.mjs'];
-    const baseWithoutExt = path.parse(basePath);
-
-    for (const ext of extensions) {
-      const candidate = path.format({
-        ...baseWithoutExt,
-        base: undefined,
-        ext: ext,
-      });
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    // If not found, throw helpful error
-    throw new Error(
-      `RevealUI config file not found: ${basePath}\n` +
-        `Searched for: ${basePath}, ${extensions.map((ext) => path.format({ ...baseWithoutExt, base: undefined, ext })).join(', ')}\n` +
-        `Please ensure the config file exists or provide a valid configPath option.`,
-    );
-  };
 
   return {
     ...nextConfig,
@@ -113,34 +82,6 @@ export function withRevealUI(
         config = nextConfig.webpack(config, context);
       }
 
-      // Resolve config path at execution time (when webpack runs)
-      // This ensures we're using the correct cwd for the Next.js project
-      const projectRoot = context.dir || process.cwd();
-      let resolvedConfigPath: string;
-
-      try {
-        resolvedConfigPath = resolveConfigPath(projectRoot);
-      } catch (error) {
-        // In development, warn but don't fail - allow for dynamic config creation
-        if (dev) {
-          // Lazy import logger to avoid ESM resolution issues at module load time
-          import('../instance/logger.js')
-            .then(({ defaultLogger }) => {
-              defaultLogger.warn(error instanceof Error ? error.message : String(error));
-            })
-            .catch(() => {
-              // Logger failed to load - silently continue (already falling back to default config path)
-            });
-          // Use fallback path
-          resolvedConfigPath = path.isAbsolute(configPath)
-            ? configPath
-            : path.resolve(projectRoot, configPath);
-        } else {
-          // In production, fail fast
-          throw error;
-        }
-      }
-
       // Add RevealUI-specific webpack aliases
       const resolve = (config.resolve || {}) as {
         alias?: Record<string, string>;
@@ -151,9 +92,6 @@ export function withRevealUI(
         ...resolve.alias,
         // RevealUI core aliases - resolve to source index file
         '@revealui/core': path.resolve(__dirname, '../index'),
-        // Config alias - resolves to the actual config file path in the Next.js project
-        // Use absolute path for reliable resolution
-        '@revealui/config': resolvedConfigPath,
       };
 
       // Also ensure it's in resolve.modules if needed (for some edge cases)
@@ -164,43 +102,8 @@ export function withRevealUI(
       return config;
     },
 
-    // Turbopack configuration (Next.js 16+)
-    // IMPORTANT: Turbopack's resolveAlias must be resolved at config evaluation time
-    // Turbopack should read tsconfig.json paths, but we also set it explicitly here for reliability
-    // If next.config.mjs already set @revealui/config, we respect it (it uses __dirname which is reliable).
-    turbopack: {
-      ...nextConfig.turbopack,
-      resolveAlias: {
-        // Start with existing aliases from next.config.mjs (which includes @revealui/config)
-        ...nextConfig.turbopack?.resolveAlias,
-        // RevealUI core aliases - use relative path for Turbopack compatibility
-        // Don't set @revealui/core here - let next.config.mjs handle it via the @revealui alias
-        // Ensure @revealui/config is set (next.config.mjs should have it, but ensure it's there)
-        // Use the existing one if present (prefer relative path for Turbopack)
-        // Otherwise resolve it to relative path from project root
-        '@revealui/config':
-          nextConfig.turbopack?.resolveAlias?.['@revealui/config'] ||
-          (() => {
-            // Prefer relative path for Turbopack (matches tsconfig.json format)
-            if (!path.isAbsolute(configPath)) {
-              return configPath;
-            }
-            // If absolute, convert to relative from project root
-            try {
-              const projectRoot = process.cwd();
-              const resolved = resolveConfigPath(projectRoot);
-              if (fs.existsSync(resolved)) {
-                // Return relative path from project root
-                return path.relative(projectRoot, resolved);
-              }
-            } catch {
-              // Fall through to fallback
-            }
-            // Fallback: use configPath as-is (should be relative)
-            return configPath;
-          })(),
-      },
-    },
+    // Turbopack config passes through verbatim via the `...nextConfig` spread —
+    // withRevealUI injects no resolveAlias entries (see the docstring constraint).
 
     // Headers for RevealUI
     async headers() {


### PR DESCRIPTION
Promotes `test` to `main`.

**Payload: #1335 only** — `fix(core): stop aliasing @revealui/config to the app config file`. Prod is otherwise caught up after #1333/#1334, so this promotion's diff is exactly the one fix.

Fixes the prod admin passkey/MFA 500 class at its true root cause: `withRevealUI()` aliased the `@revealui/config` package specifier to the app's `revealui.config.ts`, shadowing the env-config package in the admin server bundle (which is also why #1332's `serverExternalPackages` change could not take effect). Artifact-verified on a local Turbopack standalone build from the branch — see #1335 for the full evidence trail.

Post-deploy verification:
- cold `POST https://admin.revealui.com/api/auth/passkey/authenticate-options` → expect 200 (today: 500)
- `POST https://admin.revealui.com/api/revalidate` with no secret header → expect 401 (today: 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
