### PR TITLE
fix(docs,server): drop authored regex from DEBUG check and escapeHtml

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -6,7 +6,8 @@ import { defineConfig } from 'vite';
 import { isPubliclyServed } from './scripts/served-docs.mjs';
 
 /** Enable verbose docs-copy plugin logging with DEBUG=docs-copy or DEBUG=* */
-const DEBUG = /\b(docs-copy|\*)\b/.test(process.env.DEBUG ?? '');
+const debugTokens = new Set((process.env.DEBUG ?? '').split(',').map((token) => token.trim()));
+const DEBUG = debugTokens.has('docs-copy') || debugTokens.has('*');
 
 /**
  * Vite plugin to copy documentation files to public directory

--- a/apps/server/src/lib/webhook-emails.ts
+++ b/apps/server/src/lib/webhook-emails.ts
@@ -50,11 +50,11 @@ function tierLabel(tier: string): string {
 
 function escapeHtml(str: string): string {
   return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 function adminUrl(): string {

--- a/apps/server/src/routes/contact.ts
+++ b/apps/server/src/routes/contact.ts
@@ -46,11 +46,11 @@ type ContactInquiry = z.infer<typeof ContactInquirySchema>;
 
 function escapeHtml(s: string): string {
   return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 function buildEmailSubject(body: ContactInquiry): string {
@@ -68,7 +68,7 @@ function buildEmailHtml(body: ContactInquiry): string {
   }
   lines.push(`<p><strong>Topic:</strong> ${escapeHtml(body.topic)}</p>`);
   lines.push('<hr/>');
-  lines.push(`<div>${escapeHtml(body.message).replace(/\n/g, '<br/>')}</div>`);
+  lines.push(`<div>${escapeHtml(body.message).replaceAll('\n', '<br/>')}</div>`);
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary

Zero-regex sweep of `apps/docs` + `apps/marketing` (engineering posture M2, `docs/methodology.md`), plus the escapeHtml instances in `apps/server` found while triaging.

**Audit (pre-change):**
- `apps/docs/vite.config.ts:9` — the only authored regex in apps/docs: `/\b(docs-copy|\*)\b/.test(process.env.DEBUG ?? '')`.
- `apps/marketing` — already at parity: zero authored regex. Swept via `git grep` for regex literals, `new RegExp`, and regex-arg methods (`.replace(/`, `.match(/`, `.split(/`, `.exec(`, `.test(`); every hit was a string path, CSS glob, comment, or URL.
- `apps/server/src/routes/contact.ts:48-53` + `:71` and `apps/server/src/lib/webhook-emails.ts:51-58` — chained `.replace(/x/g, …)` in two copy-pasted `escapeHtml` helpers plus one `.replace(/\n/g, '<br/>')`.

## Changes

1. **docs** — parse `DEBUG` as the conventional comma-separated token list into a `Set`, check for `docs-copy` or `*`.
2. **server** — `.replace(/x/g, …)` → `.replaceAll('x', …)` in both escapeHtml copies and the newline→`<br/>` call.

## Behavior

- **escapeHtml / newline→br: byte-identical.** Verified old-vs-new on adversarial inputs (all five entities, repeats, double-escaping, multiline, 5k-char strings) — zero divergence.
- **`DEBUG=*` is fixed, not just preserved.** The old regex never matched a bare `*`: `\b` before `*` only asserts when a word character immediately precedes it, so `/\b(docs-copy|\*)\b/.test('*') === false`. The documented `DEBUG=*` form (JSDoc on the same line) silently never worked; it now does, including inside comma lists (`foo,*`). Two accidental old matches disappear: `a*b` and `docs-copy:verbose` (word-boundary artifacts; no such usage exists in the repo).

## Out of scope (noted during audit)

- `escapeHtml` is duplicated between contact.ts and webhook-emails.ts — pre-existing; consolidating it is a separate concern.
- Authored regex elsewhere in `apps/server` / `packages` — this PR covers the swept surfaces (docs, marketing) plus the server instances above; the fleet-wide zero-regex end-state remains tracked by the posture.

## Verification

- Old-vs-new parity harness over the three replaced patterns (results above).
- Biome check clean on all three files; pre-push quality gate PASS.
- Typecheck + unit tests delegated to PR CI (affected: docs, server). `replaceAll` already has precedent in both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
