### PR TITLE
fix(server): wildcard CORS for public cacheable /api/pricing

### DIFF
--- a/apps/server/src/__tests__/cors-public-cacheable.test.ts
+++ b/apps/server/src/__tests__/cors-public-cacheable.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Guards the wildcard-CORS allowlist for public, CDN-cacheable, credential-free
+ * endpoints (see the CORS middleware in index.ts). These paths must receive
+ * `Access-Control-Allow-Origin: *` rather than per-origin credentialed CORS,
+ * because coupling `Cache-Control: public` with per-origin credentialed CORS
+ * lets the CDN serve a variant cached for one origin (or none) to a browser
+ * with a different origin — surfacing as a "No Access-Control-Allow-Origin"
+ * error. Regression context: the 2026-06-14 Gate-5 billing page CORS failure.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isPublicCacheableCorsPath } from '../index.js';
+
+describe('isPublicCacheableCorsPath', () => {
+  it('marks /api/pricing as a public cacheable (wildcard-CORS) path', () => {
+    expect(isPublicCacheableCorsPath('/api/pricing')).toBe(true);
+  });
+
+  it('does NOT mark credentialed/private routes as public cacheable', () => {
+    // These must keep per-origin credentialed CORS — never wildcard.
+    expect(isPublicCacheableCorsPath('/api/billing/subscription')).toBe(false);
+    expect(isPublicCacheableCorsPath('/api/billing/checkout')).toBe(false);
+    expect(isPublicCacheableCorsPath('/api/auth/session')).toBe(false);
+    expect(isPublicCacheableCorsPath('/api/webhooks/stripe')).toBe(false);
+  });
+
+  it('is an exact match — no prefix/substring leakage', () => {
+    expect(isPublicCacheableCorsPath('/api/pricing/secret')).toBe(false);
+    expect(isPublicCacheableCorsPath('/api/pricinger')).toBe(false);
+    expect(isPublicCacheableCorsPath('/pricing')).toBe(false);
+    expect(isPublicCacheableCorsPath('')).toBe(false);
+  });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -321,10 +321,42 @@ function isTestSubdomainOrigin(origin: string): boolean {
   return validSuffixes.some((suffix) => host === `dev.${suffix}` || host === `test.${suffix}`);
 }
 
+// Public GET endpoints that are CDN-cacheable (Cache-Control: public, s-maxage)
+// and carry NO credentials. They receive wildcard CORS so a single cached
+// variant is safe for every origin. Exact-match set — no regex, no prefix
+// surprises. Add a path here only if it is genuinely public, credential-free,
+// and cacheable.
+const PUBLIC_CACHEABLE_CORS_PATHS = new Set(['/api/pricing']);
+export function isPublicCacheableCorsPath(path: string): boolean {
+  return PUBLIC_CACHEABLE_CORS_PATHS.has(path);
+}
+
 // Manual CORS middleware  -  Hono's cors() middleware was not reliably setting
 // Access-Control-Allow-Origin headers in the Vercel serverless runtime.
 app.use('*', async (c, next) => {
   const origin = c.req.header('origin') || c.req.header('Origin') || '';
+
+  // Wildcard CORS for public, cacheable, credential-free endpoints. Coupling
+  // public CDN caching with per-origin CREDENTIALED CORS is a footgun: the CDN
+  // stores one variant (keyed by `Vary: Origin`, or none when a request arrives
+  // without an Origin — e.g. an SSR fetch/prefetch), and that variant can then
+  // be served to a browser whose origin doesn't match, surfacing as
+  // "No 'Access-Control-Allow-Origin' header is present" in the browser. These
+  // routes need no credentials, so one '*' variant is correct and cache-safe.
+  if (isPublicCacheableCorsPath(c.req.path)) {
+    c.header('Access-Control-Allow-Origin', '*');
+    if (c.req.method === 'OPTIONS') {
+      c.header('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS');
+      c.header(
+        'Access-Control-Allow-Headers',
+        c.req.header('Access-Control-Request-Headers') || 'Content-Type',
+      );
+      c.header('Access-Control-Max-Age', '86400');
+      return c.body(null, 204);
+    }
+    await next();
+    return;
+  }
 
   // Preview CORS: allow project-scoped Vercel preview URLs and test subdomains.
   // Pattern: revealui-<app>-<hash>-revealuistudios-projects.vercel.app


### PR DESCRIPTION
## Summary

Fixes the intermittent CORS failure on the Gate-5 billing page (`No 'Access-Control-Allow-Origin' header is present` when fetching `/api/pricing`).

### Root cause
`/api/pricing` is served `Cache-Control: public, s-maxage=3600` (`pricing.ts:330`), but the global CORS middleware echoed a **per-origin** `ACAO` + `Access-Control-Allow-Credentials: true` for every route. Coupling public CDN caching with per-origin **credentialed** CORS is a footgun: the CDN stores one variant (keyed by `Vary: Origin`, or none when a request arrives without an `Origin` — e.g. an SSR fetch/prefetch), and that variant can then be served to a browser whose origin doesn't match → the browser reports a missing ACAO.

### Fix
Pricing is **public, credential-free** data — every consumer fetches it without credentials (marketing teaser + pricing page, admin billing + license pages; verified). Serve it with wildcard `Access-Control-Allow-Origin: *` — a single cache-safe variant correct for all origins. Non-public routes keep per-origin credentialed CORS unchanged.

Implemented as an exact-match allowlist `PUBLIC_CACHEABLE_CORS_PATHS` (`{'/api/pricing'}`) checked first in the CORS middleware — no regex, no prefix leakage.

### Tests
- New unit tests for `isPublicCacheableCorsPath` (pricing → wildcard; credentialed/private routes → not; exact-match, no substring leakage).
- Existing `cors-validation` suite still green; `server` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
