### PR TITLE
chore(stripe): add renewal + perpetual NEXT_PUBLIC price IDs to revvault-vercel manifest

### DIFF
--- a/scripts/setup/__tests__/stripe-revvault-sync.test.ts
+++ b/scripts/setup/__tests__/stripe-revvault-sync.test.ts
@@ -67,7 +67,8 @@ describe('syncToRevvault', () => {
     const result = syncToRevvault(
       {
         STRIPE_PRO_PRICE_ID: 'price_pro',
-        STRIPE_RENEWAL_PRO_PRICE_ID: 'price_renewal_not_vaulted', // no manifest path
+        STRIPE_RENEWAL_PRO_PRICE_ID: 'price_renewal_pro',
+        STRIPE_NO_MANIFEST_KEY: 'no_vault_path', // intentionally unmapped
       },
       {
         manifestPath: MANIFEST_PATH,
@@ -76,9 +77,15 @@ describe('syncToRevvault', () => {
       },
     );
 
-    expect(calls).toEqual([{ path: 'revealui/prod/stripe/pro-price-id', value: 'price_pro' }]);
-    expect(result.written).toEqual(['revealui/prod/stripe/pro-price-id']);
-    expect(result.skipped).toEqual(['STRIPE_RENEWAL_PRO_PRICE_ID']);
+    expect(calls).toEqual([
+      { path: 'revealui/prod/stripe/pro-price-id', value: 'price_pro' },
+      { path: 'revealui/prod/stripe/renewal-pro-price-id', value: 'price_renewal_pro' },
+    ]);
+    expect(result.written).toEqual([
+      'revealui/prod/stripe/pro-price-id',
+      'revealui/prod/stripe/renewal-pro-price-id',
+    ]);
+    expect(result.skipped).toEqual(['STRIPE_NO_MANIFEST_KEY']);
     expect(result.failed).toEqual([]);
   });
 

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -66,6 +66,9 @@ STRIPE_ENTERPRISE_PRICE_ID           = "revealui/prod/stripe/enterprise-price-id
 STRIPE_PERPETUAL_PRO_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
 STRIPE_PERPETUAL_MAX_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
 STRIPE_PERPETUAL_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
+STRIPE_RENEWAL_PRO_PRICE_ID          = "revealui/prod/stripe/renewal-pro-price-id"
+STRIPE_RENEWAL_MAX_PRICE_ID          = "revealui/prod/stripe/renewal-max-price-id"
+STRIPE_RENEWAL_ENTERPRISE_PRICE_ID   = "revealui/prod/stripe/renewal-enterprise-price-id"
 STRIPE_CREDITS_STARTER_PRICE_ID      = "revealui/prod/stripe/credits-starter-price-id"
 STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-price-id"
 STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
@@ -171,6 +174,10 @@ NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-
 # Bare versions on admin (server-side reads in Next.js api routes; same values)
 STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
+# Perpetual price IDs (parity twins — same vault paths as api STRIPE_PERPETUAL_* entries)
+NEXT_PUBLIC_STRIPE_PRO_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
+NEXT_PUBLIC_STRIPE_MAX_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_PERPETUAL_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
 
 # Database
 POSTGRES_URL  = { path = "revealui/prod/db/postgres-url", sensitive = true }


### PR DESCRIPTION
## Summary

- Adds 3 missing renewal price ID entries to the revealui-api section of the revvault sync manifest: STRIPE_RENEWAL_{PRO,MAX,ENTERPRISE}_PRICE_ID
- Adds 3 missing perpetual price ID entries (NEXT_PUBLIC client variants) to the revealui-admin section: NEXT_PUBLIC_STRIPE_{PRO,MAX,ENTERPRISE}_PERPETUAL_PRICE_ID
- All 6 vault paths already existed; the vars were set via the Vercel UI before the revvault sync convention was established, leaving them untracked by sync
- Updates stripe-revvault-sync.test.ts: the renewal IDs are now mapped (no longer skipped), so replaces the old fixture with a genuinely-unmapped key to preserve skip-behavior coverage

## Motivation

Gate 5/6 pre-flip orphan audit: all 6 vars are actively used in sync-billing-catalog.ts and billing-catalog.ts. Without manifest entries, future revvault sync vercel --apply runs would leave their values out of sync with vault.

## Test plan

- [x] 5/5 tests pass (stripe-revvault-sync.test.ts)
- [x] Drift-guard test passes: all STRIPE_*_PRICE_ID seeder keys have manifest paths
- [ ] CI gate
