### PR TITLE
docs(cli): align scaffold-output docs with actual template output

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4043,18 +4043,17 @@ The CLI walks through five configuration steps:
 
 ### 3. Storage
 
-- **Storage provider**  -  Cloudflare R2 (S3-compatible, default) or local filesystem (legacy Vercel Blob is being retired)
+- **Storage provider**  -  Cloudflare R2 (S3-compatible, recommended) or legacy Vercel Blob (being retired); can be skipped to configure later
 
 ### 4. Payments
 
 - **Stripe keys**  -  publishable key, secret key, and webhook secret
-- Can be skipped to configure later via `.env.local`
+- Can be skipped to configure later via `.env.development.local`
 
 ### 5. Dev environment
 
-- **Package manager**  -  `pnpm` (recommended), `npm`, or `yarn`
-- **Dev shell**  -  Nix flakes + direnv (optional)
-- **Docker Compose**  -  generates a `docker-compose.yml` for local Postgres
+- **Dev Container**  -  VS Code / GitHub Codespaces configuration (yes/no, defaults to yes)
+- **Devbox**  -  Nix-powered development shell configuration (yes/no, defaults to yes)
 
 ---
 
@@ -4072,53 +4071,91 @@ The CLI walks through five configuration steps:
 
 ## Generated Project Structure
 
+The Next.js templates (basic-blog, e-commerce, portfolio, starter) scaffold a single Next.js app:
+
 ```
 my-project/
-├── apps/
-│   ├── admin/          # Next.js admin + admin
-│   └── api/          # Hono REST API
-├── packages/
-│   └── db/           # Project-local schema extensions
-├── .env.local        # Pre-filled with your config answers
-├── .env.template     # Full env var reference
-├── package.json      # Workspace root
-├── pnpm-workspace.yaml
-├── turbo.json
-└── README.md         # Getting-started instructions
+├── src/
+│   ├── app/                    # Next.js App Router pages + template routes
+│   ├── collections/            # RevealUI collections (not in starter)
+│   └── seed.ts                 # Database seed script
+├── revealui.config.ts          # RevealUI configuration
+├── next.config.mjs
+├── postcss.config.mjs
+├── package.json
+├── tsconfig.json
+├── .env.example
+├── .gitignore                  # Renamed from the template's _gitignore
+├── .env.development.local      # Generated from your setup answers
+└── README.md                   # Generated getting-started guide
 ```
+
+The `starter-native` template scaffolds the Vite shape instead:
+
+```
+my-project/
+├── app/
+│   ├── App.tsx
+│   ├── main.tsx
+│   ├── routes/
+│   ├── layouts/
+│   └── styles/
+├── src/
+│   └── seed.ts
+├── index.html
+├── vite.config.ts
+├── vitest.config.ts
+├── revealui.config.ts
+├── package.json
+├── tsconfig.json
+├── .env.example
+├── .gitignore
+├── .env.development.local
+└── README.md
+```
+
+Both shapes are single-app projects  -  the CLI does not scaffold a monorepo. Answering yes to the Dev Container / Devbox prompts also creates `.devcontainer/` and `devbox.json`.
 
 ---
 
 ## Generated Files
 
-### `.env.local`
+### `.env.development.local`
 
-Pre-populated with all values you entered during setup. Contains:
+Pre-populated with the values you entered during setup (Next.js and Vite only load this file in development, so the generated secret and test placeholders never reach a production runtime). Contains:
 
 ```bash
 # Core
 REVEALUI_SECRET=<generated-64-char-hex>
-NEXT_PUBLIC_SERVER_URL=http://localhost:3004
+REVEALUI_PUBLIC_SERVER_URL=http://localhost:4000
+NEXT_PUBLIC_SERVER_URL=http://localhost:4000
 
 # Database
 POSTGRES_URL=postgresql://...
-
-# Stripe
-STRIPE_SECRET_KEY=sk_live_...
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
-STRIPE_WEBHOOK_SECRET=whsec_...
 
 # Storage — Cloudflare R2 (canonical, S3-compatible). Set all five R2_* vars.
 R2_ACCOUNT_ID=...
 R2_ACCESS_KEY_ID=...
 R2_SECRET_ACCESS_KEY=...
-R2_BUCKET=revealui-media
-R2_PUBLIC_BASE_URL=https://media.revealui.com
+R2_BUCKET=...
+R2_PUBLIC_BASE_URL=...
 # Legacy Vercel Blob — optional fallback, used only when the R2_* vars are unset:
 BLOB_READ_WRITE_TOKEN=vercel_blob_...
+
+# Stripe
+STRIPE_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# CORS
+REVEALUI_CORS_ORIGINS=http://localhost:3000,http://localhost:4000
+
+# Admin bootstrap (first run only)
+REVEALUI_ADMIN_EMAIL=admin@example.com
+REVEALUI_ADMIN_PASSWORD=
 ```
 
-Any values you skipped are left as `PLACEHOLDER`  -  fill them in before running `pnpm dev`.
+Values you skip fall back to safe defaults  -  a local-Postgres `POSTGRES_URL`, commented R2 examples, and Stripe `*_placeholder` test values. Fill them in before running `pnpm dev`.
 
 ### `README.md`
 
@@ -4126,11 +4163,11 @@ Auto-generated getting-started guide specific to your project configuration.
 
 ### `devbox.json` (optional)
 
-Generated if you selected Nix/Devbox during setup. Pre-configures the development shell with Node.js, pnpm, and project tools.
+Generated if you answer yes to the Devbox prompt. Pre-configures the development shell with Node.js 24, pnpm 10, PostgreSQL 16, and the Stripe CLI.
 
 ### `.devcontainer/` (optional)
 
-Generated if you selected Docker Compose. Provides a ready-to-use VS Code / GitHub Codespaces dev container.
+Generated if you answer yes to the Dev Container prompt. Contains `devcontainer.json`, `docker-compose.yml` (app container plus Postgres 16 with pgvector), a `Dockerfile`, and a setup README  -  ready for VS Code or GitHub Codespaces.
 
 ---
 
@@ -4152,7 +4189,7 @@ pnpm db:seed
 pnpm dev
 ```
 
-The admin will be at `http://localhost:4000` and the API at `http://localhost:3004`.
+The dev server runs at `http://localhost:4000`  -  scaffolded projects are a single app, with no separate API server.
 
 ---
 
@@ -4169,10 +4206,10 @@ await createProject({
     projectPath: "/tmp/my-app",
     template: "basic-blog",
   },
-  database: { url: "postgresql://localhost/myapp" },
-  storage: { blobToken: "" },
-  payment: { secretKey: "", publishableKey: "", webhookSecret: "" },
-  devenv: { packageManager: "pnpm", useNix: false, useDocker: false },
+  database: { provider: "neon", postgresUrl: "postgresql://localhost/myapp" },
+  storage: { provider: "skip" },
+  payment: { enabled: false },
+  devenv: { createDevContainer: false, createDevbox: false },
   skipGit: true,
   skipInstall: true,
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,18 +62,28 @@ Options:
 
 ## What Gets Created
 
+The Next.js templates (basic-blog, e-commerce, portfolio, starter) scaffold a single Next.js app:
+
 ```
 my-project/
-├── apps/
-│   ├── cms/              # CMS application
-│   └── mainframe/        # Frontend application
-├── packages/
-│   └── ...               # Shared packages
-├── .devcontainer/        # Dev Container configuration
-├── devbox.json           # Devbox configuration
-├── .env.development.local # Environment variables
-└── README.md             # Project documentation
+├── src/
+│   ├── app/                   # Next.js App Router pages + template routes
+│   ├── collections/           # RevealUI collections (not in starter)
+│   └── seed.ts                # Database seed script
+├── revealui.config.ts         # RevealUI configuration
+├── next.config.mjs
+├── postcss.config.mjs
+├── package.json
+├── tsconfig.json
+├── .env.example
+├── .gitignore
+├── .env.development.local     # Generated from your setup answers
+└── README.md                  # Generated getting-started guide
 ```
+
+The starter-native template scaffolds the Vite shape instead: `app/` (App.tsx, main.tsx, routes/, layouts/, styles/) plus `src/seed.ts`, `index.html`, `vite.config.ts`, and `vitest.config.ts` replace `src/app/` and the Next.js configs.
+
+Answering yes to the Dev Container and Devbox prompts also creates `.devcontainer/` and `devbox.json`.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

`packages/cli/README.md` ("What Gets Created") and `docs/REFERENCE.md` ("Generated Project Structure") described a monorepo scaffold (`apps/cms`, `apps/admin`, `packages/db`, `pnpm-workspace.yaml`, `turbo.json`) that no `create-revealui` template produces. Both now document the real per-template output, verified against `packages/cli/src/commands/create.ts`, `src/prompts/*`, `src/generators/*`, and the template directories.

## Changes

**packages/cli/README.md** (frontmatter `status: verified`)
- "What Gets Created": real single-app tree for the Next.js templates (basic-blog, e-commerce, portfolio, starter) plus the starter-native Vite shape; notes the CLI-generated `.env.development.local` / `README.md` and the optional `.devcontainer/` + `devbox.json`.

**docs/REFERENCE.md**
- "Generated Project Structure": both real shapes, with an explicit "the CLI does not scaffold a monorepo".
- "5. Dev environment": replaced fictional bullets (package-manager choice, Nix flakes + direnv, docker-compose generation) with the two real confirms in `src/prompts/devenv.ts` (Dev Container, Devbox).
- Storage prompt bullet: Cloudflare R2 / legacy Vercel Blob / skip - there is no "local filesystem" option (`src/prompts/storage.ts`).
- `.env.local` -> `.env.development.local` (rename landed in #1342); the sample now mirrors `generateEnvFile` output (port 4000 not 3004, `REVEALUI_PUBLIC_SERVER_URL`, CORS origins, admin bootstrap block, `sk_test_`/`pk_test_` placeholders) and the false "skipped values are left as `PLACEHOLDER`" claim is gone.
- `devbox.json` / `.devcontainer/` blurbs now tied to their actual prompts and contents; `.devcontainer/` ships `devcontainer.json` + `docker-compose.yml` (pgvector pg16) + `Dockerfile` + README, and was previously claimed to be "generated if you selected Docker Compose".
- Post-scaffold: dev server is a single app on `http://localhost:4000` - removed the claim of a separate API at `:3004`.
- Programmatic API example now matches the real `CreateProjectConfig` (was showing non-existent `devenv: { packageManager, useNix, useDocker }` and `database: { url }` shapes).

Untouched by design: the template enumeration tables in both files (aligned by #1362) and `docs/ROADMAP.md`.

## Verification

- `pnpm gate:quick` - PASS (claim-drift + marketing-voice hard-fails included)
- `pnpm --filter @revealui/cli test` - 20 files, 212 tests passed
- Ground-truth inventories: `packages/cli/src/__tests__/template-structure.test.ts`, `create.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
