### PR TITLE
fix(admin): repair welcome→admin link, hide stray Dashboard chrome, trial-aware billing UI

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -276,6 +276,26 @@ function BillingContent() {
   }
 
   const tier = subscription?.tier || 'free';
+  const isTrialing = subscription?.status === 'trialing';
+  const StatusLabels: Record<string, string> = {
+    trialing: 'Free Trial',
+    active: 'Active',
+    past_due: 'Past Due',
+    grace_period: 'Grace Period',
+    expired: 'Expired',
+    revoked: 'Revoked',
+    canceled: 'Canceled',
+  };
+  const statusLabel = subscription?.status
+    ? (StatusLabels[subscription.status] ?? subscription.status)
+    : 'Active';
+  const trialEndDate = subscription?.expiresAt
+    ? new Date(subscription.expiresAt).toLocaleDateString()
+    : '';
+  const cancelTitle = isTrialing
+    ? `Ends your trial. You keep Pro access until ${trialEndDate}.`
+    : 'Cancels at the end of your current billing period. You keep access until then.';
+  const cancelLabel = isTrialing ? 'End trial' : 'Cancel subscription';
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-12">
@@ -439,7 +459,7 @@ function BillingContent() {
           <div className="flex items-center justify-between">
             <span className="text-sm text-zinc-600">Status</span>
             <span
-              className={`text-sm font-medium capitalize ${
+              className={`text-sm font-medium ${
                 subscription?.status === 'active' || subscription?.status === 'trialing'
                   ? 'text-green-600 dark:text-green-400'
                   : subscription?.status === 'past_due' || subscription?.status === 'grace_period'
@@ -449,11 +469,7 @@ function BillingContent() {
                       : ''
               }`}
             >
-              {subscription?.status === 'past_due'
-                ? 'Past Due'
-                : subscription?.status === 'grace_period'
-                  ? 'Grace Period'
-                  : subscription?.status || 'active'}
+              {statusLabel}
             </span>
           </div>
 
@@ -487,37 +503,42 @@ function BillingContent() {
 
             {tier === 'pro' && (
               <div className="space-y-3">
-                <p className="text-sm text-zinc-600">
-                  Upgrade to Max for AI memory, advanced inference, audit logging, and higher limits
-                  (15 projects, 100 users).
-                </p>
-                <Button
-                  onClick={handleUpgradeToMax}
-                  disabled={actionLoading || upgradeSuccess}
-                  className="w-full"
-                >
-                  {actionLoading
-                    ? 'Upgrading...'
-                    : upgradeSuccess
-                      ? 'Upgraded to Max'
-                      : `Upgrade to Max — ${getPrice('max')}`}
-                </Button>
-                <Button
-                  onClick={handleManageBilling}
-                  disabled={actionLoading}
-                  variant="outline"
-                  className="w-full"
-                >
+                {isTrialing ? (
+                  <p className="text-sm text-zinc-600">
+                    You’re on a free Pro trial. Manage your payment method or end the trial before
+                    it converts.
+                  </p>
+                ) : (
+                  <p className="text-sm text-zinc-600">
+                    Upgrade to Max for AI memory, advanced inference, audit logging, and higher
+                    limits (15 projects, 100 users).
+                  </p>
+                )}
+                <Button onClick={handleManageBilling} disabled={actionLoading} className="w-full">
                   {actionLoading ? 'Opening portal...' : 'Manage Billing'}
                 </Button>
+                {!isTrialing && (
+                  <Button
+                    onClick={handleUpgradeToMax}
+                    disabled={actionLoading || upgradeSuccess}
+                    variant="outline"
+                    className="w-full"
+                  >
+                    {actionLoading
+                      ? 'Upgrading...'
+                      : upgradeSuccess
+                        ? 'Upgraded to Max'
+                        : `Upgrade to Max — ${getPrice('max')}`}
+                  </Button>
+                )}
                 <button
                   type="button"
                   onClick={handleManageBilling}
                   disabled={actionLoading}
-                  title="Cancels at the end of your current billing period. You keep access until then."
+                  title={cancelTitle}
                   className="w-full text-sm text-zinc-400 underline hover:text-zinc-600 disabled:cursor-not-allowed dark:text-zinc-500 dark:hover:text-zinc-300"
                 >
-                  Cancel subscription
+                  {cancelLabel}
                 </button>
               </div>
             )}

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -150,12 +150,6 @@ export default function WelcomePage() {
             Billing portal
           </a>
           <a
-            href="/admin"
-            className="rounded-md bg-card px-3 py-1.5 text-foreground ring-1 ring-border transition-colors hover:bg-muted"
-          >
-            Admin dashboard
-          </a>
-          <a
             href={DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"

--- a/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
+++ b/apps/admin/src/lib/components/AdminBar/__tests__/index.test.tsx
@@ -49,7 +49,6 @@ describe('AdminBar', () => {
     const { container } = render(<AdminBar />);
     expect(container).toBeEmptyDOMElement();
     expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
-    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 
   it('does not probe /api/auth/me on auth routes', () => {
@@ -58,16 +57,12 @@ describe('AdminBar', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('renders the bar on a content route', () => {
+  it('mounts the bar shell on a content route (hidden until admin role confirmed)', () => {
     mockUsePathname.mockReturnValue('/posts/some-post');
-    render(<AdminBar />);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-  });
-
-  it('renders the bar on the dashboard root', () => {
-    mockUsePathname.mockReturnValue('/');
-    render(<AdminBar />);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    const { container } = render(<AdminBar />);
+    // Outer wrapper renders; inner shell starts hidden (show=false) until /api/auth/me
+    // confirms role === 'admin'. With the fetch mock pending, it stays hidden.
+    expect(container.querySelector('.hidden')).not.toBeNull();
   });
 
   it('hides "Exit Preview" on a content route when preview mode is not enabled', () => {
@@ -82,9 +77,11 @@ describe('AdminBar', () => {
     expect(screen.queryByText('Exit Preview')).not.toBeInTheDocument();
   });
 
-  it('shows "Exit Preview" only when preview mode is enabled', () => {
+  it('renders "Exit Preview" markup when preview mode is enabled (visibility still gated by role)', () => {
     mockUsePathname.mockReturnValue('/posts/some-post');
     render(<AdminBar adminBarProps={{ preview: true }} />);
+    // The button is in the DOM regardless of show; the show flag only toggles the
+    // wrapper's block/hidden class. Role-gated visibility is asserted separately.
     expect(screen.getByText('Exit Preview')).toBeInTheDocument();
   });
 

--- a/apps/admin/src/lib/components/AdminBar/index.tsx
+++ b/apps/admin/src/lib/components/AdminBar/index.tsx
@@ -27,6 +27,7 @@ export interface RevealUIAdminBarProps {
 export interface RevealUIMeUser {
   id?: string | number;
   email?: string;
+  role?: string;
   [key: string]: unknown;
 }
 
@@ -83,12 +84,10 @@ const collectionLabels = {
   },
 };
 
-const Title = () => <span>Dashboard</span>;
-
 // Auth-flow pages live in the (frontend) route group alongside content pages, and the
-// AdminBar is mounted in that group's layout. The bar is only meaningful on content pages an
-// authenticated admin is browsing — never on the login/signup/setup screens. Without this
-// guard, an admin who still holds a valid session and lands on /signup sees the bar there.
+// AdminBar is mounted in that group's layout. The bar is only meaningful to an admin
+// editing content (draft preview) — never on login/signup/setup screens, and never for
+// non-admin paying customers browsing /welcome or /account/billing.
 const AUTH_ROUTES = new Set([
   '/login',
   '/signup',
@@ -109,8 +108,11 @@ export const AdminBar = (props: { adminBarProps?: RevealUIAdminBarProps }) => {
 
   const router = useRouter();
 
+  // Only admins see the AdminBar. Self-serve subscribers (role 'user') have no use
+  // for the draft-preview controls and previously saw a stray "Dashboard" label on
+  // billing/welcome — the bar is admin-only chrome now.
   const onAuthChange = React.useCallback((user: RevealUIMeUser) => {
-    setShow(Boolean(user?.id));
+    setShow(user?.role === 'admin');
   }, []);
 
   // All hooks above run unconditionally (Rules of Hooks). On auth-flow pages the bar must
@@ -159,7 +161,6 @@ export const AdminBar = (props: { adminBarProps?: RevealUIAdminBarProps }) => {
               singular: collectionLabels[collection]?.singular || 'Page',
             },
           })}
-          logo={<Title />}
           onAuthChange={onAuthChange}
           onPreviewExit={() => {
             fetch('/next/exit-preview').then(() => {


### PR DESCRIPTION
## Summary

Three production admin UX issues found while exercising the post-purchase flow on a Pro trial:

- **Welcome → Admin dashboard 404s to /login.** Self-serve subscribers have `role: 'user'`. `/admin` 301s to `/`, the proxy then requires admin role, so the link in `welcome/page.tsx` bounced paying customers to the sign-in screen. Removed the link.
- **Stray "Dashboard" label on billing.** The `AdminBar` component rendered a non-clickable `<span>Dashboard</span>` for every authenticated user on every non-auth `(frontend)` route. Removed the Title and gated the bar on `role === 'admin'` so non-admin subscribers no longer see empty chrome on `/account/billing` or `/welcome`.
- **Pro-trial billing UI was misleading.** During `status === 'trialing'`, the loud "Upgrade to Max — \$149/mo" CTA was the primary action, the Status pill read raw "trialing", and the cancel control claimed it would "cancel at the end of your current billing period" (no billing period exists yet). Added `isTrialing`/`statusLabel`/`cancelLabel` helpers, demoted the Max upsell while trialing, promoted "Manage Billing", and rewrote the cancel copy as "End trial".

## Test plan

- [x] `pnpm typecheck` (admin) — clean
- [x] `pnpm vitest run src/lib/components/AdminBar/__tests__/index.test.tsx` — 13/13 pass (updated to reflect admin-only chrome)
- [x] `pnpm biome check` on the 4 changed files — clean
- [ ] CI gate on the PR
- [ ] Manual smoke: load `/welcome` and `/account/billing` as a Pro-trial user — confirm no "Dashboard" header, no admin-dashboard link, billing CTAs are Manage Billing + End trial

🤖 Generated with [Claude Code](https://claude.com/claude-code)