### PR TITLE
chore(changeset): add missing patch changesets for @revealui/ai + @revealui/sync csrf percent-decode fix

### DIFF
--- a/.changeset/ai-csrf-percent-decode.md
+++ b/.changeset/ai-csrf-percent-decode.md
@@ -1,0 +1,5 @@
+---
+'@revealui/ai': patch
+---
+
+`useAgentStream` now decodes the `revealui-csrf` cookie value before forwarding it as the `X-CSRF-Token` header. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — the hook's POST requests were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.

--- a/.changeset/sync-csrf-percent-decode.md
+++ b/.changeset/sync-csrf-percent-decode.md
@@ -1,0 +1,5 @@
+---
+'@revealui/sync': patch
+---
+
+The sync mutations' `getCsrfToken()` helper now decodes the `revealui-csrf` cookie value before returning it. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — sync write mutations were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.


### PR DESCRIPTION
## Summary

PR #1405 fixed readCsrfToken() in packages/ai and packages/sync to decodeURIComponent the cookie value before forwarding it as X-CSRF-Token (see #1410 for context on the class). The fix shipped to test without changesets, meaning @revealui/ai and @revealui/sync would have been skipped by the version-packages PR for the security release — npm users would remain on the broken-encoding versions.

This PR adds the two missing patch changesets:

- .changeset/ai-csrf-percent-decode.md → @revealui/ai patch
- .changeset/sync-csrf-percent-decode.md → @revealui/sync patch

No code changes. Changesets only.

## Test plan

- [ ] CI green (changeset-only diff; no Unit Tests or integration impact)
- [ ] After merge: version-packages PR (#1410 tracking) should include @revealui/ai and @revealui/sync in its bumps
