### PR TITLE
ci: repin backflow reusable + correct dependency-review comment

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -26,7 +26,7 @@ jobs:
   backflow:
     # Pinned to a SHA — org-shared reusable was referenced by the mutable @main.
     # Bump this deliberately when the reusable changes.
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@5c376894f427f8cdba5471ab9d2c437b6b8e19c1 # main @ 2026-06-09
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@018dbca12f2b6588b456cb2f450aadf4814729cd # main @ 2026-06-12
     # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
     # block documents this exact form) instead of `secrets: inherit`, which would
     # forward every caller secret (VERCEL_TOKEN, PROD_POSTGRES_URL, …) into it.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,6 +135,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high


### PR DESCRIPTION
Bump action pins to node24-compatible releases

GitHub deprecates node20-declared actions with a force run on 2026-06-16.
All revealui workflow pins were updated by a prior session; this PR finishes
the two remaining items per the fleet-wide sweep proven by revdev#106.

Changes:
- Backflow reusable caller: 5c376894 (main 2026-06-09) -> 018dbca1 (main 2026-06-12)
  The reusable itself was updated in RevealUIStudio/.github#5 (actions/checkout v6 +
  create-github-app-token v3).
- security.yml dependency-review-action comment: v4 -> v5 (SHA a1d282b3 is already v5.0.0)
