### PR TITLE
fix(contracts+marketing): rename SERVICE_OFFERINGS, pin Launch Package ownership

### DIFF
--- a/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
+++ b/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
@@ -12,7 +12,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { SERVICE_OFFERINGS } from '@revealui/contracts/pricing';
+import { FOUNDER_SERVICE_OFFERINGS } from '@revealui/contracts/pricing';
 import { describe, expect, it } from 'vitest';
 import {
   AGENCY_ENGAGEMENT_LADDER,
@@ -25,6 +25,29 @@ import { PRICING_DONE_FOR_YOU } from '../content/pricing';
 const CONTENT_DIR = join(import.meta.dirname, '..', 'content');
 const FOR_OPERATORS_SRC = readFileSync(join(CONTENT_DIR, 'for-operators.ts'), 'utf8');
 const PRICING_SRC = readFileSync(join(CONTENT_DIR, 'pricing.ts'), 'utf8');
+
+// Counts literal occurrences of `needle` in code, skipping comment lines.
+// Module-scoped so multiple describes can pin single-ownership invariants.
+function countOccurrencesInCode(source: string, needle: string): number {
+  let count = 0;
+  for (const line of source.split('\n')) {
+    const trimmed = line.trimStart();
+    if (
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*/') ||
+      trimmed.startsWith('*')
+    ) {
+      continue;
+    }
+    let idx = line.indexOf(needle);
+    while (idx !== -1) {
+      count++;
+      idx = line.indexOf(needle, idx + needle.length);
+    }
+  }
+  return count;
+}
 
 describe('AGENCY_ENGAGEMENT_LADDER — canonical anchors', () => {
   it('pins the three published "from" anchors', () => {
@@ -82,27 +105,6 @@ describe('single ownership of agency-only price anchors', () => {
   // must not gate the test.
   const agencyOnly = ['$25,000', '$50,000'] as const;
 
-  function countOccurrencesInCode(source: string, needle: string): number {
-    let count = 0;
-    for (const line of source.split('\n')) {
-      const trimmed = line.trimStart();
-      if (
-        trimmed.startsWith('//') ||
-        trimmed.startsWith('/*') ||
-        trimmed.startsWith('*/') ||
-        trimmed.startsWith('*')
-      ) {
-        continue;
-      }
-      let idx = line.indexOf(needle);
-      while (idx !== -1) {
-        count++;
-        idx = line.indexOf(needle, idx + needle.length);
-      }
-    }
-    return count;
-  }
-
   for (const anchor of agencyOnly) {
     it(`${anchor} appears exactly once in content/for-operators.ts code (the ladder)`, () => {
       expect(countOccurrencesInCode(FOR_OPERATORS_SRC, anchor)).toBe(1);
@@ -114,16 +116,33 @@ describe('single ownership of agency-only price anchors', () => {
   }
 });
 
-describe('SERVICE_OFFERINGS — self-serve menu, NOT the agency ladder', () => {
+describe('FOUNDER_SERVICE_OFFERINGS — founder-led services, NOT the agency ladder', () => {
   it('does not include Fleet deployment or Custom Build', () => {
-    const names = SERVICE_OFFERINGS.map((s) => s.name);
+    const names = FOUNDER_SERVICE_OFFERINGS.map((s) => s.name);
     expect(names).not.toContain('Fleet deployment');
     expect(names).not.toContain('Custom Build');
   });
 
   it('agrees with the ladder on the shared Architecture Review price', () => {
-    const review = SERVICE_OFFERINGS.find((s) => s.id === 'architecture-review');
+    const review = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'architecture-review');
     const ladderReview = AGENCY_ENGAGEMENT_LADDER.find((e) => e.id === 'architecture-review');
     expect(review?.price).toBe(ladderReview?.price);
+  });
+
+  // $7,500 is the Launch Package price — founder-led services only. It must
+  // not leak into the agency-tier marketing surfaces (the analog of the
+  // $25,000 / $50,000 single-ownership rules above, in the opposite
+  // direction).
+  it('Launch Package price ($7,500) is owned exclusively by FOUNDER_SERVICE_OFFERINGS', () => {
+    const launch = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'launch-package');
+    expect(launch?.price).toBe('$7,500');
+  });
+
+  it('$7,500 does not appear in content/for-operators.ts code', () => {
+    expect(countOccurrencesInCode(FOR_OPERATORS_SRC, '$7,500')).toBe(0);
+  });
+
+  it('$7,500 does not appear in content/pricing.ts code', () => {
+    expect(countOccurrencesInCode(PRICING_SRC, '$7,500')).toBe(0);
   });
 });

--- a/apps/server/src/routes/__tests__/billing-services-renewal.test.ts
+++ b/apps/server/src/routes/__tests__/billing-services-renewal.test.ts
@@ -2,7 +2,7 @@
  * Billing Services & Renewal Tests
  *
  * Validates the new billing features:
- * 1. SERVICE_OFFERINGS are included in PricingResponse
+ * 1. FOUNDER_SERVICE_OFFERINGS are included in PricingResponse
  * 2. Subscription response includes perpetual and supportExpiresAt fields
  * 3. PricingResponse schema includes services array
  * 4. All perpetual tiers have comingSoon: false (enabled for purchase)
@@ -12,24 +12,24 @@
 
 import {
   CREDIT_BUNDLES,
+  FOUNDER_SERVICE_OFFERINGS,
   PERPETUAL_TIERS,
   type PricingResponse,
-  SERVICE_OFFERINGS,
   SUBSCRIPTION_TIERS,
 } from '@revealui/contracts/pricing';
 import { describe, expect, it } from 'vitest';
 
 // =============================================================================
-// SERVICE_OFFERINGS  -  Track D completeness
+// FOUNDER_SERVICE_OFFERINGS  -  Track D completeness
 // =============================================================================
 
-describe('SERVICE_OFFERINGS  -  Track D', () => {
+describe('FOUNDER_SERVICE_OFFERINGS  -  Track D', () => {
   it('exports exactly 4 service offerings', () => {
-    expect(SERVICE_OFFERINGS).toHaveLength(4);
+    expect(FOUNDER_SERVICE_OFFERINGS).toHaveLength(4);
   });
 
   it('has IDs: architecture-review, launch-package, migration-assist, consulting-hour', () => {
-    const ids = SERVICE_OFFERINGS.map((s) => s.id);
+    const ids = FOUNDER_SERVICE_OFFERINGS.map((s) => s.id);
     expect(ids).toEqual([
       'architecture-review',
       'launch-package',
@@ -39,7 +39,7 @@ describe('SERVICE_OFFERINGS  -  Track D', () => {
   });
 
   it('every offering satisfies the ServiceOffering interface', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       // Required string fields
       expect(typeof service.id).toBe('string');
       expect(typeof service.name).toBe('string');
@@ -58,39 +58,39 @@ describe('SERVICE_OFFERINGS  -  Track D', () => {
   });
 
   it('service IDs are unique', () => {
-    const ids = SERVICE_OFFERINGS.map((s) => s.id);
+    const ids = FOUNDER_SERVICE_OFFERINGS.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
   it('service names are unique', () => {
-    const names = SERVICE_OFFERINGS.map((s) => s.name);
+    const names = FOUNDER_SERVICE_OFFERINGS.map((s) => s.name);
     expect(new Set(names).size).toBe(names.length);
   });
 
   describe('individual offerings', () => {
     it('architecture-review has at least 5 includes', () => {
-      const archReview = SERVICE_OFFERINGS.find((s) => s.id === 'architecture-review');
+      const archReview = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'architecture-review');
       expect(archReview).toBeDefined();
       expect(archReview!.includes.length).toBeGreaterThanOrEqual(5);
       expect(archReview!.name).toBe('Architecture Review');
     });
 
     it('migration-assist has at least 5 includes', () => {
-      const migration = SERVICE_OFFERINGS.find((s) => s.id === 'migration-assist');
+      const migration = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'migration-assist');
       expect(migration).toBeDefined();
       expect(migration!.includes.length).toBeGreaterThanOrEqual(5);
       expect(migration!.name).toBe('Migration Assist');
     });
 
     it('launch-package has at least 5 includes', () => {
-      const launch = SERVICE_OFFERINGS.find((s) => s.id === 'launch-package');
+      const launch = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'launch-package');
       expect(launch).toBeDefined();
       expect(launch!.includes.length).toBeGreaterThanOrEqual(5);
       expect(launch!.name).toBe('Launch Package');
     });
 
     it('consulting-hour has at least 3 includes', () => {
-      const consulting = SERVICE_OFFERINGS.find((s) => s.id === 'consulting-hour');
+      const consulting = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'consulting-hour');
       expect(consulting).toBeDefined();
       expect(consulting!.includes.length).toBeGreaterThanOrEqual(3);
       expect(consulting!.name).toBe('Consulting Hour');
@@ -98,13 +98,13 @@ describe('SERVICE_OFFERINGS  -  Track D', () => {
   });
 
   it('all CTAs link to Cal.com booking', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.ctaHref).toContain('cal.com/revealuistudio');
     }
   });
 
   it('descriptions are substantive (more than 50 characters)', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.description.length).toBeGreaterThan(50);
     }
   });
@@ -120,7 +120,7 @@ describe('PricingResponse includes services', () => {
       subscriptions: SUBSCRIPTION_TIERS,
       credits: CREDIT_BUNDLES,
       perpetual: PERPETUAL_TIERS,
-      services: SERVICE_OFFERINGS,
+      services: FOUNDER_SERVICE_OFFERINGS,
     };
 
     expect(response.services).toBeDefined();
@@ -132,7 +132,7 @@ describe('PricingResponse includes services', () => {
       subscriptions: SUBSCRIPTION_TIERS,
       credits: CREDIT_BUNDLES,
       perpetual: PERPETUAL_TIERS,
-      services: SERVICE_OFFERINGS,
+      services: FOUNDER_SERVICE_OFFERINGS,
     };
 
     for (const service of response.services) {
@@ -147,7 +147,7 @@ describe('PricingResponse includes services', () => {
       subscriptions: SUBSCRIPTION_TIERS,
       credits: CREDIT_BUNDLES,
       perpetual: PERPETUAL_TIERS,
-      services: SERVICE_OFFERINGS,
+      services: FOUNDER_SERVICE_OFFERINGS,
     };
 
     // Track A  -  Subscriptions

--- a/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
@@ -11,12 +11,12 @@
 import {
   CREDIT_BUNDLES,
   type FeatureFlagKey,
+  FOUNDER_SERVICE_OFFERINGS,
   getTierLabel,
   getTiersFromCurrent,
   type LicenseTierId,
   PERPETUAL_TIERS,
   type PricingResponse,
-  SERVICE_OFFERINGS,
   SUBSCRIPTION_TIERS,
   TIER_LABELS,
   TIER_LIMITS,
@@ -372,11 +372,11 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
 
   describe('Professional services (Track D)', () => {
     it('has exactly 4 service offerings', () => {
-      expect(SERVICE_OFFERINGS).toHaveLength(4);
+      expect(FOUNDER_SERVICE_OFFERINGS).toHaveLength(4);
     });
 
     it('service IDs are architecture-review, launch-package, migration-assist, consulting-hour', () => {
-      const ids = SERVICE_OFFERINGS.map((s) => s.id);
+      const ids = FOUNDER_SERVICE_OFFERINGS.map((s) => s.id);
       expect(ids).toEqual([
         'architecture-review',
         'launch-package',
@@ -386,19 +386,19 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
     });
 
     it('every service has a non-empty includes list', () => {
-      for (const service of SERVICE_OFFERINGS) {
+      for (const service of FOUNDER_SERVICE_OFFERINGS) {
         expect(service.includes.length).toBeGreaterThan(0);
       }
     });
 
     it('every service has a deliverable description', () => {
-      for (const service of SERVICE_OFFERINGS) {
+      for (const service of FOUNDER_SERVICE_OFFERINGS) {
         expect(service.deliverable.length).toBeGreaterThan(10);
       }
     });
 
     it('service names are unique', () => {
-      const names = SERVICE_OFFERINGS.map((s) => s.name);
+      const names = FOUNDER_SERVICE_OFFERINGS.map((s) => s.name);
       expect(new Set(names).size).toBe(names.length);
     });
   });
@@ -422,7 +422,7 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
         subscriptions: SUBSCRIPTION_TIERS,
         credits: CREDIT_BUNDLES,
         perpetual: PERPETUAL_TIERS,
-        services: SERVICE_OFFERINGS,
+        services: FOUNDER_SERVICE_OFFERINGS,
       };
 
       expect(response.subscriptions).toHaveLength(4);

--- a/apps/server/src/routes/pricing.ts
+++ b/apps/server/src/routes/pricing.ts
@@ -239,7 +239,7 @@ function buildPricingResponse(stripePrices: StripeProductMap | null): PricingRes
   });
 
   // Services intentionally returned as empty array pending fulfillment infrastructure.
-  // SERVICE_OFFERINGS still exports 4 offerings from @revealui/contracts, but they are NOT
+  // FOUNDER_SERVICE_OFFERINGS still exports 4 offerings from @revealui/contracts, but they are NOT
   // exposed on the public pricing API because (a) no Stripe products exist for them,
   // (b) no `service` track exists in `billing_model` CHECK constraint, (c) no booking
   // automation fires when a customer hits the cal.com link. Services are available via

--- a/packages/contracts/src/__tests__/pricing.test.ts
+++ b/packages/contracts/src/__tests__/pricing.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   CREDIT_BUNDLES,
   FEATURE_LABELS,
+  FOUNDER_SERVICE_OFFERINGS,
   getTierColor,
   getTierLabel,
   getTiersFromCurrent,
   type LicenseTierId,
   PERPETUAL_TIERS,
   type PricingResponse,
-  SERVICE_OFFERINGS,
   type ServiceOffering,
   SUBSCRIPTION_TIERS,
   TIER_COLORS,
@@ -226,16 +226,16 @@ describe('getTierColor', () => {
 });
 
 // =============================================================================
-// SERVICE_OFFERINGS (Track D)
+// FOUNDER_SERVICE_OFFERINGS (Track D)
 // =============================================================================
 
-describe('SERVICE_OFFERINGS', () => {
+describe('FOUNDER_SERVICE_OFFERINGS', () => {
   it('has exactly 4 service offerings', () => {
-    expect(SERVICE_OFFERINGS).toHaveLength(4);
+    expect(FOUNDER_SERVICE_OFFERINGS).toHaveLength(4);
   });
 
   it('has the correct IDs in order', () => {
-    const ids = SERVICE_OFFERINGS.map((s) => s.id);
+    const ids = FOUNDER_SERVICE_OFFERINGS.map((s) => s.id);
     expect(ids).toEqual([
       'architecture-review',
       'launch-package',
@@ -245,12 +245,12 @@ describe('SERVICE_OFFERINGS', () => {
   });
 
   it('service IDs are unique', () => {
-    const ids = SERVICE_OFFERINGS.map((s) => s.id);
+    const ids = FOUNDER_SERVICE_OFFERINGS.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
 
   it('every offering has required structural fields', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.id).toBeTruthy();
       expect(service.name).toBeTruthy();
       expect(service.description).toBeTruthy();
@@ -262,25 +262,25 @@ describe('SERVICE_OFFERINGS', () => {
   });
 
   it('every offering has at least 3 includes', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.includes.length).toBeGreaterThanOrEqual(3);
     }
   });
 
   it('all offerings have prices set', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.price).toBeDefined();
     }
   });
 
   it('all CTAs point to Cal.com booking link', () => {
-    for (const service of SERVICE_OFFERINGS) {
+    for (const service of FOUNDER_SERVICE_OFFERINGS) {
       expect(service.ctaHref).toContain('cal.com/revealuistudio');
     }
   });
 
   it('ServiceOffering interface is properly typed', () => {
-    const sample: ServiceOffering = SERVICE_OFFERINGS[0];
+    const sample: ServiceOffering = FOUNDER_SERVICE_OFFERINGS[0];
     expect(typeof sample.id).toBe('string');
     expect(typeof sample.name).toBe('string');
     expect(typeof sample.description).toBe('string');
@@ -302,7 +302,7 @@ describe('PricingResponse', () => {
       subscriptions: SUBSCRIPTION_TIERS,
       credits: CREDIT_BUNDLES,
       perpetual: PERPETUAL_TIERS,
-      services: SERVICE_OFFERINGS,
+      services: FOUNDER_SERVICE_OFFERINGS,
     };
 
     expect(response.services).toBeDefined();
@@ -314,7 +314,7 @@ describe('PricingResponse', () => {
       subscriptions: SUBSCRIPTION_TIERS,
       credits: CREDIT_BUNDLES,
       perpetual: PERPETUAL_TIERS,
-      services: SERVICE_OFFERINGS,
+      services: FOUNDER_SERVICE_OFFERINGS,
     };
 
     expect(response.subscriptions.length).toBeGreaterThan(0);

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -3,7 +3,7 @@
  *
  * Single source of truth for the self-serve product surface:
  * subscriptions (Track A), credit bundles (Track B), perpetual licenses
- * (Track C), and self-serve professional services (Track D / SERVICE_OFFERINGS).
+ * (Track C), and founder-led professional services (Track D / FOUNDER_SERVICE_OFFERINGS).
  * Eliminates duplication across marketing, admin billing, license, and
  * upgrade pages for those surfaces.
  *
@@ -266,7 +266,15 @@ export interface PerpetualTier {
 }
 
 // =============================================================================
-// Professional Services (Track D)
+// Founder-led Professional Services (Track D)
+//
+// Scope: small-to-mid project services delivered direct by the founder
+// (Architecture Review, Launch Package, Migration Assist, Consulting Hour).
+// These are NOT the agency-tier offerings — the Fleet deployment ($25K+) and
+// Custom Build ($50K+) tiers live in apps/marketing/app/content/pricing.ts
+// under PRICING_DONE_FOR_YOU.rungs (agency segment, different buyer). The two
+// surfaces share only the Architecture Review entry-point, whose canonical
+// price is owned here; marketing imports it rather than re-authoring.
 // =============================================================================
 
 export interface ServiceOffering {
@@ -281,7 +289,7 @@ export interface ServiceOffering {
   ctaHref: string;
 }
 
-export const SERVICE_OFFERINGS: ServiceOffering[] = [
+export const FOUNDER_SERVICE_OFFERINGS: ServiceOffering[] = [
   {
     id: 'architecture-review',
     name: 'Architecture Review',


### PR DESCRIPTION
## Summary

Track 1 of the design-system drift-remediation handoff. Resolves the `SERVICE_OFFERINGS` vs `PRICING_DONE_FOR_YOU.rungs` ambiguity by renaming the contracts constant to state its segmentation (founder-led services, not the agency engagement ladder) and adding a single-ownership invariant for the Launch Package `$7,500` literal.

- **Determination:** the two surfaces are **different**, not drift. `FOUNDER_SERVICE_OFFERINGS` owns the four founder-led services (Architecture Review · Launch · Migration · Consulting). `AGENCY_ENGAGEMENT_LADDER` in `for-operators.ts` owns the three agency-tier rungs (Architecture Review · Fleet · Custom Build). They overlap only on Architecture Review — the cross-surface entry point.
- **Marketing wiring** (PRICING_DONE_FOR_YOU.rungs derives from AGENCY_ENGAGEMENT_LADDER) and the **$25,000 / $50,000 single-ownership gate** were already in place via `b1b5e8e9` + `ab14b382`. This PR adds the $7,500 invariant and the rename that disambiguates the contracts overclaim.
- **No behavior changes.** Renamed exports are mechanical across 6 files.

## Changes

1. `packages/contracts/src/pricing.ts` — rename `SERVICE_OFFERINGS` → `FOUNDER_SERVICE_OFFERINGS`; expand the Track D section header + file-level docstring to point at AGENCY_ENGAGEMENT_LADDER for the agency-tier surface.
2. `apps/server/src/routes/pricing.ts` + 2 server tests + contracts pricing test — update consumer references.
3. `apps/marketing/app/__tests__/agency-engagement-ladder.test.ts` — module-scope the existing `countOccurrencesInCode` helper; add a new describe block asserting `$7,500` lives only in `FOUNDER_SERVICE_OFFERINGS` and is absent from marketing content/* code.

## Acceptance (from handoff)

- ✅ `$7,500` owned by exactly one module (contracts).
- ✅ `$25,000` / `$50,000` owned by exactly one module (for-operators) — covered by prior commits.
- ✅ Rendered rows derive from one exported constant (`AGENCY_ENGAGEMENT_LADDER`) — covered by prior commits.
- ✅ Tests assert all of the above.

## Test plan

- [x] `pnpm --filter @revealui/contracts typecheck` — clean
- [x] `pnpm --filter @revealui/contracts test` — 934 pass
- [x] `pnpm --filter server typecheck` — clean
- [x] `pnpm --filter server test` — 2760 pass
- [x] `pnpm --filter marketing typecheck` — clean
- [x] `pnpm --filter marketing test` — 49 pass
- [x] `npx biome check` on all touched files — clean
- [ ] CI gate on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
