### PR TITLE
fix(billing): verify stored Stripe customer exists before reuse

### DIFF
--- a/apps/server/src/routes/__tests__/billing-comprehensive.test.ts
+++ b/apps/server/src/routes/__tests__/billing-comprehensive.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
 const mockCustomersCreate = vi.fn();
+const mockCustomersRetrieve = vi.fn().mockResolvedValue({ id: 'cus_existing', object: 'customer' });
 const mockCheckoutSessionsCreate = vi.fn();
 const mockBillingPortalSessionsCreate = vi.fn();
 const mockSubscriptionsList = vi.fn();
@@ -37,7 +38,7 @@ const mockLogger = vi.hoisted(() => ({
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
     class {
-      customers = { create: mockCustomersCreate };
+      customers = { create: mockCustomersCreate, retrieve: mockCustomersRetrieve };
       checkout = { sessions: { create: mockCheckoutSessionsCreate } };
       billingPortal = { sessions: { create: mockBillingPortalSessionsCreate } };
       subscriptions = { list: mockSubscriptionsList, update: mockSubscriptionsUpdate };

--- a/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
+++ b/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
@@ -13,6 +13,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // ─── Mocks — declared before imports so vi.mock hoisting takes effect ─────────
 
 const mockCustomersCreate = vi.hoisted(() => vi.fn());
+const mockCustomersRetrieve = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'cus_existing', object: 'customer' }),
+);
 const mockCheckoutSessionsCreate = vi.hoisted(() => vi.fn());
 const mockSubscriptionsList = vi.hoisted(() => vi.fn());
 const mockLogger = vi.hoisted(() => ({
@@ -25,7 +28,7 @@ const mockLogger = vi.hoisted(() => ({
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
     class {
-      customers = { create: mockCustomersCreate };
+      customers = { create: mockCustomersCreate, retrieve: mockCustomersRetrieve };
       checkout = { sessions: { create: mockCheckoutSessionsCreate } };
       billingPortal = { sessions: { create: vi.fn() } };
       subscriptions = { list: mockSubscriptionsList, update: vi.fn() };
@@ -38,7 +41,7 @@ vi.mock('stripe', () => ({
 
 vi.mock('@revealui/services', () => ({
   protectedStripe: {
-    customers: { create: mockCustomersCreate },
+    customers: { create: mockCustomersCreate, retrieve: mockCustomersRetrieve },
     checkout: { sessions: { create: mockCheckoutSessionsCreate } },
     billingPortal: { sessions: { create: vi.fn() } },
     subscriptions: { list: mockSubscriptionsList, update: vi.fn() },

--- a/apps/server/src/routes/__tests__/billing.test.ts
+++ b/apps/server/src/routes/__tests__/billing.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // ─── Mocks  -  declared before imports so vi.mock hoisting takes effect ─────────
 
 const mockCustomersCreate = vi.hoisted(() => vi.fn());
+const mockCustomersRetrieve = vi.hoisted(() => vi.fn());
 const mockCheckoutSessionsCreate = vi.hoisted(() => vi.fn());
 const mockBillingPortalSessionsCreate = vi.hoisted(() => vi.fn());
 const mockSubscriptionsList = vi.hoisted(() => vi.fn());
@@ -40,7 +41,7 @@ vi.mock('stripe', () => ({
 
 vi.mock('@revealui/services', () => ({
   protectedStripe: {
-    customers: { create: mockCustomersCreate },
+    customers: { create: mockCustomersCreate, retrieve: mockCustomersRetrieve },
     checkout: { sessions: { create: mockCheckoutSessionsCreate } },
     billingPortal: { sessions: { create: mockBillingPortalSessionsCreate } },
     subscriptions: { list: mockSubscriptionsList, update: mockSubscriptionsUpdate },
@@ -255,6 +256,9 @@ function resetChains() {
   // Default subscription list  -  empty (no active subscription)
   mockSubscriptionsList.mockResolvedValue({ data: [] });
   mockSubscriptionsUpdate.mockResolvedValue({});
+  // Default: a stored customer verifies as a live, non-deleted customer so the
+  // reuse fast-path returns it. Tests that exercise re-provisioning override this.
+  mockCustomersRetrieve.mockResolvedValue({ id: 'cus_existing', object: 'customer' });
 }
 
 function queueSelectResults(...results: unknown[][]) {
@@ -358,6 +362,34 @@ describe('POST /checkout', () => {
     // Must use the existing customer ID
     const sessionArgs = mockCheckoutSessionsCreate.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(sessionArgs.customer).toBe('cus_existing');
+  });
+
+  it('re-provisions when the stored Stripe customer is missing/deleted in the current mode', async () => {
+    // Regression: a stored stripe_customer_id from another mode (e.g. a live
+    // customer when the deployment runs test keys) or a deleted customer was
+    // previously reused unverified, failing checkout with "No such customer"
+    // ("Invalid billing request"). It must now be re-provisioned instead.
+    queueSelectResults(
+      [{ stripePriceId: 'price_pro_server' }], // resolveCatalogPriceId
+      [{ stripeCustomerId: 'cus_stale' }], // ensureStripeCustomer initial read
+      [{ stripeCustomerId: 'cus_new' }], // re-select after fallback create
+    );
+    // Stored customer no longer exists in this Stripe mode (deleted stub).
+    mockCustomersRetrieve.mockResolvedValue({ id: 'cus_stale', object: 'customer', deleted: true });
+    mockCustomersCreate.mockResolvedValue({ id: 'cus_new' });
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      url: 'https://checkout.stripe.com/pay/sess_new',
+    });
+
+    const app = createApp();
+    const res = await app.request(post('/checkout', { priceId: 'price_pro_server' }));
+
+    expect(res.status).toBe(200);
+    expect(mockCustomersRetrieve).toHaveBeenCalledWith('cus_stale');
+    // A fresh customer is created and used — never the stale id.
+    expect(mockCustomersCreate).toHaveBeenCalled();
+    const sessionArgs = mockCheckoutSessionsCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(sessionArgs.customer).toBe('cus_new');
   });
 
   it('includes tier and user ID in subscription_data metadata', async () => {

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -245,20 +245,45 @@ const UpgradeResponseSchema = z.object({
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+/**
+ * Returns true when `customerId` resolves to a live (non-deleted) customer in
+ * the Stripe account the current key targets. Returns false when the customer
+ * is missing ("No such customer" — e.g. an id created under a different mode's
+ * key) or has been deleted. Re-throws other errors (network, auth, rate-limit)
+ * so a transient Stripe failure does not trigger spurious re-provisioning.
+ */
+async function stripeCustomerIsUsable(
+  stripe: ProtectedStripe,
+  customerId: string,
+): Promise<boolean> {
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return !('deleted' in customer && customer.deleted === true);
+  } catch (err) {
+    if (err instanceof Stripe.errors.StripeInvalidRequestError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
 async function ensureStripeCustomer(userId: string, email: string): Promise<string> {
   const db = getClient();
 
-  // Fast path: user already has a Stripe customer id.
+  // Fast path: user already has a Stripe customer id — but verify it still
+  // exists in the CURRENT Stripe mode before reusing it. A customer created
+  // under a different key (e.g. a live customer when the deployment later runs
+  // test keys, or vice versa) or one deleted in the dashboard would otherwise
+  // be handed to checkout.sessions.create and fail with "No such customer",
+  // surfacing as a generic "Invalid billing request". When unusable we clear it
+  // and re-provision via the create paths below.
   const [user] = await db
     .select({ stripeCustomerId: users.stripeCustomerId })
     .from(users)
     .where(eq(users.id, userId));
 
-  if (user?.stripeCustomerId) {
-    return user.stripeCustomerId;
-  }
-
-  // Slow paths below need protectedStripe — load lazily and 503 if absent.
+  // protectedStripe is needed to verify an existing customer AND to create a
+  // new one — load it up front and 503 if absent.
   const services = await getServices();
   if (!services) {
     throw new HTTPException(503, {
@@ -266,6 +291,25 @@ async function ensureStripeCustomer(userId: string, email: string): Promise<stri
     });
   }
   const protectedStripe = services.protectedStripe;
+
+  const storedCustomerId = user?.stripeCustomerId;
+  if (storedCustomerId) {
+    if (await stripeCustomerIsUsable(protectedStripe, storedCustomerId)) {
+      return storedCustomerId;
+    }
+    // Stale (wrong-mode or deleted). Clear it — guarded on the stale value so a
+    // concurrent re-provision isn't clobbered — then fall through to create a
+    // fresh customer. The lock/fallback paths below treat a null id as
+    // "needs creation".
+    logger.warn(
+      'ensureStripeCustomer: stored customer not usable in current Stripe mode; re-provisioning',
+      { userId, storedCustomerId },
+    );
+    await db
+      .update(users)
+      .set({ stripeCustomerId: null, updatedAt: new Date() })
+      .where(and(eq(users.id, userId), eq(users.stripeCustomerId, storedCustomerId)));
+  }
 
   // Slow path: need to create a Stripe customer. This is the race-prone
   // section that issue #394 tracks. Two kinds of race exist:


### PR DESCRIPTION
## Summary

Root-cause fix for the Gate-5 "Invalid billing request" on checkout (customer half).

`ensureStripeCustomer`'s fast path returned a stored `stripe_customer_id` **without verifying it exists in the current Stripe mode**. A customer created under a different key (e.g. a live customer when the deployment later runs test keys, or vice versa) — or one deleted in the dashboard — was handed straight to `checkout.sessions.create`, which fails with "No such customer" and surfaces as a generic "Invalid billing request".

### Fix
The fast path now verifies the stored customer via `customers.retrieve`:
- exists + not deleted → reuse it (unchanged behavior);
- missing (`No such customer`) or deleted → clear the stale id (guarded on the stale value so a concurrent re-provision isn't clobbered) and create a fresh customer via the existing locked/fallback paths;
- transient Stripe errors (network/auth/rate-limit) are re-thrown, never triggering spurious re-provisioning.

### Tests
- New regression test: stored customer deleted/missing → re-provision (create called, fresh customer used).
- Added the now-required `customers.retrieve` to the billing test mocks (billing/comprehensive/metered).
- Full `@revealui/server` billing suite green (395); typecheck clean.

Pairs with the overage-meter resilience fix (separate PR) — together they close the two ways Gate-5 checkout hit "Invalid billing request".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
