### PR TITLE
test(contracts): use canonical license-signing path in secrets examples

### DIFF
--- a/packages/contracts/src/__tests__/secrets.test.ts
+++ b/packages/contracts/src/__tests__/secrets.test.ts
@@ -36,7 +36,7 @@ describe('Secret Schemas', () => {
     });
 
     it('accepts a 2-segment path', () => {
-      expect(SecretPathSchema.safeParse('revdev/license-signing-key').success).toBe(true);
+      expect(SecretPathSchema.safeParse('revdev/license-signing-private-key').success).toBe(true);
     });
 
     it('accepts a path with a file extension on the final segment', () => {
@@ -98,10 +98,10 @@ describe('Secret Schemas', () => {
     });
 
     it('splits a 2-segment path with empty subsystems', () => {
-      const parsed = parseSecretPath('revdev/license-signing-key');
+      const parsed = parseSecretPath('revdev/license-signing-private-key');
       expect(parsed.project).toBe('revdev');
       expect(parsed.subsystems).toEqual([]);
-      expect(parsed.name).toBe('license-signing-key');
+      expect(parsed.name).toBe('license-signing-private-key');
     });
 
     it('preserves the file extension on the name', () => {

--- a/packages/contracts/src/secrets/index.ts
+++ b/packages/contracts/src/secrets/index.ts
@@ -40,7 +40,7 @@ export const SECRETS_SCHEMA_VERSION = 1;
  * - `revealui/dev/electric/service-url`
  * - `revealui/prod/stripe/secret-key`
  * - `revealui/prod/keys/signing-key.json`
- * - `revdev/license-signing-key`
+ * - `revdev/license-signing-private-key`
  * - `credentials/github/anthropic-api-key`
  */
 export const SecretPathSchema = z


### PR DESCRIPTION
## Summary

Swaps the retired legacy secret-path example string `revdev/license-signing-key` to the canonical Ed25519 private-key path `revdev/license-signing-private-key` in the `@revealui/contracts` secrets surface:

- `packages/contracts/src/secrets/index.ts`: JSDoc example list of valid revvault paths
- `packages/contracts/src/__tests__/secrets.test.ts`: the `SecretPathSchema.safeParse` fixture and the `parseSecretPath` fixture, including the asserted `parsed.name`

Pure example/fixture string swap, no parser, schema, or behavior change. The replacement is still a 2-segment path, so the test descriptions ("accepts a 2-segment path" / "splits a 2-segment path") remain accurate.

Companion to #1350, which aligns `docs/SECRETS.md` to the canonical keypair naming (`revdev/license-signing-private-key` plus `revdev/license-signing-public-key`). With both merged, the legacy name no longer appears as a current example anywhere on `test`. File-disjoint from #1347/#1349/#1350/#1351.

## Testing

- `pnpm --filter @revealui/contracts test`: 33 files, 934 tests passed
- `pnpm --filter @revealui/contracts typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
