### PR TITLE
feat(pricing): wire the go-live conversion path on the pricing funnel

### DIFF
--- a/.changeset/pricing-funnel-cta-deeplink.md
+++ b/.changeset/pricing-funnel-cta-deeplink.md
@@ -1,0 +1,5 @@
+---
+'@revealui/contracts': patch
+---
+
+Pro and Max subscription tiers now deep-link into the existing trial checkout path (`/signup?plan=pro|max`) instead of the waitlist contact form. Display strings only; no price or schema changes.

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -58,7 +58,12 @@ function BillingContent() {
   const perpetual = searchParams.get('perpetual');
   const credits = searchParams.get('credits');
   const renewal = searchParams.get('renewal');
-  const upgrade = searchParams.get('upgrade');
+  // ?upgrade=pro|max deep link (marketing pricing cards via /signup?plan=).
+  // Unknown values are ignored. Enterprise upgrades go through the manual
+  // button below (proration confirm), never the auto-trigger.
+  const upgradeParam = searchParams.get('upgrade');
+  const upgrade: 'pro' | 'max' | null =
+    upgradeParam === 'pro' || upgradeParam === 'max' ? upgradeParam : null;
   const { data: session, isLoading: sessionLoading } = useSession();
   const [subscription, setSubscription] = useState<SubscriptionData | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
@@ -110,33 +115,38 @@ function BillingContent() {
     }
   }, [session, sessionLoading, fetchSubscription, router]);
 
-  const handleCheckout = useCallback(async () => {
-    setActionLoading(true);
-    setError(null);
-    try {
-      const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          ...(process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID && {
-            priceId: process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID,
+  const handleCheckout = useCallback(
+    async (target: 'pro' | 'max' = 'pro') => {
+      setActionLoading(true);
+      setError(null);
+      try {
+        const priceId =
+          target === 'max'
+            ? process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID
+            : process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID;
+        const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            ...(priceId && { priceId }),
+            tier: target,
           }),
-          tier: 'pro',
-        }),
-      });
-      const data = (await res.json()) as { url?: string; error?: string };
-      if (data.url) {
-        safeStripeRedirect(data.url);
-      } else {
-        setError(data.error || 'Failed to start checkout');
+        });
+        const data = (await res.json()) as { url?: string; error?: string };
+        if (data.url) {
+          safeStripeRedirect(data.url);
+        } else {
+          setError(data.error || 'Failed to start checkout');
+        }
+      } catch {
+        setError('Network error. Please try again.');
+      } finally {
+        setActionLoading(false);
       }
-    } catch {
-      setError('Network error. Please try again.');
-    } finally {
-      setActionLoading(false);
-    }
-  }, [apiUrl]);
+    },
+    [apiUrl],
+  );
 
   // Poll subscription status with exponential backoff after upgrades.
   // Retries up to 3 times (1s → 2s → 4s) to allow webhook processing.
@@ -159,10 +169,10 @@ function BillingContent() {
     };
   }, []);
 
-  // Auto-redirect to checkout on signup with ?upgrade=pro
+  // Auto-redirect to checkout on signup with ?upgrade=pro|max
   useEffect(() => {
-    if (upgrade === 'pro' && subscription?.tier === 'free' && !actionLoading) {
-      void handleCheckout();
+    if (upgrade && subscription?.tier === 'free' && !actionLoading) {
+      void handleCheckout(upgrade);
     }
   }, [upgrade, subscription, actionLoading, handleCheckout]);
 
@@ -304,7 +314,7 @@ function BillingContent() {
           Your subscription has expired. Pro features are no longer available.
           <button
             type="button"
-            onClick={handleCheckout}
+            onClick={() => void handleCheckout()}
             disabled={actionLoading}
             className="ml-2 font-medium underline hover:text-red-900 dark:hover:text-red-200"
           >
@@ -450,7 +460,11 @@ function BillingContent() {
                 <p className="text-sm text-zinc-600">
                   Upgrade to Pro for AI agents, advanced sync, built-in payments, and more.
                 </p>
-                <Button onClick={handleCheckout} disabled={actionLoading} className="w-full">
+                <Button
+                  onClick={() => void handleCheckout('pro')}
+                  disabled={actionLoading}
+                  className="w-full"
+                >
                   {actionLoading
                     ? 'Redirecting to checkout...'
                     : `Upgrade to Pro — ${getPrice('pro')}`}

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -44,7 +44,10 @@ export function SignupForm({ apiUrl }: SignupFormProps) {
 function SignupContent({ apiUrl }: SignupFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const plan = searchParams.get('plan');
+  // Paid-tier deep link from the marketing pricing cards (?plan=pro|max).
+  // Unknown values are ignored rather than forwarded to the billing page.
+  const planParam = searchParams.get('plan');
+  const plan: 'pro' | 'max' | null = planParam === 'pro' || planParam === 'max' ? planParam : null;
   const { signUp, isLoading } = useSignUp();
   const {
     register: registerPasskey,
@@ -91,8 +94,8 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       // sign in — show a confirmation screen instead of pushing them to a
       // protected route that would only bounce back to /login.
       if (result.user?.emailVerified) {
-        if (plan === 'pro') {
-          router.push('/account/billing?upgrade=pro');
+        if (plan) {
+          router.push(`/account/billing?upgrade=${plan}`);
         } else {
           router.push('/');
         }
@@ -218,8 +221,10 @@ function SignupContent({ apiUrl }: SignupFormProps) {
         Create your account
       </Heading>
 
-      {plan === 'pro' ? (
-        <p className="text-sm text-muted-foreground">Sign up to start your free 7-day Pro trial.</p>
+      {plan ? (
+        <p className="text-sm text-muted-foreground">
+          Sign up to start your free 7-day {plan === 'pro' ? 'Pro' : 'Max'} trial.
+        </p>
       ) : (
         <p className="text-sm text-muted-foreground">
           Already have an account?{' '}

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSignUp = vi.fn();
 const mockPush = vi.fn();
+// Set per-test to simulate the ?plan= deep link from the marketing pricing cards.
+let mockPlanParam: string | null = null;
 
 vi.mock('@revealui/auth/react', () => ({
   useSignUp: () => ({ signUp: mockSignUp, isLoading: false }),
@@ -24,7 +26,9 @@ vi.mock('@revealui/auth/react', () => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'plan' ? mockPlanParam : null),
+  }),
 }));
 
 vi.mock('@revealui/presentation/server', () => ({
@@ -52,6 +56,7 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPlanParam = null;
   // GDPR consent grant is fire-and-forget; stub fetch so jsdom doesn't throw.
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
 });
@@ -96,5 +101,38 @@ describe('SignupForm post-signup routing', () => {
       expect(mockPush).toHaveBeenCalledWith('/');
     });
     expect(screen.queryByText('Check your inbox')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    'pro',
+    'max',
+  ] as const)('routes an auto-verified user with ?plan=%s into the billing upgrade flow', async (plan) => {
+    mockPlanParam = plan;
+    mockSignUp.mockResolvedValue({
+      success: true,
+      user: { id: '1', email: 'ada@example.com', emailVerified: true },
+    });
+
+    render(<SignupForm apiUrl="http://api.test" />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/account/billing?upgrade=${plan}`);
+    });
+  });
+
+  it('ignores an unknown ?plan= value and routes home', async () => {
+    mockPlanParam = 'enterprise-deluxe';
+    mockSignUp.mockResolvedValue({
+      success: true,
+      user: { id: '1', email: 'ada@example.com', emailVerified: true },
+    });
+
+    render(<SignupForm apiUrl="http://api.test" />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -79,7 +79,7 @@ export function PricingTeaser() {
               >
                 {t.highlight && (
                   <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary-foreground">
-                    Most popular
+                    Recommended
                   </div>
                 )}
                 <h3 className="text-lg font-semibold">{t.name}</h3>

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -21,7 +21,7 @@ export const HOME_HERO = {
   subtitle: {
     lead: 'Stop renting your stack from a half-dozen vendors.',
     strong:
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
+      'Auth, content, offers, and payments, pre-wired into one open-source runtime you self-host.',
     body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself with',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -21,7 +21,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'How does agent task billing work?',
     answer:
-      'Every paid subscription includes a monthly task allowance. Agent task usage billing is coming soon. For now, all tiers include unlimited agent tasks during early access.',
+      'Every paid subscription includes a monthly task allowance: 10,000 tasks on Pro, 50,000 on Max, unlimited on Enterprise. Usage beyond the allowance is not billed today. Metered overage billing ships later, and usage is visible in your dashboard before any overage charge ever applies.',
   },
   {
     question: 'What are perpetual licenses?',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -47,7 +47,9 @@ export const PRICING_TRACK_A_SECTION = {
 // (Vercel / Cloudflare / Fly / Hetzner — Railway dropped).
 export const PRICING_VALUE_BAND = {
   heading: 'You own the runtime.',
-  body: 'Most backend platforms rent you auth, content, jobs, and payments as separate per-seat subscriptions you never stop paying. RevealUI ships them as one runtime you self-host under your own license.',
+  // Body wording is the approved value-context block from the go-live copy
+  // corpus (sourced range, time-sensitive: re-verify past mid-2026).
+  body: 'Teams shipping more than one product typically rent auth, content, billing, and observability from four or five vendors. On entry tiers that runs about $320 to $380 a month and climbs past $700 once enterprise SSO or compliance tiers enter. RevealUI replaces the rented stack with one runtime you own. You still pay for your own Postgres and compute.',
   points: [
     'One runtime, not five separate SaaS subscriptions',
     'Self-host on Vercel, Cloudflare, Fly, Hetzner, or your own metal',
@@ -56,12 +58,18 @@ export const PRICING_VALUE_BAND = {
   ],
 } as const;
 
-export const PRICING_HIGHLIGHTED_BADGE = 'Most Popular' as const;
+// 'Recommended' is an honest editorial signal; 'Most Popular' implied a
+// customer base that does not exist yet (truth-source: zero paying users).
+export const PRICING_HIGHLIGHTED_BADGE = 'Recommended' as const;
+
+// Rendered under the subscription grid, next to the CTA click point.
+export const PRICING_TRIAL_NOTE =
+  'Pro and Max include a 7-day free trial. Cancel during the trial and you pay nothing.' as const;
 
 export const PRICING_TRACK_C_SECTION = {
   eyebrow: 'Perpetual',
   heading: 'Perpetual Licenses',
-  body: 'Pay once, use forever. No subscription required. Support renewals are optional.',
+  body: 'A perpetual license costs about three years of the subscription. Pay once, own it forever, and renew support only if you want it.',
 } as const;
 
 // Studio / agency reseller economics, rendered in the Perpetual section where the
@@ -123,10 +131,39 @@ export const PRICING_AGENT_CTA_LINKS = {
   } satisfies Cta,
 } as const;
 
-export const PRICING_AGENCY_SECTION = {
-  heading: 'Adoption help from RevealUI Studio',
-  body: 'Architecture reviews, migrations, and launch support are offered separately by RevealUI Studio (the agency). Engagements are scoped per-project.',
-  cta: {
+// Done-for-you rung: surfaces the services ladder (canonical figures from the
+// 2026-06-07 offerings pin) where the buying decision happens, instead of a
+// bare link out. Dollar figures match the agency site and /for-operators:
+// published "from" minimums, scoped in discovery, never fixed quotes. The
+// discovery call doubles as the mid-funnel capture for buyers who are not
+// ready to self-serve (06-10 public-surfaces audit P1).
+export const PRICING_DONE_FOR_YOU = {
+  eyebrow: 'Done for you',
+  heading: 'Want it built and handed over?',
+  body: 'RevealUI Studio (the agency) ships fixed-bid engagements on the runtime: scoped in a discovery call, delivered with a full handoff, owned by you afterward.',
+  rungs: [
+    {
+      name: 'Architecture Review',
+      price: '$3,500',
+      note: 'Fixed-bid written assessment of your project, schema, deployment, and security posture. Credited toward a Fleet deployment if you proceed within 30 days.',
+    },
+    {
+      name: 'Fleet deployment',
+      price: 'From $25,000',
+      note: 'A branded, self-hosted RevealUI deployment for your business or your clients. Starting point, scoped in discovery.',
+    },
+    {
+      name: 'Custom Build',
+      price: 'From $50,000',
+      note: 'Bespoke platform engagement, 4 to 12 week sprints. Starting point, scoped in discovery.',
+    },
+  ],
+  primaryCta: {
+    label: 'Book a discovery call',
+    href: 'https://cal.com/revealuistudio/discovery',
+    external: true,
+  } satisfies Cta,
+  secondaryCta: {
     label: 'Visit revealuistudio.com →',
     href: SITE.urls.agency,
     external: true,

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -5,13 +5,13 @@ import { Footer } from '../components/Footer';
 import { NewsletterSignup } from '../components/NewsletterSignup';
 import {
   PERPETUAL_TIERS,
-  PRICING_AGENCY_SECTION,
   PRICING_AGENCY_VALUE_BAND,
   PRICING_AGENT_A2A,
   PRICING_AGENT_CTA_LINKS,
   PRICING_AGENT_MCP,
   PRICING_AGENT_X402,
   PRICING_AGENTS_SECTION,
+  PRICING_DONE_FOR_YOU,
   PRICING_FINAL_CTA,
   PRICING_FINAL_CTA_LINKS,
   PRICING_HERO,
@@ -21,6 +21,7 @@ import {
   PRICING_NEWSLETTER_LABEL,
   PRICING_TRACK_A_SECTION,
   PRICING_TRACK_C_SECTION,
+  PRICING_TRIAL_NOTE,
   PRICING_VALUE_BAND,
   type PricingResponse,
   SUBSCRIPTION_TIERS,
@@ -42,6 +43,31 @@ const FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> 
   pro: { price: '$49', period: '/month' },
   max: { price: '$299', period: '/month' },
   enterprise: { price: '$1,499', period: '/month' },
+};
+
+// Same role as FALLBACK_PRICE for the perpetual cards: without it an API
+// outage renders "Contact for pricing" on all three, hiding the published
+// anchors. Mirrors HARDCODED_PERPETUAL_PRICES in apps/server/src/routes/
+// pricing.ts (lockstep enforced by pricing-marketing-drift.test.ts).
+const FALLBACK_PERPETUAL_PRICE: Record<
+  string,
+  { price: string; priceNote: string; renewal: string }
+> = {
+  'Pro Perpetual': {
+    price: '$1,499',
+    priceNote: 'one-time',
+    renewal: '$149/yr for continued support',
+  },
+  'Agency Perpetual': {
+    price: '$8,499',
+    priceNote: 'one-time',
+    renewal: '$799/yr for continued support',
+  },
+  'Enterprise Perpetual': {
+    price: '$42,999',
+    priceNote: 'one-time',
+    renewal: '$3,999/yr for continued support',
+  },
 };
 
 function CheckIcon({ className }: { className?: string }) {
@@ -84,7 +110,15 @@ export function PricingPage() {
       ctaHref: tier.ctaHref.startsWith('/') ? `${ADMIN_URL}${tier.ctaHref}` : tier.ctaHref,
     };
   });
-  const perpetualTiers = pricing?.perpetual ?? PERPETUAL_TIERS;
+  const perpetualTiers = (pricing?.perpetual ?? PERPETUAL_TIERS).map((tier) => {
+    const fallback = FALLBACK_PERPETUAL_PRICE[tier.name];
+    return {
+      ...tier,
+      price: tier.price ?? fallback?.price,
+      priceNote: tier.priceNote ?? fallback?.priceNote,
+      renewal: tier.renewal ?? fallback?.renewal,
+    };
+  });
 
   return (
     <div className="min-h-screen bg-background">
@@ -215,6 +249,8 @@ export function PricingPage() {
               </div>
             ))}
           </div>
+
+          <p className="mt-8 text-center text-sm text-muted-foreground">{PRICING_TRIAL_NOTE}</p>
         </div>
       </section>
 
@@ -442,17 +478,50 @@ export function PricingPage() {
         </div>
       </section>
 
-      {/* Need implementation help? Hand off to the agency. */}
-      <section className="bg-primary/5 py-16 sm:py-20">
-        <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            {PRICING_AGENCY_SECTION.heading}
-          </h2>
-          <p className="mt-4 text-base text-muted-foreground">{PRICING_AGENCY_SECTION.body}</p>
-          <div className="mt-8">
-            <ButtonCVA asChild variant="outline" size="lg">
-              <a href={PRICING_AGENCY_SECTION.cta.href} target="_blank" rel="noopener noreferrer">
-                {PRICING_AGENCY_SECTION.cta.label}
+      {/* Done-for-you rung: services ladder + discovery-call capture */}
+      <section id="done-for-you" className="bg-primary/5 py-24 sm:py-32">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mb-12 text-center">
+            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+              {PRICING_DONE_FOR_YOU.eyebrow}
+            </span>
+            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+              {PRICING_DONE_FOR_YOU.heading}
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
+              {PRICING_DONE_FOR_YOU.body}
+            </p>
+          </div>
+
+          <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
+            {PRICING_DONE_FOR_YOU.rungs.map((rung) => (
+              <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+                <h3 className="text-base font-semibold text-foreground">{rung.name}</h3>
+                <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">
+                  {rung.price}
+                </p>
+                <p className="mt-3 text-sm text-muted-foreground">{rung.note}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <ButtonCVA asChild size="lg" className="w-full sm:w-auto">
+              <a
+                href={PRICING_DONE_FOR_YOU.primaryCta.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {PRICING_DONE_FOR_YOU.primaryCta.label}
+              </a>
+            </ButtonCVA>
+            <ButtonCVA asChild variant="outline" size="lg" className="w-full sm:w-auto">
+              <a
+                href={PRICING_DONE_FOR_YOU.secondaryCta.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {PRICING_DONE_FOR_YOU.secondaryCta.label}
               </a>
             </ButtonCVA>
           </div>

--- a/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
@@ -8,12 +8,13 @@
  *   1. `apps/server/src/routes/pricing.ts` HARDCODED_*_PRICES
  *   2. `apps/marketing/app/content/pricing.ts` + dependent content
  *   3. `apps/marketing/app/components/landing/PricingTeaser.tsx` TEASER_FALLBACK_PRICE
- *   4. `docs/MARKETING_METRICS.md` §2 (the canonical doc)
- *   5. Stripe live data (via `pnpm stripe:seed` post-update)
- *   6. This file
+ *   4. `apps/marketing/app/routes/PricingPage.tsx` FALLBACK_PRICE + FALLBACK_PERPETUAL_PRICE
+ *   5. `docs/MARKETING_METRICS.md` §2 (the canonical doc)
+ *   6. Stripe live data (via `pnpm stripe:seed` post-update)
+ *   7. This file
  *
  * If this test fails, the lockstep was broken. Don't update the test in
- * isolation — update all six together so the canonical truth stays canonical.
+ * isolation — update all seven together so the canonical truth stays canonical.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -152,8 +152,13 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Email support (48h response)',
       'Full source code access',
     ],
-    cta: 'Join the waitlist',
-    ctaHref: 'https://revealui.com/contact',
+    // Deep-links into the existing checkout path: /signup?plan=pro ->
+    // /account/billing?upgrade=pro -> auto-checkout (7-day trial via
+    // REVEALUI_TRIAL_DAYS). Marketing prefixes the admin origin onto
+    // '/'-relative hrefs. Signup stays 403 until REVEALUI_SIGNUP_OPEN flips
+    // (GAP-240), the same gate the marketing hero CTA already fronts.
+    cta: 'Start your 7-day free trial',
+    ctaHref: '/signup?plan=pro',
     highlighted: true,
   },
   {
@@ -172,8 +177,8 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Email support (24h response)',
       'Full source code access',
     ],
-    cta: 'Join the waitlist',
-    ctaHref: 'https://revealui.com/contact',
+    cta: 'Start your 7-day free trial',
+    ctaHref: '/signup?plan=max',
     highlighted: false,
   },
   {


### PR DESCRIPTION
## What

Finishes the pricing-funnel conversion path for go-live. The admin deep-link checkout path already exists end to end (`/signup?plan=pro` redirects to `/account/billing?upgrade=pro`, which auto-triggers Stripe checkout with the 7-day trial), but the marketing pricing cards never used it: Pro and Max sent buyers to the waitlist contact form while the page hero promised a free trial.

## Changes

**Contracts (display strings only, zero price values):**
- Pro/Max `cta` becomes "Start your 7-day free trial", `ctaHref` becomes `/signup?plan=pro|max`. The marketing page prefixes the admin origin onto `/`-relative hrefs; the admin upgrade page uses the `onSelect` button mode, so `ctaHref` never renders inside admin. Patch changeset.

**Admin (plan-param generalization, pro-only to pro|max):**
- `SignupForm` validates `?plan=` to `pro|max` (unknown values ignored, routed home) and forwards to `/account/billing?upgrade=<plan>`; the plan microcopy names the tier.
- Billing `handleCheckout` takes a `pro|max` target with the matching `NEXT_PUBLIC_STRIPE_*_PRICE_ID`; the `?upgrade=` auto-trigger honors both; `onClick` call sites wrapped in arrows so the click event can never become the tier argument.
- 3 new SignupForm routing tests (plan=pro, plan=max, unknown value).

**Marketing pricing page:**
- Perpetual cards get a client-side fallback price map mirroring the server `HARDCODED_PERPETUAL_PRICES`. Before this, any `/api/pricing` outage rendered "Contact for pricing" on all three perpetual cards, hiding the published anchors. Verified in the preview with no API running: all three prices render.
- The bare "visit the agency" link-out becomes a done-for-you rung: Architecture Review $3,500 (credited toward a Fleet deployment if you proceed within 30 days), Fleet deployment From $25,000, Custom Build From $50,000, with a cal.com discovery-call CTA. Figures and phrasing match the agency site and `/for-operators` exactly (published "from" minimums, scoped in discovery). This is the mid-funnel capture the 2026-06-10 public-surfaces assessment flagged as P1: an unready buyer now has a next step that is not "sign up or bounce".
- Trial-risk microcopy under the subscription grid ("Cancel during the trial and you pay nothing"), matching the billing page's own wording.

**Marketing copy (canon-aligned):**
- Value band adopts the approved sourced vendor-cost block ($320 to $380 a month entry-tier composite; time-sensitive, re-verify past mid-2026).
- Perpetual section adopts the approved story line ("about three years of the subscription; pay once, own it forever").
- "Most Popular" badge becomes "Recommended" on the pricing page and the homepage teaser: with zero paying users, popularity was a fabricated signal.
- Pricing FAQ task-billing answer now states the per-tier allowances (10,000 / 50,000 / unlimited) instead of contradicting the cards with "unlimited during early access".
- Home hero "products" becomes "offers" (primitive vocabulary, one word).

**Server:** drift-test header comment adds the new marketing perpetual fallback to the price-change lockstep list (comment only; no assertion changes, no price changes anywhere in this PR).

## Sequencing (owner)

Signup is 403-closed until `REVEALUI_SIGNUP_OPEN` flips, the same gate the homepage hero CTA already fronts, so this PR does not worsen the pre-flip state. It is meant to ride the go-live train: merge to `test` whenever convenient (owner-gated as always), and the Gate-5 conversion walkthrough exercises exactly this path end to end (marketing card → signup → billing → Stripe checkout with trial).

## Verification

- biome clean; marketing-voice 0 new; claim-drift 0 mismatches (both hard gates)
- contracts 934/934; marketing 31/31; SignupForm 5/5; pricing-marketing-drift 3/3
- turbo typecheck admin + marketing + server + contracts: 23/23
- Rendered preview (worktree Vite, no API running): trial CTAs deep-link to `admin.revealui.com/signup?plan=pro|max`, perpetual prices render from the new fallback, done-for-you band + discovery CTA render, badge reads Recommended, zero "Join the waitlist" residue, console clean.

Not covered here: the live logged-in checkout smoke (Gate-5, owner) and rendered visual QA on a test deploy.

## Coordination

Part of the pricing trio: file-disjoint from #1369 (repo-docs vocab sweep) and from the internal corpus/audit deliverables. Registered on the internal workboard with the full file-scope claim; the `home.ts` one-word change is the accepted handoff from the copy-corpus lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
