### PR TITLE
fix(scripts): retire destructive release changelog subcommand

### DIFF
--- a/scripts/cli/release.ts
+++ b/scripts/cli/release.ts
@@ -4,7 +4,7 @@
  * Release CLI
  *
  * Unified CLI for version management and package publishing.
- * Handles versioning, changelog generation, and npm publishing for the monorepo.
+ * Handles versioning and npm publishing for the monorepo.
  * Replaces GitHub Actions release.yml and release-pro.yml workflows.
  *
  * Commands:
@@ -13,7 +13,6 @@
  *   pro               Publish Pro packages to npm
  *   version           Bump version (major|minor|patch)
  *   preview           Preview release changes
- *   changelog         Generate changelog
  *   publish           Publish packages to npm
  *   tag               Create git release tag
  *   dry-run           Simulate a release without publishing
@@ -26,7 +25,6 @@
  *   pnpm release pro --dry-run           # dry-run Pro publish
  *   pnpm release version minor
  *   pnpm release preview
- *   pnpm release changelog --output CHANGELOG.md
  *   pnpm release publish --tag beta
  *   pnpm release tag v1.2.3
  *
@@ -43,8 +41,6 @@
  * - External: npm - Package publishing
  */
 
-import { writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import type { ParsedArgs } from '@revealui/scripts/args.js';
 import { ErrorCode } from '@revealui/scripts/errors.js';
 import { execCommand } from '@revealui/scripts/index.js';
@@ -63,12 +59,6 @@ class ReleaseCLI extends ExecutingCLI {
         type: 'string' as const,
         description: 'NPM tag for publishing (latest, beta, next, etc.)',
         default: 'latest',
-      },
-      {
-        name: 'output',
-        short: 'o',
-        type: 'string' as const,
-        description: 'Output file path',
       },
       {
         name: 'no-push',
@@ -122,24 +112,6 @@ class ReleaseCLI extends ExecutingCLI {
         name: 'preview',
         description: 'Preview release changes without making any modifications',
         handler: async (args) => this.previewRelease(args),
-      },
-      {
-        name: 'changelog',
-        description: 'Generate changelog from git commits since the last tag',
-        args: [
-          {
-            name: 'output',
-            type: 'string' as const,
-            description: 'Output file path (default: CHANGELOG.md)',
-            default: 'CHANGELOG.md',
-          },
-          {
-            name: 'since',
-            type: 'string' as const,
-            description: 'Git ref (tag, commit) to start from (default: last tag)',
-          },
-        ],
-        handler: async (args) => this.generateChangelog(args),
       },
       {
         name: 'publish',
@@ -411,93 +383,6 @@ class ReleaseCLI extends ExecutingCLI {
     }
 
     return ok({ message: 'Release preview complete' });
-  }
-
-  /**
-   * Generate changelog
-   */
-  private async generateChangelog(args: ParsedArgs) {
-    const outputFile = args.output ? String(args.output) : 'CHANGELOG.md';
-    const since = args.since ? String(args.since) : undefined;
-
-    // Get the most recent git tag as the base, or use --since override
-    let fromRef = since;
-    if (!fromRef) {
-      const tagResult = await execCommand('git', ['describe', '--tags', '--abbrev=0'], {
-        cwd: this.projectRoot,
-      });
-      fromRef = tagResult.success ? (tagResult.stdout ?? '').trim() : undefined;
-    }
-
-    const logArgs = ['log', '--pretty=format:%H|%s|%an|%ad', '--date=short', '--no-merges'];
-    if (fromRef) logArgs.push(`${fromRef}..HEAD`);
-
-    const logResult = await execCommand('git', logArgs, { cwd: this.projectRoot });
-    if (!logResult.success) {
-      return fail('Failed to read git log', ErrorCode.EXECUTION_ERROR);
-    }
-
-    const lines = (logResult.stdout ?? '').trim().split('\n').filter(Boolean);
-
-    // Parse conventional commits into sections
-    const sections: Record<string, string[]> = {
-      feat: [],
-      fix: [],
-      perf: [],
-      refactor: [],
-      docs: [],
-      test: [],
-      chore: [],
-      other: [],
-    };
-    const labelMap: Record<string, string> = {
-      feat: 'Features',
-      fix: 'Bug Fixes',
-      perf: 'Performance',
-      refactor: 'Refactoring',
-      docs: 'Documentation',
-      test: 'Tests',
-      chore: 'Chores',
-      other: 'Other Changes',
-    };
-
-    for (const line of lines) {
-      const [hash, subject] = line.split('|');
-      if (!subject) continue;
-      const match = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-      if (match) {
-        const [, type, scope, breaking, desc] = match;
-        const entry = scope
-          ? `- **${scope}**: ${desc}${breaking ? ' (**BREAKING**)' : ''} (${hash?.slice(0, 8)})`
-          : `- ${desc}${breaking ? ' (**BREAKING**)' : ''} (${hash?.slice(0, 8)})`;
-        const bucket = sections[type ?? ''] !== undefined ? (type ?? 'other') : 'other';
-        sections[bucket]?.push(entry);
-      } else {
-        sections.other?.push(`- ${subject} (${hash?.slice(0, 8)})`);
-      }
-    }
-
-    const dateStr = new Date().toISOString().slice(0, 10);
-    const header = fromRef
-      ? `## Changes since ${fromRef} (${dateStr})\n`
-      : `## Changelog (${dateStr})\n`;
-
-    const body = Object.entries(sections)
-      .filter(([, entries]) => entries.length > 0)
-      .map(([type, entries]) => `### ${labelMap[type]}\n\n${entries.join('\n')}`)
-      .join('\n\n');
-
-    const content = `${header}\n${body || '_No changes_'}\n`;
-
-    const outPath = resolve(this.projectRoot, outputFile);
-    writeFileSync(outPath, content, 'utf-8');
-
-    return ok({
-      message: `Changelog written to ${outputFile}`,
-      output: outPath,
-      commits: lines.length,
-      since: fromRef ?? 'beginning',
-    });
   }
 
   /**


### PR DESCRIPTION
## Summary

`pnpm release changelog` resolved `--output` to `CHANGELOG.md` by default and ended in an unconditional `writeFileSync` overwrite (`scripts/cli/release.ts`). Run as shipped, it would have replaced the hand-maintained keep-a-changelog narrative at the repo root, including the docs-system frontmatter enforced by `scripts/validate/validate-root-markdown.ts`, with a conventional-commit git-log digest. This PR retires the subcommand.

Follow-up to the post-merge finding recorded on #1389.

## Audit (before the change)

| Question | Result |
|---|---|
| Any `package.json` script wrapping it? | No. `release`, `release:dry-run`, `release:oss`, `release:pro`, `release:status` exist; there is no `release:changelog`. |
| Any GitHub workflow invoking it? | No. |
| Any doc referencing it? | No. `scripts/README.md`, `docs/CI_CD_GUIDE.md`, `docs/PUBLISHING.md`, `docs/AUTOMATION.md`, and `.github/workflows/README.md` document the other subcommands only. |
| Sole reference | Its own usage docblock, which recommended the destructive invocation (`pnpm release changelog --output CHANGELOG.md`). |
| Ever run against the real file? | No. `git log -S "Changes since"` and `-S "## Changelog ("` over `CHANGELOG.md` history return zero commits — the generator's section headers have never landed. |
| `scripts/workflows/definitions/release.ts` `generateChangelog` flag? | Not an invoker. The step action is a no-op stub, and nothing imports the definition (references are README-only). |

## Why retire instead of re-pointing the default or prepend-preserving

Every destination a git-log digest could target is already owned by something else:

- `packages/*/CHANGELOG.md` are changesets-owned and CI-guarded frontmatter-free since #1389 (`scripts/validate/changelog-format.ts`).
- The root `CHANGELOG.md` is curated keep-a-changelog narrative in docs-system scope; its frontmatter is required by the integrity gate, so the generated output could never pass CI even if the overwrite were intended.
- GitHub release bodies are sourced from package changelog sections since #1385, and `release oss` already uses `gh release create --generate-notes`.

Keeping a safer variant would mean maintaining parsing code for a tool with no consumers. Removal also deletes one legacy authored regex (the commit-subject matcher), in line with the no-regex posture (M2).

## Changes

- Remove the `changelog` command definition and the `generateChangelog()` handler.
- Remove the now-unused `--output`/`-o` global arg (no other subcommand reads `args.output`; the `ExecutingCLI` base does not use it).
- Remove the now-unused `node:fs` (`writeFileSync`) and `node:path` (`resolve`) imports.
- Update the file docblock (command list + usage examples).

No behavior change for any wired subcommand (`status`, `oss`, `pro`, `version`, `preview`, `publish`, `tag`, `dry-run`).

## Verification

- `biome check scripts/cli/release.ts` — clean.
- `tsx scripts/cli/release.ts --help`, A/B against the unmodified baseline — `changelog` and `-o, --output` are no longer listed; the other eight subcommands (`status`, `oss`, `pro`, `version`, `preview`, `publish`, `tag`, `dry-run`) and the remaining options (`--tag`, `--no-push`, `--dry-run`) print identically.
- `tsx scripts/cli/release.ts changelog` — no longer dispatches; falls through to the unknown-command usage path.
- The only remaining `CHANGELOG` mention in the file is the accurate comment that `pnpm changeset version` updates package changelogs.
- Pre-existing and unrelated, observed during verification: the release CLI prints help and then never exits (reproduced identically on the unmodified baseline — something keeps the event loop alive after `--help`). Flagged separately rather than scope-creeped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
