### PR TITLE
fix(ai): attach csrf double-submit token on useAgentStream posts

### DIFF
--- a/.changeset/ai-useagentstream-csrf-attach.md
+++ b/.changeset/ai-useagentstream-csrf-attach.md
@@ -1,0 +1,5 @@
+---
+'@revealui/ai': minor
+---
+
+`useAgentStream` now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues) as an `X-CSRF-Token` header on both of its POSTs, `start()` and `submitElicitation()`. The API server's CSRF middleware requires that header on any session-cookie-bearing unsafe request, so cookie-authenticated browser consumers of the hook would otherwise 403 once CSRF enforcement is active. Mirrors the cookie-read in `@revealui/core`'s admin APIClient. No API change: when the cookie is absent (API-key / server-to-server callers, non-browser environments) the header is omitted and requests are unchanged.

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -241,6 +241,13 @@ Rate limited: 10 requests/minute. Requires the `ai` feature flag.
 Client-side hook for consuming the SSE stream. Uses `fetch + ReadableStream` (not `EventSource`,
 which does not support POST).
 
+Both of the hook's POSTs (`start()` and `submitElicitation()`) automatically echo the
+JS-readable `revealui-csrf` cookie, the signed double-submit token the RevealUI admin proxy
+issues, as an `X-CSRF-Token` header. The API server's CSRF middleware requires that header on
+any session-cookie-authenticated unsafe request. Callers without a session cookie (API-key or
+server-to-server) are exempt from the check, and the header is omitted when the cookie is
+absent.
+
 ```typescript
 import { useAgentStream } from '@revealui/ai/client'
 

--- a/packages/ai/src/client/hooks/__tests__/useAgentStream.test.ts
+++ b/packages/ai/src/client/hooks/__tests__/useAgentStream.test.ts
@@ -531,3 +531,85 @@ describe('useAgentStream  -  submitElicitation (A.2b)', () => {
     );
   });
 });
+
+// ─── CSRF double-submit attach ────────────────────────────────────────────────
+
+describe('useAgentStream  -  CSRF token attach', () => {
+  const SESSION_ID = '00000000-0000-4000-8000-000000000000';
+
+  afterEach(() => {
+    // jsdom cookies persist across tests in this file  -  expire ours
+    document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('echoes the revealui-csrf cookie as X-CSRF-Token on start()', async () => {
+    document.cookie = 'other-cookie=unrelated';
+    document.cookie = 'revealui-csrf=nonce123:hmac456';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(makeOkResponse(makeSseStream([{ type: 'done' }])));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': 'nonce123:hmac456',
+    });
+  });
+
+  it('echoes the cookie on submitElicitation()', async () => {
+    document.cookie = 'revealui-csrf=tok-elicit';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeOkResponse(makeSseStream([{ type: 'session_info', sessionId: SESSION_ID }])),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+    await waitFor(() => expect(result.current.sessionId).toBe(SESSION_ID));
+
+    await act(async () => {
+      await result.current.submitElicitation('elicit-1', 'cancel');
+    });
+
+    const [, init] = fetchSpy.mock.calls[1];
+    expect(init?.headers).toMatchObject({ 'X-CSRF-Token': 'tok-elicit' });
+  });
+
+  it('omits X-CSRF-Token when the cookie is absent', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(makeOkResponse(makeSseStream([{ type: 'done' }])));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(Object.keys(init?.headers ?? {})).not.toContain('X-CSRF-Token');
+  });
+
+  it('omits X-CSRF-Token when the cookie value is empty', async () => {
+    document.cookie = 'revealui-csrf=';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(makeOkResponse(makeSseStream([{ type: 'done' }])));
+
+    const { result } = renderHook(() => useAgentStream());
+    await act(async () => {
+      await result.current.start({ instruction: 'go' });
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(Object.keys(init?.headers ?? {})).not.toContain('X-CSRF-Token');
+  });
+});

--- a/packages/ai/src/client/hooks/useAgentStream.ts
+++ b/packages/ai/src/client/hooks/useAgentStream.ts
@@ -11,6 +11,13 @@
  *   - pendingElicitations: outstanding form-mode elicitation requests by id (A.2b)
  *   - submitElicitation: POST a response to /api/agent-stream/elicit (A.2b)
  *   - abort(): cancels the stream
+ *
+ * CSRF: both POSTs echo the JS-readable `revealui-csrf` cookie (the signed
+ * double-submit token the RevealUI admin proxy issues) as an `X-CSRF-Token`
+ * header when the cookie is present — the api's csrfMiddleware requires it
+ * on session-cookie-authenticated unsafe requests. Sessionless callers
+ * (API-key / server-to-server) carry no session cookie and are exempt from
+ * the check, so omitting the header when the cookie is absent is correct.
  */
 
 'use client';
@@ -132,6 +139,26 @@ const INITIAL_STATE: UseAgentStreamState = {
   pendingElicitations: [],
 };
 
+/**
+ * Read the JS-readable `revealui-csrf` cookie. The api's csrfMiddleware
+ * (`apps/server/src/middleware/csrf.ts`) requires it as an `X-CSRF-Token`
+ * header on any session-cookie-bearing unsafe request; the admin proxy
+ * issues it on page load. Returns undefined outside the browser or when
+ * the cookie is absent/empty. Mirrors the cookie-read in `@revealui/core`'s
+ * admin APIClient (`request()`).
+ */
+function readCsrfToken(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  for (const part of document.cookie.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
+      return part.slice(eqIdx + 1).trim() || undefined;
+    }
+  }
+  return undefined;
+}
+
 export function useAgentStream(): UseAgentStreamReturn {
   const [state, setState] = useState<UseAgentStreamState>(INITIAL_STATE);
   const controllerRef = useRef<AbortController | null>(null);
@@ -154,9 +181,13 @@ export function useAgentStream(): UseAgentStreamReturn {
     setState({ ...INITIAL_STATE, isStreaming: true });
 
     try {
+      const csrfToken = readCsrfToken();
       const response = await fetch(apiBase, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
         body: JSON.stringify(request),
         credentials: 'include',
         signal: controller.signal,
@@ -234,9 +265,13 @@ export function useAgentStream(): UseAgentStreamReturn {
       const body: Record<string, unknown> = { sessionId, elicitationId, action };
       if (action === 'accept' && content) body.content = content;
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/agent-stream/elicit', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
         body: JSON.stringify(body),
         credentials: 'include',
       });


### PR DESCRIPTION
## Summary

Follow-up to #1349 (flagged there as the `packages/ai` chip). `useAgentStream` in `@revealui/ai` POSTs with `credentials: 'include'` but never attaches `X-CSRF-Token`, so any cookie-authenticated browser consumer of the published hook gets a 403 once the api's `csrfMiddleware` enforces the signed double-submit check on session-bearing unsafe requests.

## Audit

- No live in-repo consumer of the `@revealui/ai` hook: `apps/admin` uses its own boundary-decoupled copies (`src/lib/hooks/useAgentStream.ts` goes through `apiFetch`, and the inline copy in `src/lib/components/Agent/index.tsx` is covered by #1349). The `apps/server/src/routes/agent-stream.ts` reference is a doc comment only.
- The hook is published (FSL) and `docs/AI.md` advertises `import { useAgentStream } from '@revealui/ai/client'` against `/api/agent-stream`, so external cookie-authenticated consumers would hit the 403.

## Changes

- `start()` and `submitElicitation()` echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the admin proxy issues) as an `X-CSRF-Token` header when present, mirroring the cookie-read precedent in core's admin `APIClient.request()`. No new API surface and no regex; when the cookie is absent (API-key / server-to-server / non-browser callers) the request is byte-identical to before and the middleware exempts it.
- Hook JSDoc and `docs/AI.md` document the behavior.
- Changeset: `@revealui/ai` minor (behavior change while 0.x).

## Verification

- `packages/ai` hook suite: 29/29 pass locally, including 4 new CSRF tests (attach on `start()`, attach on `submitElicitation()`, omit when the cookie is absent, omit when the cookie value is empty).
- Biome clean on the changed files; the only diagnostics are the pre-existing warn-level `noDocumentCookie` nursery hints, the same pattern the existing cookie-reads in core/admin carry.
- `@revealui/ai` typecheck clean locally (dep chain built in the worktree first).

Owner-gated manual merge, base `test`. The `packages/sync` mutations csrf attach is the other #1349 follow-up chip and stays separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
