### PR TITLE
docs(secrets): name the canonical license-signing keypair paths

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -248,9 +248,11 @@ revealui/env/supabase
 ### RevDev
 
 ```
-revdev/license-signing-key               # when Ed25519 format lands (see license.ts TODO)
-revdev/license-public-key                # paired with signing-key (license verification side, for future format)
+revdev/license-signing-private-key       # Ed25519 license signing key (canonical keypair)
+revdev/license-signing-public-key        # Ed25519 license verification key (canonical keypair)
 revdev/github-token                      # perpetual license GitHub provisioning
+# The retired legacy pair (revdev/license-signing-key + revdev/license-public-key) is
+# superseded by the canonical Ed25519 keypair above.
 ```
 
 ### Licensing (RevealUI)


### PR DESCRIPTION
## Summary

Align `docs/SECRETS.md` with the canonical license-signing keypair naming.

- The RevDev section listed the retired legacy pair (`revdev/license-signing-key` + `revdev/license-public-key`) with a stale "when Ed25519 format lands (see license.ts TODO)" comment.
- The Ed25519 keypair already landed and is canonical; the entries now name the canonical paths `revdev/license-signing-private-key` and `revdev/license-signing-public-key`, with a one-line retirement note for the legacy pair.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
