### PR TITLE
fix(services): guard Stripe client against key/STRIPE_LIVE_MODE mismatch

### DIFF
--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -5,6 +5,12 @@ import {
 } from '@revealui/core/license';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
+// Shared live/test classification — same rule the runtime money-boundary guard
+// (getStripe) uses, so the boot validator and the request path can't drift.
+import {
+  classifyStripePublishableKey,
+  classifyStripeSecretKey,
+} from '@revealui/services/stripe/mode';
 
 export type EnvMap = Record<string, string | undefined>;
 
@@ -292,40 +298,41 @@ export function validateStartup(
       emitStripeTestModeWarning();
     }
 
-    // Stripe secret key — prefix depends on STRIPE_LIVE_MODE.
+    // Stripe secret key — environment must match STRIPE_LIVE_MODE. The live/test
+    // prefix rule is shared with the runtime money-boundary guard (getStripe)
+    // via @revealui/services/stripe/mode; `unknown` (empty/malformed) keys fail
+    // the strict boot check in both modes exactly as the old startsWith checks did.
     const stripeSecretKey = env.STRIPE_SECRET_KEY ?? '';
     if (!skipFormat(stripeSecretKey)) {
+      const secretKeyMode = classifyStripeSecretKey(stripeSecretKey);
       if (stripeLiveMode) {
-        if (!stripeSecretKey.startsWith('sk_live_')) {
+        if (secretKeyMode !== 'live') {
           errors.push(
             'STRIPE_SECRET_KEY must be a live key (sk_live_...) when STRIPE_LIVE_MODE=true.',
           );
         }
-      } else {
-        if (!stripeSecretKey.startsWith('sk_test_')) {
-          errors.push(
-            'STRIPE_SECRET_KEY must be a test key (sk_test_...) when STRIPE_LIVE_MODE is unset/false. ' +
-              'Set STRIPE_LIVE_MODE=true to use live keys (gated on the billing-readiness audit).',
-          );
-        }
+      } else if (secretKeyMode !== 'test') {
+        errors.push(
+          'STRIPE_SECRET_KEY must be a test key (sk_test_...) when STRIPE_LIVE_MODE is unset/false. ' +
+            'Set STRIPE_LIVE_MODE=true to use live keys (gated on the billing-readiness audit).',
+        );
       }
     }
 
     // Stripe publishable key (optional, but if set it must match the mode).
     const stripePublishable = env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
     if (stripePublishable) {
+      const publishableKeyMode = classifyStripePublishableKey(stripePublishable);
       if (stripeLiveMode) {
-        if (!stripePublishable.startsWith('pk_live_')) {
+        if (publishableKeyMode !== 'live') {
           errors.push(
             'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a live key (pk_live_...) when STRIPE_LIVE_MODE=true.',
           );
         }
-      } else {
-        if (!stripePublishable.startsWith('pk_test_')) {
-          errors.push(
-            'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a test key (pk_test_...) when STRIPE_LIVE_MODE is unset/false.',
-          );
-        }
+      } else if (publishableKeyMode !== 'test') {
+        errors.push(
+          'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a test key (pk_test_...) when STRIPE_LIVE_MODE is unset/false.',
+        );
       }
     }
 

--- a/packages/services/__tests__/stripe-mode-guard.test.ts
+++ b/packages/services/__tests__/stripe-mode-guard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Integration test for the money-boundary mode guard wired into getStripe().
+ * Verifies the client factory refuses to construct a Stripe client when the
+ * resolved secret key contradicts STRIPE_LIVE_MODE — the exact split state that
+ * previously booted clean on Vercel and detonated as a cryptic
+ * StripeInvalidRequestError at checkout.
+ *
+ * @revealui/config is mocked empty so the key resolves from process.env, and
+ * the Stripe SDK is mocked so a coherent key never touches the network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/config', () => ({ default: {} }));
+vi.mock('stripe', () => {
+  // Constructable default (a bare vi.fn returns a fresh object under `new`)
+  // carrying the static API_VERSION that getStripe reads.
+  const StripeMock = Object.assign(vi.fn(), { API_VERSION: '2026-04-22' });
+  return { default: StripeMock };
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('getStripe money-boundary mode guard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('throws on a live key with STRIPE_LIVE_MODE unset', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_live_realmoney';
+    process.env.STRIPE_LIVE_MODE = undefined;
+    const { getStripe } = await import('../src/stripe/stripeClient.js');
+    expect(() => getStripe()).toThrow(/MODE MISMATCH/);
+  });
+
+  it('throws on a test key with STRIPE_LIVE_MODE=true', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_abc';
+    process.env.STRIPE_LIVE_MODE = 'true';
+    const { getStripe } = await import('../src/stripe/stripeClient.js');
+    expect(() => getStripe()).toThrow(/MODE MISMATCH/);
+  });
+
+  it('constructs the client when key + mode agree (test mode)', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_abc';
+    process.env.STRIPE_LIVE_MODE = undefined;
+    const { getStripe } = await import('../src/stripe/stripeClient.js');
+    expect(() => getStripe()).not.toThrow();
+  });
+});

--- a/packages/services/__tests__/stripe-mode.test.ts
+++ b/packages/services/__tests__/stripe-mode.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the Stripe mode classification + coherence rule
+ * (packages/services/src/stripe/mode.ts) — the single source of truth shared by
+ * the runtime money-boundary guard (getStripe) and the boot-time env validator
+ * (apps/server validate-startup). Pure functions, no mocks.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  checkStripeModeCoherence,
+  classifyStripePublishableKey,
+  classifyStripeSecretKey,
+} from '../src/stripe/mode.js';
+
+describe('classifyStripeSecretKey', () => {
+  it('classifies full live + test secret keys', () => {
+    expect(classifyStripeSecretKey('sk_live_abc')).toBe('live');
+    expect(classifyStripeSecretKey('sk_test_abc')).toBe('test');
+  });
+
+  it('classifies restricted (rk_) live + test keys', () => {
+    expect(classifyStripeSecretKey('rk_live_abc')).toBe('live');
+    expect(classifyStripeSecretKey('rk_test_abc')).toBe('test');
+  });
+
+  it('returns unknown for empty, publishable, or malformed keys', () => {
+    expect(classifyStripeSecretKey('')).toBe('unknown');
+    expect(classifyStripeSecretKey('pk_live_abc')).toBe('unknown');
+    expect(classifyStripeSecretKey('whsec_abc')).toBe('unknown');
+    expect(classifyStripeSecretKey('not-a-key')).toBe('unknown');
+  });
+});
+
+describe('classifyStripePublishableKey', () => {
+  it('classifies live + test publishable keys', () => {
+    expect(classifyStripePublishableKey('pk_live_abc')).toBe('live');
+    expect(classifyStripePublishableKey('pk_test_abc')).toBe('test');
+  });
+
+  it('returns unknown for empty, secret, or malformed keys', () => {
+    expect(classifyStripePublishableKey('')).toBe('unknown');
+    expect(classifyStripePublishableKey('sk_live_abc')).toBe('unknown');
+    expect(classifyStripePublishableKey('garbage')).toBe('unknown');
+  });
+});
+
+describe('checkStripeModeCoherence', () => {
+  it('accepts a live key in live mode', () => {
+    const r = checkStripeModeCoherence('sk_live_abc', true);
+    expect(r.ok).toBe(true);
+    expect(r.keyMode).toBe('live');
+    expect(r.liveMode).toBe(true);
+    expect(r.message).toBeUndefined();
+  });
+
+  it('accepts a test key in test mode', () => {
+    const r = checkStripeModeCoherence('sk_test_abc', false);
+    expect(r.ok).toBe(true);
+    expect(r.keyMode).toBe('test');
+  });
+
+  it('rejects a live key when live mode is off (the production split state)', () => {
+    const r = checkStripeModeCoherence('sk_live_realmoney', false);
+    expect(r.ok).toBe(false);
+    expect(r.keyMode).toBe('live');
+    expect(r.message).toContain('MODE MISMATCH');
+    expect(r.message).toContain('STRIPE_LIVE_MODE');
+    // names the downstream symptom so the operator connects this to the bug
+    expect(r.message).toContain('StripeInvalidRequestError');
+  });
+
+  it('rejects a test key when live mode is on', () => {
+    const r = checkStripeModeCoherence('sk_test_abc', true);
+    expect(r.ok).toBe(false);
+    expect(r.keyMode).toBe('test');
+    expect(r.message).toContain('MODE MISMATCH');
+    expect(r.message).toContain('test key');
+  });
+
+  it('rejects a restricted live key when live mode is off', () => {
+    const r = checkStripeModeCoherence('rk_live_abc', false);
+    expect(r.ok).toBe(false);
+    expect(r.keyMode).toBe('live');
+  });
+
+  it('tolerates an unclassifiable key in either mode (defers to Stripe)', () => {
+    expect(checkStripeModeCoherence('garbage', true).ok).toBe(true);
+    expect(checkStripeModeCoherence('garbage', false).ok).toBe(true);
+    expect(checkStripeModeCoherence('garbage', true).keyMode).toBe('unknown');
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/email/index.d.ts",
       "import": "./dist/email/index.js"
     },
+    "./stripe/mode": {
+      "types": "./dist/stripe/mode.d.ts",
+      "import": "./dist/stripe/mode.js"
+    },
     "./stripe/payment-intent": {
       "types": "./dist/stripe/payment-intent.d.ts",
       "import": "./dist/stripe/payment-intent.js"

--- a/packages/services/src/stripe/index.ts
+++ b/packages/services/src/stripe/index.ts
@@ -1,2 +1,9 @@
+export {
+  checkStripeModeCoherence,
+  classifyStripePublishableKey,
+  classifyStripeSecretKey,
+  type StripeKeyMode,
+  type StripeModeCoherence,
+} from './mode.js';
 export { createPaymentIntent } from './payment-intent.js';
 export { getStripe, protectedStripe } from './stripeClient.js';

--- a/packages/services/src/stripe/mode.ts
+++ b/packages/services/src/stripe/mode.ts
@@ -1,0 +1,95 @@
+// Single source of truth for classifying a Stripe API key by its environment
+// (live vs test) and deciding whether a resolved key is coherent with the
+// operator's STRIPE_LIVE_MODE intent.
+//
+// Two enforcement points consume this module:
+//   1. The runtime Stripe client factory (`stripeClient.getStripe`) — the money
+//      boundary that actually runs on the Vercel serverless API. It refuses to
+//      construct a client when the key environment contradicts STRIPE_LIVE_MODE,
+//      turning a cryptic mid-checkout `StripeInvalidRequestError` into a precise
+//      boot-of-the-money-path error.
+//   2. The boot-time env validator (`apps/server` validate-startup) — the
+//      deploy/Fly/dev gate that fails the whole process on the same mismatch.
+//
+// Keeping the prefix rules here means the live/test contract can never drift
+// between the two sites. Pure module: zero imports, no side effects — safe to
+// pull into the boot path and into the serverless cold-start path alike.
+
+/** Environment a Stripe key targets, derived from its documented prefix. */
+export type StripeKeyMode = 'live' | 'test' | 'unknown';
+
+/**
+ * Classify a Stripe SECRET key by environment. Stripe issues full secret keys
+ * as `sk_live_…` / `sk_test_…` and restricted keys as `rk_live_…` / `rk_test_…`;
+ * both are accepted. Anything else (empty, malformed, or a future prefix) is
+ * `unknown` — callers decide whether `unknown` is tolerable in their context.
+ */
+export function classifyStripeSecretKey(key: string): StripeKeyMode {
+  if (key.startsWith('sk_live_') || key.startsWith('rk_live_')) return 'live';
+  if (key.startsWith('sk_test_') || key.startsWith('rk_test_')) return 'test';
+  return 'unknown';
+}
+
+/** Classify a Stripe PUBLISHABLE key (`pk_live_…` / `pk_test_…`). */
+export function classifyStripePublishableKey(key: string): StripeKeyMode {
+  if (key.startsWith('pk_live_')) return 'live';
+  if (key.startsWith('pk_test_')) return 'test';
+  return 'unknown';
+}
+
+/**
+ * Outcome of the runtime money-boundary coherence check. `ok: false` carries a
+ * ready-to-throw `message` naming the exact mismatch and remedy.
+ */
+export interface StripeModeCoherence {
+  ok: boolean;
+  keyMode: StripeKeyMode;
+  liveMode: boolean;
+  message?: string;
+}
+
+/**
+ * Decide whether a resolved secret key is coherent with STRIPE_LIVE_MODE for
+ * the purpose of constructing a live Stripe client.
+ *
+ * - `liveMode=true` requires a live-environment key.
+ * - `liveMode=false` requires a test-environment key.
+ * - An `unknown` key environment is NOT treated as a mismatch here: the client
+ *   factory historically accepted any non-empty key string, and we defer
+ *   judgement on unclassifiable keys to Stripe rather than hard-blocking a key
+ *   shape we don't recognise. The strict boot validator is the layer that
+ *   rejects `unknown`.
+ *
+ * Returns `ok: true` for a matching environment or an unknown key; `ok: false`
+ * with a `message` only on a confirmed live/test contradiction.
+ */
+export function checkStripeModeCoherence(key: string, liveMode: boolean): StripeModeCoherence {
+  const keyMode = classifyStripeSecretKey(key);
+  if (keyMode === 'unknown') {
+    return { ok: true, keyMode, liveMode };
+  }
+  if (liveMode && keyMode === 'test') {
+    return {
+      ok: false,
+      keyMode,
+      liveMode,
+      message:
+        'STRIPE MODE MISMATCH: STRIPE_LIVE_MODE=true but STRIPE_SECRET_KEY is a test key ' +
+        '(sk_test_/rk_test_). Refusing to construct the Stripe client in an incoherent money ' +
+        'mode. Provide a live key (sk_live_…) or unset STRIPE_LIVE_MODE.',
+    };
+  }
+  if (!liveMode && keyMode === 'live') {
+    return {
+      ok: false,
+      keyMode,
+      liveMode,
+      message:
+        'STRIPE MODE MISMATCH: STRIPE_SECRET_KEY is a live key (sk_live_/rk_live_) but ' +
+        'STRIPE_LIVE_MODE is not "true". This exact split state surfaces downstream as a cryptic ' +
+        'StripeInvalidRequestError at checkout. Either set STRIPE_LIVE_MODE=true (only after the ' +
+        'billing-readiness audit) or use a test key (sk_test_…).',
+    };
+  }
+  return { ok: true, keyMode, liveMode };
+}

--- a/packages/services/src/stripe/stripeClient.ts
+++ b/packages/services/src/stripe/stripeClient.ts
@@ -4,6 +4,7 @@ import configModule from '@revealui/config';
 import { createLogger } from '@revealui/core/observability/logger';
 import Stripe from 'stripe';
 import { DbCircuitBreaker } from './db-circuit-breaker.js';
+import { checkStripeModeCoherence } from './mode.js';
 
 const logger = createLogger({ service: 'Stripe' });
 
@@ -36,6 +37,21 @@ function getStripe(): Stripe {
     throw new Error(
       'STRIPE_SECRET_KEY environment variable is required. Use @revealui/config or set STRIPE_SECRET_KEY.',
     );
+  }
+
+  // Money-boundary coherence guard. The boot-time validator (apps/server
+  // validate-startup.ts) enforces the same key/STRIPE_LIVE_MODE contract, but it
+  // does not run on the Vercel serverless API (that path is intentionally
+  // side-effect-free at cold start). Without this check, a split state — e.g. a
+  // live secret key deployed with STRIPE_LIVE_MODE unset — boots clean and only
+  // detonates as a cryptic StripeInvalidRequestError mid-checkout. Asserting
+  // here fails the money path with a precise message at the moment the client is
+  // first constructed, while leaving non-money routes unaffected. Shared rule:
+  // packages/services/src/stripe/mode.ts.
+  const coherence = checkStripeModeCoherence(secretKey, process.env.STRIPE_LIVE_MODE === 'true');
+  if (!coherence.ok) {
+    logger.error('Stripe key / STRIPE_LIVE_MODE mismatch — refusing to construct client');
+    throw new Error(coherence.message);
   }
 
   _stripe = new Stripe(secretKey, {


### PR DESCRIPTION
## Summary

Durable fix for the Gate-5 checkout blocker: a Stripe **mode-coherence guard** at the runtime money boundary.

### Root cause (audit finding)
The boot validator `apps/server/src/lib/validate-startup.ts` already rejects a live secret key paired with `STRIPE_LIVE_MODE` unset/false — **but it never runs on the Vercel serverless API**. The Vercel cold-start executes only `index.ts` module-level code, which is intentionally side-effect-free in production (`index.ts:1310-1318`); boot validation lives only in `worker.ts` (Fly) and the dev block. So the split state — `sk_live_` key + `STRIPE_LIVE_MODE=false` + live catalog — booted clean on Vercel and only surfaced as a cryptic `StripeInvalidRequestError` mid-checkout.

### Fix
- Add the coherence check in `getStripe()` — the one choke point every Vercel request path flows through. It refuses to construct the client on a confirmed live/test contradiction, with a precise message, and leaves non-money routes unaffected (blast radius = money paths only).
- Extract the live/test prefix rule into a pure, dependency-free leaf `packages/services/src/stripe/mode.ts`, consumed by **both** `getStripe()` and `validate-startup` so the two enforcement points can't drift. Restricted keys (`rk_*`) are now classified too.
- `validate-startup` behavior otherwise unchanged — message strings preserved, all 106 existing tests pass.

### Tests
- 11 pure unit cases (`stripe-mode.test.ts`) covering classification + coherence branches.
- 3 `getStripe` wiring cases (`stripe-mode-guard.test.ts`) proving the factory throws on each mismatch and constructs on agreement.
- Full `@revealui/services` suite (119) + `validate-startup` (106) green; `server` + `services` typecheck clean.

### Note (out of scope — flagged for follow-up)
License + billing-catalog validation *also* don't run on the Vercel API for the same architectural reason. Restoring full boot validation on the serverless path is a separate decision (blast-radius trade-off) and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
