### PR TITLE
refactor(server): consolidate duplicate escapeHtml into shared helper

### DIFF
--- a/apps/server/src/lib/__tests__/html.test.ts
+++ b/apps/server/src/lib/__tests__/html.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../html.js';
+
+describe('escapeHtml', () => {
+  it('escapes all five HTML special characters', () => {
+    expect(escapeHtml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&#39;');
+  });
+
+  it('escapes & first so replacement-inserted entities are not double-escaped', () => {
+    expect(escapeHtml('<b>')).toBe('&lt;b&gt;');
+  });
+
+  it('re-escapes already-escaped input (not idempotent, by design)', () => {
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;');
+  });
+
+  it('escapes a script-injection payload', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+    );
+  });
+
+  it('escapes apostrophes as &#39;', () => {
+    expect(escapeHtml("it's")).toBe('it&#39;s');
+  });
+
+  it('leaves forward slashes alone (narrower than @revealui/core escapeHtml)', () => {
+    expect(escapeHtml('</p>')).toBe('&lt;/p&gt;');
+  });
+
+  it('passes through strings without special characters', () => {
+    expect(escapeHtml('Hello World 123')).toBe('Hello World 123');
+    expect(escapeHtml('')).toBe('');
+  });
+});

--- a/apps/server/src/lib/html.ts
+++ b/apps/server/src/lib/html.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared HTML helpers for server-built HTML (email templates, auth pages).
+ */
+
+/**
+ * No-regex HTML escape (per the fleet no-authored-regex rule).
+ *
+ * Replaces the five HTML special characters. `&` must stay first so the
+ * `&` introduced by the later replacements is not itself re-escaped.
+ *
+ * Narrower than `escapeHtml` in `@revealui/core` (renderPage), which also
+ * escapes `/` and emits `&#x27;` for apostrophes — keep them distinct.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/apps/server/src/lib/webhook-emails.ts
+++ b/apps/server/src/lib/webhook-emails.ts
@@ -9,6 +9,7 @@ import { logger } from '@revealui/core/observability/logger';
 import type { Database } from '@revealui/db/client';
 import { appLogs } from '@revealui/db/schema';
 import { sendEmail } from './email.js';
+import { escapeHtml } from './html.js';
 
 const ZERO_DECIMAL_CURRENCIES = new Set([
   'bif',
@@ -46,15 +47,6 @@ function tierLabel(tier: string): string {
   if (tier === 'enterprise') return 'Enterprise';
   if (tier === 'max') return 'Max';
   return 'Pro';
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 }
 
 function adminUrl(): string {

--- a/apps/server/src/routes/contact.ts
+++ b/apps/server/src/routes/contact.ts
@@ -25,6 +25,7 @@ import { zValidator } from '@revealui/openapi';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { sendEmail } from '../lib/email.js';
+import { escapeHtml } from '../lib/html.js';
 
 // Permissive enum — accommodates both marketing and agency form topics
 // without coupling them. The full set is validated downstream by length cap
@@ -43,15 +44,6 @@ const ContactInquirySchema = z.object({
 });
 
 type ContactInquiry = z.infer<typeof ContactInquirySchema>;
-
-function escapeHtml(s: string): string {
-  return s
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
 
 function buildEmailSubject(body: ContactInquiry): string {
   const tag = body.source === 'agency' ? '[agency]' : '[marketing]';

--- a/apps/server/src/routes/studio-auth.ts
+++ b/apps/server/src/routes/studio-auth.ts
@@ -26,16 +26,7 @@ import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { sendEmail } from '../lib/email.js';
-
-/** Escape HTML special characters to prevent XSS in email templates */
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+import { escapeHtml } from '../lib/html.js';
 
 // =============================================================================
 // Configuration

--- a/apps/server/src/routes/waitlist.ts
+++ b/apps/server/src/routes/waitlist.ts
@@ -48,6 +48,7 @@ import { zValidator } from '@revealui/openapi';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { sanitizeEmailHeader, sendEmail } from '../lib/email.js';
+import { escapeHtml } from '../lib/html.js';
 
 // Closed enum keeps the segmentation column clean + queryable. Add a source
 // here when a new capture surface ships — a one-line API change, deliberate
@@ -78,16 +79,6 @@ type WaitlistInput = z.infer<typeof WaitlistSchema>;
 
 // `db` is injected by middleware in some contexts; fall back to getClient().
 type WaitlistVariables = { db?: DatabaseClient };
-
-/** No-regex HTML escape (per the fleet no-authored-regex rule). */
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
 
 interface LeadNotifyContext {
   email: string;


### PR DESCRIPTION
## Summary

Audit-first consolidation of `escapeHtml` in `apps/server`.

The audit found **four** private copies of the same five-entity HTML escape (`&` first, `'` as `&#39;`), not just the two converted in #1340:

| Copy | State before this PR |
|------|----------------------|
| `src/routes/contact.ts` | `replaceAll`-based (#1340) |
| `src/lib/webhook-emails.ts` | `replaceAll`-based (#1340) |
| `src/routes/studio-auth.ts` | still regex-based (missed by #1340) |
| `src/routes/waitlist.ts` | `replaceAll`-based |

All four produce byte-identical output, so they consolidate into one shared helper at `src/lib/html.ts`, and all four call sites now import it. Folding in studio-auth also removes its authored regex (no-regex posture M2).

**Deliberately not reused:** `escapeHtml` exported from `@revealui/core` (`renderPage.ts`) has a different contract, it also escapes `/` (as `&#x2F;`) and emits `&#x27;` for apostrophes. Reusing it would have changed output. `@revealui/utils` has no HTML-escape util (checked).

No behavior change: same five entity replacements, `&` applied first so later-inserted entities are not double-escaped.

## Testing

- New focused unit test `apps/server/src/lib/__tests__/html.test.ts` (7 tests: all five entities, `&`-first ordering, double-escape semantics, injection payload, no `/` escaping)
- `pnpm --filter server exec vitest run src/lib/__tests__/html.test.ts`: 7/7 pass
- `pnpm --filter server typecheck` (`tsc --noEmit`): clean
- Existing webhook route tests through the refactored module (webhook-handler, webhook-payment-action-required, webhook-lifecycle-complete): 84/84 pass
- Biome clean on all six touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
