### PR TITLE
fix(billing): reconcile subscription view with Stripe when no license row exists

### DIFF
--- a/apps/server/src/routes/__tests__/billing.test.ts
+++ b/apps/server/src/routes/__tests__/billing.test.ts
@@ -677,6 +677,60 @@ describe('GET /subscription', () => {
     // The WHERE clause must include isNull(licenses.deletedAt)
     expect(isNull).toHaveBeenCalledWith('licenses.deletedAt');
   });
+
+  it('reconciles a trialing Stripe subscription when no license row exists', async () => {
+    // Sequence of db.select() calls on the no-license path:
+    //  1) hosted-snapshot membership (none) 2) license query (none)
+    //  3) resolveHostedStripeCustomerId membership (none) 4) users.stripeCustomerId
+    queueSelectResults([], [], [], [{ stripeCustomerId: 'cus_trial' }]);
+    const trialEnd = 1893456000; // fixed epoch seconds
+    mockSubscriptionsList.mockResolvedValue({
+      data: [{ status: 'trialing', metadata: { tier: 'pro' }, trial_end: trialEnd }],
+    });
+
+    const app = createApp();
+    const res = await app.request(get('/subscription'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.tier).toBe('pro');
+    expect(body.status).toBe('trialing');
+    expect(body.expiresAt).toBe(new Date(trialEnd * 1000).toISOString());
+    expect(body.licenseKey).toBeNull();
+    expect(mockSubscriptionsList).toHaveBeenCalledWith({
+      customer: 'cus_trial',
+      status: 'all',
+      limit: 10,
+    });
+  });
+
+  it('does not call Stripe (stays free) when the user has no Stripe customer', async () => {
+    _selectResult = []; // no membership, no license, no stored customer
+    mockSubscriptionsList.mockClear();
+
+    const app = createApp();
+    const res = await app.request(get('/subscription'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.tier).toBe('free');
+    expect(mockSubscriptionsList).not.toHaveBeenCalled();
+  });
+
+  it('stays free when a Stripe subscription has no resolvable tier metadata', async () => {
+    queueSelectResults([], [], [], [{ stripeCustomerId: 'cus_unlabeled' }]);
+    // No tier in metadata  -  never guess a paid tier.
+    mockSubscriptionsList.mockResolvedValue({
+      data: [{ status: 'trialing', metadata: {}, trial_end: null }],
+    });
+
+    const app = createApp();
+    const res = await app.request(get('/subscription'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.tier).toBe('free');
+  });
 });
 
 describe('POST /upgrade', () => {

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -604,6 +604,63 @@ async function resolveHostedStripeCustomerId(
   return dbUser?.stripeCustomerId ?? null;
 }
 
+/** Non-throwing tier resolver for Stripe subscription metadata (cf. webhook resolveTier). */
+function resolveTierFromMetadata(
+  metadata: Record<string, string> | null | undefined,
+): 'pro' | 'max' | 'enterprise' | null {
+  const tier = metadata?.tier;
+  if (tier === 'pro' || tier === 'max' || tier === 'enterprise') return tier;
+  return null;
+}
+
+/**
+ * Reconcile the subscription view against Stripe when no local license row
+ * exists yet. The checkout guard reads Stripe directly, so a trial whose
+ * `checkout.session.completed` webhook hasn't landed (or failed) would otherwise
+ * leave the UI showing "free" + an Upgrade button that dead-ends on the checkout
+ * 409. Returns a snapshot derived from the user's live Stripe subscription, or
+ * null when the user has no Stripe customer or no live subscription. Best-effort:
+ * a Stripe outage must never break the billing page, so it logs and returns null
+ * on failure rather than throwing.
+ */
+async function getStripeSubscriptionFallback(
+  userId: string,
+  accountId?: string | null,
+): Promise<{
+  tier: 'pro' | 'max' | 'enterprise';
+  status: string;
+  expiresAt: string | null;
+  licenseKey: null;
+} | null> {
+  try {
+    const customerId = await resolveHostedStripeCustomerId(userId, accountId);
+    if (!customerId) return null;
+
+    const subs = await withStripe((stripe) =>
+      stripe.subscriptions.list({ customer: customerId, status: 'all', limit: 10 }),
+    );
+    // Match the checkout guard's notion of an existing subscription so the UI
+    // and the guard agree (active / trialing / incomplete / past_due).
+    const liveStatuses = new Set(['trialing', 'active', 'incomplete', 'past_due']);
+    const sub = subs.data.find((s) => liveStatuses.has(s.status));
+    if (!sub) return null;
+
+    const tier = resolveTierFromMetadata(sub.metadata);
+    // Never guess a paid tier from an unlabeled subscription.
+    if (!tier) return null;
+
+    const expiresAt =
+      typeof sub.trial_end === 'number' ? new Date(sub.trial_end * 1000).toISOString() : null;
+
+    return { tier, status: sub.status, expiresAt, licenseKey: null };
+  } catch (error) {
+    logger.warn('subscription: Stripe reconciliation fallback failed; defaulting to free', {
+      detail: error instanceof Error ? error.message : 'unknown',
+    });
+    return null;
+  }
+}
+
 function resolveUsageQuota(c: { get: (key: string) => unknown }): number {
   const requestEntitlements = c.get('entitlements') as RequestEntitlements | undefined;
   const accountQuota = requestEntitlements?.limits?.maxAgentTasks;
@@ -914,6 +971,17 @@ app.openapi(subscriptionRoute, async (c) => {
     .limit(1);
 
   if (!license) {
+    // No local license row — but a Stripe subscription may already exist (a
+    // trial whose webhook hasn't landed or failed). Reconcile against Stripe so
+    // the UI doesn't show a misleading "free" + dead-end Upgrade button. Only
+    // users with an existing Stripe customer incur the lookup.
+    const stripeSnapshot = await getStripeSubscriptionFallback(
+      user.id,
+      requestEntitlements?.accountId,
+    );
+    if (stripeSnapshot) {
+      return c.json(stripeSnapshot, 200);
+    }
     return c.json(
       {
         tier: 'free' as const,


### PR DESCRIPTION
## Summary

Fixes the trialing-upgrade dead-end found during the Gate-5 browser test: a trialing user saw a "free" billing page with an **"Upgrade to Pro"** button that dead-ended on the checkout 409 *("You already have a subscription (status: trialing). Use the upgrade route to change tiers.")*

### Root cause — source-of-truth mismatch
- `GET /api/billing/subscription` (feeds the UI) derived tier solely from the local **`licenses`** table → returned `tier: 'free'` when no row existed (`billing.ts:919`).
- `POST /api/billing/checkout` guard reads **Stripe directly** and saw the `trialing` subscription → 409.

A user whose `checkout.session.completed` webhook hadn't landed — **or failed during the production outage** (API was 503ing) — has a live Stripe trial but no license row, so the two endpoints disagreed indefinitely. The UI's `tier === 'free'` branch renders "Upgrade to Pro"; the `tier === 'pro' && isTrialing` branch (correct one) renders "Manage Billing / End trial".

### Fix
On the no-license path, reconcile against Stripe before defaulting to free:
- Resolve the user's existing Stripe customer via `resolveHostedStripeCustomerId` (**no creation**). Genuinely-free users (no customer) skip the lookup and still return `free`.
- If a live subscription exists (`trialing`/`active`/`incomplete`/`past_due` — matching the checkout guard), derive tier from `subscription.metadata.tier` and return `{ tier, status, expiresAt: trial_end }`.
- **Never guesses** a paid tier from unlabeled metadata; **never throws** (a Stripe outage logs and falls back to `free`).

Result: a trialing user's billing page now shows the correct Manage-Billing / End-trial branch — no dead-end button.

## Tests
- 3 new `GET /subscription` cases: reconciles trialing; no Stripe call without a customer; stays free on unresolvable tier metadata.
- ✅ 47/47 billing route tests pass · biome clean · `pnpm --filter server typecheck` clean.

## Notes / follow-ups (not in this PR)
- **Orphaned trial data:** if the founder's (or other) trial license row was never created because the webhook failed during the outage, this fix makes the **UI** self-correct (reads Stripe), but the missing `licenses` row may still affect **feature gating**. Worth checking whether a webhook replay / reconciliation is needed for accounts with a live Stripe sub but no license. (Data op — owner-gated, deliberately not done here.)
- **Nav friction** (separate, minor): `/account/billing` deep-link → login → lands on `/welcome` (no return-to redirect) → manual click to reach billing. Could add a `returnTo` redirect in a follow-up.
- Optional defense-in-depth: make the checkout 409 for a trialing user return the portal URL instead of an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
