### PR TITLE
refactor(admin): consolidate session cookie domain derivation

### DIFF
--- a/apps/admin/src/__tests__/utils/session-cookies.test.ts
+++ b/apps/admin/src/__tests__/utils/session-cookies.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Session Cookie Domain Helper Tests
+ *
+ * Unit tests for sessionCookieDomain / requireSessionCookieDomain  -  the
+ * shared derivation behind every auth-cookie set site and the sign-out
+ * clearing path (route-level coverage lives in the auth route suites).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { logger } from '@revealui/utils/logger';
+import { requireSessionCookieDomain, sessionCookieDomain } from '../../lib/utils/session-cookies';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe('sessionCookieDomain', () => {
+  it('returns undefined outside production even when the variable is set', () => {
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '.revealui.com');
+    expect(sessionCookieDomain()).toBeUndefined();
+  });
+
+  it('returns the configured domain in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '.revealui.com');
+    expect(sessionCookieDomain()).toBe('.revealui.com');
+  });
+
+  it('treats an empty string as unset so the cookie stays host-only', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    expect(sessionCookieDomain()).toBeUndefined();
+  });
+
+  it('stays silent on a missing variable without logIfMissing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    sessionCookieDomain();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs an error on a missing variable in production with logIfMissing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    expect(sessionCookieDomain({ logIfMissing: true })).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
+    );
+  });
+
+  it('does not log when the variable is set in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '.revealui.com');
+    expect(sessionCookieDomain({ logIfMissing: true })).toBe('.revealui.com');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('does not log outside production even with logIfMissing', () => {
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    expect(sessionCookieDomain({ logIfMissing: true })).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireSessionCookieDomain', () => {
+  it('returns undefined outside production without throwing', () => {
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    expect(requireSessionCookieDomain()).toBeUndefined();
+  });
+
+  it('returns the configured domain in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '.revealui.com');
+    expect(requireSessionCookieDomain()).toBe('.revealui.com');
+  });
+
+  it('throws in production when the variable is missing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    expect(() => requireSessionCookieDomain()).toThrow(
+      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth',
+    );
+  });
+
+  it('falls back to host-only under REVEALUI_FLEET_MODE instead of throwing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    vi.stubEnv('REVEALUI_FLEET_MODE', 'true');
+    expect(requireSessionCookieDomain()).toBeUndefined();
+  });
+});

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -25,6 +25,7 @@ import { countActiveUsers } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { isAdminRole } from '@/lib/access/roles/isAdminRole';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -159,10 +160,7 @@ export async function GET(
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? process.env.SESSION_COOKIE_DOMAIN || undefined
-          : undefined,
+      domain: sessionCookieDomain(),
     });
 
     response.cookies.set('revealui-session', token, {
@@ -171,17 +169,7 @@ export async function GET(
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                logger.error(
-                  'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                );
-              }
-              return process.env.SESSION_COOKIE_DOMAIN || undefined;
-            })()
-          : undefined,
+      domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
     response.cookies.delete('oauth_state');

--- a/apps/admin/src/app/api/auth/mfa/backup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/backup/route.ts
@@ -20,6 +20,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -111,17 +112,7 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                logger.error(
-                  'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                );
-              }
-              return process.env.SESSION_COOKIE_DOMAIN ?? undefined;
-            })()
-          : undefined,
+      domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
     // Clear the mfa-pending cookie

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -19,6 +19,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -107,17 +108,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                logger.error(
-                  'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                );
-              }
-              return process.env.SESSION_COOKIE_DOMAIN ?? undefined;
-            })()
-          : undefined,
+      domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
     // Clear the mfa-pending cookie

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -23,6 +23,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -151,17 +152,7 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                logger.error(
-                  'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                );
-              }
-              return process.env.SESSION_COOKIE_DOMAIN ?? undefined;
-            })()
-          : undefined,
+      domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
     // Set role hint cookie
@@ -172,10 +163,7 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (process.env.SESSION_COOKIE_DOMAIN ?? undefined)
-          : undefined,
+      domain: sessionCookieDomain(),
     });
 
     // Clear challenge cookie

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -34,6 +34,7 @@ import {
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -231,17 +232,7 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
         sameSite: 'lax',
         path: '/',
         maxAge: 60 * 60 * 24 * 7,
-        domain:
-          process.env.NODE_ENV === 'production'
-            ? (() => {
-                if (!process.env.SESSION_COOKIE_DOMAIN) {
-                  logger.error(
-                    'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                  );
-                }
-                return process.env.SESSION_COOKIE_DOMAIN ?? undefined;
-              })()
-            : undefined,
+        domain: sessionCookieDomain({ logIfMissing: true }),
       });
 
       // Clear challenge cookie

--- a/apps/admin/src/app/api/auth/recovery/verify/route.ts
+++ b/apps/admin/src/app/api/auth/recovery/verify/route.ts
@@ -17,6 +17,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -89,17 +90,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       sameSite: 'lax',
       path: '/',
       maxAge: 30 * 60, // 30 minutes (matches session expiry)
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                logger.error(
-                  'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                );
-              }
-              return process.env.SESSION_COOKIE_DOMAIN ?? undefined;
-            })()
-          : undefined,
+      domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
     return response;

--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -18,6 +18,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { requireSessionCookieDomain, sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -117,10 +118,7 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? process.env.SESSION_COOKIE_DOMAIN || undefined
-          : undefined,
+      domain: sessionCookieDomain(),
     });
 
     // Set password rotation cookie (proxy.ts uses this to block /admin access)
@@ -141,19 +139,7 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
       sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
-      domain:
-        process.env.NODE_ENV === 'production'
-          ? (() => {
-              if (!process.env.SESSION_COOKIE_DOMAIN) {
-                if (!process.env.REVEALUI_FLEET_MODE) {
-                  throw new Error(
-                    'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth',
-                  );
-                }
-              }
-              return process.env.SESSION_COOKIE_DOMAIN || undefined;
-            })()
-          : undefined,
+      domain: requireSessionCookieDomain(),
     });
 
     return response;

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -25,6 +25,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -258,10 +259,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
         sameSite: 'lax',
         path: '/',
         maxAge: 60 * 60 * 24 * 7,
-        domain:
-          process.env.NODE_ENV === 'production'
-            ? process.env.SESSION_COOKIE_DOMAIN || undefined
-            : undefined,
+        domain: sessionCookieDomain(),
       });
 
       response.cookies.set('revealui-session', result.sessionToken, {
@@ -270,17 +268,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
         sameSite: 'lax',
         path: '/',
         maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
-        domain:
-          process.env.NODE_ENV === 'production'
-            ? (() => {
-                if (!process.env.SESSION_COOKIE_DOMAIN) {
-                  logger.error(
-                    'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
-                  );
-                }
-                return process.env.SESSION_COOKIE_DOMAIN || undefined;
-              })()
-            : undefined,
+        domain: sessionCookieDomain({ logIfMissing: true }),
       });
     }
 

--- a/apps/admin/src/lib/utils/session-cookies.ts
+++ b/apps/admin/src/lib/utils/session-cookies.ts
@@ -11,23 +11,61 @@
  * host-only delete is a browser-level no-op and the user stays signed in.
  */
 
+import { logger } from '@revealui/utils/logger';
 import type { NextResponse } from 'next/server';
 
 export const SESSION_COOKIE = 'revealui-session';
 export const ROLE_COOKIE = 'revealui-role';
 export const MUST_ROTATE_COOKIE = 'revealui-must-rotate';
 
+export interface SessionCookieDomainOptions {
+  /**
+   * Log an error when the variable is missing in production. The session
+   * cookie SET sites opt in (a host-only session cookie silently breaks
+   * cross-subdomain auth); the role-hint sites and sign-out stay silent.
+   */
+  logIfMissing?: boolean;
+}
+
 /**
  * Domain attribute for the session/role cookies, mirroring the sign-in
  * derivation: `SESSION_COOKIE_DOMAIN` in production, host-only otherwise.
+ * An empty string counts as unset so the cookie falls back to host-only
+ * rather than carrying `domain=""`.
  *
- * Unlike sign-in, this never throws when the variable is missing  -  sign-out
- * must still clear whatever cookie the host actually has.
+ * Unlike the sign-in session cookie, this never throws when the variable is
+ * missing  -  sign-out must still clear whatever cookie the host actually
+ * has, and the role-hint cookie is a defense-in-depth signal rather than the
+ * security boundary. The sign-in session cookie uses
+ * `requireSessionCookieDomain` instead.
  */
-export function sessionCookieDomain(): string | undefined {
-  return process.env.NODE_ENV === 'production'
-    ? process.env.SESSION_COOKIE_DOMAIN || undefined
-    : undefined;
+export function sessionCookieDomain(options?: SessionCookieDomainOptions): string | undefined {
+  if (process.env.NODE_ENV !== 'production') {
+    return undefined;
+  }
+  if (options?.logIfMissing && !process.env.SESSION_COOKIE_DOMAIN) {
+    logger.error(
+      'SESSION_COOKIE_DOMAIN env var is required in production  -  session cookie will not be set cross-subdomain',
+    );
+  }
+  return process.env.SESSION_COOKIE_DOMAIN || undefined;
+}
+
+/**
+ * Strict domain derivation for the sign-in session cookie: in production a
+ * missing `SESSION_COOKIE_DOMAIN` throws  -  unless `REVEALUI_FLEET_MODE` is
+ * set (fleet kits run host-only cookies by design).
+ */
+export function requireSessionCookieDomain(): string | undefined {
+  if (process.env.NODE_ENV !== 'production') {
+    return undefined;
+  }
+  if (!(process.env.SESSION_COOKIE_DOMAIN || process.env.REVEALUI_FLEET_MODE)) {
+    throw new Error(
+      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth',
+    );
+  }
+  return process.env.SESSION_COOKIE_DOMAIN || undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1383: that PR's audit classified the SET-side `SESSION_COOKIE_DOMAIN` derivations as accidental duplication. This consolidates the 12 inlined copies across the 8 admin auth routes onto `apps/admin/src/lib/utils/session-cookies.ts`.

## What changed

- `sessionCookieDomain()` gains an optional `{ logIfMissing }` option: the 7 session-cookie set sites keep their exact `logger.error` + host-only-fallback posture (same shared logger, byte-identical message, production-only).
- New `requireSessionCookieDomain()`: the sign-in session cookie keeps its throw-in-production-unless-`REVEALUI_FLEET_MODE` posture with the exact error message.
- The 4 role-hint cookie sites call plain `sessionCookieDomain()` (silent, as before). The existing sign-out `clearSessionCookies` caller is unchanged.

Per-site mapping (12 sites):

| Route | Cookie | Before | After |
|---|---|---|---|
| sign-in | revealui-role | plain ternary, `\|\|` | `sessionCookieDomain()` |
| sign-in | revealui-session | throwing IIFE, `\|\|` | `requireSessionCookieDomain()` |
| sign-up | revealui-role | plain ternary, `\|\|` | `sessionCookieDomain()` |
| sign-up | revealui-session | logging IIFE, `\|\|` | `sessionCookieDomain({ logIfMissing: true })` |
| callback/[provider] | revealui-role | plain ternary, `\|\|` | `sessionCookieDomain()` |
| callback/[provider] | revealui-session | logging IIFE, `\|\|` | `sessionCookieDomain({ logIfMissing: true })` |
| passkey/register-verify | revealui-session | logging IIFE, `??` | `sessionCookieDomain({ logIfMissing: true })` |
| passkey/authenticate-verify | revealui-session | logging IIFE, `??` | `sessionCookieDomain({ logIfMissing: true })` |
| passkey/authenticate-verify | revealui-role | plain ternary, `??` | `sessionCookieDomain()` |
| recovery/verify | revealui-session | logging IIFE, `??` | `sessionCookieDomain({ logIfMissing: true })` |
| mfa/verify | revealui-session | logging IIFE, `??` | `sessionCookieDomain({ logIfMissing: true })` |
| mfa/backup | revealui-session | logging IIFE, `??` | `sessionCookieDomain({ logIfMissing: true })` |

## Behavior preservation

This is a refactor; the only deliberate delta is normalizing the seven `?? undefined` copies to `||` semantics: an empty-string `SESSION_COOKIE_DOMAIN` now yields a host-only cookie instead of `domain=""`, matching the sign-in/sign-up/callback derivations and the sign-out clearing path. Everything else is exact:

- sign-in still throws in production when the variable is missing unless `REVEALUI_FLEET_MODE` is set (truthy check and message preserved verbatim; the codebase's other fleet-mode checks differ in strictness and are deliberately not touched here).
- The logging sites still `logger.error` the same message, production-only.
- All cookie attributes (`maxAge`/`httpOnly`/`secure`/`sameSite`/`path`) untouched; the host-only `revealui-must-rotate` cookie untouched.
- Helpers read `process.env` at call time (no module-level caching), so per-request behavior and test env stubs work as before.

## Tests

New `apps/admin/src/__tests__/utils/session-cookies.test.ts` (11 tests): prod/dev derivation, empty-string-as-unset, logging opt-in (exact message, production-only), throw + fleet-mode bypass.

## Verification

- `pnpm --filter admin test`: **1790 passed / 10 skipped / 0 failed** (full suite; run with `--maxWorkers=2`). Default-concurrency runs on the local box hit unrelated timeout flakes in the WebAuthn-heavy suites (hook/test timeouts under memory pressure; every affected file passes in isolation: `passkey/__tests__/routes.test.ts` 25/25, `auth/__tests__/integration.test.ts` 12/12 — neither stubs `NODE_ENV` or `SESSION_COOKIE_DOMAIN`).
- `pnpm --filter admin typecheck` (`tsc --noEmit`): clean.
- `pnpm exec biome check .`: 0 errors; the changed files carry zero diagnostics (remaining warnings are the pre-existing repo baseline).

App-only change; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
