### PR TITLE
fix(billing): customer_update on checkout sessions (tax_id_collection 400)

### DIFF
--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -760,6 +760,13 @@ app.openapi(checkoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         ...discountConfig,
         line_items: [
@@ -1564,6 +1571,13 @@ app.openapi(perpetualCheckoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         allow_promotion_codes: true,
         line_items: [{ price: resolvedPriceId, quantity: 1 }],
@@ -1688,6 +1702,13 @@ app.openapi(supportRenewalCheckoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         allow_promotion_codes: true,
         line_items: [{ price: resolvedPriceId, quantity: 1 }],


### PR DESCRIPTION
## The bug (found via the layer-3 logging)

Checkout 400'd with a `StripeInvalidRequestError`: *"Tax ID collection requires updating business name on the customer. To enable tax ID collection for an existing customer, please set `customer_update[name]` to `auto`."*

The subscription/perpetual/renewal checkout sessions set `tax_id_collection: { enabled: true }` and pass an existing `customer`, but didn't set `customer_update` — which Stripe requires for that combination. It surfaced as the generic "Invalid billing request" 400.

**This affected live checkout too**, not just the test window — any customer without a saved business name would hit it.

## Fix

Add `customer_update: { name: 'auto', address: 'auto' }` to the three affected checkout sessions (credits checkout has no `tax_id_collection`, so it's untouched).

## Verification
- `pnpm --filter server typecheck` clean
- billing + billing-comprehensive suites: 116 passed
- biome clean (1 pre-existing unrelated warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)