### PR TITLE
fix(cli): make the starter template selectable

### DIFF
--- a/.changeset/cli-starter-template-selectable.md
+++ b/.changeset/cli-starter-template-selectable.md
@@ -1,0 +1,5 @@
+---
+"@revealui/cli": patch
+---
+
+The `starter` template ships in the npm tarball and scaffolds correctly, but it was missing from the template type union, the `--template` flag validation, and the interactive picker, so `--template starter` silently fell back to the prompt (or to `basic-blog` with `--yes`). It is now selectable everywhere, the `--template` help text and docs enumerate all five templates, and a registry test pins the selectable list to the shipped `templates/` directories so the two can no longer drift.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4065,6 +4065,8 @@ The CLI walks through five configuration steps:
 | `basic-blog` | Blog with posts, pages, media, and REST API                  | Free |
 | `e-commerce` | Store with products, Stripe checkout, and license management | Free |
 | `portfolio`  | Portfolio site with projects and contact form                | Free |
+| `starter`    | Blank-canvas Next.js app  -  no sample collections           | Free |
+| `starter-native` | Vite + @revealui/router runtime  -  no Next.js dependency | Free |
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,10 +25,10 @@ pnpm create revealui@latest my-project --template basic-blog
 ## Features
 
 - Interactive project setup with guided prompts
-- Multiple templates: basic-blog, e-commerce, portfolio, starter-native (Vite + @revealui/router, no Next.js)
+- Multiple templates: basic-blog, e-commerce, portfolio, starter, starter-native (Vite + @revealui/router, no Next.js)
 - Automatic environment configuration
 - Database setup (NeonDB, Supabase, or local PostgreSQL)
-- Storage setup (Vercel Blob or Supabase)
+- Storage setup (Cloudflare R2, or legacy Vercel Blob)
 - Payment setup (Stripe)
 - Dev Container and Devbox configuration
 - Git initialization with initial commit
@@ -39,7 +39,7 @@ pnpm create revealui@latest my-project --template basic-blog
 Usage: create-revealui [options] [project-name]
 
 Options:
-  -t, --template <name>   Template to use (basic-blog, e-commerce, portfolio, starter-native)
+  -t, --template <name>   Template to use (basic-blog, e-commerce, portfolio, starter, starter-native)
   --skip-git              Skip git initialization
   --skip-install          Skip dependency installation
   -h, --help             Display help for command
@@ -52,6 +52,7 @@ Options:
 | `basic-blog` | Next.js 16 + @revealui/* | Blogs, content sites — Next.js ecosystem |
 | `e-commerce` | Next.js 16 + @revealui/* + Stripe | Online stores with checkout |
 | `portfolio` | Next.js 16 + @revealui/* | Personal portfolio sites |
+| `starter` | Next.js 16 + @revealui/* | Blank-canvas starting point — no sample collections |
 | `starter-native` | Vite + @revealui/router + @revealui/* | RevealUI-native runtime — no Next.js dep. Best when you want to dogfood the full RevealUI stack. |
 
 ## Requirements
@@ -108,7 +109,7 @@ pnpm dev
 ## Design Principles
 
 - **Justifiable**: Every prompt earns its place  -  template, database, storage, and payment choices all map to real config decisions
-- **Adaptive**: Multiple templates (blog, e-commerce, portfolio) and environment options (DevContainer, Devbox) adapt to your workflow
+- **Adaptive**: Multiple templates (blog, e-commerce, portfolio, starter, starter-native) and environment options (DevContainer, Devbox) adapt to your workflow
 - **Sovereign**: Scaffolds a self-contained project you fully own  -  no hosted dependency or account required
 
 ## License

--- a/packages/cli/src/__tests__/create.test.ts
+++ b/packages/cli/src/__tests__/create.test.ts
@@ -16,7 +16,7 @@ const minimalConfig = {
   project: {
     projectName: 'test-scaffold',
     projectPath: '', // set per-test
-    template: 'basic-blog' as const,
+    template: 'starter' as const,
   },
   database: { provider: 'skip' as const },
   storage: { provider: 'skip' as const },

--- a/packages/cli/src/__tests__/template-structure.test.ts
+++ b/packages/cli/src/__tests__/template-structure.test.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createProject } from '../commands/create.js';
+import { type ProjectConfig, VALID_TEMPLATES } from '../prompts/project.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
@@ -25,10 +26,7 @@ const TSC_BIN = path.resolve(__dirname, '../../../node_modules/.bin/tsc');
 // Shared scaffolding helper
 // ---------------------------------------------------------------------------
 
-function baseConfig(
-  template: 'basic-blog' | 'e-commerce' | 'portfolio' | 'starter-native',
-  projectPath: string,
-) {
+function baseConfig(template: ProjectConfig['template'], projectPath: string) {
   return {
     project: {
       projectName: `test-${template}`,
@@ -49,7 +47,7 @@ function baseConfig(
 // ---------------------------------------------------------------------------
 
 describe('Template file structure  -  shared (all templates)', () => {
-  const templates = ['basic-blog', 'e-commerce', 'portfolio'] as const;
+  const templates = ['basic-blog', 'e-commerce', 'portfolio', 'starter'] as const;
 
   let tmpDir: string;
 
@@ -144,7 +142,7 @@ describe('Template file structure  -  variant-specific content', () => {
 // ---------------------------------------------------------------------------
 
 describe('package.json integrity after scaffolding', () => {
-  const templates = ['basic-blog', 'e-commerce', 'portfolio'] as const;
+  const templates = ['basic-blog', 'e-commerce', 'portfolio', 'starter'] as const;
 
   let tmpDir: string;
 
@@ -192,6 +190,21 @@ describe('package.json integrity after scaffolding', () => {
       expect(pkg.dependencies?.['@revealui/core']).toMatch(/^(latest|\^?\d+\.\d+)/);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Template registry  -  the selectable list must match shipped directories
+// ---------------------------------------------------------------------------
+
+describe('Template registry', () => {
+  it('VALID_TEMPLATES matches the template directories shipped in the tarball', async () => {
+    const entries = await fs.readdir(TEMPLATES_DIR, { withFileTypes: true });
+    const shipped = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+    expect([...VALID_TEMPLATES].sort()).toEqual(shipped);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -61,7 +61,10 @@ function configureCreateCommand(command: Command): Command {
   command
     .description('Create a new RevealUI project')
     .argument('[project-name]', 'Name of the project')
-    .option('-t, --template <name>', 'Template to use (basic-blog, e-commerce, portfolio)')
+    .option(
+      '-t, --template <name>',
+      'Template to use (basic-blog, e-commerce, portfolio, starter, starter-native)',
+    )
     .option('--skip-git', 'Skip git initialization', false)
     .option('--skip-install', 'Skip dependency installation', false)
     .option('-y, --yes', 'Skip all prompts and use defaults', false)

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -99,8 +99,10 @@ async function copyDir(src: string, dest: string): Promise<void> {
 
 /**
  * Map the CLI template name to the directory name under templates/.
- * All non-starter templates fall back to starter for now.
+ * Every selectable template maps 1:1 to its directory; the `?? 'starter'`
+ * fallback is defensive for untyped JS callers only.
  *
+ * `starter` is the blank-canvas Next.js scaffold (no sample collections).
  * `starter-native` is the RevealUI-native variant (Vite + @revealui/router +
  * no Next.js) — see GAP-194 audit §1.B for the rationale. Customers choose
  * `starter-native` when they want the framework-not-stack runtime instead of
@@ -111,6 +113,7 @@ function resolveTemplateName(template: ProjectConfig['template']): string {
     'basic-blog': 'basic-blog',
     'e-commerce': 'e-commerce',
     portfolio: 'portfolio',
+    starter: 'starter',
     'starter-native': 'starter-native',
   };
   return map[template] ?? 'starter';

--- a/packages/cli/src/prompts/__tests__/prompts.test.ts
+++ b/packages/cli/src/prompts/__tests__/prompts.test.ts
@@ -148,6 +148,18 @@ describe('promptProjectConfig', () => {
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
+  it('accepts starter as templateArg (regression: starter was missing from VALID_TEMPLATES)', async () => {
+    const result = await promptProjectConfig('my-project', 'starter');
+    expect(result.template).toBe('starter');
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('accepts starter-native as templateArg', async () => {
+    const result = await promptProjectConfig('my-project', 'starter-native');
+    expect(result.template).toBe('starter-native');
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
   it('prompts for template when templateArg is invalid', async () => {
     mockSelect.mockResolvedValueOnce('basic-blog');
     const result = await promptProjectConfig('my-project', 'invalid-template');

--- a/packages/cli/src/prompts/project.ts
+++ b/packages/cli/src/prompts/project.ts
@@ -6,13 +6,29 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { isCancel, select, text } from '@clack/prompts';
 
+export const VALID_TEMPLATES = [
+  'basic-blog',
+  'e-commerce',
+  'portfolio',
+  'starter',
+  'starter-native',
+] as const;
+
+export type ProjectTemplate = (typeof VALID_TEMPLATES)[number];
+
 export interface ProjectConfig {
   projectName: string;
   projectPath: string;
-  template: 'basic-blog' | 'e-commerce' | 'portfolio' | 'starter-native';
+  template: ProjectTemplate;
 }
 
-const VALID_TEMPLATES = ['basic-blog', 'e-commerce', 'portfolio', 'starter-native'] as const;
+const TEMPLATE_LABELS: Record<ProjectTemplate, string> = {
+  'basic-blog': 'Basic Blog - A simple blog with posts and pages',
+  'e-commerce': 'E-commerce - Product catalog with checkout',
+  portfolio: 'Portfolio - Personal portfolio site',
+  starter: 'Starter - Blank-canvas Next.js app, no sample collections',
+  'starter-native': 'Starter (native) - Vite + @revealui/router, no Next.js',
+};
 
 export async function promptProjectConfig(
   defaultName?: string,
@@ -65,15 +81,7 @@ export async function promptProjectConfig(
   } else {
     const selected = await select({
       message: 'Which template would you like to use?',
-      options: [
-        { value: 'basic-blog' as const, label: 'Basic Blog - A simple blog with posts and pages' },
-        { value: 'e-commerce' as const, label: 'E-commerce - Product catalog with checkout' },
-        { value: 'portfolio' as const, label: 'Portfolio - Personal portfolio site' },
-        {
-          value: 'starter-native' as const,
-          label: 'Starter (native) - Vite + @revealui/router, no Next.js',
-        },
-      ],
+      options: VALID_TEMPLATES.map((value) => ({ value, label: TEMPLATE_LABELS[value] })),
       initialValue: 'basic-blog' as const,
     });
 


### PR DESCRIPTION
## Summary

Audit-first determination: the `starter` template's absence from CLI selection is an accidental never-wired omission, not a deprecation.

- `starter` (renamed from `minimal` in 12e5b7e5f) ships in the npm tarball (`files: ["bin","dist","templates"]`) and scaffolds correctly, but the original prompts module was authored against the three named templates only, with `minimal`/`starter` as the `resolveTemplateName` fallback. #898 then added `starter-native` to the union and picker without promoting `starter`.
- Result: `--template starter` silently fell through to the interactive prompt, or to `basic-blog` under `--yes`.
- No deprecation signal exists anywhere: `docs/ROADMAP.md` claims 5 CLI templates (post-#1358), #535 lists all five as shipped, the template is actively maintained (#1117, #1235, #1342 all touched it), and `commands/create.ts` positions `starter-native` as an alternative to the Next.js starters, not a replacement.

## Changes

- `packages/cli/src/prompts/project.ts`: single source of truth. The exported `VALID_TEMPLATES` list (now including `starter`) derives the `ProjectTemplate` union and the picker options via a `Record<ProjectTemplate, string>` label map, so a missing entry is a compile error.
- `packages/cli/src/commands/create.ts`: `starter` maps 1:1 in `resolveTemplateName` (the `Record` over the union compile-forces it); docblock updated.
- `packages/cli/src/cli.ts`: `--template` help text enumerates all five templates (it listed only the original three).
- `packages/cli/README.md`: template enumerations and the table gain `starter`; the storage feature line now matches the actual prompts (Cloudflare R2, legacy Vercel Blob).
- `docs/REFERENCE.md`: the Templates table predated both starters; added `starter` and `starter-native` rows.
- Tests:
  - `starter` joins the shared structure and package.json integrity suites in `template-structure.test.ts`; the helper's config union now imports `ProjectConfig` instead of re-declaring it.
  - New Template registry test pins `VALID_TEMPLATES` to the directories shipped in `templates/`, so the drift class that caused this bug now fails tests.
  - `create.test.ts` scaffolds `starter` again. Its first test was titled "copies starter template files" but the shared config scaffolded `basic-blog`, evidently switched when `'starter'` stopped typechecking.
  - `prompts.test.ts` regression tests: `starter` and `starter-native` accepted as `--template` args without prompting.
- Changeset: `@revealui/cli` patch.

`docs/ROADMAP.md`'s "5 CLI templates (basic-blog, e-commerce, portfolio, starter, starter-native)" claim is untouched and is now true of CLI behavior, not just the tarball.

Refs #535 (section A, template improvements).

## Test plan

- `pnpm --filter @revealui/cli test`: 20 files / 212 tests green (includes the new starter scaffold, registry, and prompt-regression cases)
- `pnpm --filter @revealui/cli typecheck` and `build`: clean
- `pnpm gate:quick`: PASS (claim-drift hard-fail included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
