### PR TITLE
fix(auth): attach csrf double-submit token on usePasskey posts

### DIFF
--- a/.changeset/auth-usepasskey-csrf-attach.md
+++ b/.changeset/auth-usepasskey-csrf-attach.md
@@ -1,0 +1,5 @@
+---
+'@revealui/auth': patch
+---
+
+`usePasskeyRegister` and `usePasskeySignIn` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on all four passkey POSTs. The admin proxy requires that header on any session-cookie-bearing unsafe request, so passkey registration — which always runs with a session — was rejected with a 403 "CSRF token missing" once CSRF enforcement went live; passkey sign-in kept working only because its endpoints are proxy-exempt pre-auth. The token is re-read before each POST so a proxy reissue between the options and verify steps cannot strand a stale token. Mirrors the attach pattern in `@revealui/core`'s admin APIClient and `@revealui/ai`'s `useAgentStream`. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1245,9 +1245,11 @@ The authentication system uses **cookie-based sessions** with the following CSRF
 - **Attachment:** browser code goes through `apiFetch`
   (`apps/admin/src/lib/utils/csrf.ts`), which attaches the header for unsafe
   requests to the admin's own `/api/*` routes and to the configured api origin;
-  the core admin `APIClient` does the same. Admin server-side forwarders
-  (collections/globals/batch proxy routes) mint a per-request token via
-  `apps/admin/src/lib/utils/api-proxy-headers.ts`.
+  the core admin `APIClient` does the same, as do the published hooks that
+  POST from the browser — `@revealui/ai`'s `useAgentStream`, `@revealui/sync`'s
+  mutation helpers, and `@revealui/auth`'s passkey hooks. Admin server-side
+  forwarders (collections/globals/batch proxy routes) mint a per-request token
+  via `apps/admin/src/lib/utils/api-proxy-headers.ts`.
 
 ### Why the Token Binds to the Session Cookie Value
 

--- a/packages/auth/src/react/__tests__/usePasskey.test.tsx
+++ b/packages/auth/src/react/__tests__/usePasskey.test.tsx
@@ -356,3 +356,198 @@ describe('usePasskeySignIn', () => {
     expect(result.current.error).toBe('Passkeys are not supported in this browser');
   });
 });
+
+describe('usePasskey - CSRF token attach', () => {
+  let originalPublicKeyCredential: typeof window.PublicKeyCredential;
+
+  beforeEach(() => {
+    originalPublicKeyCredential = window.PublicKeyCredential;
+    if (!window.PublicKeyCredential) {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: class MockPublicKeyCredential {},
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      value: originalPublicKeyCredential,
+      writable: true,
+      configurable: true,
+    });
+    // happy-dom cookies persist across tests in this file - expire ours so
+    // the exact-equality assertions in the describes above stay header-free
+    document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('register() echoes the revealui-csrf cookie as X-CSRF-Token on both POSTs', async () => {
+    document.cookie = 'other-cookie=unrelated';
+    document.cookie = 'revealui-csrf=nonce123:hmac456';
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: { backupCodes: [] } }]),
+    );
+
+    const { startRegistration } = await import('@simplewebauthn/browser');
+    vi.mocked(startRegistration).mockResolvedValue({ id: 'cred' } as never);
+
+    const { result } = renderHook(() => usePasskeyRegister());
+    await act(async () => {
+      await result.current.register({ deviceName: 'Test Device' });
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/passkey/register-options', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'nonce123:hmac456',
+      },
+      credentials: 'include',
+      body: '{}',
+    });
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/auth/passkey/register-verify', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'nonce123:hmac456',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ attestationResponse: { id: 'cred' }, deviceName: 'Test Device' }),
+    });
+  });
+
+  it('register() re-reads the cookie before each POST (proxy may reissue between steps)', async () => {
+    document.cookie = 'revealui-csrf=token-before';
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: {} }]),
+    );
+
+    const { startRegistration } = await import('@simplewebauthn/browser');
+    vi.mocked(startRegistration).mockImplementation(async () => {
+      document.cookie = 'revealui-csrf=token-rotated';
+      return { id: 'cred' } as never;
+    });
+
+    const { result } = renderHook(() => usePasskeyRegister());
+    await act(async () => {
+      await result.current.register();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/auth/passkey/register-options',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'token-before' }),
+      }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/auth/passkey/register-verify',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'token-rotated' }),
+      }),
+    );
+  });
+
+  it('signIn() echoes the cookie on both POSTs (logged-in re-auth)', async () => {
+    document.cookie = 'revealui-csrf=tok-signin';
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: { success: true } }]),
+    );
+
+    const { startAuthentication } = await import('@simplewebauthn/browser');
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'cred' } as never);
+
+    const { result } = renderHook(() => usePasskeySignIn());
+    await act(async () => {
+      await result.current.signIn();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/passkey/authenticate-options', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRF-Token': 'tok-signin' },
+    });
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/auth/passkey/authenticate-verify', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'tok-signin',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ authenticationResponse: { id: 'cred' } }),
+    });
+  });
+
+  it('register() omits X-CSRF-Token when the cookie is absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: {} }]),
+    );
+
+    const { startRegistration } = await import('@simplewebauthn/browser');
+    vi.mocked(startRegistration).mockResolvedValue({ id: 'cred' } as never);
+
+    const { result } = renderHook(() => usePasskeyRegister());
+    await act(async () => {
+      await result.current.register();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/passkey/register-options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: '{}',
+    });
+  });
+
+  it('signIn() sends no headers key at all when the cookie is absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: { success: true } }]),
+    );
+
+    const { startAuthentication } = await import('@simplewebauthn/browser');
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'cred' } as never);
+
+    const { result } = renderHook(() => usePasskeySignIn());
+    await act(async () => {
+      await result.current.signIn();
+    });
+
+    // Exact equality: cookie-less sign-in requests stay byte-identical to the
+    // pre-CSRF shape (no headers key on authenticate-options)
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/passkey/authenticate-options', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+
+  it('omits X-CSRF-Token when the cookie value is empty', async () => {
+    document.cookie = 'revealui-csrf=';
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([{ body: { options: { challenge: 'c' } } }, { body: {} }]),
+    );
+
+    const { startRegistration } = await import('@simplewebauthn/browser');
+    vi.mocked(startRegistration).mockResolvedValue({ id: 'cred' } as never);
+
+    const { result } = renderHook(() => usePasskeyRegister());
+    await act(async () => {
+      await result.current.register();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/passkey/register-options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: '{}',
+    });
+  });
+});

--- a/packages/auth/src/react/usePasskey.ts
+++ b/packages/auth/src/react/usePasskey.ts
@@ -3,11 +3,39 @@
  *
  * React hooks for WebAuthn passkey registration and authentication.
  * Uses dynamic imports for @simplewebauthn/browser to avoid SSR issues.
+ *
+ * CSRF: every POST echoes the JS-readable `revealui-csrf` cookie (the signed
+ * double-submit token the RevealUI admin proxy issues on page load) as an
+ * `X-CSRF-Token` header when the cookie is present. The proxy requires it on
+ * session-cookie-bearing unsafe requests — registration always runs with a
+ * session, so without the header it 403s ("CSRF token missing"). Cookie-less
+ * callers (no admin session) send no header and are unchanged.
  */
 
 'use client';
 
 import { useEffect, useState } from 'react';
+
+/**
+ * Read the JS-readable `revealui-csrf` cookie. The RevealUI admin proxy
+ * (`apps/admin/src/proxy.ts`) requires it as an `X-CSRF-Token` header on any
+ * session-cookie-bearing unsafe request, and may re-issue the cookie on any
+ * response — so call this immediately before each fetch rather than once per
+ * flow. Returns undefined outside the browser or when the cookie is
+ * absent/empty. Mirrors the cookie-read in `@revealui/core`'s admin APIClient
+ * (`request()`) and `@revealui/ai`'s `useAgentStream`.
+ */
+function readCsrfToken(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  for (const part of document.cookie.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
+      return part.slice(eqIdx + 1).trim() || undefined;
+    }
+  }
+  return undefined;
+}
 
 export interface PasskeyRegisterOptions {
   /** Email for passkey registration (sign-up flow) */
@@ -75,9 +103,13 @@ export function usePasskeyRegister(): UsePasskeyRegisterResult {
       setError(null);
 
       // Step 1: Get registration options from the server
+      const optionsCsrfToken = readCsrfToken();
       const optionsResponse = await fetch('/api/auth/passkey/register-options', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(optionsCsrfToken ? { 'X-CSRF-Token': optionsCsrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({
           email: options?.email,
@@ -103,9 +135,13 @@ export function usePasskeyRegister(): UsePasskeyRegisterResult {
       const attestationResponse = await startRegistration({ optionsJSON: optionsData.options });
 
       // Step 3: Verify with the server
+      const verifyCsrfToken = readCsrfToken();
       const verifyResponse = await fetch('/api/auth/passkey/register-verify', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(verifyCsrfToken ? { 'X-CSRF-Token': verifyCsrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({
           attestationResponse,
@@ -204,9 +240,13 @@ export function usePasskeySignIn(): UsePasskeySignInResult {
       setError(null);
 
       // Step 1: Get authentication options from the server
+      const optionsCsrfToken = readCsrfToken();
       const optionsResponse = await fetch('/api/auth/passkey/authenticate-options', {
         method: 'POST',
         credentials: 'include',
+        // Conditional headers key keeps cookie-less sign-in requests
+        // byte-identical to the pre-CSRF request shape.
+        ...(optionsCsrfToken ? { headers: { 'X-CSRF-Token': optionsCsrfToken } } : {}),
       });
 
       const optionsJson: unknown = await optionsResponse.json();
@@ -226,9 +266,13 @@ export function usePasskeySignIn(): UsePasskeySignInResult {
       const assertionResponse = await startAuthentication({ optionsJSON: authOptionsData.options });
 
       // Step 3: Verify with the server
+      const verifyCsrfToken = readCsrfToken();
       const verifyResponse = await fetch('/api/auth/passkey/authenticate-verify', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(verifyCsrfToken ? { 'X-CSRF-Token': verifyCsrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({ authenticationResponse: assertionResponse }),
       });


### PR DESCRIPTION
## Problem

On the production admin's `/settings/security` page, **Add passkey** fails immediately with `403 {"error":"CSRF token missing"}` (owner smoke, 2026-06-12). Passkey sign-in from `/login` still works.

## Root cause

The published `@revealui/auth` `usePasskeyRegister` / `usePasskeySignIn` hooks make four bare `fetch()` POSTs with no CSRF handling. The admin proxy's CSRF gate (#1349) requires an `X-CSRF-Token` header on any unsafe request carrying a `revealui-session` cookie:

- the **register** pair (`/api/auth/passkey/register-options`, `register-verify`) always runs with a session cookie → 403 before the WebAuthn ceremony can start.
- the **authenticate** pair kept working only because `/api/auth/passkey/authenticate*` is in the proxy's pre-auth exempt list.

The #1349 wave fixed the admin-app call sites (apiFetch + server-side forwarders), and #1352 / #1354 fixed the published `@revealui/ai` / `@revealui/sync` surfaces; the auth passkey hooks were the remaining published-hook gap.

Page-load issuance is **not** part of the bug: `proxy.ts` mints/refreshes the JS-readable `revealui-csrf` cookie on every matched page response, and the matcher covers `/settings/security`. Client-only fix.

## Fix

Mirrors #1352 (`useAgentStream`) and the core admin `APIClient.request()`:

- local no-regex `readCsrfToken()` (cookie `split`/`indexOf` walk; `undefined` outside the browser or when the cookie is absent/empty)
- echo the cookie as `X-CSRF-Token` on **all four** passkey POSTs — the register pair fixes the bug; the authenticate pair future-proofs logged-in re-auth and is harmless on the exempt paths
- the token is re-read **before each POST**: the proxy may reissue the cookie on any response, so a once-per-flow read could strand a stale token between the options and verify steps
- cookie-less callers stay byte-identical: on `authenticate-options` (which previously sent no `headers` at all) the entire `headers` key is spread conditionally

## Tests

6 new cases appended to the existing `packages/auth/src/react/__tests__/usePasskey.test.tsx` suite, mirroring the #1352 test shape:

- header echoed on both register POSTs and both sign-in POSTs when the cookie is present
- re-read-per-POST pinned by rotating the cookie between the options and verify steps
- absent-cookie requests asserted **byte-identical** via exact-equality (`authenticate-options` has no `headers` key at all)
- empty-value cookie → header omitted

## Changeset

`@revealui/auth` patch. Also adds the published hooks to the CSRF "Attachment" list in `docs/AUTH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
