### PR TITLE
fix(auth): decode percent-encoded CSRF cookie before validation

### DIFF
--- a/apps/admin/src/lib/utils/csrf.ts
+++ b/apps/admin/src/lib/utils/csrf.ts
@@ -4,8 +4,15 @@ export function getCsrfToken(): string | null {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     const key = part.slice(0, eqIdx).trim();
-    const val = part.slice(eqIdx + 1).trim();
-    if (key === 'revealui-csrf') return val || null;
+    if (key === 'revealui-csrf') {
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return null;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
+    }
   }
   return null;
 }

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -256,7 +256,13 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       if (!tokenHeader) {
         return NextResponse.json({ error: 'CSRF token missing' }, { status: 403 });
       }
-      const valid = await validateCsrfToken(tokenHeader, sessionValue, secret);
+      let decodedToken: string;
+      try {
+        decodedToken = decodeURIComponent(tokenHeader);
+      } catch {
+        decodedToken = tokenHeader;
+      }
+      const valid = await validateCsrfToken(decodedToken, sessionValue, secret);
       if (!valid) {
         return NextResponse.json({ error: 'CSRF token invalid' }, { status: 403 });
       }

--- a/packages/ai/src/client/hooks/useAgentStream.ts
+++ b/packages/ai/src/client/hooks/useAgentStream.ts
@@ -153,7 +153,13 @@ function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/auth/src/react/csrf.ts
+++ b/packages/auth/src/react/csrf.ts
@@ -20,7 +20,13 @@ export function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
+++ b/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
@@ -44,6 +44,13 @@ describe('readCsrfToken', () => {
     vi.stubGlobal('document', { cookie: 'revealui-csrf=first; revealui-csrf=second' });
     expect(readCsrfToken()).toBe('first');
   });
+
+  it('URL-decodes the value — Next.js cookie.serialize() encodes the colon separator', () => {
+    vi.stubGlobal('document', {
+      cookie: 'revealui-csrf=nonce123%3Ahmac456',
+    });
+    expect(readCsrfToken()).toBe('nonce123:hmac456');
+  });
 });
 
 describe('postSignOut - CSRF token attach', () => {

--- a/packages/core/src/client/admin/utils/csrf.ts
+++ b/packages/core/src/client/admin/utils/csrf.ts
@@ -19,7 +19,13 @@ export function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/sync/src/csrf.ts
+++ b/packages/sync/src/csrf.ts
@@ -20,8 +20,13 @@ export function getCsrfToken(): string | null {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === CSRF_COOKIE_NAME) {
-      const value = part.slice(eqIdx + 1).trim();
-      return value.length > 0 ? value : null;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return null;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return null;


### PR DESCRIPTION
## Summary

Root cause: Next.js response.cookies.set() runs encodeURIComponent on the cookie value (via the cookie npm package), encoding the nonce:hmac separator colon as %3A. The browser stores and returns the encoded form via document.cookie. All five client-side CSRF readers forwarded this raw percent-encoded value as X-CSRF-Token. The admin proxy validateCsrfToken calls indexOf(':'), finds none in the encoded string, and returns false — 403 CSRF token invalid even with a valid session and correct token.

Diagnosed via HAR capture: the X-CSRF-Token header WAS present (PR #1386 fix is working), but the value was nonce%3Ahmac rather than nonce:hmac.

Fix: decodeURIComponent in all five client-side cookie readers with try/catch fallback to raw on URIError. Defense-in-depth: admin proxy also decodes the inbound X-CSRF-Token header before calling validateCsrfToken.

## Affected files

- packages/auth/src/react/csrf.ts — readCsrfToken() (used by usePasskey, useMFA, useSignOut)
- packages/core/src/client/admin/utils/csrf.ts — readCsrfToken() (used by admin APIClient)
- apps/admin/src/lib/utils/csrf.ts — getCsrfToken() (used by apiFetch)
- packages/ai/src/client/hooks/useAgentStream.ts — inline readCsrfToken()
- packages/sync/src/csrf.ts — getCsrfToken() (used by sync mutations)
- apps/admin/src/proxy.ts — defense-in-depth decode before validateCsrfToken
- packages/core/src/client/admin/utils/__tests__/csrf.test.ts — URL-encoded test case

## Test plan

- [x] pnpm --filter @revealui/core test — 2727 tests pass (includes new URL-decode case)
- [x] pnpm --filter @revealui/auth test — 515 tests pass
- [ ] Manual: log in to admin.revealui.com, navigate to Settings > Security, click Add passkey — should no longer produce 403 CSRF token invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
