### PR TITLE
docs: document backflow-app vault paths and CI mirror step

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -287,6 +287,18 @@ credentials/sentry/auth-token           # error tracking (CI + runtime)
 ```
 credentials/github/personal-access-token
 credentials/github/actions-secrets-mirror
+# revfleet-backflow GitHub App (Contents + Pull requests r/w) — authenticates the
+# org-shared backflow-reusable.yml caller at .github/workflows/backflow-main-into-test.yml
+# in every fleet repo. Mirrored into each repo's Actions secrets as BACKFLOW_APP_ID /
+# BACKFLOW_APP_PRIVATE_KEY (publish step — value piped, never echoed or written to disk;
+# the App installation must also include the repo or the caller fails at token mint):
+#   revvault --json get credentials/github/backflow-app/app-id | jq -r .value | gh secret set BACKFLOW_APP_ID -R RevealUIStudio/<repo>
+#   revvault --json get credentials/github/backflow-app/private-key | jq -r .value | gh secret set BACKFLOW_APP_PRIVATE_KEY -R RevealUIStudio/<repo>
+# Rotation: generate a new private key on the App's settings page, revvault set --force
+# both paths, re-mirror to every repo carrying the caller, then delete the old key from
+# the App (multiple keys can be valid simultaneously, so rotation is zero-downtime).
+credentials/github/backflow-app/app-id
+credentials/github/backflow-app/private-key
 credentials/anthropic/api-key
 credentials/ssh/github                   # if distinct from system SSH
 ```


### PR DESCRIPTION
## Summary

Documents the `credentials/github/backflow-app/{app-id,private-key}` vault paths in `docs/SECRETS.md` (Shared / cross-project credentials): what the `revfleet-backflow` GitHub App authenticates (the org-shared `backflow-reusable.yml` caller present in every fleet repo at `.github/workflows/backflow-main-into-test.yml`), the per-repo Actions secrets mirror step (`BACKFLOW_APP_ID` / `BACKFLOW_APP_PRIVATE_KEY`, value piped vault to `gh secret set`, never echoed), and the zero-downtime rotation procedure.

## Why

The secrets rule requires every vault path and its CI mirror step to be indexed here. These paths have been vaulted and mirrored across nine repos since 2026-05-24 but were documented nowhere — surfaced while migrating `agency` + an internal repo to the app-based caller on 2026-06-10.

Docs-only change; no code paths touched.

Manual merge, no auto-merge.
