### PR TITLE
fix(scripts): skip gitignored artifact dirs in claim-drift walkers

### DIFF
--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,8 +8,10 @@ import {
   countCliTemplates,
   countDirs,
   countEnforcementTests,
+  countTestFiles,
   extractRevealuiPackages,
   findIncompleteProList,
+  WALK_EXCLUDED_DIRS,
 } from '../claim-drift.ts';
 
 describe('countDirs', () => {
@@ -219,5 +222,77 @@ describe('CLI template claim patterns', () => {
 
   it('does not match singular "template" phrasing', () => {
     expect(claimedCount('1 template directory was added')).toBeNull();
+  });
+});
+
+describe('countTestFiles', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-drift-walk-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('counts test-suffixed files outside excluded directories', () => {
+    fs.mkdirSync(path.join(tmp, 'packages', 'core', 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'packages', 'core', 'src', 'a.test.ts'), '');
+    fs.writeFileSync(path.join(tmp, 'packages', 'core', 'src', 'b.spec.tsx'), '');
+    fs.writeFileSync(path.join(tmp, 'packages', 'core', 'src', 'helper.ts'), '');
+    expect(countTestFiles(tmp)).toBe(2);
+  });
+
+  it('skips gitignored artifact dirs at any depth (2026-06-11 stale-opensrc incident)', () => {
+    fs.mkdirSync(path.join(tmp, 'src'));
+    fs.writeFileSync(path.join(tmp, 'src', 'real.test.ts'), '');
+    // Incident shape: a stale opensrc/ cache of fetched third-party sources
+    const opensrc = path.join(tmp, 'opensrc', 'repos', 'github.com', 'colinhacks', 'zod', 'src');
+    fs.mkdirSync(opensrc, { recursive: true });
+    fs.writeFileSync(path.join(opensrc, 'fake.test.ts'), '');
+    // Every excluded name, nested under an app dir to prove depth-independence
+    for (const dir of WALK_EXCLUDED_DIRS) {
+      const nested = path.join(tmp, 'apps', 'web', dir);
+      fs.mkdirSync(nested, { recursive: true });
+      fs.writeFileSync(path.join(nested, 'phantom.test.ts'), '');
+    }
+    expect(countTestFiles(tmp)).toBe(1);
+  });
+});
+
+describe('WALK_EXCLUDED_DIRS', () => {
+  const repoRoot = path.resolve(import.meta.dirname, '../../..');
+
+  it('every entry except .git has a covering .gitignore line', () => {
+    const gitignore = fs.readFileSync(path.join(repoRoot, '.gitignore'), 'utf8');
+    const covered = new Set<string>();
+    for (const raw of gitignore.split('\n')) {
+      const line = raw.trim();
+      if (line.length === 0 || line.startsWith('#') || line.startsWith('!')) continue;
+      let name = line;
+      if (name.startsWith('**/')) name = name.slice('**/'.length);
+      if (name.endsWith('/')) name = name.slice(0, -1);
+      covered.add(name);
+    }
+    for (const dir of WALK_EXCLUDED_DIRS) {
+      if (dir === '.git') continue;
+      expect(covered.has(dir), `"${dir}" is walker-excluded but not gitignored`).toBe(true);
+    }
+  });
+
+  it('no entry shadows git-tracked files (e.g. screenshots/ must stay walkable)', () => {
+    const tracked = execFileSync('git', ['ls-files'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const shadowed = new Set<string>();
+    for (const file of tracked.split('\n')) {
+      for (const segment of file.split('/')) {
+        if (WALK_EXCLUDED_DIRS.has(segment)) shadowed.add(file);
+      }
+    }
+    expect([...shadowed]).toEqual([]);
   });
 });

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -26,6 +26,50 @@ const ROOT = path.resolve(import.meta.dirname, '../..');
 const showFix = process.argv.includes('--fix');
 
 // ---------------------------------------------------------------------------
+// Walker exclusions
+//
+// Directory names the filesystem walkers below must never enter. The walkers
+// do not consult .gitignore, so every gitignored artifact directory that can
+// hold walker-matchable files (.ts/.tsx/.md/.txt/.json/.sh) must be listed
+// here — otherwise stale local artifacts make local counts diverge from the
+// clean checkout CI sees. Incident 2026-06-11: a stale opensrc/ cache held 53
+// third-party *.test.ts files, inflating countTestFiles() from 961 to 1014 —
+// past the ±100 testFiles tolerance — so the local gate hard-failed while CI
+// stayed green.
+//
+// Names match a single directory entry at any depth. Keep entries in sync
+// with .gitignore: the unit tests assert every entry except .git has a
+// covering .gitignore line AND that no entry shadows git-tracked files
+// (e.g. screenshots/ is gitignored yet apps/marketing/public/screenshots is
+// tracked, so it must NOT be listed here).
+// ---------------------------------------------------------------------------
+
+/** Exported for tests. */
+export const WALK_EXCLUDED_DIRS: ReadonlySet<string> = new Set([
+  '.git',
+  '.claude',
+  'node_modules',
+  // build output (gitignored)
+  'dist',
+  'build',
+  'out',
+  '.next',
+  // tool caches and generated reports (gitignored)
+  '.turbo',
+  '.vercel',
+  '.direnv',
+  '.pnpm-store',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  '__temp_discover_test__',
+  // fetched third-party package source — the 2026-06-11 incident dir
+  'opensrc',
+  // parallel-agent worktrees: full repo copies under the repo root
+  '.worktrees',
+]);
+
+// ---------------------------------------------------------------------------
 // Metric collectors
 // ---------------------------------------------------------------------------
 
@@ -46,13 +90,7 @@ function countByGlob(base: string, extensions: string[]): number {
       return;
     }
     for (const e of entries) {
-      if (
-        e.name === 'node_modules' ||
-        e.name === 'dist' ||
-        e.name === '.git' ||
-        e.name === '.claude'
-      )
-        continue;
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walk(full);
@@ -84,8 +122,12 @@ function countApps(): number {
   return countDirs(path.join(ROOT, 'apps'));
 }
 
-function countTestFiles(): number {
-  return countByGlob(ROOT, ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.e2e.ts']);
+/**
+ * Count test files across the repo. Path-injectable + exported for tests
+ * (mirrors countEnforcementTests).
+ */
+export function countTestFiles(base: string = ROOT): number {
+  return countByGlob(base, ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.e2e.ts']);
 }
 
 function countUIComponents(): number {
@@ -132,6 +174,7 @@ function countDbTables(): number {
       return;
     }
     for (const e of entries) {
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walk(full);
@@ -378,13 +421,7 @@ function walkLicenseScanFiles(callback: (filePath: string, rel: string) => void)
       return;
     }
     for (const e of entries) {
-      if (
-        e.name === 'node_modules' ||
-        e.name === 'dist' ||
-        e.name === '.git' ||
-        e.name === '.claude'
-      )
-        continue;
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       const rel = path.relative(ROOT, full).replace(/\\/g, '/');
       if (e.isDirectory()) {
@@ -797,13 +834,7 @@ function scanForClaims(metrics: Metric[]): ClaimMatch[] {
       return;
     }
     for (const e of entries) {
-      if (
-        e.name === 'node_modules' ||
-        e.name === 'dist' ||
-        e.name === '.git' ||
-        e.name === '.claude'
-      )
-        continue;
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walkAndScan(full);
@@ -1069,6 +1100,7 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
       return;
     }
     for (const e of entries) {
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walk(full);
@@ -1346,13 +1378,7 @@ function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {
       return;
     }
     for (const e of entries) {
-      if (
-        e.name === 'node_modules' ||
-        e.name === 'dist' ||
-        e.name === '.git' ||
-        e.name === '.claude'
-      )
-        continue;
+      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
       if (e.isDirectory()) {
         walk(full);


### PR DESCRIPTION
## Summary

The claim-drift validator walks the filesystem with a hardcoded exclusion set (`node_modules`/`dist`/`.git`/`.claude`) and never consults `.gitignore`, so gitignored local artifacts skew its counts relative to the clean checkout CI sees.

Incident (2026-06-11): a stale `opensrc/` cache (fetched third-party package sources) held 53 third-party `*.test.ts` files, inflating `countTestFiles()` from 961 (git-tracked reality) to 1014, past the testFiles tolerance of 100 vs `METRICS.testFiles`. That hard-failed `pnpm gate:quick` and the pre-push gate locally while CI stayed green. The affected session worked around it by deleting the cache; this PR removes the blind spot itself.

## Changes

- **`WALK_EXCLUDED_DIRS`**: one shared `ReadonlySet<string>` replaces the identical exclusion block previously duplicated across four walkers (`countByGlob`, `walkLicenseScanFiles`, `scanForClaims.walkAndScan`, `scanForRvuiTickerLeaks.walk`), classified as accidental duplication. The set is now also applied to `countDbTables` and `scanForAspirationalFeatures`, which had no exclusions at all. New entries (each verified gitignored, none shadowing tracked files): `build`, `out`, `.next`, `.turbo`, `.vercel`, `.direnv`, `.pnpm-store`, `coverage`, `playwright-report`, `test-results`, `__temp_discover_test__`, `opensrc`, `.worktrees`.
- **`countTestFiles(base = ROOT)`**: path-injectable and exported, mirroring the `countEnforcementTests` pattern.
- **Tests (4 new, 18/18 green)**: fixture-based exclusion tests (incident shape: an `opensrc/` cache plus every excluded name nested at depth), plus two sync guards that keep the set honest against the repo. Guard 1: every entry except `.git` must have a covering `.gitignore` line. Guard 2: no entry may shadow git-tracked files (`screenshots/` is gitignored yet `apps/marketing/public/screenshots` is tracked, exactly the trap this guard catches).

No authored regex (fleet no-regex rule): the new logic is `Set` membership plus string predicates only.

## Behavior on a clean checkout

Unchanged. All excluded names are gitignored artifact dirs that do not exist in CI checkouts. Counts before/after on clean `test` are identical: 961 test files, 0 mismatches, 0 METRICS drift.

## Verification

- `pnpm vitest run scripts/validate/__tests__/claim-drift.test.ts`: 18/18
- `pnpm tsx scripts/validate/claim-drift.ts`: 961 test files with AND without a fake `opensrc/repos/.../fake.test.ts` present (pre-fix, each stale file added 1)
- `pnpm gate:quick`: 20/20 PASS with the fake gitignored cache still in place (the incident scenario end to end)
- Biome clean

## Out of scope (follow-up)

Path- and pattern-shaped gitignored artifacts that a directory-name set cannot express (for example the generated `apps/docs/public/docs/` mirror and `docs/*REPORT*.md`). The durable fix there is filtering walked paths against git itself (`git ls-files --others --ignored --exclude-standard --directory`); tracked as a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
