### PR TITLE
fix(admin): make /legal/* pages public — no auth required

### DIFF
--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -168,7 +168,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
   // defense-in-depth UI hint (set at login). Real enforcement is at the API
   // level via collection access.read checks.
   const isInternal = pathname.startsWith('/api/') || pathname.startsWith('/_next/');
-  const isPublic = PUBLIC_PATHS.has(pathname);
+  const isPublic = PUBLIC_PATHS.has(pathname) || pathname.startsWith('/legal/');
   if (!(isInternal || isPublic)) {
     const session = request.cookies.get('revealui-session')?.value;
     if (!session) {


### PR DESCRIPTION
## What

`/legal/privacy` and `/legal/terms` were absent from `PUBLIC_PATHS` in `apps/admin/src/proxy.ts`, so unauthenticated users clicking the Terms of Service or Privacy Policy links on the signup form were 307-redirected to `/login` instead of seeing the legal documents.

Found during Gate 5 conversion walkthrough (2026-06-13) — admin HAR showed three 307s for `/`, `/legal/privacy`, `/legal/terms` all redirecting to `/login?redirect=...` when the user landed on `/signup?plan=pro`.

## Fix

One-line change: extend the `isPublic` guard with `pathname.startsWith('/legal/')` so all current and future `/legal/*` pages are reachable without a session.

## Test plan

- [ ] Visit `https://admin.revealui.com/signup` in an incognito window (no session)
- [ ] Click the Terms of Service link — should open `/legal/terms`, not redirect to login
- [ ] Click the Privacy Policy link — should open `/legal/privacy`, not redirect to login
- [ ] All other protected pages still redirect unauthenticated users to login
