### PR TITLE
docs: align tier and perpetual prices with canonical re-space

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ Full details in `docs/PRO.md`.
 |------|-------|--------|
 | free | $0 | 1 site, 3 users, 200 req/min |
 | pro | $49/mo | 5 sites, 25 users, 300 req/min |
-| max | $149/mo | 15 sites, 100 users, 600 req/min |
-| enterprise | $299/mo | unlimited |
+| max | $299/mo | 15 sites, 100 users, 600 req/min |
+| enterprise | $1,499/mo | unlimited |
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Pro packages are source-available under the [Functional Source License (FSL-1.1-
 | -------------- | --------- | ------------------------------------------------------------------ |
 | **Free**       | $0        | Full OSS core: users, content, products, payments, admin             |
 | **Pro**        | $49/mo    | AI agents, MCP framework, open-model inference, advanced sync, RevVault desktop + rotation engine |
-| **Max**        | $149/mo   | Full AI memory, audit log, higher limits, RevKit environment provisioning         |
-| **Enterprise** | $299/mo   | RevealUI Fleet (branded white-label, managed setup via revforge), SSO (planned — [#449](https://github.com/RevealUIStudio/revealui/issues/449)), domain-locked                                       |
+| **Max**        | $299/mo   | Full AI memory, audit log, higher limits, RevKit environment provisioning         |
+| **Enterprise** | $1,499/mo | RevealUI Fleet (branded white-label, managed setup via revforge), SSO (planned — [#449](https://github.com/RevealUIStudio/revealui/issues/449)), domain-locked                                       |
 
 ## Apps
 

--- a/apps/admin/src/lib/middleware/ai-feature-gate.ts
+++ b/apps/admin/src/lib/middleware/ai-feature-gate.ts
@@ -3,7 +3,7 @@
  *
  * Provides gate functions for AI-related API routes.
  * - `checkAIFeatureGate()` checks the `ai` feature (Pro tier, $49/mo)
- * - `checkAIMemoryFeatureGate()` checks the `aiMemory` feature (Max tier, $149/mo)
+ * - `checkAIMemoryFeatureGate()` checks the `aiMemory` feature (Max tier, $299/mo)
  */
 
 import { isFeatureEnabled } from '@revealui/core/features';

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -10,4 +10,4 @@ category: redirect
 This page has been split into two distinct guides per the 7-tier rename (ADR `RevealUIStudio/revealui-jv/docs/decisions/2026-05-03-revfleet-rename.md`):
 
 - **[`docs/FLEET.md`](./FLEET.md)** — RevealUI Fleet self-hosted runtime kit (Tier 4): Docker Compose stack, domain lock, license keys, upgrades, HA, backup/restore.
-- **[`docs/PRO.md`](./PRO.md#enterprise-tier)** — Enterprise tier (Tier 5): SaaS billing posture, hosted vs self-hosted, $299/mo.
+- **[`docs/PRO.md`](./PRO.md#enterprise-tier)** — Enterprise tier (Tier 5): SaaS billing posture, hosted vs self-hosted, $1,499/mo.

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -148,7 +148,7 @@ Complete the Stripe checkout checklist at `docs/checklists/stripe-checkout-verif
 
 ### Track A: SaaS Subscriptions
 
-- [ ] Pro ($49/mo), Max ($149/mo), Enterprise ($299/mo) price IDs created in Stripe **(blocking)**
+- [ ] Pro ($49/mo), Max ($299/mo), Enterprise ($1,499/mo) price IDs created in Stripe **(blocking)**
 - [ ] Trial period configured if applicable (`REVEALUI_TRIAL_DAYS`) **(advisory)**
 - [ ] Subscription lifecycle tested: create, upgrade, downgrade, cancel **(blocking)**
 - [ ] License records created in DB on `checkout.session.completed` **(blocking)**
@@ -160,7 +160,7 @@ Complete the Stripe checkout checklist at `docs/checklists/stripe-checkout-verif
 
 ### Track C: Perpetual Licenses
 
-- [ ] Pro ($299), Max ($799), Enterprise ($1,999) one-time price IDs created **(blocking)**
+- [ ] Pro Perpetual ($1,499), Agency Perpetual ($8,499), Enterprise Perpetual ($42,999) one-time price IDs created **(blocking)**
 - [ ] `support_expires_at` set correctly (1 year from purchase) **(blocking)**
 
 ### Track D: Professional Services

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -83,7 +83,7 @@ Architecture and security are genuinely strong (auth 9/10, crypto done right). C
 
 **Model:** Open Core (MIT core + paid Pro / Max / Enterprise tiers)
 **Target Market:** TypeScript-first agencies, SaaS builders, enterprise teams
-**Revenue:** SaaS subscriptions  -  Track A: Free / Pro $49/mo / Max $149/mo / Forge $299/mo; Track B: agent task credits ($0.001/task); Track C: perpetual licenses ($299–$1,999 one-time + annual support renewals); Track D: professional services (architecture review, migration assist, launch package, consulting)
+**Revenue:** SaaS subscriptions  -  Track A: Free / Pro $49/mo / Max $299/mo / Enterprise $1,499/mo; Track B: agent task credits ($0.001/task); Track C: perpetual licenses ($1,499–$42,999 one-time + annual support renewals); Track D: professional services (architecture review, migration assist, launch package, consulting)
 **Planned Launch:** OSS core Q3 2026, Pro tier Q4 2026
 
 See `business/BUSINESS_PLAN.md` for full business plan (not superseded  -  separate concern).

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1405,7 +1405,7 @@ GET /.well-known/marketplace.json
 
 # Enterprise tier
 
-Customers buy the Enterprise tier of RevealUI ($299/mo); the RevealUI Fleet kit (produced by RevForge) is what they deploy. Two paths:
+Customers buy the Enterprise tier of RevealUI ($1,499/mo); the RevealUI Fleet kit (produced by RevForge) is what they deploy. Two paths:
 
 - **Hosted Enterprise** — RevealUI Studio manages infrastructure. You get a dedicated instance on `revealui.com` infrastructure, domain-configured for your organization.
 - **Self-hosted Fleet** — You deploy the Docker Compose stack (API + admin + PostgreSQL) on your own infrastructure, domain-locked via `REVFORGE_LICENSED_DOMAIN`.

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -19,7 +19,7 @@ audience: developer
 | 2 | **RevFleet** | The umbrella for all RevealUI Studio software | Internal coordination |
 | 3 | **RevForge** | Operator-side stamping tool (`RevealUIStudio/revforge`). Produces branded RevealUI Fleet kits per customer. | RevealUI Studio operators |
 | 4 | **RevealUI Fleet** | Customer-facing self-hosted runtime kit — white-label, multi-tenant, domain-locked, produced by RevForge. | Enterprise customers self-hosting |
-| 5 | **Enterprise** | SaaS billing tier label ($299/mo). Hosted alternative to self-hosting a Fleet kit. | Customers on the hosted Enterprise tier |
+| 5 | **Enterprise** | SaaS billing tier label ($1,499/mo). Hosted alternative to self-hosting a Fleet kit. | Customers on the hosted Enterprise tier |
 | 6 | (customer stamps) | Customer-stamped Fleet instances per the Tier 4 model. | Enterprise customers |
 
 **Naming drift to avoid:** "Suite", "RevealUI Studio Fleet", bare "Fleet" → use **RevFleet**. Bare "Forge" is ambiguous — use RevForge (the tool), RevealUI Fleet (the kit), or Enterprise (the tier) per context.
@@ -44,7 +44,7 @@ Each of the seven products in RevFleet ships in its own repo. The table below or
 
 RevealUI is the agentic business runtime. Five primitives — users, content, products, payments, AI — are pre-wired in the monorepo. OSS packages ship MIT; Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services`) are Fair Source FSL-1.1-MIT (source-visible, non-compete, auto-converts to MIT after 2 years).
 
-Status: pre-launch (0 paying customers). Enterprise tier at $299/mo hosted; RevealUI Fleet for self-hosting via RevForge.
+Status: pre-launch (0 paying customers). Enterprise tier at $1,499/mo hosted; RevealUI Fleet for self-hosting via RevForge.
 
 ### RevForge (the stamping tool)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,9 +163,9 @@ RevealUI offers four ways to pay:
 
 | Track | Model | Description |
 |-------|-------|-------------|
-| **A  -  Subscriptions** | Monthly | Free / Pro $49/mo / Max $149/mo / Enterprise $299/mo |
+| **A  -  Subscriptions** | Monthly | Free / Pro $49/mo / Max $299/mo / Enterprise $1,499/mo |
 | **B  -  Agent Credits** | Pay-per-use | $0.001/task, first 1,000 tasks/month free (local inference) |
-| **C  -  Perpetual** | One-time | $299 / $799 / $1,999 (1 year support included, renewable) |
+| **C  -  Perpetual** | One-time | $1,499 / $8,499 / $42,999 (1 year support included, renewable) |
 | **D  -  Professional Services** | Per-engagement | Architecture review, migration assist, launch package, consulting hours |
 
 Ecosystem features by tier: RevVault desktop app + rotation engine (Pro), RevKit environment provisioning (Max).

--- a/docs/checklists/stripe-checkout-verification.md
+++ b/docs/checklists/stripe-checkout-verification.md
@@ -34,31 +34,31 @@ Use Stripe test card: `4242 4242 4242 4242` (any future expiry, any CVC).
 - [ ] Verify: license created in DB (`SELECT * FROM licenses WHERE user_id = ...`)
 - [ ] Verify: user tier shows "pro" in admin dashboard
 
-### 1b. Max subscription ($149/mo)
+### 1b. Max subscription ($299/mo)
 - [ ] Same flow as 1a but for Max tier
-- [ ] Verify correct amount ($149/mo)
+- [ ] Verify correct amount ($299/mo)
 - [ ] Verify license tier = "max"
 
-### 1c. Enterprise subscription ($299/mo)
+### 1c. Enterprise subscription ($1,499/mo)
 - [ ] Same flow as 1a but for Enterprise tier
-- [ ] Verify correct amount ($299/mo)
+- [ ] Verify correct amount ($1,499/mo)
 - [ ] Verify license tier = "enterprise"
 
 ---
 
 ## 2. Perpetual License Checkout
 
-### 2a. Pro perpetual ($299 one-time)
+### 2a. Pro perpetual ($1,499 one-time)
 - [ ] Hit `POST /api/billing/checkout-perpetual` with `{"tier":"pro"}`
 - [ ] Complete Stripe Checkout with test card
 - [ ] Verify: `checkout.session.completed` webhook received
 - [ ] Verify: license created with `perpetual = true`
 - [ ] Verify: `support_expires_at` set to 1 year from now
 
-### 2b. Max perpetual ($799 one-time)
+### 2b. Agency perpetual — Max tier ($8,499 one-time)
 - [ ] Same flow, tier = "max"
 
-### 2c. Enterprise perpetual ($1,999 one-time)
+### 2c. Enterprise perpetual ($42,999 one-time)
 - [ ] Same flow, tier = "enterprise"
 
 ### 2d. Perpetual with GitHub username


### PR DESCRIPTION
## Summary

Doc-corpus follow-up to #1290. The code pricing surfaces (Stripe seed, server fallbacks, marketing content, `docs/MARKETING_METRICS.md` §2, drift gate) were re-spaced under the 2026-06-07 pricing realignment, but the markdown corpus still carried the old ladder. This aligns every remaining stale dollar figure.

## Changes

- **Track A subscriptions:** Max $149/mo → $299/mo, Enterprise $299/mo → $1,499/mo — README, AGENTS.md, docs/ROADMAP, docs/MASTER_PLAN, docs/LAUNCH-CHECKLIST, docs/PRO.md, docs/REVFLEET.md, docs/FORGE.md, stripe-checkout-verification checklist
- **Track C perpetuals:** $299 / $799 / $1,999 → $1,499 / $8,499 / $42,999; middle tier now shown under its catalog name "Agency Perpetual" (matches seed-stripe.ts product names)
- **MASTER_PLAN revenue line:** retires the pre-rename "Forge" tier label (→ Enterprise)
- **Code-comment straggler:** `apps/admin/src/lib/middleware/ai-feature-gate.ts` JSDoc said Max $149/mo while line 33 of the same file already said $299/mo

Left as-is (historical or third-party): MASTER_PLAN dated `[x]` log entries, `docs/archive/*`, vendor prices in the licensing-platform ADR, Track B credit bundles (unchanged by the realignment).

## Verification

- Repo-wide grep for old figures (`$149/mo`, `$1,999`, `$799 one`, `$299 one`, Enterprise `$299/mo`): clean
- `pnpm gate:quick` PASS (incl. claim-drift + marketing-voice hard gates)
- All figures now match the live code surfaces (`apps/server/src/routes/pricing.ts` fallback, `seed-stripe.ts` cents, `PricingTeaser.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
