### PR TITLE
promote: test → main (billing session-only + biome 2.4.16 sweep)

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -114,4 +114,18 @@ describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => 
     );
     expect(res.headers.get('location')).toContain('/login');
   });
+
+  it('lets an authenticated non-admin (subscriber) reach /account/billing without bouncing to /login', async () => {
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/account/billing?upgrade=pro', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+      }),
+    );
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('still requires a session for /account/billing (no session redirects to /login)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/account/billing'));
+    expect(res.headers.get('location')).toContain('/login');
+  });
 });

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -107,8 +107,12 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
       const dest = isAdminRole(result.user.role)
-        ? (upgrade ? `/account/billing?upgrade=${upgrade}` : '/')
-        : (upgrade ? `/account/billing?upgrade=${upgrade}` : '/welcome');
+        ? upgrade
+          ? `/account/billing?upgrade=${upgrade}`
+          : '/'
+        : upgrade
+          ? `/account/billing?upgrade=${upgrade}`
+          : '/welcome';
       navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -107,10 +107,8 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
       const dest = isAdminRole(result.user.role)
-        ? upgrade
-          ? `/account/billing?upgrade=${upgrade}`
-          : '/'
-        : '/welcome';
+        ? (upgrade ? `/account/billing?upgrade=${upgrade}` : '/')
+        : (upgrade ? `/account/billing?upgrade=${upgrade}` : '/welcome');
       navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -54,7 +54,9 @@ const PUBLIC_PATHS = new Set([
 // paying customer to /login at the moment of conversion. The page is a client
 // component that renders only the user's own tier + generic CTAs (no privileged
 // data), so a valid session is sufficient.
-const SESSION_ONLY_PATHS = new Set(['/welcome']);
+// `/account/billing` is also session-only: subscribers arriving from /welcome
+// via the "Billing portal" link need to reach checkout without admin role.
+const SESSION_ONLY_PATHS = new Set(['/welcome', '/account/billing']);
 
 // Legacy `/admin/*` paths from before the chip-2 URL flatten (#644) — 301 to
 // flat path. Catches stale bookmarks and any external links written against

--- a/apps/server/src/routes/__tests__/gdpr-edge.test.ts
+++ b/apps/server/src/routes/__tests__/gdpr-edge.test.ts
@@ -46,9 +46,11 @@ const {
     mockRequestDeletion: vi
       .fn()
       .mockResolvedValue({ id: 'del-1', userId: 'user-1', status: 'pending' }),
-    mockProcessDeletion: vi.fn().mockImplementation(async (_id: string, cb: Function) => {
-      await cb('user-1', ['personal']);
-    }),
+    mockProcessDeletion: vi
+      .fn()
+      .mockImplementation(async (_id: string, cb: (...args: unknown[]) => unknown) => {
+        await cb('user-1', ['personal']);
+      }),
     mockGetUserRequests: vi.fn().mockResolvedValue([]),
     mockGetRequest: vi.fn().mockResolvedValue(null),
     mockAnonymizeUser: vi.fn().mockResolvedValue({ id: 'user-1' }),
@@ -181,9 +183,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGrantConsent.mockResolvedValue({ id: 'consent-1', type: 'analytics' });
   mockRequestDeletion.mockResolvedValue({ id: 'del-1', userId: 'user-1', status: 'pending' });
-  mockProcessDeletion.mockImplementation(async (_id: string, cb: Function) => {
-    await cb('user-1', ['personal']);
-  });
+  mockProcessDeletion.mockImplementation(
+    async (_id: string, cb: (...args: unknown[]) => unknown) => {
+      await cb('user-1', ['personal']);
+    },
+  );
   mockGetRequest.mockResolvedValue({
     id: 'del-1',
     userId: 'user-1',

--- a/apps/server/src/routes/__tests__/gdpr.test.ts
+++ b/apps/server/src/routes/__tests__/gdpr.test.ts
@@ -31,9 +31,11 @@ const {
     mockRequestDeletion: vi
       .fn()
       .mockResolvedValue({ id: 'del-1', userId: 'user-1', status: 'pending' }),
-    mockProcessDeletion: vi.fn().mockImplementation(async (_id: string, cb: Function) => {
-      await cb('user-1', ['personal']);
-    }),
+    mockProcessDeletion: vi
+      .fn()
+      .mockImplementation(async (_id: string, cb: (...args: unknown[]) => unknown) => {
+        await cb('user-1', ['personal']);
+      }),
     mockGetUserRequests: vi.fn().mockResolvedValue([]),
     mockGetRequest: vi.fn().mockResolvedValue(null),
     mockAnonymizeUser: vi.fn().mockResolvedValue({ id: 'user-1' }),

--- a/packages/scripts/state/workflow-state.ts
+++ b/packages/scripts/state/workflow-state.ts
@@ -270,7 +270,7 @@ export class WorkflowStateMachine {
     if (currentStep.dependsOn) {
       for (const depId of currentStep.dependsOn) {
         const depState = workflow.stepStates.get(depId);
-        if (!depState || depState.status !== 'completed') {
+        if (depState?.status !== 'completed') {
           return false;
         }
       }

--- a/packages/security/src/sanitize.ts
+++ b/packages/security/src/sanitize.ts
@@ -501,7 +501,7 @@ function filterAttrs(
 function hardenAnchor(tag: string, node: Parse5Element): void {
   if (tag !== 'a') return;
   const target = node.attrs.find((a) => a.name === 'target');
-  if (!target || target.value !== '_blank') return;
+  if (target?.value !== '_blank') return;
   const rel = node.attrs.find((a) => a.name === 'rel');
   const tokens = new Set((rel?.value ?? '').split(/\s+/).filter(Boolean));
   tokens.add('noopener');


### PR DESCRIPTION
Promote test → main (billing page session-only + biome 2.4.16 sweep)

- fix(admin): make /account/billing session-only (PR #1438)
  Subscribers can now reach the billing/checkout page without admin role.
  Also routes sign-ins with ?upgrade= param directly to /account/billing.
- chore: biome 2.4.16 noBannedTypes + useOptionalChain fixes in gdpr tests,
  workflow-state, sanitize

Gate 5 final unblock — /account/billing is now reachable for user-role subscribers.
