### PR TITLE
fix(changelogs): strip docs frontmatter from package changelogs + CI guard

### DIFF
--- a/.github/scripts/create-github-releases.cjs
+++ b/.github/scripts/create-github-releases.cjs
@@ -59,10 +59,12 @@ function buildPackageDirMap(packagesRoot) {
  * Changesets only ever emits blank lines, `###` change-type headings, `-`/`*`
  * bullets, and indented continuation lines inside a section, so any other
  * column-0 line is a boundary: the next `##` version heading, the `#` package
- * title, a `---` delimiter, or docs-frontmatter key remnants — changesets
- * prepends new sections by replacing the file's first newline, which lands
- * them inside a leading frontmatter block and strands its keys below the
- * newest sections in some package changelogs.
+ * title, a `---` delimiter, or docs-frontmatter key remnants. (Changesets
+ * prepends new sections by replacing the file's first newline, which used to
+ * land them inside the leading frontmatter blocks package changelogs carried
+ * until the 2026-06-12 cleanup; `pnpm validate:changelogs` now keeps package
+ * changelogs frontmatter-free, so this boundary tolerance is belt-and-
+ * suspenders rather than load-bearing.)
  */
 function extractChangelogSection(changelogText, version) {
   const lines = changelogText.split('\n');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,16 @@ jobs:
         # release pipeline (release.yml) on main.
         run: pnpm validate:changesets
 
+      - name: Changelog format validation (hard fail)
+        # packages/*/CHANGELOG.md are changesets-owned: changesets prepends
+        # new version sections by replacing the file's FIRST newline, so a
+        # leading docs-frontmatter block gets release sections injected
+        # inside it (#1377 corrupted 18 of 24 package changelogs). Fails if
+        # any package changelog starts with anything but its `# <package>`
+        # H1, or carries stranded frontmatter keys. See
+        # scripts/validate/changelog-format.ts.
+        run: pnpm validate:changelogs
+
       - name: Docs link validation (hard fail)
         # Fails when any served doc (apps/docs/public/ after copy-docs.sh)
         # links to a relative .md target that 404s on the public site —

--- a/docs/internal/documentation-system.md
+++ b/docs/internal/documentation-system.md
@@ -5,7 +5,7 @@ visibility: internal
 status: verified
 audience: maintainer
 owner: RevealUI Studio
-last_verified: 2026-06-08
+last_verified: 2026-06-12
 ---
 
 This is the canonical specification for how documentation works in the RevealUI
@@ -42,6 +42,21 @@ doc genuinely needs unverifiable prose; keep those docs small and dated.
 
 Required on **every** tracked doc. The gate fails closed: a missing or invalid
 `visibility` is treated as `internal` **and** flagged as an error.
+
+**Exception — changesets-owned changelogs.** `packages/*/CHANGELOG.md` are
+machine files owned by changesets and MUST NOT carry frontmatter:
+`@changesets/apply-release-plan` prepends each new version section by
+replacing the file's first newline, which injects the section inside a
+leading frontmatter block and strands its keys below it (the 2026-06-12
+version run injected release sections inside the frontmatter of 18 such
+changelogs; the 6 not bumped that day were primed to corrupt on their next
+release). They are out of
+doc-system scope, like `.changeset/`: `scripts/docs/apply-frontmatter.ts`
+skips them, and `pnpm validate:changelogs`
+(`scripts/validate/changelog-format.ts`, CI hard-fail) enforces the inverse —
+a package changelog must start with its `# <package>` H1. Anything the docs
+surface wants to say about a package changelog is derived from
+`packages/*/package.json`, never embedded in the changelog.
 
 ```yaml
 ---

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "validate:versions": "tsx scripts/validate/version-policy.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
+    "validate:changelogs": "tsx scripts/validate/changelog-format.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/ai
 
 ## 0.6.0
+
 ### Minor Changes
 
 - 2f1c551: `useAgentStream` now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues) as an `X-CSRF-Token` header on both of its POSTs, `start()` and `submitElicitation()`. The API server's CSRF middleware requires that header on any session-cookie-bearing unsafe request, so cookie-authenticated browser consumers of the hook would otherwise 403 once CSRF enforcement is active. Mirrors the cookie-read in `@revealui/core`'s admin APIClient. No API change: when the cookie is absent (API-key / server-to-server callers, non-browser environments) the header is omitted and requests are unchanged.
@@ -16,14 +17,6 @@
   - @revealui/core@0.10.0
   - @revealui/contracts@0.6.1
   - @revealui/db@0.7.1
-title: "@revealui/ai"
-description: "The tool ran tests via `execSync(..., { timeout })`, whose timeout signal only reaches the immediate child (the shell). A grandchild — e.g. `pnpm test` → `node …` — was orphaned..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/ai
 
 ## 0.5.2
 

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/auth
 
 ## 0.4.4
+
 ### Patch Changes
 
 - ec24584: Add `setStorage()` to the rate-limit/brute-force storage factory — a test hook to pin a specific backend (e.g. `InMemoryStorage`). Lets the DB-backed integration suite run the rate-limit/lockout logic against in-process state instead of the shared `DatabaseStorage` singleton, removing Postgres-pool contention that intermittently dropped writes under `isolate:false`.
@@ -16,14 +17,6 @@
   - @revealui/contracts@0.6.1
   - @revealui/db@0.7.1
   - @revealui/security@0.4.1
-title: "@revealui/auth"
-description: "These packages declare `zod` as a `catalog:` runtime dependency, so the catalog bump changes their published dependency range. No source changes — `zod` 4.4.x is API-compatible ..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/auth
 
 ## 0.4.3
 

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,17 +1,10 @@
----
+# @revealui/cache
 
 ## 0.2.2
+
 ### Patch Changes
 
   - @revealui/security@0.4.1
-title: "@revealui/cache"
-description: "@revealui/cache"
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/cache
 
 ## 0.2.1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/cli
 
 ## 0.8.0
+
 ### Minor Changes
 
 - 117445a: `create-revealui` now writes `.env.development.local` via the previously orphaned `generateEnvFile` generator instead of an inline duplicate that wrote `.env.local`. The generated file gains the admin bootstrap variables, a local Postgres default when the database prompt is skipped, and uncommented Stripe test placeholders mirroring the template `.env.example` shape. Next.js also loads `.env.local` in production, so the dev-only filename keeps generated secrets and placeholders out of production runtimes. Template `.env.example` headers, template UI copy, the generated project README, and the post-create summary all reference the same filename now.
@@ -11,14 +12,6 @@
 - Updated dependencies [145975d]
   - @revealui/config@0.4.2
   - @revealui/setup@0.4.1
-title: "@revealui/cli"
-description: "The RevealUI engine does not decode images in-process (resizing is delegated to"
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/cli
 
 ## 0.7.3
 

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,17 +1,10 @@
----
+# @revealui/config
 
 ## 0.4.2
+
 ### Patch Changes
 
 - 145975d: Treat empty-string branding env vars as unset in `getBrandingConfig`. Docker Compose `${VAR:-}` interpolation delivers unset vars to containers as empty strings, which previously short-circuited the brand-name fallback chain (producing an empty brand name) and leaked `''` into optional `logoUrl` / `primaryColor` fields.
-title: "@revealui/config"
-description: "These packages declare `zod` as a `catalog:` runtime dependency, so the catalog bump changes their published dependency range. No source changes — `zod` 4.4.x is API-compatible ..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/config
 
 ## 0.4.1
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,17 +1,10 @@
----
+# @revealui/contracts
 
 ## 0.6.1
+
 ### Patch Changes
 
 - c77ac4f: Pro and Max subscription tiers now deep-link into the existing trial checkout path (`/signup?plan=pro|max`) instead of the waitlist contact form. Display strings only; no price or schema changes.
-title: "@revealui/contracts"
-description: "Breaking for any consumer importing the removed symbols (minor bumps under pre-1.0 SemVer)."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/contracts
 
 ## 0.6.0
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/core
 
 ## 0.10.0
+
 ### Minor Changes
 
 - ebbe445: Replace the `@aws-sdk/client-s3` dependency with a native, dependency-free Cloudflare R2 storage client. The R2 `StorageProvider` now signs requests with AWS Signature V4 (`node:crypto`) over global `fetch` and reads `ListObjectsV2`/error responses with a small no-regex XML parser, instead of routing through the AWS SDK. The provider contract and all behavior are unchanged; this drops the entire `@aws-sdk` / `@aws-crypto` / `@smithy` transitive dependency tree.
@@ -15,14 +16,6 @@
   - @revealui/contracts@0.6.1
   - @revealui/security@0.4.1
   - @revealui/cache@0.2.2
-title: "@revealui/core"
-description: "When a collection's `access.read/update/delete` returns a `WhereClause` (the"
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/core
 
 ## 0.9.0
 

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,19 +1,12 @@
----
+# create-revealui
 
 ## 0.5.9
+
 ### Patch Changes
 
 - Updated dependencies [4d7d55d]
 - Updated dependencies [117445a]
   - @revealui/cli@0.8.0
-title: "create-revealui"
-description: "New `revealui terminal install` and `revealui terminal list` commands that auto-detect"
-visibility: public
-status: narrative
-audience: user
----
-
-# create-revealui
 
 ## 0.5.8
 

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,18 +1,11 @@
----
+# @revealui/db
 
 ## 0.7.1
+
 ### Patch Changes
 
 - Updated dependencies [145975d]
   - @revealui/config@0.4.2
-title: "@revealui/db"
-description: "Worker scripts and apps should depend on Drizzle through this subpath instead of importing the bare `drizzle-orm` package. Under pnpm's isolated linker, `drizzle-orm` is materia..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/db
 
 ## 0.7.0
 

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/engines
 
 ## 0.4.3
+
 ### Patch Changes
 
 - Updated dependencies [ec24584]
@@ -15,14 +16,6 @@
   - @revealui/contracts@0.6.1
   - @revealui/db@0.7.1
   - @revealui/services@0.7.2
-title: "@revealui/engines"
-description: "is removed from `@revealui/services` per the 2026-05-08 charge-readiness audit"
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/engines
 
 ## 0.4.2
 

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/harnesses
 
 ## 0.6.2
+
 ### Patch Changes
 
 - Updated dependencies [553a981]
@@ -9,14 +10,6 @@
 - Updated dependencies [a3dcac3]
 - Updated dependencies [8024933]
   - @revealui/core@0.10.0
-title: "@revealui/harnesses"
-description: "The 2026-05-18 audit found the original VAUGHN spec oversold what the code actually shipped — one working adapter for the RevealUI Agent, plus static capability-profile data for..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/harnesses
 
 ## 0.6.1
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/mcp
 
 ## 0.6.1
+
 ### Patch Changes
 
 - Updated dependencies [145975d]
@@ -14,14 +15,6 @@
   - @revealui/core@0.10.0
   - @revealui/contracts@0.6.1
   - @revealui/security@0.4.1
-title: "@revealui/mcp"
-description: "Breaking for any consumer importing the removed symbols (minor bumps under pre-1.0 SemVer)."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/mcp
 
 ## 0.6.0
 

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/openapi"
-description: "`@revealui/openapi` (0.2.3 → 0.3.0):"
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/openapi
 
 ## 0.3.0

--- a/packages/paywall/CHANGELOG.md
+++ b/packages/paywall/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/paywall"
-description: "@revealui/paywall"
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/paywall
 
 ## 0.1.2

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,18 +1,11 @@
----
+# @revealui/presentation
 
 ## 0.8.0
+
 ### Minor Changes
 
 - d861f75: Animations now honor `prefers-reduced-motion`. A new `useReducedMotion` hook is exported from `@revealui/presentation/animations`, and the `useSpring`, `useAnimation`, `useStagger`, and `usePresence` hooks collapse to their final state (no transition, no stagger, instant mount/unmount) when the user has requested reduced motion. The hook is SSR-safe and reactive to runtime changes.
 - 25c93af: `PricingTable` now styles through the cobalt semantic tokens (`primary`, `success`, `card`, `secondary`, `muted-foreground`, `border`) instead of a hardcoded `blue`/`emerald`/`zinc` palette. It now adapts to light/dark themes and tenant brand on the public pricing surface. No API or behavior changes — props and markup are unchanged.
-title: "@revealui/presentation"
-description: "Since 0.6.0 the canonical token file (`src/tokens.css`) changed brand identity and gained AA fixes + a new token, all under 0.6.0 with no version bump. This bumps to 0.7.0 so np..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/presentation
 
 ## 0.7.0
 

--- a/packages/resilience/CHANGELOG.md
+++ b/packages/resilience/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/resilience"
-description: "@revealui/resilience"
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/resilience
 
 ## 0.2.4

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,17 +1,10 @@
----
+# revealui
 
 ## 0.1.4
+
 ### Patch Changes
 
   - create-revealui@0.5.9
-title: "revealui"
-description: "revealui"
-visibility: public
-status: narrative
-audience: user
----
-
-# revealui
 
 ## 0.1.3
 

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/router"
-description: "@revealui/router"
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/router
 
 ## 0.3.9

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/scripts"
-description: "@revealui/scripts"
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/scripts
 
 ## 0.1.2

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -1,18 +1,11 @@
----
+# @revealui/security
 
 ## 0.4.1
+
 ### Patch Changes
 
 - Updated dependencies [c77ac4f]
   - @revealui/contracts@0.6.1
-title: "@revealui/security"
-description: "`@revealui/core/richtext/rsc` imported `isSafeUrl` / `sanitizeUrl` from the `@revealui/security` barrel, which statically re-exports `auth.ts` and `gdpr.ts`. Both modules have a..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/security
 
 ## 0.4.0
 

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/services
 
 ## 0.7.2
+
 ### Patch Changes
 
 - Updated dependencies [145975d]
@@ -14,14 +15,6 @@
   - @revealui/core@0.10.0
   - @revealui/contracts@0.6.1
   - @revealui/db@0.7.1
-title: "@revealui/services"
-description: "Breaking for any consumer importing the removed symbols (minor bumps under pre-1.0 SemVer)."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/services
 
 ## 0.7.1
 

--- a/packages/setup/CHANGELOG.md
+++ b/packages/setup/CHANGELOG.md
@@ -1,18 +1,11 @@
----
+# @revealui/setup
 
 ## 0.4.1
+
 ### Patch Changes
 
 - Updated dependencies [145975d]
   - @revealui/config@0.4.2
-title: "@revealui/setup"
-description: "The first user created via the setup bootstrap now receives the `owner` role (hard-capped at 3 via app-layer soft cap). Existing `admin`-role checks should be reviewed — the for..."
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/setup
 
 ## 0.4.0
 

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,6 +1,7 @@
----
+# @revealui/sync
 
 ## 0.3.12
+
 ### Patch Changes
 
 - 954667f: Attach the `revealui-csrf` double-submit token as an `X-CSRF-Token` header on unsafe-method sync requests — `useSyncMutations` create/update/remove and the `useSharedMemories` reconciliation trigger. The admin proxy rejects cookie-authenticated POST/PATCH/DELETE to `/api/sync/*` without this header, so browser mutations (deleting a conversation or an agent memory in the admin dashboard) failed with 403 "CSRF token missing" once the admin CSRF gate landed. The token is read from the JS-readable cookie in browser contexts only and attached only to same-origin targets, mirroring the admin `apiFetch` / core `APIClient` pattern.
@@ -8,14 +9,6 @@
   - @revealui/contracts@0.6.1
   - @revealui/db@0.7.1
   - @revealui/cache@0.2.2
-title: "@revealui/sync"
-description: "@revealui/sync"
-visibility: public
-status: narrative
-audience: user
----
-
-# @revealui/sync
 
 ## 0.3.11
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,11 +1,3 @@
----
-title: "@revealui/utils"
-description: "These packages declare `zod` as a `catalog:` runtime dependency, so the catalog bump changes their published dependency range. No source changes — `zod` 4.4.x is API-compatible ..."
-visibility: public
-status: narrative
-audience: user
----
-
 # @revealui/utils
 
 ## 0.3.5

--- a/scripts/docs/apply-frontmatter.ts
+++ b/scripts/docs/apply-frontmatter.ts
@@ -53,6 +53,18 @@ const IGNORE_DIRS = new Set([
 const EXCLUDE_PREFIXES = ['apps/docs/'];
 const DOC_EXTENSIONS = ['.md', '.mdx'];
 
+// Changesets-owned package changelogs are machine files, not doc-system docs:
+// @changesets/apply-release-plan prepends each new version section by
+// replacing the file's FIRST newline, so any leading frontmatter block gets
+// new sections injected inside it (the 2026-06-12 version run, #1377,
+// corrupted 18 of the 24 package changelogs stamped by the #1293 sweep). The
+// inverse is CI-enforced by scripts/validate/changelog-format.ts: these files
+// must start with their `# <package>` H1, never frontmatter.
+function isChangesetsChangelog(rel: string): boolean {
+  const parts = rel.split('/');
+  return parts.length === 3 && parts[0] === 'packages' && parts[2] === 'CHANGELOG.md';
+}
+
 function toPosix(p: string): string {
   return p.split(path.sep).join('/');
 }
@@ -73,6 +85,7 @@ function collectDocs(): string[] {
       } else if (e.isFile() && DOC_EXTENSIONS.some((ext) => e.name.endsWith(ext))) {
         const rel = toPosix(path.relative(ROOT, path.join(dir, e.name)));
         if (EXCLUDE_PREFIXES.some((pre) => rel.startsWith(pre))) continue;
+        if (isChangesetsChangelog(rel)) continue;
         out.push(path.join(dir, e.name));
       }
     }
@@ -142,13 +155,11 @@ function isPublic(rel: string): boolean {
     const name = parts[1].endsWith('.md') ? parts[1].slice(0, -3) : parts[1];
     return !INTERNAL_DOCS_ROOT.has(name);
   }
-  // packages/<pkg>/README.md and CHANGELOG.md: public (npm). Deeper package
-  // docs (src/**, docs/**, systemd/**, design-context/**) are internal.
-  if (
-    parts.length === 3 &&
-    parts[0] === 'packages' &&
-    (parts[2] === 'README.md' || parts[2] === 'CHANGELOG.md')
-  ) {
+  // packages/<pkg>/README.md: public (npm). Deeper package docs (src/**,
+  // docs/**, systemd/**, design-context/**) are internal. Package
+  // CHANGELOG.md files are changesets-owned and out of scope entirely
+  // (see isChangesetsChangelog).
+  if (parts.length === 3 && parts[0] === 'packages' && parts[2] === 'README.md') {
     return true;
   }
   return false;
@@ -158,7 +169,9 @@ function classifyStatus(rel: string): string {
   if (rel === 'docs/api/rest-api/README.md') return 'generated';
   if (rel.startsWith('packages/presentation/design-context/')) return 'generated';
   if (rel.startsWith('docs/blog/') || rel.startsWith('docs/archive/')) return 'narrative';
-  if (rel.endsWith('/CHANGELOG.md') || rel === 'CHANGELOG.md') return 'narrative';
+  // Only the root keep-a-changelog file: packages/*/CHANGELOG.md are
+  // changesets-owned and excluded from scope (see isChangesetsChangelog).
+  if (rel === 'CHANGELOG.md') return 'narrative';
   return 'verified';
 }
 

--- a/scripts/validate/__tests__/changelog-format.test.ts
+++ b/scripts/validate/__tests__/changelog-format.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for changelog-format.ts
+ *
+ * The validator guards the changesets-owned layout of
+ * packages/*\/CHANGELOG.md: line 1 must be the `# <package>` H1 (never a
+ * frontmatter fence), and no docs-frontmatter keys may sit at column 0
+ * outside fenced code. The corrupted fixture replicates the exact
+ * 2026-06-12 (#1377) signature: changesets replaced the file's first
+ * newline, injecting the new version section between the opening `---`
+ * and the stranded frontmatter keys.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkChangelogText } from '../changelog-format.ts';
+
+const FILE = 'packages/example/CHANGELOG.md';
+
+function text(lines: string[]): string {
+  return `${lines.join('\n')}\n`;
+}
+
+describe('checkChangelogText', () => {
+  it('accepts a changesets-shaped changelog', () => {
+    const clean = text([
+      '# @revealui/example',
+      '',
+      '## 0.2.0',
+      '',
+      '### Minor Changes',
+      '',
+      '- abc1234: Add a thing.',
+      '- def5678: Multi-line entry',
+      '  with an indented continuation line.',
+      '',
+      '## 0.1.0',
+      '',
+      '### Patch Changes',
+      '',
+      '- 0123abc: Fix a thing.',
+    ]);
+    expect(checkChangelogText(clean, FILE)).toEqual([]);
+  });
+
+  it('flags a leading frontmatter fence with the prepend explanation', () => {
+    const frontmattered = text([
+      '---',
+      'title: "@revealui/example"',
+      'visibility: public',
+      '---',
+      '',
+      '# @revealui/example',
+      '',
+      '## 0.1.0',
+    ]);
+    const violations = checkChangelogText(frontmattered, FILE);
+    expect(violations.some((v) => v.line === 1 && v.problem.includes('frontmatter fence'))).toBe(
+      true,
+    );
+    expect(violations.some((v) => v.problem.includes('title:'))).toBe(true);
+  });
+
+  it('flags the #1377 corruption signature (section injected inside frontmatter)', () => {
+    const corrupted = text([
+      '---',
+      '',
+      '## 0.10.0',
+      '### Minor Changes',
+      '',
+      '- ebbe445: A release note.',
+      'title: "@revealui/example"',
+      'description: "junk derived from the first paragraph"',
+      'visibility: public',
+      'status: narrative',
+      'audience: user',
+      '---',
+      '',
+      '# @revealui/example',
+      '',
+      '## 0.9.0',
+    ]);
+    const violations = checkChangelogText(corrupted, FILE);
+    expect(violations.some((v) => v.line === 1)).toBe(true);
+    expect(violations.filter((v) => v.problem.includes('stranded')).length).toBe(5);
+  });
+
+  it('flags a first line that is neither the H1 nor a fence', () => {
+    const headless = text(['## 0.1.0', '', '- abc1234: note']);
+    const violations = checkChangelogText(headless, FILE);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.problem).toContain('# <package name>');
+  });
+
+  it('ignores frontmatter-shaped lines inside fenced code blocks', () => {
+    const fenced = text([
+      '# @revealui/example',
+      '',
+      '## 0.1.0',
+      '',
+      '- abc1234: Document config frontmatter:',
+      '',
+      '```yaml',
+      'title: not frontmatter',
+      'status: just an example',
+      '```',
+    ]);
+    expect(checkChangelogText(fenced, FILE)).toEqual([]);
+  });
+
+  it('ignores indented continuations and mid-file horizontal rules', () => {
+    const indented = text([
+      '# @revealui/example',
+      '',
+      '## 0.1.0',
+      '',
+      '- abc1234: Entry',
+      '  title: indented continuation, not frontmatter',
+      '',
+      '---',
+      '',
+      '## 0.0.1',
+    ]);
+    expect(checkChangelogText(indented, FILE)).toEqual([]);
+  });
+});

--- a/scripts/validate/changelog-format.ts
+++ b/scripts/validate/changelog-format.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env tsx
+
+/**
+ * Changelog Format Validator
+ *
+ * packages/*\/CHANGELOG.md are machine files owned by changesets, and
+ * changesets' apply-release-plan PREPENDS each new version section by
+ * replacing the file's FIRST newline. That only composes with the
+ * changesets layout — line 1 is the `# <package>` H1 — so a changelog
+ * that starts with anything else (most dangerously a `---`
+ * docs-frontmatter fence) gets every new version section injected
+ * INSIDE the leading block: the 2026-06-12 version run (#1377)
+ * corrupted 18 of the 24 package changelogs that the #1293
+ * docs-frontmatter sweep had stamped.
+ *
+ * This validator runs in the `quality` CI job on every PR (same
+ * placement as validate:changesets) and hard-fails when any package
+ * changelog:
+ *   - does not start with a `# ` H1 on line 1 (a leading `---` gets a
+ *     dedicated message), or
+ *   - carries stranded docs-frontmatter keys (title:/description:/
+ *     visibility:/status:/audience:) at column 0 outside fenced code —
+ *     the signature of a half-corrupted or re-stamped file.
+ *
+ * The docs system derives anything it wants to say about a package
+ * changelog (e.g. the package name from packages/*\/package.json)
+ * instead of embedding frontmatter; see the exception in
+ * docs/internal/documentation-system.md and the matching skip in
+ * scripts/docs/apply-frontmatter.ts. Release-note extraction
+ * (.github/scripts/create-github-releases.cjs) tolerates stray
+ * non-changesets lines as section boundaries; with this validator in
+ * place that tolerance is belt-and-suspenders, not load-bearing.
+ *
+ * No authored regex (M2 hardline) — line scans + startsWith only.
+ *
+ * Exit codes:
+ *   0 — all package changelogs are changesets-shaped
+ *   1 — one or more violations detected
+ *   2 — filesystem error
+ */
+
+import type { Dirent } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+/** Docs-frontmatter keys the #1293 sweep stamped; stranded copies mark corruption. */
+const FRONTMATTER_KEYS = ['title:', 'description:', 'visibility:', 'status:', 'audience:'];
+
+export interface ChangelogViolation {
+  file: string;
+  line: number;
+  problem: string;
+}
+
+interface ScanResult {
+  checked: number;
+  violations: ChangelogViolation[];
+}
+
+/** Structured stdout/stderr output — scripts/** cannot use the console object. */
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+function err(line: string): void {
+  process.stderr.write(`${line}\n`);
+}
+
+/**
+ * Check one changelog's text against the changesets-owned layout.
+ * Exported for unit tests.
+ */
+export function checkChangelogText(text: string, file: string): ChangelogViolation[] {
+  const violations: ChangelogViolation[] = [];
+  const lines = text.split('\n');
+  const first = lines[0] ?? '';
+
+  if (first.trim() === '---') {
+    violations.push({
+      file,
+      line: 1,
+      problem:
+        "starts with a frontmatter fence (---). changesets prepends new version sections by replacing the file's first newline, so frontmatter gets release sections injected inside it. Package changelogs must not carry frontmatter — see docs/internal/documentation-system.md.",
+    });
+  } else if (!first.startsWith('# ')) {
+    violations.push({
+      file,
+      line: 1,
+      problem: `must start with the package H1 ("# <package name>"); found ${JSON.stringify(first)}.`,
+    });
+  }
+
+  let inFence = false;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    for (const key of FRONTMATTER_KEYS) {
+      if (line.startsWith(key)) {
+        violations.push({
+          file,
+          line: i + 1,
+          problem: `stranded docs-frontmatter key at column 0 (${key} …) — the signature of a frontmatter block split by a changesets prepend.`,
+        });
+        break;
+      }
+    }
+  }
+
+  return violations;
+}
+
+function scanPackages(): ScanResult {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  } catch (e) {
+    err(`[changelog-format] FATAL: could not read ${PACKAGES_DIR}: ${String(e)}`);
+    process.exit(2);
+  }
+
+  const violations: ChangelogViolation[] = [];
+  let checked = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const changelogPath = join(PACKAGES_DIR, entry.name, 'CHANGELOG.md');
+    // A brand-new package has no changelog until its first changesets release.
+    if (!existsSync(changelogPath)) continue;
+    let content: string;
+    try {
+      content = readFileSync(changelogPath, 'utf8');
+    } catch (e) {
+      err(`[changelog-format] WARN: could not read ${changelogPath}: ${String(e)}`);
+      continue;
+    }
+    checked++;
+    violations.push(...checkChangelogText(content, `packages/${entry.name}/CHANGELOG.md`));
+  }
+
+  return { checked, violations };
+}
+
+function main(): void {
+  const { checked, violations } = scanPackages();
+
+  if (violations.length === 0) {
+    out(
+      `[changelog-format] OK: ${checked} package changelogs are changesets-shaped (no frontmatter).`,
+    );
+    return;
+  }
+
+  err('[changelog-format] FAIL: package CHANGELOG.md files are changesets-owned and must');
+  err('                    start with their `# <package>` H1 — never a frontmatter block.');
+  err("                    changesets prepends new version sections by replacing the file's");
+  err('                    first newline, so anything above the H1 gets release sections');
+  err('                    injected into it (this corrupted 18 changelogs on 2026-06-12).');
+  err('                    Remove the frontmatter; the docs system derives changelog');
+  err('                    metadata instead (docs/internal/documentation-system.md).');
+  err('');
+  for (const v of violations) {
+    err(`  ${v.file}:${v.line}  ${v.problem}`);
+  }
+  err('');
+  err(
+    `Found ${violations.length} violation${violations.length === 1 ? '' : 's'} across ${checked} changelogs.`,
+  );
+  process.exit(1);
+}
+
+if (process.argv[1]?.endsWith('changelog-format.ts')) {
+  main();
+}


### PR DESCRIPTION
## Summary

`packages/*/CHANGELOG.md` carried docs-frontmatter (from the #1293 documentation-system sweep), but changesets' `apply-release-plan` prepends each new version section by **replacing the file's first newline** — the two are structurally incompatible. The #1377 version run (2026-06-12) injected the new `## x.y.z` sections *inside* the frontmatter block of every changelog it touched. This PR repairs all 24 package changelogs, removes them from the docs-frontmatter system at the producer, and adds a hard-fail CI guard so the combination can never land again.

## Root cause

- #1293's `scripts/docs/apply-frontmatter.ts` treated `packages/*/CHANGELOG.md` as in-scope docs and stamped `title`/`description`/`visibility`/`status`/`audience` on them (`description` was derived from the "first paragraph" — i.e. the latest release-note line, truncated).
- changesets prepends with `fileData.replace("\n", newSection)`, which assumes line 1 is the `# <package>` H1. With frontmatter, line 1 is `---`, so new sections land between the opening fence and the (now stranded) keys.

## Audit (origin/test b0701bbf7)

| Class | Count | Files |
|---|---|---|
| Mangled by #1377 | 18 | ai, auth, cache, cli, config, contracts, core, create-revealui, db, engines, harnesses, mcp, presentation, revealui, security, services, setup, sync |
| Intact frontmatter (corrupts on next bump) | 6 | openapi, paywall, resilience, router, scripts, utils |
| Structural anomalies | 0 | every post-fence body starts `# <package.json name>`; every top `## x.y.z` equals the current package version; injected blocks are pure changesets grammar |

**Consumers of this frontmatter: none.** The docs app's visibility boundary (`apps/docs/scripts/copy-docs.sh` → `prune-non-public.mjs`) only covers files copied from `docs/` — it never touches `packages/`. The spec's `doc-integrity.ts` gate (added by #1293) was deleted as unreferenced by #1295. So removal breaks nothing, and the docs system needs no shim: anything it ever wants to say about a package changelog is derivable from `packages/*/package.json`.

## Fix

1. **Repair (data)** — all 24 changelogs restored to the changesets layout: `# <package>` H1, version sections newest-first. For the 18 mangled files the injected section was moved verbatim from inside the frontmatter block to under the H1 (with a normalized blank line after moved `## x.y.z` headings); the frontmatter block was dropped everywhere. Each file was verified post-write: line 1 equals `# <package.json name>`, top section heading equals `package.json` version.
2. **Producer** — `apply-frontmatter.ts` now skips changesets-owned changelogs (and no longer classifies them); a full `--dry-run` proposes **0 changes** across the 218 in-scope docs, so re-running the migration can never re-stamp them.
3. **Guard (CI hard fail)** — new `scripts/validate/changelog-format.ts`, wired as `pnpm validate:changelogs` and a quality-job step beside `validate:changesets`. Fails when any `packages/*/CHANGELOG.md` doesn't start with a `# ` H1 on line 1 (dedicated message for a leading `---`), or carries stranded frontmatter keys at column 0 outside fenced code (the half-corrupted signature). No authored regex — line scans only.
4. **Spec** — `docs/internal/documentation-system.md` documents the exception next to the frontmatter contract.

## Verification

- `pnpm validate:changelogs` → `OK: 24 package changelogs are changesets-shaped (no frontmatter)`; negative path exercised with a temp `---` fixture → loud FAIL, exit 1.
- New unit tests (6) cover the #1377 corruption signature, intact-frontmatter, missing-H1, fenced-code and indented-continuation false-positive guards; `vitest run` green.
- `pnpm validate:changesets` still green; Biome clean on all touched code; `node --check` clean on the release script.
- Release-notes extraction (`.github/scripts/create-github-releases.cjs`, #1385) is untouched behaviorally — comment-only update. Its changesets-grammar section boundary now acts as belt-and-suspenders instead of a load-bearing workaround; the next `changeset version` run will prepend into a clean `# <package>` line-1 file, which is exactly the layout it expects.

## Notes

- No "Version Packages" PR is currently open, so nothing regenerates against the corrupted state.
- `@revealui/scripts` is in the changesets `ignore` list (its changelog can't corrupt today), but it was stripped and is guarded uniformly with the rest — un-ignoring it later must not re-arm the time bomb.
- Apps can't hit this class: all apps are in the changesets `ignore` list and have no `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
