### PR TITLE
chore(release): version packages — security csrf patch

### DIFF
--- a/.changeset/ai-csrf-percent-decode.md
+++ b/.changeset/ai-csrf-percent-decode.md
@@ -1,5 +1,0 @@
----
-'@revealui/ai': patch
----
-
-`useAgentStream` now decodes the `revealui-csrf` cookie value before forwarding it as the `X-CSRF-Token` header. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — the hook's POST requests were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.

--- a/.changeset/auth-hooks-csrf-attach.md
+++ b/.changeset/auth-hooks-csrf-attach.md
@@ -1,5 +1,0 @@
----
-'@revealui/auth': patch
----
-
-`useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs, completing the sweep `usePasskeyRegister`/`usePasskeySignIn` started: the admin proxy requires that header on any session-cookie-bearing unsafe request, and `/api/auth/mfa/*` and `/api/auth/sign-out` are not proxy-exempt — MFA enrollment and sign-out always run with a session, so without the header they were rejected with a 403 "CSRF token missing" (and a rejected sign-out left the server-side session alive). The `readCsrfToken()` helper the passkey hooks introduced now lives in a shared module used by all three hook files; passkey behavior is unchanged. The token is re-read before each POST so a proxy reissue between steps cannot strand a stale token. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/.changeset/auth-jsdoc-full-navigation.md
+++ b/.changeset/auth-jsdoc-full-navigation.md
@@ -1,5 +1,0 @@
----
-"@revealui/auth": patch
----
-
-docs(auth): post-auth hook examples now use a full document navigation instead of router.push(). In the Next.js App Router, a soft navigation after the session cookie changes replays the pre-auth client Router Cache (the logged-out RSC payload) and bounces the user back to the login page. The useSignIn, useSignUp, useMFAVerify, and usePasskeySignIn examples now use window.location.href, matching useSignOut and the admin auth forms. Doc comments only, no runtime change.

--- a/.changeset/auth-usepasskey-csrf-attach.md
+++ b/.changeset/auth-usepasskey-csrf-attach.md
@@ -1,5 +1,0 @@
----
-'@revealui/auth': patch
----
-
-`usePasskeyRegister` and `usePasskeySignIn` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on all four passkey POSTs. The admin proxy requires that header on any session-cookie-bearing unsafe request, so passkey registration — which always runs with a session — was rejected with a 403 "CSRF token missing" once CSRF enforcement went live; passkey sign-in kept working only because its endpoints are proxy-exempt pre-auth. The token is re-read before each POST so a proxy reissue between the options and verify steps cannot strand a stale token. Mirrors the attach pattern in `@revealui/core`'s admin APIClient and `@revealui/ai`'s `useAgentStream`. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.

--- a/.changeset/core-admin-signout-csrf.md
+++ b/.changeset/core-admin-signout-csrf.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": patch
----
-
-The admin dashboard sign-out button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its POST. The proxy requires that header on any session-cookie-bearing unsafe request, and sign-out always runs with a session, so the request was rejected with a 403 "CSRF token missing" while the swallowed failure still navigated to /login  -  the server-side session was never revoked and cookies were never cleared. The cookie is read immediately before the POST via a shared `readCsrfToken()` helper, extracted verbatim from the admin `APIClient` (which now uses it too, behavior unchanged). When the cookie is absent (non-browser callers, no admin session) the request stays byte-identical to before  -  no `headers` key is sent.

--- a/.changeset/core-richtext-image-upload-csrf.md
+++ b/.changeset/core-richtext-image-upload-csrf.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": patch
----
-
-The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.

--- a/.changeset/signout-revoke-all-presented-tokens.md
+++ b/.changeset/signout-revoke-all-presented-tokens.md
@@ -1,5 +1,0 @@
----
-"@revealui/auth": patch
----
-
-`deleteSession` now revokes every session token presented in the Cookie header instead of only the first. Browsers can hold duplicate `revealui-session` cookies (e.g. a stale host-only cookie alongside the domain-scoped one), and the stale duplicate could shadow the live token, leaving the live session row in place after sign-out.

--- a/.changeset/sync-csrf-percent-decode.md
+++ b/.changeset/sync-csrf-percent-decode.md
@@ -1,5 +1,0 @@
----
-'@revealui/sync': patch
----
-
-The sync mutations' `getCsrfToken()` helper now decodes the `revealui-csrf` cookie value before returning it. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — sync write mutations were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/ai
 
+## 0.6.1
+
+### Patch Changes
+
+- 07b1c8b: `useAgentStream` now decodes the `revealui-csrf` cookie value before forwarding it as the `X-CSRF-Token` header. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — the hook's POST requests were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @revealui/auth
 
+## 0.4.5
+
+### Patch Changes
+
+- d5e3ff7: `useMFASetup`, `useMFAVerify`, and `useSignOut` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on their five POSTs, completing the sweep `usePasskeyRegister`/`usePasskeySignIn` started: the admin proxy requires that header on any session-cookie-bearing unsafe request, and `/api/auth/mfa/*` and `/api/auth/sign-out` are not proxy-exempt — MFA enrollment and sign-out always run with a session, so without the header they were rejected with a 403 "CSRF token missing" (and a rejected sign-out left the server-side session alive). The `readCsrfToken()` helper the passkey hooks introduced now lives in a shared module used by all three hook files; passkey behavior is unchanged. The token is re-read before each POST so a proxy reissue between steps cannot strand a stale token. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.
+- 21fe1d8: docs(auth): post-auth hook examples now use a full document navigation instead of router.push(). In the Next.js App Router, a soft navigation after the session cookie changes replays the pre-auth client Router Cache (the logged-out RSC payload) and bounces the user back to the login page. The useSignIn, useSignUp, useMFAVerify, and usePasskeySignIn examples now use window.location.href, matching useSignOut and the admin auth forms. Doc comments only, no runtime change.
+- f98881d: `usePasskeyRegister` and `usePasskeySignIn` now echo the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on all four passkey POSTs. The admin proxy requires that header on any session-cookie-bearing unsafe request, so passkey registration — which always runs with a session — was rejected with a 403 "CSRF token missing" once CSRF enforcement went live; passkey sign-in kept working only because its endpoints are proxy-exempt pre-auth. The token is re-read before each POST so a proxy reissue between the options and verify steps cannot strand a stale token. Mirrors the attach pattern in `@revealui/core`'s admin APIClient and `@revealui/ai`'s `useAgentStream`. No API change: when the cookie is absent (no admin session, non-browser callers) the header is omitted and requests are byte-identical to before.
+- cf13376: `deleteSession` now revokes every session token presented in the Cookie header instead of only the first. Browsers can hold duplicate `revealui-session` cookies (e.g. a stale host-only cookie alongside the domain-scoped one), and the stale duplicate could shadow the live token, leaving the live session row in place after sign-out.
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/cli
 
+## 0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/core
 
+## 0.10.1
+
+### Patch Changes
+
+- ff8096d: The admin dashboard sign-out button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its POST. The proxy requires that header on any session-cookie-bearing unsafe request, and sign-out always runs with a session, so the request was rejected with a 403 "CSRF token missing" while the swallowed failure still navigated to /login - the server-side session was never revoked and cookies were never cleared. The cookie is read immediately before the POST via a shared `readCsrfToken()` helper, extracted verbatim from the admin `APIClient` (which now uses it too, behavior unchanged). When the cookie is absent (non-browser callers, no admin session) the request stays byte-identical to before - no `headers` key is sent.
+- ed45978: The rich-text editor's image-upload button now echoes the JS-readable `revealui-csrf` cookie (the signed double-submit token the RevealUI admin proxy issues on page load) as an `X-CSRF-Token` header on its upload POST. The admin proxy requires that header on any session-cookie-bearing unsafe `/api/*` request and the editor's default `/api/media` endpoint is not CSRF-exempt, so editor image uploads from the admin app were rejected with a 403 "CSRF token missing" before reaching any route. The token is re-read immediately before each POST via the shared `readCsrfToken()` helper and attached by spreading a whole `headers` key only when a token is readable - callers without the cookie (non-browser, no admin session, cross-origin pages) keep a byte-identical request with no `headers` key, and `Content-Type` is never set so `fetch` continues to derive the multipart boundary from the `FormData` body.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.10
+
+### Patch Changes
+
+- @revealui/cli@0.8.1
+
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @revealui/engines
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies [d5e3ff7]
+- Updated dependencies [21fe1d8]
+- Updated dependencies [f98881d]
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+- Updated dependencies [cf13376]
+  - @revealui/auth@0.4.5
+  - @revealui/core@0.10.1
+  - @revealui/services@0.7.3
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, agents.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/harnesses
 
+## 0.6.3
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI harness integration — adapters, daemon, workboard coordination, JSON-RPC server.",
   "repository": {
     "type": "git",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/mcp
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Model Context Protocol framework — MCP server hypervisor, adapter pattern, tool discovery, and adapters for Stripe, Supabase, and Vercel.",
   "repository": {
     "type": "git",

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,10 +1,16 @@
 # revealui
 
+## 0.1.5
+
+### Patch Changes
+
+- create-revealui@0.5.10
+
 ## 0.1.4
 
 ### Patch Changes
 
-  - create-revealui@0.5.9
+- create-revealui@0.5.9
 
 ## 0.1.3
 

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/services
 
+## 0.7.3
+
+### Patch Changes
+
+- Updated dependencies [ff8096d]
+- Updated dependencies [ed45978]
+  - @revealui/core@0.10.1
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "External service integrations — Stripe (billing + circuit breaker), Vercel (deploy + DNS). Ships with RevealUI.",
   "repository": {
     "type": "git",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/sync
 
+## 0.3.13
+
+### Patch Changes
+
+- 07b1c8b: The sync mutations' `getCsrfToken()` helper now decodes the `revealui-csrf` cookie value before returning it. Next.js encodes cookie values with `encodeURIComponent` (via the `cookie` package), storing and returning the nonce:hmac string as `nonce%3Ahmac`; the admin proxy's `validateCsrfToken` calls `indexOf(':')` which finds nothing in the encoded form and returns false — sync write mutations were rejected with a 403 "CSRF token invalid" even when a valid session and correct token were present. The fix applies `decodeURIComponent` with a `try/catch` fallback to the raw value on `URIError`, matching the fix applied to all other CSRF readers in the same release cycle (#1405). No API change: callers without the cookie continue to send requests byte-identical to before.
+
 ## 0.3.12
 
 ### Patch Changes

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/sync",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Real-time sync layer wrapping ElectricSQL and Yjs CRDT — offline queue, shape cache, conflict resolution, collaborative documents. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Closes #1410

## Summary

Runs changeset version to consume the 8 CSRF-hardening changesets accumulated on test since #1394. Bumps:

- @revealui/auth patch (4 changesets: CSRF header attach, usePasskey CSRF, sign-out revoke-all, JSDoc navigation)
- @revealui/core patch (2 changesets: admin sign-out CSRF, rich-text image upload CSRF)
- @revealui/ai patch (1 changeset: percent-decode CSRF cookie before forwarding header)
- @revealui/sync patch (1 changeset: percent-decode CSRF cookie in mutations helper)
- Transitive dependents get patch bumps via changeset dependency tracking

## Release path

After this merges to test, promote test to main, then dispatch Actions > Release OSS Packages from main to publish to npm.

## Test plan

- [ ] CI green on this PR
- [ ] Changeset files deleted (8 x .changeset/*.md)
- [ ] CHANGELOGs written for all bumped packages
