### PR TITLE
fix(docs): per-page head wiring + meta fixes (counts, og:image, env)

### DIFF
--- a/apps/docs/app/lib/__tests__/head.test.ts
+++ b/apps/docs/app/lib/__tests__/head.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyDocHead, buildOgUrl } from '../head';
+
+function metaContent(attr: 'name' | 'property', key: string): string | null {
+  return document.head.querySelector(`meta[${attr}="${key}"]`)?.getAttribute('content') ?? null;
+}
+
+describe('applyDocHead', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.title = '';
+  });
+
+  it('sets the page title with the site suffix and syncs og/twitter tags', () => {
+    applyDocHead({ title: 'Quick Start', description: 'Get a local dev stack running.' });
+    expect(document.title).toBe('Quick Start · RevealUI Docs');
+    expect(metaContent('name', 'description')).toBe('Get a local dev stack running.');
+    expect(metaContent('property', 'og:title')).toBe('Quick Start · RevealUI Docs');
+    expect(metaContent('property', 'og:image')).toContain('title=Quick+Start');
+    expect(metaContent('name', 'twitter:image')).toContain('title=Quick+Start');
+  });
+
+  it('restores the site defaults when fields are omitted', () => {
+    applyDocHead({ title: 'Quick Start', description: 'Page-level description.' });
+    applyDocHead();
+    expect(document.title).toBe('RevealUI Documentation');
+    expect(metaContent('name', 'description') ?? '').toContain('agentic business runtime');
+    expect(metaContent('property', 'og:title')).toBe('RevealUI Documentation');
+  });
+
+  it('updates existing meta tags instead of duplicating them', () => {
+    applyDocHead({ title: 'A' });
+    applyDocHead({ title: 'B' });
+    expect(document.head.querySelectorAll('meta[property="og:title"]')).toHaveLength(1);
+    expect(metaContent('property', 'og:title')).toBe('B · RevealUI Docs');
+  });
+
+  it('treats whitespace-only fields as absent', () => {
+    applyDocHead({ title: '   ', description: '  ' });
+    expect(document.title).toBe('RevealUI Documentation');
+    expect(metaContent('name', 'description') ?? '').toContain('agentic business runtime');
+  });
+});
+
+describe('buildOgUrl', () => {
+  it('URL-encodes the title and optional description', () => {
+    const url = buildOgUrl('RevealUI Documentation', 'Guides, API reference');
+    expect(url).toContain('/api/og?');
+    expect(url).toContain('title=RevealUI+Documentation');
+    expect(url).toContain('description=Guides%2C+API+reference');
+  });
+
+  it('omits an empty description', () => {
+    expect(buildOgUrl('Docs')).not.toContain('description=');
+  });
+});

--- a/apps/docs/app/lib/head.ts
+++ b/apps/docs/app/lib/head.ts
@@ -1,0 +1,63 @@
+/**
+ * Document-head manager for the docs SPA.
+ *
+ * `index.html` carries the static defaults that crawlers without JS see;
+ * this helper keeps the live DOM in sync during client-side navigation and
+ * lets markdown frontmatter (`title`, `description`) override the head per
+ * page. OG images come from the same satori renderer in apps/server that
+ * the marketing app uses (see apps/marketing/app/lib/og.ts).
+ */
+
+const SITE_TITLE = 'RevealUI Documentation';
+
+/** Mirrors the static default in index.html; keep the two in sync. */
+const DEFAULT_DESCRIPTION =
+  'Documentation for RevealUI  -  open-source agentic business runtime. Auth, billing, CMS, AI agents, and the pre-wired UI component library. Build your business, not your boilerplate.';
+
+const OG_BASE_URL = `${
+  import.meta.env.VITE_API_URL ??
+  (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004')
+}/api/og`;
+
+export function buildOgUrl(title: string, description?: string): string {
+  const params = new URLSearchParams({ title });
+  if (description !== undefined && description !== '') {
+    params.set('description', description);
+  }
+  return `${OG_BASE_URL}?${params.toString()}`;
+}
+
+export interface DocHead {
+  /** Page title, rendered as "<title> · RevealUI Docs". Omitted/empty = site default. */
+  title?: string;
+  /** Meta description. Omitted/empty = site default. */
+  description?: string;
+}
+
+function setMeta(attr: 'name' | 'property', key: string, value: string): void {
+  let el = document.head.querySelector(`meta[${attr}="${key}"]`);
+  if (el === null) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', value);
+}
+
+/** Apply per-page head state; omitted fields restore the site defaults. */
+export function applyDocHead(head: DocHead = {}): void {
+  const pageTitle = head.title?.trim() ?? '';
+  const fullTitle = pageTitle === '' ? SITE_TITLE : `${pageTitle} · RevealUI Docs`;
+  const rawDescription = head.description?.trim() ?? '';
+  const description = rawDescription === '' ? DEFAULT_DESCRIPTION : rawDescription;
+  const ogImage = buildOgUrl(pageTitle === '' ? SITE_TITLE : pageTitle);
+
+  document.title = fullTitle;
+  setMeta('name', 'description', description);
+  setMeta('property', 'og:title', fullTitle);
+  setMeta('property', 'og:description', description);
+  setMeta('property', 'og:image', ogImage);
+  setMeta('name', 'twitter:title', fullTitle);
+  setMeta('name', 'twitter:description', description);
+  setMeta('name', 'twitter:image', ogImage);
+}

--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -17,7 +17,7 @@ Agentic business runtime. Users, content, products, payments, and AI  -  pre-wir
 \`\`\`bash
 npx create-revealui@latest my-app
 cd my-app
-cp .env.example .env.development.local
+# review .env.development.local (created by the scaffolder)
 pnpm db:migrate
 pnpm dev
 \`\`\`

--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -1,6 +1,13 @@
+import { useEffect } from 'react';
+import { applyDocHead } from '../lib/head';
 import { renderMarkdown } from '../utils/markdown';
 
 export function DocsIndexPage() {
+  // Restore the site-default head after per-page overrides (SPA navigation).
+  useEffect(() => {
+    applyDocHead();
+  }, []);
+
   const content = `# RevealUI Documentation
 
 Agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.
@@ -10,7 +17,7 @@ Agentic business runtime. Users, content, products, payments, and AI  -  pre-wir
 \`\`\`bash
 npx create-revealui@latest my-app
 cd my-app
-cp .env.template .env
+cp .env.example .env.development.local
 pnpm db:migrate
 pnpm dev
 \`\`\`
@@ -44,7 +51,7 @@ See the [Quick Start guide](/quick-start) for the full walkthrough, or browse th
 ### Reference
 - [Package Reference](/reference)  -  All packages: core, auth, db, contracts, presentation, router, CLI
 - [REST API](/api/rest-api)  -  OpenAPI reference for all endpoints
-- [Component Catalog](/component-catalog)  -  57 pre-wired UI components
+- [Component Catalog](/component-catalog)  -  Pre-wired UI components
 - [AI](/ai)  -  AI agents, prompt/response/semantic caching
 - [Marketplace](/marketplace)  -  Extensibility and integrations
 
@@ -62,7 +69,7 @@ See the [Quick Start guide](/quick-start) for the full walkthrough, or browse th
 - [Open Source & Pro](/blog/06-open-source-and-pro)  -  Our monetization philosophy
 - [Agent-First Future](/blog/07-agent-first-future)  -  Building for the agent economy
 - [Getting Started in About 30 Minutes](/blog/08-getting-started)  -  From zero to deployed
-- [59 Components, One Dependency](/blog/09-component-library)  -  The UI layer you own
+- [60 Components, One Dependency](/blog/09-component-library)  -  The UI layer you own
 - [Your Database, Your Storage, Your Sync](/blog/10-own-your-data)  -  Standard Postgres, S3 storage, built-in sync
 
 ---

--- a/apps/docs/app/routes/SectionPage.tsx
+++ b/apps/docs/app/routes/SectionPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { useWildcardPath } from '../hooks/useWildcardPath';
+import { applyDocHead } from '../lib/head';
 import { slugToPath } from '../lib/slug-manifest';
 import { loadMarkdownFile, parseFrontmatter, renderMarkdown } from '../utils/markdown';
 import type { DocSection } from '../utils/paths';
@@ -88,6 +89,22 @@ Document not found at \`${resolved.markdownPath}\`.
 
     void loadDoc();
   }, [path, section, title]);
+
+  // Per-page head: frontmatter title/description when present, else the
+  // section title. The crawl-time defaults live in index.html; this keeps
+  // SPA navigation in sync.
+  useEffect(() => {
+    if (loading || error !== null) {
+      return;
+    }
+    const { data } = parseFrontmatter(content);
+    const fmTitle = typeof data.title === 'string' ? data.title.trim() : '';
+    const fmDescription = typeof data.description === 'string' ? data.description.trim() : '';
+    applyDocHead({
+      title: fmTitle === '' ? title : fmTitle,
+      description: fmDescription,
+    });
+  }, [loading, error, content, title]);
 
   if (loading) {
     return <LoadingSkeleton />;
@@ -186,6 +203,13 @@ Content is being organized. Check back soon!
 
     void loadIndex();
   }, [section, title, fallbackIndex]);
+
+  // Section landing pages carry the section title in the head.
+  useEffect(() => {
+    if (!loading) {
+      applyDocHead({ title });
+    }
+  }, [loading, title]);
 
   if (loading) {
     return <LoadingSkeleton />;

--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -8,17 +8,19 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>RevealUI Documentation</title>
-    <meta name="description" content="Documentation for RevealUI  -  open-source agentic business runtime. Auth, billing, CMS, AI agents, and 57 UI components. Build your business, not your boilerplate." />
+    <meta name="description" content="Documentation for RevealUI  -  open-source agentic business runtime. Auth, billing, CMS, AI agents, and the pre-wired UI component library. Build your business, not your boilerplate." />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="RevealUI Documentation" />
-    <meta property="og:description" content="Documentation for RevealUI  -  open-source agentic business runtime. Auth, billing, CMS, AI agents, and 57 UI components." />
+    <meta property="og:description" content="Documentation for RevealUI  -  open-source agentic business runtime. Auth, billing, CMS, AI agents, and the pre-wired UI component library." />
     <meta property="og:url" content="https://docs.revealui.com" />
     <meta property="og:site_name" content="RevealUI" />
+    <meta property="og:image" content="https://api.revealui.com/api/og?title=RevealUI+Documentation&amp;description=Guides%2C+API+reference%2C+and+the+component+catalog" />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="RevealUI Documentation" />
-    <meta name="twitter:description" content="Open-source agentic business runtime. Auth, billing, CMS, AI agents, 57 UI components. Build your business, not your boilerplate." />
+    <meta name="twitter:description" content="Open-source agentic business runtime. Auth, billing, CMS, AI agents, and the pre-wired UI component library. Build your business, not your boilerplate." />
+    <meta name="twitter:image" content="https://api.revealui.com/api/og?title=RevealUI+Documentation&amp;description=Guides%2C+API+reference%2C+and+the+component+catalog" />
     <!-- SEO -->
     <link rel="canonical" href="https://docs.revealui.com" />
     <meta name="keywords" content="revealui, typescript, react, cms, saas, ai agents, open source, business runtime, stripe, authentication" />


### PR DESCRIPTION
## Summary

Docs-surface batch from the 2026-06-10 public-surfaces assessment (internal audit), rec #3.

- **Per-page document head.** New `app/lib/head.ts` syncs `<title>`, meta description, and og/twitter tags during SPA navigation; markdown frontmatter (`title`, `description`) overrides per page, section landings use the section title, and the docs index restores the site defaults. OG images come from the existing satori renderer at `/api/og` in apps/server (same pattern as the marketing app), so every doc page gets a branded social card.
- **`og:image` for crawlers.** `index.html` declared `twitter:card summary_large_image` with no image; static `og:image` + `twitter:image` now point at the prod `/api/og` endpoint (probed live: 200, image/png).
- **Count-drift fix.** The metas claimed "57 UI components" (canonical is 60, and docs static HTML sits outside claim-drift governance). The number is dropped rather than synced: marketing carries the governed count, so the docs meta no longer has a number that can drift. The blog 09 link label is aligned with the actual post title (60).
- **Quickstart env step.** `cp .env.template .env` matched neither what `create-revealui` scaffolds (`.env.example`) nor the env file the templates gitignore and the CLI documents (`.env.development.local`). Now `cp .env.example .env.development.local`.

Known limitation: some blog posts carry a byline-style frontmatter `description` ("*By Joshua Vaughn...*"), which now flows into their meta description verbatim. Improving those frontmatter descriptions is content work, separate from this wiring.

## Verification

- `pnpm --filter docs test`: all pass, including new jsdom tests asserting the head DOM behavior (set, restore-defaults, no-duplicate-tags, whitespace handling, OG URL encoding)
- `pnpm --filter docs typecheck`: clean
- Biome clean on changed files
- Rendered QA: deferred to the test-deploy preview; the head changes are DOM-asserted in jsdom and this isolated worktree does not host the preview server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
