### PR TITLE
chore(release): version packages — auth 0.4.5, core 0.10.1 (CSRF + session fixes)

### DIFF
--- a/.changeset/auth-hooks-csrf-attach.md
+++ b/.changeset/auth-hooks-csrf-attach.md
@@ -1,5 +1,0 @@
----
-'@revealui/auth': patch
----
-
-`useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs, completing the sweep `usePasskeyRegister`/`usePasskeySignIn` started: the admin proxy requires that header on any session-cookie-bearing unsafe request, and `/api/auth/mfa/*` and `/api/auth/sign-out` are not proxy-exempt — MFA enrollment and sign-out always run with a session, so without the header they were rejected with a 403 "CSRF token missing" (and a rejected sign-out left the server-side session alive). The `readCsrfToken()` helper the passkey hooks introduced now lives in a shared module used by all three hook files; passkey behavior is unchanged. The token is re-read before each POST so a proxy reissue between steps cannot strand a stale token. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/.changeset/auth-jsdoc-full-navigation.md
+++ b/.changeset/auth-jsdoc-full-navigation.md
@@ -1,5 +1,0 @@
----
-"@revealui/auth": patch
----
-
-docs(auth): post-auth hook examples now use a full document navigation instead of router.push(). In the Next.js App Router, a soft navigation after the session cookie changes replays the pre-auth client Router Cache (the logged-out RSC payload) and bounces the user back to the login page. The useSignIn, useSignUp, useMFAVerify, and usePasskeySignIn examples now use window.location.href, matching useSignOut and the admin auth forms. Doc comments only, no runtime change.

--- a/.changeset/auth-usepasskey-csrf-attach.md
+++ b/.changeset/auth-usepasskey-csrf-attach.md
@@ -1,5 +1,0 @@
----
-'@revealui/auth': patch
----
-
-`usePasskeyRegister` and `usePasskeySignIn` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on all four passkey POSTs. The admin proxy requires that header on any session-cookie-bearing unsafe request, so passkey registration — which always runs with a session — was rejected with a 403 "CSRF token missing" once CSRF enforcement went live; passkey sign-in kept working only because its endpoints are proxy-exempt pre-auth. The token is re-read before each POST so a proxy reissue between the options and verify steps cannot strand a stale token. Mirrors the attach pattern in `@revealui/core`'s admin APIClient and `@revealui/ai`'s `useAgentStream`. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/.changeset/core-admin-signout-csrf.md
+++ b/.changeset/core-admin-signout-csrf.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": patch
----
-
-The admin dashboard sign-out button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its POST. The proxy requires that header on any session-cookie-bearing unsafe request, and sign-out always runs with a session, so the request was rejected with a 403 "CSRF token missing" while the swallowed failure still navigated to /login  -  the server-side session was never revoked and cookies were never cleared. The cookie is read immediately before the POST via a shared `readCsrfToken()` helper, extracted verbatim from the admin `APIClient` (which now uses it too, behavior unchanged). When the cookie is absent (non-browser callers, no admin session) the request stays byte-identical to before  -  no `headers` key is sent.

--- a/.changeset/core-richtext-image-upload-csrf.md
+++ b/.changeset/core-richtext-image-upload-csrf.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": patch
----
-
-The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.

--- a/.changeset/signout-revoke-all-presented-tokens.md
+++ b/.changeset/signout-revoke-all-presented-tokens.md
@@ -1,5 +1,0 @@
----
-"@revealui/auth": patch
----
-
-`deleteSession` now revokes every session token presented in the Cookie header instead of only the first. Browsers can hold duplicate `revealui-session` cookies (e.g. a stale host-only cookie alongside the domain-scoped one), and the stale duplicate could shadow the live token, leaving the live session row in place after sign-out.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/ai
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @revealui/auth
 
+## 0.4.5
+
+### Patch Changes
+
+- d5e3ff7: `useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs, completing the sweep `usePasskeyRegister`/`usePasskeySignIn` started: the admin proxy requires that header on any session-cookie-bearing unsafe request, and `/api/auth/mfa/*` and `/api/auth/sign-out` are not proxy-exempt — MFA enrollment and sign-out always run with a session, so without the header they were rejected with a 403 "CSRF token missing" (and a rejected sign-out left the server-side session alive). The `readCsrfToken()` helper the passkey hooks introduced now lives in a shared module used by all three hook files; passkey behavior is unchanged. The token is re-read before each POST so a proxy reissue between steps cannot strand a stale token. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.
+- 21fe1d8: docs(auth): post-auth hook examples now use a full document navigation instead of router.push(). In the Next.js App Router, a soft navigation after the session cookie changes replays the pre-auth client Router Cache (the logged-out RSC payload) and bounces the user back to the login page. The useSignIn, useSignUp, useMFAVerify, and usePasskeySignIn examples now use window.location.href, matching useSignOut and the admin auth forms. Doc comments only, no runtime change.
+- f98881d: `usePasskeyRegister` and `usePasskeySignIn` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on all four passkey POSTs. The admin proxy requires that header on any session-cookie-bearing unsafe request, so passkey registration — which always runs with a session — was rejected with a 403 "CSRF token missing" once CSRF enforcement went live; passkey sign-in kept working only because its endpoints are proxy-exempt pre-auth. The token is re-read before each POST so a proxy reissue between the options and verify steps cannot strand a stale token. Mirrors the attach pattern in `@revealui/core`'s admin APIClient and `@revealui/ai`'s `useAgentStream`. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.
+- cf13376: `deleteSession` now revokes every session token presented in the Cookie header instead of only the first. Browsers can hold duplicate `revealui-session` cookies (e.g. a stale host-only cookie alongside the domain-scoped one), and the stale duplicate could shadow the live token, leaving the live session row in place after sign-out.
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/cli
 
+## 0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/core
 
+## 0.10.1
+
+### Patch Changes
+
+- ff8096d: The admin dashboard sign-out button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its POST. The proxy requires that header on any session-cookie-bearing unsafe request, and sign-out always runs with a session, so the request was rejected with a 403 "CSRF token missing" while the swallowed failure still navigated to /login - the server-side session was never revoked and cookies were never cleared. The cookie is read immediately before the POST via a shared `readCsrfToken()` helper, extracted verbatim from the admin `APIClient` (which now uses it too, behavior unchanged). When the cookie is absent (non-browser callers, no admin session) the request stays byte-identical to before - no `headers` key is sent.
+- ed45978: The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.10
+
+### Patch Changes
+
+- @revealui/cli@0.8.1
+
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @revealui/engines
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies [d5e3ff7]
+- Updated dependencies [21fe1d8]
+- Updated dependencies [f98881d]
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+- Updated dependencies [cf13376]
+  - @revealui/auth@0.4.5
+  - @revealui/core@0.10.1
+  - @revealui/services@0.7.3
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, agents.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/harnesses
 
+## 0.6.3
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI harness integration — adapters, daemon, workboard coordination, JSON-RPC server.",
   "repository": {
     "type": "git",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/mcp
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Model Context Protocol framework — MCP server hypervisor, adapter pattern, tool discovery, and adapters for Stripe, Supabase, and Vercel.",
   "repository": {
     "type": "git",

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,10 +1,16 @@
 # revealui
 
+## 0.1.5
+
+### Patch Changes
+
+- create-revealui@0.5.10
+
 ## 0.1.4
 
 ### Patch Changes
 
-  - create-revealui@0.5.9
+- create-revealui@0.5.9
 
 ## 0.1.3
 

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/services
 
+## 0.7.3
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "External service integrations — Stripe (billing + circuit breaker), Vercel (deploy + DNS). Ships with RevealUI.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #1410

## Summary

- Applies 6 pending changesets via `pnpm changeset:version`
- `@revealui/auth` 0.4.4 → **0.4.5**: passkey CSRF attach, MFA CSRF attach, sign-out CSRF attach, multi-token session revocation
- `@revealui/core` 0.10.0 → **0.10.1**: admin sign-out CSRF attach, rich-text image upload CSRF attach
- Cascading patch bumps on packages that depend on auth/core: `ai`, `cli`, `create-revealui`, `engines`, `harnesses`, `mcp`, `services`

## Impact of the fixes in auth@0.4.5 and core@0.10.1

All six fixes address the same root cause: the admin proxy requires an `X-CSRF-Token` header on any session-bearing unsafe request, but several client-side hooks and UI buttons were not attaching it. The result was a 403 with a swallowed error — the UI navigated as if the action succeeded while the server-side state was never changed.

- **Passkey registration**: silently failed (403) after CSRF enforcement went live
- **MFA enrollment and sign-out**: returned 403; server session was never revoked
- **Admin dashboard sign-out button**: navigated to /login but left the session alive
- **Rich-text image uploads**: blocked at the proxy before reaching any route handler

## After merging

Once this lands on `main`, trigger **Actions → Release OSS Packages → Run workflow** to publish to npm via OIDC trusted publishing.

## Test plan

- [ ] Gate passes (CI)
- [ ] No changeset files remain in `.changeset/` after this merges
- [ ] Auth and core CHANGELOG entries are present and accurate
- [ ] After release: `npm view @revealui/auth version` returns `0.4.5`
- [ ] After release: `npm view @revealui/core version` returns `0.10.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
