### PR TITLE
fix(admin): session-less verification email resend

### DIFF
--- a/apps/admin/src/__tests__/api/resend-verification.test.ts
+++ b/apps/admin/src/__tests__/api/resend-verification.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Resend Verification Route Tests
+ *
+ * POST /api/auth/resend-verification — covers the authenticated mode
+ * (token rotation + send for the session user) and the no-session mode
+ * (constant generic 200, per-email rate limit, deferred send only for
+ * existing unverified accounts — the anti-enumeration contract).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetSession = vi.fn();
+const mockCheckRateLimit = vi.fn();
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}));
+
+const mockGetUserByEmail = vi.fn();
+const mockUpdateUser = vi.fn();
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => ({}),
+}));
+
+vi.mock('@revealui/db/queries/users', () => ({
+  getUserByEmail: (...args: unknown[]) => mockGetUserByEmail(...args),
+  updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+}));
+
+const mockSendVerificationEmail = vi.fn();
+
+vi.mock('@/lib/email/verification', () => ({
+  sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+}));
+
+// Run after() callbacks inline so the deferred lookup/rotate/send is
+// observable synchronously in assertions.
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return {
+    ...actual,
+    after: (task: unknown) => {
+      if (typeof task === 'function') {
+        return (task as () => unknown)();
+      }
+      return undefined;
+    },
+  };
+});
+
+// Import NextRequest + the route after mocks.
+import { NextRequest } from 'next/server';
+import { POST } from '../../app/api/auth/resend-verification/route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(body?: unknown): NextRequest {
+  return new NextRequest('http://localhost:4000/api/auth/resend-verification', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** First recorded call of a mock, typed — throws instead of returning undefined. */
+function firstCall<T extends unknown[]>(mock: { mock: { calls: unknown[][] } }): T {
+  const call = mock.mock.calls[0];
+  if (!call) {
+    throw new Error('expected mock to have been called');
+  }
+  return call as T;
+}
+
+interface TokenRotationFields {
+  emailVerificationToken: string;
+  emailVerificationTokenExpiresAt: Date;
+}
+
+const ALLOWED = { allowed: true, remaining: 2, resetAt: 0 };
+const BLOCKED = { allowed: false, remaining: 0, resetAt: 0 };
+
+const UNVERIFIED_USER = {
+  id: 'user-1',
+  email: 'pending@example.com',
+  emailVerified: false,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue(ALLOWED);
+  mockSendVerificationEmail.mockResolvedValue({ success: true });
+  mockUpdateUser.mockResolvedValue(undefined);
+  mockGetUserByEmail.mockResolvedValue(null);
+  mockGetSession.mockResolvedValue(null);
+});
+
+describe('POST /api/auth/resend-verification — authenticated mode', () => {
+  it('rotates the token (with a fresh expiry) and sends to the session user', async () => {
+    mockGetSession.mockResolvedValue({ user: UNVERIFIED_USER });
+
+    const response = await POST(createRequest({}));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    const [, userId, fields] = firstCall<[unknown, string, TokenRotationFields]>(mockUpdateUser);
+    expect(userId).toBe('user-1');
+    expect(typeof fields.emailVerificationToken).toBe('string');
+    expect(fields.emailVerificationToken).toHaveLength(64); // sha256 hex
+    expect(fields.emailVerificationTokenExpiresAt).toBeInstanceOf(Date);
+
+    expect(mockSendVerificationEmail).toHaveBeenCalledTimes(1);
+    const [sentTo, rawToken] = firstCall<[string, string]>(mockSendVerificationEmail);
+    expect(sentTo).toBe('pending@example.com');
+    // The raw token goes to email; only its hash is stored.
+    expect(rawToken).toHaveLength(64);
+    expect(rawToken).not.toBe(fields.emailVerificationToken);
+  });
+
+  it('returns ALREADY_VERIFIED for a verified session user', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { ...UNVERIFIED_USER, emailVerified: true },
+    });
+
+    const response = await POST(createRequest({}));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.code).toBe('ALREADY_VERIFIED');
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns EMAIL_SEND_FAILED when the provider send fails', async () => {
+    mockGetSession.mockResolvedValue({ user: UNVERIFIED_USER });
+    mockSendVerificationEmail.mockResolvedValue({ success: false, error: 'smtp down' });
+
+    const response = await POST(createRequest({}));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.code).toBe('EMAIL_SEND_FAILED');
+  });
+});
+
+describe('POST /api/auth/resend-verification — no-session mode', () => {
+  it('sends to an existing unverified account and returns the generic 200', async () => {
+    mockGetUserByEmail.mockResolvedValue(UNVERIFIED_USER);
+
+    const response = await POST(createRequest({ email: 'pending@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    expect(mockGetUserByEmail).toHaveBeenCalledWith({}, 'pending@example.com');
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1);
+    const [, , rotatedFields] = firstCall<[unknown, string, TokenRotationFields]>(mockUpdateUser);
+    expect(rotatedFields.emailVerificationTokenExpiresAt).toBeInstanceOf(Date);
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith(
+      'pending@example.com',
+      expect.any(String),
+    );
+  });
+
+  it('returns the identical body for a nonexistent account and sends nothing', async () => {
+    mockGetUserByEmail.mockResolvedValue(UNVERIFIED_USER);
+    const existing = await (await POST(createRequest({ email: 'pending@example.com' }))).json();
+
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockResolvedValue(ALLOWED);
+    mockGetSession.mockResolvedValue(null);
+    mockGetUserByEmail.mockResolvedValue(null);
+
+    const response = await POST(createRequest({ email: 'nobody@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual(existing); // anti-enumeration: byte-identical body
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not send for an already-verified account (same generic 200)', async () => {
+    mockGetUserByEmail.mockResolvedValue({ ...UNVERIFIED_USER, emailVerified: true });
+
+    const response = await POST(createRequest({ email: 'pending@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('enforces the per-email rate limit without changing the response', async () => {
+    mockGetUserByEmail.mockResolvedValue(UNVERIFIED_USER);
+    mockCheckRateLimit.mockImplementation((key: string) =>
+      Promise.resolve(key.startsWith('resend-verification:email:') ? BLOCKED : ALLOWED),
+    );
+
+    const response = await POST(createRequest({ email: 'pending@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockGetUserByEmail).not.toHaveBeenCalled();
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+
+    // The per-email key is a hash, never the raw address.
+    const emailKeyCall = mockCheckRateLimit.mock.calls.find(([key]) =>
+      String(key).startsWith('resend-verification:email:'),
+    );
+    expect(emailKeyCall).toBeDefined();
+    expect(String(emailKeyCall?.[0])).not.toContain('pending@example.com');
+  });
+
+  it('rejects a missing or invalid email with 400 INVALID_EMAIL', async () => {
+    const missing = await POST(createRequest({}));
+    expect(missing.status).toBe(400);
+    expect((await missing.json()).code).toBe('INVALID_EMAIL');
+
+    const invalid = await POST(createRequest({ email: 'not-an-email' }));
+    expect(invalid.status).toBe(400);
+    expect((await invalid.json()).code).toBe('INVALID_EMAIL');
+
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('still returns the generic 200 when the deferred send fails (logged only)', async () => {
+    mockGetUserByEmail.mockResolvedValue(UNVERIFIED_USER);
+    mockSendVerificationEmail.mockResolvedValue({ success: false, error: 'smtp down' });
+
+    const response = await POST(createRequest({ email: 'pending@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+});

--- a/apps/admin/src/__tests__/auth/auth-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/auth-routes.test.ts
@@ -385,12 +385,16 @@ describe('POST /api/auth/resend-verification', () => {
     POST = mod.POST as (req: NextRequest) => Promise<Response>;
   });
 
-  it('returns 401 when not authenticated', async () => {
+  it('serves the session-less mode when not authenticated (400 without a valid email)', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
 
+    // No session is no longer a 401: the route accepts { email } so stuck
+    // unverified users can self-serve a resend. Without a valid email it
+    // rejects with INVALID_EMAIL; the full session-less contract is covered
+    // in src/__tests__/api/resend-verification.test.ts.
     const req = makeRequest('/api/auth/resend-verification', {});
     const res = await POST(req);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
   });
 
   it('returns 400 when email is already verified', async () => {

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -59,6 +59,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
   const [awaitingVerification, setAwaitingVerification] = useState(false);
+  const [resendState, setResendState] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const anyLoading = isLoading || isPasskeyLoading;
 
@@ -130,6 +131,22 @@ function SignupContent({ apiUrl }: SignupFormProps) {
     }
   };
 
+  const handleResendVerification = async () => {
+    setResendState('sending');
+    try {
+      // Session-less resend: the route accepts { email } without a session and
+      // always answers with the same generic 200, so this needs no auth state.
+      await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+    } catch {
+      // The endpoint answers identically either way; a network blip reads the same.
+    }
+    setResendState('sent');
+  };
+
   if (awaitingVerification) {
     return (
       <div className="w-full max-w-sm space-y-6">
@@ -144,6 +161,18 @@ function SignupContent({ apiUrl }: SignupFormProps) {
         <p className="text-xs text-zinc-600">
           Didn&apos;t get it? Check your spam folder — the link can take a minute to arrive.
         </p>
+        <Button
+          variant="outline"
+          onClick={handleResendVerification}
+          disabled={resendState === 'sending'}
+          className="w-full"
+        >
+          {resendState === 'sent'
+            ? 'Sent. Check your inbox again.'
+            : resendState === 'sending'
+              ? 'Sending…'
+              : 'Resend verification email'}
+        </Button>
         <Button onClick={() => router.push('/login')} className="w-full">
           Go to sign in
         </Button>

--- a/apps/admin/src/app/api/auth/__tests__/account-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/account-routes.test.ts
@@ -221,11 +221,15 @@ describe('POST /api/auth/resend-verification', () => {
     return mod.POST;
   }
 
-  it('returns 401 when not authenticated', async () => {
+  it('serves the session-less mode when not authenticated (400 without a valid email)', async () => {
     mockGetSession.mockResolvedValue(null);
+    // No session is no longer a 401: the route accepts { email } so stuck
+    // unverified users can self-serve a resend. Without a valid email it
+    // rejects with INVALID_EMAIL; the full session-less contract is covered
+    // in src/__tests__/api/resend-verification.test.ts.
     const POST = await loadRoute();
     const res = await POST(makeRequest());
-    expect((res as { status: number }).status).toBe(401);
+    expect((res as { status: number }).status).toBe(400);
   });
 
   it('returns 400 when email is already verified', async () => {

--- a/apps/admin/src/app/api/auth/resend-verification/route.ts
+++ b/apps/admin/src/app/api/auth/resend-verification/route.ts
@@ -3,16 +3,24 @@
  *
  * POST /api/auth/resend-verification
  *
- * Resends the email verification link to the authenticated user.
- * Rate-limited to prevent abuse.
+ * Two modes:
+ * - Authenticated session: resends to the session user (original behavior).
+ * - No session: accepts { email }. The response is the same generic 200 for
+ *   existing, nonexistent, already-verified, and per-email-rate-limited
+ *   addresses, and the actual token rotation + send run after the response
+ *   is sent — so neither the body nor the latency reveals whether an
+ *   account exists.
+ *
+ * Rate-limited per IP (wrapper) and, in the no-session mode, per email.
  */
 
-import { createHash } from 'node:crypto';
-import { getSession } from '@revealui/auth/server';
+import { createHash, randomBytes } from 'node:crypto';
+import { checkRateLimit, getSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
-import { updateUser } from '@revealui/db/queries/users';
+import { getUserByEmail, updateUser } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
-import { type NextRequest, NextResponse } from 'next/server';
+import { after, type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { sendVerificationEmail } from '@/lib/email/verification';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
@@ -21,11 +29,98 @@ import { extractRequestContext } from '@/lib/utils/request-context';
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
+// Matches the TTL signUp stamps on the initial verification token.
+const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+const unauthenticatedBody = z.object({
+  email: z.email().max(254),
+});
+
+/**
+ * Rotate the stored verification token and send the link. Stores only the
+ * SHA-256 hash, and refreshes the expiry alongside the token so a resent
+ * link never inherits the original signup deadline.
+ */
+async function rotateTokenAndSend(
+  userId: string,
+  email: string,
+): Promise<{ success: boolean; error?: string }> {
+  const rawToken = randomBytes(32).toString('hex');
+  const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+  const db = getClient();
+
+  await updateUser(db, userId, {
+    emailVerificationToken: tokenHash,
+    emailVerificationTokenExpiresAt: new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS),
+  });
+
+  return sendVerificationEmail(email, rawToken);
+}
+
+function genericAcceptedResponse(): NextResponse {
+  return NextResponse.json({
+    success: true,
+    message: 'If that account exists and is unverified, a new verification link is on its way.',
+  });
+}
+
+/**
+ * No-session mode. The constant response and the deferred lookup/send are
+ * load-bearing: changing either lets this endpoint be used to probe which
+ * emails have accounts.
+ */
+async function resendWithoutSession(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json().catch(() => null);
+  const parsed = unauthenticatedBody.safeParse(body);
+  if (!parsed.success) {
+    return createApplicationErrorResponse(
+      'A valid email address is required',
+      'INVALID_EMAIL',
+      400,
+    );
+  }
+  const email = parsed.data.email;
+
+  // Per-email limiter on top of the wrapper's per-IP one, counted before the
+  // user lookup so nonexistent addresses consume the same budget. The key is
+  // hashed so raw addresses never become rate-limit storage keys.
+  const emailKey = `resend-verification:email:${createHash('sha256').update(email.toLowerCase()).digest('hex')}`;
+  const { allowed } = await checkRateLimit(emailKey, {
+    maxAttempts: 3,
+    windowMs: 15 * 60 * 1000,
+  });
+
+  if (allowed) {
+    after(async () => {
+      try {
+        const db = getClient();
+        // Exact-match lookup — the same semantics signIn uses, so any address
+        // that can sign in can also request a resend.
+        const user = await getUserByEmail(db, email);
+        if (!user || user.emailVerified || !user.email) {
+          return;
+        }
+        const result = await rotateTokenAndSend(user.id, user.email);
+        if (!result.success) {
+          logger.warn('Failed to resend verification email (no-session mode)', {
+            userId: user.id,
+            error: result.error,
+          });
+        }
+      } catch (error) {
+        logger.error('Error in deferred verification resend', { error });
+      }
+    });
+  }
+
+  return genericAcceptedResponse();
+}
+
 async function resendHandler(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
-      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+      return resendWithoutSession(request);
     }
 
     if (session.user.emailVerified) {
@@ -36,16 +131,7 @@ async function resendHandler(request: NextRequest): Promise<NextResponse> {
       return createApplicationErrorResponse('No email address on account', 'NO_EMAIL', 400);
     }
 
-    // Generate a new token  -  store the SHA-256 hash, send the raw token via email
-    const newToken = crypto.randomUUID();
-    const tokenHash = createHash('sha256').update(newToken).digest('hex');
-    const db = getClient();
-
-    await updateUser(db, session.user.id, {
-      emailVerificationToken: tokenHash,
-    });
-
-    const result = await sendVerificationEmail(session.user.email, newToken);
+    const result = await rotateTokenAndSend(session.user.id, session.user.email);
 
     if (!result.success) {
       logger.warn('Failed to resend verification email', {


### PR DESCRIPTION
## Problem

After signup, every non-first user is unverified and has **no session** (by design — verify-to-activate). The signup "Check your inbox" screen tells them to verify, but if the email is delayed or spam-foldered they have no self-serve recovery: `POST /api/auth/resend-verification` required a session (401 for them), and re-signing-up is rejected as a duplicate email. A stuck unverified user stays stuck.

## Change

`apps/admin/src/app/api/auth/resend-verification/route.ts` becomes dual-mode:

- **Authenticated session:** unchanged behavior (rotate token, send, surface `EMAIL_SEND_FAILED` on provider failure).
- **No session:** accepts `{ email }` and always answers with the **same generic 200** — for existing, nonexistent, already-verified, and per-email-rate-limited addresses. The user lookup + token rotation + send run via `next/server`'s `after()` once the response has been sent, so neither the body nor the latency reveals whether an account exists (anti-enumeration, both channels).
- **Per-email rate limit** (3 / 15 min, `checkRateLimit` with a SHA-256-hashed key — raw addresses never become storage keys) layered under the existing per-IP wrapper, counted **before** the lookup so nonexistent addresses consume the same budget.
- The lookup is exact-match `getUserByEmail` — the same semantics `signIn` uses, so any address that can sign in can request a resend.

Shared-helper hardening that falls out of the refactor (both modes):

- Token rotation now **also refreshes `emailVerificationTokenExpiresAt`** — previously the session-gated resend rotated the token but kept the original signup deadline, so a "fresh" link could carry an already-dead expiry.
- Raw token entropy upgraded from `crypto.randomUUID()` (~122 bits) to `randomBytes(32)` hex (256 bits), matching what `signUp` already uses.

`SignupForm` wires a "Resend verification email" button (outline variant) into the existing check-your-inbox screen, with sending/sent states that mirror the constant-response contract.

## Tests

New `apps/admin/src/__tests__/api/resend-verification.test.ts` (9 cases): authenticated rotate+send with fresh expiry + hash≠raw assertion, ALREADY_VERIFIED, EMAIL_SEND_FAILED; no-session send for existing-unverified, **byte-identical generic body for nonexistent vs existing**, no send for verified, per-email rate limit (constant response + hashed key assertion), 400 INVALID_EMAIL on missing/invalid, generic 200 even when the deferred send fails. `after()` is inline-mocked so the deferred work is observable.

## Verification

- Vitest suite green; Biome clean; admin `tsc --noEmit` clean.
- Self-serve signup remains 403-closed in prod (`REVEALUI_SIGNUP_OPEN` unset), so the screen is unreachable until that flag flips — this PR is the hardening that should land **before** the flip. Post-merge click-through happens on a deploy-test preview or after the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
