### PR TITLE
chore(ci): fix deploy app-detection for apps/server + declare @revealui/services root devDep

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,9 +252,17 @@ jobs:
             else
               AFFECTED=""
 
-              # Check each app directory for direct changes
+              # Check each app directory for direct changes.
+              # The "api" deploy target lives in apps/server/, not apps/api/,
+              # so map the logical app name to its source directory before the
+              # path check — otherwise server-only merges never match and the
+              # API deploy is silently skipped.
               for app in $ALL_APPS; do
-                if echo "$CHANGED" | grep -q "^apps/$app/"; then
+                case "$app" in
+                  api) app_dir="server" ;;
+                  *) app_dir="$app" ;;
+                esac
+                if echo "$CHANGED" | grep -q "^apps/$app_dir/"; then
                   AFFECTED="$AFFECTED $app"
                 fi
               done

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@electric-sql/pglite": "catalog:",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "catalog:",
+    "@revealui/services": "workspace:*",
     "@size-limit/file": "^12.1.0",
     "@size-limit/webpack": "^12.1.0",
     "@stripe/mcp": "^0.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
+      '@revealui/services':
+        specifier: workspace:*
+        version: link:packages/services
       '@size-limit/file':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))


### PR DESCRIPTION
## Summary

Two non-blocking build/CI plumbing cleanups carried over from the Stripe-checkout-fix session handoff.

### 1. `ci(deploy)`: affected-detection skipped `apps/server`
`deploy.yml` iterated `ALL_APPS="api admin marketing docs"` and matched each against `^apps/$app/`. The API app lives in `apps/server/`, not `apps/api/`, so any merge touching **only** `apps/server/` never matched the path check and the API deploy was silently skipped (shared-package / root-config changes still triggered a full deploy, which masked it).

Fix: map the logical `api` name to its source directory (`server`) before the path check. The other three apps already match their directory name 1:1.

### 2. `chore`: declare `@revealui/services` as a root devDependency
Root scripts `billing:catalog:sync` and `db:seed:billing` run `scripts/setup/{sync-billing-catalog,seed-billing}.ts`, both of which `import '@revealui/services/stripe/mode'`. The dependency resolved only via pnpm hoisting; declaring it explicitly makes the root package's imports honest. `@revealui/services` is tracked in git (not gitignored like `ai`/`harnesses`), so this is safe for public installs. Lockfile change is the single root-importer `link:packages/services` entry.

## Test plan
- [x] `pnpm install --lockfile-only` — lockfile updated, single root-importer entry, no unrelated churn
- [x] deploy.yml change is a self-contained POSIX `case` inside the existing `run:` block (no YAML structure change)
- [ ] CI gate green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
