### PR TITLE
fix(admin): clear session cookies with the domain they were set with

### DIFF
--- a/.changeset/signout-revoke-all-presented-tokens.md
+++ b/.changeset/signout-revoke-all-presented-tokens.md
@@ -1,0 +1,5 @@
+---
+"@revealui/auth": patch
+---
+
+`deleteSession` now revokes every session token presented in the Cookie header instead of only the first. Browsers can hold duplicate `revealui-session` cookies (e.g. a stale host-only cookie alongside the domain-scoped one), and the stale duplicate could shadow the live token, leaving the live session row in place after sign-out.

--- a/apps/admin/src/__tests__/auth/session-signout-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/session-signout-routes.test.ts
@@ -5,7 +5,7 @@
  * Mocks auth service to test route logic in isolation.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks -- must be before route imports
@@ -21,6 +21,10 @@ vi.mock('@revealui/core/utils/logger', () => ({
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
@@ -44,6 +48,7 @@ vi.mock('@/lib/utils/error-response', () => ({
 }));
 
 import { deleteSession, getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
 import { NextRequest } from 'next/server';
 
 // ---------------------------------------------------------------------------
@@ -172,8 +177,16 @@ describe('POST /api/auth/sign-out', () => {
     POST = mod.POST as (req: NextRequest) => Promise<Response>;
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function deletionCookies(res: Response): string[] {
+    return res.headers.getSetCookie().map((cookie) => cookie.toLowerCase());
+  }
+
   it('returns 200 with success on sign-out', async () => {
-    vi.mocked(deleteSession).mockResolvedValue(undefined as never);
+    vi.mocked(deleteSession).mockResolvedValue(true);
 
     const req = makePostRequest('/api/auth/sign-out', {
       cookie: 'revealui-session=tok-abc',
@@ -185,20 +198,58 @@ describe('POST /api/auth/sign-out', () => {
     expect(body.success).toBe(true);
   });
 
-  it('clears the revealui-session cookie', async () => {
-    vi.mocked(deleteSession).mockResolvedValue(undefined as never);
+  it('clears the session, role, and must-rotate cookies', async () => {
+    vi.mocked(deleteSession).mockResolvedValue(true);
 
     const req = makePostRequest('/api/auth/sign-out');
     const res = await POST(req);
 
-    const setCookie = res.headers.get('set-cookie');
-    expect(setCookie).toContain('revealui-session');
-    // Cookie deletion sets max-age=0 or expires in the past
-    expect(setCookie).toMatch(/max-age=0|expires=Thu, 01 Jan 1970/i);
+    const setCookies = deletionCookies(res);
+    for (const name of ['revealui-session=', 'revealui-role=', 'revealui-must-rotate=']) {
+      const cookie = setCookies.find((entry) => entry.startsWith(name));
+      expect(cookie).toBeDefined();
+      // Cookie deletion sets max-age=0 with the path the cookies were set with
+      expect(cookie).toContain('max-age=0');
+      expect(cookie).toContain('path=/');
+    }
+  });
+
+  it('deletion cookies carry the domain the session cookies were set with', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '.revealui.com');
+    vi.mocked(deleteSession).mockResolvedValue(true);
+
+    const res = await POST(makePostRequest('/api/auth/sign-out'));
+    const setCookies = deletionCookies(res);
+
+    const sessionCookie = setCookies.find((entry) => entry.startsWith('revealui-session='));
+    const roleCookie = setCookies.find((entry) => entry.startsWith('revealui-role='));
+    expect(sessionCookie).toContain('domain=.revealui.com');
+    expect(roleCookie).toContain('domain=.revealui.com');
+
+    // revealui-must-rotate is set host-only at sign-in; its deletion must stay
+    // host-only to match.
+    const mustRotateCookie = setCookies.find((entry) => entry.startsWith('revealui-must-rotate='));
+    expect(mustRotateCookie).toBeDefined();
+    expect(mustRotateCookie).not.toContain('domain=');
+  });
+
+  it('omits the domain attribute when SESSION_COOKIE_DOMAIN is unset', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    vi.mocked(deleteSession).mockResolvedValue(true);
+
+    const res = await POST(makePostRequest('/api/auth/sign-out'));
+    const setCookies = deletionCookies(res);
+
+    expect(setCookies.length).toBeGreaterThan(0);
+    for (const cookie of setCookies) {
+      expect(cookie).not.toContain('domain=');
+    }
   });
 
   it('passes request headers to deleteSession', async () => {
-    vi.mocked(deleteSession).mockResolvedValue(undefined as never);
+    vi.mocked(deleteSession).mockResolvedValue(true);
 
     const req = makePostRequest('/api/auth/sign-out', {
       cookie: 'revealui-session=tok-xyz',
@@ -210,16 +261,35 @@ describe('POST /api/auth/sign-out', () => {
     expect(passedHeaders).toBeDefined();
   });
 
-  it('returns 500 when deleteSession throws', async () => {
+  it('still succeeds and warns when no session row was deleted', async () => {
+    vi.mocked(deleteSession).mockResolvedValue(false);
+
+    const res = await POST(makePostRequest('/api/auth/sign-out'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears cookies and returns 200 even when deleteSession throws', async () => {
     vi.mocked(deleteSession).mockRejectedValue(new Error('Storage unavailable'));
 
-    const req = makePostRequest('/api/auth/sign-out');
-    const res = await POST(req);
-    expect(res.status).toBe(500);
+    const res = await POST(makePostRequest('/api/auth/sign-out'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    const setCookies = deletionCookies(res);
+    const sessionCookie = setCookies.find((entry) => entry.startsWith('revealui-session='));
+    expect(sessionCookie).toBeDefined();
+    expect(sessionCookie).toContain('max-age=0');
   });
 
   it('succeeds even without a session cookie (no-op sign-out)', async () => {
-    vi.mocked(deleteSession).mockResolvedValue(undefined as never);
+    vi.mocked(deleteSession).mockResolvedValue(false);
 
     const req = makePostRequest('/api/auth/sign-out');
     const res = await POST(req);

--- a/apps/admin/src/app/api/auth/__tests__/session-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/session-routes.test.ts
@@ -51,6 +51,12 @@ vi.mock('next/server', () => {
     delete(name: string) {
       this.deleted.push(name);
     }
+    set(name: string, value: string, options?: { maxAge?: number }) {
+      // An empty value with maxAge 0 is cookie deletion.
+      if (value === '' && options?.maxAge === 0) {
+        this.deleted.push(name);
+      }
+    }
     getDeleted() {
       return this.deleted;
     }
@@ -215,7 +221,7 @@ describe('POST /api/auth/sign-out', () => {
   }
 
   it('deletes session and clears cookies on success', async () => {
-    mockDeleteSession.mockResolvedValue(undefined);
+    mockDeleteSession.mockResolvedValue(true);
     const POST = await loadRoute();
     const res = await POST(makeRequest());
 
@@ -229,13 +235,23 @@ describe('POST /api/auth/sign-out', () => {
     ).cookies.getDeleted();
     expect(cookies).toContain('revealui-session');
     expect(cookies).toContain('revealui-role');
+    expect(cookies).toContain('revealui-must-rotate');
   });
 
-  it('returns error response when deleteSession throws', async () => {
+  it('clears cookies and returns success even when deleteSession throws', async () => {
     mockDeleteSession.mockRejectedValue(new Error('Session not found'));
     const POST = await loadRoute();
     const res = await POST(makeRequest());
 
-    expect((res as { status: number }).status).toBe(500);
+    // Sign-out is idempotent: server-side revocation is best-effort, but the
+    // browser cookies must be cleared on every path.
+    expect((res as { status: number }).status).toBe(200);
+    expect((res as unknown as { body: { success: boolean } }).body.success).toBe(true);
+
+    const cookies = (
+      res as unknown as { cookies: { getDeleted: () => string[] } }
+    ).cookies.getDeleted();
+    expect(cookies).toContain('revealui-session');
+    expect(cookies).toContain('revealui-role');
   });
 });

--- a/apps/admin/src/app/api/auth/sign-out/route.ts
+++ b/apps/admin/src/app/api/auth/sign-out/route.ts
@@ -3,39 +3,41 @@
  *
  * POST /api/auth/sign-out
  *
- * Signs out the current user by deleting their session.
+ * Signs out the current user: best-effort server-side session revocation,
+ * then unconditional cookie clearing. Sign-out is idempotent  -  an
+ * already-dead session still gets a success response with cleared cookies.
  */
 
 import { deleteSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
-import { createErrorResponse } from '@/lib/utils/error-response';
+import { clearSessionCookies } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 async function signOutHandler(request: NextRequest): Promise<NextResponse> {
+  // Server-side revocation is best-effort: the cookie clearing below must run
+  // even when it fails, or the browser keeps a live session cookie.
+  let deleted = false;
   try {
-    await deleteSession(request.headers);
-
-    // Create response
-    const response = NextResponse.json({
-      success: true,
-    });
-
-    // Clear session and role cookies
-    response.cookies.delete('revealui-session');
-    response.cookies.delete('revealui-role');
-
-    return response;
+    deleted = await deleteSession(request.headers);
   } catch (error) {
-    logger.error('Error signing out', { error });
-    return createErrorResponse(error, {
-      endpoint: '/api/auth/sign-out',
-      operation: 'sign_out',
-    });
+    logger.error('Sign-out: server-side session deletion failed', { error });
   }
+
+  if (!deleted) {
+    logger.warn('Sign-out: no session row deleted (missing, unknown, or already-revoked token)');
+  }
+
+  const response = NextResponse.json({
+    success: true,
+  });
+
+  clearSessionCookies(response);
+
+  return response;
 }
 
 // Export rate-limited handler

--- a/apps/admin/src/lib/utils/session-cookies.ts
+++ b/apps/admin/src/lib/utils/session-cookies.ts
@@ -1,0 +1,52 @@
+/**
+ * Session Cookie Helpers
+ *
+ * Shared attribute derivation for the auth cookies set at sign-in and
+ * cleared at sign-out.
+ *
+ * Cookie identity is (name, domain, path): a deletion cookie only matches
+ * what sign-in set when it carries the SAME domain and path attributes.
+ * Sign-in sets `revealui-session` / `revealui-role` with
+ * `domain: SESSION_COOKIE_DOMAIN` in production (cross-subdomain auth), so a
+ * host-only delete is a browser-level no-op and the user stays signed in.
+ */
+
+import type { NextResponse } from 'next/server';
+
+export const SESSION_COOKIE = 'revealui-session';
+export const ROLE_COOKIE = 'revealui-role';
+export const MUST_ROTATE_COOKIE = 'revealui-must-rotate';
+
+/**
+ * Domain attribute for the session/role cookies, mirroring the sign-in
+ * derivation: `SESSION_COOKIE_DOMAIN` in production, host-only otherwise.
+ *
+ * Unlike sign-in, this never throws when the variable is missing  -  sign-out
+ * must still clear whatever cookie the host actually has.
+ */
+export function sessionCookieDomain(): string | undefined {
+  return process.env.NODE_ENV === 'production'
+    ? process.env.SESSION_COOKIE_DOMAIN || undefined
+    : undefined;
+}
+
+/**
+ * Expire the auth cookies with the same attributes they were set with:
+ * `revealui-session` / `revealui-role` domain-scoped in production,
+ * `revealui-must-rotate` host-only (it is set host-only at sign-in).
+ */
+export function clearSessionCookies(response: NextResponse): void {
+  const expire = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: 0,
+    expires: new Date(0),
+  };
+  const domain = sessionCookieDomain();
+
+  response.cookies.set(SESSION_COOKIE, '', { ...expire, domain });
+  response.cookies.set(ROLE_COOKIE, '', { ...expire, domain });
+  response.cookies.set(MUST_ROTATE_COOKIE, '', expire);
+}

--- a/packages/auth/src/__tests__/session.test.ts
+++ b/packages/auth/src/__tests__/session.test.ts
@@ -6,9 +6,11 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSession, deleteSession, getSession } from '../server/session.js';
+import { hashToken } from '../utils/token.js';
 
 // Mock database client
 const mockInsert = vi.fn();
+const mockDeleteWhere = vi.fn();
 vi.mock('@revealui/db/client', () => ({
   getClient: vi.fn(() => ({
     select: vi.fn(() => ({
@@ -25,15 +27,26 @@ vi.mock('@revealui/db/client', () => ({
       })),
     })),
     delete: vi.fn(() => ({
-      where: vi.fn(() => Promise.resolve({ rowCount: 1 })),
+      where: mockDeleteWhere,
     })),
   })),
 }));
 
+// Pass-through spy on hashToken so tests can assert which tokens were hashed
+// without changing the real hashing behavior.
+vi.mock('../utils/token.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/token.js')>();
+  return {
+    ...actual,
+    hashToken: vi.fn((token: string) => actual.hashToken(token)),
+  };
+});
+
 describe('Session Management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset mock to default behavior
+    // Reset mocks to default behavior
+    mockDeleteWhere.mockResolvedValue({ rowCount: 1 });
     mockInsert.mockReturnValue({
       values: vi.fn(() => ({
         returning: vi.fn(() => [
@@ -148,6 +161,53 @@ describe('Session Management', () => {
       const headers = new Headers();
       const deleted = await deleteSession(headers);
       expect(deleted).toBe(false);
+    });
+
+    it('revokes every distinct session token when duplicate cookies are present', async () => {
+      const headers = new Headers();
+      headers.set(
+        'cookie',
+        'revealui-session=tok-a; revealui-role=admin; revealui-session=tok-b; revealui-session=tok-a',
+      );
+
+      const deleted = await deleteSession(headers);
+      expect(deleted).toBe(true);
+
+      // Both distinct tokens hashed (deduped), single batched delete.
+      const hashedTokens = vi.mocked(hashToken).mock.calls.map((call) => call[0]);
+      expect(hashedTokens).toEqual(['tok-a', 'tok-b']);
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when no matching session row exists', async () => {
+      mockDeleteWhere.mockResolvedValueOnce({ rowCount: 0 });
+
+      const headers = new Headers();
+      headers.set('cookie', 'revealui-session=unknown-token');
+
+      const deleted = await deleteSession(headers);
+      expect(deleted).toBe(false);
+    });
+
+    it('returns false when the driver result exposes no rowCount', async () => {
+      mockDeleteWhere.mockResolvedValueOnce({});
+
+      const headers = new Headers();
+      headers.set('cookie', 'revealui-session=tok-a');
+
+      const deleted = await deleteSession(headers);
+      expect(deleted).toBe(false);
+    });
+
+    it('skips malformed percent-encoded duplicates without aborting sign-out', async () => {
+      const headers = new Headers();
+      headers.set('cookie', 'revealui-session=%E0%A4%A; revealui-session=tok-ok');
+
+      const deleted = await deleteSession(headers);
+      expect(deleted).toBe(true);
+
+      const hashedTokens = vi.mocked(hashToken).mock.calls.map((call) => call[0]);
+      expect(hashedTokens).toEqual(['tok-ok']);
     });
   });
 });

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -8,7 +8,7 @@
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
 import { sessions, users } from '@revealui/db/schema';
-import { and, eq, gt, isNull, ne } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, ne } from 'drizzle-orm';
 import type { Session, User } from '../types.js';
 import { hashToken } from '../utils/token.js';
 import { DatabaseError, TokenError } from './errors.js';
@@ -385,8 +385,14 @@ export async function rotateSession(
 /**
  * Delete a session (sign out)
  *
+ * Revokes EVERY session token presented in the cookie header, not just the
+ * first: a browser can hold duplicate `revealui-session` cookies (e.g. a
+ * stale host-only cookie alongside the domain-scoped one), and RFC 6265
+ * ordering lets the stale duplicate shadow the live token. Sign-out must
+ * revoke them all.
+ *
  * @param headers - Request headers containing session cookie
- * @returns True if session was deleted, false if not found
+ * @returns True if at least one session row was deleted, false otherwise
  */
 export async function deleteSession(headers: Headers): Promise<boolean> {
   const cookieHeader = headers.get('cookie');
@@ -394,15 +400,26 @@ export async function deleteSession(headers: Headers): Promise<boolean> {
     return false;
   }
 
-  const sessionToken = extractSessionToken(cookieHeader);
-  if (!sessionToken) {
+  const sessionTokens = extractAllSessionTokens(cookieHeader);
+  if (sessionTokens.length === 0) {
     return false;
   }
 
-  const tokenHash = hashToken(sessionToken);
+  const tokenHashes: string[] = [];
+  for (const sessionToken of sessionTokens) {
+    try {
+      tokenHashes.push(hashToken(sessionToken));
+    } catch {
+      logger.error('Error hashing session token during sign-out');
+    }
+  }
+  if (tokenHashes.length === 0) {
+    return false;
+  }
+
   const db = getClient();
 
-  const result = await db.delete(sessions).where(eq(sessions.tokenHash, tokenHash));
+  const result = await db.delete(sessions).where(inArray(sessions.tokenHash, tokenHashes));
 
   // Check if any rows were deleted - Drizzle delete returns result with rowCount or similar
   const rowCount =
@@ -488,6 +505,33 @@ function extractSessionToken(cookieHeader: string): string | null {
   }
 
   return decodeURIComponent(sessionCookie.substring('revealui-session='.length));
+}
+
+/**
+ * Extract every distinct session token from a cookie header.
+ *
+ * Duplicate `revealui-session` cookies are real: a host-only and a
+ * domain-scoped cookie with the same name travel together in one header.
+ * Deletion must see all of them; validation (getSession) deliberately keeps
+ * first-match semantics via extractSessionToken.
+ */
+function extractAllSessionTokens(cookieHeader: string): string[] {
+  const prefix = 'revealui-session=';
+  const tokens = new Set<string>();
+
+  for (const part of cookieHeader.split(';')) {
+    const cookie = part.trim();
+    if (!cookie.startsWith(prefix)) {
+      continue;
+    }
+    try {
+      tokens.add(decodeURIComponent(cookie.substring(prefix.length)));
+    } catch {
+      // Malformed percent-encoding in one duplicate must not abort sign-out.
+    }
+  }
+
+  return [...tokens];
 }
 
 /**


### PR DESCRIPTION
## Summary

Production bug (owner smoke of the admin app): clicking Sign out left the user fully signed in — no error shown, cookies intact after a hard refresh, dashboard still rendering.

Three compounding defects:

1. **Host-only cookie deletion vs domain-scoped cookies.** `POST /api/auth/sign-out` called `response.cookies.delete('revealui-session')` / `('revealui-role')` with no attributes, but sign-in sets both with `domain: SESSION_COOKIE_DOMAIN` in production. Cookie identity is (name, domain, path), so the deletion never matched and the browser kept both cookies. The surviving `revealui-role` cookie alone keeps `/admin` rendering (proxy.ts presence gate).
2. **Discarded `deleteSession` result + unguarded throw.** The route ignored the boolean, and a `deleteSession` throw skipped cookie clearing entirely (the catch path returned an error response with no Set-Cookie headers).
3. **First-match token extraction.** `deleteSession` only tried the first `revealui-session` value in the Cookie header. With duplicate cookies (stale host-only + live domain-scoped — exactly what the asymmetric set/delete produces), RFC 6265 ordering lets the stale one shadow the live token, so the live session row survived sign-out.

## Changes

- New `apps/admin/src/lib/utils/session-cookies.ts`: shared attribute derivation mirroring sign-in; sign-out now expires `revealui-session` + `revealui-role` with the same domain/path they were set with, plus the previously-stranded host-only `revealui-must-rotate`.
- `sign-out/route.ts`: server-side revocation is best-effort; cookies are cleared on every path (including throw) with warn/error logs; always 200 — sign-out is idempotent. This matches the documented endpoint contract in `docs/AUTH.md` (200 + `success: true` + cookie cleared); the previous 500-on-throw behavior was never the documented contract.
- `packages/auth` `deleteSession`: revokes every distinct presented token (`inArray`), skips malformed percent-encoded duplicates, returns true if any row was deleted. `getSession` first-match validation semantics deliberately unchanged.
- Patch changeset for `@revealui/auth`.

## Tests

- Route: deletion Set-Cookie carries `Domain` when `SESSION_COOKIE_DOMAIN` is set and omits it when unset; role + must-rotate coverage; `deleteSession` false → 200 + warn; `deleteSession` throw → 200 + cookies cleared + error log.
- Auth package: duplicate-cookie revocation (dedupe + single batched delete), rowCount-0 and missing-rowCount → false, malformed-decode guard.

## Verification

- `@revealui/auth`: 33 files, 499 passed / 19 skipped
- admin: 126 files, 1767 passed / 10 skipped (full suite)
- `tsc --noEmit` clean for both; `biome check .` 0 errors

Not reproduced against production from this environment; the fix is verified at the route/unit layer. The owner's production sign-out re-check after deploy is the live confirmation.

Also reviewed: `useSignOut` hook surfaces errors via state + rethrow (no change needed); the dashboard sign-out button's fire-and-forget fetch is its documented intent and is sound now that the route clears cookies on every path. The eight inlined `SESSION_COOKIE_DOMAIN` derivations across the cookie-setting auth routes are accidental duplication — consolidation is deliberately left out of this fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
