### PR TITLE
fix(billing): skip overage meter when its price is unusable in current mode

### DIFF
--- a/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
+++ b/apps/server/src/routes/__tests__/billing-metered-checkout.test.ts
@@ -16,6 +16,9 @@ const mockCustomersCreate = vi.hoisted(() => vi.fn());
 const mockCustomersRetrieve = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ id: 'cus_existing', object: 'customer' }),
 );
+const mockPricesRetrieve = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'price_overage', active: true }),
+);
 const mockCheckoutSessionsCreate = vi.hoisted(() => vi.fn());
 const mockSubscriptionsList = vi.hoisted(() => vi.fn());
 const mockLogger = vi.hoisted(() => ({
@@ -29,6 +32,7 @@ vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
     class {
       customers = { create: mockCustomersCreate, retrieve: mockCustomersRetrieve };
+      prices = { retrieve: mockPricesRetrieve };
       checkout = { sessions: { create: mockCheckoutSessionsCreate } };
       billingPortal = { sessions: { create: vi.fn() } };
       subscriptions = { list: mockSubscriptionsList, update: vi.fn() };
@@ -42,6 +46,7 @@ vi.mock('stripe', () => ({
 vi.mock('@revealui/services', () => ({
   protectedStripe: {
     customers: { create: mockCustomersCreate, retrieve: mockCustomersRetrieve },
+    prices: { retrieve: mockPricesRetrieve },
     checkout: { sessions: { create: mockCheckoutSessionsCreate } },
     billingPortal: { sessions: { create: vi.fn() } },
     subscriptions: { list: mockSubscriptionsList, update: vi.fn() },
@@ -262,6 +267,24 @@ describe('POST /checkout — metered overage price attachment', () => {
     expect(lineItems).toHaveLength(2);
     expect(lineItems[0]).toEqual({ price: 'price_pro_test', quantity: 1 });
     expect(lineItems[1]).toEqual({ price: OVERAGE_PRICE_ID });
+  });
+
+  it('omits the metered item when the overage price is missing/inactive in the current mode (resilience)', async () => {
+    // Regression: a cross-mode/misconfigured STRIPE_AGENT_OVERAGE_PRICE_ID
+    // (e.g. a live price while running test keys) must NOT fail the whole
+    // checkout — the meter is skipped and the core subscription proceeds.
+    queueSelectResults([{ stripePriceId: 'price_pro_test' }], [{ stripeCustomerId: 'cus_pro' }]);
+    mockPricesRetrieve.mockResolvedValueOnce({ id: OVERAGE_PRICE_ID, active: false });
+    mockCheckoutSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/pro' });
+
+    const app = createApp();
+    const res = await app.request(post('/checkout', { tier: 'pro' }));
+    expect(res.status).toBe(200);
+
+    const sessionArgs = mockCheckoutSessionsCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    const lineItems = sessionArgs.line_items as Array<Record<string, unknown>>;
+    expect(lineItems).toHaveLength(1);
+    expect(lineItems[0]).toEqual({ price: 'price_pro_test', quantity: 1 });
   });
 
   it('appends metered item as second line_item for max tier', async () => {

--- a/apps/server/src/routes/__tests__/billing-upgrade.test.ts
+++ b/apps/server/src/routes/__tests__/billing-upgrade.test.ts
@@ -14,6 +14,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSubscriptionsList = vi.hoisted(() => vi.fn());
 const mockSubscriptionsUpdate = vi.hoisted(() => vi.fn());
+const mockPricesRetrieve = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'price_overage', active: true }),
+);
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
   error: vi.fn(),
@@ -25,6 +28,7 @@ vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(
     class {
       customers = { create: vi.fn() };
+      prices = { retrieve: mockPricesRetrieve };
       checkout = { sessions: { create: vi.fn() } };
       billingPortal = { sessions: { create: vi.fn() } };
       subscriptions = { list: mockSubscriptionsList, update: mockSubscriptionsUpdate };
@@ -38,6 +42,7 @@ vi.mock('stripe', () => ({
 vi.mock('@revealui/services', () => ({
   protectedStripe: {
     customers: { create: vi.fn() },
+    prices: { retrieve: mockPricesRetrieve },
     checkout: { sessions: { create: vi.fn() } },
     billingPortal: { sessions: { create: vi.fn() } },
     subscriptions: { list: mockSubscriptionsList, update: mockSubscriptionsUpdate },

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -267,6 +267,26 @@ async function stripeCustomerIsUsable(
   }
 }
 
+/**
+ * Returns true when `priceId` resolves to an ACTIVE price in the Stripe account
+ * the current key targets. Returns false when the price is missing ("No such
+ * price" — e.g. a live price id while running test keys) or archived. Re-throws
+ * other errors (network/auth/rate-limit) so a transient failure does not
+ * silently drop the metered line item. Used to keep a misconfigured overage
+ * add-on from failing the entire subscription checkout.
+ */
+async function stripePriceIsUsable(stripe: ProtectedStripe, priceId: string): Promise<boolean> {
+  try {
+    const price = await stripe.prices.retrieve(priceId);
+    return price.active === true;
+  } catch (err) {
+    if (err instanceof Stripe.errors.StripeInvalidRequestError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
 async function ensureStripeCustomer(userId: string, email: string): Promise<string> {
   const db = getClient();
 
@@ -668,7 +688,24 @@ app.openapi(checkoutRoute, async (c) => {
   const discountConfig = getEarlyAdopterDiscount(resolvedTier);
 
   const meterPriceId = process.env.STRIPE_AGENT_OVERAGE_PRICE_ID;
-  const includeMeter = meterPriceId && (resolvedTier === 'pro' || resolvedTier === 'max');
+  let includeMeter = Boolean(meterPriceId) && (resolvedTier === 'pro' || resolvedTier === 'max');
+  // Resilience: only attach the metered overage item if its price actually
+  // exists + is active in the current Stripe mode. A misconfigured/cross-mode
+  // STRIPE_AGENT_OVERAGE_PRICE_ID (e.g. a live price while the deployment runs
+  // test keys) would otherwise fail the WHOLE checkout with "No such price"
+  // ("Invalid billing request"). The overage add-on must never block the core
+  // subscription — skip it and warn instead.
+  if (
+    includeMeter &&
+    meterPriceId &&
+    !(await withStripe((s) => stripePriceIsUsable(s, meterPriceId)))
+  ) {
+    logger.warn(
+      'checkout: agent-overage meter price not usable in current Stripe mode — omitting meter line item',
+      { meterPriceId, tier: resolvedTier },
+    );
+    includeMeter = false;
+  }
 
   // 10-minute idempotency window: prevents duplicate checkout sessions from
   // double-clicks or network retries while allowing a fresh attempt after 10 min.
@@ -1060,13 +1097,26 @@ app.openapi(upgradeRoute, async (c) => {
   //   - remove the meter item when upgrading to Enterprise (no overage on Enterprise)
   //   - add the meter item if upgrading to Pro/Max and it isn't already present
   //   - leave the meter item unchanged when switching between Pro and Max (same SKU)
-  const includeMeter = meterPriceId && (targetTier === 'pro' || targetTier === 'max');
+  let includeMeter = Boolean(meterPriceId) && (targetTier === 'pro' || targetTier === 'max');
+  // Same resilience as checkout: a missing/cross-mode overage price must not
+  // fail the upgrade. Skip the meter item + warn if its price isn't usable.
+  if (
+    includeMeter &&
+    meterPriceId &&
+    !(await withStripe((s) => stripePriceIsUsable(s, meterPriceId)))
+  ) {
+    logger.warn(
+      'upgrade: agent-overage meter price not usable in current Stripe mode — omitting meter line item',
+      { meterPriceId, targetTier },
+    );
+    includeMeter = false;
+  }
   const upgradeItems: Stripe.SubscriptionUpdateParams.Item[] = [
     { id: flatItem.id, price: resolvedPriceId },
   ];
   if (meterItem && !includeMeter) {
     upgradeItems.push({ id: meterItem.id, deleted: true });
-  } else if (!meterItem && includeMeter) {
+  } else if (!meterItem && includeMeter && meterPriceId) {
     upgradeItems.push({ price: meterPriceId });
   }
 


### PR DESCRIPTION
## Summary

Overage half of the Gate-5 "Invalid billing request" (pairs with #1455, the customer half).

Checkout/upgrade attach a metered overage line item from `STRIPE_AGENT_OVERAGE_PRICE_ID` (env, synced live from revvault). When that price doesn't exist in the active Stripe mode — e.g. a live price while the API runs test keys — Stripe rejects the **entire** checkout with `No such price`, blocking the core subscription.

### Fix
Add `stripePriceIsUsable` (symmetric with `stripeCustomerIsUsable` from #1455): verify the meter price exists + is active before attaching it. If it's missing/inactive, **omit the meter and warn** — the subscription proceeds without the overage add-on instead of failing. Applied to both the subscription checkout and the tier-upgrade paths.

### Tests
- New: "omit meter when price unusable" (resilience) case.
- Added `prices.retrieve` to the metered + upgrade mocks.
- Full `@revealui/server` billing suite green (396); typecheck clean.

### Follow-up (tracked)
The **complete** fix — seed the agent-overage billing meter + metered price in `stripe:seed` so test/live both have it — is **an internal repo** (Fix 2b). This PR is the resilience safety net that prevents a misconfigured add-on from ever blocking checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
