### PR TITLE
fix(admin): thread plan context through email verification loop

### DIFF
--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -90,6 +90,8 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   );
   const messageKey = searchParams.get('message');
   const successMessage = messageKey ? SUCCESS_MESSAGES[messageKey] : undefined;
+  const rawUpgrade = searchParams.get('upgrade');
+  const upgrade: 'pro' | 'max' | null = rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
 
   const anyLoading = isLoading || isPasskeyLoading;
   const hasAlternates = oauthProviders.length > 0 || passkeySupported;
@@ -102,7 +104,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
-      navigateAfterAuthChange('/');
+      navigateAfterAuthChange(upgrade ? `/account/billing?upgrade=${upgrade}` : '/');
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');
     } else {

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -91,7 +91,8 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   const messageKey = searchParams.get('message');
   const successMessage = messageKey ? SUCCESS_MESSAGES[messageKey] : undefined;
   const rawUpgrade = searchParams.get('upgrade');
-  const upgrade: 'pro' | 'max' | null = rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
+  const upgrade: 'pro' | 'max' | null =
+    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
 
   const anyLoading = isLoading || isPasskeyLoading;
   const hasAlternates = oauthProviders.length > 0 || passkeySupported;

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePasskeyRegister, useSignUp } from '@revealui/auth/react';
+import { usePasskeyRegister } from '@revealui/auth/react';
 import {
   ButtonCVA as Button,
   FormLabel,
@@ -49,7 +49,6 @@ function SignupContent({ apiUrl }: SignupFormProps) {
   // Unknown values are ignored rather than forwarded to the billing page.
   const planParam = searchParams.get('plan');
   const plan: 'pro' | 'max' | null = planParam === 'pro' || planParam === 'max' ? planParam : null;
-  const { signUp, isLoading } = useSignUp();
   const {
     register: registerPasskey,
     isLoading: isPasskeyLoading,
@@ -64,6 +63,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
   const [awaitingVerification, setAwaitingVerification] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [resendState, setResendState] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const anyLoading = isLoading || isPasskeyLoading;
@@ -77,34 +77,46 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       return;
     }
 
-    const result = await signUp({ email, password, name, tosAccepted: true });
-    if (result.success) {
-      for (const type of ['necessary', 'functional'] as const) {
-        apiFetch(`${apiUrl}/api/gdpr/consent/grant`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ type }),
-        }).catch(() => {
-          // Best-effort — consent tracking should not block signup
-        });
-      }
-
-      // The first user is auto-verified and gets a session immediately, so send
-      // them straight in. Everyone else must verify their email before they can
-      // sign in — show a confirmation screen instead of pushing them to a
-      // protected route that would only bounce back to /login.
-      if (result.user?.emailVerified) {
-        if (plan) {
-          navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
+    setIsLoading(true);
+    try {
+      const res = await apiFetch(`/api/auth/sign-up${plan ? `?plan=${plan}` : ''}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password, name, tosAccepted: true }),
+      });
+      const data = (await res.json()) as { user?: { emailVerified?: boolean }; error?: string };
+      if (res.ok) {
+        for (const type of ['necessary', 'functional'] as const) {
+          apiFetch(`${apiUrl}/api/gdpr/consent/grant`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ type }),
+          }).catch(() => {
+            // Best-effort — consent tracking should not block signup
+          });
+        }
+        // The first user is auto-verified and gets a session immediately, so send
+        // them straight in. Everyone else must verify their email before they can
+        // sign in — show a confirmation screen instead of pushing them to a
+        // protected route that would only bounce back to /login.
+        if (data.user?.emailVerified) {
+          if (plan) {
+            navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
+          } else {
+            navigateAfterAuthChange('/');
+          }
         } else {
-          navigateAfterAuthChange('/');
+          setAwaitingVerification(true);
         }
       } else {
-        setAwaitingVerification(true);
+        setError(data.error || 'Failed to create account');
       }
-    } else {
-      setError(result.error || 'Failed to create account');
+    } catch {
+      setError('Failed to create account');
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -143,7 +143,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       if (result.backupCodes?.length) {
         setBackupCodes(result.backupCodes);
       } else {
-        navigateAfterAuthChange('/');
+        navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/');
       }
     }
   };
@@ -219,7 +219,10 @@ function SignupContent({ apiUrl }: SignupFormProps) {
         <p className="text-xs text-zinc-600">
           Each code can only be used once. Keep them somewhere safe.
         </p>
-        <Button onClick={() => navigateAfterAuthChange('/')} className="w-full">
+        <Button
+          onClick={() => navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/')}
+          className="w-full"
+        >
           I&apos;ve saved my codes
         </Button>
       </div>

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -97,10 +97,13 @@ describe('SignupForm post-signup routing', () => {
   });
 
   it('sends an auto-verified (first) user straight in', async () => {
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();
@@ -117,10 +120,13 @@ describe('SignupForm post-signup routing', () => {
     'max',
   ] as const)('routes an auto-verified user with ?plan=%s into the billing upgrade flow', async (plan) => {
     mockPlanParam = plan;
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();
@@ -133,10 +139,13 @@ describe('SignupForm post-signup routing', () => {
 
   it('ignores an unknown ?plan= value and routes home', async () => {
     mockPlanParam = 'enterprise-deluxe';
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -227,14 +227,16 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
 
     // Send verification email (fire-and-forget  -  don't block signup)
     if (!isFirstUser && resolvedUser?.email && resolvedUser?.emailVerificationToken) {
-      sendVerificationEmail(resolvedUser.email, resolvedUser.emailVerificationToken, plan ?? undefined).catch(
-        (emailError) => {
-          logger.warn('Failed to send verification email', {
-            userId: resolvedUser?.id,
-            error: emailError,
-          });
-        },
-      );
+      sendVerificationEmail(
+        resolvedUser.email,
+        resolvedUser.emailVerificationToken,
+        plan ?? undefined,
+      ).catch((emailError) => {
+        logger.warn('Failed to send verification email', {
+          userId: resolvedUser?.id,
+          error: emailError,
+        });
+      });
     }
 
     // Create response with user data

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -63,6 +63,9 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const rawPlan = request.nextUrl.searchParams.get('plan');
+    const plan: 'pro' | 'max' | null = rawPlan === 'pro' || rawPlan === 'max' ? rawPlan : null;
+
     let body: unknown;
     try {
       body = await request.json();
@@ -224,7 +227,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
 
     // Send verification email (fire-and-forget  -  don't block signup)
     if (!isFirstUser && resolvedUser?.email && resolvedUser?.emailVerificationToken) {
-      sendVerificationEmail(resolvedUser.email, resolvedUser.emailVerificationToken).catch(
+      sendVerificationEmail(resolvedUser.email, resolvedUser.emailVerificationToken, plan ?? undefined).catch(
         (emailError) => {
           logger.warn('Failed to send verification email', {
             userId: resolvedUser?.id,

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -75,7 +75,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       emailVerificationToken: null,
     });
 
-    return NextResponse.redirect(`${baseUrl}/login?message=email_verified${upgrade ? `&upgrade=${upgrade}` : ''}`);
+    return NextResponse.redirect(
+      `${baseUrl}/login?message=email_verified${upgrade ? `&upgrade=${upgrade}` : ''}`,
+    );
   } catch (error) {
     logger.error('Email verification failed', { error });
     return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -21,6 +21,9 @@ export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const token = request.nextUrl.searchParams.get('token');
+  const rawUpgrade = request.nextUrl.searchParams.get('upgrade');
+  const upgrade: 'pro' | 'max' | null =
+    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
   const baseUrl = request.nextUrl.origin;
 
   if (!token) {
@@ -72,7 +75,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       emailVerificationToken: null,
     });
 
-    return NextResponse.redirect(`${baseUrl}/login?message=email_verified`);
+    return NextResponse.redirect(`${baseUrl}/login?message=email_verified${upgrade ? `&upgrade=${upgrade}` : ''}`);
   } catch (error) {
     logger.error('Email verification failed', { error });
     return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);

--- a/apps/admin/src/lib/email/verification.ts
+++ b/apps/admin/src/lib/email/verification.ts
@@ -14,10 +14,12 @@ import { sendEmail } from './index';
 export async function sendVerificationEmail(
   email: string,
   token: string,
+  plan?: 'pro' | 'max',
 ): Promise<{ success: boolean; error?: string }> {
   const baseUrl = config.reveal.serverURL;
 
-  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}`;
+  const planSuffix = plan ? `&upgrade=${plan}` : '';
+  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}${planSuffix}`;
 
   const html = `
     <!DOCTYPE html>
@@ -28,10 +30,10 @@ export async function sendVerificationEmail(
         <title>Verify Your Email</title>
       </head>
       <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <h1 style="color: #ea580c;">Verify Your Email</h1>
+        <h1 style="color: #2563eb;">Verify Your Email</h1>
         <p>Thanks for signing up for RevealUI! Please verify your email address by clicking the button below:</p>
         <p style="text-align: center; margin: 30px 0;">
-          <a href="${verifyUrl}" style="background-color: #ea580c; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+          <a href="${verifyUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
             Verify Email
           </a>
         </p>


### PR DESCRIPTION
## Summary

- When a user arrives via `/signup?plan=pro`, the `plan` param was silently dropped after the email verification loop, landing the user at `/` instead of `/account/billing?upgrade=pro`
- Fix threads the plan context through all 5 hops: SignupForm -> sign-up API -> verification email -> verify-email route -> login form
- First-user (auto-verified) path also handled: immediate billing redirect when plan is set
- Email brand color updated from orange (#ea580c) to cobalt (#2563eb) in the verification email template

## Changed files

- `apps/admin/src/app/(frontend)/signup/SignupForm.tsx` — drop `useSignUp` hook; direct `apiFetch` call with `?plan=` query param; billing redirect on first-user auto-verify
- `apps/admin/src/app/api/auth/sign-up/route.ts` — read `plan` from query string (typed predicate); pass to `sendVerificationEmail`
- `apps/admin/src/lib/email/verification.ts` — accept optional `plan?: 'pro' | 'max'`; embed `&upgrade=${plan}` in verify link
- `apps/admin/src/app/api/auth/verify-email/route.ts` — read `upgrade` from query string; pass through to login redirect
- `apps/admin/src/app/(frontend)/login/LoginForm.tsx` — read `upgrade` from search params; redirect to `/account/billing?upgrade=${upgrade}` on sign-in success

## Notes

No new dependencies. All `'pro' | 'max'` guards use typed predicates (no regex). No changeset needed (apps/admin is unpublished).

Owner-gated: `REVEALUI_SIGNUP_OPEN` must be `'true'` for any registration. This PR does not flip that flag.
