### PR TITLE
feat(billing): surface team seat usage on the account billing page

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -37,6 +37,12 @@ interface UsageData {
   resetAt: string;
 }
 
+interface SeatsData {
+  active: number;
+  max: number | null;
+  tier: LicenseTierId;
+}
+
 export default function BillingPage() {
   return (
     <Suspense
@@ -67,6 +73,7 @@ function BillingContent() {
   const { data: session, isLoading: sessionLoading } = useSession();
   const [subscription, setSubscription] = useState<SubscriptionData | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
+  const [seats, setSeats] = useState<SeatsData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -83,10 +90,11 @@ function BillingContent() {
 
   const fetchSubscription = useCallback(async () => {
     try {
-      const [subRes, usageRes, pricingRes] = await Promise.all([
+      const [subRes, usageRes, pricingRes, seatsRes] = await Promise.all([
         fetch(`${apiUrl}/api/billing/subscription`, { credentials: 'include' }),
         fetch(`${apiUrl}/api/billing/usage`, { credentials: 'include' }),
         fetch(`${apiUrl}/api/pricing`),
+        fetch(`${apiUrl}/api/billing/seats`, { credentials: 'include' }),
       ]);
       if (subRes.ok) {
         const data = (await subRes.json()) as SubscriptionData;
@@ -99,6 +107,10 @@ function BillingContent() {
       if (pricingRes.ok) {
         const data = (await pricingRes.json()) as PricingResponse;
         setPricing(data);
+      }
+      if (seatsRes.ok) {
+        const data = (await seatsRes.json()) as SeatsData;
+        setSeats(data);
       }
     } catch {
       setError('Failed to load subscription data');
@@ -571,6 +583,58 @@ function BillingContent() {
           </div>
         </CardContent>
       </Card>
+
+      {seats && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Team Seats</CardTitle>
+            <CardDescription>
+              {seats.max === null
+                ? 'Unlimited members (Enterprise tier).'
+                : `${seats.max.toLocaleString()} member seats included on the ${TIER_LABELS[seats.tier]} tier.`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-end justify-between text-sm">
+              <span className="font-medium">{seats.active.toLocaleString()} active</span>
+              <span className="text-zinc-600">
+                {seats.max === null ? 'Unlimited' : `of ${seats.max.toLocaleString()}`}
+              </span>
+            </div>
+            {seats.max !== null && (
+              <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    seats.active / seats.max >= 1
+                      ? 'bg-red-500'
+                      : seats.active / seats.max >= 0.8
+                        ? 'bg-amber-500'
+                        : 'bg-blue-500'
+                  }`}
+                  style={{ width: `${Math.min((seats.active / seats.max) * 100, 100)}%` }}
+                />
+              </div>
+            )}
+            {seats.max !== null && seats.active >= seats.max && (
+              <div className="flex items-center justify-between gap-3 rounded-lg bg-red-50 p-3 dark:bg-red-950/30">
+                <p className="text-xs text-red-600 dark:text-red-400">
+                  {seats.tier === 'max'
+                    ? "You've reached your seat limit. Contact us about Enterprise to add more members."
+                    : "You've reached your seat limit. Upgrade to add more members."}
+                </p>
+                {seats.tier !== 'max' && (
+                  <Link
+                    href={`/account/billing?upgrade=${seats.tier === 'free' ? 'pro' : 'max'}`}
+                    className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+                  >
+                    Upgrade
+                  </Link>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {usage && (
         <Card>

--- a/apps/server/src/routes/__tests__/billing-comprehensive.test.ts
+++ b/apps/server/src/routes/__tests__/billing-comprehensive.test.ts
@@ -663,6 +663,65 @@ describe('Billing Route Tests  -  Comprehensive Coverage', { timeout: 60_000 }, 
     });
   });
 
+  describe('GET /seats', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetChains();
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      const res = await billingApp.request(get('/seats'));
+      expect(res.status).toBe(401);
+    });
+
+    it('treats a user with no account membership as a single free seat', async () => {
+      queueSelectResults([]); // membership lookup -> none
+      const app = createApp();
+      const res = await app.request(get('/seats'));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ active: 1, max: 3, tier: 'free' });
+    });
+
+    it('returns active member count and the pro seat cap for a pro account', async () => {
+      queueSelectResults(
+        [{ accountId: 'acct-1' }], // handler: membership lookup
+        [{ value: 7 }], // handler: active member count
+        [{ accountId: 'acct-1' }], // snapshot: membership lookup
+        [{ tier: 'pro', status: 'active', graceUntil: null }], // snapshot: entitlement
+      );
+      const app = createApp();
+      const res = await app.request(get('/seats'));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ active: 7, max: 25, tier: 'pro' });
+    });
+
+    it('reports an unlimited cap (max=null) for an enterprise account', async () => {
+      queueSelectResults(
+        [{ accountId: 'acct-ent' }],
+        [{ value: 40 }],
+        [{ accountId: 'acct-ent' }],
+        [{ tier: 'enterprise', status: 'active', graceUntil: null }],
+      );
+      const app = createApp();
+      const res = await app.request(get('/seats'));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ active: 40, max: null, tier: 'enterprise' });
+    });
+
+    it('surfaces a full account at the cap (active === max)', async () => {
+      queueSelectResults(
+        [{ accountId: 'acct-full' }],
+        [{ value: 25 }],
+        [{ accountId: 'acct-full' }],
+        [{ tier: 'pro', status: 'active', graceUntil: null }],
+      );
+      const app = createApp();
+      const res = await app.request(get('/seats'));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ active: 25, max: 25, tier: 'pro' });
+    });
+  });
+
   describe('GET /usage', () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -25,6 +25,7 @@ import { and, count, countDistinct, desc, eq, gt, gte, isNull, lt, lte, sql } fr
 import { HTTPException } from 'hono/http-exception';
 import Stripe from 'stripe';
 import { getServices, type ProtectedStripe } from '../lib/services-loader.js';
+import { getHostedLimitsForTier } from '../lib/tier-limits.js';
 import { MRR_TIER_PRICE_FALLBACK_CENTS } from '../lib/tier-pricing.js';
 import {
   sendDowngradeConfirmationEmail,
@@ -1820,6 +1821,72 @@ app.openapi(usageRoute, async (c) => {
     },
     200,
   );
+});
+
+// GET /api/billing/seats  -  Active member count vs the tier seat cap for the current account
+const SeatsResponseSchema = z.object({
+  active: z.number().openapi({ description: 'Active members on the account' }),
+  max: z
+    .number()
+    .nullable()
+    .openapi({ description: 'Seat cap for the tier (null = unlimited / Enterprise)' }),
+  tier: z
+    .enum(['free', 'pro', 'max', 'enterprise'])
+    .openapi({ description: 'Current account tier' }),
+});
+
+const seatsRoute = createRoute({
+  method: 'get',
+  path: '/seats',
+  tags: ['billing'],
+  summary: 'Seat usage',
+  description: 'Returns active member count and the tier seat cap for the current account.',
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SeatsResponseSchema } },
+      description: 'Current seat usage',
+    },
+    401: {
+      content: { 'application/json': { schema: ErrorSchema } },
+      description: 'Not authenticated',
+    },
+  },
+});
+
+app.openapi(seatsRoute, async (c) => {
+  const user = c.get('user');
+  if (!user) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+
+  const db = getClient();
+  const [membership] = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, user.id), eq(accountMemberships.status, 'active')))
+    .limit(1);
+
+  // No account membership = solo/free context: the user is the only active seat.
+  if (!membership?.accountId) {
+    const soloLimits = getHostedLimitsForTier('free');
+    return c.json({ active: 1, max: soloLimits.maxUsers ?? null, tier: 'free' as const }, 200);
+  }
+
+  const [activeRow] = await db
+    .select({ value: count() })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.accountId, membership.accountId),
+        eq(accountMemberships.status, 'active'),
+      ),
+    );
+
+  const snapshot = await getHostedSubscriptionSnapshot(user.id);
+  const tier = snapshot?.tier ?? 'free';
+  const limits = getHostedLimitsForTier(tier);
+
+  return c.json({ active: activeRow?.value ?? 0, max: limits.maxUsers ?? null, tier }, 200);
 });
 
 // POST /api/billing/support-renewal-check  -  Internal cron: send 30-day support renewal reminders


### PR DESCRIPTION
Adds team-seat visibility to the account billing page (Phase 1 of #880).

## What
- **`GET /api/billing/seats`** (`apps/server/src/routes/billing.ts`) returns `{ active, max, tier }` for the current account. Reuses the existing `getHostedSubscriptionSnapshot` resolver and `getHostedLimitsForTier`. `max` is `null` for the unlimited Enterprise tier; a user with no account membership reports as a single free seat.
- **Team Seats card** on the billing page (`apps/admin/src/app/(frontend)/account/billing/page.tsx`), mirroring the existing usage card: `active / max`, a bar that turns amber at 80% and red at 100%, and an upgrade CTA when the account is at the seat limit.

## Why
Seat-count *enforcement* already shipped (the guard blocks over-cap membership inserts), but the count was never surfaced — accounts could approach the cap with no signal. This closes that visibility gap.

## Tests
5 route cases added to `billing-comprehensive.test.ts`: unauthenticated 401, solo to free seat, pro under cap, enterprise unlimited (`max: null`), at-cap. Full suite green (72 tests); server + admin typecheck clean; pre-push gate PASS.

## Scope
Phase 1 (settings counter) only. Phase 2 (team-invite cap preview) stays deferred on #880 — it depends on a team-invite flow that does not exist yet.

Part of #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
