### PR TITLE
corpus-finish: Foundation hero §4.1 lock + /philosophy draft

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -11,6 +11,7 @@ import { ForOperatorsManagedPage } from './routes/ForOperatorsManagedPage';
 import { ForOperatorsPage } from './routes/ForOperatorsPage';
 import { HomePage } from './routes/HomePage';
 import { NotFoundPage } from './routes/NotFoundPage';
+import { PhilosophyPage } from './routes/PhilosophyPage';
 import { PricingPage } from './routes/PricingPage';
 import { PrivacyPage } from './routes/PrivacyPage';
 import { ProductsPage } from './routes/ProductsPage';

--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -34,6 +34,11 @@ export function App() {
     router.registerRoutes([
       { path: '/', component: HomePage, meta: { title: 'RevealUI' } },
       { path: '/products', component: ProductsPage, meta: { title: 'Products | RevealUI' } },
+      {
+        path: '/philosophy',
+        component: PhilosophyPage,
+        meta: { title: 'Why RevealUI exists | RevealUI' },
+      },
       { path: '/pricing', component: PricingPage, meta: { title: 'Pricing | RevealUI' } },
       { path: '/blog', component: BlogIndexPage, meta: { title: 'Blog | RevealUI' } },
       { path: '/blog/:slug', component: BlogPostPage, meta: { title: 'Blog | RevealUI' } },

--- a/apps/marketing/app/__tests__/hero-variant.test.ts
+++ b/apps/marketing/app/__tests__/hero-variant.test.ts
@@ -16,12 +16,15 @@ describe('selectHomeHero', () => {
     expect(selectHomeHero('?other=1')).toBe(HOME_HERO);
   });
 
-  it('isolates the noun: only h1 + subtitle.strong differ from HOME_HERO', () => {
+  it('isolates the noun in the H1 only (corpus §4.1 lock: Sub unchanged)', () => {
     expect(HOME_HERO_FOUNDATION.h1).not.toBe(HOME_HERO.h1);
-    expect(HOME_HERO_FOUNDATION.subtitle.strong).not.toBe(HOME_HERO.subtitle.strong);
+    expect(HOME_HERO_FOUNDATION.subtitle).toEqual(HOME_HERO.subtitle);
     expect(HOME_HERO_FOUNDATION.eyebrow).toBe(HOME_HERO.eyebrow);
-    expect(HOME_HERO_FOUNDATION.subtitle.body).toBe(HOME_HERO.subtitle.body);
     expect(HOME_HERO_FOUNDATION.cta).toEqual(HOME_HERO.cta);
     expect(HOME_HERO_FOUNDATION.shipsToday).toEqual(HOME_HERO.shipsToday);
+  });
+
+  it('matches the corpus §4.1 H1 lock verbatim', () => {
+    expect(HOME_HERO_FOUNDATION.h1).toBe('The foundation your business runs on.');
   });
 });

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -74,24 +74,20 @@ export const HOME_HERO = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Hero — "Foundation" A/B variant.
-// Tests the noun "foundation" against the canonical "runtime" in HOME_HERO.
-// The two strings below (h1 + subtitle.strong) are the only difference, so the
-// A/B isolates the noun; "runtime" stays the canonical noun on every other
-// surface. Served via selectHomeHero() (app/lib/hero-variant.ts): the homepage
-// hero renders this variant when the URL carries ?hero=foundation, else
-// HOME_HERO. An automatic traffic split + conversion measurement is separate
-// (the marketing app has no analytics sink yet).
+// Hero — "Foundation" A/B variant (canonical lock).
+// Per docs/marketing/06-copy-corpus.md §4.1 (sanctioned A/B variant under ADR
+// 2026-06-07 decision 6, hero only): H1 reframes around "foundation"; subtitle
+// inherits the default unchanged. The noun-test is the H1 only — the subtitle
+// keeps the canonical "runtime" noun. Served via selectHomeHero()
+// (app/lib/hero-variant.ts): the homepage hero renders this variant when the
+// URL carries ?hero=foundation, else HOME_HERO. An automatic traffic split +
+// conversion measurement is separate (the marketing app has no analytics sink
+// yet).
 // ---------------------------------------------------------------------------
 
 export const HOME_HERO_FOUNDATION = {
   ...HOME_HERO,
-  h1: 'Run your whole business on a foundation you own.',
-  subtitle: {
-    ...HOME_HERO.subtitle,
-    strong:
-      'Auth, content, products, and payments, pre-wired into one open-source foundation you self-host.',
-  },
+  h1: 'The foundation your business runs on.',
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/content/philosophy.ts
+++ b/apps/marketing/app/content/philosophy.ts
@@ -1,0 +1,32 @@
+// Content for /philosophy. Locked verbatim to
+// docs/marketing/06-copy-corpus.md §4.6 "The manifesto block".
+// If this file drifts from the corpus, this file is wrong and gets
+// fixed here first (per the corpus §0 authority rule).
+
+export const PHILOSOPHY = {
+  eyebrow: 'Why RevealUI exists',
+  h1: 'Software that compounds.',
+  sections: [
+    {
+      lead: true,
+      body: "Human progress accelerates when the outputs of today's work become the inputs of tomorrow's work.",
+    },
+    {
+      body: 'Most software effort evaporates. The project ships, the lessons scatter, and the next project starts from zero. Tools that promise productivity make the work faster. They do not make the next project start further ahead.',
+    },
+    {
+      body: 'RevealUI is built for compounding. Five primitives, People, Content, Offers, Payments, and Agents, are a contract you implement once and reuse in every product you ship. A deployment that works becomes a RevealUI Fleet kit, branded and domain-locked for the next client you serve. An agent that works in your business keeps its memory in a store you own. Every action lands in a tamper-evident audit log, so the record of your work is an asset, not an afterthought.',
+    },
+    {
+      body: "Large organizations buy this kind of accumulation with headcount. RevealUI packages it as software you self-host, so a small team can build on yesterday's work instead of repeating it.",
+    },
+    {
+      footer: true,
+      body: 'Used in production by the team that maintains it.',
+    },
+  ],
+  cta: {
+    primary: { label: 'Start free', href: '/pricing' },
+    secondary: { label: 'See it on GitHub', href: 'https://github.com/RevealUIStudio/revealui' },
+  },
+} as const;

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -1,0 +1,67 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import { PHILOSOPHY } from '../content/philosophy';
+
+export function PhilosophyPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            {PHILOSOPHY.eyebrow}
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+            {PHILOSOPHY.h1}
+          </h1>
+        </div>
+      </section>
+
+      <section className="px-6 py-16 sm:py-24 lg:px-8">
+        <div className="mx-auto max-w-3xl space-y-8">
+          {PHILOSOPHY.sections.map((section, index) => {
+            if ('lead' in section && section.lead) {
+              return (
+                <p
+                  key={index}
+                  className="text-2xl font-medium leading-relaxed text-foreground sm:text-3xl"
+                >
+                  {section.body}
+                </p>
+              );
+            }
+            if ('footer' in section && section.footer) {
+              return (
+                <p
+                  key={index}
+                  className="mt-12 border-t border-border pt-8 text-base font-medium text-muted-foreground"
+                >
+                  {section.body}
+                </p>
+              );
+            }
+            return (
+              <p key={index} className="text-lg leading-8 text-muted-foreground">
+                {section.body}
+              </p>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="px-6 pb-24 sm:pb-32 lg:px-8">
+        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+          <ButtonCVA asChild size="lg" variant="primary">
+            <a href={PHILOSOPHY.cta.primary.href}>{PHILOSOPHY.cta.primary.label}</a>
+          </ButtonCVA>
+          <ButtonCVA asChild size="lg" variant="outline">
+            <a href={PHILOSOPHY.cta.secondary.href} target="_blank" rel="noopener noreferrer">
+              {PHILOSOPHY.cta.secondary.label}
+            </a>
+          </ButtonCVA>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the revealui-side of the corpus-finish lane (internal docs companion PR open separately on an internal repo). Two surfaces:

**1. Foundation hero A/B variant locked to corpus §4.1.**

`docs/marketing/06-copy-corpus.md` §4.1 sanctioned A/B variant (ADR 2026-06-07 decision 6) calls for:
- H1: `The foundation your business runs on.`
- Sub: unchanged from default.

The previous variant in `apps/marketing/app/content/home.ts:87-95` drifted on both lines: H1 read `Run your whole business on a foundation you own.` and `subtitle.strong` carried a custom string with the dead primitive vocab `products` plus the `foundation` noun. Corpus says the noun-test is the H1 only — the subtitle keeps the canonical `runtime` noun.

The test at `apps/marketing/app/__tests__/hero-variant.test.ts:19` asserted the dual-line difference. Updated assertion: variant differs on h1 only; subtitle is shared. New assertion locks the H1 to corpus text verbatim so future drift is caught on the unit-test gate, not the marketing-voice gate.

Closes corpus §7 row 1 line 93 residual + row 4 SHIPPED.

**2. `/philosophy` draft for owner placement ruling.**

New standalone route rendering the manifesto block locked verbatim to corpus §4.6 \"The manifesto block.\" Adds `PHILOSOPHY` content to `app/content/philosophy.ts` (mirrors home.ts content/route separation), routes `/philosophy` in `App.tsx`, follows existing `RoadmapPage`/`SponsorPage` layout pattern with `ButtonCVA asChild`.

Audit findings:
- Marketing app uses `@revealui/router` with `app/routes/*.tsx` pattern, NOT Next.js `(routes)/page.tsx` — lane plan was wrong about the syntax; standalone route file is the correct shape.
- No existing About surface — alternative \"add to About\" collapses to `/fair-source` section or blog post.
- Not adding to header nav — owner picks placement first.

## Owner placement decision (please pick one)

- [ ] **(a) Keep as standalone `/philosophy` route** (this draft). Stable URL, clean isolation.
- [ ] **(b) Fold into `/fair-source`** as a new section. Reduces page count; philosophy adjacent to licensing philosophy; mixes concerns slightly.
- [ ] **(c) Launch blog post under `/blog`.** Matches §4.6 \"or the launch post\" option but won't earn a stable URL.

Closes corpus §7 row 3 (DRAFT pending placement).

## Test plan

- [x] gate:quick → 20/20 PASS (Biome, claim-drift, marketing-voice, em-dash, brand-bridge, client-bundle-safety all green)
- [x] `hero-variant.test.ts` → 5/5 (incl. new \"matches the corpus §4.1 H1 lock verbatim\" assertion)
- [ ] Owner click-through on preview deploy: visit `?hero=foundation` to see the new H1 + canonical subtitle
- [ ] Owner click-through on preview deploy: visit `/philosophy` to read the manifesto rendering
- [ ] Owner picks placement (a/b/c above)

## Related

- internal docs companion PR (lane plan close + corpus body edits + outcome-pricing cross-references) opens separately at an internal repo.
- Lane plan archived at an internal repo:docs/lanes/_closed/corpus-finish/plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)