### PR TITLE
chore(design-system): ignore .thumbnail (file-manager WebP)

### DIFF
--- a/design-system/.gitignore
+++ b/design-system/.gitignore
@@ -26,6 +26,7 @@ _ds_bundle.js
 contrast-results.json
 _ds_manifest.json
 _adherence.oxlintrc.json
+.thumbnail
 
 # Design documentation (context for agents, not source code; anchored to root)
 /README.md


### PR DESCRIPTION
## Summary
- Adds `.thumbnail` to `design-system/.gitignore`
- Auto-generated 15KB WebP by file manager / Zed folder preview; not source, not an artifact the gate needs
- Same category as the other generated files already ignored in that `.gitignore`

## Test plan
- [ ] CI green (gitignore-only change, no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)