### PR TITLE
fix(stripe): defer default-price archive + add missing renewal/perpetual price IDs

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -15,7 +15,11 @@ import { generateDevbox } from '../generators/devbox.js';
 import { generateDevContainer } from '../generators/devcontainer.js';
 import { generateEnvFile } from '../generators/env-file.js';
 import { generateReadme } from '../generators/readme.js';
-import { installDependencies, isPnpmInstalled } from '../installers/dependencies.js';
+import {
+  checkPnpmVersion,
+  installDependencies,
+  isPnpmInstalled,
+} from '../installers/dependencies.js';
 import type { DatabaseConfig } from '../prompts/database.js';
 import type { DevEnvConfig } from '../prompts/devenv.js';
 import type { PaymentConfig } from '../prompts/payments.js';
@@ -279,6 +283,12 @@ export async function createProject(cfg: CreateProjectConfig): Promise<void> {
         'pnpm not found  -  skipping dependency installation. Run `pnpm install` manually.',
       );
     } else {
+      const { version, valid } = await checkPnpmVersion();
+      if (!valid) {
+        logger.error(`pnpm 10.28.2 or higher is required. You have ${version}.`);
+        logger.info('Upgrade: https://pnpm.io/installation');
+        process.exit(1);
+      }
       await installDependencies(projectPath);
     }
   } else {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -120,101 +120,6 @@ function resolveTemplateName(template: ProjectConfig['template']): string {
 }
 
 /**
- * Pull OSS AI rules from the revealui-rules repo.
- * Best-effort  -  if the network is unavailable or the repo doesn't exist yet, skip silently.
- */
-async function pullContentRules(projectPath: string): Promise<void> {
-  const rawBaseUrl =
-    process.env.REVEALUI_RULES_URL ??
-    'https://raw.githubusercontent.com/RevealUIStudio/editor-configs/main/harnesses';
-
-  // Validate URL protocol to prevent file:// or other dangerous schemes
-  let baseUrl: string;
-  try {
-    const parsed = new URL(rawBaseUrl);
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      return; // silently skip non-HTTP URLs
-    }
-    baseUrl = rawBaseUrl;
-  } catch {
-    return; // invalid URL  -  skip
-  }
-
-  const spinner = ora('Pulling AI coding rules...').start();
-  try {
-    const manifestRes = await fetch(`${baseUrl}/manifest.json`, {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!manifestRes.ok) {
-      spinner.info('AI rules not available  -  skipping');
-      return;
-    }
-
-    const manifest = (await manifestRes.json()) as {
-      definitions: Array<{
-        tier: string;
-        generatorPaths: Record<string, string[]>;
-      }>;
-    };
-
-    // Only pull OSS definitions, rendered for Claude Code
-    const generatorId = 'claude-code';
-    const ossDefs = manifest.definitions.filter((d) => d.tier === 'oss');
-    let written = 0;
-
-    // Allowed file extensions for downloaded rule files
-    const allowedExtensions = new Set(['.md', '.json', '.txt', '.yaml', '.yml', '.ts', '.js']);
-    // Maximum file size (1 MB) to prevent abuse
-    const maxFileSize = 1_048_576;
-
-    for (const def of ossDefs) {
-      const paths = def.generatorPaths[generatorId] ?? [];
-      for (const relPath of paths) {
-        try {
-          // Reject paths containing traversal sequences before fetching
-          if (relPath.includes('..') || relPath.startsWith('/')) continue;
-          // Only allow known text file extensions
-          const ext = path.extname(relPath).toLowerCase();
-          if (!allowedExtensions.has(ext)) continue;
-
-          const absolutePath = path.resolve(projectPath, relPath);
-          // Verify resolved path stays within project (prevent path traversal)
-          if (!absolutePath.startsWith(path.resolve(projectPath))) continue;
-
-          const fileRes = await fetch(`${baseUrl}/generators/${generatorId}/${relPath}`, {
-            signal: AbortSignal.timeout(5_000),
-          });
-          if (!fileRes.ok) continue;
-
-          // Enforce size limit before reading body
-          const contentLength = fileRes.headers.get('content-length');
-          if (contentLength && Number.parseInt(contentLength, 10) > maxFileSize) continue;
-
-          const content = await fileRes.text();
-          if (content.length > maxFileSize) continue;
-
-          await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-          // lgtm[js/http-to-file-access]  -  intentional: CLI scaffolding downloads text rule files
-          // from a trusted HTTPS source with path traversal, extension, and size guards
-          await fs.writeFile(absolutePath, content, 'utf-8');
-          written++;
-        } catch {
-          // Individual file failures are non-fatal
-        }
-      }
-    }
-
-    if (written > 0) {
-      spinner.succeed(`Pulled ${written} AI coding rules`);
-    } else {
-      spinner.info('No AI rules pulled');
-    }
-  } catch {
-    spinner.info('AI rules not available  -  skipping');
-  }
-}
-
-/**
  * Main project creation function  -  wires everything together.
  */
 export async function createProject(cfg: CreateProjectConfig): Promise<void> {
@@ -267,9 +172,6 @@ export async function createProject(cfg: CreateProjectConfig): Promise<void> {
     await generateDevbox(projectPath);
     logger.success('devbox.json generated');
   }
-
-  // 4c. Pull OSS AI rules from the rules repo (best-effort)
-  await pullContentRules(projectPath);
 
   // 5. Install dependencies
   if (!skipInstall) {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "@revealui/test",
   "version": "0.0.1",
   "description": "E2E specs (Playwright), integration tests, fixtures, mocks, and test utilities for RevealUI.",
   "private": true,


### PR DESCRIPTION
## Summary

- Defer archiving a Stripe price that is the product's \`default_price\` until after \`stripe.products.update({default_price})\` — previously failed with Stripe API error
- Add 6 missing entries to \`revvault-vercel.toml\`: renewal price IDs (Pro/Max/Enterprise) and perpetual price IDs (Pro/Max/Enterprise)
- Correct \`REVEALUI_BILLING_PORTAL_CONFIG_ID\` revvault path (\`billing/portal-config-id\` → \`stripe/billing-portal-config-id\`)
- Increase PGlite \`hookTimeout\`/\`testTimeout\` to 90s in \`@revealui/ai\` and \`@revealui/harnesses\` vitest configs — PGlite WASM init exceeds the 10–30s defaults under concurrent turbo test load

## Test plan

- [ ] Gate passes (pre-push gate ran on \`test\` before push)
- [ ] CI green on this PR
- [ ] After merge + Vercel redeploy: \`revvault sync vercel --apply\` propagates new price IDs
- [ ] After redeploy: run \`billing:catalog:sync\` against prod Neon