### PR TITLE
feat(presentation+claim-drift): publish token pack + gate license-split phrasing

### DIFF
--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -61,6 +61,9 @@
       "import": "./dist/hooks/index.js"
     },
     "./tokens.css": "./dist/tokens.css",
+    "./design-context/MANIFEST.sha256": "./dist/design-context/MANIFEST.sha256",
+    "./design-context/brand-meta.json": "./dist/design-context/brand-meta.json",
+    "./design-context/tokens.css": "./dist/design-context/tokens.css",
     "./animations": {
       "types": "./dist/animations/index.d.ts",
       "import": "./dist/animations/index.js"
@@ -80,7 +83,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "cross-env NODE_ENV=production vite build && cp src/tokens.css dist/tokens.css && pnpm gen:design-context",
+    "build": "cross-env NODE_ENV=production vite build && cp src/tokens.css dist/tokens.css && pnpm gen:design-context && mkdir -p dist/design-context && cp design-context/MANIFEST.sha256 design-context/brand-meta.json design-context/tokens.css dist/design-context/",
     "gen:design-context": "tsx scripts/build-design-context.ts",
     "clean": "rm -rf dist",
     "dev": "vite build --watch --mode development",

--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -11,6 +11,7 @@ import {
   countTestFiles,
   extractRevealuiPackages,
   findIncompleteProList,
+  findLicenseSplitAntiPattern,
   makeIgnoredPathPredicate,
   parseGitIgnoredOutput,
   WALK_EXCLUDED_DIRS,
@@ -356,5 +357,51 @@ describe('WALK_EXCLUDED_DIRS', () => {
       }
     }
     expect([...shadowed]).toEqual([]);
+  });
+});
+
+describe('findLicenseSplitAntiPattern', () => {
+  it('flags the canonical equation form', () => {
+    expect(findLicenseSplitAntiPattern('21 published + 5 private')).toBe('N published + M private');
+    expect(findLicenseSplitAntiPattern('Pre-launch: 21 published + 5 private = 26')).toBe(
+      'N published + M private',
+    );
+  });
+
+  it('flags bare "N published packages"', () => {
+    expect(findLicenseSplitAntiPattern('21 published packages on npm')).toBe(
+      'N published packages',
+    );
+    expect(findLicenseSplitAntiPattern('We ship 25 published package adapters.')).toBe(
+      'N published packages',
+    );
+  });
+
+  it('flags bare "N private packages"', () => {
+    expect(findLicenseSplitAntiPattern('5 private packages internal to the suite')).toBe(
+      'N private packages',
+    );
+  });
+
+  it('does NOT flag the canonical taxonomy phrasing', () => {
+    expect(findLicenseSplitAntiPattern('20 of 26 packages are MIT')).toBeNull();
+    expect(findLicenseSplitAntiPattern('5 Pro packages are Fair Source (FSL-1.1-MIT)')).toBeNull();
+    expect(findLicenseSplitAntiPattern('20 MIT + 5 FSL + 1 internal = 26')).toBeNull();
+  });
+
+  it('does NOT flag prose that happens to use "published" without a package count', () => {
+    expect(findLicenseSplitAntiPattern('Packages are published to npm.')).toBeNull();
+    expect(
+      findLicenseSplitAntiPattern('See SLSA Build Level 2 provenance on published packages'),
+    ).toBeNull();
+    expect(findLicenseSplitAntiPattern('private function defined here')).toBeNull();
+  });
+
+  it('equation form takes precedence over bare forms', () => {
+    // A line that contains both halves should report the equation shape, not
+    // "N published packages" — otherwise multi-flagging clutters the report.
+    expect(findLicenseSplitAntiPattern('21 published + 5 private packages')).toBe(
+      'N published + M private',
+    );
   });
 });

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -831,6 +831,93 @@ function scanForIncompleteProList(map: PackageLicenseMap): IncompleteProMatch[] 
 }
 
 // ---------------------------------------------------------------------------
+// License-split anti-pattern detector (added 2026-06-14)
+//
+// Catches the canonical "N published + M private" drift class: prior copy
+// stated "21 published + 5 private" against an actual license split of
+// "20 MIT + 5 FSL + 1 internal = 26", off by 4 on both numbers. The phrase
+// is ambiguous (does "published" mean MIT-only or MIT+FSL? does "private"
+// mean internal-only or FSL+internal?), so the fix is to forbid the
+// phrasing entirely and steer authors to the canonical MIT / FSL / internal
+// taxonomy already gated by the license-membership detector above.
+//
+// Anti-patterns:
+//   - "N published packages"   — implies an OSS-vs-other split the
+//     canonical taxonomy doesn't carry (FSL packages also publish to npm).
+//   - "N private packages"     — implies M packages are not on npm; in the
+//     canonical taxonomy only 1 workspace is internal/private.
+//   - "N published + M private" — the explicit equation form prior copy
+//     used to count toward 26; flagged regardless of N + M arithmetic.
+//
+// REGEX-CONFIG-BOUNDARY — patterns only (pre-existing convention in this
+// file; AST refactor queued under GAP-192). The shape predicate
+// (findLicenseSplitAntiPattern) is exported for unit testing.
+// ---------------------------------------------------------------------------
+
+export type LicenseSplitAntiShape =
+  | 'N published packages'
+  | 'N private packages'
+  | 'N published + M private';
+
+interface LicenseSplitAntiMatch {
+  file: string;
+  line: number;
+  shape: LicenseSplitAntiShape;
+  text: string;
+}
+
+const PUBLISHED_PACKAGES_PATTERN = /\b[1-9]\d?\s+published\s+packages?\b/i;
+const PRIVATE_PACKAGES_PATTERN = /\b[1-9]\d?\s+private\s+packages?\b/i;
+const PUBLISHED_PLUS_PRIVATE_PATTERN = /\b[1-9]\d?\s+published\s*\+\s*[1-9]\d?\s+private\b/i;
+
+/**
+ * Returns the anti-pattern shape if `line` matches one, otherwise null.
+ * Equation form takes precedence — a single line that names both halves of
+ * the bug should be flagged once. Pure + exported for unit testing.
+ */
+export function findLicenseSplitAntiPattern(line: string): LicenseSplitAntiShape | null {
+  if (PUBLISHED_PLUS_PRIVATE_PATTERN.test(line)) return 'N published + M private';
+  if (PUBLISHED_PACKAGES_PATTERN.test(line)) return 'N published packages';
+  if (PRIVATE_PACKAGES_PATTERN.test(line)) return 'N private packages';
+  return null;
+}
+
+/**
+ * Files documenting the bug as part of their drift-correction prose
+ * (post-Phase-3.4 marketing-overhaul fixes). Their comments deliberately
+ * quote the old phrasing; the gate must not fire on them.
+ */
+const LICENSE_SPLIT_ANTIPATTERN_ALLOWLIST = new Set<string>([
+  'apps/marketing/app/content/home.ts',
+  'apps/marketing/app/content/proof.ts',
+  'apps/marketing/app/content/fair-source.ts',
+  // The validator itself + its tests — pattern strings are not claims
+  'scripts/validate/claim-drift.ts',
+]);
+
+function scanForLicenseSplitAntiPatterns(): LicenseSplitAntiMatch[] {
+  const matches: LicenseSplitAntiMatch[] = [];
+  walkLicenseScanFiles((filePath, rel) => {
+    if (LICENSE_SPLIT_ANTIPATTERN_ALLOWLIST.has(rel)) return;
+    if (rel.startsWith('scripts/validate/__tests__/')) return;
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const shape = findLicenseSplitAntiPattern(lines[i]);
+      if (shape) {
+        matches.push({ file: rel, line: i + 1, shape, text: lines[i].trim() });
+      }
+    }
+  });
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Claim scanner
 // ---------------------------------------------------------------------------
 
@@ -1769,6 +1856,11 @@ function run(): void {
   const membershipMatches = scanForLicenseMembershipDrift(pkgMap);
   const incompleteProMatches = scanForIncompleteProList(pkgMap);
 
+  // License-split anti-pattern gate (added 2026-06-14) — forbids the
+  // "N published + M private" phrasing class that prior copy used to reach
+  // 26 with off-by-4 arithmetic on both halves.
+  const licenseSplitAntiMatches = scanForLicenseSplitAntiPatterns();
+
   // Marketing METRICS drift (Phase 6) — site.ts METRICS vs canonical counts
   const marketingMetricDrifts = checkMarketingMetrics([
     { key: 'packages', actual: packages },
@@ -1795,6 +1887,7 @@ function run(): void {
   console.log(`Phantom-package mentions: ${phantomMatches.length}`);
   console.log(`License-membership mismatches: ${membershipMatches.length}`);
   console.log(`Incomplete Pro-list claims: ${incompleteProMatches.length}`);
+  console.log(`License-split anti-pattern phrasings: ${licenseSplitAntiMatches.length}`);
   console.log(`Marketing METRICS drift (site.ts): ${marketingMetricDrifts.length}`);
 
   if (futureClaims.length > 0) {
@@ -1880,6 +1973,19 @@ function run(): void {
     );
   }
 
+  if (licenseSplitAntiMatches.length > 0) {
+    console.log(
+      '\nLicense-split anti-pattern phrasings (ambiguous "published"/"private" package counts):',
+    );
+    for (const m of licenseSplitAntiMatches) {
+      console.log(`  ${m.file}:${m.line}  ${m.shape}`);
+      console.log(`    ${m.text.substring(0, 140)}`);
+    }
+    console.log(
+      `\nUse the canonical taxonomy instead: "${licenseSplit.mit} MIT + ${licenseSplit.fsl} FSL + ${licenseSplit.internal} internal = ${licenseSplit.mit + licenseSplit.fsl + licenseSplit.internal}". The "published"/"private" split is ambiguous (FSL packages also publish to npm) and historically drifted by 4 on both halves.`,
+    );
+  }
+
   if (marketingMetricDrifts.length > 0) {
     console.log(
       '\nMarketing METRICS drift — apps/marketing/app/content/site.ts out of sync with codebase:',
@@ -1902,6 +2008,7 @@ function run(): void {
     phantomMatches.length > 0 ||
     membershipMatches.length > 0 ||
     incompleteProMatches.length > 0 ||
+    licenseSplitAntiMatches.length > 0 ||
     marketingMetricDrifts.length > 0;
 
   if (anyFailures) {
@@ -1932,13 +2039,16 @@ function run(): void {
     if (incompleteProMatches.length > 0) {
       console.log('\nFailed: incomplete Pro-package lists in docs.');
     }
+    if (licenseSplitAntiMatches.length > 0) {
+      console.log('\nFailed: license-split anti-pattern phrasings in docs.');
+    }
     if (marketingMetricDrifts.length > 0) {
       console.log('\nFailed: marketing METRICS out of sync with codebase counts.');
     }
     process.exit(1);
   } else {
     console.log(
-      '\nAll claims match codebase reality, future-tense markers are tracked, aspirational features are qualified, fleet products are attributed, no $RVUI ticker leaks were found, no phantom-package mentions were found, and license membership matches package.json reality.',
+      '\nAll claims match codebase reality, future-tense markers are tracked, aspirational features are qualified, fleet products are attributed, no $RVUI ticker leaks were found, no phantom-package mentions were found, license membership matches package.json reality, and no license-split anti-pattern phrasings were found.',
     );
   }
 }


### PR DESCRIPTION
## Summary

Codebase half of Task 3 from the design-system handoff. Two independent threads land together because both protect the same canonical phrasing class (the "20 MIT + 5 FSL + 1 internal = 26" taxonomy) from silent drift.

### Thread 1 — publish the token pack canon as stable exports

The DS-repo's `token-drift-gate.cjs` needs a known location to pin against so its local mirror can't drift from the source without CI noticing. Today the gate consumes `RVUI_TOKENS_SRC` (developer-pointed) or its own mirror; we want it to be able to pin against the **published** canon.

- **`packages/presentation/package.json`**:
  - New `exports`: `./design-context/MANIFEST.sha256`, `./design-context/brand-meta.json`, `./design-context/tokens.css`.
  - `build` script extended to copy `design-context/{MANIFEST.sha256, brand-meta.json, tokens.css}` into `dist/design-context/` so the exports resolve once `dist/` is published.
- `pnpm --filter @revealui/presentation build` verified emits `dist/design-context/`.
- `tokens.contract.test.ts` already runs in CI on every push/PR via the test-unit job (`pnpm test`), so the MANIFEST.sha256 pack-in-sync assertion stays load-bearing.

### Thread 2 — claim-drift anti-pattern gate for the "published/private" phrasing

The prior copy stated `21 published + 5 private` against an actual `20 MIT + 5 FSL + 1 internal = 26` split — off by 4 on both halves. The bug was hand-corrected back in the marketing-overhaul lane but nothing prevented regression. The "published"/"private" framing is also fundamentally ambiguous (FSL packages also publish to npm), so the gate forbids the phrasing entirely.

- **`scripts/validate/claim-drift.ts`**:
  - `findLicenseSplitAntiPattern(line)` — pure predicate, exported for tests. Returns `'N published + M private'`, `'N published packages'`, `'N private packages'`, or `null`.
  - `scanForLicenseSplitAntiPatterns()` — walks the existing `LICENSE_SCAN_ROOTS`, applies the predicate line-by-line, with an allowlist for the three marketing files that document the bug as part of their drift-correction prose.
  - Wired into `run()`: counted in the summary line, reported with `file:line` + the offending shape, contributes to overall failure exit code. The fail message interpolates the live `licenseSplit` counts so authors get the canonical phrasing to copy into their fix.
- **`scripts/validate/__tests__/claim-drift.test.ts`**: six tests pinning the predicate's contract — equation form, bare forms, canonical-taxonomy non-matches, generic prose non-matches, equation precedence.
- `pnpm validate:claims` green; the new line "License-split anti-pattern phrasings: 0" confirms the scanner ran and the allowlist is correctly scoped.

### Acceptance against the handoff

- [x] Confirm `tokens.contract.test.ts` runs in CI on every change to `packages/presentation` — confirmed: `pnpm test` in `test-unit` job covers it; not path-filtered.
- [x] Publish `tokens.css` + `MANIFEST.sha256` as stable files/exports of `@revealui/presentation` — done via the three new export paths.
- [x] Extend `claim-drift` so authored package/MCP/table counts must match `METRICS` — the existing `MIT/FSL/internal` numeric patterns already cover this; this PR adds the **anti-phrasing** gate that catches the `21 published + 5 private` failure mode the existing patterns missed.
- [x] CI fails if `tokens.css` changes without a matching `MANIFEST.sha256` bump — pre-existing gate (the `pack is in sync` assertion in `tokens.contract.test.ts`) already does this; this PR makes the canon externally consumable so the DS-repo can also pin against it.

## Test plan

- [x] `pnpm exec vitest run --root scripts/validate` — 37 tests, all green (6 new)
- [x] `pnpm validate:claims` — clean (License-split anti-pattern phrasings: 0)
- [x] `pnpm --filter @revealui/presentation build` — emits `dist/design-context/{MANIFEST.sha256, brand-meta.json, tokens.css}`
- [x] `pnpm lint` — clean (warnings unrelated)
- [ ] DS-repo follow-up: `RVUI_TOKENS_SRC` + `--writesourcepin` to wire the token-drift-gate.cjs against this monorepo's tokens.css (cross-repo, called out in HANDOFF.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)