### PR TITLE
docs(secrets): index RevDev Tauri updater signing paths

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -251,8 +251,15 @@ revealui/env/supabase
 revdev/license-signing-private-key       # Ed25519 license signing key (canonical keypair)
 revdev/license-signing-public-key        # Ed25519 license verification key (canonical keypair)
 revdev/github-token                      # perpetual license GitHub provisioning
+revdev/tauri-signing-private-key          # Tauri updater signing key (Studio auto-update; generated 2026-06-11)
+revdev/tauri-signing-private-key-password # password for the Tauri updater key
+revdev/tauri-signing-public-key           # updater public key (also embedded in apps/studio tauri.conf.json)
 # The retired legacy pair (revdev/license-signing-key + revdev/license-public-key) is
 # superseded by the canonical Ed25519 keypair above.
+# CI mirror: TAURI_SIGNING_PRIVATE_KEY + TAURI_SIGNING_PRIVATE_KEY_PASSWORD repo secrets
+# on RevealUIStudio/revdev (consumed by studio-release.yml) are mirrored FROM the two
+# tauri-signing vault paths above — re-mirror after any rotation, never hand-type.
+# Rotating the updater key orphans installed Studio builds; see revdev docs/KEY_GENERATION.md §1.
 ```
 
 ### Licensing (RevealUI)


### PR DESCRIPTION
## What

Indexes the **RevDev Tauri updater signing keypair** (generated 2026-06-11, closing revdev launch-plan H1) in the fleet secrets index, per the secrets rule: every new secret gets a `docs/SECRETS.md` entry plus a documented CI-mirror step.

RevDev section additions:

- `revdev/tauri-signing-private-key` — Studio auto-update signing key
- `revdev/tauri-signing-private-key-password` — its password
- `revdev/tauri-signing-public-key` — updater public key (also embedded in `apps/studio` `tauri.conf.json` on the revdev side)
- CI-mirror note: the `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets on the revdev repo are **mirrored from the vault** (consumed by `studio-release.yml`) — re-mirror after rotation, never hand-type
- Rotation caveat: a new updater key orphans installed Studio builds (pointer to the revdev key-generation runbook)

Docs-only, single file. Companion to revdev PR #101 (which embedded the public key + set the repo secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
