### PR TITLE
fix(docs): lift muted text to WCAG AA

### DIFF
--- a/apps/docs/app/index.css
+++ b/apps/docs/app/index.css
@@ -20,7 +20,9 @@
   --color-border-subtle: #f0f1f3;
   --color-text-primary: #1a1a2e;
   --color-text-secondary: #5f6368;
-  --color-text-muted: #9aa0a6;
+  /* WCAG AA: 4.84:1 on #ffffff, 4.64:1 on #fafafa. The previous #9aa0a6
+   * tested ~2.5:1 on both (fails AA for the h6 / del / byline text using it). */
+  --color-text-muted: #6b7280;
   --color-accent: var(--rvui-brand);
   --color-accent-hover: var(--rvui-brand-hover);
   --color-accent-bg: var(--rvui-brand-soft);


### PR DESCRIPTION
## Summary

Design item from the 2026-06-10 public-surfaces assessment (internal audit), rec #6: the docs palette's `--color-text-muted` (`#9aa0a6`) tested ~2.5:1 on the docs paper backgrounds, failing WCAG AA for the markdown `h6`/`del` styles and the blog byline that use it.

Lifted to `#6b7280` (4.84:1 on `#ffffff`, 4.64:1 on `#fafafa`), staying in the cool-gray family. Ratios documented inline. This is a one-variable accessibility fix inside the documented-intentional docs palette (`index.css` "Intentionally NOT bridged" note), not a palette migration.

## Verification

- `pnpm --filter docs build` clean; Biome clean
- Ratios computed (WCAG relative luminance); rendered QA on the test-deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
