### PR TITLE
fix(server): run validateStartup() on the Vercel serverless cold start

### DIFF
--- a/apps/server/src/__tests__/index.startup.test.ts
+++ b/apps/server/src/__tests__/index.startup.test.ts
@@ -125,6 +125,28 @@ describe('apps/server/src/index.ts — post-Phase-2 invariants', () => {
       'export function initAlerting',
     );
   });
+
+  it('runs synchronous validateStartup() in a production guard (Vercel cold-start env validation), without the async boot chain', () => {
+    // The Vercel serverless API executes ONLY index.ts top-level code, so the
+    // synchronous env validator must run here to fail fast on a misconfigured
+    // deploy. It must NOT pull in the long-running boot chain — that lives in
+    // worker.ts (asserted by the test above). The VITEST inner guard keeps it
+    // from firing in suites that re-import this module with NODE_ENV=production.
+    const body = extractBranchBody(indexSource, PROD_GUARD, 'validateStartup()');
+    expect(
+      body,
+      'index.ts must call validateStartup() in a NODE_ENV===production guard for Vercel cold-start validation',
+    ).toContain('validateStartup()');
+    expect(body, 'cold-start validation must be guarded against the test runner').toContain(
+      '!process.env.VITEST',
+    );
+    expect(
+      body,
+      'cold-start validation must stay synchronous — no license/serve/alerting side effects',
+    ).not.toContain('validateLicenseAtStartup');
+    expect(body).not.toContain('serve({ fetch: app.fetch, port }');
+    expect(body).not.toContain('initAlerting()');
+  });
 });
 
 describe('apps/server/src/worker.ts — Fly entry invariants', () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1307,11 +1307,40 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
 // IPs / 'unknown' for everyone.
 configureClientIp({ trustedProxyCount: 1 });
 
-// NODE_ENV === 'production' boot is handled by src/worker.ts (Fly entry).
-// This module is intentionally side-effect-free in production so the Vercel
-// serverless handler (api/index.js → dist/index.js) doesn't kick off
-// long-running side effects (serve(), injectWebSocket, initAlerting,
-// hydrateInferenceConfigs, startExecutor) on every cold start. The dev
-// block above still fires for `pnpm dev:api` because that runs with
-// NODE_ENV=development. See the internal infra-consolidation lane plan
-// (Phase 2) for the extraction history.
+// NODE_ENV === 'production' LONG-RUNNING boot is handled by src/worker.ts (Fly
+// entry). This module stays free of long-running side effects in production so
+// the Vercel serverless handler (api/index.js → dist/index.js) doesn't kick off
+// serve(), injectWebSocket, initAlerting, hydrateInferenceConfigs, or
+// startExecutor on every cold start. The dev block above still fires for
+// `pnpm dev:api` (NODE_ENV=development). See the internal infra-consolidation
+// lane plan (Phase 2) for the extraction history.
+//
+// One synchronous, side-effect-free exception runs here: validateStartup().
+// The Vercel serverless API executes ONLY this module's top-level code, so
+// without this call it had NO boot-time env validation at all — a deploy whose
+// config was internally inconsistent (e.g. a live Stripe key with
+// STRIPE_LIVE_MODE unset, or a malformed REVEALUI_KEK) booted clean and failed
+// only on the first request that happened to touch the broken value.
+// validateStartup() is pure (process.env reads + format checks + a stderr
+// warning) and throws on misconfig, so calling it at module load fails the cold
+// start fast and loud. We deliberately do NOT run the async chain here:
+// validateLicenseAtStartup is a no-op in hosted mode, validateBillingCatalog-
+// AtStartup is a per-cold-start DB round-trip we don't want on the request path
+// (the daily billing-readiness cron already covers catalog drift), and
+// serve()/intervals/executor are serverless-incompatible. Those stay in worker.ts.
+//
+// Trade-off (intentional): any missing/malformed REQUIRED_IN_PRODUCTION_HOSTED
+// var now fails the WHOLE API at cold start rather than degrading one feature.
+// For a money-handling deployment that fail-fast posture is the desired one and
+// matches worker.ts. SKIP_ENV_VALIDATION (honored inside validateStartup) still
+// lets Docker-build / build-only contexts compile without live credentials.
+//
+// The VITEST inner guard mirrors the dev block: the runner sets VITEST
+// regardless of any NODE_ENV stub, and several suites re-import this module with
+// NODE_ENV='production' (vi.resetModules) — without the guard those imports
+// would throw on the test env's intentionally-incomplete config.
+if (process.env.NODE_ENV === 'production') {
+  if (!process.env.VITEST) {
+    validateStartup();
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1441. Restores boot-time env validation on the **Vercel serverless API**, which previously ran none.

### Root cause
The Vercel serverless handler executes only `index.ts` top-level code, kept side-effect-free in production to avoid `serve()`/intervals on cold start. As a result `validateStartup()` (env-format + Stripe key↔`STRIPE_LIVE_MODE` coherence) only ran in `worker.ts` (Fly) and the dev block — the customer-facing API could boot with an internally inconsistent config and fail only on the first request that hit the broken value. (Same architectural gap that let the Gate-5 Stripe split state through.)

### Change
Add a **synchronous, side-effect-free** `validateStartup()` call in a `NODE_ENV===production` guard so the function fails fast at cold start on any required-var/format misconfig.

Deliberately **not** run here (stay in `worker.ts`):
- `validateLicenseAtStartup` — no-op in hosted mode
- `validateBillingCatalogAtStartup` — a per-cold-start DB round-trip; the daily billing-readiness cron already covers catalog drift
- `serve()` / intervals / executor — serverless-incompatible

A `VITEST` inner guard mirrors the dev block (the runner sets `VITEST` regardless of `NODE_ENV` stubs; several suites re-import this module with `NODE_ENV=production`).

### Trade-off (intentional, owner-approved)
A missing/malformed `REQUIRED_IN_PRODUCTION_HOSTED` var now fails the **whole API** at cold start rather than degrading one feature — the fail-fast posture `worker.ts` already uses. For a money-handling deployment that's the desired behavior.

### Tests
- New source-text regression test asserts the guard runs `validateStartup()` without the long-running boot chain.
- `index.startup` (12) + the 4 suites that re-import `index.ts` under `NODE_ENV=production` (cors-validation/errors/error/logs, 105) all green; `server` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
