### PR TITLE
fix(admin): hard-navigate after auth transitions to bypass stale cache

### DIFF
--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -13,9 +13,10 @@ import {
   VercelIcon,
 } from '@revealui/presentation/server';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
+import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 
 export type OAuthProvider = 'github' | 'google' | 'vercel' | 'linkedin';
 
@@ -72,7 +73,6 @@ export function LoginForm({ oauthProviders }: LoginFormProps) {
 }
 
 function LoginContent({ oauthProviders }: LoginFormProps) {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const { signIn, isLoading } = useSignIn();
   const {
@@ -100,11 +100,11 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
 
     const result = await signIn({ email, password });
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
-      router.push('/rotate-password');
+      navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
-      router.push('/');
+      navigateAfterAuthChange('/');
     } else if ('requiresMfa' in result && result.requiresMfa) {
-      router.push('/mfa');
+      navigateAfterAuthChange('/mfa');
     } else {
       const errorMessage = 'error' in result ? result.error : 'Failed to sign in';
       setError(errorMessage || 'Failed to sign in');
@@ -115,7 +115,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     setError(null);
     const success = await passkeySignIn();
     if (success) {
-      router.push('/');
+      navigateAfterAuthChange('/');
     }
   };
 

--- a/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for LoginForm's post-sign-in navigation.
+ *
+ * The critical behavior: every navigation that follows an auth-state change
+ * must be a full document navigation (navigateAfterAuthChange), never a soft
+ * router.push. The App Router client cache still holds the logged-out RSC
+ * payload for '/' (a redirect back to /login), so a soft push after sign-in
+ * replays it and bounces the user straight back to /login.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSignIn = vi.fn();
+const mockPasskeySignIn = vi.fn();
+const mockNavigate = vi.fn();
+const mockPush = vi.fn();
+// Set per-test to render the passkey button.
+let mockPasskeySupported = false;
+
+vi.mock('@revealui/auth/react', () => ({
+  useSignIn: () => ({ signIn: mockSignIn, isLoading: false }),
+  usePasskeySignIn: () => ({
+    signIn: mockPasskeySignIn,
+    isLoading: false,
+    error: null,
+    supported: mockPasskeySupported,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('@/lib/utils/auth-navigation', () => ({
+  // Deferred closure: direct `mockNavigate` here would hit the TDZ — the
+  // hoisted component import runs this factory before the const initializes.
+  navigateAfterAuthChange: (path: string) => mockNavigate(path),
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  ButtonCVA: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  FormLabel: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Heading: ({ children }: any) => <h2>{children}</h2>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  InputCVA: (props: any) => <input {...props} />,
+  GitHubIcon: () => <svg aria-hidden="true" />,
+  GoogleIcon: () => <svg aria-hidden="true" />,
+  LinkedInIcon: () => <svg aria-hidden="true" />,
+  PasskeyIcon: () => <svg aria-hidden="true" />,
+  VercelIcon: () => <svg aria-hidden="true" />,
+}));
+
+vi.mock('@/lib/components/PasswordInput', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  PasswordInput: ({ children }: any) => <div>{children}</div>,
+}));
+
+import { LoginForm } from '../LoginForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPasskeySupported = false;
+});
+
+function fillAndSubmit(): void {
+  const set = (selector: string, value: string) => {
+    const el = document.querySelector(selector);
+    if (el) fireEvent.change(el, { target: { value } });
+  };
+  set('#email', 'owner@example.com');
+  set('#password', 'Password123');
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+}
+
+describe('LoginForm post-sign-in navigation', () => {
+  it('full-navigates home after a successful credentials sign-in (no soft push)', async () => {
+    mockSignIn.mockResolvedValue({
+      success: true,
+      user: { id: '1', email: 'owner@example.com' },
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('full-navigates to /rotate-password when the account requires rotation', async () => {
+    mockSignIn.mockResolvedValue({
+      success: true,
+      user: { id: '1', email: 'owner@example.com' },
+      requiresPasswordRotation: true,
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/rotate-password');
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('full-navigates to /mfa when the server answers with an MFA challenge', async () => {
+    mockSignIn.mockResolvedValue({ success: false, requiresMfa: true, mfaUserId: 'u-1' });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/mfa');
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('shows the error and does not navigate on a failed sign-in', async () => {
+    mockSignIn.mockResolvedValue({ success: false, error: 'Invalid email or password' });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid email or password');
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('full-navigates home after a successful passkey sign-in (no soft push)', async () => {
+    mockPasskeySupported = true;
+    mockPasskeySignIn.mockResolvedValue(true);
+
+    render(<LoginForm oauthProviders={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Passkey' }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('stays put when a passkey sign-in is cancelled or fails', async () => {
+    mockPasskeySupported = true;
+    mockPasskeySignIn.mockResolvedValue(false);
+
+    render(<LoginForm oauthProviders={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Passkey' }));
+
+    await waitFor(() => {
+      expect(mockPasskeySignIn).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
@@ -8,15 +8,14 @@ import {
   InputCVA as Input,
 } from '@revealui/presentation/server';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, useState } from 'react';
+import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 
 function filterDigits(value: string): string {
   return [...value].filter((c) => c >= '0' && c <= '9').join('');
 }
 
 export function MFAForm() {
-  const router = useRouter();
   const { verify, verifyBackupCode, isLoading, error } = useMFAVerify();
   const [code, setCode] = useState('');
   const [useBackupCode, setUseBackupCode] = useState(false);
@@ -39,7 +38,7 @@ export function MFAForm() {
     const success = useBackupCode ? await verifyBackupCode(code.trim()) : await verify(code.trim());
 
     if (success) {
-      router.push('/');
+      navigateAfterAuthChange('/');
     }
   };
 

--- a/apps/admin/src/app/(frontend)/mfa/__tests__/MFAForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/__tests__/MFAForm.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for MFAForm's post-verify navigation — must be a full document
+ * navigation so the App Router client cache from the pre-auth state is
+ * discarded (same class as the LoginForm sign-in bounce).
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockVerify = vi.fn();
+const mockVerifyBackupCode = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@revealui/auth/react', () => ({
+  useMFAVerify: () => ({
+    verify: mockVerify,
+    verifyBackupCode: mockVerifyBackupCode,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/lib/utils/auth-navigation', () => ({
+  navigateAfterAuthChange: (path: string) => mockNavigate(path),
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  ButtonCVA: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  FormLabel: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Heading: ({ children }: any) => <h2>{children}</h2>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  InputCVA: (props: any) => <input {...props} />,
+}));
+
+import { MFAForm } from '../MFAForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function submitCode(code: string): void {
+  const el = document.querySelector('#totp-code');
+  if (el) fireEvent.change(el, { target: { value: code } });
+  fireEvent.click(screen.getByRole('button', { name: 'Verify' }));
+}
+
+describe('MFAForm post-verify navigation', () => {
+  it('full-navigates home after a successful TOTP verification', async () => {
+    mockVerify.mockResolvedValue(true);
+
+    render(<MFAForm />);
+    submitCode('123456');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('stays put when verification fails', async () => {
+    mockVerify.mockResolvedValue(false);
+
+    render(<MFAForm />);
+    submitCode('000000');
+
+    await waitFor(() => {
+      expect(mockVerify).toHaveBeenCalledWith('000000');
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
+++ b/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
@@ -6,13 +6,12 @@ import {
   Heading,
   InputCVA as Input,
 } from '@revealui/presentation/server';
-import { useRouter } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
+import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 import { apiFetch } from '@/lib/utils/csrf';
 
 export function RotatePasswordForm() {
-  const router = useRouter();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -55,7 +54,7 @@ export function RotatePasswordForm() {
         return;
       }
 
-      router.push('/');
+      navigateAfterAuthChange('/');
     } catch {
       setError('An unexpected error occurred.');
     } finally {

--- a/apps/admin/src/app/(frontend)/rotate-password/__tests__/RotatePasswordForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/rotate-password/__tests__/RotatePasswordForm.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for RotatePasswordForm's post-rotation navigation — must be a full
+ * document navigation so the App Router client cache from the
+ * rotation-pending state is discarded (same class as the LoginForm sign-in
+ * bounce).
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApiFetch = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (url: string, init?: RequestInit) => mockApiFetch(url, init),
+}));
+
+vi.mock('@/lib/utils/auth-navigation', () => ({
+  navigateAfterAuthChange: (path: string) => mockNavigate(path),
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  ButtonCVA: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  FormLabel: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Heading: ({ children }: any) => <h2>{children}</h2>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  InputCVA: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@/lib/components/PasswordInput', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  PasswordInput: ({ children }: any) => <div>{children}</div>,
+}));
+
+import { RotatePasswordForm } from '../RotatePasswordForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function fillAndSubmit(): void {
+  const set = (selector: string, value: string) => {
+    const el = document.querySelector(selector);
+    if (el) fireEvent.change(el, { target: { value } });
+  };
+  set('#current-password', 'OldPassword1');
+  set('#new-password', 'NewPassword2');
+  set('#confirm-password', 'NewPassword2');
+  fireEvent.click(screen.getByRole('button', { name: 'Change password' }));
+}
+
+describe('RotatePasswordForm post-rotation navigation', () => {
+  it('full-navigates home after a successful rotation', async () => {
+    mockApiFetch.mockResolvedValue({ ok: true });
+
+    render(<RotatePasswordForm />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('shows the API error and does not navigate on failure', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { message: 'Current password is incorrect.' } }),
+    });
+
+    render(<RotatePasswordForm />);
+    fillAndSubmit();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Current password is incorrect.');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
+import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 import { apiFetch } from '@/lib/utils/csrf';
 
 interface SignupFormProps {
@@ -95,9 +96,9 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       // protected route that would only bounce back to /login.
       if (result.user?.emailVerified) {
         if (plan) {
-          router.push(`/account/billing?upgrade=${plan}`);
+          navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
         } else {
-          router.push('/');
+          navigateAfterAuthChange('/');
         }
       } else {
         setAwaitingVerification(true);
@@ -130,7 +131,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       if (result.backupCodes?.length) {
         setBackupCodes(result.backupCodes);
       } else {
-        router.push('/');
+        navigateAfterAuthChange('/');
       }
     }
   };
@@ -206,7 +207,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
         <p className="text-xs text-zinc-600">
           Each code can only be used once. Keep them somewhere safe.
         </p>
-        <Button onClick={() => router.push('/')} className="w-full">
+        <Button onClick={() => navigateAfterAuthChange('/')} className="w-full">
           I&apos;ve saved my codes
         </Button>
       </div>

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -3,7 +3,9 @@
  *
  * The critical behavior: a NEW unverified user must NOT be pushed to a
  * protected route (which would bounce to /login) — they see a "Check your
- * inbox" confirmation instead. Only the auto-verified first user is sent in.
+ * inbox" confirmation instead. Only the auto-verified first user is sent in,
+ * via a full document navigation (navigateAfterAuthChange), never a soft
+ * router.push (see LoginForm.test.tsx for the stale-cache rationale).
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -11,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSignUp = vi.fn();
 const mockPush = vi.fn();
+const mockNavigate = vi.fn();
 // Set per-test to simulate the ?plan= deep link from the marketing pricing cards.
 let mockPlanParam: string | null = null;
 
@@ -29,6 +32,10 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => ({
     get: (key: string) => (key === 'plan' ? mockPlanParam : null),
   }),
+}));
+
+vi.mock('@/lib/utils/auth-navigation', () => ({
+  navigateAfterAuthChange: (path: string) => mockNavigate(path),
 }));
 
 vi.mock('@revealui/presentation/server', () => ({
@@ -86,6 +93,7 @@ describe('SignupForm post-signup routing', () => {
 
     expect(await screen.findByText('Check your inbox')).toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('sends an auto-verified (first) user straight in', async () => {
@@ -98,8 +106,9 @@ describe('SignupForm post-signup routing', () => {
     fillAndSubmit();
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
+    expect(mockPush).not.toHaveBeenCalled();
     expect(screen.queryByText('Check your inbox')).not.toBeInTheDocument();
   });
 
@@ -117,8 +126,9 @@ describe('SignupForm post-signup routing', () => {
     fillAndSubmit();
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith(`/account/billing?upgrade=${plan}`);
+      expect(mockNavigate).toHaveBeenCalledWith(`/account/billing?upgrade=${plan}`);
     });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('ignores an unknown ?plan= value and routes home', async () => {
@@ -132,7 +142,8 @@ describe('SignupForm post-signup routing', () => {
     fillAndSubmit();
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/lib/utils/__tests__/auth-navigation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/auth-navigation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { navigateAfterAuthChange } from '../auth-navigation';
+
+describe('navigateAfterAuthChange', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // jsdom's location is read-only; swap in a writable double (same pattern
+    // as packages/auth/src/react/__tests__/useSignOut.test.tsx).
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: '' },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('performs a full document navigation via location.href', () => {
+    navigateAfterAuthChange('/');
+    expect(window.location.href).toBe('/');
+  });
+
+  it('passes through paths with query strings', () => {
+    navigateAfterAuthChange('/account/billing?upgrade=pro');
+    expect(window.location.href).toBe('/account/billing?upgrade=pro');
+  });
+});

--- a/apps/admin/src/lib/utils/auth-navigation.ts
+++ b/apps/admin/src/lib/utils/auth-navigation.ts
@@ -1,0 +1,14 @@
+/**
+ * Full-document navigation for auth-state transitions (sign-in, sign-up,
+ * MFA verify, password rotation).
+ *
+ * After the session cookie changes, a soft `router.push` replays the App
+ * Router client cache, which still holds RSC payloads rendered under the
+ * previous auth state — '/' cached as a redirect-to-/login before sign-in
+ * bounces the user straight back to /login. A document load re-renders
+ * every segment under the new cookie. Sign-out already navigates this way
+ * (`useSignOut`, core's SignOutButton); auth entry points must match.
+ */
+export function navigateAfterAuthChange(path: string): void {
+  window.location.href = path;
+}


### PR DESCRIPTION
## Summary

Fixes the prod login UX bug from the 2026-06-12 Gate 1.4 owner smoke on admin.revealui.com: submitting valid credentials on /login appeared to do nothing (screen flash, still on /login, no error box). The sign-in POST succeeded and the session cookie was set; only the post-login client navigation was broken. A hard refresh immediately afterwards rendered the dashboard.

**Root cause.** `LoginForm` called `router.push('/')` after `signIn()` succeeded. In the App Router that is a soft navigation served from the client Router Cache, which still holds the RSC payload for `/` rendered under the logged-out state (a redirect back to `/login`), so the user bounced login -> / -> login. Hard refresh worked because a document load bypasses the client cache. OAuth sign-in never exhibited the bug because it round-trips through `/api/auth/<provider>` as a full document navigation.

**Fix.** Auth-state transitions now use a full document navigation instead of a soft push: new `apps/admin/src/lib/utils/auth-navigation.ts` exporting `navigateAfterAuthChange()` (`window.location.href`). This mirrors how the reverse transition already works (`useSignOut` and core's `SignOutButton` both do `window.location.href = '/login'`) and the existing auth-boundary redirects in the upgrade/refunds pages. All 10 post-auth-change navigations are rewired:

| Form | Sites |
|---|---|
| `LoginForm` | `/` (credentials), `/` (passkey), `/rotate-password`, `/mfa` |
| `SignupForm` | `/`, `/account/billing?upgrade=<plan>` (pricing deep-link trial path), `/` (passkey), `/` (backup-codes ack) |
| `RotatePasswordForm` | `/` after rotation |
| `MFAForm` | `/` after verify |

Deliberately untouched: SignupForm's "Go to sign in" button (`router.push('/login')` from the verify-email screen carries no auth-state change and /login is public), sign-out (already a full navigation), and OAuth anchors. `useRouter` is removed from the three forms that no longer need it.

## Tests

- New `LoginForm` suite (6) regression-locks the prod bug: credentials -> `/`, rotation -> `/rotate-password`, MFA challenge -> `/mfa`, passkey -> `/`, failure shows the alert and never navigates; `router.push` is asserted un-called on every success path.
- New `MFAForm` (2) and `RotatePasswordForm` (2) suites on the same harness.
- New `navigateAfterAuthChange` unit test (2) using the location-mock pattern from `packages/auth` `useSignOut.test.tsx`.
- `SignupForm` suite updated: post-auth assertions now expect the full navigation and assert no soft push remains.

Verified locally in a fresh worktree off `origin/test`: admin Vitest suite, admin `tsc --noEmit`, and repo Biome check all green. Not browser-verified against a running prod-like stack from this session; the live login smoke re-run folds into the owner's Gate 1.4 pass.

## Notes

- `apps/admin` only; no changeset (the app is unpublished).
- Related: `fix/admin-signout-cookie-domain` (the sign-out half of the same Gate 1.4 smoke) is a separate in-flight lane; zero file overlap.
- Follow-up chipped separately: the JSDoc usage examples in the `@revealui/auth` hooks (`useSignIn`/`useSignUp`/`useMFA`/`usePasskey`) still illustrate `router.push` after sign-in. Doc-only patch, deferred so it does not ride the open release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
