### PR TITLE
fix(core): white-label the admin engine chrome

### DIFF
--- a/.changeset/core-admin-chrome-branding.md
+++ b/.changeset/core-admin-chrome-branding.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': patch
+---
+
+White-label the admin engine chrome: `RootLayout`'s document title, `RootPage`'s header, and `generatePageMetadata` now resolve the brand from `REVEALUI_BRAND_NAME` / `REVEALUI_TENANT_NAME` server-side (empty strings treated as unset), and `AdminDashboard` accepts an optional `siteName` prop for its top-bar heading and status copy. Hosted deployments without overrides keep the canonical "RevealUI Admin" everywhere.

--- a/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
+++ b/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
@@ -21,6 +21,11 @@ type Args = {
 export default async function Page({ params: _params, searchParams: _searchParams }: Args) {
   // Serialize config to remove functions before passing to client component
   const serializedConfig = serializeConfig(config as RevealConfig);
+  // White-label: resolve the brand server-side and pass down; client files
+  // can't read these env vars at runtime (build-time inlining). `||` not
+  // `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
+  const siteName =
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 
   return (
     <div className="relative">
@@ -45,7 +50,7 @@ export default async function Page({ params: _params, searchParams: _searchParam
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
       </Link>
-      <AdminDashboard config={serializedConfig} />
+      <AdminDashboard config={serializedConfig} siteName={siteName} />
     </div>
   );
 }

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -158,7 +158,7 @@ function AdminSidebarContent({ siteName }: { siteName: string }) {
       <SidebarHeader>
         <SidebarSection>
           <SidebarItem href="/" current={isCurrent('/')}>
-            <span className="text-lg font-bold text-foreground">RevealUI</span>
+            <span className="text-lg font-bold text-foreground">{siteName}</span>
           </SidebarItem>
         </SidebarSection>
       </SidebarHeader>

--- a/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
@@ -1,0 +1,82 @@
+import { AdminDashboard, generatePageMetadata } from '@revealui/core/admin';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminSidebarLayout } from '../AdminSidebarLayout';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+// The admin chrome must show the kit's brand, never the framework name,
+// when tenant identity is configured (canonical default otherwise).
+
+const ENV_KEYS = ['REVEALUI_BRAND_NAME', 'REVEALUI_TENANT_NAME'] as const;
+const saved: Record<string, string | undefined> = {};
+
+describe('admin chrome white-label branding', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  describe('AdminSidebarLayout', () => {
+    it('renders the tenant name in the wordmark and footer with no framework leak', () => {
+      render(<AdminSidebarLayout siteName="Acme">content</AdminSidebarLayout>);
+      expect(screen.getByText('Acme')).toBeDefined();
+      expect(screen.getByText('Acme Admin')).toBeDefined();
+      expect(screen.queryByText(/RevealUI/)).toBeNull();
+    });
+
+    it('keeps the canonical wordmark by default', () => {
+      render(<AdminSidebarLayout>content</AdminSidebarLayout>);
+      expect(screen.getByText('RevealUI')).toBeDefined();
+      expect(screen.getByText('RevealUI Admin')).toBeDefined();
+    });
+  });
+
+  describe('AdminDashboard', () => {
+    it('brands the top-bar heading and status copy from the siteName prop', () => {
+      render(<AdminDashboard config={{ collections: [], globals: [] } as never} siteName="Acme" />);
+      expect(screen.getByRole('heading', { name: 'Acme Admin' })).toBeDefined();
+      expect(screen.queryByText(/RevealUI/)).toBeNull();
+    });
+
+    it('defaults to the canonical heading', () => {
+      render(<AdminDashboard config={{ collections: [], globals: [] } as never} />);
+      expect(screen.getByRole('heading', { name: 'RevealUI Admin' })).toBeDefined();
+    });
+  });
+
+  describe('generatePageMetadata', () => {
+    it('brands the title from REVEALUI_TENANT_NAME', () => {
+      process.env.REVEALUI_TENANT_NAME = 'Acme';
+      delete process.env.REVEALUI_BRAND_NAME;
+      expect(generatePageMetadata().title).toBe('Acme Admin');
+    });
+
+    it('treats compose-injected empty strings as unset', () => {
+      // Docker Compose `${VAR:-}` interpolation delivers unset vars as ''.
+      process.env.REVEALUI_BRAND_NAME = '';
+      process.env.REVEALUI_TENANT_NAME = 'Acme';
+      expect(generatePageMetadata().title).toBe('Acme Admin');
+    });
+
+    it('defaults to the canonical title', () => {
+      delete process.env.REVEALUI_BRAND_NAME;
+      delete process.env.REVEALUI_TENANT_NAME;
+      expect(generatePageMetadata().title).toBe('RevealUI Admin');
+    });
+  });
+});

--- a/packages/core/src/client/admin/components/AdminDashboard.tsx
+++ b/packages/core/src/client/admin/components/AdminDashboard.tsx
@@ -19,6 +19,12 @@ import { GlobalForm } from './GlobalForm.js';
 
 interface AdminDashboardProps {
   config: RevealConfig;
+  /**
+   * Resolved brand name for the dashboard chrome. Pass from a server
+   * component (e.g. REVEALUI_BRAND_NAME / REVEALUI_TENANT_NAME): client
+   * files cannot read those env vars at runtime (build-time inlining).
+   */
+  siteName?: string;
 }
 
 type ViewType = 'dashboard' | 'collection' | 'edit' | 'global';
@@ -204,11 +210,13 @@ function SignOutButton() {
 // =============================================================================
 
 function DashboardHome({
+  siteName,
   collections,
   globals,
   onCollectionClick,
   onGlobalClick,
 }: {
+  siteName: string;
   collections: RevealCollectionConfig[];
   globals: RevealGlobalConfig[];
   onCollectionClick: (c: RevealCollectionConfig) => void;
@@ -220,7 +228,7 @@ function DashboardHome({
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-foreground">RevealUI Admin</h1>
+              <h1 className="text-2xl font-bold text-foreground">{`${siteName} Admin`}</h1>
             </div>
             <div className="flex items-center space-x-4">
               <span className="text-sm text-muted-foreground">v0.1.0</span>
@@ -385,7 +393,7 @@ function DashboardHome({
               </div>
               <div className="bg-muted px-5 py-3">
                 <div className="text-sm text-muted-foreground">
-                  RevealUI admin is running successfully
+                  {siteName} admin is running successfully
                 </div>
               </div>
             </div>
@@ -415,7 +423,7 @@ function logApiError(err: unknown, context: string): void {
 // Main component
 // =============================================================================
 
-export function AdminDashboard({ config }: AdminDashboardProps) {
+export function AdminDashboard({ config, siteName = 'RevealUI' }: AdminDashboardProps) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const collections = config.collections || [];
@@ -747,6 +755,7 @@ export function AdminDashboard({ config }: AdminDashboardProps) {
   // ── Dashboard home ────────────────────────────────────────────────────
   return (
     <DashboardHome
+      siteName={siteName}
       collections={collections}
       globals={globals}
       onCollectionClick={(c) => void handleCollectionClick(c)}

--- a/packages/core/src/client/admin/layout.tsx
+++ b/packages/core/src/client/admin/layout.tsx
@@ -11,12 +11,17 @@ export interface RootLayoutProps {
 }
 
 export function RootLayout({ children, serverFunction }: RootLayoutProps) {
+  // Server component: resolved per request. White-label kits override via
+  // REVEALUI_BRAND_NAME / REVEALUI_TENANT_NAME. `||` not `??`: Compose
+  // `${VAR:-}` interpolation delivers unset vars as empty strings.
+  const siteName =
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   return (
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>RevealUI Admin</title>
+        <title>{`${siteName} Admin`}</title>
       </head>
       <body className="antialiased">
         <ServerFunctionProvider serverFunction={serverFunction}>

--- a/packages/core/src/client/admin/page.tsx
+++ b/packages/core/src/client/admin/page.tsx
@@ -31,6 +31,11 @@ export function RootPage({ config }: RootPageProps) {
   type AdminCollectionSummary = { slug?: string; fields?: unknown[] };
   const collections = (config.collections || []) as AdminCollectionSummary[];
   const globals = (config.globals || []) as AdminCollectionSummary[];
+  // Server component: white-label kits override via REVEALUI_BRAND_NAME /
+  // REVEALUI_TENANT_NAME. `||` not `??`: Compose `${VAR:-}` interpolation
+  // delivers unset vars as empty strings.
+  const siteName =
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 
   return (
     <div className="min-h-screen bg-background">
@@ -38,7 +43,7 @@ export function RootPage({ config }: RootPageProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-foreground">RevealUI Admin</h1>
+              <h1 className="text-2xl font-bold text-foreground">{`${siteName} Admin`}</h1>
             </div>
             <div className="flex items-center space-x-4">
               <span className="text-sm text-muted-foreground">v0.1.0</span>
@@ -187,7 +192,7 @@ export function RootPage({ config }: RootPageProps) {
               </div>
               <div className="bg-muted px-5 py-3">
                 <div className="text-sm text-muted-foreground">
-                  RevealUI admin is running successfully with {collections.length} collections and{' '}
+                  {siteName} admin is running successfully with {collections.length} collections and{' '}
                   {globals.length} globals configured.
                 </div>
               </div>
@@ -209,8 +214,12 @@ export function NotFoundPage() {
 }
 
 export function generatePageMetadata(): Metadata {
+  // Server-side, resolved per call. White-label kits override via env.
+  // `||` not `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
+  const siteName =
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
   return {
-    title: 'RevealUI Admin',
-    description: 'RevealUI Content Management System',
+    title: `${siteName} Admin`,
+    description: `${siteName} Content Management System`,
   };
 }


### PR DESCRIPTION
## Summary

The `@revealui/core` admin engine hardcoded the framework name in the post-login chrome, so white-label kits showed "RevealUI" within seconds of authenticating regardless of tenant configuration. Found by rendered-text audit of a stamped kit:

- `RootLayout` document `<title>RevealUI Admin</title>` (browser tab on every admin page)
- `AdminDashboard` top-bar `<h1>RevealUI Admin</h1>` + "RevealUI admin is running successfully" status copy
- `RootPage` header h1 + the same status copy variant
- `generatePageMetadata` `title: 'RevealUI Admin'` (404/error surfaces)
- app-side: the admin sidebar wordmark hardcoded `RevealUI` two lines above its already-white-labeled `{siteName} Admin` footer

## Approach

- **Server surfaces** (`RootLayout`, `RootPage`, `generatePageMetadata`) resolve the brand per request from `REVEALUI_BRAND_NAME` / `REVEALUI_TENANT_NAME` directly — no API change, every consumer white-labels for free. `||` not `??` so compose-injected empty strings fall through (same convention as #1345, which this PR shares no files with; both merge independently in either order).
- **Client surface** (`AdminDashboard`, `'use client'`) takes an optional `siteName` prop (default `'RevealUI'`) — client bundles can't read these env vars at runtime (build-time inlining), so its server mount point (`apps/admin` catch-all page) resolves and passes it down. Same pattern as `AdminSidebarLayout`.
- Hosted SaaS with no overrides keeps canonical "RevealUI Admin" everywhere (defaults unchanged).
- Changeset: patch `@revealui/core`.

## Tests

New `apps/admin/src/lib/utilities/__tests__`-style suite (`adminChromeBranding.test.tsx`, 7 green):
- `AdminSidebarLayout` with `siteName="Acme"`: wordmark + footer show Acme, zero `RevealUI` text in the tree; canonical default preserved
- `AdminDashboard` with `siteName="Acme"`: top-bar heading "Acme Admin", no framework leak; canonical default preserved
- `generatePageMetadata`: tenant-name title, compose-empty-string safety, canonical default

Biome clean; `tsc --noEmit` clean on core + admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
