### PR TITLE
feat(scripts): gate CLI template count in claim-drift

### DIFF
--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  CLI_TEMPLATE_CLAIM_PATTERNS,
+  countCliTemplates,
   countDirs,
   countEnforcementTests,
   extractRevealuiPackages,
@@ -150,5 +152,72 @@ describe('findIncompleteProList', () => {
     expect(
       findIncompleteProList('@revealui/ai and @revealui/harnesses are used here', fsl, mit),
     ).toBeNull();
+  });
+});
+
+describe('countCliTemplates', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-drift-tpl-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('counts template directories that ship a package.json', () => {
+    for (const name of ['basic-blog', 'starter']) {
+      fs.mkdirSync(path.join(tmp, name));
+      fs.writeFileSync(path.join(tmp, name, 'package.json'), '{}');
+    }
+    // A bare directory is not a scaffoldable template
+    fs.mkdirSync(path.join(tmp, 'shared-assets'));
+    expect(countCliTemplates(tmp)).toBe(2);
+  });
+
+  it('returns 0 when the templates directory is missing', () => {
+    expect(countCliTemplates(path.join(tmp, 'does-not-exist'))).toBe(0);
+  });
+});
+
+describe('CLI template claim patterns', () => {
+  /**
+   * Mirrors scanForClaims semantics: first matching pattern on a line wins
+   * and capture group 1 carries the claimed count. null = no pattern matched.
+   */
+  function claimedCount(line: string): number | null {
+    for (const pattern of CLI_TEMPLATE_CLAIM_PATTERNS) {
+      const match = pattern.exec(line);
+      if (match) return Number.parseInt(match[1], 10);
+    }
+    return null;
+  }
+
+  it('matches "ships N templates" prose', () => {
+    expect(claimedCount('`@revealui/cli` ships 5 templates (`basic-blog`, `e-commerce`)')).toBe(5);
+  });
+
+  it('captures the template count, not the repo count, in the ROADMAP launch bullet', () => {
+    expect(
+      claimedCount(
+        '- **5 CLI templates** (basic-blog, e-commerce, portfolio, starter, starter-native)  -  4 published as standalone template repos',
+      ),
+    ).toBe(5);
+  });
+
+  it('does not match the standalone-template-repo phrasing (GitHub fact, not a filesystem count)', () => {
+    expect(claimedCount('4 published as standalone template repos')).toBeNull();
+    expect(claimedCount('4 standalone template repos')).toBeNull();
+    expect(claimedCount('4 template repos under the RevealUIStudio org')).toBeNull();
+  });
+
+  it('does not match "N templates repos" thanks to the repos lookahead', () => {
+    expect(claimedCount('4 templates repos')).toBeNull();
+    expect(claimedCount('4 templates repo mirrors')).toBeNull();
+  });
+
+  it('does not match singular "template" phrasing', () => {
+    expect(claimedCount('1 template directory was added')).toBeNull();
   });
 });

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -153,6 +153,40 @@ function countDbTables(): number {
 }
 
 // ---------------------------------------------------------------------------
+// CLI-template collector + claim patterns (added 2026-06-11)
+//
+// PR #1358 hand-corrected "4 templates" -> 5 in docs/ROADMAP.md; nothing
+// gated that drift class, so the next template addition would silently
+// re-drift the docs. countCliTemplates counts template directories under
+// packages/cli/templates/ (each ships a package.json — the scaffold copies a
+// complete project — so the package.json-gated countDirs applies directly).
+//
+// The claim patterns deliberately do NOT match "N template repos" /
+// "N standalone template repos": docs/ROADMAP.md legitimately pairs the
+// template count with "4 published as standalone template repos", a GitHub
+// fact (the revealui-template-* repos; starter-native has none) that cannot
+// be derived from this filesystem. Plural-only `templates` plus a repos
+// lookahead keeps that phrasing out of this hard-fail gate.
+//
+// REGEX-CONFIG-BOUNDARY — claim patterns only (pre-existing convention in
+// this file; AST refactor queued under GAP-192); the collector authors no
+// regex. Both exports are unit-tested in __tests__/claim-drift.test.ts.
+// ---------------------------------------------------------------------------
+
+/** Path-injectable + exported for tests. */
+export function countCliTemplates(
+  base: string = path.join(ROOT, 'packages/cli/templates'),
+): number {
+  return countDirs(base);
+}
+
+export const CLI_TEMPLATE_CLAIM_PATTERNS: RegExp[] = [
+  // "5 templates" / "5 CLI templates" — not "4 template repos" (singular
+  // never matches) and not "4 templates repos" (repos lookahead)
+  /\b(\d+)\s+(?:CLI\s+)?templates\b(?!\s+repos?\b)/i,
+];
+
+// ---------------------------------------------------------------------------
 // Enforcement-test collector
 //
 // The access-control story is quoted fleet-wide as "N enforcement tests": the
@@ -1428,6 +1462,7 @@ function run(): void {
   const uiComponents = countUIComponents();
   const mcpServers = countMCPServers();
   const dbTables = countDbTables();
+  const cliTemplates = countCliTemplates();
   const enforcementTests = countEnforcementTests();
   const licenseSplit = countLicenseSplit();
 
@@ -1439,6 +1474,7 @@ function run(): void {
   console.log(`  UI components: ${uiComponents}`);
   console.log(`  MCP servers:   ${mcpServers}`);
   console.log(`  DB tables:     ${dbTables}`);
+  console.log(`  CLI templates: ${cliTemplates}`);
   console.log(`  Enforcement:   ${enforcementTests}`);
   console.log(
     `  License split: ${licenseSplit.mit} MIT | ${licenseSplit.fsl} FSL-1.1-MIT | ${licenseSplit.internal} internal/none`,
@@ -1493,6 +1529,14 @@ function run(): void {
         // "Schema (85 tables)" parenthetical
         /\(\s*([1-9]\d{1,2})\s+tables?\s*\)/i,
       ],
+    },
+    {
+      name: 'CLI templates',
+      actual: cliTemplates,
+      // Patterns defined module-level (CLI_TEMPLATE_CLAIM_PATTERNS, exported
+      // for unit tests); see their definition for the "N template repos"
+      // non-match rationale.
+      claimPatterns: CLI_TEMPLATE_CLAIM_PATTERNS,
     },
     {
       name: 'enforcement tests',


### PR DESCRIPTION
## Summary

Follow-up to #1358, which hand-corrected the docs/ROADMAP.md "4 templates" claim to 5. Nothing gated that drift class: the next template addition would silently re-drift the docs. This PR adds the missing claim-drift metric.

- `countCliTemplates()`: package.json-gated `countDirs` over `packages/cli/templates/` (currently 5: basic-blog, e-commerce, portfolio, starter, starter-native); path-injectable and exported for tests
- New `CLI templates` metric scanning docs for "N templates" / "N CLI templates" claims (REGEX-CONFIG-BOUNDARY per the file's pre-existing convention; AST refactor stays queued under GAP-192)
- The claim pattern deliberately does NOT match "N template repos" / "N standalone template repos". ROADMAP line 62 legitimately pairs the template count with "4 published as standalone template repos" - that figure is a GitHub fact (4 revealui-template-* repos exist; starter-native has none) and cannot be derived from the filesystem, so matching it would false-positive this hard-fail gate. Plural-only `templates` plus a repos lookahead keep that phrasing out.
- 7 new unit tests in `scripts/validate/__tests__/claim-drift.test.ts`: match shapes ("ships 5 templates"), the real ROADMAP launch bullet capturing 5 (not the trailing 4), repo-phrasing non-matches, and collector tmpdir cases.

## Testing

- `pnpm biome check` clean on both files
- `pnpm tsx scripts/validate/claim-drift.ts` green against real docs: `CLI templates: 5`, 87 claims scanned, 0 mismatches
- `pnpm vitest run scripts/validate/__tests__/claim-drift.test.ts` 21/21
- `pnpm gate:quick` PASS (claim-drift hard-fail check included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
