### PR TITLE
fix(webhooks): license status 'active' not 'trialing' (trial activation 500)

### DIFF
--- a/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
+++ b/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
@@ -346,7 +346,9 @@ describe('Billing lifecycle integration', () => {
       // calls[0] = idempotency insert; calls[1] = license insert
       expect(mockDb.insert).toHaveBeenCalledTimes(2);
       const insertValues = mockDbInsertChain.values.mock.calls[1]?.[0] as Record<string, unknown>;
-      expect(insertValues.status).toBe('trialing');
+      // A trialing subscription writes an ACTIVE license (licenses_status_check
+      // forbids 'trialing'); the trial window is captured by expiresAt.
+      expect(insertValues.status).toBe('active');
       expect(insertValues.tier).toBe('pro');
       expect(insertValues.subscriptionId).toBe('sub_happy');
       expect(insertValues.expiresAt).toBeInstanceOf(Date);

--- a/apps/server/src/routes/__tests__/webhooks.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks.test.ts
@@ -512,7 +512,7 @@ describe('POST /stripe webhook', () => {
       );
     });
 
-    it('creates license with trialing status when subscription is in trial', async () => {
+    it('creates an active license with trial-end expiry when subscription is in trial', async () => {
       const trialEnd = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60; // +7 days
       mockSubscriptionsRetrieve.mockResolvedValueOnce({ status: 'trialing', trial_end: trialEnd });
       // Transaction's inner user-existence check must find a matching user
@@ -540,7 +540,10 @@ describe('POST /stripe webhook', () => {
       // calls[0] = idempotency insert; calls[1] = license insert
       expect(mockDb.insert).toHaveBeenCalledTimes(2);
       const insertValues = mockDbInsertChain.values.mock.calls[1]?.[0] as Record<string, unknown>;
-      expect(insertValues.status).toBe('trialing');
+      // A trialing subscription yields an ACTIVE license (license-lifecycle
+      // status). The trial is reflected by expiresAt = trial_end, not by the
+      // status field — licenses_status_check forbids 'trialing'.
+      expect(insertValues.status).toBe('active');
       expect(insertValues.expiresAt).toBeInstanceOf(Date);
     });
 

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -1442,7 +1442,15 @@ app.openapi(stripeWebhookRoute, async (c) => {
         const normalizedKey = privateKey.replaceAll('\\n', '\n');
 
         const isTrialing = checkoutSubscription.status === 'trialing';
-        const licenseStatus = isTrialing ? 'trialing' : 'active';
+        // `licenses.status` is the license-lifecycle vocabulary
+        // (active/expired/revoked/support_expired) enforced by
+        // `licenses_status_check` — NOT the Stripe subscription status. A
+        // trialing subscription is an ACTIVE license (its trial expiry is
+        // captured by `licenseExpiresAt = trial_end` below); the trialing state
+        // itself is tracked in the hosted-subscription/entitlement layer via
+        // syncHostedSubscriptionState. Writing 'trialing' here violated the
+        // check constraint and failed the whole checkout saga on every trial.
+        const licenseStatus = 'active';
         const licenseExpiresAt =
           isTrialing && checkoutSubscription.trial_end
             ? new Date(checkoutSubscription.trial_end * 1000)


### PR DESCRIPTION
## THE root cause (finally surfaced)
Trial-subscription checkout failed at the `licenses` insert. `licenses_status_check` permits only `('active','expired','revoked','support_expired')`, but the saga wrote `status: 'trialing'` for trials → **check-constraint violation → saga fails → subscription never activates**.

Because the constraint *always* rejected 'trialing', no such row could ever exist — so this has blocked **every** trial activation. (The earlier #1470 idempotency change + cause-logging were defensive improvements; the truncated saga error hid the real "violates check constraint" reason. The cause is a category error: Stripe *subscription* status written into the *license-lifecycle* status field.)

## Fix
A trialing subscription = an **active license** (trial window already captured by `expiresAt = trial_end`; the trialing state lives in the entitlement layer via `syncHostedSubscriptionState`). Set `licenseStatus = 'active'`. Test updated to match.

## Verify
- typecheck clean; webhook suites **278 passed, 1 skipped**; biome clean.

After deploy → **Resend** the failed `checkout.session.completed` → license + entitlement write → Pro activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)