### PR TITLE
promote: test → main (Gate 5 fixes — legal pages + login redirect + biome 2.4.16)

### DIFF
--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { usePasskeySignIn, useSignIn } from '@revealui/auth/react';
-import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import {
   ButtonCVA as Button,
   FormLabel,
@@ -16,6 +15,7 @@ import {
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 
@@ -107,7 +107,9 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
       const dest = isAdminRole(result.user.role)
-        ? (upgrade ? `/account/billing?upgrade=${upgrade}` : '/')
+        ? upgrade
+          ? `/account/billing?upgrade=${upgrade}`
+          : '/'
         : '/welcome';
       navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { usePasskeySignIn, useSignIn } from '@revealui/auth/react';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import {
   ButtonCVA as Button,
   FormLabel,
@@ -105,7 +106,10 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
-      navigateAfterAuthChange(upgrade ? `/account/billing?upgrade=${upgrade}` : '/');
+      const dest = isAdminRole(result.user.role)
+        ? (upgrade ? `/account/billing?upgrade=${upgrade}` : '/')
+        : '/welcome';
+      navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');
     } else {

--- a/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
@@ -85,7 +85,7 @@ describe('LoginForm post-sign-in navigation', () => {
   it('full-navigates home after a successful credentials sign-in (no soft push)', async () => {
     mockSignIn.mockResolvedValue({
       success: true,
-      user: { id: '1', email: 'owner@example.com' },
+      user: { id: '1', email: 'owner@example.com', role: 'admin' },
     });
 
     render(<LoginForm oauthProviders={[]} />);
@@ -93,6 +93,21 @@ describe('LoginForm post-sign-in navigation', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('full-navigates to /welcome for a user-role sign-in (subscriber, not admin)', async () => {
+    mockSignIn.mockResolvedValue({
+      success: true,
+      user: { id: '2', email: 'subscriber@example.com', role: 'user' },
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/welcome');
     });
     expect(mockPush).not.toHaveBeenCalled();
   });

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -89,7 +89,7 @@ export async function GET(
     // unverified — without this gate, upsertOAuthUser would create an
     // account with a null email which is unworkable for password reset,
     // notifications, etc.
-    if (!existingOAuth && !providerUser.email) {
+    if (!(existingOAuth || providerUser.email)) {
       return loginUrl('verified_email_required');
     }
 

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -47,7 +47,7 @@ export const runtime = 'nodejs';
 function isSignupGloballyClosed(): boolean {
   const open = process.env.REVEALUI_SIGNUP_OPEN === 'true';
   const whitelisted = Boolean(process.env.REVEALUI_SIGNUP_WHITELIST);
-  return !open && !whitelisted;
+  return !(open || whitelisted);
 }
 
 async function signUpHandler(request: NextRequest): Promise<NextResponse> {

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -168,7 +168,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
   // defense-in-depth UI hint (set at login). Real enforcement is at the API
   // level via collection access.read checks.
   const isInternal = pathname.startsWith('/api/') || pathname.startsWith('/_next/');
-  const isPublic = PUBLIC_PATHS.has(pathname);
+  const isPublic = PUBLIC_PATHS.has(pathname) || pathname.startsWith('/legal/');
   if (!(isInternal || isPublic)) {
     const session = request.cookies.get('revealui-session')?.value;
     if (!session) {

--- a/apps/server/src/routes/__tests__/billing-upgrade.test.ts
+++ b/apps/server/src/routes/__tests__/billing-upgrade.test.ts
@@ -365,7 +365,7 @@ describe('POST /upgrade — A.1 explicit item resolution', () => {
 
     const meterDelete = items.find((i) => i.id === 'si_meter' && i.deleted === true);
     expect(meterDelete).toBeDefined();
-    expect(items.find((i) => !i.id && !i.deleted)).toBeUndefined();
+    expect(items.find((i) => !(i.id || i.deleted))).toBeUndefined();
   });
 
   it('rejects when flat-tier item cannot be found by catalog price ID', async () => {

--- a/apps/server/src/routes/gdpr.ts
+++ b/apps/server/src/routes/gdpr.ts
@@ -534,7 +534,7 @@ app.openapi(
   // @ts-expect-error -- OpenAPI response union narrowing
   async (c) => {
     const user = c.get('user');
-    if (!user || user.role !== 'admin') {
+    if (user?.role !== 'admin') {
       throw new HTTPException(403, { message: 'Admin access required' });
     }
 

--- a/apps/server/src/routes/revmarket.ts
+++ b/apps/server/src/routes/revmarket.ts
@@ -656,7 +656,7 @@ app.openapi(
         .where(eq(marketplaceAgents.id, assignedAgentId))
         .limit(1);
 
-      if (!agent || agent.status !== 'published') {
+      if (agent?.status !== 'published') {
         throw new HTTPException(404, { message: 'Agent not found or unavailable' });
       }
       costUsdc = agent.basePriceUsdc;

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/ai/src/llm/providers/openai-compat.ts
+++ b/packages/ai/src/llm/providers/openai-compat.ts
@@ -66,7 +66,7 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined => {
 
 const isFunctionToolCall = (call: unknown): call is OpenAIChatToolCall => {
   const record = asRecord(call);
-  if (!record || record.type !== 'function' || typeof record.id !== 'string') {
+  if (record?.type !== 'function' || typeof record.id !== 'string') {
     return false;
   }
   const fn = asRecord(record.function);

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -985,7 +985,7 @@ async function main(): Promise<void> {
     log.header('Webhook Endpoint');
     const apiUrl = webhookUrlFlag ?? process.env.API_URL;
     // Trim a single trailing slash without regex (no-regex hardline).
-    const trimmedApiUrl = apiUrl && apiUrl.endsWith('/') ? apiUrl.slice(0, -1) : apiUrl;
+    const trimmedApiUrl = apiUrl?.endsWith('/') ? apiUrl.slice(0, -1) : apiUrl;
     const webhookUrl = trimmedApiUrl ? `${trimmedApiUrl}/api/webhooks/stripe` : undefined;
 
     if (!webhookUrl) {

--- a/scripts/validate/prod-env.ts
+++ b/scripts/validate/prod-env.ts
@@ -82,7 +82,7 @@ export function isVercelEncryptedBlob(value: string): boolean {
     const decoded = Buffer.from(value, 'base64').toString('utf8');
     const parsed: unknown = JSON.parse(decoded);
     if (typeof parsed !== 'object' || parsed === null) return false;
-    if (!('v' in parsed) || !('c' in parsed)) return false;
+    if (!('v' in parsed && 'c' in parsed)) return false;
     return (parsed as { v: unknown }).v === 'v2';
   } catch {
     return false;


### PR DESCRIPTION
Promote test → main (Gate 5 fixes)

9 commits from this session:

- fix(admin): make /legal/* pages public — no auth required (PR #1434)
  Terms/Privacy links on signup form now reachable without a session.

- fix(admin): route user-role sign-ins to /welcome instead of / (PR #1435)
  New subscribers (role=user) were stuck in an infinite login loop post-verification;
  now land on /welcome which is SESSION_ONLY.

- chore: bump biome schema to 2.4.16 + fleet-wide lint fixes
  useSimplifiedLogicExpression + useOptionalChain fixes across admin, server, ai, scripts.

Gate 5 conversion walkthrough blockers — both fixes verified CI green on test.
