### PR TITLE
style(marketing): declutter What's-shipped grid — auto-fill cols + asymmetric gaps

### DIFF
--- a/apps/marketing/app/components/landing/WhatsShipped.tsx
+++ b/apps/marketing/app/components/landing/WhatsShipped.tsx
@@ -16,7 +16,7 @@ export function WhatsShipped() {
           </p>
         </div>
 
-        <div className="mx-auto mt-16 grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-16 grid grid-cols-[repeat(auto-fill,minmax(min(100%,18rem),1fr))] gap-x-8 gap-y-10">
           {CAPABILITIES.map((c) => (
             <a
               key={c.path}
@@ -28,7 +28,7 @@ export function WhatsShipped() {
               <h3 className="text-base font-semibold text-foreground group-hover:text-primary">
                 {c.title}
               </h3>
-              <p className="mt-2 flex-1 text-sm leading-6 text-muted-foreground">{c.body}</p>
+              <p className="mt-3 flex-1 text-sm leading-6 text-muted-foreground">{c.body}</p>
               <code className="mt-4 inline-block self-start rounded bg-card px-2 py-1 font-mono text-[11px] text-primary ring-1 ring-primary/20 group-hover:bg-primary/10">
                 {c.path}
               </code>


### PR DESCRIPTION
## What

Declutter the **What's-shipped** landing section (`WhatsShipped.tsx`). It read crowded — tight gutters, columns clipped narrower than the container, and cards packed at a flat 24px pitch. Layout-only; no copy or count change.

## Why

Audit (file:line) found three contributors to the crowding plus one structural fragility:

1. **Columns artificially narrowed** — the grid was `max-w-6xl` (1152px) inside a `max-w-7xl` (1280px) container, clipping ~64px each side → ~368px columns, ~320px after `p-6`, forcing 3–4 line wraps.
2. **Equal x/y gutters** — a single `gap-6` (24px) on both axes; rows of dense, ring-bordered cards need more vertical than horizontal separation.
3. **Tight internal rhythm** — title→body `mt-2` (8px).
4. **Count-fragile layout** — the fixed `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` ladder only looks balanced at multiples of the column count. 9 = a clean 3×3 *today*, but that balance is incidental.

## Changes (`apps/marketing/app/components/landing/WhatsShipped.tsx`)

- **Grid:** `max-w-6xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6` → `grid-cols-[repeat(auto-fill,minmax(min(100%,18rem),1fr))] gap-x-8 gap-y-10`, dropping the `max-w-6xl` clip so the grid fills the container.
  - Flows **1→2→3 columns by available width**, caps at 3 inside the container, and stacks gracefully at **any** entry count (the "works regardless of add/remove" requirement). `min(100%,18rem)` guards against overflow on very narrow viewports.
- **Card rhythm:** title→body `mt-2` → `mt-3`. Body `leading-6` left as-is (already loose).

At today's 9 cards the render stays a 3×3 — just roomier (wider columns, 32px column gutters + 40px row gaps, more air under titles). The auto-fill track is the future-proofing.

## auto-fill vs auto-fit (decision + the one tradeoff)

Chose **`auto-fill`** (keeps cards at their natural track width). The two diverge only when tracks-that-fit > items-in-the-last-row:

- **Desktop (3 col):** 9 = 3×3 → identical to auto-fit. **Mobile (1 col):** identical.
- **Tablet (2 col):** odd count → the orphan 9th card sits **left-aligned with empty space to its right** (auto-fit would instead stretch it full-width).

That tablet orphan is the only side effect. If it reads worse than the full-width stretch on preview, it's a **one-token flip** to `auto-fill` → `auto-fit`.

## Deliberately NOT changed

- **Count↔copy "Nine" lockstep.** `capabilities.ts:19` copy spells the count, and `content.test.ts:29-33` enforces it *by design* ("keep them in lockstep"). Decoupling the count from the copy is a **messaging decision** (conversion trust copy, marketing-voice gated), not part of a spacing fix — deferred to the owner.

## Verification

- `pnpm --filter marketing test` → **50/50 pass** (incl. the `content.test.ts` lockstep invariant).
- `pnpm --filter marketing typecheck` → clean.
- Biome → clean.

## Coordination

File-disjoint from the corpus-finish lane (which touched the home hero `home.ts` + a `/philosophy` page, not `WhatsShipped.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
