### PR TITLE
fix(marketing): top-align Fork cards — button no longer vertically centers

### DIFF
--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -39,7 +39,7 @@ export function Fork() {
           <button
             type="button"
             onClick={handleSelfBuildScroll}
-            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            className="group flex flex-col rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
           >
             <h3 className="text-lg font-semibold leading-7 text-foreground">
               {HOME_FORK.branchA.title}
@@ -52,7 +52,7 @@ export function Fork() {
 
           <a
             href={HOME_FORK.branchB.href}
-            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            className="group flex flex-col rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
           >
             <h3 className="text-lg font-semibold leading-7 text-foreground">
               {HOME_FORK.branchB.title}
@@ -65,7 +65,7 @@ export function Fork() {
 
           <a
             href={HOME_FORK.branchC.href}
-            className="group rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            className="group flex flex-col rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
           >
             <h3 className="text-lg font-semibold leading-7 text-foreground">
               {HOME_FORK.branchC.title}


### PR DESCRIPTION
## What

Fix vertical misalignment in the **"Three ways to use RevealUI"** section (`Fork.tsx`). The first card's title ("I'm building this myself.") rendered vertically centered while the other two card titles sat at the top.

## Root cause

- The first card (branchA) is a **`<button>`** (`:39`, it has a self-build scroll handler); the other two are **`<a>`** anchors (`:53`, `:66`).
- The grid stretches all three cards to equal height (`align-items: stretch`).
- A **`<button>` vertically centers its content** by browser UA default when taller than its content; block `<a>` cards top-align.
- branchA also has the **shortest body** ("Source, packages, the CLI, and docs. Read on."), so it gets the most stretch space — pushing its title to the vertical middle, out of line with the other two.

## Fix (`apps/marketing/app/components/landing/Fork.tsx`)

Add `flex flex-col` to the shared card class (identical across all three cards → one `replace_all`). A flex column lays children out from the top (`justify-content: flex-start`), which **overrides the button's UA centering**. Equal-height cards are preserved; the two anchors are visually unchanged; all three titles now top-align on the same line.

## Verification

- `pnpm --filter marketing test` → **50/50 pass**
- `pnpm --filter marketing typecheck` → clean
- Biome → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
