### PR TITLE
fix(billing): surface original Stripe error before remapping

### DIFF
--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -123,6 +123,32 @@ async function withStripe<T>(operation: (stripe: ProtectedStripe) => Promise<T>)
         message: 'Payment service temporarily unavailable. Please try again shortly.',
       });
     }
+    // Surface the original Stripe error before it is remapped to a user-safe
+    // message below. Stripe's diagnostic fields (type/code/param/statusCode/
+    // requestId/message) describe the API misuse  -  e.g. "No such price: …; a
+    // similar object exists in live mode, but a test mode key was used"  -  and
+    // carry no secret material. Without this, a price/coupon/meter mode mismatch
+    // surfaces only as an opaque "Invalid billing request" with no way to
+    // identify the offending parameter from logs.
+    if (error instanceof Stripe.errors.StripeError) {
+      const diagnostics = {
+        type: error.type,
+        code: error.code,
+        statusCode: error.statusCode,
+        requestId: error.requestId,
+        param: error instanceof Stripe.errors.StripeInvalidRequestError ? error.param : undefined,
+        stripeMessage: error.message,
+      };
+      // Card declines and rate limits are expected outcomes, not system faults.
+      if (
+        error instanceof Stripe.errors.StripeCardError ||
+        error instanceof Stripe.errors.StripeRateLimitError
+      ) {
+        logger.warn('Stripe operation rejected', diagnostics);
+      } else {
+        logger.error('Stripe operation failed before remap', error, diagnostics);
+      }
+    }
     // Map Stripe-specific errors to actionable HTTP status codes
     if (error instanceof Stripe.errors.StripeCardError) {
       throw new HTTPException(402, {


### PR DESCRIPTION
## Problem

Pro/Max checkout on `admin.revealui.com/account/billing` fails with **400 "Invalid billing request. Please contact support if this persists."** The request reaches the route authenticated (confirmed: 400 from inside the handler, not 401/404; route is correctly mounted at `/api/billing/checkout`), and no `priceId` is sent from the client — so the price resolves solely from the `billing_catalog` table and Stripe rejects `checkout.sessions.create` with a `StripeInvalidRequestError`.

The root problem this PR addresses: **`withStripe` swallowed the original Stripe error.** It caught the `StripeInvalidRequestError` and threw a brand-new generic `HTTPException(400)` **without ever logging the underlying diagnostic** — so the actual cause (a price/coupon/meter Stripe-mode mismatch: *"No such price… a similar object exists in live mode, but a test mode key was used"*) was undiagnosable from logs.

## Change

In `withStripe`'s catch block, log the original Stripe error's diagnostic fields (`type`/`code`/`param`/`statusCode`/`requestId`/`message` — none are secret) **before** remapping to the user-safe message:

- `logger.warn` for expected outcomes (card declines, rate limits)
- `logger.error` otherwise (invalid-request, API, auth, connection)

The user-facing messages are unchanged.

## Why this first

This is **Step 0 / layer 3** of the Stripe mode-coherence durable plan (ADR to follow). It is low-risk (pure observability), ships independently, and on the next prod deploy the log will name the exact offending parameter among the candidates (catalog price ID, overage meter price, early-adopter coupon, automatic_tax origin) — turning the next incident into a log-read instead of an investigation. Steps 1-2 (mode-key the `billing_catalog`; verify catalog/coupon/meter against the deployed key at the money boundary) come as a separate, ADR-gated change.

## Verification

- `pnpm --filter server typecheck` — clean
- server test suite — 2760 passed, 1 skipped
- `biome check` — clean (one pre-existing unrelated warning at billing.ts:978)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
