### PR TITLE
feat(presentation): extend tokens contract with canon + contrast guards

### DIFF
--- a/packages/presentation/design-context/brand-meta.json
+++ b/packages/presentation/design-context/brand-meta.json
@@ -11,6 +11,34 @@
     "font-mono": "'JetBrains Mono', 'Fira Code', ui-monospace, monospace",
     "font-display": "'Inter Tight', 'Inter', system-ui, sans-serif"
   },
+  "shape": {
+    "radius-sm": "6px",
+    "radius-md": "10px",
+    "radius-lg": "16px",
+    "radius-xl": "24px"
+  },
+  "ladders": {
+    "note": "Declared canon for the contrast-load-bearing tokens. Values are single-spaced; the contract test collapses tokens.css whitespace before matching. Changing a value here AND in tokens.css is the deliberate two-place edit the gate exists to force.",
+    "dark": {
+      "surface-0": "oklch(0.16 0.030 260)",
+      "surface-1": "oklch(0.22 0.025 258)",
+      "surface-2": "oklch(0.28 0.028 256)",
+      "text-0": "oklch(0.985 0.005 250)",
+      "text-1": "oklch(0.83 0.015 245)",
+      "text-2": "oklch(0.65 0.025 250)",
+      "text-on-brand": "oklch(0.985 0.005 250)",
+      "warning-text": "oklch(0.70 0.165 80)"
+    },
+    "light": {
+      "surface-0": "oklch(0.985 0.005 250)",
+      "surface-1": "oklch(1.000 0 0)",
+      "surface-2": "oklch(0.965 0.006 248)",
+      "text-0": "oklch(0.16 0.030 260)",
+      "text-1": "oklch(0.34 0.030 250)",
+      "text-2": "oklch(0.50 0.030 250)",
+      "warning-text": "oklch(0.45 0.130 75)"
+    }
+  },
   "voice": {
     "note": "Voice/headline rules consolidation deferred to lane Phase 3 (DS-V1). Canonical voice corpus: .jv messaging-funnel-audit/voice-and-headline-rules.md"
   }

--- a/packages/presentation/src/__tests__/tokens.contract.test.ts
+++ b/packages/presentation/src/__tests__/tokens.contract.test.ts
@@ -11,29 +11,110 @@ const MANIFEST = join(PKG_ROOT, 'design-context', 'MANIFEST.sha256');
 const BRAND_LIGHT = 'oklch(0.36 0.190 240)';
 const BRAND_DARK = 'oklch(0.58 0.150 240)';
 
+interface BrandMeta {
+  brand: { 'rvui-brand-light': string; 'rvui-brand-dark': string };
+  type: Record<string, string>;
+  shape: Record<string, string>;
+  ladders: {
+    note: string;
+    dark: Record<string, string>;
+    light: Record<string, string>;
+  };
+}
+
+const META = JSON.parse(readFileSync(BRAND_META, 'utf8')) as BrandMeta;
+const CSS = readFileSync(TOKENS_SRC, 'utf8');
+
+/** tokens.css aligns values with extra spaces; collapse runs so the declared
+ *  canon (single-spaced) matches regardless of alignment. No regex. */
+const CSS_COLLAPSED = CSS.split('\n')
+  .map((line) =>
+    line
+      .split(' ')
+      .filter((part) => part !== '')
+      .join(' '),
+  )
+  .join('\n');
+
+function expectDeclaration(name: string, value: string): void {
+  const declaration = `--rvui-${name}: ${value}`;
+  expect(CSS_COLLAPSED.includes(declaration), `missing ${declaration}`).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Color math — exact oklch() → WCAG relative luminance via OKLab → linear
+// sRGB. Pure functions, no deps, no regex (string slicing + split only).
+// Matrices: Björn Ottosson's OKLab reference implementation.
+// Calibration: tokens.css documents brand-dark on surface-0-dark at 4.73:1
+// and warning-text-dark at 7.45:1; this math reproduces both within ~1%.
+// ---------------------------------------------------------------------------
+
+function parseOklch(value: string): { L: number; C: number; h: number } {
+  const open = value.indexOf('(');
+  const close = value.lastIndexOf(')');
+  if (open === -1 || close === -1) throw new Error(`not an oklch() value: ${value}`);
+  const inner = value.slice(open + 1, close);
+  if (inner.includes('/')) throw new Error(`declared canon must not carry alpha: ${value}`);
+  const parts = inner.split(' ').filter((part) => part !== '');
+  if (parts.length !== 3) throw new Error(`expected 3 oklch components: ${value}`);
+  const L = Number(parts[0]);
+  const C = Number(parts[1]);
+  const h = Number(parts[2]);
+  if (Number.isNaN(L) || Number.isNaN(C) || Number.isNaN(h)) {
+    throw new Error(`non-numeric oklch components: ${value}`);
+  }
+  return { L, C, h };
+}
+
+function clamp01(v: number): number {
+  return Math.min(1, Math.max(0, v));
+}
+
+/** WCAG relative luminance of an oklch() color (sRGB-clamped). */
+function relativeLuminance(value: string): number {
+  const { L, C, h } = parseOklch(value);
+  const rad = (h * Math.PI) / 180;
+  const a = C * Math.cos(rad);
+  const b = C * Math.sin(rad);
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ ** 3;
+  const m = m_ ** 3;
+  const s = s_ ** 3;
+
+  const r = clamp01(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s);
+  const g = clamp01(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s);
+  const bl = clamp01(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s);
+
+  return 0.2126729 * r + 0.7151522 * g + 0.072175 * bl;
+}
+
+/** WCAG 1.4.3 contrast ratio between two oklch() colors. */
+function contrast(fg: string, bg: string): number {
+  const yFg = relativeLuminance(fg);
+  const yBg = relativeLuminance(bg);
+  const hi = Math.max(yFg, yBg);
+  const lo = Math.min(yFg, yBg);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 describe('tokens contract', () => {
   it('src/tokens.css contains the cobalt light brand value', () => {
-    const css = readFileSync(TOKENS_SRC, 'utf8');
-    expect(css.includes(BRAND_LIGHT)).toBe(true);
+    expect(CSS.includes(BRAND_LIGHT)).toBe(true);
   });
 
   it('src/tokens.css contains the cobalt dark brand value', () => {
-    const css = readFileSync(TOKENS_SRC, 'utf8');
-    expect(css.includes(BRAND_DARK)).toBe(true);
+    expect(CSS.includes(BRAND_DARK)).toBe(true);
   });
 
   it('brand-meta.json rvui-brand-light matches cobalt canon', () => {
-    const meta = JSON.parse(readFileSync(BRAND_META, 'utf8')) as {
-      brand: { 'rvui-brand-light': string; 'rvui-brand-dark': string };
-    };
-    expect(meta.brand['rvui-brand-light']).toBe(BRAND_LIGHT);
+    expect(META.brand['rvui-brand-light']).toBe(BRAND_LIGHT);
   });
 
   it('brand-meta.json rvui-brand-dark matches cobalt canon', () => {
-    const meta = JSON.parse(readFileSync(BRAND_META, 'utf8')) as {
-      brand: { 'rvui-brand-light': string; 'rvui-brand-dark': string };
-    };
-    expect(meta.brand['rvui-brand-dark']).toBe(BRAND_DARK);
+    expect(META.brand['rvui-brand-dark']).toBe(BRAND_DARK);
   });
 
   it('MANIFEST.sha256 matches sha256(src/tokens.css) — pack is in sync', () => {
@@ -45,5 +126,90 @@ describe('tokens contract', () => {
     const committed = manifestLine.split(' ')[0];
 
     expect(committed).toBe(actual);
+  });
+});
+
+describe('declared canon — tokens.css carries every brand-meta value', () => {
+  // Declaration-level matching (name + value) pins the binding, not just the
+  // value's presence somewhere in the file. Light and dark blocks share names
+  // with different values; each declared value must exist as a declaration.
+  it('typography stacks', () => {
+    for (const [name, value] of Object.entries(META.type)) {
+      expectDeclaration(name, value);
+    }
+  });
+
+  it('radius scale', () => {
+    for (const [name, value] of Object.entries(META.shape)) {
+      expectDeclaration(name, value);
+    }
+  });
+
+  it('dark surface/text ladder', () => {
+    for (const [name, value] of Object.entries(META.ladders.dark)) {
+      expectDeclaration(name, value);
+    }
+  });
+
+  it('light surface/text ladder', () => {
+    for (const [name, value] of Object.entries(META.ladders.light)) {
+      expectDeclaration(name, value);
+    }
+  });
+});
+
+describe('contrast guards — WCAG AA invariants on the declared canon', () => {
+  // The gray-500-on-dark failure class (pre-rebrand) shipped because no gate
+  // computed contrast. These guards make the AA floor a CI invariant: any
+  // future ladder tweak that re-breaks a pairing fails this suite.
+  const dark = META.ladders.dark;
+  const light = META.ladders.light;
+
+  const AA_TEXT = 4.5;
+
+  const aaPairs: Array<[string, string, string]> = [
+    // dark mode — body + muted text on the layered surfaces
+    ['dark text-0 on surface-0', dark['text-0'] ?? '', dark['surface-0'] ?? ''],
+    ['dark text-0 on surface-1', dark['text-0'] ?? '', dark['surface-1'] ?? ''],
+    ['dark text-0 on surface-2', dark['text-0'] ?? '', dark['surface-2'] ?? ''],
+    ['dark text-1 on surface-0', dark['text-1'] ?? '', dark['surface-0'] ?? ''],
+    ['dark text-1 on surface-1', dark['text-1'] ?? '', dark['surface-1'] ?? ''],
+    ['dark text-2 on surface-0', dark['text-2'] ?? '', dark['surface-0'] ?? ''],
+    // The historical failure pair: muted text on a card. Pre-remap gray-500
+    // tested 4.19:1 here; the v4 ladder tests ~5.4:1.
+    ['dark text-2 on surface-1', dark['text-2'] ?? '', dark['surface-1'] ?? ''],
+    ['dark warning-text on surface-0', dark['warning-text'] ?? '', dark['surface-0'] ?? ''],
+    // brand used as text/link on the page bg (tokens.css documents 4.73:1)
+    ['dark brand on surface-0', BRAND_DARK, dark['surface-0'] ?? ''],
+    // light mode
+    ['light text-0 on surface-0', light['text-0'] ?? '', light['surface-0'] ?? ''],
+    ['light text-0 on surface-1', light['text-0'] ?? '', light['surface-1'] ?? ''],
+    ['light text-1 on surface-0', light['text-1'] ?? '', light['surface-0'] ?? ''],
+    ['light text-1 on surface-1', light['text-1'] ?? '', light['surface-1'] ?? ''],
+    ['light text-2 on surface-0', light['text-2'] ?? '', light['surface-0'] ?? ''],
+    ['light text-2 on surface-1', light['text-2'] ?? '', light['surface-1'] ?? ''],
+    ['light warning-text on surface-0', light['warning-text'] ?? '', light['surface-0'] ?? ''],
+    ['light brand on surface-0', BRAND_LIGHT, light['surface-0'] ?? ''],
+    // CTA label in light mode (white on deep cobalt, ~9.6:1)
+    ['light text-on-brand on brand', dark['text-on-brand'] ?? '', BRAND_LIGHT],
+  ];
+
+  for (const [label, fg, bg] of aaPairs) {
+    it(`${label} >= ${AA_TEXT}:1`, () => {
+      const ratio = contrast(fg, bg);
+      expect(ratio, `${label} = ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+  }
+
+  // KNOWN BORDERLINE — dark-mode CTA label (white on cobalt-300) computes to
+  // ~3.97:1: above the WCAG 3:1 large-text/UI floor, below 4.5:1 normal-text
+  // AA. The L=0.58 dark-brand lift fixed brand-on-midnight (4.73:1) but pulled
+  // the label below normal-text AA. Guarded here at the 3:1 floor so it cannot
+  // silently get WORSE; raising it to 4.5 needs an owner palette decision
+  // (e.g. a dark CTA label ink, or a brand tweak) — tracked in the 2026-06-10
+  // public-surfaces assessment follow-ups.
+  it('dark text-on-brand on brand >= 3:1 (UI floor; 4.5 pending owner palette decision)', () => {
+    const ratio = contrast(dark['text-on-brand'] ?? '', BRAND_DARK);
+    expect(ratio, `dark text-on-brand on brand = ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary

Design item from the 2026-06-10 public-surfaces assessment (internal audit), rec #6: the tokens drift gate asserted brand values + the design-context pack hash, leaving the gray ladders, radii, fonts, and every contrast pairing unguarded — the exact gap that let the pre-rebrand gray-500-on-dark AA failure ship.

- **Declared canon** in `design-context/brand-meta.json`: typography stacks, radius scale, and the dark + light surface/text ladders (the contrast-load-bearing tokens). The contract test asserts each as a `--rvui-name: value` declaration in tokens.css (whitespace-collapsed matching, no regex).
- **Computed WCAG contrast guards**: exact `oklch()` → OKLab → linear-sRGB relative luminance (pure functions, zero deps, zero regex), asserting 18 text/surface/brand pairings at the 4.5:1 AA floor. The historical failure pair (muted text on a dark card) is now a named CI invariant.
- **Calibration**: the math reproduces both ratios tokens.css already documents (brand-dark on midnight 4.73:1; dark warning-text 7.45:1) within ~1%.

### Finding surfaced by the new guards (owner decision, deliberately not changed here)

`--rvui-text-on-brand` on `--rvui-brand` in **dark mode** computes to **~3.97:1**: above the WCAG 3:1 large-text/UI floor, below the 4.5:1 normal-text line. The L=0.58 dark-brand lift fixed brand-on-midnight but pulled the white CTA label under normal-text AA. The suite guards it at the 3:1 floor so it cannot silently worsen; raising it to 4.5 means a palette decision (a dark CTA label ink, or a brand value tweak).

## Verification

- Contract suite green locally; every pair prints its computed ratio on failure
- Biome clean; `MANIFEST.sha256` untouched (tokens.css is unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
