### PR TITLE
chore: restrict lint:fix to biome format-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "gate:types": "tsx scripts/gates/types-gate.ts",
     "install:clean": "cross-env NODE_OPTIONS=\"--no-deprecation\" pnpm install",
     "lint": "biome check --max-diagnostics=100 .",
-    "lint:fix": "biome check --write --max-diagnostics=100 .",
+    "lint:fix": "biome format --write --no-errors-on-unmatched .",
     "playwright:install": "playwright install --with-deps",
     "preflight": "tsx scripts/validate/pre-launch.ts",
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
biome check --write applies safe lint auto-fixes on top of formatting — it can change code logic (removes unused imports, rewrites expressions, widens return types). Replace with biome format --write which only touches whitespace/style, matching the lint-staged pre-commit config.