### PR TITLE
fix(scripts): remove duplicate keys in revvault-vercel.toml

### DIFF
--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -74,9 +74,6 @@ STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/prod/stripe/credits-standard-pr
 STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/prod/stripe/credits-scale-price-id"
 STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/prod/stripe/agent-overage-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/prod/stripe/max-annual-price-id"
-STRIPE_RENEWAL_PRO_PRICE_ID          = "revealui/prod/stripe/renewal-pro-price-id"
-STRIPE_RENEWAL_MAX_PRICE_ID          = "revealui/prod/stripe/renewal-max-price-id"
-STRIPE_RENEWAL_ENTERPRISE_PRICE_ID   = "revealui/prod/stripe/renewal-enterprise-price-id"
 
 # Observability — Sentry (server-side error capture; required by validate-startup.ts
 # REQUIRED_IN_PRODUCTION_HOSTED per revealui#787)
@@ -180,10 +177,6 @@ NEXT_PUBLIC_STRIPE_ENTERPRISE_PERPETUAL_PRICE_ID = "revealui/prod/stripe/perpetu
 # Bare versions on admin (server-side reads in Next.js api routes; same values)
 STRIPE_MAX_PRICE_ID        = "revealui/prod/stripe/max-price-id"
 STRIPE_MAX_ANNUAL_PRICE_ID = "revealui/prod/stripe/max-annual-price-id"
-# Perpetual price IDs (parity twins — same vault paths as api STRIPE_PERPETUAL_* entries)
-NEXT_PUBLIC_STRIPE_PRO_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-pro-price-id"
-NEXT_PUBLIC_STRIPE_MAX_PERPETUAL_PRICE_ID        = "revealui/prod/stripe/perpetual-max-price-id"
-NEXT_PUBLIC_STRIPE_ENTERPRISE_PERPETUAL_PRICE_ID = "revealui/prod/stripe/perpetual-enterprise-price-id"
 
 # Database
 POSTGRES_URL  = { path = "revealui/prod/db/postgres-url", sensitive = true }


### PR DESCRIPTION
## Summary

Removes two within-section duplicate key blocks in `scripts/sync/revvault-vercel.toml` that caused last-wins ambiguity and blocked the revvault→Vercel sync.

- **api section:** `STRIPE_RENEWAL_{PRO,MAX,ENTERPRISE}_PRICE_ID` were listed twice — trailing copy removed.
- **admin section:** `NEXT_PUBLIC_STRIPE_{PRO,MAX,ENTERPRISE}_PERPETUAL_PRICE_ID` were listed twice — redundant "Perpetual price IDs (parity twins…)" block removed.

### Audit note
The handoff that surfaced this named lines `181–183` for the admin removal; those are actually `STRIPE_MAX_PRICE_ID` / `STRIPE_MAX_ANNUAL_PRICE_ID` — the **sole** admin-section occurrences (distinct keys per Vercel project, not dupes). Deleting them would have broken admin env sync. The real admin dupes were the `*_PERPETUAL` block below them. This PR removes only genuine within-section duplicates; all legitimate per-section entries are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
