### PR TITLE
fix(core): attach csrf token to admin dashboard sign-out

### DIFF
--- a/.changeset/core-admin-signout-csrf.md
+++ b/.changeset/core-admin-signout-csrf.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+The admin dashboard sign-out button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its POST. The proxy requires that header on any session-cookie-bearing unsafe request, and sign-out always runs with a session, so the request was rejected with a 403 "CSRF token missing" while the swallowed failure still navigated to /login  -  the server-side session was never revoked and cookies were never cleared. The cookie is read immediately before the POST via a shared `readCsrfToken()` helper, extracted verbatim from the admin `APIClient` (which now uses it too, behavior unchanged). When the cookie is absent (non-browser callers, no admin session) the request stays byte-identical to before  -  no `headers` key is sent.

--- a/packages/core/src/client/admin/components/AdminDashboard.tsx
+++ b/packages/core/src/client/admin/components/AdminDashboard.tsx
@@ -8,7 +8,7 @@ import type {
   RevealDocument,
   RevealGlobalConfig,
 } from '../../../types/index.js';
-import { APIError, APIErrorType, apiClient } from '../utils/index.js';
+import { APIError, APIErrorType, apiClient, postSignOut } from '../utils/index.js';
 import { CollectionList } from './CollectionList.js';
 import { DocumentForm } from './DocumentForm.js';
 import { GlobalForm } from './GlobalForm.js';
@@ -183,10 +183,7 @@ function SignOutButton() {
   const handleSignOut = useCallback(async () => {
     setLoading(true);
     try {
-      await fetch('/api/auth/sign-out', {
-        method: 'POST',
-        credentials: 'include',
-      });
+      await postSignOut();
     } catch {
       // Sign out even if the API call fails  -  clear client state regardless
     }

--- a/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
+++ b/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
@@ -1,0 +1,119 @@
+/**
+ * CSRF Helper Tests
+ *
+ * Covers readCsrfToken() cookie parsing and the postSignOut() request shape:
+ * the X-CSRF-Token header is echoed exactly when the revealui-csrf cookie is
+ * readable, and the request stays byte-identical to the historical bare fetch
+ * (no `headers` key at all) when it is not. This package's vitest environment
+ * is node, so `document` is absent by default and stubbed per test  -  no
+ * happy-dom cookie-jar persistence applies; stubs reset in afterEach.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { postSignOut, readCsrfToken } from '../csrf.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('readCsrfToken', () => {
+  it('returns undefined outside the browser (no document)', () => {
+    expect(typeof document).toBe('undefined');
+    expect(readCsrfToken()).toBeUndefined();
+  });
+
+  it('reads the revealui-csrf cookie among other cookies', () => {
+    vi.stubGlobal('document', {
+      cookie: 'other-cookie=unrelated; revealui-csrf=nonce123:hmac456; later=2',
+    });
+    expect(readCsrfToken()).toBe('nonce123:hmac456');
+  });
+
+  it('returns undefined when the cookie is absent', () => {
+    vi.stubGlobal('document', { cookie: 'other-cookie=unrelated' });
+    expect(readCsrfToken()).toBeUndefined();
+  });
+
+  it('returns undefined when the cookie value is empty', () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=' });
+    expect(readCsrfToken()).toBeUndefined();
+  });
+
+  it('returns the first match when duplicate cookies exist', () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=first; revealui-csrf=second' });
+    expect(readCsrfToken()).toBe('first');
+  });
+});
+
+describe('postSignOut - CSRF token attach', () => {
+  it('echoes the revealui-csrf cookie as X-CSRF-Token', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=nonce123:hmac456' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    await postSignOut();
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRF-Token': 'nonce123:hmac456' },
+    });
+  });
+
+  it('stays byte-identical to the bare fetch when no cookie exists (no headers key)', async () => {
+    vi.stubGlobal('document', { cookie: 'other-cookie=unrelated' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postSignOut();
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'credentials']);
+  });
+
+  it('omits the header when the cookie value is empty', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postSignOut();
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'credentials']);
+  });
+
+  it('omits the header outside the browser (no document)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postSignOut();
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'credentials']);
+  });
+
+  it('re-reads the cookie on every call (proxy may reissue)', async () => {
+    const doc = { cookie: 'revealui-csrf=token-before' };
+    vi.stubGlobal('document', doc);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    await postSignOut();
+    doc.cookie = 'revealui-csrf=token-rotated';
+    await postSignOut();
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/auth/sign-out',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-before' } }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/auth/sign-out',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-rotated' } }),
+    );
+  });
+});

--- a/packages/core/src/client/admin/utils/apiClient.ts
+++ b/packages/core/src/client/admin/utils/apiClient.ts
@@ -4,6 +4,7 @@
  */
 
 import type { RevealDocument } from '../../../types/index.js';
+import { readCsrfToken } from './csrf.js';
 
 export interface APIResponse<T = RevealDocument> {
   docs?: T[];
@@ -133,17 +134,7 @@ export class APIClient {
   private async request<T = unknown>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const Unsafe = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
     const method = (options.method ?? 'GET').toUpperCase();
-    let csrfToken: string | undefined;
-    if (Unsafe.has(method) && typeof document !== 'undefined') {
-      for (const part of document.cookie.split(';')) {
-        const eqIdx = part.indexOf('=');
-        if (eqIdx === -1) continue;
-        if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-          csrfToken = part.slice(eqIdx + 1).trim() || undefined;
-          break;
-        }
-      }
-    }
+    const csrfToken = Unsafe.has(method) ? readCsrfToken() : undefined;
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',

--- a/packages/core/src/client/admin/utils/csrf.ts
+++ b/packages/core/src/client/admin/utils/csrf.ts
@@ -1,0 +1,43 @@
+/**
+ * CSRF helpers for the admin client.
+ *
+ * The admin proxy and the api server's csrfMiddleware require any unsafe
+ * request carrying a `revealui-session` cookie to echo the JS-readable
+ * `revealui-csrf` cookie as an `X-CSRF-Token` header. The token is re-read
+ * immediately before each request because the proxy re-issues the cookie
+ * whenever it no longer validates against the current session (e.g. after
+ * re-login or session rotation).
+ */
+
+/**
+ * Read the `revealui-csrf` cookie value. Returns `undefined` outside the
+ * browser, when the cookie is absent, or when its value is empty.
+ */
+export function readCsrfToken(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  for (const part of document.cookie.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
+      return part.slice(eqIdx + 1).trim() || undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * POST `/api/auth/sign-out`, echoing the CSRF cookie as `X-CSRF-Token` when
+ * one is readable. Sign-out always runs with a session cookie, so without the
+ * header the admin proxy rejects the request with 403 "CSRF token missing"
+ * and the server-side session is never revoked. When no cookie is readable
+ * the request stays byte-identical to the historical bare fetch (no `headers`
+ * key at all).
+ */
+export async function postSignOut(): Promise<Response> {
+  const csrfToken = readCsrfToken();
+  return fetch('/api/auth/sign-out', {
+    method: 'POST',
+    credentials: 'include',
+    ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
+  });
+}

--- a/packages/core/src/client/admin/utils/index.ts
+++ b/packages/core/src/client/admin/utils/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './apiClient.js';
+export * from './csrf.js';


### PR DESCRIPTION
## Summary

`SignOutButton` in `@revealui/core`'s AdminDashboard POSTed `/api/auth/sign-out` with `credentials: 'include'` and no `X-CSRF-Token` header. The admin proxy requires that header on any unsafe request carrying a `revealui-session` cookie, and `/api/auth/sign-out` is (correctly) not CSRF-exempt — sign-out always runs with a session — so the POST was rejected with 403 "CSRF token missing". The `catch` swallowed the failure and `window.location.href = '/login'` still navigated, making sign-out a silent no-op: the server-side session was never revoked and cookies were never cleared (same end-state as the #1383 cookie-domain bug, different cause).

This is the `@revealui/core` instance of the bug class already fixed for `@revealui/auth` usePasskey in #1386 and `@revealui/ai` useAgentStream in #1352.

## Fix

- NEW `packages/core/src/client/admin/utils/csrf.ts`: `readCsrfToken()` extracted **verbatim** from `APIClient.request()`'s inline cookie loop (no-regex `split`/`indexOf` parse), plus `postSignOut()` which echoes the cookie as `X-CSRF-Token` and spreads the whole `headers` key conditionally — when no cookie is readable the request stays **byte-identical** to the historical bare fetch (no `headers` key at all).
- `APIClient.request()` migrated to the shared helper (behavior identical; removes the now-duplicated loop).
- `SignOutButton.handleSignOut` calls `postSignOut()`; the swallow-and-navigate UX is unchanged.
- Barrel export added in `client/admin/utils/index.ts`.

## Audit (origin/test 66ac66cd4)

- The `docs/AUTH.md` "Attachment" claim that core's `APIClient` attaches the header is TRUE (`apiClient.ts` conditional attach); AdminDashboard was the bypass.
- Grep of `packages/core/src` for other bare unsafe same-origin `/api/*` fetches: the only other instance is richtext `ImageUploadButton.tsx:105` (POSTs `/api/media` by default, not proxy-exempt) — flagged as a separate follow-up rather than scope-creeping this PR.
- `storage/r2.ts`, `observability/{health-check,alerts}.ts`, `error-handling/error-reporter.ts`: server-side runtimes or configurable endpoints (`/api/logs` is proxy-exempt by design) — not in the class.
- `docs/AUTH.md` deliberately untouched here: its attachment list is being broadened by the in-flight auth-hooks CSRF lane, and the claim it makes about core is accurate once this lands.

## Tests

`packages/core` vitest runs `environment: 'node'` with an `*.test.ts`-only include (no happy-dom / component-render infra), so coverage is exact request-shape module tests instead of rendered-component tests:

- cookie present → header echoed (exact `toHaveBeenNthCalledWith` equality)
- cookie absent / empty / no `document` → exact legacy shape, plus `Object.keys(init)` proving no `headers` key exists at all
- token re-read on every call (proxy may reissue between requests)
- `readCsrfToken` parsing: among other cookies, absent, empty value, duplicate-cookie first-match, no document

## Verification

- `pnpm --filter @revealui/core test` — 107 files / 2720 tests pass (includes the 10 new)
- `pnpm --filter @revealui/core typecheck` — clean
- `pnpm exec biome check packages/core/src/client/admin` — clean
- `@revealui/core` patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
