### PR TITLE
docs: adopt People/Content/Offers/Payments/Agents primitive vocab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 title: "RevealUI"
-description: "RevealUI is the agentic business runtime. Users, content, products, payments, and AI - pre-wired, open source, and ready to deploy."
+description: "RevealUI is the agentic business runtime. People, content, offers, payments, and agents - pre-wired, open source, and ready to deploy."
 visibility: public
 status: verified
 audience: agent
@@ -8,15 +8,15 @@ audience: agent
 
 # RevealUI
 
-RevealUI is the agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.
+RevealUI is the agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.
 
 ## Five Primitives
 
-1. **Users**  -  authentication, sessions, RBAC/ABAC, rate limiting, brute force protection
+1. **People**  -  authentication, sessions, RBAC/ABAC, rate limiting, brute force protection
 2. **Content**  -  collections, rich text (Lexical), media, draft/live workflows, REST API
-3. **Products**  -  catalog, pricing tiers, license key management
+3. **Offers**  -  catalog, pricing tiers, license key management
 4. **Payments**  -  Stripe checkout, subscriptions, webhooks, billing portal
-5. **Intelligence**  -  AI agents, CRDT memory, open-model inference, orchestration (Pro tier)
+5. **Agents**  -  AI agents, CRDT memory, open-model inference, orchestration (Pro tier)
 
 ## Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 title: "RevealUI Monorepo"
-description: "Agentic business runtime. Users, content, products, payments, and AI - pre-wired, open source, and ready to deploy."
+description: "Agentic business runtime. People, content, offers, payments, and agents - pre-wired, open source, and ready to deploy."
 visibility: internal
 status: verified
 audience: agent
@@ -8,7 +8,7 @@ audience: agent
 
 # RevealUI Monorepo
 
-Agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.
+Agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.
 
 ## Current Phase
 **Phase 5  -  Agent-First Infrastructure** (post-Phase 4). See `docs/MASTER_PLAN.md` for the active 5.x tracks.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ audience: user
 
 **Agentic business runtime.**
 
-Users. Content. Products. Payments. Intelligence. Five primitives for humans and agents, one deployment, one runtime.
+People. Content. Offers. Payments. Agents. Five primitives for humans and agents, one deployment, one runtime.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![React 19](https://img.shields.io/badge/React-19-61dafb.svg)](https://react.dev)
@@ -53,15 +53,15 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 
 | Primitive        | For you                                                          | For your agents                                              |
 | ---------------- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| **Users**        | Session auth, RBAC + ABAC, rate limiting, GDPR compliance        | Same RBAC governs agent access. Every action auditable.      |
+| **People**       | Session auth, RBAC + ABAC, rate limiting, GDPR compliance        | Same RBAC governs agent access. Every action auditable.      |
 | **Content**      | Collections, rich text (Lexical), media, draft/live, REST API    | Collections auto-exposed as MCP tools. No integration step.  |
-| **Products**     | Product catalog, pricing tiers, usage tracking                   | Feature gates control which agent capabilities unlock.       |
+| **Offers**       | Product catalog, pricing tiers, usage tracking                   | Feature gates control which agent capabilities unlock.       |
 | **Payments**     | Stripe checkout, subscriptions, webhooks, billing portal         | Same Stripe primitives, available to agents.                 |
-| **Intelligence** | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 14 MCP servers.                   |
+| **Agents**       | AI agents, open-model inference, task history _(Pro)_            | A2A protocol, CRDT memory, 14 MCP servers.                   |
 
 ## Open-model first
 
-The Intelligence primitive ships with open-model defaults. No proprietary API keys required, no API bill that scales with usage.
+The Agents primitive ships with open-model defaults. No proprietary API keys required, no API bill that scales with usage.
 
 - **Ollama** — local model runner; the standard developer-machine path.
 - **Ubuntu Inference Snaps** — Apache-2.0-preferred model runtimes for production. `sudo snap install gemma3` (or `deepseek-r1`, `qwen-vl`, `nemotron-3-nano`, `nemotron-3-nano-omni`).
@@ -143,7 +143,7 @@ Pro packages are source-available under the [Functional Source License (FSL-1.1-
 
 | Tier           | Price     | What you get                                                       |
 | -------------- | --------- | ------------------------------------------------------------------ |
-| **Free**       | $0        | Full OSS core: users, content, products, payments, admin             |
+| **Free**       | $0        | Full OSS core: people, content, offers, payments, admin              |
 | **Pro**        | $49/mo    | AI agents, MCP framework, open-model inference, advanced sync, RevVault desktop + rotation engine |
 | **Max**        | $299/mo   | Full AI memory, audit log, higher limits, RevKit environment provisioning         |
 | **Enterprise** | $1,499/mo | RevealUI Fleet (branded white-label, managed setup via revforge), SSO (planned — [#449](https://github.com/RevealUIStudio/revealui/issues/449)), domain-locked                                       |

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -865,7 +865,7 @@ About Us
 **Description**:
 
 ```
-[Your Site Name] is built on RevealUI — an open-source business runtime for software companies. Users, content, products, payments, and AI, pre-wired and ready to deploy.
+[Your Site Name] is built on RevealUI — an open-source business runtime for software companies. People, content, offers, payments, and agents, pre-wired and ready to deploy.
 ```
 
 **Image**:

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -348,7 +348,7 @@ In ~45 minutes you went from nothing to a deployed application with:
 - **Feature gating**  -  routes and components that check subscription tier
 - **Admin dashboard**  -  manage products, users, and billing from a browser
 
-This is the foundation. The five primitives  -  Users, Content, Products, Payments, Intelligence  -  are all here. Build your business logic on top.
+This is the foundation. The five primitives  -  People, Content, Offers, Payments, Agents  -  are all here. Build your business logic on top.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,7 +7,7 @@ category: index
 audience: developer
 ---
 
-Agentic business runtime. Five primitives for humans and agents: users, content, products, payments, and intelligence.
+Agentic business runtime. Five primitives for humans and agents: people, content, offers, payments, and agents.
 
 Six **[design principles](./JOSHUA.md)** govern every architectural decision: Justifiable, Orthogonal, Sovereign, Hermetic, Unified, Adaptive.
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -32,7 +32,7 @@ Each of the seven products in RevFleet ships in its own repo. The table below or
 
 | Product | Repo | What it is | License |
 |---|---|---|---|
-| **RevealUI** | [revealui](https://github.com/RevealUIStudio/revealui) | The agentic business runtime. Five primitives — users, content, products, payments, AI — pre-wired and ready to compose against. | MIT (OSS) + FSL-1.1-MIT (Pro packages) |
+| **RevealUI** | [revealui](https://github.com/RevealUIStudio/revealui) | The agentic business runtime. Five primitives — people, content, offers, payments, agents — pre-wired and ready to compose against. | MIT (OSS) + FSL-1.1-MIT (Pro packages) |
 | **RevForge** | [revforge](https://github.com/RevealUIStudio/revforge) | Operator-side stamping tool. Generates a branded RevealUI Fleet kit per customer — domain lock, unlimited users, Docker Compose stack. | per-product LICENSE |
 | **RevDev** | [revdev](https://github.com/RevealUIStudio/revdev) | Native developer tools: Studio (Tauri 2 desktop AI editor + agent dashboard) and Console (Go SSH TUI). Both talk to a shared harness daemon that coordinates agents and routes tools to the RevealUI API. | per-product LICENSE |
 | **RevVault** | [revvault](https://github.com/RevealUIStudio/revvault) | Age-encrypted secret vault. CLI + Tauri 2 desktop app. 100% passage-compatible. Source of truth for every secret in RevFleet per the fleet-wide secrets rule. | per-product LICENSE |
@@ -42,7 +42,7 @@ Each of the seven products in RevFleet ships in its own repo. The table below or
 
 ### RevealUI (the runtime)
 
-RevealUI is the agentic business runtime. Five primitives — users, content, products, payments, AI — are pre-wired in the monorepo. OSS packages ship MIT; Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services`) are Fair Source FSL-1.1-MIT (source-visible, non-compete, auto-converts to MIT after 2 years).
+RevealUI is the agentic business runtime. Five primitives — people, content, offers, payments, agents — are pre-wired in the monorepo. OSS packages ship MIT; Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services`) are Fair Source FSL-1.1-MIT (source-visible, non-compete, auto-converts to MIT after 2 years).
 
 Status: pre-launch (0 paying customers). Enterprise tier at $1,499/mo hosted; RevealUI Fleet for self-hosting via RevForge.
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -11,17 +11,17 @@ I've started three software companies. Each time, I spent the first three to six
 
 That's not a skills problem. That's an infrastructure problem. And after the third time, I decided to solve it.
 
-RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
+RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
 
 ## The problem nobody talks about
 
 Every software company needs the same five things on day one:
 
-1. **Users** — sign up, sign in, sessions, roles, permissions (RBAC + ABAC)
+1. **People** — sign up, sign in, sessions, roles, permissions (RBAC + ABAC)
 2. **Content** — pages, posts, media, rich text, an API to serve it
-3. **Products** — a catalog, pricing tiers, license keys
+3. **Offers** — a catalog, pricing tiers, license keys
 4. **Payments** — checkout, subscriptions, invoices, a billing portal
-5. **Intelligence** — AI that actually knows your business context
+5. **Agents** — AI that actually knows your business context
 
 None of these are your product. All of them are required before your product can exist.
 
@@ -225,7 +225,7 @@ RevealUI is not an admin with plugins bolted on. It's not a boilerplate you clon
 
 When a user signs up, the auth system creates their session, assigns their default role, and checks their license tier. When they access content, the collection's `access.read` function can reference their tier, their role, or any custom claim. When they upgrade via Stripe, the webhook handler updates their license, which updates their feature flags, which unlocks gated content and capabilities — all in the same request cycle.
 
-This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. Users, content, products, payments, and features share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
+This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. People, content, offers, payments, and features share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
 
 Some numbers on what's actually shipped:
 
@@ -257,7 +257,7 @@ RevDev Studio (Tauri + React) is the native AI experience — agent coordination
 
 The near-term roadmap includes MCP server registry listings, A2A agent discovery for RevealUI-to-RevealUI communication, a broader template library, and a template marketplace where developers can publish project starters. The community lives on [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions), so join early and help shape what gets built next.
 
-But the core thesis won't change: **every software company needs users, content, products, payments, and intelligence. You shouldn't have to build them from scratch.**
+But the core thesis won't change: **every software company needs people, content, offers, payments, and agents. You shouldn't have to build them from scratch.**
 
 Build your business, not your boilerplate.
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -107,7 +107,7 @@ sudo snap install gemma3             # Or: ollama pull gemma4:e2b
 └── @revealui/mcp                    # MCP tool integrations
 ```
 
-The entire AI-powered business stack  -  auth, content, products, payments, agents  -  running without a cloud API call in sight.
+The entire AI-powered business stack  -  people, content, offers, payments, agents  -  running without a cloud API call in sight.
 
 ## Who this is for
 

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -1,6 +1,6 @@
 ---
 title: "The Five Primitives of Business Software"
-description: "Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell products, a way to collect payments, and increasingly, a way to ..."
+description: "Every software company ships the same five things: a way to manage people, a way to manage content, a way to sell your offers, a way to collect payments, and increasingly, a way to ..."
 visibility: public
 status: narrative
 audience: user
@@ -11,7 +11,7 @@ author: Joshua Vaughn
 
 ---
 
-Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell products, a way to collect payments, and increasingly, a way to run AI. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
+Every software company ships the same five things: a way to manage people, a way to manage content, a way to sell your offers, a way to collect payments, and increasingly, a way to run agents. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
 
 RevealUI is the open runtime for businesses that run their own AI. Its thesis is simple: these five primitives should be pre-wired, open source, and ready to deploy. You bring your business logic. We bring the infrastructure.
 
@@ -19,7 +19,7 @@ This post is a deep technical walkthrough of all five. Not marketing copy. Real 
 
 ---
 
-## 1. Users
+## 1. People
 
 Authentication is the foundation. Get it wrong and nothing else matters. RevealUI's auth system is session-based, not JWT-based, and that is a deliberate choice.
 
@@ -129,15 +129,15 @@ export const hasAnyRole = (roles: string[]) => ({ req }) =>
 
 These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 59 enforcement tests proving role isolation.
 
-### How Users connects to everything else
+### How People connects to everything else
 
-The user ID is the foreign key for everything. Content has an `authorId`. Products have licenses keyed to `customerId`. Payments are tied via `stripeCustomerId`. AI agent tasks are metered per `userId`. One identity, five primitives.
+The user ID is the foreign key for everything. Content has an `authorId`. Offers have licenses keyed to `customerId`. Payments are tied via `stripeCustomerId`. Agent tasks are metered per `userId`. One identity, five primitives.
 
 ---
 
 ## 2. Content
 
-Content is the second primitive. Not because it is more important than users, but because it is what users interact with first.
+Content is the second primitive. Not because it is more important than people, but because it is what people interact with first.
 
 ### Collections
 
@@ -199,13 +199,13 @@ Every route is defined using Hono's OpenAPI integration with Zod schemas. This m
 
 ### How Content connects to everything else
 
-Content is authored by Users (the `authorId` foreign key). Premium content can be gated behind Products (license tier checks). Content creation by AI agents feeds back through the Intelligence layer. Media uploads integrate with CDN delivery via the cache package.
+Content is authored by People (the `authorId` foreign key). Premium content can be gated behind Offers (license tier checks). Content creation by AI agents feeds back through the Agents layer. Media uploads integrate with CDN delivery via the cache package.
 
 ---
 
-## 3. Products
+## 3. Offers
 
-Products are what turns your software from a project into a business. RevealUI's product primitive covers the catalog, license generation, and runtime feature gating.
+Offers are what turns your software from a project into a business. RevealUI's offers primitive covers the catalog, license generation, and runtime feature gating.
 
 ### License keys: Ed25519-signed JWTs
 
@@ -301,9 +301,9 @@ Content-Type: application/json
 
 Verification checks both the JWT signature and the database. A structurally valid JWT can still be revoked in the database (chargeback, refund, manual revoke), so the verify endpoint checks both. The license cache TTL is 15 minutes, meaning a revoked license loses access within 15 minutes at most.
 
-### How Products connects to everything else
+### How Offers connects to everything else
 
-Products are purchased by Users. License keys are generated from the Payments webhook. Feature gates control access to Content (premium collections) and Intelligence (AI agent execution). The tier hierarchy flows through the entire stack.
+Offers are purchased by People. License keys are generated from the Payments webhook. Feature gates control access to Content (premium collections) and Agents (AI agent execution). The tier hierarchy flows through the entire stack.
 
 ---
 
@@ -382,13 +382,13 @@ RevealUI implements the x402 payment protocol for machine-to-machine payments �
 
 ### How Payments connects to everything else
 
-Payments are initiated by Users (checkout requires a session). Successful payments generate Products (license keys). Payment status controls feature access across Content and Intelligence. Webhook events update the Users table (`stripeCustomerId`) and the licenses table (Products). Chargebacks revoke licenses instantly.
+Payments are initiated by People (checkout requires a session). Successful payments generate Offers (license keys). Payment status controls feature access across Content and Agents. Webhook events update the `users` table (`stripeCustomerId`) and the licenses table (Offers). Chargebacks revoke licenses instantly.
 
 ---
 
-## 5. Intelligence (AI) -- Pro Tier
+## 5. Agents (AI) -- Pro Tier
 
-The fifth primitive is AI. Not a chatbot bolted onto a sidebar, but an agent orchestration system with memory, streaming, and inter-agent communication.
+The fifth primitive is Agents. Not a chatbot bolted onto a sidebar, but an agent orchestration system with memory, streaming, and inter-agent communication.
 
 ### Agent streaming
 
@@ -489,9 +489,9 @@ AI is not free. RevealUI tracks task usage per billing cycle:
 
 Usage beyond the quota is tracked in the `agent_task_usage` table. Reporting that overage to Stripe Billing Meters is in development — during early access, usage is recorded but not billed, so execution is never blocked on a meter.
 
-### How Intelligence connects to everything else
+### How Agents connects to everything else
 
-AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered as a Product (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
+AI agents authenticate through the People system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered through Offers (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
 
 ---
 
@@ -502,15 +502,15 @@ Any one of these primitives can be built in a weekend with the right libraries. 
 The five primitives are not independent features. They are a directed graph:
 
 ```
-Users --> Content (authorship)
-Users --> Products (licensing)
-Users --> Payments (billing)
-Users --> Intelligence (metering)
-Products --> Content (feature gating)
-Products --> Intelligence (feature gating)
-Payments --> Products (license generation)
-Intelligence --> Content (AI authoring)
-Intelligence --> Payments (usage billing)
+People --> Content (authorship)
+People --> Offers (licensing)
+People --> Payments (billing)
+People --> Agents (metering)
+Offers --> Content (feature gating)
+Offers --> Agents (feature gating)
+Payments --> Offers (license generation)
+Agents --> Content (AI authoring)
+Agents --> Payments (usage billing)
 ```
 
 Every edge in that graph is a piece of integration code you do not have to write. Every node is a piece of infrastructure you do not have to maintain. And because RevealUI is open source (MIT for the core, source-available for Pro), you can read every line, fork every module, and extend every API.
@@ -519,4 +519,4 @@ Build your business, not your boilerplate.
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. The core — Users, Content, Products, and Payments — is MIT licensed and free forever. Intelligence (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. The core — People, Content, Offers, and Payments — is MIT licensed and free forever. Agents (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -25,7 +25,7 @@ This wasn't a naive decision. I'm aware of the arguments for more restrictive li
 
 I understand that risk. I accept it. Here's why.
 
-RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
+RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- People, Content, Offers, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
 The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 14 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
@@ -37,7 +37,7 @@ What MIT means practically: you can take RevealUI, strip the branding, deploy it
 
 If everything important is MIT, what's left to sell?
 
-Intelligence.
+Agents.
 
 RevealUI Pro includes:
 
@@ -91,7 +91,7 @@ A few things worth noting about this table.
 
 **The free tier is genuinely useful.** Unlimited admin collections, session-based auth, basic real-time sync, local AI inference (Inference Snaps / Ollama), and full source code access. You can build and run a real product on the free tier. I don't want "free" to mean "demo."
 
-**All four business primitives work on free.** Users, Content, Products, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
+**All four business primitives work on free.** People, Content, Offers, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
 
 **Pro will have a 7-day trial with no credit card required (coming soon).** The signup flow won't ask for payment information. You try it, you decide, you pay if it's worth it. If the product can't convince you in seven days, a payment wall on day one wasn't going to help.
 
@@ -177,7 +177,7 @@ I don't know if this model will work. MIT open source with a commercial AI tier 
 
 What I do know is that the alternative -- restrictive licensing, crippled free tiers, dark patterns in the upgrade flow -- might generate more short-term revenue but would make me build a product I don't want to use.
 
-RevealUI is the business stack I wanted when I started building software companies. Users, content, products, payments, and AI -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
+RevealUI is the business stack I wanted when I started building software companies. People, content, offers, payments, and agents -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
 
 The code is on [GitHub](https://github.com/RevealUIStudio/revealui). The license is MIT. The Pro features will have a free trial (coming soon). Everything I've described in this post is verifiable.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -15,7 +15,7 @@ author: Joshua Vaughn
 
 ---
 
-I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get users, content, products, payments, and intelligence pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
+I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get people, content, offers, payments, and agents pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
 
 But somewhere around the third month of building, I realized something that changed the architecture fundamentally: **the next wave of customers for software platforms are not human.**
 
@@ -306,6 +306,6 @@ The user interface for the future has yet to reveal itself. But we know one thin
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
 
 *Follow the project on [GitHub](https://github.com/RevealUIStudio/revealui).*

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 
-RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get users, content, products, payments, and intelligence pre-wired and ready to deploy.
+RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get people, content, offers, payments, and agents pre-wired and ready to deploy.
 
 This tutorial walks you through creating a real business application from scratch. By the end, you will have a working admin with typed collections, session-based authentication, a REST API with Swagger documentation, Stripe billing, license enforcement, and an admin dashboard  -  deployed to production on Vercel.
 
@@ -600,7 +600,7 @@ Stop the clock. With accounts pre-provisioned (NeonDB, Stripe, Vercel) and copy-
 - **An admin dashboard**  -  manage content, users, licenses, and settings from a single interface
 - **Deployed to production on Vercel**  -  global edge network, automatic SSL, zero-config scaling
 
-This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  users, content, products, payments, and intelligence  -  is pre-wired and ready.
+This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  people, content, offers, payments, and agents  -  is pre-wired and ready.
 
 ---
 
@@ -632,4 +632,4 @@ The pattern scales. Add products, orders, tickets, knowledge bases  -  each coll
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*

--- a/docs/guides/audit-chain.md
+++ b/docs/guides/audit-chain.md
@@ -53,11 +53,11 @@ The chain is verifiable in two directions:
 
 Every mutation across the five primitives writes a row:
 
-- **Users** — auth events, RBAC role changes, GDPR consent and deletion events.
+- **People** — auth events, RBAC role changes, GDPR consent and deletion events.
 - **Content** — collection mutations, draft/live transitions, media uploads.
-- **Products** — catalog edits, pricing tier changes, license events.
+- **Offers** — catalog edits, pricing tier changes, license events.
 - **Payments** — Stripe webhook events, subscription transitions, refunds.
-- **Intelligence** — agent task lifecycle (`started`, `tool:called`, `completed`, `errored`), policy violations, memory writes.
+- **Agents** — agent task lifecycle (`started`, `tool:called`, `completed`, `errored`), policy violations, memory writes.
 
 Agents and humans use the same signing path. There is no separate "agent audit" surface — they are principals on the same chain.
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -7,7 +7,7 @@ category: guide
 audience: developer
 ---
 
-RevealUI is a framework, not a stack. The five primitives (users, content, products, payments, intelligence) are the contract; `@revealui/*` packages are one implementation of that contract. This page documents the libraries that implementation uses today, with one-line rationale for each choice. Future implementations could carry the same primitives on different code.
+RevealUI is a framework, not a stack. The five primitives (people, content, offers, payments, agents) are the contract; `@revealui/*` packages are one implementation of that contract. This page documents the libraries that implementation uses today, with one-line rationale for each choice. Future implementations could carry the same primitives on different code.
 
 ## Apps
 


### PR DESCRIPTION
## Summary

Repo-docs half of the primitive-vocabulary propagation: the 2026-06-07 realignment renamed the five primitives to **People / Content / Offers / Payments / Agents** (superseding both `Users/Content/Products/Payments/Intelligence` and the auth-led variant). #1291 propagated the display vocab into `apps/marketing` content; this PR does the same for the md corpus.

## Changes (15 files, 64/64 lines)

- **Root surfaces:** AGENTS.md (description, tagline, five-primitives list), CLAUDE.md (description, tagline), README.md (hero line, primitives table rows, "The Agents primitive ships with open-model defaults", Free-tier row)
- **Docs:** INDEX.md intro, REVFLEET.md product table + runtime section, ADMIN_GUIDE.md customer-site template description, BUILD_YOUR_BUSINESS.md foundation line, guides/technology-stack.md framework-contract line, guides/audit-chain.md audit-event domain bullets
- **Blog:** 01 (intro, numbered list, data-model line, closing thesis), 04 (stack enumeration), **05 — the five-primitives deep-dive, full-body flip** (frontmatter description, opening, `## 1. People` / `## 3. Offers` / `## 5. Agents` headings, every "How X connects" section, the dependency graph, footer; "the Users table" became the literal `users` table), 06 (MIT-core lists, "what's left to sell? Agents."), 07 + 08 (intros and footers)

## Deliberately left (classified, not missed)

- Technical/table enumerations: `docs/ARCHITECTURE.md:252`, `docs/security/VENDOR_RISK_ASSESSMENTS.md:71`, glossary tenant definition, historical `architecture/ADR-002`
- Admin collection labels (`docs/ADMIN_GUIDE.md:54-55`) and Stripe's own dashboard nav (`docs/guides/billing.md:69`) — they name real UI
- All code identifiers: `users`/`products` tables, `@revealui/ai`, engines subpaths (rename explicitly deferred)

## Verification

- Repo-wide re-grep: old vocab survives only in the classified-LEAVE files above; flipped files carry zero `Intelligence`/old-list residue
- `pnpm gate:quick` PASS (incl. claim-drift + marketing-voice hard gates)
- Casing mirrors the shipped marketing canon (`content.test.ts` FIVE_PRIMITIVES)

Promotion #1366 landed (19:33Z) while this PR was being opened, so no freeze is in effect — owner-gated manual merge on green; rides the next test→main promotion to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
