### PR TITLE
fix(security): unify csrf binding + attach tokens on admin api calls

### DIFF
--- a/apps/admin/src/__tests__/api/proxy-routes.test.ts
+++ b/apps/admin/src/__tests__/api/proxy-routes.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateCsrfToken } from '../../lib/utils/csrf-token';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -308,5 +309,84 @@ describe('DELETE /api/collections/[collection]/[id]', () => {
       params: Promise.resolve({ collection: 'posts', id: 'gone' }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests  -  forwarded headers (Cookie, User-Agent, minted X-CSRF-Token)
+// ---------------------------------------------------------------------------
+
+describe('api forward headers', () => {
+  const SECRET = 'proxy-test-secret-32-chars-long!!';
+  const SESSION_COOKIE_VALUE = 'sess-forward-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('REVEALUI_SECRET', SECRET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function forwardedHeaders(): Record<string, string> {
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  it('forwards Cookie + User-Agent and mints a cookie-value-bound X-CSRF-Token on unsafe forwards', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ updated: true }));
+    const req = new NextRequest('http://localhost/api/globals/nav', {
+      method: 'POST',
+      body: '{}',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `revealui-session=${SESSION_COOKIE_VALUE}`,
+        'User-Agent': 'TestBrowser/1.0',
+      },
+    });
+    await globalsPost(req, { params: Promise.resolve({ slug: 'nav' }) });
+
+    const headers = forwardedHeaders();
+    expect(headers.Cookie).toBe(`revealui-session=${SESSION_COOKIE_VALUE}`);
+    expect(headers['User-Agent']).toBe('TestBrowser/1.0');
+    expect(headers['Content-Type']).toBe('application/json');
+    // The api's csrfMiddleware validates this exact shape against the same
+    // session cookie value it receives  -  assert the minted token verifies.
+    const token = headers['X-CSRF-Token'] ?? '';
+    expect(token).toBeTruthy();
+    await expect(validateCsrfToken(token, SESSION_COOKIE_VALUE, SECRET)).resolves.toBe(true);
+  });
+
+  it('mints the token for collection item PATCH forwards too', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ id: 'post-1' }));
+    const req = new NextRequest('http://localhost/api/collections/posts/post-1', {
+      method: 'PATCH',
+      body: '{}',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `revealui-session=${SESSION_COOKIE_VALUE}`,
+        'User-Agent': 'TestBrowser/1.0',
+      },
+    });
+    await collectionItemPatch(req, {
+      params: Promise.resolve({ collection: 'posts', id: 'post-1' }),
+    });
+
+    const headers = forwardedHeaders();
+    expect(headers['User-Agent']).toBe('TestBrowser/1.0');
+    const token = headers['X-CSRF-Token'] ?? '';
+    expect(token).toBeTruthy();
+    await expect(validateCsrfToken(token, SESSION_COOKIE_VALUE, SECRET)).resolves.toBe(true);
+  });
+
+  it('omits Cookie and X-CSRF-Token when the request carries no session cookie', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ docs: [] }));
+    const req = new NextRequest('http://localhost/api/collections/posts');
+    await collectionsGet(req, { params: Promise.resolve({ collection: 'posts' }) });
+
+    const headers = forwardedHeaders();
+    expect(headers.Cookie).toBeUndefined();
+    expect(headers['X-CSRF-Token']).toBeUndefined();
   });
 });

--- a/apps/admin/src/__tests__/utils/api-fetch.test.ts
+++ b/apps/admin/src/__tests__/utils/api-fetch.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch, getCsrfToken, isCsrfTarget } from '../../lib/utils/csrf';
+
+const TOKEN = 'aabbccdd:eeff0011';
+const DEFAULT_API_ORIGIN = 'https://api.revealui.com';
+
+function setCsrfCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to seed cookies in tests
+  document.cookie = `revealui-csrf=${value}`;
+}
+
+function clearCsrfCookie(): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to clear cookies in tests
+  document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+}
+
+describe('getCsrfToken', () => {
+  afterEach(() => {
+    clearCsrfCookie();
+  });
+
+  it('reads the revealui-csrf cookie', () => {
+    setCsrfCookie(TOKEN);
+    expect(getCsrfToken()).toBe(TOKEN);
+  });
+
+  it('returns null when the cookie is absent', () => {
+    expect(getCsrfToken()).toBeNull();
+  });
+});
+
+describe('isCsrfTarget', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('matches relative admin /api/ paths', () => {
+    expect(isCsrfTarget('/api/chat')).toBe(true);
+    expect(isCsrfTarget('/api/mcp/servers')).toBe(true);
+  });
+
+  it('does not match relative non-/api/ paths', () => {
+    expect(isCsrfTarget('/account/billing')).toBe(false);
+  });
+
+  it('matches absolute URLs on the default api origin', () => {
+    expect(isCsrfTarget(`${DEFAULT_API_ORIGIN}/api/billing/checkout`)).toBe(true);
+  });
+
+  it('matches absolute URLs on a configured NEXT_PUBLIC_API_URL origin', () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3004');
+    expect(isCsrfTarget('http://localhost:3004/api/billing/checkout')).toBe(true);
+    // The default prod origin is no longer the configured one.
+    expect(isCsrfTarget(`${DEFAULT_API_ORIGIN}/api/billing/checkout`)).toBe(false);
+  });
+
+  it('matches absolute URLs on the page origin', () => {
+    expect(isCsrfTarget(`${window.location.origin}/api/collections/posts`)).toBe(true);
+  });
+
+  it('does not match foreign origins, even on /api/ paths', () => {
+    expect(isCsrfTarget('https://evil.example/api/billing/checkout')).toBe(false);
+  });
+
+  it('does not match non-/api/ paths on the api origin', () => {
+    expect(isCsrfTarget(`${DEFAULT_API_ORIGIN}/health`)).toBe(false);
+  });
+
+  it('rejects unparseable URLs', () => {
+    expect(isCsrfTarget('http://[bad')).toBe(false);
+  });
+});
+
+describe('apiFetch', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    clearCsrfCookie();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  function sentHeaders(): Record<string, string> {
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  it('attaches X-CSRF-Token on POST to a relative /api/ path', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch('/api/chat', { method: 'POST' });
+    expect(sentHeaders()['X-CSRF-Token']).toBe(TOKEN);
+  });
+
+  it('attaches X-CSRF-Token on POST to the api origin (absolute URL)', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch(`${DEFAULT_API_ORIGIN}/api/billing/checkout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    expect(sentHeaders()['X-CSRF-Token']).toBe(TOKEN);
+  });
+
+  it('attaches X-CSRF-Token on DELETE to the api origin', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch(`${DEFAULT_API_ORIGIN}/api/content/media/abc`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    expect(sentHeaders()['X-CSRF-Token']).toBe(TOKEN);
+  });
+
+  it('preserves caller headers and init options when attaching', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch(`${DEFAULT_API_ORIGIN}/api/billing/checkout`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"tier":"pro"}',
+    });
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(sentHeaders()['Content-Type']).toBe('application/json');
+    expect(sentHeaders()['X-CSRF-Token']).toBe(TOKEN);
+    expect(init.credentials).toBe('include');
+    expect(init.body).toBe('{"tier":"pro"}');
+  });
+
+  it('does not attach on GET', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch(`${DEFAULT_API_ORIGIN}/api/billing/subscription`, {
+      credentials: 'include',
+    });
+    expect(sentHeaders()['X-CSRF-Token']).toBeUndefined();
+  });
+
+  it('does not attach on POST to a foreign origin', async () => {
+    setCsrfCookie(TOKEN);
+    await apiFetch('https://evil.example/api/billing/checkout', { method: 'POST' });
+    expect(sentHeaders()['X-CSRF-Token']).toBeUndefined();
+  });
+
+  it('falls through to plain fetch when no token cookie exists', async () => {
+    await apiFetch(`${DEFAULT_API_ORIGIN}/api/billing/checkout`, { method: 'POST' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentHeaders()['X-CSRF-Token']).toBeUndefined();
+  });
+});

--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -9,6 +9,7 @@ import { AgentMemory } from '@/lib/components/agents/agent-memory';
 import { TaskHistory } from '@/lib/components/agents/task-history';
 import { TaskTester } from '@/lib/components/agents/task-tester';
 import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
 
 interface PageProps {
   params: Promise<{ agentId: string }>;
@@ -96,7 +97,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setRetiring(true);
     setRetireError(null);
     try {
-      const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -120,7 +121,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setSaving(true);
     setSaveError(null);
     try {
-      const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
 // Template definitions
@@ -189,7 +190,7 @@ export default function NewAgentPage() {
     };
 
     try {
-      const res = await fetch(`${apiUrl}/a2a/agents`, {
+      const res = await apiFetch(`${apiUrl}/a2a/agents`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { type ChangeEvent, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
 // Types
@@ -263,7 +264,7 @@ function ReviewsPanel({
     setSubmitting(true);
 
     try {
-      const res = await fetch(`${apiUrl}/api/revmarket/agents/${agentId}/reviews`, {
+      const res = await apiFetch(`${apiUrl}/api/revmarket/agents/${agentId}/reviews`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -430,7 +431,7 @@ function SubmitTaskPanel({
     }
 
     try {
-      const res = await fetch(`${apiUrl}/api/revmarket/tasks`, {
+      const res = await apiFetch(`${apiUrl}/api/revmarket/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
 // Types
@@ -130,7 +131,7 @@ export default function PublishAgentPage() {
 
     try {
       // Create agent
-      const agentRes = await fetch(`${apiUrl}/api/revmarket/agents`, {
+      const agentRes = await apiFetch(`${apiUrl}/api/revmarket/agents`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -159,7 +160,7 @@ export default function PublishAgentPage() {
       // Add skills
       for (const skill of skills) {
         if (!skill.name) continue;
-        await fetch(`${apiUrl}/api/revmarket/agents/${agent.id}/skills`, {
+        await apiFetch(`${apiUrl}/api/revmarket/agents/${agent.id}/skills`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { type ChangeEvent, useCallback, useRef, useState } from 'react';
+import { apiFetch } from '@/lib/utils/csrf';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,7 +73,7 @@ async function uploadMedia(serverUrl: string, file: File, alt?: string): Promise
   const formData = new FormData();
   formData.append('file', file);
   if (alt) formData.append('alt', alt);
-  const res = await fetch(`${serverUrl}/api/content/media`, {
+  const res = await apiFetch(`${serverUrl}/api/content/media`, {
     method: 'POST',
     credentials: 'include',
     body: formData,
@@ -86,7 +87,7 @@ async function uploadMedia(serverUrl: string, file: File, alt?: string): Promise
 }
 
 async function deleteMediaItem(serverUrl: string, id: string): Promise<void> {
-  const res = await fetch(`${serverUrl}/api/content/media/${id}`, {
+  const res = await apiFetch(`${serverUrl}/api/content/media/${id}`, {
     method: 'DELETE',
     credentials: 'include',
   });

--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -2,6 +2,7 @@
 
 import { type ChangeEvent, useEffect, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
 // Types
@@ -163,7 +164,7 @@ function RefundsDashboard() {
         body.amount = Math.round(dollars * 100);
       }
 
-      const res = await fetch(`${apiUrl}/api/billing/refund`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/refund`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/upgrade/page.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/page.tsx
@@ -6,6 +6,7 @@ import { PricingTable } from '@revealui/presentation/client';
 import { useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
 import { useLicense } from '@/lib/providers/LicenseProvider';
+import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 export default function UpgradePage() {
@@ -30,7 +31,7 @@ export default function UpgradePage() {
         enterprise: process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID,
       };
       const priceId = priceIdMap[tierId];
-      const res = await fetch(`${apiUrl}/api/billing/checkout`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -19,6 +19,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
+import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 interface SubscriptionData {
@@ -113,7 +114,7 @@ function BillingContent() {
     setActionLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/billing/checkout`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -169,7 +170,7 @@ function BillingContent() {
     setActionLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/billing/upgrade`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/upgrade`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -198,7 +199,7 @@ function BillingContent() {
     setActionLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/billing/upgrade`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/upgrade`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -227,7 +228,7 @@ function BillingContent() {
     setActionLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/billing/portal`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/portal`, {
         method: 'POST',
         credentials: 'include',
       });

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -20,6 +20,7 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 interface SubscriptionData {
@@ -111,7 +112,7 @@ export default function LicensePage() {
     setError(null);
     try {
       const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
-      const res = await fetch(`${apiUrl}/api/billing/checkout-perpetual`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/checkout-perpetual`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
@@ -139,7 +140,7 @@ export default function LicensePage() {
     setError(null);
     try {
       const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
-      const res = await fetch(`${apiUrl}/api/billing/checkout-support-renewal`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/checkout-support-renewal`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
+import { apiFetch } from '@/lib/utils/csrf';
 
 interface SignupFormProps {
   /** API base URL resolved server-side to avoid build-time env inlining. */
@@ -75,7 +76,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
     const result = await signUp({ email, password, name, tosAccepted: true });
     if (result.success) {
       for (const type of ['necessary', 'functional'] as const) {
-        fetch(`${apiUrl}/api/gdpr/consent/grant`, {
+        apiFetch(`${apiUrl}/api/gdpr/consent/grant`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -136,7 +137,9 @@ function SignupContent({ apiUrl }: SignupFormProps) {
     try {
       // Session-less resend: the route accepts { email } without a session and
       // always answers with the same generic 200, so this needs no auth state.
-      await fetch('/api/auth/resend-verification', {
+      // apiFetch still matters here: a lingering session cookie (stale or
+      // live) makes the admin proxy demand a CSRF token on this POST.
+      await apiFetch('/api/auth/resend-verification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),

--- a/apps/admin/src/app/api/batch/[action]/route.ts
+++ b/apps/admin/src/app/api/batch/[action]/route.ts
@@ -1,6 +1,7 @@
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
+import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 const API_URL =
@@ -28,10 +29,7 @@ export async function POST(
     const body = await request.json();
     const apiResponse = await fetch(`${API_URL}/api/content/batch/${action}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Cookie: request.headers.get('Cookie') ?? '',
-      },
+      headers: await apiForwardHeaders(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
 

--- a/apps/admin/src/app/api/collections/[collection]/[id]/route.ts
+++ b/apps/admin/src/app/api/collections/[collection]/[id]/route.ts
@@ -1,5 +1,6 @@
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
+import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -17,9 +18,7 @@ async function proxyRequest(
 ): Promise<NextResponse> {
   const { collection, id } = await params;
 
-  const headers: Record<string, string> = {
-    Cookie: request.headers.get('Cookie') ?? '',
-  };
+  const headers = await apiForwardHeaders(request);
 
   const init: RequestInit = { method, headers };
 

--- a/apps/admin/src/app/api/collections/[collection]/route.ts
+++ b/apps/admin/src/app/api/collections/[collection]/route.ts
@@ -1,6 +1,7 @@
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
+import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 const API_URL =
@@ -53,9 +54,7 @@ export async function GET(
     const apiResponse = await fetch(
       `${API_URL}/api/content/${collection}?${searchParams.toString()}`,
       {
-        headers: {
-          Cookie: request.headers.get('Cookie') ?? '',
-        },
+        headers: await apiForwardHeaders(request),
       },
     );
     return proxyResponse(apiResponse);
@@ -79,10 +78,7 @@ export async function POST(
   try {
     const apiResponse = await fetch(`${API_URL}/api/content/${collection}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Cookie: request.headers.get('Cookie') ?? '',
-      },
+      headers: await apiForwardHeaders(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
     return proxyResponse(apiResponse);

--- a/apps/admin/src/app/api/globals/[slug]/route.ts
+++ b/apps/admin/src/app/api/globals/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -33,9 +34,7 @@ export async function GET(
   const { searchParams } = new URL(request.url);
 
   const apiResponse = await fetch(`${API_URL}/api/globals/${slug}?${searchParams.toString()}`, {
-    headers: {
-      Cookie: request.headers.get('Cookie') ?? '',
-    },
+    headers: await apiForwardHeaders(request),
   });
 
   if (!apiResponse.ok) {
@@ -58,10 +57,7 @@ export async function POST(
 
   const apiResponse = await fetch(`${API_URL}/api/globals/${slug}`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Cookie: request.headers.get('Cookie') ?? '',
-    },
+    headers: await apiForwardHeaders(request, { 'Content-Type': 'application/json' }),
     body: JSON.stringify(body),
   });
 

--- a/apps/admin/src/lib/components/Agent/index.tsx
+++ b/apps/admin/src/lib/components/Agent/index.tsx
@@ -156,7 +156,7 @@ function useAgentStream() {
       setError(null);
 
       try {
-        const response = await fetch(`${apiBase}/api/agent-stream`, {
+        const response = await apiFetch(`${apiBase}/api/agent-stream`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/apps/admin/src/lib/components/UpgradeDialog.tsx
+++ b/apps/admin/src/lib/components/UpgradeDialog.tsx
@@ -12,6 +12,7 @@ import { PricingTable } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { useLicense } from '@/lib/providers/LicenseProvider';
+import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
 /**
@@ -48,7 +49,7 @@ export function UpgradeDialog() {
         enterprise: process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID,
       };
       const priceId = priceIdMap[tierId];
-      const res = await fetch(`${apiUrl}/api/billing/checkout`, {
+      const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -2,6 +2,7 @@
 
 import type { A2ATask } from '@revealui/contracts';
 import { useState } from 'react';
+import { apiFetch } from '@/lib/utils/csrf';
 
 interface TaskTesterProps {
   agentId: string;
@@ -35,7 +36,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
     };
 
     try {
-      const res = await fetch(`${apiUrl}/a2a`, {
+      const res = await apiFetch(`${apiUrl}/a2a`, {
         method: 'POST',
         headers,
         credentials: 'include',

--- a/apps/admin/src/lib/utils/api-proxy-headers.ts
+++ b/apps/admin/src/lib/utils/api-proxy-headers.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { generateCsrfToken } from './csrf-token';
+
+/**
+ * Headers for a server-side forward of a browser request to the api server.
+ *
+ * - Forwards the Cookie header so the api authenticates the same session.
+ * - Forwards the browser's User-Agent: the api's session binding deletes a
+ *   session outright when a cookie arrives under a different UA (stolen-cookie
+ *   defense), and an absent UA merely skips that check  -  forwarding keeps
+ *   the defense meaningful for proxied traffic instead of silently disarming
+ *   it.
+ * - Mints an X-CSRF-Token bound to the session cookie value: the api's
+ *   csrfMiddleware enforces the signed double-submit check on every
+ *   cookie-bearing unsafe request, and this forwarder holds both inputs
+ *   (cookie value + REVEALUI_SECRET) that the browser-side issuer uses.
+ */
+export async function apiForwardHeaders(
+  request: NextRequest,
+  extra?: Record<string, string>,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = { ...extra };
+
+  const cookie = request.headers.get('Cookie');
+  if (cookie) headers.Cookie = cookie;
+
+  const userAgent = request.headers.get('User-Agent');
+  if (userAgent) headers['User-Agent'] = userAgent;
+
+  const sessionValue = request.cookies.get('revealui-session')?.value;
+  const secret = process.env.REVEALUI_SECRET;
+  if (sessionValue && secret) {
+    headers['X-CSRF-Token'] = await generateCsrfToken(sessionValue, secret);
+  }
+
+  return headers;
+}

--- a/apps/admin/src/lib/utils/csrf.ts
+++ b/apps/admin/src/lib/utils/csrf.ts
@@ -12,10 +12,35 @@ export function getCsrfToken(): string | null {
 
 const CSRF_UNSAFE = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+/** Origin of the api server the admin browser talks to (cross-subdomain in prod). */
+function configuredApiOrigin(): string | null {
+  const raw = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
+  return URL.canParse(raw) ? new URL(raw).origin : null;
+}
+
+/**
+ * True when `urlStr` targets a RevealUI surface that enforces the signed
+ * double-submit CSRF check: the admin's own `/api/*` routes (relative or
+ * same-origin absolute) or the api server's `/api/*` routes (absolute,
+ * cross-origin). Both validate the same token  -  HMAC over the session
+ * cookie value  -  so one attach predicate covers both.
+ *
+ * Foreign origins never get the token: it would be useless to them, and
+ * request headers are not something to hand out.
+ */
+export function isCsrfTarget(urlStr: string): boolean {
+  if (urlStr.startsWith('/api/')) return true;
+  if (!URL.canParse(urlStr)) return false;
+  const target = new URL(urlStr);
+  if (!target.pathname.startsWith('/api/')) return false;
+  if (target.origin === configuredApiOrigin()) return true;
+  return typeof window !== 'undefined' && target.origin === window.location.origin;
+}
+
 export function apiFetch(url: string | URL, init: RequestInit = {}): Promise<Response> {
   const method = (init.method ?? 'GET').toUpperCase();
   const urlStr = typeof url === 'string' ? url : url.toString();
-  const needsCsrf = CSRF_UNSAFE.has(method) && urlStr.startsWith('/api/');
+  const needsCsrf = CSRF_UNSAFE.has(method) && isCsrfTarget(urlStr);
   if (!needsCsrf) return fetch(url, init);
   const token = getCsrfToken();
   if (!token) return fetch(url, init);

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -249,32 +249,20 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
 
     const sessionValue = request.cookies.get('revealui-session')?.value;
-    const csrfCookieValue = request.cookies.get('revealui-csrf')?.value;
     const secret = process.env.REVEALUI_SECRET;
 
-    if (sessionValue && secret) {
-      if (UNSAFE_METHODS.has(request.method) && !isCsrfExempt(pathname)) {
-        const tokenHeader = request.headers.get('X-CSRF-Token');
-        if (!tokenHeader) {
-          return NextResponse.json({ error: 'CSRF token missing' }, { status: 403 });
-        }
-        const valid = await validateCsrfToken(tokenHeader, sessionValue, secret);
-        if (!valid) {
-          return NextResponse.json({ error: 'CSRF token invalid' }, { status: 403 });
-        }
+    if (sessionValue && secret && UNSAFE_METHODS.has(request.method) && !isCsrfExempt(pathname)) {
+      const tokenHeader = request.headers.get('X-CSRF-Token');
+      if (!tokenHeader) {
+        return NextResponse.json({ error: 'CSRF token missing' }, { status: 403 });
       }
-
-      if (!csrfCookieValue) {
-        const token = await generateCsrfToken(sessionValue, secret);
-        response.cookies.set('revealui-csrf', token, {
-          httpOnly: false,
-          sameSite: 'strict',
-          secure: process.env.NODE_ENV !== 'development',
-          path: '/',
-          maxAge: 60 * 60 * 24,
-        });
+      const valid = await validateCsrfToken(tokenHeader, sessionValue, secret);
+      if (!valid) {
+        return NextResponse.json({ error: 'CSRF token invalid' }, { status: 403 });
       }
     }
+
+    await ensureCsrfCookie(request, response);
 
     return response;
   }
@@ -283,7 +271,37 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
   // its inline bootstrap scripts, and set the matching CSP on the response.
   const response = NextResponse.next({ request: { headers: requestHeaders } });
   response.headers.set('Content-Security-Policy', cspValue);
+  // Mint/refresh the CSRF token cookie on page loads too. The billing,
+  // marketplace, and agents pages call the api server (cross-origin) directly
+  // from the browser  -  those fetches never traverse this proxy, so issuing
+  // only on same-origin /api responses would leave the first unsafe call
+  // after a fresh sign-in without a token.
+  await ensureCsrfCookie(request, response);
   return response;
+}
+
+/**
+ * Ensure the JS-readable `revealui-csrf` cookie holds a token that validates
+ * against the CURRENT session cookie value. Issues on first contact and
+ * re-issues after session rotation (re-login, recovery, privilege change)  -
+ * issue-only-when-missing left a stale binding 403-ing every unsafe call for
+ * up to the cookie's 24h lifetime. The same token authorizes unsafe requests
+ * to the admin's own /api routes (validated above) and to the api server's
+ * csrfMiddleware (validated there against the same cookie value).
+ */
+async function ensureCsrfCookie(request: NextRequest, response: NextResponse): Promise<void> {
+  const sessionValue = request.cookies.get('revealui-session')?.value;
+  const secret = process.env.REVEALUI_SECRET;
+  if (!(sessionValue && secret)) return;
+  const existing = request.cookies.get('revealui-csrf')?.value;
+  if (existing && (await validateCsrfToken(existing, sessionValue, secret))) return;
+  response.cookies.set('revealui-csrf', await generateCsrfToken(sessionValue, secret), {
+    httpOnly: false,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV !== 'development',
+    path: '/',
+    maxAge: 60 * 60 * 24,
+  });
 }
 
 // Define matcher configuration for Next.js proxy

--- a/apps/server/src/middleware/__tests__/csrf.test.ts
+++ b/apps/server/src/middleware/__tests__/csrf.test.ts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { csrfMiddleware, generateCsrfToken, validateCsrfToken } from '../csrf.js';
 
 const SECRET = 'test-secret-key-32chars-long!!';
+// Arbitrary binding string for the token-primitive unit tests below.
 const SESSION_ID = 'session-abc-123';
+// The middleware binds tokens to the raw session COOKIE VALUE (signed
+// double-submit  -  the vocabulary the admin app issues against), NOT the
+// DB session row id that auth middleware puts on context.
+const SESSION_COOKIE = 'sess-123';
+const DB_SESSION_ROW_ID = 'a1b2c3d4-e5f6-7890-uuid-sessionrow00';
 
 // ─── generateCsrfToken ────────────────────────────────────────────────────────
 
@@ -172,7 +178,7 @@ describe('csrfMiddleware', () => {
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware());
@@ -180,7 +186,7 @@ describe('csrfMiddleware', () => {
 
     const res = await app.request('/test', {
       method: 'POST',
-      headers: { Cookie: 'revealui-session=sess-123' },
+      headers: { Cookie: `revealui-session=${SESSION_COOKIE}` },
     });
     expect(res.status).toBe(500);
   });
@@ -212,7 +218,7 @@ describe('csrfMiddleware', () => {
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware());
@@ -220,7 +226,7 @@ describe('csrfMiddleware', () => {
 
     const res = await app.request('/test', {
       method: 'POST',
-      headers: { Cookie: 'revealui-session=sess-123' },
+      headers: { Cookie: `revealui-session=${SESSION_COOKIE}` },
     });
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error: string };
@@ -232,7 +238,7 @@ describe('csrfMiddleware', () => {
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware());
@@ -241,7 +247,7 @@ describe('csrfMiddleware', () => {
     const res = await app.request('/test', {
       method: 'POST',
       headers: {
-        Cookie: 'revealui-session=sess-123',
+        Cookie: `revealui-session=${SESSION_COOKIE}`,
         'X-CSRF-Token': 'invalid-token',
       },
     });
@@ -250,14 +256,16 @@ describe('csrfMiddleware', () => {
     expect(body.error).toContain('invalid');
   });
 
-  it('allows POST with a valid CSRF token', async () => {
+  it('allows POST with a token bound to the session cookie value (admin-issued shape)', async () => {
     vi.stubEnv('REVEALUI_SECRET', SECRET);
 
-    const token = generateCsrfToken(SESSION_ID, SECRET);
+    // What the admin app actually issues: HMAC over the raw session cookie
+    // value (proxy.ts `revealui-csrf` cookie / server-side forwarders).
+    const token = generateCsrfToken(SESSION_COOKIE, SECRET);
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware());
@@ -266,11 +274,40 @@ describe('csrfMiddleware', () => {
     const res = await app.request('/test', {
       method: 'POST',
       headers: {
-        Cookie: 'revealui-session=sess-123',
+        Cookie: `revealui-session=${SESSION_COOKIE}`,
         'X-CSRF-Token': token,
       },
     });
     expect(res.status).toBe(200);
+  });
+
+  it('rejects a token bound to the DB session row id (the pre-fix binding no issuer speaks)', async () => {
+    vi.stubEnv('REVEALUI_SECRET', SECRET);
+
+    // Regression for the binding unification: tokens minted against
+    // session.id used to be the only accepted shape, yet no browser-reachable
+    // issuer produced them  -  every cookie-bearing unsafe admin→api call
+    // 403'd. They must NOT validate now that the cookie value is the binding.
+    const legacyBoundToken = generateCsrfToken(DB_SESSION_ROW_ID, SECRET);
+
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('session', { id: DB_SESSION_ROW_ID });
+      await next();
+    });
+    app.use('*', csrfMiddleware());
+    app.post('/test', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        Cookie: `revealui-session=${SESSION_COOKIE}`,
+        'X-CSRF-Token': legacyBoundToken,
+      },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('invalid');
   });
 
   it('respects custom cookie name option', async () => {
@@ -278,7 +315,7 @@ describe('csrfMiddleware', () => {
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware({ cookieName: 'my-session' }));
@@ -287,7 +324,7 @@ describe('csrfMiddleware', () => {
     // Correct custom cookie name  -  triggers CSRF check, token is missing → 403
     const res = await app.request('/test', {
       method: 'POST',
-      headers: { Cookie: 'my-session=sess-123' },
+      headers: { Cookie: `my-session=${SESSION_COOKIE}` },
     });
     expect(res.status).toBe(403);
   });
@@ -295,11 +332,11 @@ describe('csrfMiddleware', () => {
   it('respects custom header name option', async () => {
     vi.stubEnv('REVEALUI_SECRET', SECRET);
 
-    const token = generateCsrfToken(SESSION_ID, SECRET);
+    const token = generateCsrfToken(SESSION_COOKIE, SECRET);
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware({ headerName: 'X-My-CSRF' }));
@@ -308,7 +345,7 @@ describe('csrfMiddleware', () => {
     const res = await app.request('/test', {
       method: 'POST',
       headers: {
-        Cookie: 'revealui-session=sess-123',
+        Cookie: `revealui-session=${SESSION_COOKIE}`,
         'X-My-CSRF': token,
       },
     });
@@ -318,11 +355,11 @@ describe('csrfMiddleware', () => {
   it('allows DELETE with valid CSRF token', async () => {
     vi.stubEnv('REVEALUI_SECRET', SECRET);
 
-    const token = generateCsrfToken(SESSION_ID, SECRET);
+    const token = generateCsrfToken(SESSION_COOKIE, SECRET);
 
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('session', { id: SESSION_ID });
+      c.set('session', { id: DB_SESSION_ROW_ID });
       await next();
     });
     app.use('*', csrfMiddleware());
@@ -331,7 +368,31 @@ describe('csrfMiddleware', () => {
     const res = await app.request('/test', {
       method: 'DELETE',
       headers: {
-        Cookie: 'revealui-session=sess-123',
+        Cookie: `revealui-session=${SESSION_COOKIE}`,
+        'X-CSRF-Token': token,
+      },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('validates the token against the custom cookie name value when overridden', async () => {
+    vi.stubEnv('REVEALUI_SECRET', SECRET);
+
+    const customCookieValue = 'custom-sess-value-789';
+    const token = generateCsrfToken(customCookieValue, SECRET);
+
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('session', { id: DB_SESSION_ROW_ID });
+      await next();
+    });
+    app.use('*', csrfMiddleware({ cookieName: 'my-session' }));
+    app.post('/test', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        Cookie: `my-session=${customCookieValue}`,
         'X-CSRF-Token': token,
       },
     });

--- a/apps/server/src/middleware/csrf.ts
+++ b/apps/server/src/middleware/csrf.ts
@@ -1,12 +1,20 @@
 /**
  * CSRF protection middleware for Hono.
  *
- * Defense-in-depth on top of sameSite:lax cookies.
- * Generates HMAC-SHA256 tokens bound to session IDs.
+ * Defense-in-depth on top of sameSite:lax cookies, using the signed
+ * double-submit pattern: tokens are HMAC-SHA256 over the SESSION COOKIE
+ * VALUE plus a nonce. The admin app issues the token as the JS-readable
+ * `revealui-csrf` cookie (admin proxy.ts) and attaches it as X-CSRF-Token;
+ * admin's server-side forwarders mint the same shape per request. Validating
+ * against the cookie value (not the DB session row id) is what lets every
+ * REVEALUI_SECRET holder issue without a DB lookup — the browser never
+ * learns anything it didn't already have, because the HMAC is one-way.
  *
  * Skip logic:
  * - Safe methods (GET, HEAD, OPTIONS)
  * - Requests without session cookies (API-key/server-to-server)
+ * - Requests whose cookie did not resolve to an authenticated session
+ *   (auth middleware owns that failure)
  * - Webhook routes (use signature verification)
  * - Cron routes (use X-Cron-Secret)
  */
@@ -35,27 +43,32 @@ const DEFAULT_EXEMPT_PATHS = [
 ];
 
 /**
- * Generate a CSRF token bound to a session ID.
+ * Generate a CSRF token bound to a session binding value — the raw
+ * `revealui-session` cookie value, matching the admin issuer
+ * (apps/admin/src/lib/utils/csrf-token.ts).
  *
  * Format: `<nonce-hex>:<hmac-hex>`
  */
-export function generateCsrfToken(sessionId: string, secret: string): string {
+export function generateCsrfToken(sessionBinding: string, secret: string): string {
   const nonce = randomBytes(16).toString('hex');
-  const hmac = createHmac('sha256', secret).update(`${sessionId}:${nonce}`).digest('hex');
+  const hmac = createHmac('sha256', secret).update(`${sessionBinding}:${nonce}`).digest('hex');
   return `${nonce}:${hmac}`;
 }
 
 /**
- * Validate a CSRF token against a session ID using timing-safe comparison.
+ * Validate a CSRF token against a session binding value using timing-safe
+ * comparison.
  */
-export function validateCsrfToken(token: string, sessionId: string, secret: string): boolean {
+export function validateCsrfToken(token: string, sessionBinding: string, secret: string): boolean {
   const parts = token.split(':');
   if (parts.length !== 2) return false;
 
   const [nonce, providedHmac] = parts;
   if (!(nonce && providedHmac)) return false;
 
-  const expectedHmac = createHmac('sha256', secret).update(`${sessionId}:${nonce}`).digest('hex');
+  const expectedHmac = createHmac('sha256', secret)
+    .update(`${sessionBinding}:${nonce}`)
+    .digest('hex');
 
   try {
     const a = Buffer.from(providedHmac, 'hex');
@@ -99,21 +112,24 @@ export function csrfMiddleware(options?: CsrfMiddlewareOptions): MiddlewareHandl
       return c.json({ error: 'Server configuration error' }, 500);
     }
 
-    // Get session ID from context (set by auth middleware)
+    // Enforce only for authenticated sessions (set by auth middleware)  -
+    // cookie-bearing requests that failed auth get their 401 downstream.
     const session = c.get('session') as { id?: string } | undefined;
-    const sessionId = session?.id;
-    if (!sessionId) {
-      // No authenticated session  -  skip CSRF (auth middleware will handle)
+    if (!session?.id) {
       return next();
     }
 
-    // Read token from header or body
+    // Read token from header
     const token = c.req.header(headerName);
     if (!token) {
       return c.json({ error: 'CSRF token missing' }, 403);
     }
 
-    if (!validateCsrfToken(token, sessionId, secret)) {
+    // Bind to the session COOKIE VALUE  -  the vocabulary every issuer speaks
+    // (admin proxy.ts cookie, admin apiFetch, core APIClient, admin server-side
+    // forwarders). Binding to session.id would require an issuance channel that
+    // knows the DB row id; no browser-reachable issuer for that exists.
+    if (!validateCsrfToken(token, sessionCookie, secret)) {
       return c.json({ error: 'CSRF token invalid' }, 403);
     }
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1227,56 +1227,50 @@ The authentication system uses **cookie-based sessions** with the following CSRF
 - **Protection:** Ensures cookies only sent over HTTPS in production
 - **Location:** All auth API routes
 
-### Why Additional CSRF Tokens Are Not Required
+#### 4. Signed Double-Submit CSRF Tokens
+- **Status:** ✅ Implemented (defense-in-depth on top of `sameSite: 'lax'`)
+- **Token:** `HMAC-SHA256(REVEALUI_SECRET, sessionCookieValue:nonce)`, formatted `nonce:hmac`
+- **Issuance:** the admin proxy (`apps/admin/src/proxy.ts`) sets the token as the
+  JS-readable `revealui-csrf` cookie (`sameSite: 'strict'`) on page and `/api`
+  responses, re-issuing whenever the existing token no longer validates against
+  the current session cookie (e.g. after re-login)
+- **Enforcement:** any `POST`/`PUT`/`PATCH`/`DELETE` carrying a `revealui-session`
+  cookie must send the token as `X-CSRF-Token`, in two validators speaking the
+  same binding:
+  - admin's own routes: `apps/admin/src/proxy.ts` (pre-auth endpoints such as
+    sign-in/sign-up/password-reset are exempt)
+  - the api server: `apps/server/src/middleware/csrf.ts` on `/api/*` (skips safe
+    methods, cookie-less API-key clients, webhooks, and cron routes; enforces
+    only when the cookie resolved to an authenticated session)
+- **Attachment:** browser code goes through `apiFetch`
+  (`apps/admin/src/lib/utils/csrf.ts`), which attaches the header for unsafe
+  requests to the admin's own `/api/*` routes and to the configured api origin;
+  the core admin `APIClient` does the same. Admin server-side forwarders
+  (collections/globals/batch proxy routes) mint a per-request token via
+  `apps/admin/src/lib/utils/api-proxy-headers.ts`.
 
-#### For Read Operations (GET)
-- **No CSRF risk:** GET requests are idempotent and don't modify state
-- **Current protection:** Session validation ensures user is authenticated
+### Why the Token Binds to the Session Cookie Value
 
-#### For Write Operations (POST)
-- **SameSite: 'lax' protection:** Sufficient for most use cases
-- **Origin validation:** Could be added but not critical with SameSite
-- **Double-submit cookie pattern:** Not needed with SameSite
+The HMAC is computed over the raw session cookie value, not the DB session row
+id. Every issuer (admin proxy, server-side forwarders) and both validators hold
+the cookie value at validation time, so no database lookup is needed to issue
+or verify; the HMAC is one-way, so the JS-readable token discloses nothing
+about the `httpOnly` session cookie. A binding only the database knows (such as
+the session row id) would have no browser-reachable issuance channel.
 
-### When CSRF Tokens Would Be Needed
+This requires `REVEALUI_SECRET` parity between the admin and api deployments —
+they already share it for other HMAC duties, and self-hosted kits configure one
+secret for both.
 
-CSRF tokens would be required if:
-1. SameSite cookies are set to `'none'` (not our case)
-2. Supporting legacy browsers without SameSite support (not a priority)
-3. Need to support cross-origin requests (not our use case)
+### What Each Layer Covers
 
-### Current Protection Assessment
-
-**Current CSRF protection is sufficient** for the following reasons:
-
-1. ✅ SameSite: 'lax' provides strong protection
-2. ✅ HttpOnly prevents XSS-based token theft
-3. ✅ Secure flag ensures HTTPS-only in production
-4. ✅ All state-changing operations require authentication
-5. ✅ No cross-origin requirements
-
-### Future Enhancements (Optional)
-
-If additional CSRF protection is needed in the future:
-
-1. **Origin Header Validation**
-   ```typescript
-   const origin = request.headers.get('origin')
-   const expectedOrigin = process.env.NEXT_PUBLIC_SERVER_URL
-   if (origin && origin !== expectedOrigin) {
-     return NextResponse.json({ error: 'Invalid origin' }, { status: 403 })
-   }
-   ```
-
-2. **CSRF Token Pattern**
-   - Generate token on session creation
-   - Store in httpOnly cookie
-   - Require token in request body/header
-   - Validate token matches cookie
-
-3. **Referer Header Validation**
-   - Validate Referer header matches expected domain
-   - Less reliable than Origin (can be spoofed)
+1. `sameSite: 'lax'` blocks foreign-site cookie sends on everything except
+   top-level GET navigations (which are CSRF-safe by the method skip)
+2. The signed double-submit token covers what SameSite cannot: same-site but
+   cross-subdomain attack surfaces, and browsers with degraded SameSite
+   behavior
+3. `httpOnly` keeps the session cookie itself out of script reach
+4. All state-changing operations additionally require an authenticated session
 
 ---
 


### PR DESCRIPTION
## Problem

Found during an internal security verification pass: **every cookie-bearing unsafe request from the admin app to the api server fails CSRF validation** — checkout, upgrade, portal, refunds, license activation, GDPR consent grants, marketplace publish/install, agent create/update/delete, media upload/delete, and the admin collections/globals/batch server-side forwards.

Three compounding causes:

1. **Binding mismatch.** `apps/server/src/middleware/csrf.ts` validated `X-CSRF-Token` against `session.id` (the DB session row UUID). But every issuer in the system — the admin proxy's `revealui-csrf` cookie, `apiFetch`, core `APIClient` — binds tokens to the **raw session cookie value** (signed double-submit). No browser-reachable issuer for the `session.id` binding exists, so no browser request could ever pass the api's gate.
2. **Attach predicate too narrow.** `apiFetch` only attached the header to relative `/api/` URLs. The billing/marketplace/agents surfaces call the api origin with absolute URLs (`NEXT_PUBLIC_API_URL`), so even call sites already routed through the helper sent no token.
3. **Issuance gaps.** The admin proxy minted the token cookie only on same-origin `/api` responses and only when missing — a fresh sign-in followed by a direct cross-origin api call could race issuance, and session rotation left a stale token 403-ing for up to 24h.

## Fix

- **`apps/server/src/middleware/csrf.ts`** — validate against the session cookie value the middleware already extracts. Same signed-double-submit scheme, now speaking the one vocabulary every issuer uses. Skip logic (safe methods, cookie-less API-key clients, exempt webhook/cron paths, unauthenticated sessions) and 403 semantics unchanged.
- **`apps/admin/src/proxy.ts`** — `ensureCsrfCookie()` runs on page responses too, and re-issues whenever the existing token no longer validates against the current session cookie.
- **`apps/admin/src/lib/utils/csrf.ts`** — `apiFetch` attaches to unsafe requests targeting the configured api origin and the page origin (`isCsrfTarget`, `URL`-parsed, no regex). Foreign origins never receive the token.
- **Call-site migration** — raw `fetch` swapped for `apiFetch` at: UpgradeDialog, account/billing (×4), account/license (×2), refunds, upgrade, marketplace publish (×2) + detail (×2), agents new + detail (PUT/DELETE), task-tester, media upload/delete (FormData untouched), Agent stream POST, signup GDPR consent, and the #1341 resend-verification call (a lingering session cookie would otherwise 403 it at the admin proxy).
- **Server-side forwarders** (`app/api/{collections,globals,batch}`) — new `lib/utils/api-proxy-headers.ts` forwards the browser `User-Agent` and mints a per-request token bound to the forwarded session cookie. UA forwarding also keeps the api's stolen-cookie UA binding meaningful for proxied traffic instead of silently skipping it.
- **`docs/AUTH.md`** — the "CSRF tokens are not required" strategy section predated the token middleware entirely; replaced with the implemented design and the rationale for the cookie-value binding.

## Why binding to the cookie value is sound

Signed double-submit (OWASP-endorsed): the token is `HMAC-SHA256(REVEALUI_SECRET, cookieValue:nonce)`. Forging requires the secret; the HMAC is one-way, so the JS-readable token cookie discloses nothing about the `httpOnly` session cookie; `sameSite: 'strict'` on the token cookie plus the header requirement preserves the cross-site protection. Both validators (admin proxy, api middleware) hold the cookie value at validation time, so issuance needs no DB lookup.

Requires `REVEALUI_SECRET` parity between the admin and api deployments — already the case (both deployments read the same secret source), and self-hosted kits configure one secret for both. Nothing could pass the old gate, so mixed-version deploys keep today's failure mode (403) and heal once both sides run this change.

## Tests

- **Red→green at the enforcement point**: the new middleware tests minted tokens the way admin actually issues them — against the original middleware 5 fail (token rejected); with the fix 30/30 pass. A dedicated regression asserts `session.id`-bound tokens are now rejected.
- `apiFetch`/`isCsrfTarget` suite: relative `/api/`, api-origin absolute, page-origin absolute, foreign-origin exclusion, GET skip, no-cookie fall-through, init preservation.
- Proxy-route forward tests: Cookie + User-Agent forwarded, minted token validates against the forwarded session cookie value, no token without a session cookie.
- Full admin + server suites + typecheck + Biome run locally; results in the PR checks.

## Verification still owed

Code-trace + test-level proof only; not yet exercised against a live deployment. After merge to `test`, a logged-in browser smoke (billing page → checkout POST returns a Stripe URL instead of 403) closes the loop.
