### PR TITLE
fix(admin): serve /api/media as an upload forward to the api server

### DIFF
--- a/apps/admin/src/app/api/media/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/media/__tests__/route.test.ts
@@ -1,0 +1,210 @@
+/**
+ * /api/media upload-forward route tests
+ *
+ * The route is a thin server-side forward to the api server's
+ * POST /api/content/media (the single upload implementation: contracts
+ * validation + object storage + media DB row). These tests pin the forward
+ * contract: session gate, multipart content-type requirement, target URL,
+ * header shape (Cookie/User-Agent passthrough, minted X-CSRF-Token bound to
+ * the session cookie value, original Content-Type with its boundary), the
+ * byte-identical streamed body with `duplex: 'half'`, success status/body
+ * passthrough, preserved status with a generic body on upstream failure, and
+ * 503 when the api server is unreachable.
+ *
+ * The multipart body is hand-encoded with a fixed boundary: this suite runs
+ * under jsdom, whose FormData/File globals are not undici's, and undici's
+ * multipart machinery rejects entries built from foreign classes. The route
+ * never parses the body (it streams it through), so the tests assert the
+ * forwarded bytes instead.
+ */
+
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateCsrfToken } from '@/lib/utils/csrf-token';
+
+const mockGetSession = vi.fn();
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: undefined, ipAddress: undefined }),
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const API_BASE = 'http://api-server.test';
+const SESSION_COOKIE = 'session-cookie-value';
+const BOUNDARY = 'vitest-boundary-2f1c55114';
+const MULTIPART_CONTENT_TYPE = `multipart/form-data; boundary=${BOUNDARY}`;
+
+function multipartUploadBody(): string {
+  return [
+    `--${BOUNDARY}`,
+    'Content-Disposition: form-data; name="file"; filename="hero.png"',
+    'Content-Type: image/png',
+    '',
+    'png-bytes',
+    `--${BOUNDARY}`,
+    'Content-Disposition: form-data; name="alt"',
+    '',
+    'Hero image',
+    `--${BOUNDARY}--`,
+    '',
+  ].join('\r\n');
+}
+
+function makeUploadRequest(): NextRequest {
+  return new NextRequest('http://admin.test/api/media', {
+    method: 'POST',
+    headers: {
+      cookie: `revealui-session=${SESSION_COOKIE}`,
+      'user-agent': 'vitest-agent',
+      'content-type': MULTIPART_CONTENT_TYPE,
+    },
+    body: multipartUploadBody(),
+  });
+}
+
+function uploadCreatedResponse(): Response {
+  return Response.json(
+    { success: true, data: { url: 'https://cdn.test/media/x.png' } },
+    { status: 201 },
+  );
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('NEXT_PUBLIC_API_URL', API_BASE);
+  mockGetSession.mockReset();
+  mockGetSession.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('POST /api/media', () => {
+  it('returns 401 without a session and never contacts the api server', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../route.js');
+    const res = await POST(makeUploadRequest());
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-multipart body and never contacts the api server', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../route.js');
+    const res = await POST(
+      new NextRequest('http://admin.test/api/media', {
+        method: 'POST',
+        headers: {
+          cookie: `revealui-session=${SESSION_COOKIE}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ nope: true }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards to the api server media route with the proxy header set', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(uploadCreatedResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../route.js');
+    await POST(makeUploadRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit & { duplex?: string }];
+    expect(url).toBe(`${API_BASE}/api/content/media`);
+    expect(init.method).toBe('POST');
+    expect(init.duplex).toBe('half');
+
+    const headers = init.headers as Record<string, string>;
+    // The original Content-Type is forwarded verbatim so the api server
+    // parses against the client's multipart boundary.
+    expect(Object.keys(headers).sort()).toEqual([
+      'Content-Type',
+      'Cookie',
+      'User-Agent',
+      'X-CSRF-Token',
+    ]);
+    expect(headers['Content-Type']).toBe(MULTIPART_CONTENT_TYPE);
+    expect(headers.Cookie).toBe(`revealui-session=${SESSION_COOKIE}`);
+    expect(headers['User-Agent']).toBe('vitest-agent');
+    // The minted token must validate against the binding the api server's
+    // csrfMiddleware checks: the session cookie value + REVEALUI_SECRET.
+    const secret = process.env.REVEALUI_SECRET ?? '';
+    expect(secret).not.toBe('');
+    await expect(
+      validateCsrfToken(headers['X-CSRF-Token'] ?? '', SESSION_COOKIE, secret),
+    ).resolves.toBe(true);
+  });
+
+  it('streams the multipart body through byte-identical', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(uploadCreatedResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../route.js');
+    await POST(makeUploadRequest());
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const forwarded = await new Response(init.body as ReadableStream<Uint8Array>).text();
+    expect(forwarded).toBe(multipartUploadBody());
+  });
+
+  it('passes the api server success status and body through to the editor', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(uploadCreatedResponse()));
+
+    const { POST } = await import('../route.js');
+    const res = await POST(makeUploadRequest());
+
+    expect(res.status).toBe(201);
+    // The editor's getUploadUrl reads `data.url` from this body.
+    await expect(res.json()).resolves.toEqual({
+      success: true,
+      data: { url: 'https://cdn.test/media/x.png' },
+    });
+  });
+
+  it('preserves the upstream status with a generic body on api failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          Response.json({ success: false, error: { message: 'File too large' } }, { status: 413 }),
+        ),
+    );
+
+    const { POST } = await import('../route.js');
+    const res = await POST(makeUploadRequest());
+
+    expect(res.status).toBe(413);
+    await expect(res.json()).resolves.toEqual({ error: 'API request failed' });
+  });
+
+  it('returns 503 when the api server is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')));
+
+    const { POST } = await import('../route.js');
+    const res = await POST(makeUploadRequest());
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'Content API unavailable' });
+  });
+});

--- a/apps/admin/src/app/api/media/route.ts
+++ b/apps/admin/src/app/api/media/route.ts
@@ -1,0 +1,63 @@
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.REVEALUI_PUBLIC_SERVER_URL ||
+  'http://localhost:3004';
+
+/**
+ * POST /api/media — upload forward to the api server.
+ *
+ * The rich-text editor's ImageUploadButton POSTs multipart FormData to its
+ * default `/api/media` endpoint. The upload implementation (contracts-driven
+ * MIME/size/magic-byte validation, object storage, media DB row) lives on the
+ * api server at POST /api/content/media; forwarding server-side — like the
+ * /api/collections/* routes — keeps that implementation single-sourced.
+ *
+ * The body is streamed through verbatim with the original Content-Type
+ * header, so the client's multipart boundary is preserved and the file is
+ * never buffered or re-encoded here. `duplex: 'half'` is required by fetch
+ * for any streamed request body (and is absent from lib.dom's RequestInit,
+ * hence the intersection type).
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const session = await getSession(request.headers, extractRequestContext(request));
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.startsWith('multipart/form-data')) {
+    return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 });
+  }
+
+  try {
+    const init: RequestInit & { duplex: 'half' } = {
+      method: 'POST',
+      headers: await apiForwardHeaders(request, { 'Content-Type': contentType }),
+      body: request.body,
+      duplex: 'half',
+    };
+    const apiResponse = await fetch(`${API_URL}/api/content/media`, init);
+
+    if (!apiResponse.ok) {
+      const text = await apiResponse.text();
+      logger.error('Content API request failed', new Error(text || 'Unknown error'), {
+        route: 'media-upload',
+        status: apiResponse.status,
+      });
+      return NextResponse.json({ error: 'API request failed' }, { status: apiResponse.status });
+    }
+
+    const data = await apiResponse.json();
+    return NextResponse.json(data, { status: apiResponse.status });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.error('Content API unavailable', error, { route: 'media-upload' });
+    return NextResponse.json({ error: 'Content API unavailable' }, { status: 503 });
+  }
+}


### PR DESCRIPTION
## Summary

The rich-text editor's `ImageUploadButton` POSTs multipart `FormData` to its default `/api/media` endpoint (`packages/core/src/client/richtext/components/ImageUploadButton.tsx:51`), rendered prop-less in both admin toolbars — but apps/admin has never served `/api/media`: no route handler under `src/app/api/` and no rewrite in `next.config.mjs`. Today the upload dies earlier with a 403 "CSRF token missing" at the admin proxy; once the in-flight richtext CSRF attach (`fix/richtext-image-upload-csrf`) lands, it would die at a 404 instead. This PR adds the missing route.

## Change

- NEW `apps/admin/src/app/api/media/route.ts` — a thin POST forward to the api server's `POST /api/content/media`, mirroring how the `/api/collections/*` routes persist:
  - `getSession` gate (401) and multipart content-type guard (400).
  - `apiForwardHeaders()` (#1349): Cookie + User-Agent passthrough plus a freshly minted `X-CSRF-Token` bound to the session cookie value for the api server's `csrfMiddleware`.
  - The body is **streamed through verbatim** with the original `Content-Type` (client boundary preserved, no buffering or re-encode; `duplex: 'half'`).
  - Success status/body pass through unchanged — the editor's `getUploadUrl` already parses `data.url` from the api envelope. Upstream failures keep their status with a generic body (collections-forwarder semantics); network failures map to 503.
- Validation stays single-sourced on the api server (`ALL_MIME_TYPES` whitelist, per-type size limits, magic-byte verification, sanitized filenames, object storage, media DB row) — nothing is duplicated in the admin app.

## Why a forward (not a rewrite, not a client endpoint change)

- Admin collections already persist via server-side forwards; there is no admin-local media storage path to reuse.
- A `next.config.mjs` rewrite bakes the api origin at build time (wrong for self-hosted kits) and cannot mint the api-side CSRF token or forward the UA uniformly.
- Pointing `uploadEndpoint` at the api origin from the browser means cross-origin CORS + credentials churn, and no in-tree consumer passes that prop today.
- Listing and id ops already work through the generic `/api/collections/media` forwarders; only the editor's `POST /api/media` default was unserved.

## Tests

- NEW `__tests__/route.test.ts` (7 tests): session gate, multipart guard, target URL + `duplex: 'half'`, exact forwarded header set (Cookie / User-Agent / original Content-Type with its boundary / X-CSRF-Token validated against the session-cookie binding using the real csrf-token helper), byte-identical streamed body, success passthrough, preserved-status generic error, 503 on unreachable api.
- Local: full admin suite 1797 passed / 10 skipped (132 files), `pnpm --filter admin typecheck` clean, `biome check` clean on changed paths.

## Notes

- apps/admin only — no changeset (the app is unpublished).
- Composes with the in-flight `fix/richtext-image-upload-csrf` lane (file-disjoint): that PR attaches the CSRF header on the editor's browser leg; this PR gives the request somewhere to land. The full editor-upload flow needs both.
- Owner-gated manual merge (no `--auto`); base `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
