### PR TITLE
chore: preserve unpushed local test fixes (stripe seed, revvault path, vitest timeouts)

### DIFF
--- a/packages/ai/src/__tests__/imports.test.ts
+++ b/packages/ai/src/__tests__/imports.test.ts
@@ -16,7 +16,7 @@ const distDir = resolve(import.meta.dirname, '../../dist');
 const distExists = existsSync(distDir);
 
 describe.skipIf(!distExists)('@revealui/ai - Import Paths', () => {
-  it('should import from memory export', { timeout: 30_000 }, async () => {
+  it('should import from memory export', { timeout: 90_000 }, async () => {
     const memory = await import(resolve(distDir, 'memory/index.js'));
     expect(memory).toBeDefined();
   });
@@ -29,7 +29,7 @@ describe.skipIf(!distExists)('@revealui/ai - Import Paths', () => {
   it('should import from main package export', async () => {
     const main = await import(resolve(distDir, 'index.js'));
     expect(main).toBeDefined();
-  }, 30_000);
+  }, 90_000);
 
   it('should have consistent exports between memory and main', async () => {
     const memory = await import(resolve(distDir, 'memory/index.js'));
@@ -37,7 +37,7 @@ describe.skipIf(!distExists)('@revealui/ai - Import Paths', () => {
 
     // Main should re-export everything from memory
     expect(main).toMatchObject(memory);
-  }, 30_000);
+  }, 90_000);
 
   it('should import client export with React hooks', async () => {
     const client = await import(resolve(distDir, 'client/index.js'));

--- a/packages/ai/src/__tests__/performance.test.ts
+++ b/packages/ai/src/__tests__/performance.test.ts
@@ -30,7 +30,7 @@ let db: Database;
 beforeAll(async () => {
   testDb = await createTestDb();
   db = testDb.drizzle as unknown as Database;
-}, 30_000);
+}, 90_000);
 
 afterAll(async () => {
   await testDb?.close();

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     hookTimeout: 90_000,
+    testTimeout: 90_000,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
     exclude: [

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    hookTimeout: 90_000,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
     exclude: [

--- a/packages/harnesses/vitest.config.ts
+++ b/packages/harnesses/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    hookTimeout: 90_000,
+    testTimeout: 90_000,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
     exclude: ['**/node_modules/**', '**/dist/**'],

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -530,6 +530,7 @@ async function syncCatalog(
     const subscriptionPriceIds: string[] = [];
     const currentDefaultPriceId =
       typeof product.default_price === 'string' ? product.default_price : product.default_price?.id;
+    const stalePricesToArchiveLast: string[] = [];
 
     for (const priceDef of productDef.prices) {
       const matchingPrice = existingPrices.find((p) => priceMatchesDefinition(p, priceDef));
@@ -558,6 +559,8 @@ async function syncCatalog(
       if (stalePrice) {
         if (dryRun) {
           log.info(`  Would archive stale price: ${stalePrice.id}`);
+        } else if (stalePrice.id === currentDefaultPriceId) {
+          stalePricesToArchiveLast.push(stalePrice.id);
         } else {
           await stripe.prices.update(stalePrice.id, { active: false });
           log.warn(`  Archived stale price: ${stalePrice.id}`);
@@ -621,6 +624,10 @@ async function syncCatalog(
       } else {
         await stripe.products.update(product.id, { default_price: String(defaultPriceId) });
         log.success(`  Set default price: ${defaultPriceId}`);
+        for (const staleId of stalePricesToArchiveLast) {
+          await stripe.prices.update(staleId, { active: false });
+          log.warn(`  Archived stale price (was default): ${staleId}`);
+        }
       }
     }
 

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -71,6 +71,9 @@ STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-pr
 STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
 STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/prod/stripe/max-annual-price-id"
+STRIPE_RENEWAL_PRO_PRICE_ID          = "revealui/prod/stripe/renewal-pro-price-id"
+STRIPE_RENEWAL_MAX_PRICE_ID          = "revealui/prod/stripe/renewal-max-price-id"
+STRIPE_RENEWAL_ENTERPRISE_PRICE_ID   = "revealui/prod/stripe/renewal-enterprise-price-id"
 
 # Observability — Sentry (server-side error capture; required by validate-startup.ts
 # REQUIRED_IN_PRODUCTION_HOSTED per revealui#787)
@@ -168,6 +171,9 @@ NEXT_PUBLIC_STRIPE_PRO_PRICE_ID        = "revealui/prod/stripe/pro-price-id"
 NEXT_PUBLIC_STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
 NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = "revealui/prod/stripe/enterprise-price-id"
 NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
+NEXT_PUBLIC_STRIPE_PRO_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
+NEXT_PUBLIC_STRIPE_MAX_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_PERPETUAL_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
 # Bare versions on admin (server-side reads in Next.js api routes; same values)
 STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -132,7 +132,7 @@ CORS_ORIGIN            = "revealui/prod/cors-origin"
 MARKETPLACE_CONNECT_RETURN_URL = "revealui/prod/marketplace-connect-return-url"
 
 # Billing (Stripe customer-portal config id; consumed by apps/server/src/routes/billing.ts)
-REVEALUI_BILLING_PORTAL_CONFIG_ID = "revealui/prod/billing/portal-config-id"
+REVEALUI_BILLING_PORTAL_CONFIG_ID = "revealui/prod/stripe/billing-portal-config-id"
 
 # Electric (real-time sync)
 ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"


### PR DESCRIPTION
Preserves five fixes that had been committed directly to a local `test` checkout and never pushed (the old commit-straight-to-`test` pattern, superseded by the named-branch-PR rule). Cherry-picked cleanly onto current `origin/test`, no conflicts.

## Commits
- `fix(scripts)` — defer archive of current-default Stripe prices until after the `default_price` update (`scripts/setup/seed-stripe.ts`)
- `fix(sync)` — correct the `billing-portal-config-id` revvault path (`scripts/sync/revvault-vercel.toml`)
- `test(ai)` — raise PGlite `hookTimeout` to 90s for concurrent turbo runs
- `test(ai)` — raise import-test timeouts to 90s for turbo concurrency
- `test(harnesses)` — raise `hookTimeout` to 90s for concurrent turbo runs

## Why
These were stray unpushed commits on a local `test` branch discovered during session cleanup. Routed through a named branch + PR so they aren't lost when the local `test` checkout is reset to `origin/test`. No app code changes — scripts + test-config only.

Pre-push gate PASS.
