### PR TITLE
fix(admin): add missing sync mutation routes for published sync hooks

### DIFF
--- a/apps/admin/src/app/api/shapes/coordination-work-items/route.ts
+++ b/apps/admin/src/app/api/shapes/coordination-work-items/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Coordination Work Items Shape Proxy Route
+ *
+ * GET /api/shapes/coordination-work-items
+ *
+ * Authenticated proxy for ElectricSQL coordination_work_items shape.
+ * Admin-scoped: any authenticated user can observe all coordination work
+ * items (this endpoint backs the coordination dashboard, not a per-user view).
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'coordination_work_items');
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying coordination-work-items shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/coordination-work-items',
+      operation: 'coordination_work_items_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/task-submissions/route.ts
+++ b/apps/admin/src/app/api/shapes/task-submissions/route.ts
@@ -16,25 +16,11 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { isUuid } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-
-const UUID_SEGMENTS = [8, 4, 4, 4, 12] as const;
-const HEX_CHARS = new Set('0123456789abcdef');
-
-function isUuid(value: string): boolean {
-  if (value.length !== 36) return false;
-  const parts = value.toLowerCase().split('-');
-  if (parts.length !== UUID_SEGMENTS.length) return false;
-  return UUID_SEGMENTS.every((len, i) => {
-    const part = parts[i];
-    return (
-      part !== undefined && part.length === len && Array.from(part).every((c) => HEX_CHARS.has(c))
-    );
-  });
-}
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {

--- a/apps/admin/src/app/api/sync/coordination-sessions/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/coordination-sessions/[id]/route.ts
@@ -1,0 +1,201 @@
+/**
+ * Coordination Session Sync Mutation Route (by ID)
+ *
+ * PATCH /api/sync/coordination-sessions/:id  -  Update a coordination session
+ * DELETE /api/sync/coordination-sessions/:id  -  Delete a coordination session
+ *
+ * Authenticated. Coordination data is workspace-shared (this surface backs
+ * the agent-activity dashboard), so rows are not scoped to one auth session.
+ * Deleting a session that coordination events or work items still reference
+ * returns 409 (those FKs have no cascade).
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { coordinationSessions } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { eq } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const VALID_SESSION_STATUSES = new Set(['active', 'ended', 'crashed']);
+const PG_FOREIGN_KEY_VIOLATION = '23503';
+
+function hasErrorCode(value: unknown, code: string): boolean {
+  return typeof value === 'object' && value !== null && (value as { code?: unknown }).code === code;
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  if (hasErrorCode(error, PG_FOREIGN_KEY_VIOLATION)) return true;
+  const cause = (error as { cause?: unknown } | null)?.cause;
+  return hasErrorCode(cause, PG_FOREIGN_KEY_VIOLATION);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const body = (await request.json()) as {
+      task?: string;
+      status?: string;
+      ended_at?: string;
+      tools?: Record<string, number>;
+      metadata?: Record<string, unknown>;
+    };
+
+    const updates: Record<string, unknown> = {};
+
+    if (body.task !== undefined) {
+      if (typeof body.task !== 'string' || body.task.trim().length === 0) {
+        return createValidationErrorResponse('task must be a non-empty string', 'task', body.task);
+      }
+      updates.task = body.task;
+    }
+
+    if (body.status !== undefined) {
+      if (!VALID_SESSION_STATUSES.has(body.status)) {
+        return createValidationErrorResponse(
+          `status must be one of: ${[...VALID_SESSION_STATUSES].join(', ')}`,
+          'status',
+          body.status,
+        );
+      }
+      updates.status = body.status;
+    }
+
+    if (body.ended_at !== undefined) {
+      if (typeof body.ended_at !== 'string' || Number.isNaN(Date.parse(body.ended_at))) {
+        return createValidationErrorResponse(
+          'ended_at must be an ISO 8601 date string',
+          'ended_at',
+          body.ended_at,
+        );
+      }
+      updates.endedAt = new Date(body.ended_at);
+    }
+
+    if (body.tools !== undefined) {
+      if (
+        typeof body.tools !== 'object' ||
+        body.tools === null ||
+        Array.isArray(body.tools) ||
+        !Object.values(body.tools).every((value) => typeof value === 'number')
+      ) {
+        return createValidationErrorResponse(
+          'tools must be a record of numbers',
+          'tools',
+          body.tools,
+        );
+      }
+      updates.tools = body.tools;
+    }
+
+    if (body.metadata !== undefined) {
+      if (
+        typeof body.metadata !== 'object' ||
+        body.metadata === null ||
+        Array.isArray(body.metadata)
+      ) {
+        return createValidationErrorResponse(
+          'metadata must be an object',
+          'metadata',
+          body.metadata,
+        );
+      }
+      updates.metadata = body.metadata;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return createValidationErrorResponse('No fields to update', 'body', body);
+    }
+
+    const db = getClient();
+    const [updated] = await db
+      .update(coordinationSessions)
+      .set(updates)
+      .where(eq(coordinationSessions.id, id))
+      .returning();
+
+    if (!updated) {
+      return createApplicationErrorResponse('Session not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error('Error updating coordination session', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-sessions/[id]',
+      operation: 'update_coordination_session',
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const db = getClient();
+    const [deleted] = await db
+      .delete(coordinationSessions)
+      .where(eq(coordinationSessions.id, id))
+      .returning();
+
+    if (!deleted) {
+      return createApplicationErrorResponse('Session not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (isForeignKeyViolation(error)) {
+      return createApplicationErrorResponse(
+        'Session is still referenced by coordination events or work items',
+        'CONFLICT',
+        409,
+      );
+    }
+    logger.error('Error deleting coordination session', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-sessions/[id]',
+      operation: 'delete_coordination_session',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/coordination-sessions/route.ts
+++ b/apps/admin/src/app/api/sync/coordination-sessions/route.ts
@@ -1,0 +1,108 @@
+/**
+ * Coordination Sessions Sync Mutation Route
+ *
+ * POST /api/sync/coordination-sessions  -  Register a coordination session
+ *
+ * Authenticated. Upserts the coordination_agents identity first (session
+ * rows carry a NOT NULL FK to the agent and no other writer exists on this
+ * surface), then inserts the session. coordination_agents.env is NOT NULL
+ * and the hook input has no env field, so an optional metadata.env hint is
+ * honored with an 'unknown' fallback. ElectricSQL fans the change out to
+ * all shape subscribers.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { coordinationAgents, coordinationSessions } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { sql } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      agent_id?: string;
+      task?: string;
+      pid?: number;
+      metadata?: Record<string, unknown>;
+    };
+
+    if (!(body.agent_id && isSyncIdentifier(body.agent_id))) {
+      return createValidationErrorResponse(
+        'agent_id is required and must be alphanumeric with hyphens/underscores',
+        'agent_id',
+        body.agent_id,
+      );
+    }
+
+    if (
+      body.task !== undefined &&
+      (typeof body.task !== 'string' || body.task.trim().length === 0)
+    ) {
+      return createValidationErrorResponse('task must be a non-empty string', 'task', body.task);
+    }
+
+    if (body.pid !== undefined && (!Number.isInteger(body.pid) || body.pid <= 0)) {
+      return createValidationErrorResponse('pid must be a positive integer', 'pid', body.pid);
+    }
+
+    if (
+      body.metadata !== undefined &&
+      (typeof body.metadata !== 'object' || body.metadata === null || Array.isArray(body.metadata))
+    ) {
+      return createValidationErrorResponse('metadata must be an object', 'metadata', body.metadata);
+    }
+
+    const db = getClient();
+    const now = new Date();
+
+    const metadataEnv = body.metadata?.env;
+    const env =
+      typeof metadataEnv === 'string' && metadataEnv.trim().length > 0 ? metadataEnv : 'unknown';
+
+    await db
+      .insert(coordinationAgents)
+      .values({ id: body.agent_id, env, firstSeen: now, lastSeen: now, totalSessions: 1 })
+      .onConflictDoUpdate({
+        target: coordinationAgents.id,
+        set: {
+          lastSeen: now,
+          totalSessions: sql`${coordinationAgents.totalSessions} + 1`,
+        },
+      });
+
+    const values: typeof coordinationSessions.$inferInsert = {
+      id: crypto.randomUUID(),
+      agentId: body.agent_id,
+    };
+    if (body.task !== undefined) values.task = body.task;
+    if (body.pid !== undefined) values.pid = body.pid;
+    if (body.metadata !== undefined) values.metadata = body.metadata;
+
+    const [created] = await db.insert(coordinationSessions).values(values).returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating coordination session', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-sessions',
+      operation: 'create_coordination_session',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/coordination-work-items/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/coordination-work-items/[id]/route.ts
@@ -1,0 +1,196 @@
+/**
+ * Coordination Work Item Sync Mutation Route (by ID)
+ *
+ * PATCH /api/sync/coordination-work-items/:id  -  Update a work item
+ * DELETE /api/sync/coordination-work-items/:id  -  Delete a work item
+ *
+ * Authenticated. Coordination data is workspace-shared (this surface backs
+ * the coordination dashboard), so rows are not scoped to one auth session.
+ * completed_at tracks the status transition  -  the published update input
+ * has no completed_at field, so this route manages it: entering 'done' sets
+ * it, leaving 'done' clears it.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { coordinationWorkItems } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { eq } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const VALID_WORK_ITEM_STATUSES = new Set(['open', 'claimed', 'done', 'cancelled']);
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const body = (await request.json()) as {
+      title?: string;
+      description?: string;
+      status?: string;
+      priority?: number;
+      owner_agent?: string;
+      metadata?: Record<string, unknown>;
+    };
+
+    const updates: Record<string, unknown> = {};
+
+    if (body.title !== undefined) {
+      if (typeof body.title !== 'string' || body.title.trim().length === 0) {
+        return createValidationErrorResponse(
+          'title must be a non-empty string',
+          'title',
+          body.title,
+        );
+      }
+      updates.title = body.title;
+    }
+
+    if (body.description !== undefined) {
+      if (typeof body.description !== 'string') {
+        return createValidationErrorResponse(
+          'description must be a string',
+          'description',
+          body.description,
+        );
+      }
+      updates.description = body.description;
+    }
+
+    if (body.status !== undefined) {
+      if (!VALID_WORK_ITEM_STATUSES.has(body.status)) {
+        return createValidationErrorResponse(
+          `status must be one of: ${[...VALID_WORK_ITEM_STATUSES].join(', ')}`,
+          'status',
+          body.status,
+        );
+      }
+      updates.status = body.status;
+      updates.completedAt = body.status === 'done' ? new Date() : null;
+    }
+
+    if (body.priority !== undefined) {
+      if (!Number.isInteger(body.priority)) {
+        return createValidationErrorResponse(
+          'priority must be an integer',
+          'priority',
+          body.priority,
+        );
+      }
+      updates.priority = body.priority;
+    }
+
+    if (body.owner_agent !== undefined) {
+      if (!isSyncIdentifier(body.owner_agent)) {
+        return createValidationErrorResponse(
+          'owner_agent must be alphanumeric with hyphens/underscores',
+          'owner_agent',
+          body.owner_agent,
+        );
+      }
+      updates.ownerAgent = body.owner_agent;
+    }
+
+    if (body.metadata !== undefined) {
+      if (
+        typeof body.metadata !== 'object' ||
+        body.metadata === null ||
+        Array.isArray(body.metadata)
+      ) {
+        return createValidationErrorResponse(
+          'metadata must be an object',
+          'metadata',
+          body.metadata,
+        );
+      }
+      updates.metadata = body.metadata;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return createValidationErrorResponse('No fields to update', 'body', body);
+    }
+
+    const db = getClient();
+    const [updated] = await db
+      .update(coordinationWorkItems)
+      .set(updates)
+      .where(eq(coordinationWorkItems.id, id))
+      .returning();
+
+    if (!updated) {
+      return createApplicationErrorResponse('Work item not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error('Error updating coordination work item', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-work-items/[id]',
+      operation: 'update_coordination_work_item',
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const db = getClient();
+    const [deleted] = await db
+      .delete(coordinationWorkItems)
+      .where(eq(coordinationWorkItems.id, id))
+      .returning();
+
+    if (!deleted) {
+      return createApplicationErrorResponse('Work item not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('Error deleting coordination work item', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-work-items/[id]',
+      operation: 'delete_coordination_work_item',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/coordination-work-items/route.ts
+++ b/apps/admin/src/app/api/sync/coordination-work-items/route.ts
@@ -1,0 +1,111 @@
+/**
+ * Coordination Work Items Sync Mutation Route
+ *
+ * POST /api/sync/coordination-work-items  -  Create a coordination work item
+ *
+ * Authenticated. Coordination data is workspace-shared (this surface backs
+ * the coordination dashboard). owner_session is intentionally not settable
+ * here  -  it carries an FK to coordination_sessions and is managed by the
+ * session that claims the item. ElectricSQL fans the change out to all
+ * shape subscribers.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { coordinationWorkItems } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      title?: string;
+      description?: string;
+      priority?: number;
+      owner_agent?: string;
+      parent_id?: string;
+      metadata?: Record<string, unknown>;
+    };
+
+    if (!body.title || typeof body.title !== 'string' || body.title.trim().length === 0) {
+      return createValidationErrorResponse('title is required', 'title', body.title);
+    }
+
+    if (body.description !== undefined && typeof body.description !== 'string') {
+      return createValidationErrorResponse(
+        'description must be a string',
+        'description',
+        body.description,
+      );
+    }
+
+    if (body.priority !== undefined && !Number.isInteger(body.priority)) {
+      return createValidationErrorResponse(
+        'priority must be an integer',
+        'priority',
+        body.priority,
+      );
+    }
+
+    if (body.owner_agent !== undefined && !isSyncIdentifier(body.owner_agent)) {
+      return createValidationErrorResponse(
+        'owner_agent must be alphanumeric with hyphens/underscores',
+        'owner_agent',
+        body.owner_agent,
+      );
+    }
+
+    if (body.parent_id !== undefined && !isSyncIdentifier(body.parent_id)) {
+      return createValidationErrorResponse(
+        'parent_id must be alphanumeric with hyphens/underscores',
+        'parent_id',
+        body.parent_id,
+      );
+    }
+
+    if (
+      body.metadata !== undefined &&
+      (typeof body.metadata !== 'object' || body.metadata === null || Array.isArray(body.metadata))
+    ) {
+      return createValidationErrorResponse('metadata must be an object', 'metadata', body.metadata);
+    }
+
+    const db = getClient();
+
+    const values: typeof coordinationWorkItems.$inferInsert = {
+      id: crypto.randomUUID(),
+      title: body.title,
+    };
+    if (body.description !== undefined) values.description = body.description;
+    if (body.priority !== undefined) values.priority = body.priority;
+    if (body.owner_agent !== undefined) values.ownerAgent = body.owner_agent;
+    if (body.parent_id !== undefined) values.parentId = body.parent_id;
+    if (body.metadata !== undefined) values.metadata = body.metadata;
+
+    const [created] = await db.insert(coordinationWorkItems).values(values).returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating coordination work item', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/coordination-work-items',
+      operation: 'create_coordination_work_item',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/shared-memories/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/shared-memories/[id]/route.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared Memory Sync Mutation Route (by ID)
+ *
+ * PATCH /api/sync/shared-memories/:id  -  Update a shared memory
+ * DELETE /api/sync/shared-memories/:id  -  Delete a shared memory
+ *
+ * Authenticated. Operates only on agent_memories rows with scope 'shared'
+ * or 'reconciled'  -  private memories are managed via
+ * /api/sync/agent-memories/:id. ID must be a valid UUID.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { agentMemories } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { and, eq, or } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isUuid } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// Mirrors VALID_MEMORY_TYPES in ../route.ts (route files may only export handlers).
+const VALID_MEMORY_TYPES = new Set([
+  'fact',
+  'preference',
+  'decision',
+  'feedback',
+  'example',
+  'correction',
+  'skill',
+  'warning',
+]);
+
+/** Restricts writes to shared-scope rows so this route cannot touch private memories. */
+function sharedScopeById(id: string) {
+  return and(
+    eq(agentMemories.id, id),
+    or(eq(agentMemories.scope, 'shared'), eq(agentMemories.scope, 'reconciled')),
+  );
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isUuid(id)) {
+      return createValidationErrorResponse('id must be a valid UUID', 'id', id);
+    }
+
+    const body = (await request.json()) as {
+      content?: string;
+      type?: string;
+      metadata?: Record<string, unknown>;
+    };
+
+    const updates: Record<string, unknown> = {};
+
+    if (body.content !== undefined) {
+      if (typeof body.content !== 'string' || body.content.trim().length === 0) {
+        return createValidationErrorResponse(
+          'content must be a non-empty string',
+          'content',
+          body.content,
+        );
+      }
+      updates.content = body.content;
+    }
+
+    if (body.type !== undefined) {
+      if (!VALID_MEMORY_TYPES.has(body.type)) {
+        return createValidationErrorResponse(
+          `type must be one of: ${[...VALID_MEMORY_TYPES].join(', ')}`,
+          'type',
+          body.type,
+        );
+      }
+      updates.type = body.type;
+    }
+
+    if (body.metadata !== undefined) {
+      if (
+        typeof body.metadata !== 'object' ||
+        body.metadata === null ||
+        Array.isArray(body.metadata)
+      ) {
+        return createValidationErrorResponse(
+          'metadata must be an object',
+          'metadata',
+          body.metadata,
+        );
+      }
+      updates.metadata = body.metadata;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return createValidationErrorResponse('No fields to update', 'body', body);
+    }
+
+    const db = getClient();
+    const [updated] = await db
+      .update(agentMemories)
+      .set(updates)
+      .where(sharedScopeById(id))
+      .returning();
+
+    if (!updated) {
+      return createApplicationErrorResponse('Shared memory not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error('Error updating shared memory', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-memories/[id]',
+      operation: 'update_shared_memory',
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isUuid(id)) {
+      return createValidationErrorResponse('id must be a valid UUID', 'id', id);
+    }
+
+    const db = getClient();
+    const [deleted] = await db.delete(agentMemories).where(sharedScopeById(id)).returning();
+
+    if (!deleted) {
+      return createApplicationErrorResponse('Shared memory not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('Error deleting shared memory', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/shared-memories/[id]',
+      operation: 'delete_shared_memory',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/task-submissions/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/task-submissions/[id]/route.ts
@@ -1,0 +1,196 @@
+/**
+ * Task Submission Sync Mutation Route (by ID)
+ *
+ * PATCH /api/sync/task-submissions/:id  -  Update a task submission's status
+ * DELETE /api/sync/task-submissions/:id  -  Delete a task submission
+ *
+ * Authenticated, owner-scoped. Mirrors the revmarket API's cancellation
+ * policy (POST /api/revmarket/tasks/:id/cancel): non-admin users may only
+ * cancel their own pending/queued tasks. Admins may set any valid status.
+ * Deletion is owner-or-admin; non-admins may only delete unbilled tasks
+ * that are not running or completed.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { taskSubmissions } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { eq } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const VALID_TASK_STATUSES = new Set([
+  'pending',
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+const CANCELLABLE_STATUSES = new Set(['pending', 'queued']);
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const body = (await request.json()) as { status?: string };
+
+    if (body.status === undefined) {
+      return createValidationErrorResponse('status is required', 'status', body.status);
+    }
+
+    if (!VALID_TASK_STATUSES.has(body.status)) {
+      return createValidationErrorResponse(
+        `status must be one of: ${[...VALID_TASK_STATUSES].join(', ')}`,
+        'status',
+        body.status,
+      );
+    }
+
+    const db = getClient();
+    const [task] = await db
+      .select({ submitterId: taskSubmissions.submitterId, status: taskSubmissions.status })
+      .from(taskSubmissions)
+      .where(eq(taskSubmissions.id, id))
+      .limit(1);
+
+    if (!task) {
+      return createApplicationErrorResponse('Task not found', 'NOT_FOUND', 404);
+    }
+
+    if (session.user.role !== 'admin') {
+      if (task.submitterId !== session.user.id) {
+        return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+      }
+      if (body.status !== 'cancelled') {
+        return createApplicationErrorResponse(
+          'Only cancellation is allowed for your own tasks',
+          'FORBIDDEN',
+          403,
+        );
+      }
+      if (!CANCELLABLE_STATUSES.has(task.status)) {
+        return createApplicationErrorResponse(
+          `Cannot cancel task in '${task.status}' state`,
+          'VALIDATION_ERROR',
+          400,
+        );
+      }
+    }
+
+    const [updated] = await db
+      .update(taskSubmissions)
+      .set({ status: body.status, updatedAt: new Date() })
+      .where(eq(taskSubmissions.id, id))
+      .returning();
+
+    if (!updated) {
+      return createApplicationErrorResponse('Task not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    logger.error('Error updating task submission', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/task-submissions/[id]',
+      operation: 'update_task_submission',
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const { id } = await params;
+    if (!isSyncIdentifier(id)) {
+      return createValidationErrorResponse(
+        'id must be alphanumeric with hyphens/underscores',
+        'id',
+        id,
+      );
+    }
+
+    const db = getClient();
+    const [task] = await db
+      .select({
+        submitterId: taskSubmissions.submitterId,
+        status: taskSubmissions.status,
+        costUsdc: taskSubmissions.costUsdc,
+      })
+      .from(taskSubmissions)
+      .where(eq(taskSubmissions.id, id))
+      .limit(1);
+
+    if (!task) {
+      return createApplicationErrorResponse('Task not found', 'NOT_FOUND', 404);
+    }
+
+    if (session.user.role !== 'admin') {
+      if (task.submitterId !== session.user.id) {
+        return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+      }
+      if (task.costUsdc !== null) {
+        return createApplicationErrorResponse(
+          'Billed task submissions cannot be deleted',
+          'FORBIDDEN',
+          403,
+        );
+      }
+      if (task.status === 'running' || task.status === 'completed') {
+        return createApplicationErrorResponse(
+          `Cannot delete task in '${task.status}' state`,
+          'VALIDATION_ERROR',
+          400,
+        );
+      }
+    }
+
+    const [deleted] = await db
+      .delete(taskSubmissions)
+      .where(eq(taskSubmissions.id, id))
+      .returning();
+
+    if (!deleted) {
+      return createApplicationErrorResponse('Task not found', 'NOT_FOUND', 404);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('Error deleting task submission', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/task-submissions/[id]',
+      operation: 'delete_task_submission',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/task-submissions/route.ts
+++ b/apps/admin/src/app/api/sync/task-submissions/route.ts
@@ -1,0 +1,88 @@
+/**
+ * Task Submissions Sync Mutation Route
+ *
+ * POST /api/sync/task-submissions  -  Submit an unmatched marketplace task
+ *
+ * Authenticated. Inserts a 'pending' submission owned by the current user.
+ * Agent matching, pricing, and the x402 payment gate live in the server's
+ * revmarket API (POST /api/revmarket/tasks)  -  this surface never assigns
+ * an agent or sets billing fields, so it cannot bypass that gate.
+ */
+
+import crypto from 'node:crypto';
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
+import { taskSubmissions } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body = (await request.json()) as {
+      skill_name?: string;
+      input?: Record<string, unknown>;
+      priority?: number;
+    };
+
+    if (
+      !body.skill_name ||
+      typeof body.skill_name !== 'string' ||
+      body.skill_name.trim().length === 0
+    ) {
+      return createValidationErrorResponse('skill_name is required', 'skill_name', body.skill_name);
+    }
+
+    if (!body.input || typeof body.input !== 'object' || Array.isArray(body.input)) {
+      return createValidationErrorResponse(
+        'input is required and must be an object',
+        'input',
+        body.input,
+      );
+    }
+
+    if (
+      body.priority !== undefined &&
+      (!Number.isInteger(body.priority) || body.priority < 1 || body.priority > 5)
+    ) {
+      return createValidationErrorResponse(
+        'priority must be an integer between 1 and 5',
+        'priority',
+        body.priority,
+      );
+    }
+
+    const db = getClient();
+
+    const values: typeof taskSubmissions.$inferInsert = {
+      id: crypto.randomUUID(),
+      submitterId: session.user.id,
+      skillName: body.skill_name,
+      input: body.input,
+    };
+    if (body.priority !== undefined) values.priority = body.priority;
+
+    const [created] = await db.insert(taskSubmissions).values(values).returning();
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    logger.error('Error creating task submission', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/task-submissions',
+      operation: 'create_task_submission',
+    });
+  }
+}

--- a/apps/admin/src/lib/utils/__tests__/identifier-validation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/identifier-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { isSyncIdentifier, isUuid } from '../identifier-validation';
+
+describe('isUuid', () => {
+  it('accepts lowercase UUIDs', () => {
+    expect(isUuid('0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(true);
+  });
+
+  it('accepts uppercase and mixed-case UUIDs', () => {
+    expect(isUuid('0B9F2A4E-1C3D-4E5F-8A7B-9C0D1E2F3A4B')).toBe(true);
+    expect(isUuid('0b9F2a4E-1c3D-4e5F-8a7B-9c0D1e2F3a4B')).toBe(true);
+  });
+
+  it('rejects wrong lengths', () => {
+    expect(isUuid('')).toBe(false);
+    expect(isUuid('0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4')).toBe(false);
+    expect(isUuid('0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4bc')).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(isUuid('0b9f2a4g-1c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(false);
+    expect(isUuid('zb9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(false);
+  });
+
+  it('rejects misplaced dashes at the correct total length', () => {
+    expect(isUuid('0b9f2a4e1-c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(false);
+    expect(isUuid('0b9f2a4e-1c3d-4e5f-8a7b9-c0d1e2f3a4b')).toBe(false);
+  });
+
+  it('rejects identifiers that are not UUID-shaped at all', () => {
+    expect(isUuid('task_abc123')).toBe(false);
+    expect(isUuid('not-a-uuid')).toBe(false);
+  });
+});
+
+describe('isSyncIdentifier', () => {
+  it('accepts alphanumeric ids with hyphens and underscores', () => {
+    expect(isSyncIdentifier('agent-system')).toBe(true);
+    expect(isSyncIdentifier('task_abc123XYZ')).toBe(true);
+    expect(isSyncIdentifier('0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(true);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isSyncIdentifier('')).toBe(false);
+  });
+
+  it('rejects whitespace and punctuation', () => {
+    expect(isSyncIdentifier('agent system')).toBe(false);
+    expect(isSyncIdentifier('agent/system')).toBe(false);
+    expect(isSyncIdentifier('agent.system')).toBe(false);
+    expect(isSyncIdentifier('agent:system')).toBe(false);
+  });
+
+  it('rejects path traversal and quoting attempts', () => {
+    expect(isSyncIdentifier('../etc/passwd')).toBe(false);
+    expect(isSyncIdentifier("a'; DROP TABLE--")).toBe(false);
+  });
+
+  it('rejects non-ASCII characters', () => {
+    expect(isSyncIdentifier('agént')).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/utils/identifier-validation.ts
+++ b/apps/admin/src/lib/utils/identifier-validation.ts
@@ -1,0 +1,34 @@
+/**
+ * Identifier validation helpers for the sync/shape API routes.
+ *
+ * Character-set predicates (no authored regex, per the no-regex posture).
+ */
+
+const UUID_SEGMENTS = [8, 4, 4, 4, 12] as const;
+const HEX_CHARS = new Set('0123456789abcdef');
+
+/** RFC 4122 textual UUID shape (case-insensitive). */
+export function isUuid(value: string): boolean {
+  if (value.length !== 36) return false;
+  const parts = value.toLowerCase().split('-');
+  if (parts.length !== UUID_SEGMENTS.length) return false;
+  return UUID_SEGMENTS.every((len, i) => {
+    const part = parts[i];
+    return (
+      part !== undefined && part.length === len && Array.from(part).every((c) => HEX_CHARS.has(c))
+    );
+  });
+}
+
+const IDENTIFIER_CHARS = new Set(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-',
+);
+
+/**
+ * Sync identifier: non-empty, alphanumeric plus hyphen/underscore. Covers the
+ * id formats used across sync collections (agent ids, coordination session
+ * and work-item ids, UUIDs, and prefixed ids like the revmarket task ids).
+ */
+export function isSyncIdentifier(value: string): boolean {
+  return value.length > 0 && Array.from(value).every((c) => IDENTIFIER_CHARS.has(c));
+}


### PR DESCRIPTION
## Summary

The published `@revealui/sync` package exports four hooks whose write paths 404'd against the admin app:

| Hook | Collection | What was missing |
|---|---|---|
| `useCoordinationSessions` | `coordination-sessions` | sync route dir (POST + `[id]` PATCH/DELETE) |
| `useCoordinationWorkItems` | `coordination-work-items` | sync route dir AND the `/api/shapes` read proxy |
| `useTaskSubmissions` | `task-submissions` | sync route dir |
| `useSharedMemories` | `shared-memories` | `[id]/route.ts` (update/remove 404'd) |

All four hooks and their input/record types are exported from the package root (`packages/sync/src/index.ts`), so per the orphan-exports convention the default is wire-up, not pruning. This PR adds the 7 missing route files plus the missing shape proxy, mirroring the existing sync route family (auth, validation style, error envelope, Drizzle writes, response shapes).

## Audit (preceded the change)

- Verified all 9 existing `/api/sync/*` and `/api/shapes/*` handlers; the new routes mirror the `agent-contexts` / `shared-facts` / `shared-memories` / coordination-sessions-shape patterns.
- `packages/db` schema confirmed for all three tables: `coordination_sessions` + `coordination_work_items` (`packages/db/src/schema/coordination.ts`), `task_submissions` (`packages/db/src/schema/revmarket.ts`). `useSharedMemories` backs onto `agent_memories` with scope `shared`/`reconciled`.
- `apps/server` has no `/api/sync` surface (admin is the only sync mutation surface), but it owns the full-featured task-submission lifecycle at `/api/revmarket/tasks` (agent matching, pricing, x402). The new sync route is deliberately narrower, see decision 3.
- CSRF: `apps/admin/src/proxy.ts` gates all unsafe methods generically, so the new routes are covered with no allowlist change. Pairs with #1354 (clients attach `X-CSRF-Token`); no file overlap with it.

## Design decisions (flagged for owner review)

1. **coordination-sessions POST upserts `coordination_agents`.** Session rows carry a NOT NULL FK to the agent identity and no writer for that table exists in this repo. `env` comes from an optional `metadata.env` hint with an `'unknown'` fallback (the hook input has no env field).
2. **coordination-sessions DELETE returns 409** when coordination events or work items still reference the session (those FKs have no cascade), instead of surfacing a 500.
3. **task-submissions POST cannot bypass billing.** It only inserts unmatched `'pending'` rows owned by the session user, never assigning an agent, cost, or payment fields. Matched + billed submission stays exclusively on `POST /api/revmarket/tasks`. PATCH mirrors the revmarket cancel policy (non-admin: own pending/queued to `cancelled` only; admin: any valid status). DELETE is owner-or-admin; non-admins only for unbilled tasks not running/completed.
4. **Gate distribution mirrors each collection family.** `shared-memories/[id]` carries `checkAIFeatureGate` (its siblings gate); the coordination and task-submissions routes do not (their shape routes and the revmarket surface do not).
5. **`completed_at` on work items is managed by `[id]` PATCH** (set on `'done'`, cleared when leaving it). The published update input has no `completed_at` field, so the column would otherwise be unreachable from this surface.
6. **No-regex.** New validation uses Set-based predicates (`lib/utils/identifier-validation.ts`); the existing no-regex `isUuid` in the task-submissions shape route was extracted into it. Pre-existing regexes in the older sync routes are left for the no-regex sweep lane.

Observation, no change made: `agent-memories/[id]` and `shared-facts/[id]` PATCH/DELETE do not ownership-scope rows (any authenticated user may modify any row). The new `shared-memories/[id]` mirrors that family behavior; tightening the whole family is a separate owner decision.

## Not in scope

- No `packages/sync` changes (hook contracts already match these routes), so no changeset.
- The sync mutations CSRF attach is #1354.

## Testing

- `pnpm exec biome check` on the changed files: clean (11 files).
- `apps/admin` vitest `src/lib/utils/__tests__/identifier-validation.test.ts`: 11/11 pass.
- `pnpm --filter admin typecheck` (tsc --noEmit): clean.
- No route-handler tests added: none of the 9 existing sync/shape routes have them (parity kept); route behavior rides PR CI and the existing admin suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
