### PR TITLE
docs(auth): use full document navigation in post-auth hook examples

### DIFF
--- a/.changeset/auth-jsdoc-full-navigation.md
+++ b/.changeset/auth-jsdoc-full-navigation.md
@@ -1,0 +1,5 @@
+---
+"@revealui/auth": patch
+---
+
+docs(auth): post-auth hook examples now use a full document navigation instead of router.push(). In the Next.js App Router, a soft navigation after the session cookie changes replays the pre-auth client Router Cache (the logged-out RSC payload) and bounces the user back to the login page. The useSignIn, useSignUp, useMFAVerify, and usePasskeySignIn examples now use window.location.href, matching useSignOut and the admin auth forms. Doc comments only, no runtime change.

--- a/packages/auth/src/react/useMFA.ts
+++ b/packages/auth/src/react/useMFA.ts
@@ -151,7 +151,8 @@ export interface UseMFAVerifyResult {
  *   const handleSubmit = async (code: string) => {
  *     const success = await verify(code);
  *     if (success) {
- *       router.push('/admin');
+ *       // Full navigation: a soft router.push() would replay the pre-auth Router Cache
+ *       window.location.href = '/admin';
  *     }
  *   };
  * }

--- a/packages/auth/src/react/usePasskey.ts
+++ b/packages/auth/src/react/usePasskey.ts
@@ -167,7 +167,8 @@ export interface UsePasskeySignInResult {
  *   const handlePasskeyLogin = async () => {
  *     const success = await signIn();
  *     if (success) {
- *       router.push('/admin');
+ *       // Full navigation: a soft router.push() would replay the pre-auth Router Cache
+ *       window.location.href = '/admin';
  *     }
  *   };
  *

--- a/packages/auth/src/react/useSignIn.ts
+++ b/packages/auth/src/react/useSignIn.ts
@@ -73,7 +73,8 @@ export interface UseSignInResult {
  *     e.preventDefault()
  *     const result = await signIn({ email, password })
  *     if (result.success) {
- *       router.push('/dashboard')
+ *       // Full navigation: a soft router.push() would replay the pre-auth Router Cache
+ *       window.location.href = '/dashboard'
  *     }
  *   }
  * }

--- a/packages/auth/src/react/useSignUp.ts
+++ b/packages/auth/src/react/useSignUp.ts
@@ -70,7 +70,8 @@ export interface UseSignUpResult {
  *     e.preventDefault()
  *     const result = await signUp({ email, password, name })
  *     if (result.success) {
- *       router.push('/dashboard')
+ *       // Full navigation: a soft router.push() would replay the pre-auth Router Cache
+ *       window.location.href = '/dashboard'
  *     }
  *   }
  * }


### PR DESCRIPTION
## Summary

Companion to #1381. The `@revealui/auth` React hook JSDoc examples (`useSignIn`, `useSignUp`, `useMFAVerify`, `usePasskeySignIn`) recommended calling `router.push()` right after a successful authentication, the exact pattern #1381 removed from the admin auth forms. In the Next.js App Router, a soft navigation issued after the session cookie changes replays the client Router Cache, which still holds the pre-auth RSC payload for the target route (a redirect back to the login page), so the user bounces login -> app -> login.

The examples now demonstrate a full document navigation with a one-line comment explaining why, matching `useSignOut` (which already navigates via `window.location.href`) and core's `SignOutButton`.

Doc comments only, no runtime code change.

## Changes

- `packages/auth/src/react/useSignIn.ts`: example success path now uses `window.location.href = '/dashboard'`
- `packages/auth/src/react/useSignUp.ts`: same
- `packages/auth/src/react/useMFA.ts` (`useMFAVerify`): example now uses `window.location.href = '/admin'`
- `packages/auth/src/react/usePasskey.ts` (`usePasskeySignIn`): same
- `.changeset/auth-jsdoc-full-navigation.md`: patch changeset for `@revealui/auth`

## Verification

- `pnpm --filter @revealui/auth test`: 495 passed, 19 skipped (35 files)
- `pnpm --filter @revealui/auth typecheck`: clean
- `pnpm lint` (Biome, repo-wide): 0 errors, no findings in changed files
- Pre-push phase-1 gate: PASS (the doc-import structure warnings it prints are pre-existing and warn-only)

## Sequencing

Opened after promotion #1380 (test -> main) landed and after #1381 merged to test; no file overlap with either. Rides the next test -> main train. Owner-gated manual merge, no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
