### PR TITLE
fix(ci): build before typecheck on PRs + pin turbo --affected base ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,13 +429,21 @@ jobs:
           SKIP_ENV_VALIDATION: "true"
 
       - name: Validate generated types are in sync (hard fail)
+        # generate.ts imports @revealui/utils/dist and reads @revealui/db/dist, so
+        # build db + its workspace deps first. This previously rode on the
+        # build-affected step compiling everything via the base-ref fallback; now
+        # that --affected resolves correctly it can skip unaffected deps, so make
+        # this step self-sufficient (mirrors the Drizzle Migrations job).
         run: |
+          pnpm --filter '@revealui/db...' build
           pnpm --filter @revealui/db generate:all
           if [ -n "$(git diff --name-only)" ]; then
             echo "::error::Generated types are out of sync. Run 'pnpm --filter @revealui/db generate:all' and commit."
             git diff --stat
             exit 1
           fi
+        env:
+          SKIP_ENV_VALIDATION: "true"
 
   # ---------------------------------------------------------------------------
   # Phase 4: E2E smoke tests (main only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,20 @@ jobs:
 
       - name: Typecheck affected packages (PRs — hard fail)
         if: github.event_name == 'pull_request'
-        run: pnpm turbo typecheck --affected
+        # Build affected packages first so consumer typechecks resolve upstream
+        # subpath exports (e.g. @revealui/ai/* -> dist/*.d.ts). Dependabot PRs run
+        # without TURBO_TOKEN (GitHub withholds secrets), so the remote cache is
+        # cold and a typecheck-only run can race the not-yet-emitted dep builds.
+        run: |
+          pnpm turbo build --affected
+          pnpm turbo typecheck --affected
         env:
           SKIP_ENV_VALIDATION: "true"
+          # Pin the --affected base to the PR base tip (a concrete SHA always
+          # reachable via fetch-depth: 0). Without this turbo tries to resolve the
+          # bare branch name and fails with "ambiguous argument 'test'", falling
+          # back to a full cold-cache run that amplifies the race above.
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
       - name: Typecheck all packages (push — hard fail)
         if: github.event_name == 'push'
@@ -407,6 +418,9 @@ jobs:
         run: pnpm turbo build --affected
         env:
           SKIP_ENV_VALIDATION: "true"
+          # See typecheck job: pin the --affected base to the PR base tip so turbo
+          # does not fall back to a full run on "ambiguous argument 'test'".
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
       - name: Build all (push to protected branches — hard fail)
         if: github.event_name == 'push'


### PR DESCRIPTION
## What

Fixes the intermittent `admin#typecheck` failure on Dependabot PRs (observed on `dependabot/sharp` #1486) by (1) building affected packages before typechecking them and (2) pinning the `turbo --affected` base ref.

## Root cause

The failure is **not** the dependency bump. It is a CI cache-coherence + base-ref bug:

1. **No remote cache on Dependabot PRs.** `TURBO_TOKEN` resolves from `secrets.*`, and GitHub withholds Actions secrets from Dependabot PRs, so the Turbo remote cache is cold there.
2. **Base ref fails to resolve.** `turbo --affected` tried to resolve the bare branch name `test` (which exists only as `origin/test`), logging `Failed to resolve base ref 'test' ... fatal: ambiguous argument 'test'`, and fell back to a **full cold-cache run** of all packages.
3. **Race.** In that cold full run, the consumer typechecks (`admin`, `server`, `engines`) resolved modules before `@revealui/ai`'s `dist/*.d.ts` were emitted, producing `TS2307: Cannot find module '@revealui/ai/memory/stores'` (and the other subpath exports).

Pushes to `test` were unaffected because the push path runs with a valid `TURBO_TOKEN` (warm cache → `@revealui/ai:build` restores instantly), which is why `test` stayed green and the failure looked flaky.

## Changes (`.github/workflows/ci.yml`)

- **Typecheck job (PR step):** run `turbo build --affected` before `turbo typecheck --affected`, so upstream `dist/*.d.ts` are guaranteed present before any consumer typecheck. Eliminates the race regardless of cache state.
- **Typecheck + Build jobs (PR steps):** set `TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}` — a concrete commit SHA always reachable via `fetch-depth: 0` — so `--affected` compares correctly instead of falling back to the full graph.

## Impact

- Unblocks #1486 and any future dep bump that pulls an `@revealui/ai` consumer into the affected set.
- Push-path behavior (`typecheck:all`, `build all`) is unchanged.
- Slight extra work on PR typecheck (it now also builds affected deps), which is a cache hit for contributor PRs and the cost of correctness for Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
