### PR TITLE
fix(cli): wire checkPnpmVersion into create flow

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -15,7 +15,11 @@ import { generateDevbox } from '../generators/devbox.js';
 import { generateDevContainer } from '../generators/devcontainer.js';
 import { generateEnvFile } from '../generators/env-file.js';
 import { generateReadme } from '../generators/readme.js';
-import { installDependencies, isPnpmInstalled } from '../installers/dependencies.js';
+import {
+  checkPnpmVersion,
+  installDependencies,
+  isPnpmInstalled,
+} from '../installers/dependencies.js';
 import type { DatabaseConfig } from '../prompts/database.js';
 import type { DevEnvConfig } from '../prompts/devenv.js';
 import type { PaymentConfig } from '../prompts/payments.js';
@@ -279,6 +283,12 @@ export async function createProject(cfg: CreateProjectConfig): Promise<void> {
         'pnpm not found  -  skipping dependency installation. Run `pnpm install` manually.',
       );
     } else {
+      const { version, valid } = await checkPnpmVersion();
+      if (!valid) {
+        logger.error(`pnpm 10.28.2 or higher is required. You have ${version}.`);
+        logger.info('Upgrade: https://pnpm.io/installation');
+        process.exit(1);
+      }
       await installDependencies(projectPath);
     }
   } else {


### PR DESCRIPTION
Closes #1416

## Summary

- Imports `checkPnpmVersion` alongside `isPnpmInstalled` in `packages/cli/src/commands/create.ts`
- After `isPnpmInstalled()` returns true, calls `checkPnpmVersion()` and exits with a clear error if pnpm is below 10.28.2
- Users on pnpm 9 or early pnpm 10 now see: `pnpm 10.28.2 or higher is required. Upgrade: https://pnpm.io/installation`
- No change for users on a compatible pnpm version

## Test plan

- [ ] Gate passes (CI)
- [ ] `pnpm --filter @revealui/cli typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
