### PR TITLE
fix(auth): attach csrf token on remaining auth hook posts

### DIFF
--- a/.changeset/auth-hooks-csrf-attach.md
+++ b/.changeset/auth-hooks-csrf-attach.md
@@ -1,0 +1,5 @@
+---
+'@revealui/auth': patch
+---
+
+`useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs, completing the sweep `usePasskeyRegister`/`usePasskeySignIn` started: the admin proxy requires that header on any session-cookie-bearing unsafe request, and `/api/auth/mfa/*` and `/api/auth/sign-out` are not proxy-exempt — MFA enrollment and sign-out always run with a session, so without the header they were rejected with a 403 "CSRF token missing" (and a rejected sign-out left the server-side session alive). The `readCsrfToken()` helper the passkey hooks introduced now lives in a shared module used by all three hook files; passkey behavior is unchanged. The token is re-read before each POST so a proxy reissue between steps cannot strand a stale token. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1247,7 +1247,8 @@ The authentication system uses **cookie-based sessions** with the following CSRF
   requests to the admin's own `/api/*` routes and to the configured api origin;
   the core admin `APIClient` does the same, as do the published hooks that
   POST from the browser — `@revealui/ai`'s `useAgentStream`, `@revealui/sync`'s
-  mutation helpers, and `@revealui/auth`'s passkey hooks. Admin server-side
+  mutation helpers, and `@revealui/auth`'s react hooks (passkey, MFA,
+  sign-out). Admin server-side
   forwarders (collections/globals/batch proxy routes) mint a per-request token
   via `apps/admin/src/lib/utils/api-proxy-headers.ts`.
 

--- a/packages/auth/src/react/__tests__/useMFA.test.tsx
+++ b/packages/auth/src/react/__tests__/useMFA.test.tsx
@@ -292,3 +292,156 @@ describe('useMFAVerify', () => {
     expect(result.current.error).toBeNull();
   });
 });
+
+describe('useMFA - CSRF token attach', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // happy-dom cookies persist across tests in this file - expire ours so
+    // the exact-equality assertions in the describes above stay header-free
+    document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('setup() echoes the revealui-csrf cookie as X-CSRF-Token', async () => {
+    document.cookie = 'other-cookie=unrelated';
+    document.cookie = 'revealui-csrf=nonce123:hmac456';
+    vi.stubGlobal('fetch', mockFetch({ secret: 's', uri: 'otpauth://t', backupCodes: [] }));
+
+    const { result } = renderHook(() => useMFASetup());
+    await act(async () => {
+      await result.current.setup();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/setup', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRF-Token': 'nonce123:hmac456' },
+    });
+  });
+
+  it('verifySetup() echoes the cookie alongside Content-Type', async () => {
+    document.cookie = 'revealui-csrf=nonce123:hmac456';
+    vi.stubGlobal('fetch', mockFetch({ verified: true }));
+
+    const { result } = renderHook(() => useMFASetup());
+    await act(async () => {
+      await result.current.verifySetup('123456');
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/verify-setup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'nonce123:hmac456',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ code: '123456' }),
+    });
+  });
+
+  it('verify() and verifyBackupCode() echo the cookie during MFA login', async () => {
+    document.cookie = 'revealui-csrf=tok-login';
+    vi.stubGlobal('fetch', mockFetch({ success: true }));
+
+    const { result } = renderHook(() => useMFAVerify());
+    await act(async () => {
+      await result.current.verify('123456');
+      await result.current.verifyBackupCode('backup-1');
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/verify', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'tok-login',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ code: '123456' }),
+    });
+    expect(fetch).toHaveBeenNthCalledWith(2, '/api/auth/mfa/backup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'tok-login',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ code: 'backup-1' }),
+    });
+  });
+
+  it('re-reads the cookie before each POST (proxy may reissue between steps)', async () => {
+    document.cookie = 'revealui-csrf=token-before';
+    vi.stubGlobal('fetch', mockFetch({ secret: 's', uri: 'otpauth://t', backupCodes: [] }));
+
+    const { result } = renderHook(() => useMFASetup());
+    await act(async () => {
+      await result.current.setup();
+    });
+
+    document.cookie = 'revealui-csrf=token-rotated';
+    await act(async () => {
+      await result.current.verifySetup('123456');
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/auth/mfa/setup',
+      expect.objectContaining({
+        headers: { 'X-CSRF-Token': 'token-before' },
+      }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/auth/mfa/verify-setup',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'token-rotated' }),
+      }),
+    );
+  });
+
+  it('setup() sends no headers key at all when the cookie is absent', async () => {
+    vi.stubGlobal('fetch', mockFetch({ secret: 's', uri: 'otpauth://t', backupCodes: [] }));
+
+    const { result } = renderHook(() => useMFASetup());
+    await act(async () => {
+      await result.current.setup();
+    });
+
+    // Exact equality: cookie-less setup requests stay byte-identical to the
+    // pre-CSRF shape (no headers key)
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/setup', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+
+  it('verify() omits X-CSRF-Token when the cookie is absent', async () => {
+    vi.stubGlobal('fetch', mockFetch({ success: true }));
+
+    const { result } = renderHook(() => useMFAVerify());
+    await act(async () => {
+      await result.current.verify('123456');
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ code: '123456' }),
+    });
+  });
+
+  it('omits X-CSRF-Token when the cookie value is empty', async () => {
+    document.cookie = 'revealui-csrf=';
+    vi.stubGlobal('fetch', mockFetch({ secret: 's', uri: 'otpauth://t', backupCodes: [] }));
+
+    const { result } = renderHook(() => useMFASetup());
+    await act(async () => {
+      await result.current.setup();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/mfa/setup', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+});

--- a/packages/auth/src/react/__tests__/useSignOut.test.tsx
+++ b/packages/auth/src/react/__tests__/useSignOut.test.tsx
@@ -68,3 +68,74 @@ describe('useSignOut', () => {
     });
   });
 });
+
+describe('useSignOut - CSRF token attach', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: '' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+    // happy-dom cookies persist across tests in this file - expire ours so
+    // the exact-equality assertion in the describe above stays header-free
+    document.cookie = 'revealui-csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('signOut() echoes the revealui-csrf cookie as X-CSRF-Token', async () => {
+    document.cookie = 'other-cookie=unrelated';
+    document.cookie = 'revealui-csrf=nonce123:hmac456';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    const { result } = renderHook(() => useSignOut());
+    await waitFor(async () => {
+      await result.current.signOut();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRF-Token': 'nonce123:hmac456' },
+    });
+    expect(window.location.href).toBe('/login');
+  });
+
+  it('signOut() sends no headers key at all when the cookie is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    const { result } = renderHook(() => useSignOut());
+    await waitFor(async () => {
+      await result.current.signOut();
+    });
+
+    // Exact equality: cookie-less sign-out requests stay byte-identical to
+    // the pre-CSRF shape (no headers key)
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+
+  it('omits X-CSRF-Token when the cookie value is empty', async () => {
+    document.cookie = 'revealui-csrf=';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    const { result } = renderHook(() => useSignOut());
+    await waitFor(async () => {
+      await result.current.signOut();
+    });
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+});

--- a/packages/auth/src/react/csrf.ts
+++ b/packages/auth/src/react/csrf.ts
@@ -1,0 +1,27 @@
+/**
+ * CSRF Double-Submit Token Helper
+ *
+ * Shared by the react auth hooks (`usePasskey`, `useMFA`, `useSignOut`) whose
+ * POSTs target the RevealUI admin proxy's CSRF-gated endpoints.
+ */
+
+/**
+ * Read the JS-readable `revealui-csrf` cookie. The RevealUI admin proxy
+ * (`apps/admin/src/proxy.ts`) requires it as an `X-CSRF-Token` header on any
+ * session-cookie-bearing unsafe request, and may re-issue the cookie on any
+ * response — so call this immediately before each fetch rather than once per
+ * flow. Returns undefined outside the browser or when the cookie is
+ * absent/empty. Mirrors the cookie-read in `@revealui/core`'s admin APIClient
+ * (`request()`) and `@revealui/ai`'s `useAgentStream`.
+ */
+export function readCsrfToken(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  for (const part of document.cookie.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
+      return part.slice(eqIdx + 1).trim() || undefined;
+    }
+  }
+  return undefined;
+}

--- a/packages/auth/src/react/useMFA.ts
+++ b/packages/auth/src/react/useMFA.ts
@@ -2,11 +2,20 @@
  * MFA Hooks
  *
  * React hooks for Multi-Factor Authentication setup and verification.
+ *
+ * CSRF: every POST echoes the JS-readable `revealui-csrf` cookie (the signed
+ * double-submit token the RevealUI admin proxy issues on page load) as an
+ * `X-CSRF-Token` header when the cookie is present. The proxy requires it on
+ * session-cookie-bearing unsafe requests and `/api/auth/mfa/*` is not exempt —
+ * MFA enrollment always runs with a session, so without the header it 403s
+ * ("CSRF token missing"). Cookie-less callers send no header and are
+ * unchanged.
  */
 
 'use client';
 
 import { useState } from 'react';
+import { readCsrfToken } from './csrf.js';
 
 /**
  * MFA setup data returned when initiating TOTP setup.
@@ -64,9 +73,13 @@ export function useMFASetup(): UseMFASetupResult {
       setIsLoading(true);
       setError(null);
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/auth/mfa/setup', {
         method: 'POST',
         credentials: 'include',
+        // Conditional headers key keeps cookie-less setup requests
+        // byte-identical to the pre-CSRF request shape.
+        ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
       });
 
       const json: unknown = await response.json();
@@ -93,9 +106,13 @@ export function useMFASetup(): UseMFASetupResult {
       setIsLoading(true);
       setError(null);
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/auth/mfa/verify-setup', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({ code }),
       });
@@ -167,9 +184,13 @@ export function useMFAVerify(): UseMFAVerifyResult {
       setIsLoading(true);
       setError(null);
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/auth/mfa/verify', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({ code }),
       });
@@ -197,9 +218,13 @@ export function useMFAVerify(): UseMFAVerifyResult {
       setIsLoading(true);
       setError(null);
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/auth/mfa/backup', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({ code }),
       });

--- a/packages/auth/src/react/usePasskey.ts
+++ b/packages/auth/src/react/usePasskey.ts
@@ -15,27 +15,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-/**
- * Read the JS-readable `revealui-csrf` cookie. The RevealUI admin proxy
- * (`apps/admin/src/proxy.ts`) requires it as an `X-CSRF-Token` header on any
- * session-cookie-bearing unsafe request, and may re-issue the cookie on any
- * response — so call this immediately before each fetch rather than once per
- * flow. Returns undefined outside the browser or when the cookie is
- * absent/empty. Mirrors the cookie-read in `@revealui/core`'s admin APIClient
- * (`request()`) and `@revealui/ai`'s `useAgentStream`.
- */
-function readCsrfToken(): string | undefined {
-  if (typeof document === 'undefined') return undefined;
-  for (const part of document.cookie.split(';')) {
-    const eqIdx = part.indexOf('=');
-    if (eqIdx === -1) continue;
-    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
-    }
-  }
-  return undefined;
-}
+import { readCsrfToken } from './csrf.js';
 
 export interface PasskeyRegisterOptions {
   /** Email for passkey registration (sign-up flow) */

--- a/packages/auth/src/react/useSignOut.ts
+++ b/packages/auth/src/react/useSignOut.ts
@@ -2,11 +2,20 @@
  * useSignOut Hook
  *
  * React hook for signing out a user.
+ *
+ * CSRF: the sign-out POST echoes the JS-readable `revealui-csrf` cookie (the
+ * signed double-submit token the RevealUI admin proxy issues on page load) as
+ * an `X-CSRF-Token` header when the cookie is present. The proxy requires it
+ * on session-cookie-bearing unsafe requests and `/api/auth/sign-out` is not
+ * exempt — sign-out always carries a session, so without the header it 403s
+ * ("CSRF token missing") and the server-side session survives. Cookie-less
+ * callers send no header and are unchanged.
  */
 
 'use client';
 
 import { useState } from 'react';
+import { readCsrfToken } from './csrf.js';
 
 export interface UseSignOutResult {
   signOut: () => Promise<void>;
@@ -41,9 +50,13 @@ export function useSignOut(): UseSignOutResult {
       setIsLoading(true);
       setError(null);
 
+      const csrfToken = readCsrfToken();
       const response = await fetch('/api/auth/sign-out', {
         method: 'POST',
         credentials: 'include',
+        // Conditional headers key keeps cookie-less sign-out requests
+        // byte-identical to the pre-CSRF request shape.
+        ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Completes the CSRF sweep #1386 started for the published `@revealui/auth` react hooks: `useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs.

The admin proxy requires that header on any unsafe request carrying a `revealui-session` cookie. `/api/auth/mfa/*` and `/api/auth/sign-out` are not in the exempt-prefix list, and both flows always run with a session, so the bare fetches were rejected with a 403 "CSRF token missing" — for sign-out that also means the server-side session survived (the hook's catch swallows the failure and navigates to /login anyway).

## What changed

- New `packages/auth/src/react/csrf.ts`: the `readCsrfToken()` helper from `usePasskey.ts`, extracted verbatim (no-regex cookie parse) now that three hook files need it. `usePasskey.ts` imports it; passkey behavior is unchanged.
- `useMFA.ts`: token attached on all four POSTs (`setup`, `verify-setup`, `verify`, `backup`), re-read immediately before each fetch (the proxy may reissue the cookie between steps).
- `useSignOut.ts`: token attached on the sign-out POST.
- Call sites that previously had no `headers` key (`mfa/setup`, `sign-out`) spread the whole headers entry conditionally, so cookie-less requests stay byte-identical to the pre-CSRF shape (asserted by exact-equality tests).
- `docs/AUTH.md` attachment list: "passkey hooks" broadened to "react hooks (passkey, MFA, sign-out)".
- `@revealui/auth` patch changeset.

## Who is affected

- **apps/admin is affected in prod today**: `settings/security/page.tsx` imports `useMFASetup`, so MFA enrollment 403s exactly like passkey registration did before #1386; `(frontend)/mfa/MFAForm.tsx` imports `useMFAVerify`, which 403s whenever a session cookie (including a stale one) is present during MFA login.
- `useSignOut` is **not** imported by apps/admin (the admin app signs out via its own route) — that hook's fix protects external consumers of the published package.
- Follow-up (separate PR): core's `AdminDashboard` `handleSignOut` makes the same bare sign-out fetch in `@revealui/core` and will get the same treatment.

## Tests

10 new tests mirroring the `usePasskey - CSRF token attach` describe: cookie present → header echoed on every POST; cookie absent → byte-identical request shape asserted with exact `toHaveBeenNthCalledWith` equality; empty cookie value → header omitted; cookie re-read between POSTs (proxy reissue); cookie expired in `afterEach` (happy-dom cookies persist across tests in a file).

## Verification

- `pnpm --filter @revealui/auth test`: 515 passed / 19 skipped (35 files)
- `pnpm --filter @revealui/auth typecheck`: clean
- `pnpm --filter admin typecheck`: clean
- `pnpm --filter admin test` (maxWorkers=2): 1776 passed / 10 skipped, with 3 fails in `conversation-routes.test.ts` + `gdpr-routes.test.ts` carrying 5.5–6.5s timeout signatures — files this diff does not touch; both pass 23/23 in isolation (the known box-load vitest flake class; CI Unit Tests is the real gate)
- `biome check packages/auth/src/react`: 0 errors; 19 advisory warnings vs 7 on the base branch — the delta is the same `document.cookie` advisory class the #1386 tests introduced (cookie setup in the new test describes + the moved helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
