### PR TITLE
chore: promote test → main (2026-06-12)

### DIFF
--- a/.changeset/core-richtext-image-upload-csrf.md
+++ b/.changeset/core-richtext-image-upload-csrf.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -90,6 +90,9 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   );
   const messageKey = searchParams.get('message');
   const successMessage = messageKey ? SUCCESS_MESSAGES[messageKey] : undefined;
+  const rawUpgrade = searchParams.get('upgrade');
+  const upgrade: 'pro' | 'max' | null =
+    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
 
   const anyLoading = isLoading || isPasskeyLoading;
   const hasAlternates = oauthProviders.length > 0 || passkeySupported;
@@ -102,7 +105,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
-      navigateAfterAuthChange('/');
+      navigateAfterAuthChange(upgrade ? `/account/billing?upgrade=${upgrade}` : '/');
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');
     } else {

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePasskeyRegister, useSignUp } from '@revealui/auth/react';
+import { usePasskeyRegister } from '@revealui/auth/react';
 import {
   ButtonCVA as Button,
   FormLabel,
@@ -49,7 +49,6 @@ function SignupContent({ apiUrl }: SignupFormProps) {
   // Unknown values are ignored rather than forwarded to the billing page.
   const planParam = searchParams.get('plan');
   const plan: 'pro' | 'max' | null = planParam === 'pro' || planParam === 'max' ? planParam : null;
-  const { signUp, isLoading } = useSignUp();
   const {
     register: registerPasskey,
     isLoading: isPasskeyLoading,
@@ -64,6 +63,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
   const [awaitingVerification, setAwaitingVerification] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [resendState, setResendState] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const anyLoading = isLoading || isPasskeyLoading;
@@ -77,34 +77,46 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       return;
     }
 
-    const result = await signUp({ email, password, name, tosAccepted: true });
-    if (result.success) {
-      for (const type of ['necessary', 'functional'] as const) {
-        apiFetch(`${apiUrl}/api/gdpr/consent/grant`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ type }),
-        }).catch(() => {
-          // Best-effort — consent tracking should not block signup
-        });
-      }
-
-      // The first user is auto-verified and gets a session immediately, so send
-      // them straight in. Everyone else must verify their email before they can
-      // sign in — show a confirmation screen instead of pushing them to a
-      // protected route that would only bounce back to /login.
-      if (result.user?.emailVerified) {
-        if (plan) {
-          navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
+    setIsLoading(true);
+    try {
+      const res = await apiFetch(`/api/auth/sign-up${plan ? `?plan=${plan}` : ''}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password, name, tosAccepted: true }),
+      });
+      const data = (await res.json()) as { user?: { emailVerified?: boolean }; error?: string };
+      if (res.ok) {
+        for (const type of ['necessary', 'functional'] as const) {
+          apiFetch(`${apiUrl}/api/gdpr/consent/grant`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ type }),
+          }).catch(() => {
+            // Best-effort — consent tracking should not block signup
+          });
+        }
+        // The first user is auto-verified and gets a session immediately, so send
+        // them straight in. Everyone else must verify their email before they can
+        // sign in — show a confirmation screen instead of pushing them to a
+        // protected route that would only bounce back to /login.
+        if (data.user?.emailVerified) {
+          if (plan) {
+            navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
+          } else {
+            navigateAfterAuthChange('/');
+          }
         } else {
-          navigateAfterAuthChange('/');
+          setAwaitingVerification(true);
         }
       } else {
-        setAwaitingVerification(true);
+        setError(data.error || 'Failed to create account');
       }
-    } else {
-      setError(result.error || 'Failed to create account');
+    } catch {
+      setError('Failed to create account');
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -131,7 +143,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       if (result.backupCodes?.length) {
         setBackupCodes(result.backupCodes);
       } else {
-        navigateAfterAuthChange('/');
+        navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/');
       }
     }
   };
@@ -207,7 +219,10 @@ function SignupContent({ apiUrl }: SignupFormProps) {
         <p className="text-xs text-zinc-600">
           Each code can only be used once. Keep them somewhere safe.
         </p>
-        <Button onClick={() => navigateAfterAuthChange('/')} className="w-full">
+        <Button
+          onClick={() => navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/')}
+          className="w-full"
+        >
           I&apos;ve saved my codes
         </Button>
       </div>

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -97,10 +97,13 @@ describe('SignupForm post-signup routing', () => {
   });
 
   it('sends an auto-verified (first) user straight in', async () => {
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();
@@ -117,10 +120,13 @@ describe('SignupForm post-signup routing', () => {
     'max',
   ] as const)('routes an auto-verified user with ?plan=%s into the billing upgrade flow', async (plan) => {
     mockPlanParam = plan;
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();
@@ -133,10 +139,13 @@ describe('SignupForm post-signup routing', () => {
 
   it('ignores an unknown ?plan= value and routes home', async () => {
     mockPlanParam = 'enterprise-deluxe';
-    mockSignUp.mockResolvedValue({
-      success: true,
-      user: { id: '1', email: 'ada@example.com', emailVerified: true },
-    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ user: { emailVerified: true } }) })
+        .mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
 
     render(<SignupForm apiUrl="http://api.test" />);
     fillAndSubmit();

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -63,6 +63,9 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const rawPlan = request.nextUrl.searchParams.get('plan');
+    const plan: 'pro' | 'max' | null = rawPlan === 'pro' || rawPlan === 'max' ? rawPlan : null;
+
     let body: unknown;
     try {
       body = await request.json();
@@ -224,14 +227,16 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
 
     // Send verification email (fire-and-forget  -  don't block signup)
     if (!isFirstUser && resolvedUser?.email && resolvedUser?.emailVerificationToken) {
-      sendVerificationEmail(resolvedUser.email, resolvedUser.emailVerificationToken).catch(
-        (emailError) => {
-          logger.warn('Failed to send verification email', {
-            userId: resolvedUser?.id,
-            error: emailError,
-          });
-        },
-      );
+      sendVerificationEmail(
+        resolvedUser.email,
+        resolvedUser.emailVerificationToken,
+        plan ?? undefined,
+      ).catch((emailError) => {
+        logger.warn('Failed to send verification email', {
+          userId: resolvedUser?.id,
+          error: emailError,
+        });
+      });
     }
 
     // Create response with user data

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -21,6 +21,9 @@ export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const token = request.nextUrl.searchParams.get('token');
+  const rawUpgrade = request.nextUrl.searchParams.get('upgrade');
+  const upgrade: 'pro' | 'max' | null =
+    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
   const baseUrl = request.nextUrl.origin;
 
   if (!token) {
@@ -72,7 +75,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       emailVerificationToken: null,
     });
 
-    return NextResponse.redirect(`${baseUrl}/login?message=email_verified`);
+    return NextResponse.redirect(
+      `${baseUrl}/login?message=email_verified${upgrade ? `&upgrade=${upgrade}` : ''}`,
+    );
   } catch (error) {
     logger.error('Email verification failed', { error });
     return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);

--- a/apps/admin/src/lib/email/verification.ts
+++ b/apps/admin/src/lib/email/verification.ts
@@ -14,10 +14,12 @@ import { sendEmail } from './index';
 export async function sendVerificationEmail(
   email: string,
   token: string,
+  plan?: 'pro' | 'max',
 ): Promise<{ success: boolean; error?: string }> {
   const baseUrl = config.reveal.serverURL;
 
-  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}`;
+  const planSuffix = plan ? `&upgrade=${plan}` : '';
+  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}${planSuffix}`;
 
   const html = `
     <!DOCTYPE html>
@@ -28,10 +30,10 @@ export async function sendVerificationEmail(
         <title>Verify Your Email</title>
       </head>
       <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <h1 style="color: #ea580c;">Verify Your Email</h1>
+        <h1 style="color: #2563eb;">Verify Your Email</h1>
         <p>Thanks for signing up for RevealUI! Please verify your email address by clicking the button below:</p>
         <p style="text-align: center; margin: 30px 0;">
-          <a href="${verifyUrl}" style="background-color: #ea580c; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+          <a href="${verifyUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
             Verify Email
           </a>
         </p>

--- a/apps/admin/src/lib/utils/csrf.ts
+++ b/apps/admin/src/lib/utils/csrf.ts
@@ -4,8 +4,15 @@ export function getCsrfToken(): string | null {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     const key = part.slice(0, eqIdx).trim();
-    const val = part.slice(eqIdx + 1).trim();
-    if (key === 'revealui-csrf') return val || null;
+    if (key === 'revealui-csrf') {
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return null;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
+    }
   }
   return null;
 }

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -256,7 +256,13 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       if (!tokenHeader) {
         return NextResponse.json({ error: 'CSRF token missing' }, { status: 403 });
       }
-      const valid = await validateCsrfToken(tokenHeader, sessionValue, secret);
+      let decodedToken: string;
+      try {
+        decodedToken = decodeURIComponent(tokenHeader);
+      } catch {
+        decodedToken = tokenHeader;
+      }
+      const valid = await validateCsrfToken(decodedToken, sessionValue, secret);
       if (!valid) {
         return NextResponse.json({ error: 'CSRF token invalid' }, { status: 403 });
       }

--- a/package.json
+++ b/package.json
@@ -223,9 +223,9 @@
     "validate:seed-wiring": "tsx scripts/validate/seed-script-wiring.ts",
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
-    "vercel:sync": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
-    "vercel:sync:apply": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
-    "vercel:drift-check": "revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json"
+    "vercel:sync": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
+    "vercel:sync:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
+    "vercel:drift-check": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "gate:types": "tsx scripts/gates/types-gate.ts",
     "install:clean": "cross-env NODE_OPTIONS=\"--no-deprecation\" pnpm install",
     "lint": "biome check --max-diagnostics=100 .",
-    "lint:fix": "biome check --write --max-diagnostics=100 .",
+    "lint:fix": "biome format --write --no-errors-on-unmatched .",
     "playwright:install": "playwright install --with-deps",
     "preflight": "tsx scripts/validate/pre-launch.ts",
     "preinstall": "npx only-allow pnpm",

--- a/packages/ai/src/client/hooks/useAgentStream.ts
+++ b/packages/ai/src/client/hooks/useAgentStream.ts
@@ -153,7 +153,13 @@ function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/auth/src/react/csrf.ts
+++ b/packages/auth/src/react/csrf.ts
@@ -20,7 +20,13 @@ export function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
+++ b/packages/core/src/client/admin/utils/__tests__/csrf.test.ts
@@ -44,6 +44,13 @@ describe('readCsrfToken', () => {
     vi.stubGlobal('document', { cookie: 'revealui-csrf=first; revealui-csrf=second' });
     expect(readCsrfToken()).toBe('first');
   });
+
+  it('URL-decodes the value — Next.js cookie.serialize() encodes the colon separator', () => {
+    vi.stubGlobal('document', {
+      cookie: 'revealui-csrf=nonce123%3Ahmac456',
+    });
+    expect(readCsrfToken()).toBe('nonce123:hmac456');
+  });
 });
 
 describe('postSignOut - CSRF token attach', () => {

--- a/packages/core/src/client/admin/utils/csrf.ts
+++ b/packages/core/src/client/admin/utils/csrf.ts
@@ -19,7 +19,13 @@ export function readCsrfToken(): string | undefined {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      return part.slice(eqIdx + 1).trim() || undefined;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return undefined;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return undefined;

--- a/packages/core/src/client/richtext/components/ImageUploadButton.tsx
+++ b/packages/core/src/client/richtext/components/ImageUploadButton.tsx
@@ -11,6 +11,7 @@ import { logger } from '@revealui/core/utils/logger';
 import type React from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { INSERT_IMAGE_COMMAND } from '../nodes/ImageNode.js';
+import { postMediaUpload } from './upload.js';
 
 /** Default maximum file size: 10 MB */
 const DEFAULT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -102,11 +103,7 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({
 
         let response: Response;
         try {
-          response = await fetch(uploadEndpoint, {
-            method: 'POST',
-            body: formData,
-            signal: controller.signal,
-          });
+          response = await postMediaUpload(uploadEndpoint, formData, controller.signal);
         } finally {
           clearTimeout(timeoutId);
         }

--- a/packages/core/src/client/richtext/components/__tests__/upload.test.ts
+++ b/packages/core/src/client/richtext/components/__tests__/upload.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Media-upload CSRF helper tests
+ *
+ * Covers the postMediaUpload() request shape: the X-CSRF-Token header is
+ * echoed exactly when the revealui-csrf cookie is readable, and the request
+ * stays byte-identical to the historical bare fetch (no `headers` key at
+ * all) when it is not. Content-Type is asserted ABSENT in every case -
+ * fetch must derive the multipart boundary from the FormData body. This
+ * package's vitest environment is node, so `document` is absent by default
+ * and stubbed per test; stubs reset in afterEach.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { postMediaUpload } from '../upload.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function makeUpload(): { body: FormData; signal: AbortSignal } {
+  const body = new FormData();
+  body.append('file', new Blob(['x'], { type: 'image/png' }), 'x.png');
+  return { body, signal: new AbortController().signal };
+}
+
+describe('postMediaUpload - CSRF token attach', () => {
+  it('echoes the revealui-csrf cookie as X-CSRF-Token', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=nonce123:hmac456' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/media', {
+      method: 'POST',
+      body,
+      signal,
+      headers: { 'X-CSRF-Token': 'nonce123:hmac456' },
+    });
+  });
+
+  it('never sets Content-Type (FormData owns the multipart boundary)', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=nonce123:hmac456' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init?.headers ?? {})).toEqual(['X-CSRF-Token']);
+  });
+
+  it('stays byte-identical to the bare fetch when no cookie exists (no headers key)', async () => {
+    vi.stubGlobal('document', { cookie: 'other-cookie=unrelated' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(1, '/api/media', {
+      method: 'POST',
+      body,
+      signal,
+    });
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('omits the header when the cookie value is empty', async () => {
+    vi.stubGlobal('document', { cookie: 'revealui-csrf=' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('omits the header outside the browser (no document)', async () => {
+    expect(typeof document).toBe('undefined');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/api/media', body, signal);
+
+    const init: RequestInit | undefined = fetchMock.mock.calls[0]?.[1];
+    expect(Object.keys(init ?? {})).toEqual(['method', 'body', 'signal']);
+  });
+
+  it('re-reads the cookie on every call and posts to the given endpoint', async () => {
+    const doc = { cookie: 'revealui-csrf=token-before' };
+    vi.stubGlobal('document', doc);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    const { body, signal } = makeUpload();
+
+    await postMediaUpload('/custom/upload', body, signal);
+    doc.cookie = 'revealui-csrf=token-rotated';
+    await postMediaUpload('/custom/upload', body, signal);
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      '/custom/upload',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-before' } }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/custom/upload',
+      expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-rotated' } }),
+    );
+  });
+});

--- a/packages/core/src/client/richtext/components/upload.ts
+++ b/packages/core/src/client/richtext/components/upload.ts
@@ -1,0 +1,35 @@
+/**
+ * RevealUI Rich Text Editor - media upload POST
+ *
+ * The admin proxy and the api server's csrfMiddleware require any unsafe
+ * request carrying a `revealui-session` cookie to echo the JS-readable
+ * `revealui-csrf` cookie as an `X-CSRF-Token` header. The editor's default
+ * `/api/media` endpoint is not CSRF-exempt, so the historical bare upload
+ * POST was rejected with 403 "CSRF token missing" in the admin app. The
+ * token is re-read immediately before each request because the proxy
+ * re-issues the cookie whenever it no longer validates against the current
+ * session (e.g. after re-login or session rotation).
+ */
+
+import { readCsrfToken } from '../../admin/utils/csrf.js';
+
+/**
+ * POST `body` to `uploadEndpoint`, echoing the CSRF cookie as `X-CSRF-Token`
+ * when one is readable. `Content-Type` is never set here - `fetch` derives
+ * the multipart boundary from the FormData body, and an explicit value would
+ * break it. When no cookie is readable the request stays byte-identical to
+ * the historical bare fetch (no `headers` key at all).
+ */
+export async function postMediaUpload(
+  uploadEndpoint: string,
+  body: FormData,
+  signal: AbortSignal,
+): Promise<Response> {
+  const csrfToken = readCsrfToken();
+  return fetch(uploadEndpoint, {
+    method: 'POST',
+    body,
+    signal,
+    ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
+  });
+}

--- a/packages/scripts/audit/execution-logger.ts
+++ b/packages/scripts/audit/execution-logger.ts
@@ -566,6 +566,7 @@ export class ExecutionLogger {
       await this.db.close();
       this.db = null;
     }
+    ExecutionLogger.instance = null;
   }
 
   // ===========================================================================

--- a/packages/scripts/telemetry.ts
+++ b/packages/scripts/telemetry.ts
@@ -186,6 +186,9 @@ export class Telemetry {
         logger.warn(`Auto-flush failed: ${error.message}`);
       });
     }, this.autoFlushInterval);
+    // Unref so short-lived CLIs (--help, etc.) can exit without waiting for
+    // the flush interval; long-running scripts keep the loop alive themselves.
+    this.flushTimer.unref();
 
     // Cleanup on process exit
     process.on('beforeExit', () => {

--- a/packages/sync/src/csrf.ts
+++ b/packages/sync/src/csrf.ts
@@ -20,8 +20,13 @@ export function getCsrfToken(): string | null {
     const eqIdx = part.indexOf('=');
     if (eqIdx === -1) continue;
     if (part.slice(0, eqIdx).trim() === CSRF_COOKIE_NAME) {
-      const value = part.slice(eqIdx + 1).trim();
-      return value.length > 0 ? value : null;
+      const raw = part.slice(eqIdx + 1).trim();
+      if (!raw) return null;
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return raw;
+      }
     }
   }
   return null;

--- a/scripts/cli/_base.ts
+++ b/scripts/cli/_base.ts
@@ -249,9 +249,8 @@ export abstract class BaseCLI {
       }
 
       // Run lifecycle hooks and command
-      await this.beforeRun();
-
       try {
+        await this.beforeRun();
         const result = await command.handler(this.args);
 
         // If handler returned a result, output it
@@ -524,6 +523,10 @@ export abstract class ExecutingCLI extends BaseCLI {
         success: this.executionSuccess,
         error: this.executionError,
       });
+    }
+    if (this.logger) {
+      await this.logger.close();
+      this.logger = null;
     }
   }
 


### PR DESCRIPTION
Regular test→main promotion. Includes:

- fix(auth): decode percent-encoded CSRF cookie before validation (#1405)
- fix(core): attach csrf token to richtext image upload (#1403)
- fix(scripts): unref telemetry timer + close ExecutionLogger in afterRun (#1402)
- fix(admin): thread plan context through email verification loop (#1404)
- chore: restrict lint:fix to biome format-only (#1406)
- chore: inject vercel token from revvault in sync scripts (#1407)