### PR TITLE
fix(ci): source GitHub release bodies from package changelogs

### DIFF
--- a/.github/scripts/create-github-releases.cjs
+++ b/.github/scripts/create-github-releases.cjs
@@ -1,0 +1,188 @@
+'use strict';
+
+/**
+ * Creates one GitHub release per package tag pointing at HEAD, with the release
+ * body sourced from that package's own CHANGELOG.md section for the tagged
+ * version (changesets convention).
+ *
+ * `generate_release_notes: true` is deliberately not used: GitHub generates
+ * those notes from every commit since the previous tag of the same package, so
+ * for monorepo package tags the body can exceed GitHub's 125,000-character
+ * release-body limit and the API rejects the creation with a 422.
+ *
+ * Loaded by .github/workflows/release.yml via actions/github-script. CommonJS
+ * (.cjs) because github-script exposes a CommonJS `require` resolved against
+ * the workspace root. No-regex (methodology M2): string operations only.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// GitHub rejects release bodies over 125,000 characters ("body is too long",
+// 422); truncate below the limit with room for the truncation notice.
+const MAX_BODY_CHARS = 120000;
+
+/**
+ * Parse `<npm-name>@<version>` at the last `@` so scoped names keep their
+ * scope: `@revealui/core@0.10.0` -> { name: '@revealui/core', version:
+ * '0.10.0' }, `create-revealui@0.5.9` -> { name: 'create-revealui', ... }.
+ */
+function parseTag(tag) {
+  const separator = tag.lastIndexOf('@');
+  if (separator <= 0 || separator === tag.length - 1) return null;
+  return { name: tag.slice(0, separator), version: tag.slice(separator + 1) };
+}
+
+/**
+ * Map workspace package names to their directory by reading every
+ * packages/<dir>/package.json — names are never hardcoded here.
+ */
+function buildPackageDirMap(packagesRoot) {
+  const dirByName = new Map();
+  for (const entry of fs.readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = path.join(packagesRoot, entry.name, 'package.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.name === 'string' && manifest.name.length > 0) {
+      dirByName.set(manifest.name, path.join(packagesRoot, entry.name));
+    }
+  }
+  return dirByName;
+}
+
+/**
+ * Extract the body of the `## <version>` section from a changesets CHANGELOG.
+ *
+ * The section ends at the first line that is not changesets section content.
+ * Changesets only ever emits blank lines, `###` change-type headings, `-`/`*`
+ * bullets, and indented continuation lines inside a section, so any other
+ * column-0 line is a boundary: the next `##` version heading, the `#` package
+ * title, a `---` delimiter, or docs-frontmatter key remnants — changesets
+ * prepends new sections by replacing the file's first newline, which lands
+ * them inside a leading frontmatter block and strands its keys below the
+ * newest sections in some package changelogs.
+ */
+function extractChangelogSection(changelogText, version) {
+  const lines = changelogText.split('\n');
+  const heading = `## ${version}`;
+  let start = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].trim() === heading) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const isSectionContent =
+      line.startsWith('###') ||
+      line.startsWith('- ') ||
+      line.startsWith('* ') ||
+      line.startsWith(' ') ||
+      line.startsWith('\t');
+    if (!isSectionContent) {
+      end = i;
+      break;
+    }
+  }
+  while (start < end && lines[start].trim() === '') start += 1;
+  while (end > start && lines[end - 1].trim() === '') end -= 1;
+  if (start >= end) return null;
+  return lines.slice(start, end).join('\n');
+}
+
+/**
+ * A 422 whose error list contains `already_exists` means the release was
+ * already created (manual creation or a re-run) — a skip, not a failure.
+ */
+function isAlreadyExistsError(error) {
+  if (error === null || typeof error !== 'object' || error.status !== 422) return false;
+  const apiErrors = error.response?.data?.errors;
+  if (!Array.isArray(apiErrors)) return false;
+  return apiErrors.some(
+    (apiError) => apiError !== null && typeof apiError === 'object' && apiError.code === 'already_exists',
+  );
+}
+
+async function run({ github, context, core }) {
+  const tags = execFileSync('git', ['tag', '--points-at', 'HEAD'], { encoding: 'utf8' })
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+
+  if (tags.length === 0) {
+    core.notice(
+      'No tags point at HEAD: `changeset publish` creates tags only for packages it actually publishes. ' +
+        'On a re-run of an already-published release this is expected — packages are already on npm and no GitHub releases are created here.',
+    );
+    return;
+  }
+  core.info(`Tags at HEAD (${tags.length}): ${tags.join(', ')}`);
+
+  const dirByName = buildPackageDirMap(path.join(process.cwd(), 'packages'));
+  const failures = [];
+
+  for (const tag of tags) {
+    const parsed = parseTag(tag);
+    if (parsed === null) {
+      failures.push({ tag, reason: 'tag is not <package-name>@<version>' });
+      continue;
+    }
+    const packageDir = dirByName.get(parsed.name);
+    if (packageDir === undefined) {
+      failures.push({ tag, reason: `no workspace package named "${parsed.name}" under packages/` });
+      continue;
+    }
+    const changelogPath = path.join(packageDir, 'CHANGELOG.md');
+    const relativeChangelogPath = path.relative(process.cwd(), changelogPath);
+    if (!fs.existsSync(changelogPath)) {
+      failures.push({ tag, reason: `missing ${relativeChangelogPath}` });
+      continue;
+    }
+    const section = extractChangelogSection(fs.readFileSync(changelogPath, 'utf8'), parsed.version);
+    if (section === null) {
+      failures.push({ tag, reason: `no "## ${parsed.version}" section in ${relativeChangelogPath}` });
+      continue;
+    }
+
+    let body = section;
+    if (body.length > MAX_BODY_CHARS) {
+      core.warning(`${tag}: changelog section is ${body.length} chars; truncating to ${MAX_BODY_CHARS}.`);
+      body = `${body.slice(0, MAX_BODY_CHARS)}\n\n_Truncated — see ${relativeChangelogPath} for the full entry._`;
+    }
+
+    try {
+      await github.rest.repos.createRelease({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        tag_name: tag,
+        name: tag,
+        body,
+        make_latest: 'false',
+      });
+      core.info(`Created release ${tag} (${body.length}-char body from ${relativeChangelogPath})`);
+    } catch (error) {
+      if (isAlreadyExistsError(error)) {
+        core.info(`Release already exists, skipping: ${tag}`);
+        continue;
+      }
+      failures.push({ tag, reason: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      core.error(`Release failed for ${failure.tag}: ${failure.reason}`);
+    }
+    core.setFailed(`${failures.length} of ${tags.length} GitHub release(s) failed; see errors above.`);
+    return;
+  }
+  core.info(`All ${tags.length} GitHub release(s) created or already present.`);
+}
+
+module.exports = { run, parseTag, buildPackageDirMap, extractChangelogSection, isAlreadyExistsError };

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,31 +104,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
+      # `changeset publish` creates tags only for the packages it actually
+      # publishes — on a re-run after a successful publish there are no tags at
+      # HEAD, so this step and the release step after it intentionally no-op.
+      # Say so explicitly instead of silently pushing nothing.
       - name: Push tags
         if: ${{ !inputs.dry-run }}
-        run: git push --follow-tags
+        run: |
+          tag_count="$(git tag --points-at HEAD | wc -l)"
+          if [ "$tag_count" -eq 0 ]; then
+            echo "::notice title=No tags at HEAD::changeset publish created no tags (nothing newly published — likely a re-run), so no tags are pushed and no GitHub releases will be created."
+          else
+            echo "Pushing $tag_count tag(s) created by changeset publish."
+          fi
+          git push --follow-tags
 
+      # Release bodies come from each package's own CHANGELOG.md section for the
+      # tagged version (changesets convention). generate_release_notes is
+      # deliberately NOT used: GitHub builds those notes from every commit since
+      # the previous tag of the same package, which exceeds the 125,000-char
+      # release-body limit for monorepo package tags (422 "body is too long").
+      # The script fails this step if any release creation fails — the previous
+      # per-tag catch-and-warn reported success while every creation 422'd.
       - name: Create GitHub releases
         if: ${{ !inputs.dry-run }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { execSync } = require('child_process')
-            const tags = execSync('git tag --points-at HEAD', { encoding: 'utf8' })
-              .trim().split('\n').filter(Boolean)
-
-            for (const tag of tags) {
-              try {
-                await github.rest.repos.createRelease({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag_name: tag,
-                  name: tag,
-                  generate_release_notes: true,
-                  make_latest: 'false',
-                })
-                console.log(`Created release: ${tag}`)
-              } catch (e) {
-                console.warn(`Could not create release for ${tag}: ${e.message}`)
-              }
-            }
+            const { run } = require('./.github/scripts/create-github-releases.cjs')
+            await run({ github, context, core })


### PR DESCRIPTION
## Problem

`release.yml`'s **Create GitHub releases** step created every package release with `generate_release_notes: true`. GitHub generates those notes from all commits since the previous tag of the same package — for monorepo package tags that span months of history, every generated body exceeded GitHub's 125,000-character release-body limit, and **all 16 release creations in run 27391393609 (2026-06-12) failed with 422 "body is too long"**. The step still reported success because each failure was caught and logged as a warning — a silent failure mode that hid the bug for an entire release.

The 16 releases were subsequently created manually with each package's CHANGELOG section as the body; this PR makes the workflow produce exactly that shape itself.

## Fix

- **New `.github/scripts/create-github-releases.cjs`**, loaded by the step via `actions/github-script`'s workspace `require` (no 100-line inline script in YAML, and it can be exercised locally):
  - Parses each tag at the **last `@`** — `@revealui/core@0.10.0` → name + version; unscoped `create-revealui@0.5.9` works the same way.
  - Maps npm name → `packages/<dir>` by reading every `packages/*/package.json` name. Nothing hardcoded (26 workspace packages mapped today); a tag whose name has no workspace package is a loud failure, not a skip.
  - Extracts the `## <version>` section from that package's `CHANGELOG.md` at the checked-out ref and passes it as `body`. The section is bounded by the changesets content grammar (blank lines, `###` change-type headings, `-`/`*` bullets, indented continuations); any other column-0 line ends it. This matters: changesets prepends new sections by replacing the file's *first newline*, so changelogs carrying docs frontmatter get new sections injected inside the frontmatter block — the grammar boundary keeps stranded `title:`/`status:`/… keys out of release bodies.
  - Truncates defensively at 120,000 chars with a pointer to the changelog file, so the failure mode this PR fixes cannot recur even for a pathological section.
  - `make_latest: 'false'` kept; release name = tag, as before. No regex anywhere in the script (string ops only, per repo methodology M2).
- **Failures are loud now**: per-tag failures (parse, mapping, missing changelog/section, API errors) are collected and the step fails at the end via `core.setFailed`. A 422 `already_exists` is treated as a skip so re-runs stay idempotent against the manually-created releases.
- **Push tags** now logs explicitly when `changeset publish` created no tags (fully-skipped publish on a re-run), instead of silently no-oping — that silence cost an hour of diagnosis on this release.
- `env.HUSKY: "0"` (#1379) untouched.

## Dry reasoning trace — `@revealui/core@0.10.0`

1. Tag `@revealui/core@0.10.0` → split at last `@` → name `@revealui/core`, version `0.10.0`.
2. Workspace map (built from `packages/*/package.json` names) → `@revealui/core` → `packages/core`.
3. `packages/core/CHANGELOG.md` → `## 0.10.0` section: **2,610 chars, 14 lines**, starting `### Minor Changes`, ending `  - @revealui/cache@0.2.2` — and **not** including the stranded frontmatter keys that sit directly below that section in the current file.
4. `createRelease({ tag_name, name: tag, body: <section>, make_latest: 'false' })` → today this returns 422 `already_exists` (release was created manually) → logged as a skip, not a failure; on a future release it creates the release with the changelog body.

## Verification

Workflow-only payload (the workflow plus the script it loads). actionlint isn't available locally, so:

- `node --check` clean on the script; Biome check clean.
- Workflow YAML parses (js-yaml); all 13 steps intact; `env.HUSKY` still `"0"`; the release step's script is the two-line loader.
- A harness ran the **exact exported functions the workflow loads** against the real repo: all **16 tags of the 2026-06-12 release** resolve and extract — 16/16 sections found, zero frontmatter leakage, body sizes 47–2,610 chars.
- `run()` executed end-to-end at a tag-less HEAD with a mock `core`/`github`: takes the explicit no-tags notice path and calls `createRelease` zero times.
- Not exercised against the live API; the next real release run is the live test, and re-run safety is covered by the `already_exists` skip.

## Note for the merger

Workflow-only payloads can hit the **skipped-required-checks merge block** (path-filtered required checks report SKIPPED, which branch protection doesn't count as success — the known gotcha on backflows/promotions). If the merge UI blocks on skipped contexts, that's this, not a CI failure.
