### PR TITLE
chore(release): promote test to main (release.yml husky fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.28.2"
+  # CI runners must not execute dev-machine git hooks: the husky pre-push gate
+  # fired on the "Push tags" step (run 27389106334) and ran the full repo gate
+  # inside the release runner — an environment the admin test suite was never
+  # provisioned for — blocking the tag push AFTER packages had already
+  # published. Husky honors HUSKY=0 by skipping hook install + execution.
+  HUSKY: "0"
 
 jobs:
   release:


### PR DESCRIPTION
## Promotion: test -> main

Single-purpose payload: #1379 (ci(release): skip husky hooks on release runner pushes — HUSKY=0 at workflow env level) + backflow lineage merges.

Unblocks the release tail: re-dispatching release.yml from main after this lands lets the Push tags + Create GitHub releases steps complete (packages themselves already published by run 27389106334; changeset publish skips them idempotently).

Merge with a MERGE COMMIT (no squash) per the promotion convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)