### PR TITLE
fix(ci): drop Pro builds from server#build (deploy timeout) — keep on typecheck

### DIFF
--- a/apps/server/turbo.json
+++ b/apps/server/turbo.json
@@ -2,9 +2,6 @@
   "extends": ["//"],
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build": {
-      "dependsOn": ["^build", "@revealui/ai#build", "@revealui/services#build"]
-    },
     "typecheck": {
       "dependsOn": ["^build", "@revealui/ai#build", "@revealui/services#build"]
     }


### PR DESCRIPTION
## Problem
#1508's prod deploy (and a rerun) **cancelled** at the ~20-min job timeout. #1507 added `@revealui/ai#build` + `@revealui/services#build` to **both** `server#build` and `server#typecheck`. The `build` override was incorrect:
- `server#build` is **tsup**, which *externalizes* the optional-peer Pro imports — it never needed them built (the proven 22be58e77 deploy built server without them).
- The override made the deploy's buildCommand `turbo build --filter=server` redundantly rebuild Pro + their dependency closures. Combined with `vercel-build.mjs`'s own `turbo build` pass, the cold-cache work exceeded the Deploy api timeout → "operation canceled". (The `cli`/`ai` `tsc` lines in the log are pre-existing non-fatal noise, not the failure.)

## Fix
Keep the Pro build deps **only on `server#typecheck`** (the PR-gate fix from #1507, runs in a separate untimed job). Drop the `build` override so `server#build` matches the proven 22be58e77 graph.

Verified via `turbo run build/typecheck --filter=server --dry`: `server#build` no longer depends on Pro; `server#typecheck` still does.

Prod is healthy throughout (serving 22be58e77); no Stripe change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)