### PR TITLE
fix: treat empty white-label env vars as unset in brand fallbacks

### DIFF
--- a/.changeset/config-branding-empty-env.md
+++ b/.changeset/config-branding-empty-env.md
@@ -1,0 +1,5 @@
+---
+'@revealui/config': patch
+---
+
+Treat empty-string branding env vars as unset in `getBrandingConfig`. Docker Compose `${VAR:-}` interpolation delivers unset vars to containers as empty strings, which previously short-circuited the brand-name fallback chain (producing an empty brand name) and leaked `''` into optional `logoUrl` / `primaryColor` fields.

--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -17,7 +17,8 @@ type Args = {
 // White-label: read tenant identity in the server component and prop-drill
 // to the client sidebar (env vars in `'use client'` files get inlined at
 // framework build time, missing the kit's stamped value at runtime).
-const siteName = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+// `||` not `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
+const siteName = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 
 const Layout = ({ children }: Args) => (
   <RootLayout config={config} importMap={importMap}>

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -126,7 +126,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  // `||` not `??`: Compose `${VAR:-}` interpolation delivers unset vars as
+  // empty strings, which must fall through to the next candidate.
+  const name = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   const adminLabel = `${name} admin`;
   // White-label: REVEALUI_BRAND_TWITTER lets a kit set its own Twitter/X
   // handle (e.g. '@AcmeCorp'); when unset, fall back to the canonical
@@ -136,7 +138,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const brandOverridden =
     Boolean(process.env.REVEALUI_BRAND_NAME) || Boolean(process.env.REVEALUI_TENANT_NAME);
   const twitterCreator =
-    process.env.REVEALUI_BRAND_TWITTER ?? (brandOverridden ? undefined : '@RevealUI');
+    process.env.REVEALUI_BRAND_TWITTER || (brandOverridden ? undefined : '@RevealUI');
   return {
     title: {
       default: adminLabel,

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -146,8 +146,9 @@ export async function GET(request: Request) {
   // White-label: RevForge customer kits override the brand identity via
   // REVEALUI_BRAND_NAME or REVEALUI_TENANT_NAME so uptime monitors / status
   // pages show the operator's brand instead of the framework name.
+  // `||` not `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
   const brandName =
-    process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 
   return NextResponse.json(
     {

--- a/apps/admin/src/lib/components/BrandedAuthLayout.tsx
+++ b/apps/admin/src/lib/components/BrandedAuthLayout.tsx
@@ -29,7 +29,10 @@ import type React from 'react';
  * vars injected at the root in `apps/admin/src/app/(frontend)/layout.tsx`.
  */
 export function BrandedAuthLayout({ children }: { children: React.ReactNode }) {
-  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  // `||` not `??`: Compose `${VAR:-}` interpolation delivers unset vars as
+  // empty strings, which must fall through. tagline/logoUrl below are
+  // truthy-guarded in JSX, so empty strings are already safe there.
+  const name = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   const hideName = process.env.REVEALUI_TENANT_HIDE_NAME === 'true';
   const tagline = process.env.REVEALUI_TENANT_TAGLINE;
   const logoUrl = process.env.REVEALUI_BRAND_LOGO_URL;

--- a/apps/admin/src/lib/utilities/__tests__/brandEnvFallback.test.ts
+++ b/apps/admin/src/lib/utilities/__tests__/brandEnvFallback.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mergeOpenGraph } from '../mergeOpenGraph';
+
+// Docker Compose `${VAR:-}` interpolation delivers unset env vars to the
+// container as empty strings, not undefined. The brand fallback chains must
+// treat '' as unset so a kit without overrides keeps canonical branding
+// instead of rendering an empty brand name.
+
+const ENV_KEYS = [
+  'REVEALUI_BRAND_NAME',
+  'REVEALUI_TENANT_NAME',
+  'REVEALUI_BRAND_DESCRIPTION',
+  'NEXT_PUBLIC_SITE_NAME',
+  'NEXT_PUBLIC_SITE_OPERATOR',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+describe('brand env fallback (empty-string safety)', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+    vi.resetModules();
+  });
+
+  describe('mergeOpenGraph identity', () => {
+    it('treats an empty brand name as unset (falls through to tenant name)', () => {
+      process.env.REVEALUI_BRAND_NAME = '';
+      process.env.REVEALUI_TENANT_NAME = 'Acme';
+      const og = mergeOpenGraph();
+      expect(og?.siteName).toBe('Acme');
+      expect(og?.title).toBe('Acme');
+    });
+
+    it('falls back to the canonical name when both overrides are empty', () => {
+      process.env.REVEALUI_BRAND_NAME = '';
+      process.env.REVEALUI_TENANT_NAME = '';
+      const og = mergeOpenGraph();
+      expect(og?.siteName).toBe('RevealUI');
+    });
+
+    it('keeps the empty-string description opt-out', () => {
+      process.env.REVEALUI_BRAND_DESCRIPTION = '';
+      const og = mergeOpenGraph();
+      expect(og?.description).toBeUndefined();
+    });
+  });
+
+  describe('siteBranding constants', () => {
+    it('treats empty NEXT_PUBLIC_SITE_NAME / SITE_OPERATOR as unset', async () => {
+      process.env.NEXT_PUBLIC_SITE_NAME = '';
+      process.env.NEXT_PUBLIC_SITE_OPERATOR = '';
+      vi.resetModules();
+      const mod = await import('../siteBranding');
+      expect(mod.SITE_NAME).toBe('RevealUI');
+      expect(mod.SITE_OPERATOR).toBe('REVEALUI STUDIO L.L.C.');
+      expect(mod.IS_CANONICAL_BRANDING).toBe(true);
+    });
+
+    it('uses the configured site name when set', async () => {
+      process.env.NEXT_PUBLIC_SITE_NAME = 'Acme';
+      vi.resetModules();
+      const mod = await import('../siteBranding');
+      expect(mod.SITE_NAME).toBe('Acme');
+      expect(mod.IS_CANONICAL_BRANDING).toBe(false);
+    });
+  });
+});

--- a/apps/admin/src/lib/utilities/mergeOpenGraph.ts
+++ b/apps/admin/src/lib/utilities/mergeOpenGraph.ts
@@ -12,7 +12,10 @@ import type { Metadata } from 'next';
  * description can set REVEALUI_BRAND_DESCRIPTION='' (empty string opt-out).
  */
 function getOpenGraphIdentity() {
-  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  // `||` not `??` for the name: Compose `${VAR:-}` interpolation delivers
+  // unset vars as empty strings, which must fall through. The description
+  // keeps `??`: its empty string is a documented opt-out (see above).
+  const name = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   const description =
     process.env.REVEALUI_BRAND_DESCRIPTION ??
     'Agentic business runtime. Build your business, not your boilerplate.';

--- a/apps/admin/src/lib/utilities/siteBranding.ts
+++ b/apps/admin/src/lib/utilities/siteBranding.ts
@@ -6,10 +6,12 @@
  * their own. Defaults match the canonical revealui.com install.
  */
 
-export const SITE_NAME: string = process.env.NEXT_PUBLIC_SITE_NAME ?? 'RevealUI';
+// `||` not `??`: Compose `${VAR:-}` interpolation delivers unset vars as
+// empty strings, which must fall through to the canonical defaults.
+export const SITE_NAME: string = process.env.NEXT_PUBLIC_SITE_NAME || 'RevealUI';
 
 export const SITE_OPERATOR: string =
-  process.env.NEXT_PUBLIC_SITE_OPERATOR ?? 'REVEALUI STUDIO L.L.C.';
+  process.env.NEXT_PUBLIC_SITE_OPERATOR || 'REVEALUI STUDIO L.L.C.';
 
 /** True when running with default (canonical) branding — used to gate
  * platform-specific copy that shouldn't appear in white-labeled deployments. */

--- a/apps/server/src/routes/__tests__/health.test.ts
+++ b/apps/server/src/routes/__tests__/health.test.ts
@@ -104,6 +104,55 @@ describe('GET /  -  liveness probe', () => {
       }
     }
   });
+
+  it('treats compose-injected empty strings as unset (BRAND_NAME="" falls through)', async () => {
+    const prevBrand = process.env.REVEALUI_BRAND_NAME;
+    const prevTenant = process.env.REVEALUI_TENANT_NAME;
+    // Docker Compose `${VAR:-}` interpolation delivers unset vars as ''.
+    process.env.REVEALUI_BRAND_NAME = '';
+    process.env.REVEALUI_TENANT_NAME = 'Acme';
+    try {
+      const app = createApp();
+      const res = await app.request('/');
+      const body = await parseBody(res);
+      expect(body.service).toBe('Acme API');
+    } finally {
+      if (prevBrand === undefined) {
+        delete process.env.REVEALUI_BRAND_NAME;
+      } else {
+        process.env.REVEALUI_BRAND_NAME = prevBrand;
+      }
+      if (prevTenant === undefined) {
+        delete process.env.REVEALUI_TENANT_NAME;
+      } else {
+        process.env.REVEALUI_TENANT_NAME = prevTenant;
+      }
+    }
+  });
+
+  it('falls back to the canonical name when both overrides are empty strings', async () => {
+    const prevBrand = process.env.REVEALUI_BRAND_NAME;
+    const prevTenant = process.env.REVEALUI_TENANT_NAME;
+    process.env.REVEALUI_BRAND_NAME = '';
+    process.env.REVEALUI_TENANT_NAME = '';
+    try {
+      const app = createApp();
+      const res = await app.request('/');
+      const body = await parseBody(res);
+      expect(body.service).toBe('RevealUI API');
+    } finally {
+      if (prevBrand === undefined) {
+        delete process.env.REVEALUI_BRAND_NAME;
+      } else {
+        process.env.REVEALUI_BRAND_NAME = prevBrand;
+      }
+      if (prevTenant === undefined) {
+        delete process.env.REVEALUI_TENANT_NAME;
+      } else {
+        process.env.REVEALUI_TENANT_NAME = prevTenant;
+      }
+    }
+  });
 });
 
 describe('GET /ready  -  readiness probe', () => {

--- a/apps/server/src/routes/health.ts
+++ b/apps/server/src/routes/health.ts
@@ -87,7 +87,9 @@ const livenessRoute = createRoute({
  * Hosted SaaS (no overrides) keeps the canonical "RevealUI API" identity.
  */
 function getServiceName(): string {
-  const name = process.env.REVEALUI_BRAND_NAME ?? process.env.REVEALUI_TENANT_NAME ?? 'RevealUI';
+  // `||` not `??`: Compose `${VAR:-}` interpolation delivers unset vars as
+  // empty strings, which must fall through to the next candidate.
+  const name = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   return `${name} API`;
 }
 

--- a/packages/config/src/__tests__/modules.test.ts
+++ b/packages/config/src/__tests__/modules.test.ts
@@ -58,6 +58,36 @@ describe('config modules', () => {
       );
       expect(getBrandingConfig(makeEnv({ REVEALUI_SHOW_POWERED_BY: '' })).showPoweredBy).toBe(true);
     });
+
+    it('prefers brand name over tenant name when both are set', () => {
+      const config = getBrandingConfig(
+        makeEnv({ REVEALUI_BRAND_NAME: 'BrandWins', REVEALUI_TENANT_NAME: 'Tenant' }),
+      );
+      expect(config.name).toBe('BrandWins');
+    });
+
+    it('treats compose-injected empty strings as unset', () => {
+      // Docker Compose `${VAR:-}` interpolation delivers unset vars as ''.
+      const config = getBrandingConfig(
+        makeEnv({
+          REVEALUI_BRAND_NAME: '',
+          REVEALUI_TENANT_NAME: 'Acme',
+          REVEALUI_BRAND_LOGO_URL: '',
+          REVEALUI_BRAND_PRIMARY_COLOR: '',
+          REVEALUI_TENANT_BRAND: '',
+        }),
+      );
+      expect(config.name).toBe('Acme');
+      expect(config.logoUrl).toBeUndefined();
+      expect(config.primaryColor).toBeUndefined();
+    });
+
+    it('falls back to the canonical name when both name overrides are empty', () => {
+      const config = getBrandingConfig(
+        makeEnv({ REVEALUI_BRAND_NAME: '', REVEALUI_TENANT_NAME: '' }),
+      );
+      expect(config.name).toBe('RevealUI');
+    });
   });
 
   describe('getDatabaseConfig', () => {

--- a/packages/config/src/modules/branding.ts
+++ b/packages/config/src/modules/branding.ts
@@ -24,9 +24,12 @@ export interface BrandingConfig {
 
 export function getBrandingConfig(env: EnvConfig): BrandingConfig {
   return {
-    name: env.REVEALUI_BRAND_NAME ?? env.REVEALUI_TENANT_NAME ?? 'RevealUI',
-    logoUrl: env.REVEALUI_BRAND_LOGO_URL,
-    primaryColor: env.REVEALUI_BRAND_PRIMARY_COLOR ?? env.REVEALUI_TENANT_BRAND,
+    // `||` not `??`: Compose `${VAR:-}` interpolation delivers unset vars as
+    // empty strings, which must fall through (optional fields normalize ''
+    // to undefined so consumers' truthy checks behave).
+    name: env.REVEALUI_BRAND_NAME || env.REVEALUI_TENANT_NAME || 'RevealUI',
+    logoUrl: env.REVEALUI_BRAND_LOGO_URL || undefined,
+    primaryColor: env.REVEALUI_BRAND_PRIMARY_COLOR || env.REVEALUI_TENANT_BRAND || undefined,
     showPoweredBy: env.REVEALUI_SHOW_POWERED_BY !== 'false',
   };
 }


### PR DESCRIPTION
## Summary

Docker Compose `${VAR:-}` (default-empty) interpolation delivers unset env vars to containers as empty strings, not `undefined`. The white-label brand fallback chains used nullish coalescing (`??`), which only falls through on `null`/`undefined`, so a compose-templated but unset `REVEALUI_BRAND_NAME` produced `service: " API"` on `/health` and an empty brand name across admin metadata surfaces.

This swaps `??` for `||` (empty string treated as unset) at every brand fallback chain:

- `apps/server/src/routes/health.ts`: `getServiceName()`
- `apps/admin/src/app/api/health/route.ts`: `brandName`
- `apps/admin/src/lib/utilities/mergeOpenGraph.ts`: name only; the `REVEALUI_BRAND_DESCRIPTION` empty-string opt-out is documented behavior and keeps `??`
- `apps/admin/src/app/(frontend)/layout.tsx`: `generateMetadata` name + `twitterCreator`
- `apps/admin/src/app/(backend)/layout.tsx`: `siteName` prop-drilled to the admin sidebar
- `apps/admin/src/lib/components/BrandedAuthLayout.tsx`: heading name (tagline/logoUrl already truthy-guarded in JSX)
- `apps/admin/src/lib/utilities/siteBranding.ts`: `SITE_NAME` / `SITE_OPERATOR`
- `packages/config/src/modules/branding.ts`: `getBrandingConfig` name chain; `logoUrl`/`primaryColor` normalize `''` to `undefined` (changeset: patch)

## Behavior (each surface)

- `BRAND=''`, `TENANT='Acme'` resolves to `Acme` (was `''`)
- both empty or unset resolves to `RevealUI` (canonical default, unchanged)
- `BRAND='X'`, `TENANT='Y'` resolves to `X` (precedence unchanged)

## Tests

- server health: 2 new regression tests, suite 28/28 green
- new `apps/admin/src/lib/utilities/__tests__/brandEnvFallback.test.ts` (5 green): mergeOpenGraph identity + siteBranding constants, including the description opt-out staying intact
- config `modules.test.ts`: 3 new `getBrandingConfig` cases, suite 139/139 green
- Biome clean; `tsc --noEmit` clean on config / server / admin

## Why now

This unblocks propagating tenant env vars to the api service in stamped-kit compose templates (follow-up lands in the stamping repo). Without this fix, a parity-templated `${REVEALUI_TENANT_NAME:-}` line in a kit without a tenant name would regress `/health` to `" API"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
