### PR TITLE
feat(admin): free-tier in-app banner + UpgradeDialog wire-up

### DIFF
--- a/apps/admin/src/components/FreeTierBanner.tsx
+++ b/apps/admin/src/components/FreeTierBanner.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { useLicense } from '@/lib/providers/LicenseProvider';
+
+const DISMISS_KEY = 'rvui-free-tier-dismissed';
+
+export function FreeTierBanner() {
+  const { tier, isLoading } = useLicense();
+  // Start dismissed=true to avoid a hydration flash on the server render.
+  // useEffect corrects it client-side after sessionStorage is available.
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    setDismissed(sessionStorage.getItem(DISMISS_KEY) === '1');
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    sessionStorage.setItem(DISMISS_KEY, '1');
+    setDismissed(true);
+  }, []);
+
+  if (isLoading || dismissed || tier !== 'free') return null;
+
+  return (
+    <div className="mb-4 flex items-center justify-between gap-x-6 rounded-lg bg-primary px-5 py-2.5 text-sm text-primary-foreground">
+      <p>
+        You&apos;re on the <span className="font-semibold">Free plan</span> &mdash; 3 users and
+        1,000 agent tasks/month.{' '}
+        <Link
+          href="/account/billing?upgrade=pro"
+          className="font-semibold underline underline-offset-2 hover:opacity-80"
+        >
+          Start your 7-day Pro trial &rarr;
+        </Link>
+      </p>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="-m-1.5 flex-none p-1.5 opacity-70 hover:opacity-100"
+        aria-label="Dismiss"
+      >
+        <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -13,6 +13,8 @@ import {
   SidebarSpacer,
 } from '@revealui/presentation/client';
 import { usePathname } from 'next/navigation';
+import { FreeTierBanner } from '@/components/FreeTierBanner';
+import { UpgradeDialog } from './UpgradeDialog';
 
 interface NavItem {
   href: string;
@@ -222,7 +224,9 @@ export function AdminSidebarLayout({
 }) {
   return (
     <SidebarLayout navbar={<span />} sidebar={<AdminSidebarContent siteName={siteName} />}>
+      <FreeTierBanner />
       {children}
+      <UpgradeDialog />
     </SidebarLayout>
   );
 }

--- a/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
@@ -8,6 +8,10 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => ({ tier: 'pro', features: {}, isLoading: false, refetch: () => {} }),
+}));
+
 // The admin chrome must show the kit's brand, never the framework name,
 // when tenant identity is configured (canonical default otherwise).
 


### PR DESCRIPTION
## Summary

- New `FreeTierBanner` component: shows a dismissible cobalt banner to users on the free tier with plan limits (3 users, 1,000 agent tasks/month) and a CTA to start the 7-day Pro trial
- Wires the existing (orphaned) `UpgradeDialog` into `AdminSidebarLayout` so any component can dispatch a `revealui:upgrade-required` event and the pricing modal appears
- Banner is per-session dismissible via `sessionStorage`; initialises as dismissed to avoid hydration flash

## Details

**`FreeTierBanner`** (`apps/admin/src/components/FreeTierBanner.tsx`)
- Reads tier from `useLicense()` — renders only when `tier === 'free'` and not dismissed
- Cobalt (`bg-primary`) banner with dismiss button; link goes to `/account/billing?upgrade=pro`
- No-regex: typed `!== 'free'` predicate

**`AdminSidebarLayout`** (`apps/admin/src/lib/components/AdminSidebarLayout.tsx`)
- Adds `<FreeTierBanner />` above `{children}` and `<UpgradeDialog />` below
- `UpgradeDialog` was previously built but unreachable from the layout; now in the component tree

## Test plan

- [ ] Log in as a free-tier user → banner visible below sidebar nav
- [ ] Dismiss banner → hidden for the session; refresh → banner reappears
- [ ] Log in as pro/max/enterprise user → banner not rendered
- [ ] Trigger `window.dispatchEvent(new CustomEvent('revealui:upgrade-required', { detail: { feature: 'test' } }))` in browser console → `UpgradeDialog` opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
