### PR TITLE
promote: billing customer_update fix → production

### DIFF
--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -760,6 +760,13 @@ app.openapi(checkoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         ...discountConfig,
         line_items: [
@@ -1564,6 +1571,13 @@ app.openapi(perpetualCheckoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         allow_promotion_codes: true,
         line_items: [{ price: resolvedPriceId, quantity: 1 }],
@@ -1688,6 +1702,13 @@ app.openapi(supportRenewalCheckoutRoute, async (c) => {
         payment_method_types: ['card'],
         billing_address_collection: 'required',
         tax_id_collection: { enabled: true },
+        // Required by Stripe when tax_id_collection is enabled AND an existing
+        // `customer` is supplied: it lets Checkout persist the collected tax ID,
+        // business name, and billing address back onto the customer. Without it
+        // Stripe rejects the session with a StripeInvalidRequestError ("Tax ID
+        // collection requires updating business name on the customer…"), which
+        // surfaced to users as the generic "Invalid billing request".
+        customer_update: { name: 'auto', address: 'auto' },
         automatic_tax: { enabled: isStripeTaxEnabled },
         allow_promotion_codes: true,
         line_items: [{ price: resolvedPriceId, quantity: 1 }],


### PR DESCRIPTION
Promotes #1466 (the `customer_update` / tax_id_collection checkout fix) to production. Delta is the single billing.ts fix. Deploys the api, which re-pulls current prod env (overage meter already removed for the test window).

After deploy: retest 4242 at admin.revealui.com/account/billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)