### PR TITLE
fix(ci): build Pro packages before server typecheck (affected job)

### DIFF
--- a/apps/server/turbo.json
+++ b/apps/server/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["//"],
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "@revealui/ai#build", "@revealui/services#build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build", "@revealui/ai#build", "@revealui/services#build"]
+    }
+  }
+}


### PR DESCRIPTION
## Problem
The PR-level **Typecheck** job (`turbo build --affected` → `turbo typecheck --affected`) fails on any PR that makes `server` an affected package. `@revealui/ai` + `@revealui/services` are optional peers, absent from `server`'s turbo dependency graph, so they're never built — and `server#typecheck` (full `tsc` resolution) fails:
- `rag-index.ts: Cannot find module '@revealui/ai/embeddings'` (TS2307)
- `billing.ts: 'session'/'refund' is of type 'unknown'` (TS18046 — Stripe types via @revealui/services)

`server#build` passes only because tsup *externalizes* those imports. This surfaced on #1505 and #1506 (both touch `server`); #1504 escaped it (e2e-only).

## Fix
`apps/server/turbo.json` mirrors the #1501 admin fix, adding `@revealui/ai#build` + `@revealui/services#build` to server's `build` **and** `typecheck` dependsOn.

Verified: `turbo run typecheck --filter=server --dry` now lists both Pro builds with `Dependents = server#typecheck`. The full-gate `pnpm -r typecheck` (push to test/main) was never affected — this only fixes the `turbo --affected` PR path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)