### PR TITLE
fix(scripts): skip git-reported ignored paths in claim-drift walkers

### DIFF
--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -11,6 +11,8 @@ import {
   countTestFiles,
   extractRevealuiPackages,
   findIncompleteProList,
+  makeIgnoredPathPredicate,
+  parseGitIgnoredOutput,
   WALK_EXCLUDED_DIRS,
 } from '../claim-drift.ts';
 
@@ -258,6 +260,66 @@ describe('countTestFiles', () => {
       fs.writeFileSync(path.join(nested, 'phantom.test.ts'), '');
     }
     expect(countTestFiles(tmp)).toBe(1);
+  });
+
+  it('skips path-shaped ignored dirs the name set cannot express (generated docs-mirror class)', () => {
+    fs.mkdirSync(path.join(tmp, 'src'));
+    fs.writeFileSync(path.join(tmp, 'src', 'real.test.ts'), '');
+    // Generated-mirror shape: apps/docs/public/docs/ — "docs" is a normal
+    // directory name, so WALK_EXCLUDED_DIRS must not (and does not) list it.
+    const mirror = path.join(tmp, 'apps', 'docs', 'public', 'docs');
+    fs.mkdirSync(mirror, { recursive: true });
+    fs.writeFileSync(path.join(mirror, 'copied.test.ts'), '');
+
+    // Without the git-derived set the mirror inflates the count…
+    expect(countTestFiles(tmp)).toBe(2);
+    // …with it, the walker prunes at the collapsed directory entry.
+    const isIgnored = makeIgnoredPathPredicate(tmp, new Set(['apps/docs/public/docs']));
+    expect(countTestFiles(tmp, isIgnored)).toBe(1);
+  });
+
+  it('skips pattern-shaped ignored files inside scanned dirs (report-artifact class)', () => {
+    fs.mkdirSync(path.join(tmp, 'docs'));
+    fs.writeFileSync(path.join(tmp, 'docs', 'kept.test.ts'), '');
+    fs.writeFileSync(path.join(tmp, 'docs', 'STALE_REPORT.test.ts'), '');
+
+    expect(countTestFiles(tmp)).toBe(2);
+    // File-granular skip: exactly the listed file, nothing else.
+    const isIgnored = makeIgnoredPathPredicate(tmp, new Set(['docs/STALE_REPORT.test.ts']));
+    expect(countTestFiles(tmp, isIgnored)).toBe(1);
+  });
+});
+
+describe('parseGitIgnoredOutput', () => {
+  it('splits on NUL and strips the trailing slash from collapsed directories', () => {
+    const raw = 'apps/docs/public/docs/\0docs/LOCAL_VERIFICATION.md\0node_modules/\0';
+    expect(parseGitIgnoredOutput(raw)).toEqual(
+      new Set(['apps/docs/public/docs', 'docs/LOCAL_VERIFICATION.md', 'node_modules']),
+    );
+  });
+
+  it('returns an empty set for empty output', () => {
+    expect(parseGitIgnoredOutput('')).toEqual(new Set());
+  });
+});
+
+describe('makeIgnoredPathPredicate', () => {
+  const base = path.join(os.tmpdir(), 'claim-drift-pred-fixture');
+
+  it('matches files and collapsed directories by base-relative path', () => {
+    const isIgnored = makeIgnoredPathPredicate(
+      base,
+      new Set(['generated/docs', 'docs/STALE_REPORT.md']),
+    );
+    expect(isIgnored(path.join(base, 'generated', 'docs'))).toBe(true);
+    expect(isIgnored(path.join(base, 'docs', 'STALE_REPORT.md'))).toBe(true);
+    expect(isIgnored(path.join(base, 'docs', 'CURRENT.md'))).toBe(false);
+    expect(isIgnored(path.join(base, 'generated'))).toBe(false);
+  });
+
+  it('never matches when the ignored set is empty', () => {
+    const isIgnored = makeIgnoredPathPredicate(base, new Set());
+    expect(isIgnored(path.join(base, 'anything.md'))).toBe(false);
   });
 });
 

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -19,6 +19,7 @@
  * no-console-log rule (per .revealui/code-standards.json).
  */
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -28,20 +29,31 @@ const showFix = process.argv.includes('--fix');
 // ---------------------------------------------------------------------------
 // Walker exclusions
 //
-// Directory names the filesystem walkers below must never enter. The walkers
-// do not consult .gitignore, so every gitignored artifact directory that can
-// hold walker-matchable files (.ts/.tsx/.md/.txt/.json/.sh) must be listed
-// here — otherwise stale local artifacts make local counts diverge from the
-// clean checkout CI sees. Incident 2026-06-11: a stale opensrc/ cache held 53
-// third-party *.test.ts files, inflating countTestFiles() from 961 to 1014 —
-// past the ±100 testFiles tolerance — so the local gate hard-failed while CI
-// stayed green.
+// Two layers keep stale local artifacts from skewing local validator runs vs
+// the clean checkout CI sees (incident 2026-06-11: a stale opensrc/ cache
+// held 53 third-party *.test.ts files, inflating countTestFiles() from 961
+// to 1014 — past the ±100 testFiles tolerance — so the local gate
+// hard-failed while CI stayed green):
 //
-// Names match a single directory entry at any depth. Keep entries in sync
-// with .gitignore: the unit tests assert every entry except .git has a
-// covering .gitignore line AND that no entry shadows git-tracked files
-// (e.g. screenshots/ is gitignored yet apps/marketing/public/screenshots is
-// tracked, so it must NOT be listed here).
+// 1. WALK_EXCLUDED_DIRS — directory NAMES the walkers below must never
+//    enter, matched per entry at any depth. This is the only protection when
+//    git is unavailable, so every gitignored artifact directory name that
+//    can hold walker-matchable files (.ts/.tsx/.md/.txt/.json/.sh) still
+//    belongs here. Keep entries in sync with .gitignore: the unit tests
+//    assert every entry except .git has a covering .gitignore line AND that
+//    no entry shadows git-tracked files (e.g. screenshots/ is gitignored yet
+//    apps/marketing/public/screenshots is tracked, so it must NOT be listed
+//    here).
+//
+// 2. The git-derived ignored-path set (below) — one lazy `git ls-files` pass
+//    covering what a name set cannot express: path-shaped ignores (the
+//    generated docs mirrors apps/docs/public/docs/ + apps/docs/dist/docs/
+//    written by apps/docs/scripts/copy-docs.sh, where a local docs build
+//    duplicates every scan hit under the generated copy) and pattern-shaped
+//    file ignores inside scanned dirs (docs/*VERIFICATION*.md /
+//    docs/*REPORT*.md report artifacts carrying stale counts). It also
+//    honors nested .gitignore files (apps/docs/.gitignore `public/*/`),
+//    which the name set and its sync-guard test never see.
 // ---------------------------------------------------------------------------
 
 /** Exported for tests. */
@@ -69,6 +81,94 @@ export const WALK_EXCLUDED_DIRS: ReadonlySet<string> = new Set([
   '.worktrees',
 ]);
 
+/** Skip-predicate the walkers consult for every entry. Exported for tests. */
+export type IgnoredPathPredicate = (fullPath: string) => boolean;
+
+const NEVER_IGNORED: IgnoredPathPredicate = () => false;
+
+/**
+ * Parse `git ls-files --others --ignored --exclude-standard --directory -z`
+ * output into repo-relative ignored paths. Entries are NUL-separated (split
+ * on the literal NUL — no authored regex, per the fleet no-regex rule);
+ * fully-ignored directories arrive collapsed with a trailing slash, stripped
+ * here so one Set lookup serves both file and directory entries.
+ * Exported for tests.
+ */
+export function parseGitIgnoredOutput(raw: string): Set<string> {
+  const ignored = new Set<string>();
+  for (const entry of raw.split('\0')) {
+    if (entry.length === 0) continue;
+    ignored.add(entry.endsWith('/') ? entry.slice(0, -1) : entry);
+  }
+  return ignored;
+}
+
+/**
+ * Build the skip-predicate for `ignoredPaths` rooted at `base`. Matching is
+ * an exact Set lookup on the base-relative path — git collapses fully-
+ * ignored directories to a single entry, so pruning at the directory entry
+ * is sufficient and no prefix scan is needed. Exported for tests.
+ */
+export function makeIgnoredPathPredicate(
+  base: string,
+  ignoredPaths: ReadonlySet<string>,
+): IgnoredPathPredicate {
+  if (ignoredPaths.size === 0) return NEVER_IGNORED;
+  return (fullPath: string): boolean =>
+    ignoredPaths.has(path.relative(base, fullPath).split(path.sep).join('/'));
+}
+
+/**
+ * One upfront git pass: every gitignored path under `root`, repo-relative.
+ * Covers the two classes the WALK_EXCLUDED_DIRS name set cannot express
+ * (path-shaped directory ignores; pattern-shaped file ignores) and honors
+ * nested .gitignore files. By construction the set can never shadow tracked
+ * files — git lists only ignored UNTRACKED paths, so e.g. the tracked
+ * apps/marketing/public/screenshots/ never appears here even though
+ * `screenshots/` is a .gitignore line.
+ *
+ * Returns null when git is unavailable (no git binary, deleted .git, tarball
+ * checkout) — walkers then fall back to WALK_EXCLUDED_DIRS alone, the
+ * pre-existing behavior.
+ */
+function loadGitIgnoredPaths(root: string): ReadonlySet<string> | null {
+  try {
+    const raw = execFileSync(
+      'git',
+      ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory', '-z'],
+      { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+    return parseGitIgnoredOutput(raw);
+  } catch {
+    return null;
+  }
+}
+
+let rootPredicateCache: IgnoredPathPredicate | undefined;
+
+/**
+ * Skip-predicate for walks rooted inside the real repo tree. Lazy + cached:
+ * the git pass runs once per process on first walker use — never at import
+ * time (the unit tests import this module). Walks rooted OUTSIDE the repo
+ * (the mkdtemp fixtures in the unit tests — fixture dirs are not git repos)
+ * default to no path-based skipping, keeping the suite hermetic; tests that
+ * want path-skipping inject their own predicate instead.
+ */
+function ignoredPathPredicateFor(base: string): IgnoredPathPredicate {
+  if (base !== ROOT && !base.startsWith(ROOT + path.sep)) return NEVER_IGNORED;
+  if (rootPredicateCache === undefined) {
+    const ignored = loadGitIgnoredPaths(ROOT);
+    if (ignored === null) {
+      console.warn(
+        'claim-drift: git unavailable — gitignored-path skipping disabled; ' +
+          'walkers fall back to WALK_EXCLUDED_DIRS names only.',
+      );
+    }
+    rootPredicateCache = ignored === null ? NEVER_IGNORED : makeIgnoredPathPredicate(ROOT, ignored);
+  }
+  return rootPredicateCache;
+}
+
 // ---------------------------------------------------------------------------
 // Metric collectors
 // ---------------------------------------------------------------------------
@@ -80,7 +180,11 @@ interface Metric {
   claimPatterns: RegExp[];
 }
 
-function countByGlob(base: string, extensions: string[]): number {
+function countByGlob(
+  base: string,
+  extensions: string[],
+  isIgnored: IgnoredPathPredicate = ignoredPathPredicateFor(base),
+): number {
   let count = 0;
   function walk(dir: string): void {
     let entries: fs.Dirent[];
@@ -90,8 +194,8 @@ function countByGlob(base: string, extensions: string[]): number {
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       if (e.isDirectory()) {
         walk(full);
       } else if (extensions.some((ext) => e.name.endsWith(ext))) {
@@ -103,12 +207,19 @@ function countByGlob(base: string, extensions: string[]): number {
   return count;
 }
 
-function countDirs(base: string): number {
+function countDirs(
+  base: string,
+  isIgnored: IgnoredPathPredicate = ignoredPathPredicateFor(base),
+): number {
   try {
     return fs
       .readdirSync(base, { withFileTypes: true })
-      .filter((e) => e.isDirectory() && fs.existsSync(path.join(base, e.name, 'package.json')))
-      .length;
+      .filter(
+        (e) =>
+          e.isDirectory() &&
+          !isIgnored(path.join(base, e.name)) &&
+          fs.existsSync(path.join(base, e.name, 'package.json')),
+      ).length;
   } catch {
     return 0;
   }
@@ -124,10 +235,14 @@ function countApps(): number {
 
 /**
  * Count test files across the repo. Path-injectable + exported for tests
- * (mirrors countEnforcementTests).
+ * (mirrors countEnforcementTests); tests may also inject a skip-predicate.
  */
-export function countTestFiles(base: string = ROOT): number {
-  return countByGlob(base, ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.e2e.ts']);
+export function countTestFiles(base: string = ROOT, isIgnored?: IgnoredPathPredicate): number {
+  return countByGlob(
+    base,
+    ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.e2e.ts'],
+    isIgnored,
+  );
 }
 
 function countUIComponents(): number {
@@ -165,6 +280,7 @@ function countWorkspaces(): number {
 function countDbTables(): number {
   const schemaDir = path.join(ROOT, 'packages/db/src/schema');
   if (!fs.existsSync(schemaDir)) return 0;
+  const isIgnored = ignoredPathPredicateFor(schemaDir);
   let total = 0;
   function walk(dir: string): void {
     let entries: fs.Dirent[];
@@ -174,8 +290,8 @@ function countDbTables(): number {
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       if (e.isDirectory()) {
         walk(full);
       } else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) {
@@ -413,6 +529,7 @@ const LICENSE_SCAN_EXTENSIONS_FULL = ['.md', '.txt', '.ts', '.tsx', '.json', '.s
 const LICENSE_SCAN_EXTENSIONS_PACKAGES = ['.md']; // packages/* is huge; restrict to docs
 
 function walkLicenseScanFiles(callback: (filePath: string, rel: string) => void): void {
+  const isIgnored = ignoredPathPredicateFor(ROOT);
   function walk(dir: string): void {
     let entries: fs.Dirent[];
     try {
@@ -421,8 +538,8 @@ function walkLicenseScanFiles(callback: (filePath: string, rel: string) => void)
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       const rel = path.relative(ROOT, full).replace(/\\/g, '/');
       if (e.isDirectory()) {
         walk(full);
@@ -772,6 +889,7 @@ const EXCLUDE_FILES = ['docs/system-tune/CRASH-POSTMORTEMS.md'];
 
 function scanForClaims(metrics: Metric[]): ClaimMatch[] {
   const matches: ClaimMatch[] = [];
+  const isIgnored = ignoredPathPredicateFor(ROOT);
 
   function scanFile(filePath: string): void {
     const rel = path.relative(ROOT, filePath);
@@ -834,8 +952,8 @@ function scanForClaims(metrics: Metric[]): ClaimMatch[] {
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       if (e.isDirectory()) {
         walkAndScan(full);
       } else if (
@@ -1047,6 +1165,7 @@ const QUALIFIER_PATTERN =
 
 function scanForAspirationalFeatures(): AspirationalMatch[] {
   const matches: AspirationalMatch[] = [];
+  const isIgnored = ignoredPathPredicateFor(ROOT);
 
   function scanFile(filePath: string): void {
     const rel = path.relative(ROOT, filePath);
@@ -1100,8 +1219,8 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       if (e.isDirectory()) {
         walk(full);
       } else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts') || e.name.endsWith('.md')) {
@@ -1343,6 +1462,7 @@ const RVUI_LEAK_ALLOWLIST = new Set<string>([
 
 function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {
   const matches: RvuiLeakMatch[] = [];
+  const isIgnored = ignoredPathPredicateFor(ROOT);
 
   function isAllowlisted(rel: string): boolean {
     return RVUI_LEAK_ALLOWLIST.has(rel) || rel.startsWith('docs/fleet/revealcoin');
@@ -1378,8 +1498,8 @@ function scanForRvuiTickerLeaks(): RvuiLeakMatch[] {
       return;
     }
     for (const e of entries) {
-      if (WALK_EXCLUDED_DIRS.has(e.name)) continue;
       const full = path.join(dir, e.name);
+      if (WALK_EXCLUDED_DIRS.has(e.name) || isIgnored(full)) continue;
       if (e.isDirectory()) {
         walk(full);
       } else if (e.name.endsWith('.md')) {


### PR DESCRIPTION
## Summary

Follow-on to #1363 (merged). `WALK_EXCLUDED_DIRS` is a directory-NAME set; two residual gitignored-artifact classes are path- or pattern-shaped, so a name set cannot express them, and stale local artifacts in either class make the local hard-fail gate diverge from CI's clean checkout (same failure mode as the 2026-06-11 opensrc incident #1363 documents):

1. **Path-shaped** - the generated docs mirrors `apps/docs/public/docs/` + `apps/docs/dist/docs/` (output of `apps/docs/scripts/copy-docs.sh`; ignored via `apps/docs/.gitignore:16` `public/*/` and root `.gitignore:150`). `walkLicenseScanFiles` walks all of `apps/docs/public`, so a local docs build duplicates every claim/phantom/membership scan hit under the generated copy.
2. **Pattern-shaped** - gitignored report files inside scanned dirs (root `.gitignore:145-146`: `docs/*VERIFICATION*.md`, `docs/*REPORT*.md`). A locally generated report with stale counts fails `scanForClaims` locally only.

## The fix

One lazy upfront git pass at first walker use: `execFileSync` (no shell) runs `git ls-files --others --ignored --exclude-standard --directory -z` at ROOT, parsed by splitting on NUL (no authored regex) into a `Set` of repo-relative ignored paths. Fully-ignored directories arrive collapsed with a trailing slash (stripped), so one exact `Set.has` lookup prunes both files and whole directory subtrees. Every recursive walker plus `countDirs` consults it alongside the existing name check.

- `WALK_EXCLUDED_DIRS` stays, as the fallback when git is unavailable (and the cheap first-level check). Both sync-guard tests untouched and green.
- Honors nested `.gitignore` files - the docs mirror is actually attributed to `apps/docs/.gitignore` by `git check-ignore -v`, a layer the name-set sync-guard (which reads only the root `.gitignore`) never sees.
- Cannot shadow tracked files by construction: git lists only ignored *untracked* paths (the tracked `apps/marketing/public/screenshots/` never appears even though `screenshots/` is a gitignore line).
- Hermetic unit tests: the skip-predicate is injectable, and walks rooted outside ROOT (the mkdtemp fixtures) default to no path-skipping - no git ever runs during unit tests.
- Lazy + cached: one git exec per validator run, never at import time.

## Verification (fresh worktree)

| step | result |
|---|---|
| baseline validator + suite, pre-change | PASS, 25/25 |
| create gitignored phantom-mention artifacts `apps/docs/public/docs/claim-drift-repro.md` + `docs/CLAIM_DRIFT_REPRO_REPORT.md` (`git check-ignore -v` attributes both; `git status --short` empty) | validator **FAIL** pre-change, phantom hits at both paths |
| same artifacts present, post-change | validator **PASS**, 0 hits |
| artifacts removed, post-change | validator PASS |
| `vitest run scripts/validate/__tests__/claim-drift.test.ts` | **31/31** (25 existing incl. both `WALK_EXCLUDED_DIRS` sync-guards + 6 new) |
| `biome check` on both files | clean |
| `pnpm gate:quick` | PASS (includes the claim-drift hard-fail check itself) |

Branch was built on #1363's head and rebased onto `test` after #1363 merged - single commit, same two files as #1363 (`scripts/validate/claim-drift.ts` + its test suite), no other surface touched.

Owner-gated manual merge, no auto-merge, per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
