### PR TITLE
fix(test): rename package from "test" to "@revealui/test"

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "@revealui/test",
   "version": "0.0.1",
   "description": "E2E specs (Playwright), integration tests, fixtures, mocks, and test utilities for RevealUI.",
   "private": true,


### PR DESCRIPTION
Closes #1415

## Summary

- Renames `packages/test/package.json` `"name"` from `"test"` to `"@revealui/test"`
- Aligns the package name with the documented `@revealui/test` entry in the monorepo package map
- Package is `private: true` — no npm publish needed; the rename affects internal tooling and documentation consistency only
- No workspace consumers reference the bare `"test"` name, so there are no import-path changes

## Test plan

- [ ] Gate passes (CI)
- [ ] `pnpm --filter @revealui/test typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
