### PR TITLE
promote: test to main (2026-06-12)

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -26,7 +26,7 @@ jobs:
   backflow:
     # Pinned to a SHA — org-shared reusable was referenced by the mutable @main.
     # Bump this deliberately when the reusable changes.
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@5c376894f427f8cdba5471ab9d2c437b6b8e19c1 # main @ 2026-06-09
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@018dbca12f2b6588b456cb2f450aadf4814729cd # main @ 2026-06-12
     # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
     # block documents this exact form) instead of `secrets: inherit`, which would
     # forward every caller secret (VERCEL_TOKEN, PROD_POSTGRES_URL, …) into it.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,6 +135,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high

--- a/apps/marketing/app/__tests__/pricing-fallbacks.test.ts
+++ b/apps/marketing/app/__tests__/pricing-fallbacks.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Drift gate: asserts that the shared client-side fallback constants exported from
+ * apps/marketing/app/lib/pricing-fallbacks.ts match the canonical values in
+ * .jv/business/offerings-canonical.md (pinned 2026-06-07).
+ *
+ * When prices change, update ALL surfaces listed in pricing-fallbacks.ts header
+ * and keep this test in lockstep.
+ */
+import { describe, expect, it } from 'vitest';
+import { PERPETUAL_PRICE_FALLBACKS, SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
+
+describe('pricing-fallbacks — canonical value assertions', () => {
+  it('subscription fallbacks match canonical prices', () => {
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.free.price).toBe('$0');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.pro.price).toBe('$49');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.pro.period).toBe('/month');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.max.price).toBe('$299');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.max.period).toBe('/month');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.enterprise.price).toBe('$1,499');
+    expect(SUBSCRIPTION_PRICE_FALLBACKS.enterprise.period).toBe('/month');
+  });
+
+  it('perpetual fallbacks match canonical prices', () => {
+    expect(PERPETUAL_PRICE_FALLBACKS['Pro Perpetual'].price).toBe('$1,499');
+    expect(PERPETUAL_PRICE_FALLBACKS['Pro Perpetual'].renewal).toBe(
+      '$149/yr for continued support',
+    );
+    expect(PERPETUAL_PRICE_FALLBACKS['Agency Perpetual'].price).toBe('$8,499');
+    expect(PERPETUAL_PRICE_FALLBACKS['Agency Perpetual'].renewal).toBe(
+      '$799/yr for continued support',
+    );
+    expect(PERPETUAL_PRICE_FALLBACKS['Enterprise Perpetual'].price).toBe('$42,999');
+    expect(PERPETUAL_PRICE_FALLBACKS['Enterprise Perpetual'].renewal).toBe(
+      '$3,999/yr for continued support',
+    );
+  });
+
+  it('covers all four subscription tiers', () => {
+    const ids = Object.keys(SUBSCRIPTION_PRICE_FALLBACKS);
+    expect(ids).toEqual(expect.arrayContaining(['free', 'pro', 'max', 'enterprise']));
+    expect(ids).toHaveLength(4);
+  });
+
+  it('covers all three perpetual tiers', () => {
+    const names = Object.keys(PERPETUAL_PRICE_FALLBACKS);
+    expect(names).toEqual(
+      expect.arrayContaining(['Pro Perpetual', 'Agency Perpetual', 'Enterprise Perpetual']),
+    );
+    expect(names).toHaveLength(3);
+  });
+});

--- a/apps/marketing/app/__tests__/pricing-fallbacks.test.ts
+++ b/apps/marketing/app/__tests__/pricing-fallbacks.test.ts
@@ -21,18 +21,11 @@ describe('pricing-fallbacks — canonical value assertions', () => {
   });
 
   it('perpetual fallbacks match canonical prices', () => {
-    expect(PERPETUAL_PRICE_FALLBACKS['Pro Perpetual'].price).toBe('$1,499');
-    expect(PERPETUAL_PRICE_FALLBACKS['Pro Perpetual'].renewal).toBe(
-      '$149/yr for continued support',
-    );
-    expect(PERPETUAL_PRICE_FALLBACKS['Agency Perpetual'].price).toBe('$8,499');
-    expect(PERPETUAL_PRICE_FALLBACKS['Agency Perpetual'].renewal).toBe(
-      '$799/yr for continued support',
-    );
-    expect(PERPETUAL_PRICE_FALLBACKS['Enterprise Perpetual'].price).toBe('$42,999');
-    expect(PERPETUAL_PRICE_FALLBACKS['Enterprise Perpetual'].renewal).toBe(
-      '$3,999/yr for continued support',
-    );
+    expect(PERPETUAL_PRICE_FALLBACKS).toMatchObject({
+      'Pro Perpetual': { price: '$1,499', renewal: '$149/yr for continued support' },
+      'Agency Perpetual': { price: '$8,499', renewal: '$799/yr for continued support' },
+      'Enterprise Perpetual': { price: '$42,999', renewal: '$3,999/yr for continued support' },
+    });
   });
 
   it('covers all four subscription tiers', () => {

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -1,4 +1,4 @@
-import type { LicenseTierId, PricingResponse } from '@revealui/contracts/pricing';
+import type { PricingResponse } from '@revealui/contracts/pricing';
 import { ButtonCVA } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import {
@@ -6,24 +6,14 @@ import {
   PRICING_TEASER_SECTION,
   PRICING_TEASER_TIERS,
 } from '../../content/pricing-teaser';
-
-// Fallback used when /api/pricing is unreachable. Mirrors HARDCODED_SUBSCRIPTION_PRICES
-// in apps/server/src/routes/pricing.ts. The billing-readiness cron drift-checks the API
-// hardcodes against Stripe; keep these in sync when that cron fires. Stripe Dashboard
-// is the canonical source of truth.
-const TEASER_FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> = {
-  free: { price: '$0' },
-  pro: { price: '$49', period: '/month' },
-  max: { price: '$299', period: '/month' },
-  enterprise: { price: '$1,499', period: '/month' },
-};
+import { SUBSCRIPTION_PRICE_FALLBACKS } from '../../lib/pricing-fallbacks';
 
 const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
 
 export function PricingTeaser() {
-  const [prices, setPrices] = useState(TEASER_FALLBACK_PRICE);
+  const [prices, setPrices] = useState(SUBSCRIPTION_PRICE_FALLBACKS);
 
   useEffect(() => {
     let cancelled = false;
@@ -33,7 +23,7 @@ export function PricingTeaser() {
         if (!res.ok) return;
         const data = (await res.json()) as PricingResponse;
         if (cancelled) return;
-        const next = { ...TEASER_FALLBACK_PRICE };
+        const next = { ...SUBSCRIPTION_PRICE_FALLBACKS };
         for (const tier of data.subscriptions) {
           if (tier.price) {
             next[tier.id] = { price: tier.price, period: tier.period };

--- a/apps/marketing/app/lib/pricing-fallbacks.ts
+++ b/apps/marketing/app/lib/pricing-fallbacks.ts
@@ -1,0 +1,43 @@
+import type { LicenseTierId } from '@revealui/contracts/pricing';
+
+/**
+ * Client-side display fallback prices — used by PricingPage and PricingTeaser
+ * when /api/pricing is unreachable. Must stay in lockstep with:
+ *   - apps/server/src/routes/pricing.ts HARDCODED_*_PRICES (server fallback)
+ *   - apps/server/src/lib/tier-pricing.ts MRR_TIER_PRICE_FALLBACK_USD
+ *   - offerings-canonical.md (canonical source, pinned 2026-06-07)
+ *   - apps/marketing/app/__tests__/pricing-fallbacks.test.ts (drift gate)
+ *
+ * Update all surfaces together when prices change.
+ */
+
+export const SUBSCRIPTION_PRICE_FALLBACKS: Record<
+  LicenseTierId,
+  { price: string; period?: string }
+> = {
+  free: { price: '$0' },
+  pro: { price: '$49', period: '/month' },
+  max: { price: '$299', period: '/month' },
+  enterprise: { price: '$1,499', period: '/month' },
+};
+
+export const PERPETUAL_PRICE_FALLBACKS: Record<
+  string,
+  { price: string; priceNote: string; renewal: string }
+> = {
+  'Pro Perpetual': {
+    price: '$1,499',
+    priceNote: 'one-time',
+    renewal: '$149/yr for continued support',
+  },
+  'Agency Perpetual': {
+    price: '$8,499',
+    priceNote: 'one-time',
+    renewal: '$799/yr for continued support',
+  },
+  'Enterprise Perpetual': {
+    price: '$42,999',
+    priceNote: 'one-time',
+    renewal: '$3,999/yr for continued support',
+  },
+};

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -1,4 +1,3 @@
-import type { LicenseTierId } from '@revealui/contracts/pricing';
 import { ButtonCVA } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { Footer } from '../components/Footer';
@@ -27,48 +26,12 @@ import {
   SUBSCRIPTION_TIERS,
 } from '../content/pricing';
 import { PRICING_FAQ_SECTION, PRICING_FAQS } from '../content/pricing-faq';
+import { PERPETUAL_PRICE_FALLBACKS, SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
 
 const ADMIN_URL = import.meta.env.VITE_ADMIN_URL ?? 'https://admin.revealui.com';
 const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
-
-// Fallback prices shown when /api/pricing is unreachable (local dev without the API
-// running, or a transient API error) — without this the cards render "Contact us" for
-// every tier. Mirrors TEASER_FALLBACK_PRICE (PricingTeaser.tsx) and
-// HARDCODED_SUBSCRIPTION_PRICES in apps/server/src/routes/pricing.ts. Stripe Dashboard
-// is canonical; the billing-readiness cron drift-checks these.
-const FALLBACK_PRICE: Record<LicenseTierId, { price: string; period?: string }> = {
-  free: { price: '$0' },
-  pro: { price: '$49', period: '/month' },
-  max: { price: '$299', period: '/month' },
-  enterprise: { price: '$1,499', period: '/month' },
-};
-
-// Same role as FALLBACK_PRICE for the perpetual cards: without it an API
-// outage renders "Contact for pricing" on all three, hiding the published
-// anchors. Mirrors HARDCODED_PERPETUAL_PRICES in apps/server/src/routes/
-// pricing.ts (lockstep enforced by pricing-marketing-drift.test.ts).
-const FALLBACK_PERPETUAL_PRICE: Record<
-  string,
-  { price: string; priceNote: string; renewal: string }
-> = {
-  'Pro Perpetual': {
-    price: '$1,499',
-    priceNote: 'one-time',
-    renewal: '$149/yr for continued support',
-  },
-  'Agency Perpetual': {
-    price: '$8,499',
-    priceNote: 'one-time',
-    renewal: '$799/yr for continued support',
-  },
-  'Enterprise Perpetual': {
-    price: '$42,999',
-    priceNote: 'one-time',
-    renewal: '$3,999/yr for continued support',
-  },
-};
 
 function CheckIcon({ className }: { className?: string }) {
   return (
@@ -102,7 +65,7 @@ export function PricingPage() {
   }, []);
 
   const tiers = (pricing?.subscriptions ?? SUBSCRIPTION_TIERS).map((tier) => {
-    const fallback = FALLBACK_PRICE[tier.id];
+    const fallback = SUBSCRIPTION_PRICE_FALLBACKS[tier.id];
     return {
       ...tier,
       price: tier.price ?? fallback?.price,
@@ -111,7 +74,7 @@ export function PricingPage() {
     };
   });
   const perpetualTiers = (pricing?.perpetual ?? PERPETUAL_TIERS).map((tier) => {
-    const fallback = FALLBACK_PERPETUAL_PRICE[tier.name];
+    const fallback = PERPETUAL_PRICE_FALLBACKS[tier.name];
     return {
       ...tier,
       price: tier.price ?? fallback?.price,

--- a/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-marketing-drift.test.ts
@@ -7,14 +7,16 @@
  *
  *   1. `apps/server/src/routes/pricing.ts` HARDCODED_*_PRICES
  *   2. `apps/marketing/app/content/pricing.ts` + dependent content
- *   3. `apps/marketing/app/components/landing/PricingTeaser.tsx` TEASER_FALLBACK_PRICE
- *   4. `apps/marketing/app/routes/PricingPage.tsx` FALLBACK_PRICE + FALLBACK_PERPETUAL_PRICE
- *   5. `docs/MARKETING_METRICS.md` §2 (the canonical doc)
- *   6. Stripe live data (via `pnpm stripe:seed` post-update)
- *   7. This file
+ *   3. `apps/marketing/app/lib/pricing-fallbacks.ts` SUBSCRIPTION/PERPETUAL_PRICE_FALLBACKS
+ *   4. `apps/marketing/app/routes/PricingPage.tsx` (imports from #3)
+ *   5. `apps/marketing/app/components/landing/PricingTeaser.tsx` (imports from #3)
+ *   6. `apps/server/src/lib/tier-pricing.ts` MRR_TIER_PRICE_FALLBACK_USD
+ *   7. `docs/MARKETING_METRICS.md` §2 (the canonical doc)
+ *   8. Stripe live data (via `pnpm stripe:seed` post-update)
+ *   9. This file
  *
  * If this test fails, the lockstep was broken. Don't update the test in
- * isolation — update all seven together so the canonical truth stays canonical.
+ * isolation — update all nine surfaces together so the canonical truth stays canonical.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -45,6 +47,7 @@ vi.mock('@revealui/core/observability/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+import { MRR_TIER_PRICE_FALLBACK_USD } from '../../lib/tier-pricing.js';
 import app from '../pricing.js';
 
 // ---------------------------------------------------------------------------
@@ -141,6 +144,12 @@ describe('Pricing Marketing Drift — fallback prices match docs/MARKETING_METRI
       );
       expect(credit.costPer, `Credit bundle ${credit.name} costPer drift`).toBe(canonical.costPer);
     }
+  });
+
+  it('MRR_TIER_PRICE_FALLBACK_USD matches canonical subscription prices', () => {
+    expect(MRR_TIER_PRICE_FALLBACK_USD.pro, 'MRR pro price drift').toBe(49);
+    expect(MRR_TIER_PRICE_FALLBACK_USD.max, 'MRR max price drift').toBe(299);
+    expect(MRR_TIER_PRICE_FALLBACK_USD.enterprise, 'MRR enterprise price drift').toBe(1499);
   });
 
   it('perpetual-tier fallback prices match canonical map exactly', async () => {


### PR DESCRIPTION
Promotion: test to main (2026-06-12)

Included:
- PR #1399 fix/pricing-current-truth -- shared fallback module, 9-surface drift gate, typecheck fix
- PR #1398 chore/node24-action-pins -- bump action pins to node24 (deadline 2026-06-16)
- PR #1397 backflow merge (main into test)

Deploy note: push to main triggers deploy.yml auto-deploy.

Merge: use MERGE COMMIT (not squash).
