### PR TITLE
fix(scripts): unref telemetry timer + close ExecutionLogger in afterRun

### DIFF
--- a/packages/scripts/audit/execution-logger.ts
+++ b/packages/scripts/audit/execution-logger.ts
@@ -566,6 +566,7 @@ export class ExecutionLogger {
       await this.db.close();
       this.db = null;
     }
+    ExecutionLogger.instance = null;
   }
 
   // ===========================================================================

--- a/packages/scripts/telemetry.ts
+++ b/packages/scripts/telemetry.ts
@@ -186,6 +186,9 @@ export class Telemetry {
         logger.warn(`Auto-flush failed: ${error.message}`);
       });
     }, this.autoFlushInterval);
+    // Unref so short-lived CLIs (--help, etc.) can exit without waiting for
+    // the flush interval; long-running scripts keep the loop alive themselves.
+    this.flushTimer.unref();
 
     // Cleanup on process exit
     process.on('beforeExit', () => {

--- a/scripts/cli/_base.ts
+++ b/scripts/cli/_base.ts
@@ -249,9 +249,8 @@ export abstract class BaseCLI {
       }
 
       // Run lifecycle hooks and command
-      await this.beforeRun();
-
       try {
+        await this.beforeRun();
         const result = await command.handler(this.args);
 
         // If handler returned a result, output it
@@ -524,6 +523,10 @@ export abstract class ExecutingCLI extends BaseCLI {
         success: this.executionSuccess,
         error: this.executionError,
       });
+    }
+    if (this.logger) {
+      await this.logger.close();
+      this.logger = null;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `packages/scripts/telemetry.ts` creates a module-scope singleton with a ref'd 60-second setInterval. Any import chain touching `@revealui/scripts/index.js` or `@revealui/scripts/telemetry.js` keeps the event loop alive, blocking vitest worker exit. The beforeExit cleanup self-deadlocks (flush fires while the loop is already draining).
- **Fix 1** (`telemetry.ts`): `this.flushTimer.unref()` immediately after setInterval — the timer no longer holds the event loop; long-running scripts keep it alive themselves via their own work.
- **Fix 2** (`execution-logger.ts`): Null out `ExecutionLogger.instance` inside `close()` to allow GC.
- **Fix 3** (`scripts/cli/_base.ts`): `ExecutingCLI.afterRun()` now closes `this.logger` unconditionally (not gated on `executionId`), so PGlite is always flushed. Also moved `beforeRun()` inside the `try` block so `afterRun()` always runs even when `beforeRun()` throws.

## Test plan

- [ ] `pnpm --filter @revealui/scripts test` — 14/14 pass, vitest exits cleanly (pre-existing `exec-monitoring.test.ts` miss is unrelated: missing `@revealui/core/monitoring` in worktree, confirmed on base branch too)
- [ ] `pnpm biome check packages/scripts/telemetry.ts packages/scripts/audit/execution-logger.ts scripts/cli/_base.ts` — clean
- [ ] CI gate passes on this branch
