### PR TITLE
refactor(pricing): bind Architecture Review price to a single contracts export

### DIFF
--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -7,6 +7,7 @@
 // The future managed offering is named "RevealUI Cloud" (OQ-1) — referenced
 // only via the inline link to /for-operators/managed (Page 3, not this PR).
 
+import { ARCHITECTURE_REVIEW_PRICE } from '@revealui/contracts/pricing';
 import { SITE } from './site';
 import type { Cta, FaqItem } from './types';
 
@@ -90,15 +91,18 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Agency engagement ladder — single source of truth for the three published
-// "from" anchors RevealUI Studio offers (Architecture Review, Fleet deployment,
-// Custom Build). Two surfaces consume it: this file's FOR_OPERATORS_PRICING
-// (the agency page at /for-operators) and content/pricing.ts's
-// PRICING_DONE_FOR_YOU (the done-for-you band at the bottom of /pricing).
-// Body copy and CTA labels are surface-specific (operator-voice on the agency
-// page, dev-voice on the pricing band); only `id`, `name`, and `price` are
-// pinned here so a single edit propagates to every render site, including the
-// FAQ prose below.
+// Agency engagement ladder — single source of truth for the agency-only "from"
+// anchors RevealUI Studio offers (Fleet deployment, Custom Build). The shared
+// Architecture Review rung imports its price from @revealui/contracts/pricing
+// (`ARCHITECTURE_REVIEW_PRICE`) so the agency surface cannot drift from the
+// self-serve FOUNDER_SERVICE_OFFERINGS menu that also lists it.
+//
+// Two surfaces consume the ladder: this file's FOR_OPERATORS_PRICING (the
+// agency page at /for-operators) and content/pricing.ts's PRICING_DONE_FOR_YOU
+// (the done-for-you band at the bottom of /pricing). Body copy and CTA labels
+// are surface-specific (operator-voice on the agency page, dev-voice on the
+// pricing band); only `id`, `name`, and `price` are pinned here so a single
+// edit propagates to every render site, including the FAQ prose below.
 //
 // `price` is the bare numeric anchor ("$25,000") so it can drop into prose;
 // `startsFrom` decides whether the rendered ladder rung prefixes "from ".
@@ -116,7 +120,12 @@ export interface AgencyEngagement {
 }
 
 export const AGENCY_ENGAGEMENT_LADDER: readonly AgencyEngagement[] = [
-  { id: 'architecture-review', name: 'Architecture Review', price: '$3,500', startsFrom: false },
+  {
+    id: 'architecture-review',
+    name: 'Architecture Review',
+    price: ARCHITECTURE_REVIEW_PRICE,
+    startsFrom: false,
+  },
   { id: 'fleet-deployment', name: 'Fleet deployment', price: '$25,000', startsFrom: true },
   { id: 'custom-build', name: 'Custom Build', price: '$50,000', startsFrom: true },
 ] as const;

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -7,12 +7,12 @@
  * Eliminates duplication across marketing, admin billing, license, and
  * upgrade pages for those surfaces.
  *
- * NOT the source of truth for the **agency engagement ladder** (Architecture
- * Review · Fleet deployment · Custom Build). Those anchors are
- * marketing-owned and live in `apps/marketing/app/content/for-operators.ts`
- * as `AGENCY_ENGAGEMENT_LADDER`. The two ladders deliberately overlap on
- * "Architecture Review · $3,500" (the agency entry point doubles as a
- * self-serve service); every other anchor sits in exactly one ladder.
+ * NOT the source of truth for the **agency-only** anchors (Fleet deployment ·
+ * Custom Build). Those live in `apps/marketing/app/content/for-operators.ts`
+ * as `AGENCY_ENGAGEMENT_LADDER`. The two ladders deliberately overlap on the
+ * Architecture Review entry point (it doubles as a self-serve service); its
+ * canonical price is `ARCHITECTURE_REVIEW_PRICE` below, and marketing imports
+ * it so the agency-side rung cannot drift from the self-serve menu.
  *
  * @packageDocumentation
  */
@@ -289,11 +289,20 @@ export interface ServiceOffering {
   ctaHref: string;
 }
 
+/**
+ * Canonical price of the Architecture Review entry point. Owned here (the
+ * lower-level package) so the agency engagement ladder in
+ * `apps/marketing/app/content/for-operators.ts` can import it rather than
+ * re-author the literal. A cross-package equality guard lives in
+ * `apps/marketing/app/__tests__/agency-engagement-ladder.test.ts`.
+ */
+export const ARCHITECTURE_REVIEW_PRICE = '$3,500' as const;
+
 export const FOUNDER_SERVICE_OFFERINGS: ServiceOffering[] = [
   {
     id: 'architecture-review',
     name: 'Architecture Review',
-    price: '$3,500',
+    price: ARCHITECTURE_REVIEW_PRICE,
     description:
       'I review your project structure, database schema, deployment pipeline, and security posture. You receive a written report with prioritized, actionable recommendations.',
     includes: [


### PR DESCRIPTION
## Summary

- Promote `$3,500` Architecture Review price to a named export `ARCHITECTURE_REVIEW_PRICE` in `@revealui/contracts/pricing` (the lower-level package) and have `apps/marketing/app/content/for-operators.ts` import it instead of re-authoring the literal. The two ladders (agency-side `AGENCY_ENGAGEMENT_LADDER`, self-serve `FOUNDER_SERVICE_OFFERINGS`) deliberately overlap on this rung; they were not structurally bound and could drift silently. They no longer can.
- Fleet deployment (`$25K+`) and Custom Build (`$50K+`) stay agency-only. Marketing → contracts import direction only (no cycle).
- No rendered or displayed price values change.

## Task-2 finding (no edits)

The dark-mode `--rvui-text-on-brand` AA assertion the parent prompt asked me to harden is already airtight in `packages/presentation/src/__tests__/tokens.contract.test.ts`:

- Line 198 asserts `dark text-on-brand on brand >= 4.5:1`.
- Line 197 asserts the light-mode pair.
- Line 148 pins the CSS declaration to `brand-meta.json`'s near-black canon.

The regression scenario (someone flips dark `--rvui-text-on-brand` to paper-white) fails one of the two: the declaration pin if only `tokens.css` changes, or the AA contrast assertion if both `tokens.css` AND `brand-meta.json` change.

## Follow-up duplicate-literal candidates (NOT fixed in this PR)

Repo sweep surfaced three other shared-literal classes worth promoting to single ownership in a follow-up:

1. **Monthly tier prices `$49` / `$299` / `$1,499`** duplicated across:
   - `apps/marketing/app/lib/pricing-fallbacks.ts`
   - `apps/server/src/routes/pricing.ts:52-54`
   - `packages/test/src/e2e/smoke-production.spec.ts:66-67`
   - An existing drift-gate test at `pricing-fallbacks.test.ts` already binds them at runtime, so the gate works; the structural binding is still missing.

2. **Perpetual prices `$1,499` / `$8,499` / `$42,999`** and renewals **`$149` / `$799` / `$3,999`** duplicated across `pricing-fallbacks.ts` and `apps/server/src/routes/pricing.ts`.

3. **`$300/hr`** authored twice in `packages/contracts/src/pricing.ts` (Migration Assist line 341, Consulting Hour line 359). Same-file duplication.

## Test plan

- [x] `pnpm --filter marketing exec vitest run app/__tests__/agency-engagement-ladder.test.ts` (14/14 pass, including the cross-package equality guard)
- [x] `pnpm --filter '@revealui/contracts' exec vitest run src/__tests__/pricing.test.ts` (39/39 pass)
- [x] `pnpm --filter '@revealui/contracts' typecheck`
- [x] `pnpm --filter marketing typecheck`
- [x] `pnpm exec biome check apps/marketing/app/content/for-operators.ts packages/contracts/src/pricing.ts`
- [ ] CI green
- [ ] Acceptance: search shows `$3,500` literal exists in exactly one place in source (`packages/contracts/src/pricing.ts`, `ARCHITECTURE_REVIEW_PRICE` declaration). Marketing surfaces resolve via import.

## Sequencing

Per the parent prompt: land before the `service` billing track goes live (while `/api/pricing` returns `services: []`), so the duplicate never becomes customer-facing.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
