### PR TITLE
fix(webhooks): idempotent subscription-license insert (activation 500)

### DIFF
--- a/apps/server/src/routes/__tests__/webhook-handler.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-handler.test.ts
@@ -1028,8 +1028,11 @@ describe('POST /stripe webhook  -  handler tests', () => {
       expect(body.error).toBe('Webhook processing failed');
       expect(vi.mocked(loggerModule.logger).error).toHaveBeenCalledWith(
         'Webhook handler error',
-        undefined,
-        expect.objectContaining({ eventType: 'customer.subscription.deleted' }),
+        expect.any(Error),
+        expect.objectContaining({
+          detail: 'DB down',
+          eventType: 'customer.subscription.deleted',
+        }),
       );
     });
 

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -1479,9 +1479,14 @@ app.openapi(stripeWebhookRoute, async (c) => {
           {
             name: 'insert-subscription-license',
             execute: async (ctx) => {
-              // WH-2 fix: idempotency guard — check for existing license before
-              // generating a key. Prevents duplicate keys on saga retry after
-              // crash between step execution and idempotency key recording.
+              // Idempotency guard. CRITICAL: match ANY existing row for this
+              // (customer, subscription) — including soft-deleted ones — because
+              // the `licenses_customer_subscription_unique` index spans
+              // deleted_at. Stripe redelivers webhooks (and this handler clears
+              // its idempotency marker on failure to force retries), so a plain
+              // INSERT collides with a pre-existing/soft-deleted row and fails
+              // the whole saga ("Subscription checkout saga failed"). When a row
+              // exists we UPDATE/reactivate it; only INSERT when there is none.
               const [existing] = await ctx.db
                 .select({ id: licenses.id })
                 .from(licenses)
@@ -1489,16 +1494,27 @@ app.openapi(stripeWebhookRoute, async (c) => {
                   and(
                     eq(licenses.customerId, customerId),
                     eq(licenses.subscriptionId, subscriptionId),
-                    isNull(licenses.deletedAt),
                   ),
                 )
                 .limit(1);
 
-              if (existing) {
-                return { licenseId: existing.id, skipped: true };
-              }
-
               const licenseKey = await generateLicenseKey({ tier, customerId }, normalizedKey);
+
+              if (existing) {
+                await ctx.db
+                  .update(licenses)
+                  .set({
+                    userId: resolvedUserId,
+                    licenseKey,
+                    tier,
+                    status: licenseStatus,
+                    expiresAt: licenseExpiresAt,
+                    deletedAt: null,
+                    updatedAt: new Date(),
+                  })
+                  .where(eq(licenses.id, existing.id));
+                return { licenseId: existing.id, skipped: false };
+              }
 
               await ctx.db.insert(licenses).values({
                 id: licenseId,
@@ -3540,7 +3556,16 @@ app.openapi(stripeWebhookRoute, async (c) => {
   } catch (err) {
     const cleanedUp = await unmarkProcessed(db, event.id);
     const msg = err instanceof Error ? err.message : 'Unknown error';
-    logger.error('Webhook handler error', undefined, { detail: msg, eventType: event.type });
+    // Surface the wrapped DB/driver cause (e.g. a Postgres "duplicate key" or
+    // "column does not exist" inside a DrizzleQueryError). err.message alone is
+    // just the failed-query text, which hides the actual reason.
+    const cause =
+      err instanceof Error && err.cause instanceof Error ? err.cause.message : undefined;
+    logger.error('Webhook handler error', err instanceof Error ? err : undefined, {
+      detail: msg,
+      cause,
+      eventType: event.type,
+    });
 
     // Fire-and-forget alert to founder  -  critical for checkout failures where
     // customer has paid but license was not generated.


### PR DESCRIPTION
## Root cause (from the live log + schema)
`checkout.session.completed` returned 500 `{"error":"Webhook processing failed"}` → log detail: `Subscription checkout saga failed: Failed query: insert into "licenses" …`. The license JWT generated fine; the **DB insert** failed.

The `licenses_customer_subscription_unique` index is on `(customer_id, subscription_id)` and spans **soft-deleted** rows, but the saga's idempotency guard only matched `deleted_at IS NULL`. Stripe redelivers webhooks (and the handler clears its idempotency marker on failure to force retries), so a pre-existing/soft-deleted license row makes the plain `INSERT` collide → whole saga fails → **customer paid but subscription never activated** (no license, no entitlement → /welcome stuck on Free).

## Fix
- Guard now matches **any** existing `(customer, subscription)` row (incl. soft-deleted) and **UPDATEs/reactivates** it; `INSERT` runs only when none exists.
- Surface the wrapped DB cause (`err.cause`) in the handler's catch log, so the real Postgres reason is logged, not just the failed-query text (the gap that hid this).

## Verify
- typecheck clean; webhook suites **278 passed, 1 skipped**; biome clean.

After deploy, **Resend** the failed `checkout.session.completed` in Stripe → license+entitlement write → Pro activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)