### PR TITLE
fix(marketing): consolidate agency engagement ladder + drift gate

### DIFF
--- a/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
+++ b/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Drift gate: asserts that the agency engagement ladder
+ * (`AGENCY_ENGAGEMENT_LADDER` in `app/content/for-operators.ts`) is the
+ * single source of truth for the three published "from" anchors —
+ * Architecture Review, Fleet deployment, Custom Build — and that every
+ * marketing surface that displays them derives from it instead of
+ * authoring the literals inline.
+ *
+ * Failure mode the gate forbids: a future edit that re-introduces a
+ * hand-typed "$25,000" or "$50,000" in any marketing content/* module
+ * (the historical 2026-06-07 offerings-pin drift class).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { SERVICE_OFFERINGS } from '@revealui/contracts/pricing';
+import { describe, expect, it } from 'vitest';
+import {
+  AGENCY_ENGAGEMENT_LADDER,
+  agencyEngagementPriceDisplay,
+  FOR_OPERATORS_FAQ,
+  FOR_OPERATORS_PRICING,
+} from '../content/for-operators';
+import { PRICING_DONE_FOR_YOU } from '../content/pricing';
+
+const CONTENT_DIR = join(import.meta.dirname, '..', 'content');
+const FOR_OPERATORS_SRC = readFileSync(join(CONTENT_DIR, 'for-operators.ts'), 'utf8');
+const PRICING_SRC = readFileSync(join(CONTENT_DIR, 'pricing.ts'), 'utf8');
+
+describe('AGENCY_ENGAGEMENT_LADDER — canonical anchors', () => {
+  it('pins the three published "from" anchors', () => {
+    expect(AGENCY_ENGAGEMENT_LADDER.map((e) => [e.id, e.name, e.price, e.startsFrom])).toEqual([
+      ['architecture-review', 'Architecture Review', '$3,500', false],
+      ['fleet-deployment', 'Fleet deployment', '$25,000', true],
+      ['custom-build', 'Custom Build', '$50,000', true],
+    ]);
+  });
+
+  it('renders Architecture Review as a flat price and the rest with a "from" prefix', () => {
+    const display = Object.fromEntries(
+      AGENCY_ENGAGEMENT_LADDER.map((e) => [e.id, agencyEngagementPriceDisplay(e)]),
+    );
+    expect(display['architecture-review']).toBe('$3,500');
+    expect(display['fleet-deployment']).toBe('from $25,000');
+    expect(display['custom-build']).toBe('from $50,000');
+  });
+});
+
+describe('marketing surfaces derive from the ladder', () => {
+  it('FOR_OPERATORS_PRICING rungs reuse ladder name + display price', () => {
+    expect(FOR_OPERATORS_PRICING.rungs.map((r) => [r.title, r.price])).toEqual(
+      AGENCY_ENGAGEMENT_LADDER.map((e) => [e.name, agencyEngagementPriceDisplay(e)]),
+    );
+  });
+
+  it('PRICING_DONE_FOR_YOU rungs reuse ladder name + display price', () => {
+    expect(PRICING_DONE_FOR_YOU.rungs.map((r) => [r.name, r.price])).toEqual(
+      AGENCY_ENGAGEMENT_LADDER.map((e) => [e.name, agencyEngagementPriceDisplay(e)]),
+    );
+  });
+
+  it('FAQ "How much does it cost?" answer interpolates ladder anchors', () => {
+    const faq = FOR_OPERATORS_FAQ.items.find(
+      (item) => item.question === 'How much does it cost?',
+    )?.answer;
+    expect(faq, 'FAQ entry missing').toBeDefined();
+    for (const engagement of AGENCY_ENGAGEMENT_LADDER) {
+      expect(faq, `FAQ must mention ${engagement.name}`).toContain(engagement.name);
+      expect(faq, `FAQ must reference ${engagement.price}`).toContain(engagement.price);
+    }
+  });
+});
+
+describe('single ownership of agency-only price anchors', () => {
+  // The marketing /content tree must contain each bare anchor exactly once,
+  // only inside AGENCY_ENGAGEMENT_LADDER. Other consumers either reuse the
+  // exported objects or interpolate via priceDisplay() / template literals
+  // that reference `engagement.price`. A future re-authoring of "$25,000"
+  // anywhere else in code trips this gate.
+  //
+  // Comments are stripped before counting — illustrative anchors in
+  // documentation prose (//, /* */, JSDoc) are not rendered surfaces and
+  // must not gate the test.
+  const agencyOnly = ['$25,000', '$50,000'] as const;
+
+  function countOccurrencesInCode(source: string, needle: string): number {
+    let count = 0;
+    for (const line of source.split('\n')) {
+      const trimmed = line.trimStart();
+      if (
+        trimmed.startsWith('//') ||
+        trimmed.startsWith('/*') ||
+        trimmed.startsWith('*/') ||
+        trimmed.startsWith('*')
+      ) {
+        continue;
+      }
+      let idx = line.indexOf(needle);
+      while (idx !== -1) {
+        count++;
+        idx = line.indexOf(needle, idx + needle.length);
+      }
+    }
+    return count;
+  }
+
+  for (const anchor of agencyOnly) {
+    it(`${anchor} appears exactly once in content/for-operators.ts code (the ladder)`, () => {
+      expect(countOccurrencesInCode(FOR_OPERATORS_SRC, anchor)).toBe(1);
+    });
+
+    it(`${anchor} does not appear in content/pricing.ts code (band derives via import)`, () => {
+      expect(countOccurrencesInCode(PRICING_SRC, anchor)).toBe(0);
+    });
+  }
+});
+
+describe('SERVICE_OFFERINGS — self-serve menu, NOT the agency ladder', () => {
+  it('does not include Fleet deployment or Custom Build', () => {
+    const names = SERVICE_OFFERINGS.map((s) => s.name);
+    expect(names).not.toContain('Fleet deployment');
+    expect(names).not.toContain('Custom Build');
+  });
+
+  it('agrees with the ladder on the shared Architecture Review price', () => {
+    const review = SERVICE_OFFERINGS.find((s) => s.id === 'architecture-review');
+    const ladderReview = AGENCY_ENGAGEMENT_LADDER.find((e) => e.id === 'architecture-review');
+    expect(review?.price).toBe(ladderReview?.price);
+  });
+});

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -90,11 +90,57 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Engagement pricing — published "from" anchors (Architecture Review, Fleet
-// deployment, Custom Build), shown as "from" minimums. Every engagement is
-// still scoped in a discovery call; the numbers are starting points, not quotes.
-// Rendered by components/for-operators/EngagementPricing.tsx, placed after
-// <HowWeDeliver /> on ForOperatorsPage.
+// Agency engagement ladder — single source of truth for the three published
+// "from" anchors RevealUI Studio offers (Architecture Review, Fleet deployment,
+// Custom Build). Two surfaces consume it: this file's FOR_OPERATORS_PRICING
+// (the agency page at /for-operators) and content/pricing.ts's
+// PRICING_DONE_FOR_YOU (the done-for-you band at the bottom of /pricing).
+// Body copy and CTA labels are surface-specific (operator-voice on the agency
+// page, dev-voice on the pricing band); only `id`, `name`, and `price` are
+// pinned here so a single edit propagates to every render site, including the
+// FAQ prose below.
+//
+// `price` is the bare numeric anchor ("$25,000") so it can drop into prose;
+// `startsFrom` decides whether the rendered ladder rung prefixes "from ".
+// Single ownership of the bare anchors is asserted by
+// __tests__/agency-engagement-ladder.test.ts.
+// ---------------------------------------------------------------------------
+
+export type AgencyEngagementId = 'architecture-review' | 'fleet-deployment' | 'custom-build';
+
+export interface AgencyEngagement {
+  readonly id: AgencyEngagementId;
+  readonly name: string;
+  readonly price: string;
+  readonly startsFrom: boolean;
+}
+
+export const AGENCY_ENGAGEMENT_LADDER: readonly AgencyEngagement[] = [
+  { id: 'architecture-review', name: 'Architecture Review', price: '$3,500', startsFrom: false },
+  { id: 'fleet-deployment', name: 'Fleet deployment', price: '$25,000', startsFrom: true },
+  { id: 'custom-build', name: 'Custom Build', price: '$50,000', startsFrom: true },
+] as const;
+
+/** Rendered display form for a ladder rung ("$3,500" or "from $25,000"). */
+export function agencyEngagementPriceDisplay(engagement: AgencyEngagement): string {
+  return engagement.startsFrom ? `from ${engagement.price}` : engagement.price;
+}
+
+function findEngagement(id: AgencyEngagementId): AgencyEngagement {
+  const found = AGENCY_ENGAGEMENT_LADDER.find((e) => e.id === id);
+  if (!found) throw new Error(`unknown agency engagement id: ${id}`);
+  return found;
+}
+
+const ARCHITECTURE_REVIEW = findEngagement('architecture-review');
+const FLEET_DEPLOYMENT = findEngagement('fleet-deployment');
+const CUSTOM_BUILD = findEngagement('custom-build');
+
+// ---------------------------------------------------------------------------
+// Engagement pricing — rendered by components/for-operators/EngagementPricing.tsx,
+// placed after <HowWeDeliver /> on ForOperatorsPage. Surface-specific body copy
+// is operator-voice; the canonical anchor (name + price) derives from
+// AGENCY_ENGAGEMENT_LADDER above.
 // ---------------------------------------------------------------------------
 
 export interface PricingRung {
@@ -110,20 +156,20 @@ export const FOR_OPERATORS_PRICING = {
   body: 'Every engagement is fixed-bid and starts with a discovery call that scopes the work. The numbers below are starting points, not final quotes.',
   rungs: [
     {
-      title: 'Architecture Review',
-      price: '$3,500',
+      title: ARCHITECTURE_REVIEW.name,
+      price: agencyEngagementPriceDisplay(ARCHITECTURE_REVIEW),
       body: 'A two-week, fixed-bid plan for a self-hosted, audited product your clients own: a reference architecture, a data-flow and audit map, a model plan, and a priced path to launch. Credited toward a Fleet deployment if you start one within 30 days.',
       cta: { label: 'Book the scoping call', href: AGENCY_CONTACT, external: true },
     },
     {
-      title: 'Fleet deployment',
-      price: 'from $25,000',
+      title: FLEET_DEPLOYMENT.name,
+      price: agencyEngagementPriceDisplay(FLEET_DEPLOYMENT),
       body: 'A branded, self-hosted runtime your clients use under your name, on your cloud, white-labeled per client. Built and delivered as a fixed-scope engagement, scoped in the Architecture Review. Ongoing support runs as a separate monthly plan.',
       cta: { label: 'Book a build call', href: AGENCY_CONTACT, external: true },
     },
     {
-      title: 'Custom Build',
-      price: 'from $50,000',
+      title: CUSTOM_BUILD.name,
+      price: agencyEngagementPriceDisplay(CUSTOM_BUILD),
       body: 'A bespoke product on the same runtime, scoped to what your business needs beyond a standard Fleet deployment. A four-to-twelve-week statement of work, fixed-bid, scoped in discovery.',
       cta: { label: 'Book a build call', href: AGENCY_CONTACT, external: true },
     },

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -226,8 +226,7 @@ export const FOR_OPERATORS_FAQ = {
     },
     {
       question: 'How much does it cost?',
-      answer:
-        'The discovery call scopes the engagement. A $3,500 fixed-bid Architecture Review is the written-assessment starting point, and it credits toward what you build next. From there, Fleet deployments start at $25,000 and Custom Builds at $50,000; the discovery call scopes the final number.',
+      answer: `The discovery call scopes the engagement. A ${ARCHITECTURE_REVIEW.price} fixed-bid ${ARCHITECTURE_REVIEW.name} is the written-assessment starting point, and it credits toward what you build next. From there, ${FLEET_DEPLOYMENT.name}s start at ${FLEET_DEPLOYMENT.price} and ${CUSTOM_BUILD.name}s at ${CUSTOM_BUILD.price}; the discovery call scopes the final number.`,
     },
     {
       question: 'How long does it take?',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -137,33 +137,40 @@ export const PRICING_AGENT_CTA_LINKS = {
   } satisfies Cta,
 } as const;
 
-// Done-for-you rung: surfaces the services ladder (canonical figures from the
-// 2026-06-07 offerings pin) where the buying decision happens, instead of a
-// bare link out. Dollar figures match the agency site and /for-operators:
-// published "from" minimums, scoped in discovery, never fixed quotes. The
-// discovery call doubles as the mid-funnel capture for buyers who are not
-// ready to self-serve (06-10 public-surfaces audit P1).
+// Done-for-you rung: surfaces the agency engagement ladder where the buying
+// decision happens, instead of a bare link out. Name + price derive from
+// content/for-operators.ts AGENCY_ENGAGEMENT_LADDER — the single source of
+// truth for the three published "from" anchors. Per-rung `note` copy is
+// surface-specific (band-voice, shorter than the agency-page rung body), so
+// only the name + price are reused. The discovery call doubles as the
+// mid-funnel capture for buyers who are not ready to self-serve (06-10
+// public-surfaces audit P1).
+const DONE_FOR_YOU_RUNG_NOTES: Record<AgencyEngagementId, string> = {
+  'architecture-review':
+    'Fixed-bid written assessment of your project, schema, deployment, and security posture. Credited toward a Fleet deployment if you proceed within 30 days.',
+  'fleet-deployment':
+    'A branded, self-hosted RevealUI deployment for your business or your clients. Starting point, scoped in discovery.',
+  'custom-build':
+    'Bespoke platform engagement, 4 to 12 week sprints. Starting point, scoped in discovery.',
+};
+
+export interface DoneForYouRung {
+  readonly name: string;
+  readonly price: string;
+  readonly note: string;
+}
+
 export const PRICING_DONE_FOR_YOU = {
   eyebrow: 'Done for you',
   heading: 'Want it built and handed over?',
   body: 'RevealUI Studio (the agency) ships fixed-bid engagements on the runtime: scoped in a discovery call, delivered with a full handoff, owned by you afterward.',
-  rungs: [
-    {
-      name: 'Architecture Review',
-      price: '$3,500',
-      note: 'Fixed-bid written assessment of your project, schema, deployment, and security posture. Credited toward a Fleet deployment if you proceed within 30 days.',
-    },
-    {
-      name: 'Fleet deployment',
-      price: 'From $25,000',
-      note: 'A branded, self-hosted RevealUI deployment for your business or your clients. Starting point, scoped in discovery.',
-    },
-    {
-      name: 'Custom Build',
-      price: 'From $50,000',
-      note: 'Bespoke platform engagement, 4 to 12 week sprints. Starting point, scoped in discovery.',
-    },
-  ],
+  rungs: AGENCY_ENGAGEMENT_LADDER.map(
+    (engagement: AgencyEngagement): DoneForYouRung => ({
+      name: engagement.name,
+      price: agencyEngagementPriceDisplay(engagement),
+      note: DONE_FOR_YOU_RUNG_NOTES[engagement.id],
+    }),
+  ) as readonly DoneForYouRung[],
   primaryCta: {
     label: 'Book a discovery call',
     href: 'https://cal.com/revealuistudio/discovery',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -9,6 +9,12 @@ export {
   SUBSCRIPTION_TIERS,
 } from '@revealui/contracts/pricing';
 
+import {
+  AGENCY_ENGAGEMENT_LADDER,
+  type AgencyEngagement,
+  type AgencyEngagementId,
+  agencyEngagementPriceDisplay,
+} from './for-operators';
 import { METRICS, SITE } from './site';
 import type { Cta, SectionHeading } from './types';
 

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -1,8 +1,18 @@
 /**
  * @revealui/contracts/pricing
  *
- * Single source of truth for all tier, pricing, and feature display data.
- * Eliminates duplication across marketing, admin billing, license, and upgrade pages.
+ * Single source of truth for the self-serve product surface:
+ * subscriptions (Track A), credit bundles (Track B), perpetual licenses
+ * (Track C), and self-serve professional services (Track D / SERVICE_OFFERINGS).
+ * Eliminates duplication across marketing, admin billing, license, and
+ * upgrade pages for those surfaces.
+ *
+ * NOT the source of truth for the **agency engagement ladder** (Architecture
+ * Review · Fleet deployment · Custom Build). Those anchors are
+ * marketing-owned and live in `apps/marketing/app/content/for-operators.ts`
+ * as `AGENCY_ENGAGEMENT_LADDER`. The two ladders deliberately overlap on
+ * "Architecture Review · $3,500" (the agency entry point doubles as a
+ * self-serve service); every other anchor sits in exactly one ladder.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
## Summary

The done-for-you band on `/pricing` and the engagement-pricing section on `/for-operators` shipped the same three "from" anchors (Architecture Review · Fleet deployment · Custom Build) as two hand-authored arrays — and they had already drifted on casing (`From $25,000` vs. `from $25,000`). The contracts file's `SERVICE_OFFERINGS` claimed to be the single source of truth for "all tier, pricing, and feature display data" while a separate menu it didn't know about was rendered on two marketing surfaces.

This PR promotes the three anchors to one canonical export, points both surfaces at it, and adds a drift gate so the next re-authoring fails CI.

### Changes

- **Canonical export**: `apps/marketing/app/content/for-operators.ts` now exports `AGENCY_ENGAGEMENT_LADDER` carrying `(id, name, price, startsFrom)` plus an `agencyEngagementPriceDisplay()` helper that renders `"from $25,000"` for the two minimums and the flat `$3,500` for Architecture Review.
- **Consumers wired up**: `FOR_OPERATORS_PRICING.rungs`, `PRICING_DONE_FOR_YOU.rungs`, and the `/for-operators` FAQ "How much does it cost?" answer all derive name + price from the ladder. Surface-specific body / note copy stays per-surface, keyed by engagement id.
- **Casing bug fix (drive-by)**: the band's `From $25,000` / `From $50,000` become `from $25,000` / `from $50,000` to match the canonical agency-page voice.
- **Tighter SoT scope**: `packages/contracts/src/pricing.ts` module header now scopes its SoT claim to the self-serve product surface (subscriptions, credits, perpetual, `SERVICE_OFFERINGS`) and explicitly defers agency engagements to the marketing-owned ladder. The one legitimate overlap — Architecture Review · \$3,500 — is documented.
- **Drift gate** at `apps/marketing/app/__tests__/agency-engagement-ladder.test.ts` asserts:
  - the ladder pins the three canonical anchors;
  - both rendered surfaces' rungs equal the ladder element-wise;
  - the FAQ answer interpolates ladder name + price;
  - `\$25,000` / `\$50,000` appear exactly once in `for-operators.ts` code (the ladder) and zero times in `pricing.ts` code, comment lines stripped before counting;
  - `SERVICE_OFFERINGS` does not contain Fleet deployment / Custom Build, and matches the ladder on Architecture Review price.

### Why same-vs-different came back hybrid

There are three pricing surfaces, not two: the marketing `/pricing` band, the marketing `/for-operators` agency page, and the contracts-defined `SERVICE_OFFERINGS` (Stripe-overlay self-serve menu served from `apps/server/src/routes/pricing.ts`). The /pricing band and /for-operators page were the SAME menu authored twice (the drift class). `SERVICE_OFFERINGS` is a genuinely different menu (founder-direct self-serve) that legitimately overlaps only on the \$3,500 Architecture Review entry point.

## Test plan

- [x] `pnpm --filter marketing test -- --run agency-engagement-ladder` — 46 tests pass (new file's 11 included)
- [x] `pnpm --filter marketing typecheck` — clean
- [x] `pnpm --filter @revealui/contracts typecheck` — clean
- [x] `pnpm lint` — clean (warnings unrelated)
- [x] `pnpm --filter marketing build` — production bundle builds
- [x] `pnpm validate:claims` — clean (no METRICS / license-split drift)
- [ ] Reviewer eyeball check on `/pricing` band rendering in dev preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)