### PR TITLE
fix(cli): remove pullContentRules — editor-configs repo does not exist

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -120,101 +120,6 @@ function resolveTemplateName(template: ProjectConfig['template']): string {
 }
 
 /**
- * Pull OSS AI rules from the revealui-rules repo.
- * Best-effort  -  if the network is unavailable or the repo doesn't exist yet, skip silently.
- */
-async function pullContentRules(projectPath: string): Promise<void> {
-  const rawBaseUrl =
-    process.env.REVEALUI_RULES_URL ??
-    'https://raw.githubusercontent.com/RevealUIStudio/editor-configs/main/harnesses';
-
-  // Validate URL protocol to prevent file:// or other dangerous schemes
-  let baseUrl: string;
-  try {
-    const parsed = new URL(rawBaseUrl);
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      return; // silently skip non-HTTP URLs
-    }
-    baseUrl = rawBaseUrl;
-  } catch {
-    return; // invalid URL  -  skip
-  }
-
-  const spinner = ora('Pulling AI coding rules...').start();
-  try {
-    const manifestRes = await fetch(`${baseUrl}/manifest.json`, {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!manifestRes.ok) {
-      spinner.info('AI rules not available  -  skipping');
-      return;
-    }
-
-    const manifest = (await manifestRes.json()) as {
-      definitions: Array<{
-        tier: string;
-        generatorPaths: Record<string, string[]>;
-      }>;
-    };
-
-    // Only pull OSS definitions, rendered for Claude Code
-    const generatorId = 'claude-code';
-    const ossDefs = manifest.definitions.filter((d) => d.tier === 'oss');
-    let written = 0;
-
-    // Allowed file extensions for downloaded rule files
-    const allowedExtensions = new Set(['.md', '.json', '.txt', '.yaml', '.yml', '.ts', '.js']);
-    // Maximum file size (1 MB) to prevent abuse
-    const maxFileSize = 1_048_576;
-
-    for (const def of ossDefs) {
-      const paths = def.generatorPaths[generatorId] ?? [];
-      for (const relPath of paths) {
-        try {
-          // Reject paths containing traversal sequences before fetching
-          if (relPath.includes('..') || relPath.startsWith('/')) continue;
-          // Only allow known text file extensions
-          const ext = path.extname(relPath).toLowerCase();
-          if (!allowedExtensions.has(ext)) continue;
-
-          const absolutePath = path.resolve(projectPath, relPath);
-          // Verify resolved path stays within project (prevent path traversal)
-          if (!absolutePath.startsWith(path.resolve(projectPath))) continue;
-
-          const fileRes = await fetch(`${baseUrl}/generators/${generatorId}/${relPath}`, {
-            signal: AbortSignal.timeout(5_000),
-          });
-          if (!fileRes.ok) continue;
-
-          // Enforce size limit before reading body
-          const contentLength = fileRes.headers.get('content-length');
-          if (contentLength && Number.parseInt(contentLength, 10) > maxFileSize) continue;
-
-          const content = await fileRes.text();
-          if (content.length > maxFileSize) continue;
-
-          await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-          // lgtm[js/http-to-file-access]  -  intentional: CLI scaffolding downloads text rule files
-          // from a trusted HTTPS source with path traversal, extension, and size guards
-          await fs.writeFile(absolutePath, content, 'utf-8');
-          written++;
-        } catch {
-          // Individual file failures are non-fatal
-        }
-      }
-    }
-
-    if (written > 0) {
-      spinner.succeed(`Pulled ${written} AI coding rules`);
-    } else {
-      spinner.info('No AI rules pulled');
-    }
-  } catch {
-    spinner.info('AI rules not available  -  skipping');
-  }
-}
-
-/**
  * Main project creation function  -  wires everything together.
  */
 export async function createProject(cfg: CreateProjectConfig): Promise<void> {
@@ -267,9 +172,6 @@ export async function createProject(cfg: CreateProjectConfig): Promise<void> {
     await generateDevbox(projectPath);
     logger.success('devbox.json generated');
   }
-
-  // 4c. Pull OSS AI rules from the rules repo (best-effort)
-  await pullContentRules(projectPath);
 
   // 5. Install dependencies
   if (!skipInstall) {


### PR DESCRIPTION
Closes #1414

## Summary

- Removes  and its call site from 
- The function fetched  from  which was never created, silently timing out on every  run (10s AbortSignal timeout on a 404)
- 98 lines of dead code deleted; no behavior change for users

## Test plan

- [ ] Gate passes (CI)
- [ ]  passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)