### PR TITLE
test(presentation): disambiguate Card footer link text (unblocks #1479)

### DIFF
--- a/packages/presentation/src/__tests__/components/Card.test.tsx
+++ b/packages/presentation/src/__tests__/components/Card.test.tsx
@@ -379,11 +379,11 @@ describe('CardFooter', () => {
     it('should render links', () => {
       render(
         <CardFooter>
-          <a href="/learn-more">Learn more</a>
+          <a href="/learn-more">Learn more about pricing</a>
         </CardFooter>,
       );
 
-      expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Learn more about pricing' })).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What

Disambiguate the `CardFooter` link-rendering test fixture: change the link label from the ambiguous `"Learn more"` to `"Learn more about pricing"` and update the matching `getByRole` assertion.

## Why

Dependabot #1479 (devdependencies group) bumps Biome to a version that promotes the `useAnchorContent` / `noAmbiguousAnchorText` accessibility rule from warning to **error**. The only error it surfaces across 3168 files is this test fixture's `<a href="/learn-more">Learn more</a>`, which fails the Quality gate and blocks #1479.

This is a test-only fixture change (no shipped UI affected). Once on `test`, #1479 rebases clean and the Biome bump can merge.

## Verification

- Accessible name of the link = its text content, so the updated `getByRole('link', { name: 'Learn more about pricing' })` assertion matches by construction.
- Biome auto-format applied; `biome check` clean on the file.
- Full `@revealui/presentation` suite runs in CI.

Unblocks #1479.
