### PR TITLE
fix(core): attach csrf token to richtext image upload

### DIFF
--- a/.changeset/core-richtext-image-upload-csrf.md
+++ b/.changeset/core-richtext-image-upload-csrf.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.

--- a/packages/core/src/client/richtext/components/ImageUploadButton.tsx
+++ b/packages/core/src/client/richtext/components/ImageUploadButton.tsx
@@ -11,6 +11,7 @@ import { logger } from '@revealui/core/utils/logger';
 import type React from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { INSERT_IMAGE_COMMAND } from '../nodes/ImageNode.js';
+import { postMediaUpload } from './upload.js';
 
 /** Default maximum file size: 10 MB */
 const DEFAULT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -102,11 +103,7 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({
 
         let response: Response;
         try {
-          response = await fetch(uploadEndpoint, {
-            method: 'POST',
-            body: formData,
-            signal: controller.signal,
-          });
+          response = await postMediaUpload(uploadEndpoint, formData, controller.signal);
         } finally {
           clearTimeout(timeoutId);
         }

--- a/packages/core/src/client/richtext/components/__tests__/upload.test.ts
+++ b/packages/core/src/client/richtext/components/__tests__/upload.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Media-upload CSRF helper tests
+ *
+ * Covers the postMediaUpload() request shape: the X-CSRF-Token header is
+ * echoed exactly when the revealui-csrf cookie is readable, and the request
+ * stays byte-identical to the historical bare fetch (no `headers` key at
+ * all) when it is not. Content-Type is asserted ABSENT in every case -
+ * fetch must derive the multipart boundary from the FormData body. This
+ * package's vitest environment is node, so `document` is absent by default
+ * and stubbed per test; stubs reset in afterEach.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { postMediaUpload } from '../upload.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function makeUpload(): { body: FormData; signal: AbortSignal } {
+  const body = new FormData();
+  body.append('file', new Blob(['x'], { type: 'image/png' }), 'x.png');
+  return { body, signal: new AbortController().signal };
+}
+
+describe('postMediaUpload - CSRF token attach', () => {
+  it('echoes the revealui-csrf cookie as X-CSRF-Token', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=nonce123:hmac456' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/media', {
+      method: 'POST',
+      body,
+      signal,
+      headers: { 'X-CSRF-Token': 'nonce123:hmac456' },
+    });
+  });
+
+  it('never sets Content-Type (FormData owns the multipart boundary)', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=nonce123:hmac456' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init?.headers ?? {})).toEqual(['X-CSRF-Token']);
+  });
+
+  it('stays byte-identical to the bare fetch when no cookie exists (no headers key)', async () => {
+    vi.stubGlobal('document', { cookie: 'other-cookie=unrelated' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/media', {
+      method: 'POST',
+      body,
+      signal,
+    });
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('omits the header when the cookie value is empty', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('omits the header outside the browser (no document)', async () => {
+    expect(typeof document).toBe('undefined');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('re-reads the cookie on every call and posts to the given endpoint', async () => {
+    const doc = { cookie: 'revealui-csrf=token-before' };
+    vi.stubGlobal('document', doc);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/custom/upload', body, signal);
+    doc.cookie = 'revealui-csrf=token-rotated';
+    await postMediaUpload('/custom/upload', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      '/custom/upload',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-before' } }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/custom/upload',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-rotated' } }),
+    );
+  });
+});

--- a/packages/core/src/client/richtext/components/upload.ts
+++ b/packages/core/src/client/richtext/components/upload.ts
@@ -1,0 +1,35 @@
+/**
+ * RevealUI Rich Text Editor - media upload POST
+ *
+ * The admin proxy and the api server's csrfMiddleware require any unsafe
+ * request carrying a `revealui-session` cookie to echo the JS-readable
+ * `revealui-csrf` cookie as an `X-CSRF-Token` header. The editor's default
+ * `/api/media` endpoint is not CSRF-exempt, so the historical bare upload
+ * POST was rejected with 403 "CSRF token missing" in the admin app. The
+ * token is re-read immediately before each request because the proxy
+ * re-issues the cookie whenever it no longer validates against the current
+ * session (e.g. after re-login or session rotation).
+ */
+
+import { readCsrfToken } from '../../admin/utils/csrf.js';
+
+/**
+ * POST `body` to `uploadEndpoint`, echoing the CSRF cookie as `X-CSRF-Token`
+ * when one is readable. `Content-Type` is never set here - `fetch` derives
+ * the multipart boundary from the FormData body, and an explicit value would
+ * break it. When no cookie is readable the request stays byte-identical to
+ * the historical bare fetch (no `headers` key at all).
+ */
+export async function postMediaUpload(
+  uploadEndpoint: string,
+  body: FormData,
+  signal: AbortSignal,
+): Promise<Response> {
+  const csrfToken = readCsrfToken();
+  return fetch(uploadEndpoint, {
+    method: 'POST',
+    body,
+    signal,
+    ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
+  });
+}


### PR DESCRIPTION
## Summary

The rich-text editor's `ImageUploadButton` POSTs `FormData` to its `uploadEndpoint` (default `/api/media`) with no `X-CSRF-Token` header. The admin proxy requires that header on any unsafe same-origin `/api/*` request carrying a `revealui-session` cookie, and `/api/media` is not in `CSRF_EXEMPT_PREFIXES` - in the admin app the upload runs same-origin with a session present (fetch-default `credentials: 'same-origin'` sends the cookie), so editor image uploads were rejected with 403 "CSRF token missing" before reaching any route. Same confirmed bug class as #1391 (AdminDashboard sign-out), #1390/#1386 (`@revealui/auth` hooks), #1352 (`@revealui/ai` useAgentStream).

## Change

- Extract the upload POST into `postMediaUpload()` (`client/richtext/components/upload.ts`), reusing `readCsrfToken()` from #1391; the token is fresh-read immediately before each POST (the proxy re-issues the cookie after session rotation).
- Conditional whole-`headers`-key spread: cookie-less callers (non-browser, no admin session, cross-origin pages where the cookie isn't readable) stay byte-identical - no `headers` key at all, no CORS-preflight change.
- `Content-Type` is never set - `fetch` keeps deriving the multipart boundary from `FormData`.
- The api server's `csrfMiddleware` enforces the same binding on `/api/*`, so the attach is equally correct when a consumer points `uploadEndpoint` at the api server.
- Render sites unchanged (`ToolbarPlugin`, `FloatingToolbarPlugin` - both use the default endpoint; no in-tree consumer passes a custom one).

## Tests

- New node-env shape tests (`__tests__/upload.test.ts`) mirroring the #1391 csrf tests: exact `toHaveBeenNthCalledWith` equality, `Object.keys(init)` proving no `headers` key for cookie-less callers, headers containing ONLY `X-CSRF-Token` (no `Content-Type`), fresh-read per call.

## Notes

- `@revealui/core` patch changeset.
- Boundary audit: `client/richtext` -> `client/admin/utils/csrf.js` is a relative import inside the same package's client tree; the boundary validator gates OSS->Pro imports only and there is no Biome `noRestrictedImports` - verified before writing.
- Owner-gated manual merge (no `--auto`); base `test`.
