### PR TITLE
fix(sync): attach csrf token to admin sync mutation requests

### DIFF
--- a/.changeset/sync-csrf-token-attach.md
+++ b/.changeset/sync-csrf-token-attach.md
@@ -1,0 +1,5 @@
+---
+"@revealui/sync": patch
+---
+
+Attach the `revealui-csrf` double-submit token as an `X-CSRF-Token` header on unsafe-method sync requests — `useSyncMutations` create/update/remove and the `useSharedMemories` reconciliation trigger. The admin proxy rejects cookie-authenticated POST/PATCH/DELETE to `/api/sync/*` without this header, so browser mutations (deleting a conversation or an agent memory in the admin dashboard) failed with 403 "CSRF token missing" once the admin CSRF gate landed. The token is read from the JS-readable cookie in browser contexts only and attached only to same-origin targets, mirroring the admin `apiFetch` / core `APIClient` pattern.

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -71,6 +71,8 @@ function MyComponent() {
 
 Each hook returns `create`, `update`, and `remove` functions. Mutations go through authenticated REST endpoints at `/api/sync/*`. ElectricSQL picks up the database changes and pushes updates to all subscribers automatically.
 
+In browser contexts, mutation requests echo the JS-readable `revealui-csrf` cookie back as an `X-CSRF-Token` header (same-origin targets only), satisfying the admin proxy's signed double-submit CSRF check on unsafe methods.
+
 ```typescript
 import { useAgentContexts } from '@revealui/sync'
 

--- a/packages/sync/src/__tests__/csrf.test.ts
+++ b/packages/sync/src/__tests__/csrf.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { csrfHeaders, getCsrfToken } from '../csrf.js';
+
+function seedCookie(cookie: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to seed cookies in tests
+  document.cookie = cookie;
+}
+
+function expireCookie(name: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to clear cookies in tests
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}
+
+afterEach(() => {
+  // Unstub before touching document — a test may have stubbed it to undefined
+  vi.unstubAllGlobals();
+  expireCookie('revealui-csrf');
+  expireCookie('other');
+  expireCookie('x-revealui-csrf');
+});
+
+describe('getCsrfToken', () => {
+  it('returns null when the cookie is absent', () => {
+    expect(getCsrfToken()).toBeNull();
+  });
+
+  it('reads the token value', () => {
+    seedCookie('revealui-csrf=tok-123');
+    expect(getCsrfToken()).toBe('tok-123');
+  });
+
+  it('finds the token among other cookies', () => {
+    seedCookie('other=1');
+    seedCookie('revealui-csrf=tok-456');
+    expect(getCsrfToken()).toBe('tok-456');
+  });
+
+  it('returns null for an empty value', () => {
+    seedCookie('revealui-csrf=');
+    expect(getCsrfToken()).toBeNull();
+  });
+
+  it('does not match cookie names that merely contain the csrf cookie name', () => {
+    seedCookie('x-revealui-csrf=evil');
+    expect(getCsrfToken()).toBeNull();
+  });
+
+  it('returns null outside a browser context', () => {
+    vi.stubGlobal('document', undefined);
+    expect(getCsrfToken()).toBeNull();
+  });
+});
+
+describe('csrfHeaders', () => {
+  it('returns the header for a relative URL when the cookie is set', () => {
+    seedCookie('revealui-csrf=tok-123');
+    expect(csrfHeaders('/api/sync/items')).toEqual({ 'X-CSRF-Token': 'tok-123' });
+  });
+
+  it('returns the header for an absolute same-origin URL', () => {
+    seedCookie('revealui-csrf=tok-123');
+    expect(csrfHeaders(`${window.location.origin}/api/sync/items`)).toEqual({
+      'X-CSRF-Token': 'tok-123',
+    });
+  });
+
+  it('returns an empty object for a cross-origin URL', () => {
+    seedCookie('revealui-csrf=tok-123');
+    expect(csrfHeaders('https://admin.example.com/api/sync/items')).toEqual({});
+  });
+
+  it('returns an empty object for an unparseable URL', () => {
+    seedCookie('revealui-csrf=tok-123');
+    expect(csrfHeaders('http://')).toEqual({});
+  });
+
+  it('returns an empty object when the cookie is not set', () => {
+    expect(csrfHeaders('/api/sync/items')).toEqual({});
+  });
+
+  it('returns an empty object outside a browser context', () => {
+    vi.stubGlobal('window', undefined);
+    expect(csrfHeaders('/api/sync/items')).toEqual({});
+  });
+});

--- a/packages/sync/src/__tests__/mutations.test.ts
+++ b/packages/sync/src/__tests__/mutations.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MutationResult } from '../mutations.js';
 import { useSyncMutations } from '../mutations.js';
 
@@ -48,6 +48,16 @@ function createErrorResponse(error: string, status: number): Response {
 
 function createNonJsonErrorResponse(status: number): Response {
   return new Response('Internal Server Error', { status });
+}
+
+function setCsrfCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to seed cookies in tests
+  document.cookie = `revealui-csrf=${value}`;
+}
+
+function clearCsrfCookie(): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to clear cookies in tests
+  document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
 }
 
 const sampleRecord: TestRecord = {
@@ -685,6 +695,101 @@ describe('useSyncMutations', () => {
       expect(mutationResult?.success).toBe(false);
       expect(mutationResult?.error).toBe('Bad request');
       expect(mutationResult?.data).toBeUndefined();
+    });
+  });
+
+  // ---- CSRF token attach ----
+
+  describe('CSRF token attach', () => {
+    afterEach(() => {
+      clearCsrfCookie();
+    });
+
+    it('should attach X-CSRF-Token to POST when the csrf cookie is present', async () => {
+      setCsrfCookie('tok-123');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse(sampleRecord));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() =>
+        useSyncMutations<TestCreateInput, TestUpdateInput, TestRecord>('items'),
+      );
+
+      await act(async () => {
+        await result.current.create({ title: 'Test' });
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/sync/items',
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': 'tok-123' },
+        }),
+      );
+    });
+
+    it('should attach X-CSRF-Token to PATCH when the csrf cookie is present', async () => {
+      setCsrfCookie('tok-123');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse(sampleRecord));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() =>
+        useSyncMutations<TestCreateInput, TestUpdateInput, TestRecord>('items'),
+      );
+
+      await act(async () => {
+        await result.current.update('rec-1', { title: 'Updated' });
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/sync/items/rec-1',
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': 'tok-123' },
+        }),
+      );
+    });
+
+    it('should send only the token header for DELETE (no Content-Type, no body)', async () => {
+      setCsrfCookie('tok-123');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse(null));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() =>
+        useSyncMutations<TestCreateInput, TestUpdateInput, TestRecord>('items'),
+      );
+
+      await act(async () => {
+        await result.current.remove('rec-1');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/sync/items/rec-1',
+        expect.objectContaining({
+          headers: { 'X-CSRF-Token': 'tok-123' },
+          body: undefined,
+        }),
+      );
+    });
+
+    it('should not attach the token to a cross-origin proxyBaseUrl', async () => {
+      mockUseElectricConfig.mockReturnValue({
+        serviceUrl: null,
+        proxyBaseUrl: 'https://admin.example.com',
+        debug: false,
+      });
+      setCsrfCookie('tok-123');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse(sampleRecord));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() =>
+        useSyncMutations<TestCreateInput, TestUpdateInput, TestRecord>('items'),
+      );
+
+      await act(async () => {
+        await result.current.create({ title: 'Test' });
+      });
+
+      expect((mockFetch.mock.calls[0][1] as RequestInit).headers).toEqual({
+        'Content-Type': 'application/json',
+      });
     });
   });
 });

--- a/packages/sync/src/csrf.ts
+++ b/packages/sync/src/csrf.ts
@@ -1,0 +1,50 @@
+/**
+ * Signed double-submit CSRF support for the admin sync mutation routes.
+ *
+ * The admin proxy rejects any unsafe-method `/api/*` request that carries a
+ * `revealui-session` cookie without an `X-CSRF-Token` header echoing the
+ * JS-readable `revealui-csrf` cookie. Mirrors the attach pattern used by the
+ * admin `apiFetch` helper and the core admin `APIClient`.
+ */
+
+const CSRF_COOKIE_NAME = 'revealui-csrf';
+const CSRF_HEADER_NAME = 'X-CSRF-Token';
+
+/**
+ * Read the `revealui-csrf` cookie value.
+ * Returns null outside a browser context or when the cookie is absent or empty.
+ */
+export function getCsrfToken(): string | null {
+  if (typeof document === 'undefined') return null;
+  for (const part of document.cookie.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (part.slice(0, eqIdx).trim() === CSRF_COOKIE_NAME) {
+      const value = part.slice(eqIdx + 1).trim();
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * CSRF header for an unsafe-method request to `url`, or an empty object when
+ * none applies. The token is only attached to same-origin targets: the cookie
+ * is scoped to the admin origin, and an absolute `proxyBaseUrl` pointing at a
+ * foreign origin must never receive it. Relative URLs resolve against the page
+ * origin, so they always qualify.
+ */
+export function csrfHeaders(url: string): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  let target: URL;
+  try {
+    target = new URL(url, window.location.origin);
+  } catch {
+    return {};
+  }
+  if (target.origin !== window.location.origin) {
+    return {};
+  }
+  const token = getCsrfToken();
+  return token === null ? {} : { [CSRF_HEADER_NAME]: token };
+}

--- a/packages/sync/src/hooks/__tests__/useSharedMemories.test.tsx
+++ b/packages/sync/src/hooks/__tests__/useSharedMemories.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ElectricProvider } from '../../provider/index.js';
+import { useSharedMemories } from '../useSharedMemories.js';
+
+vi.mock('@electric-sql/react', () => ({
+  useShape: vi.fn(),
+}));
+
+import { useShape } from '@electric-sql/react';
+
+const mockUseShape = useShape as ReturnType<typeof vi.fn>;
+
+function createJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function setCsrfCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to seed cookies in tests
+  document.cookie = `revealui-csrf=${value}`;
+}
+
+function clearCsrfCookie(): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; direct assignment is the only way to clear cookies in tests
+  document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+}
+
+describe('useSharedMemories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearCsrfCookie();
+  });
+
+  describe('triggerReconciliation', () => {
+    it('should POST to the reconcile endpoint with the csrf token when the cookie is present', async () => {
+      setCsrfCookie('tok-789');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse({ status: 'queued' }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() => useSharedMemories('session-1'));
+
+      await act(async () => {
+        await result.current.triggerReconciliation('sess-id', 'site-id');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/sync/reconcile', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': 'tok-789' },
+        body: JSON.stringify({ session_id: 'sess-id', site_id: 'site-id' }),
+      });
+    });
+
+    it('should omit the token for a cross-origin proxyBaseUrl', async () => {
+      setCsrfCookie('tok-789');
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse({ status: 'queued' }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <ElectricProvider proxyBaseUrl="https://admin.example.com">{children}</ElectricProvider>
+      );
+      const { result } = renderHook(() => useSharedMemories('session-1'), { wrapper });
+
+      await act(async () => {
+        await result.current.triggerReconciliation('sess-id', 'site-id');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://admin.example.com/api/sync/reconcile',
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('should omit the token when the cookie is not set', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse({ status: 'queued' }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() => useSharedMemories('session-1'));
+
+      await act(async () => {
+        await result.current.triggerReconciliation('sess-id', 'site-id');
+      });
+
+      expect((mockFetch.mock.calls[0][1] as RequestInit).headers).toEqual({
+        'Content-Type': 'application/json',
+      });
+    });
+
+    it('should return the parsed result on success', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(createJsonResponse({ status: 'queued' }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() => useSharedMemories('session-1'));
+
+      let outcome: unknown;
+      await act(async () => {
+        outcome = await result.current.triggerReconciliation('sess-id', 'site-id');
+      });
+
+      expect(outcome).toEqual({ success: true, data: { status: 'queued' } });
+    });
+
+    it('should return an error result on a failed response', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(createJsonResponse({ error: 'CSRF token missing' }, 403));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { result } = renderHook(() => useSharedMemories('session-1'));
+
+      let outcome: unknown;
+      await act(async () => {
+        outcome = await result.current.triggerReconciliation('sess-id', 'site-id');
+      });
+
+      expect(outcome).toEqual({ success: false, error: 'CSRF token missing' });
+    });
+  });
+});

--- a/packages/sync/src/hooks/useSharedMemories.ts
+++ b/packages/sync/src/hooks/useSharedMemories.ts
@@ -2,6 +2,7 @@
 
 import { useShape } from '@electric-sql/react';
 import { useCallback } from 'react';
+import { csrfHeaders } from '../csrf.js';
 import { fetchWithTimeout } from '../fetch-with-timeout.js';
 import type { MutationResult } from '../mutations.js';
 import { useSyncMutations } from '../mutations.js';
@@ -75,10 +76,11 @@ export function useSharedMemories(sessionScope: string): UseSharedMemoriesResult
 
   const triggerReconciliation = useCallback(
     async (sessionId: string, siteId: string): Promise<MutationResult<unknown>> => {
-      const response = await fetch(`${proxyBaseUrl}/api/sync/reconcile`, {
+      const url = `${proxyBaseUrl}/api/sync/reconcile`;
+      const response = await fetch(url, {
         method: 'POST',
         credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...csrfHeaders(url) },
         body: JSON.stringify({ session_id: sessionId, site_id: siteId }),
       });
 

--- a/packages/sync/src/mutations.ts
+++ b/packages/sync/src/mutations.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
+import { csrfHeaders } from './csrf.js';
 import { useElectricConfig } from './provider/index.js';
 
 /** Default timeout for mutation fetch requests (milliseconds). */
@@ -15,6 +16,8 @@ export interface MutationResult<T = unknown> {
 /**
  * Make an authenticated mutation request to the admin API.
  * Credentials are included so the session cookie is sent cross-origin.
+ * Same-origin requests echo the `revealui-csrf` double-submit cookie as an
+ * `X-CSRF-Token` header — the admin proxy 403s cookie-bearing writes without it.
  * Requests are aborted after {@link MUTATION_FETCH_TIMEOUT_MS} (10 s).
  */
 async function mutationFetch<T>(
@@ -25,13 +28,18 @@ async function mutationFetch<T>(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), MUTATION_FETCH_TIMEOUT_MS);
 
+  const headers: Record<string, string> = csrfHeaders(url);
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
   let response: Response;
   try {
     response = await fetch(url, {
       method,
       credentials: 'include',
       signal: controller.signal,
-      headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
   } finally {


### PR DESCRIPTION
## Problem

`@revealui/sync` mutation requests send the session cookie (`credentials: 'include'`) but no CSRF token. The admin proxy has required an `X-CSRF-Token` header on every cookie-bearing unsafe-method `/api/*` request since #853 (2026-05-13), and `/api/sync/*` is not exempt — so every cookie-authenticated browser write through the package's hooks fails with 403 "CSRF token missing" before reaching the route handler.

Audit trail (traced call sites, same-origin because the admin `Providers` mounts `ElectricProvider` without `proxyBaseUrl`, defaulting to `''`):

- **Live today — `/chat`**: `useConversations().remove` → DELETE `/api/sync/conversations/:id` (delete-conversation button)
- **Live today — agent-memory viewer**: `useAgentMemory().remove` → DELETE `/api/sync/agent-memories/:id`
- Every other exported sync hook (`useSharedMemories`, `useSharedFacts`, `useAgentContexts`, `useConversations`, …) funnels unsafe methods through the same `mutationFetch`, so external consumers of the published package hit the same wall. Reads (GET shape requests) were never affected.

## Fix

New internal `packages/sync/src/csrf.ts` mirroring the admin `apiFetch` / core `APIClient` attach pattern (the #1349 unified design):

- `getCsrfToken()` — reads the JS-readable `revealui-csrf` cookie (split/indexOf parsing, no regex); null outside browser contexts.
- `csrfHeaders(url)` — returns `{ 'X-CSRF-Token': … }` only for same-origin targets, resolved with the `URL` parser. A foreign absolute `proxyBaseUrl` never receives the token (a cross-origin page can't read the cookie anyway, so nothing is lost there).

Wired into both unsafe-method fetch sites in the package:

- `mutationFetch` (POST/PATCH/DELETE behind every `useSyncMutations`-based hook)
- `useSharedMemories().triggerReconciliation` (POST `/api/sync/reconcile`)

DELETE keeps `headers: undefined` when no token is present, so cookie-less call shapes (API-key/server contexts the proxy gate doesn't apply to) are byte-for-byte unchanged.

## Out of scope — recorded findings

- `useCoordinationSessions` / `useCoordinationWorkItems` / `useTaskSubmissions` target `/api/sync/{coordination-sessions,coordination-work-items,task-submissions}`, which have **no admin route handlers** — those mutations 404 independently of CSRF. No admin UI invokes them today (the coordination and marketplace/tasks pages only read).
- `shared-memories` has no `[id]` route, so `update`/`remove` there 404 as well.

## Tests

- New `csrf.test.ts` (12): cookie parsing (absent / empty / multiple cookies / near-name collision), same-origin vs cross-origin vs unparseable URLs, non-browser guards.
- `mutations.test.ts` (+4): token attached on POST/PATCH/DELETE when the cookie is present; never attached to a cross-origin `proxyBaseUrl`; DELETE carries only the token header.
- New `useSharedMemories.test.tsx` (5): reconcile POST carries the token; cross-origin and no-cookie omission; success/error result shapes.
- Package suite: 17 files / 229 tests green locally; `tsc --noEmit` and Biome clean.

Verification honesty: unit-level + code-trace proof. A logged-in admin smoke after merge (delete a conversation on `/chat` without a 403) closes the loop end-to-end.

## Release

Patch changeset for `@revealui/sync` (published package).

Complements #1349 (admin-app call sites + api-server middleware binding) — this PR covers the published sync package those admin pages consume. Owner-gated merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
