### PR TITLE
marketing: corpus copy reconcile + mobile table/snapshot fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 > via npm rather than via workspace links — same brand surface, decoupled
 > repo + deploy cadence.
 
-### OSS Packages (MIT) — 20
+### OSS Packages (MIT) — 21
 | Package | Purpose |
 |---------|---------|
 | @revealui/core | admin engine, REST API, auth, rich text, admin UI, plugins |
@@ -80,6 +80,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/test | E2E specs (Playwright), integration tests, fixtures, mocks, test utilities |
 | @revealui/openapi | Type-safe OpenAPI 3.x for Hono — route definitions, Zod validation, spec generation + Swagger UI |
 | @revealui/paywall | Runtime license enforcement, feature gating, and upgrade UI (Stripe + x402) |
+| @revealui/tokens | Design tokens — canonical CSS variables, typed TS export, brand canon (zero internal deps) |
 
 ### Pro Packages (Fair Source  -  FSL-1.1-MIT, converts to MIT after 2 years) — 5
 | Package | Purpose |

--- a/apps/marketing/app/components/ProductMockup.tsx
+++ b/apps/marketing/app/components/ProductMockup.tsx
@@ -130,7 +130,7 @@ export function ProductMockup() {
         </div>
 
         {/* Real screenshot */}
-        <div className="relative bg-gray-100" style={{ minHeight: '380px' }}>
+        <div className="relative min-h-[240px] bg-gray-100 sm:min-h-[320px] lg:min-h-[380px]">
           {/* biome-ignore lint/performance/noImgElement: Vite SPA, no Next image optimizer available */}
           <img
             src={SCREENSHOTS[activeTab]?.src ?? ''}
@@ -156,8 +156,9 @@ export function ProductMockup() {
           </div>
         </div>
 
-        {/* Code */}
-        <div className="flex-1 px-5 py-5 font-mono text-xs leading-6 overflow-hidden">
+        {/* Code — horizontal scroll within the panel on narrow screens so no
+            line is clipped (conventional for code, not a deceptive page-level scroll). */}
+        <div className="flex-1 overflow-x-auto px-5 py-5 font-mono text-xs leading-6">
           {codeLines.map((line, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: static display list, no reordering
             <div key={i} className="flex">

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -55,7 +55,7 @@ export function PricingTeaser() {
           </p>
         </div>
 
-        <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="mx-auto mt-16 grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {PRICING_TEASER_TIERS.map((t) => {
             const { price, period } = prices[t.id];
             return (

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -14,46 +14,75 @@ export function Problem() {
           <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
         </div>
 
-        <div className="mx-auto mt-16 max-w-6xl overflow-hidden rounded-2xl ring-1 ring-border shadow-sm">
-          <section
-            // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable comparison table — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally on narrow viewports
-            tabIndex={0}
-            aria-label={HOME_PROBLEM.tableAriaLabel}
-            className="overflow-x-auto"
-          >
-            <table className="w-full text-left text-sm">
-              <thead>
-                <tr className="bg-secondary text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                  <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                    {HOME_PROBLEM.columns.capability}
-                  </th>
-                  <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
+        {/* Mobile (<md): each capability becomes a card so the RevealUI column is
+            never hidden behind a horizontal scrollbar. No sidescroll. */}
+        <div className="mt-16 space-y-4 md:hidden">
+          <h3 className="sr-only">{HOME_PROBLEM.tableAriaLabel}</h3>
+          {HOME_PROBLEM.rows.map((r) => (
+            <div
+              key={r.capability}
+              className="overflow-hidden rounded-2xl bg-card ring-1 ring-border shadow-sm"
+            >
+              <p className="bg-secondary px-4 py-3 text-sm font-semibold text-foreground">
+                {r.capability}
+              </p>
+              <dl className="divide-y divide-border">
+                <div className="flex items-start justify-between gap-4 px-4 py-3">
+                  <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     {HOME_PROBLEM.columns.sprawl}
-                  </th>
-                  <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
+                  </dt>
+                  <dd className="text-right text-sm text-muted-foreground">{r.sprawl}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4 px-4 py-3">
+                  <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     {HOME_PROBLEM.columns.agentOnly}
-                  </th>
-                  <th scope="col" className="bg-primary/10 px-4 py-3 text-primary sm:px-6 sm:py-4">
+                  </dt>
+                  <dd className="text-right text-sm text-muted-foreground">{r.agentOnly}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4 bg-primary/5 px-4 py-3">
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-primary">
                     {HOME_PROBLEM.columns.revealui}
-                  </th>
+                  </dt>
+                  <dd className="text-right text-sm font-medium text-primary">{r.revealui}</dd>
+                </div>
+              </dl>
+            </div>
+          ))}
+        </div>
+
+        {/* Tablet/desktop (>=md): full comparison table. Four short columns fit
+            within the container at md+, so no horizontal scroll is needed. */}
+        <div className="mx-auto mt-16 hidden max-w-6xl overflow-hidden rounded-2xl ring-1 ring-border shadow-sm md:block">
+          <table className="w-full text-left text-sm" aria-label={HOME_PROBLEM.tableAriaLabel}>
+            <thead>
+              <tr className="bg-secondary text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
+                  {HOME_PROBLEM.columns.capability}
+                </th>
+                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
+                  {HOME_PROBLEM.columns.sprawl}
+                </th>
+                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
+                  {HOME_PROBLEM.columns.agentOnly}
+                </th>
+                <th scope="col" className="bg-primary/10 px-4 py-3 text-primary sm:px-6 sm:py-4">
+                  {HOME_PROBLEM.columns.revealui}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border bg-card">
+              {HOME_PROBLEM.rows.map((r) => (
+                <tr key={r.capability} className="hover:bg-secondary/60 transition">
+                  <td className="px-4 py-4 font-medium text-foreground sm:px-6">{r.capability}</td>
+                  <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.sprawl}</td>
+                  <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.agentOnly}</td>
+                  <td className="bg-primary/5 px-4 py-4 font-medium text-primary sm:px-6">
+                    {r.revealui}
+                  </td>
                 </tr>
-              </thead>
-              <tbody className="divide-y divide-border bg-card">
-                {HOME_PROBLEM.rows.map((r) => (
-                  <tr key={r.capability} className="hover:bg-secondary/60 transition">
-                    <td className="px-4 py-4 font-medium text-foreground sm:px-6">
-                      {r.capability}
-                    </td>
-                    <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.sprawl}</td>
-                    <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.agentOnly}</td>
-                    <td className="bg-primary/5 px-4 py-4 font-medium text-primary sm:px-6">
-                      {r.revealui}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </section>
+              ))}
+            </tbody>
+          </table>
         </div>
 
         <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">

--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -10,7 +10,9 @@ import { METRICS, SITE } from '../site';
 // rules the marketing-overhaul lane established. Metric VALUES are enforced
 // separately against the codebase by scripts/validate/claim-drift.ts.
 
-const FIVE_PRIMITIVES = ['People', 'Content', 'Offers', 'Payments', 'Agents'];
+// Canonical primitive contract (Joshua's methodology corpus): Users / Content /
+// Products / Payments / Intelligence. Body copy and footer reconcile to these.
+const FIVE_PRIMITIVES = ['Users', 'Content', 'Products', 'Payments', 'Intelligence'];
 
 describe('marketing content contracts', () => {
   describe('primitives', () => {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -3,9 +3,9 @@
 //   app/components/GetStarted.tsx (Phase 1c extraction).
 // Phase 3 (2026-05-18) update: Hero "What ships today" metrics now reference
 // METRICS from site.ts (single source per docs/MARKETING_METRICS.md §1).
-// FSL package detail rewritten: now states 20 MIT + 5 FSL + 1 internal = 26 total
-// (matches validator licenseSplit; original copy's "21 published + 5 private" math
-// counted 26 by including create-revealui in the 21 — drift caught Phase 3.4).
+// FSL package detail references METRICS: 21 MIT + 5 FSL + 1 internal = 27 total
+// (matches validator licenseSplit; counted against packages/ on 2026-06-17 —
+// @revealui/tokens addition took MIT 20→21 and total 26→27).
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
 
 import { METRICS, SITE } from './site';
@@ -21,7 +21,7 @@ export const HOME_HERO = {
   subtitle: {
     lead: 'Stop renting your stack from a half-dozen vendors.',
     strong:
-      'Auth, content, offers, and payments, pre-wired into one open-source runtime you self-host.',
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
     body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself with',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
@@ -48,7 +48,7 @@ export const HOME_HERO = {
       {
         metric: `${METRICS.dbTables} database tables`,
         detail:
-          'Every table maps to a primitive: people, content, offers, payments, or agents. See the [database reference](https://docs.revealui.com/database).',
+          'Every table maps to a primitive: users, content, products, payments, or intelligence. See the [database reference](https://docs.revealui.com/database).',
       },
       {
         metric: `${METRICS.mcpServers} first-party MCP servers`,
@@ -260,7 +260,7 @@ export const HOME_FAQ = {
     {
       question: 'How does AI inference work?',
       answer:
-        'Pair RevealUI with Ollama or Ubuntu Inference Snaps. Bring Gemma 3/4, DeepSeek R1, Qwen VL, or Nemotron locally, so your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
+        'Pair RevealUI with Ollama or Ubuntu Inference Snaps. Bring Gemma 4 or Phi-4-mini locally, so your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
     },
     {
       question: 'How do agent payments work?',

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -56,7 +56,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
 ] as const;
 
 export const FOOTER_TAGLINE =
-  'Agentic business runtime. Users, content, products, payments, and AI, pre-wired, open source, and ready to deploy.' as const;
+  'Agentic business runtime. Users, content, products, payments, and intelligence, pre-wired, open source, and ready to deploy.' as const;
 
 export const FOOTER_SOLO_OPERATOR_NOTE =
   'Built by one engineer in Tennessee. See Support for response SLAs.' as const;

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -35,7 +35,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'How does AI inference work?',
     answer:
-      'Bring your own model. The default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ollama or Ubuntu Inference Snaps from Canonical (canonical default, Studio lifecycle pending), so your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
+      'Bring your own model. The default ships open-weight (Gemma 4, Phi-4-mini) via Ollama or Ubuntu Inference Snaps from Canonical (canonical default, Studio lifecycle pending), so your bill does not scale with usage. Switch to Claude, GPT, or any provider in one config line. The runtime is provider-agnostic; the default is sovereignty-friendly.',
   },
   {
     question: 'What does "full source code access" mean?',
@@ -53,6 +53,6 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'What is RevFleet?',
     answer:
-      'RevFleet is the RevealUI Studio product family: seven products that compose around the RevealUI runtime. RevealUI is the agentic business runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness for multi-agent coordination across Claude, Cursor, and Copilot (Studio + Console MIT, Daemon Fair Source). RevCon syncs editor configs (MIT). RevSkills is the Claude Code skills library (MIT). RevForge is the operator-side stamping tool that produces white-label trial kits (operator-only). RevKit is the portable WSL dev environment toolkit (MIT). Use RevealUI standalone, or compose what you need.',
+      'RevFleet is the RevealUI Studio product family: eight products that compose around the RevealUI runtime. RevealUI is the agentic business runtime. RevVault encrypts secrets (CLI MIT, desktop Pro). RevDev is the engineering harness for multi-agent coordination across Claude, Cursor, and Copilot (Studio + Console MIT, Daemon Fair Source). RevCon syncs editor configs (MIT). RevSkills is the Claude Code skills library (MIT). RevForge is the operator-side stamping tool that produces white-label trial kits (operator-only). RevKit is the portable WSL dev environment toolkit (MIT). RevMarket is the agent tool marketplace (bundled with the runtime, on the way). Use RevealUI standalone, or compose what you need.',
   },
 ];

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -18,7 +18,7 @@ export interface TeaserTier {
 export const PRICING_TEASER_SECTION = {
   eyebrow: 'Pricing',
   heading: 'Start free. Pay when you scale.',
-  body: 'Self-host the open-source stack at no cost. Paid tiers (Pro, Enterprise) are previews. Subscription billing opens when we flip Stripe live mode.',
+  body: 'Self-host the open-source stack at no cost. Paid tiers (Pro, Max, Enterprise) are previews. Subscription billing opens when we flip Stripe live mode.',
 } as const;
 
 export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
@@ -52,15 +52,30 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     highlight: true,
   },
   {
+    id: 'max',
+    name: 'Max',
+    description: 'For teams that need AI memory, advanced inference, and compliance tooling.',
+    features: [
+      'Everything in Pro',
+      'Full AI memory (working + episodic + vector)',
+      'Audit logging + 50,000 agent tasks / month',
+      'Up to 15 sites and 100 users',
+    ],
+    cta: 'See Max pricing',
+    href: '/pricing',
+    highlight: false,
+  },
+  {
     id: 'enterprise',
     name: 'Enterprise',
     description:
-      'Audit logs, multi-tenant architecture, and a named contact. Custom plans for high volume; SSO and on-prem on the roadmap.',
+      'Full ecosystem access with scale, compliance, and agent payments. SSO/SAML and on-prem on the roadmap.',
     features: [
-      'Everything in Pro',
-      'Audit logs + compliance reports',
-      'Multi-tenant architecture',
-      'Roadmap: SSO, SCIM, on-prem deploy',
+      'Everything in Max',
+      'SSO/SAML authentication (coming soon)',
+      'x402 agent payments (USDC)',
+      'RevealUI Fleet white-label license',
+      'Unlimited sites, users, and agent tasks',
     ],
     cta: 'Talk to us',
     href: '/contact',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -1,6 +1,6 @@
 // Sourced from: app/routes/PricingPage.tsx (Phase 1 extraction).
 // Phase 3 (2026-05-18) update: agent-section MCP count now references
-// METRICS.mcpServers (canonical 13 per docs/MARKETING_METRICS.md §1).
+// METRICS.mcpServers (canonical 14 per docs/MARKETING_METRICS.md §1).
 // Canonical pricing numbers re-exported from @revealui/contracts/pricing for component convenience.
 
 export {
@@ -53,9 +53,10 @@ export const PRICING_TRACK_A_SECTION = {
 // (Vercel / Cloudflare / Fly / Hetzner — Railway dropped).
 export const PRICING_VALUE_BAND = {
   heading: 'You own the runtime.',
-  // Body wording is the approved value-context block from the go-live copy
-  // corpus (sourced range, time-sensitive: re-verify past mid-2026).
-  body: 'Teams shipping more than one product typically rent auth, content, billing, and observability from four or five vendors. On entry tiers that runs about $320 to $380 a month and climbs past $700 once enterprise SSO or compliance tiers enter. RevealUI replaces the rented stack with one runtime you own. You still pay for your own Postgres and compute.',
+  // Cost anchor reconciled to the homepage comparison table (HOME_PROBLEM,
+  // content/home.ts: ~$1,200/mo for a 5-dev mid-startup) so the two surfaces
+  // agree. Time-sensitive: re-verify past mid-2026.
+  body: 'Teams shipping more than one product typically rent auth, content, billing, and observability from four or five vendors. On a typical mid-startup invoice that runs about $1,200 a month for a five-developer team, and climbs further once enterprise SSO or compliance tiers enter. RevealUI replaces the rented stack with one runtime you own. You still pay for your own Postgres and compute.',
   points: [
     'One runtime, not five separate SaaS subscriptions',
     'Self-host on Vercel, Cloudflare, Fly, Hetzner, or your own metal',

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -4,8 +4,8 @@
 //   - ProductsPrimitive: full forYou/forAgents/together/features deep-dive (used by ProductsPage.tsx)
 //   Both are canonical here. Phase 4 reconciles any copy redundancy.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
-// Phase 3 (2026-05-18) update: Intelligence primitive MCP count 12→13 per
-// docs/MARKETING_METRICS.md §1. Now uses METRICS.mcpServers.
+// Intelligence primitive MCP count is sourced from METRICS.mcpServers
+// (currently 14, per docs/MARKETING_METRICS.md §1) — never hardcoded here.
 
 import { METRICS, SITE } from './site';
 
@@ -23,13 +23,13 @@ export interface HomePrimitive {
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login. One audit trail.',
   heading: "Everything a business needs. Nothing you don't.",
-  body: 'People, content, offers, payments, and agents: the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
+  body: 'Users, content, products, payments, and intelligence: the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 
 export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
   {
-    label: 'People',
+    label: 'Users',
     body: 'Auth, sessions, RBAC + ABAC. Same policy governs human and agent access.',
     color: 'emerald',
     iconPath:
@@ -43,7 +43,7 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
   },
   {
-    label: 'Offers',
+    label: 'Products',
     body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
     color: 'amber',
     iconPath:
@@ -57,7 +57,7 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
-    label: 'Agents',
+    label: 'Intelligence',
     body: 'Agents, MCP servers, CRDT memory. Bring-your-own-model; open-weight default.',
     color: 'violet',
     iconPath:
@@ -88,7 +88,7 @@ export interface ProductsPrimitive {
 
 export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
   {
-    name: 'People',
+    name: 'Users',
     icon: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
     color: 'text-blue-600',
     bgColor: 'bg-blue-500/10',
@@ -148,7 +148,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Offers',
+    name: 'Products',
     icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
     color: 'text-purple-600',
     bgColor: 'bg-purple-500/10',
@@ -206,7 +206,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Agents',
+    name: 'Intelligence',
     icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z',
     color: 'text-violet-600',
     bgColor: 'bg-violet-500/10',

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -106,7 +106,7 @@ export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
   version: 'v0.3.0',
   priceLabel: 'Free to self-host · Pro tier optional',
   tagline: 'The agentic business runtime',
-  body: 'People, content, offers, payments, and agents: pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
+  body: 'Users, content, products, payments, and intelligence: pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
   iconPath: 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5',
   facts: [
     { stat: String(METRICS.packages), label: 'packages' },

--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -79,7 +79,7 @@ const POST_METADATA: PostMeta[] = [
     slug: 'five-primitives',
     title: 'The Five Primitives of Business Software',
     excerpt:
-      'A deep technical walkthrough of People, Content, Offers, Payments, and Agents: the building blocks every software company needs.',
+      'A deep technical walkthrough of Users, Content, Products, Payments, and Intelligence: the building blocks every software company needs.',
     publishedAt: '2026-03-24T12:00:00.000Z',
     author: 'RevealUI Team',
     file: '05-five-primitives.md',

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -152,7 +152,8 @@ export function BlogPostPage() {
             Ready to build?
           </h2>
           <p className="mt-4 text-base leading-7 text-muted-foreground">
-            Users, content, products, payments, and intelligence, pre-wired. Start locally in minutes.
+            Users, content, products, payments, and intelligence, pre-wired. Start locally in
+            minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" variant="primary">

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -152,7 +152,7 @@ export function BlogPostPage() {
             Ready to build?
           </h2>
           <p className="mt-4 text-base leading-7 text-muted-foreground">
-            Users, content, products, payments, and AI, pre-wired. Start locally in minutes.
+            Users, content, products, payments, and intelligence, pre-wired. Start locally in minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" variant="primary">

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -11,17 +11,17 @@ I've started three software companies. Each time, I spent the first three to six
 
 That's not a skills problem. That's an infrastructure problem. And after the third time, I decided to solve it.
 
-RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
+RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence — the five primitives every product needs — pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
 
 ## The problem nobody talks about
 
 Every software company needs the same five things on day one:
 
-1. **People** — sign up, sign in, sessions, roles, permissions (RBAC + ABAC)
+1. **Users** — sign up, sign in, sessions, roles, permissions (RBAC + ABAC)
 2. **Content** — pages, posts, media, rich text, an API to serve it
-3. **Offers** — a catalog, pricing tiers, license keys
+3. **Products** — a catalog, pricing tiers, license keys
 4. **Payments** — checkout, subscriptions, invoices, a billing portal
-5. **Agents** — AI that actually knows your business context
+5. **Intelligence** — AI that actually knows your business context
 
 None of these are your product. All of them are required before your product can exist.
 
@@ -225,7 +225,7 @@ RevealUI is not an admin with plugins bolted on. It's not a boilerplate you clon
 
 When a user signs up, the auth system creates their session, assigns their default role, and checks their license tier. When they access content, the collection's `access.read` function can reference their tier, their role, or any custom claim. When they upgrade via Stripe, the webhook handler updates their license, which updates their feature flags, which unlocks gated content and capabilities — all in the same request cycle.
 
-This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. People, content, offers, payments, and features share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
+This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. Users, content, products, payments, and features share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
 
 Some numbers on what's actually shipped:
 
@@ -257,7 +257,7 @@ RevDev Studio (Tauri + React) is the native AI experience — agent coordination
 
 The near-term roadmap includes MCP server registry listings, A2A agent discovery for RevealUI-to-RevealUI communication, a broader template library, and a template marketplace where developers can publish project starters. The community lives on [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions), so join early and help shape what gets built next.
 
-But the core thesis won't change: **every software company needs people, content, offers, payments, and agents. You shouldn't have to build them from scratch.**
+But the core thesis won't change: **every software company needs users, content, products, payments, and intelligence. You shouldn't have to build them from scratch.**
 
 Build your business, not your boilerplate.
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -107,7 +107,7 @@ sudo snap install gemma3             # Or: ollama pull gemma4:e2b
 └── @revealui/mcp                    # MCP tool integrations
 ```
 
-The entire AI-powered business stack  -  people, content, offers, payments, agents  -  running without a cloud API call in sight.
+The entire AI-powered business stack  -  users, content, products, payments, intelligence  -  running without a cloud API call in sight.
 
 ## Who this is for
 

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -1,6 +1,6 @@
 ---
 title: "The Five Primitives of Business Software"
-description: "Every software company ships the same five things: a way to manage people, a way to manage content, a way to sell your offers, a way to collect payments, and increasingly, a way to ..."
+description: "Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell your products, a way to collect payments, and increasingly, an intelligence layer ..."
 visibility: public
 status: narrative
 audience: user
@@ -11,7 +11,7 @@ author: Joshua Vaughn
 
 ---
 
-Every software company ships the same five things: a way to manage people, a way to manage content, a way to sell your offers, a way to collect payments, and increasingly, a way to run agents. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
+Every software company ships the same five things: a way to manage users, a way to manage content, a way to sell your products, a way to collect payments, and increasingly, an intelligence layer to run AI. These are not features. They are primitives. And yet every engineering team builds them from scratch, bolting together auth libraries, content engines, payment wrappers, and AI SDKs, spending months on plumbing before writing a single line of differentiated code.
 
 RevealUI is the open runtime for businesses that run their own AI. Its thesis is simple: these five primitives should be pre-wired, open source, and ready to deploy. You bring your business logic. We bring the infrastructure.
 
@@ -19,7 +19,7 @@ This post is a deep technical walkthrough of all five. Not marketing copy. Real 
 
 ---
 
-## 1. People
+## 1. Users
 
 Authentication is the foundation. Get it wrong and nothing else matters. RevealUI's auth system is session-based, not JWT-based, and that is a deliberate choice.
 
@@ -129,9 +129,9 @@ export const hasAnyRole = (roles: string[]) => ({ req }) =>
 
 These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 59 enforcement tests proving role isolation.
 
-### How People connects to everything else
+### How Users connects to everything else
 
-The user ID is the foreign key for everything. Content has an `authorId`. Offers have licenses keyed to `customerId`. Payments are tied via `stripeCustomerId`. Agent tasks are metered per `userId`. One identity, five primitives.
+The user ID is the foreign key for everything. Content has an `authorId`. Products have licenses keyed to `customerId`. Payments are tied via `stripeCustomerId`. Agent tasks are metered per `userId`. One identity, five primitives.
 
 ---
 
@@ -199,13 +199,13 @@ Every route is defined using Hono's OpenAPI integration with Zod schemas. This m
 
 ### How Content connects to everything else
 
-Content is authored by People (the `authorId` foreign key). Premium content can be gated behind Offers (license tier checks). Content creation by AI agents feeds back through the Agents layer. Media uploads integrate with CDN delivery via the cache package.
+Content is authored by Users (the `authorId` foreign key). Premium content can be gated behind Products (license tier checks). Content creation by AI agents feeds back through the Intelligence layer. Media uploads integrate with CDN delivery via the cache package.
 
 ---
 
-## 3. Offers
+## 3. Products
 
-Offers are what turns your software from a project into a business. RevealUI's offers primitive covers the catalog, license generation, and runtime feature gating.
+Products are what turns your software from a project into a business. RevealUI's products primitive covers the catalog, license generation, and runtime feature gating.
 
 ### License keys: Ed25519-signed JWTs
 
@@ -301,9 +301,9 @@ Content-Type: application/json
 
 Verification checks both the JWT signature and the database. A structurally valid JWT can still be revoked in the database (chargeback, refund, manual revoke), so the verify endpoint checks both. The license cache TTL is 15 minutes, meaning a revoked license loses access within 15 minutes at most.
 
-### How Offers connects to everything else
+### How Products connects to everything else
 
-Offers are purchased by People. License keys are generated from the Payments webhook. Feature gates control access to Content (premium collections) and Agents (AI agent execution). The tier hierarchy flows through the entire stack.
+Products are purchased by Users. License keys are generated from the Payments webhook. Feature gates control access to Content (premium collections) and Intelligence (AI agent execution). The tier hierarchy flows through the entire stack.
 
 ---
 
@@ -382,13 +382,13 @@ RevealUI implements the x402 payment protocol for machine-to-machine payments �
 
 ### How Payments connects to everything else
 
-Payments are initiated by People (checkout requires a session). Successful payments generate Offers (license keys). Payment status controls feature access across Content and Agents. Webhook events update the `users` table (`stripeCustomerId`) and the licenses table (Offers). Chargebacks revoke licenses instantly.
+Payments are initiated by Users (checkout requires a session). Successful payments generate Products (license keys). Payment status controls feature access across Content and Intelligence. Webhook events update the `users` table (`stripeCustomerId`) and the licenses table (Products). Chargebacks revoke licenses instantly.
 
 ---
 
-## 5. Agents (AI) -- Pro Tier
+## 5. Intelligence (AI) -- Pro Tier
 
-The fifth primitive is Agents. Not a chatbot bolted onto a sidebar, but an agent orchestration system with memory, streaming, and inter-agent communication.
+The fifth primitive is Intelligence. Not a chatbot bolted onto a sidebar, but an agent orchestration system with memory, streaming, and inter-agent communication.
 
 ### Agent streaming
 
@@ -489,9 +489,9 @@ AI is not free. RevealUI tracks task usage per billing cycle:
 
 Usage beyond the quota is tracked in the `agent_task_usage` table. Reporting that overage to Stripe Billing Meters is in development — during early access, usage is recorded but not billed, so execution is never blocked on a meter.
 
-### How Agents connects to everything else
+### How Intelligence connects to everything else
 
-AI agents authenticate through the People system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered through Offers (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
+AI agents authenticate through the Users system (session cookies or API keys). Agents create and modify Content (posts, pages, media). Agent execution is metered through Products (task quotas per tier). Overage billing feeds through Payments (Stripe Billing Meters). The A2A protocol enables agents to purchase services from other agents via x402, closing the loop.
 
 ---
 
@@ -502,15 +502,15 @@ Any one of these primitives can be built in a weekend with the right libraries. 
 The five primitives are not independent features. They are a directed graph:
 
 ```
-People --> Content (authorship)
-People --> Offers (licensing)
-People --> Payments (billing)
-People --> Agents (metering)
-Offers --> Content (feature gating)
-Offers --> Agents (feature gating)
-Payments --> Offers (license generation)
-Agents --> Content (AI authoring)
-Agents --> Payments (usage billing)
+Users --> Content (authorship)
+Users --> Products (licensing)
+Users --> Payments (billing)
+Users --> Intelligence (metering)
+Products --> Content (feature gating)
+Products --> Intelligence (feature gating)
+Payments --> Products (license generation)
+Intelligence --> Content (AI authoring)
+Intelligence --> Payments (usage billing)
 ```
 
 Every edge in that graph is a piece of integration code you do not have to write. Every node is a piece of infrastructure you do not have to maintain. And because RevealUI is open source (MIT for the core, source-available for Pro), you can read every line, fork every module, and extend every API.
@@ -519,4 +519,4 @@ Build your business, not your boilerplate.
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. The core — People, Content, Offers, and Payments — is MIT licensed and free forever. Agents (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. The core — Users, Content, Products, and Payments — is MIT licensed and free forever. Intelligence (AI agents, memory, the MCP framework) is Fair Source (FSL-1.1-MIT), available with a Pro license. Learn more at [revealui.com](https://revealui.com).*

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -25,7 +25,7 @@ This wasn't a naive decision. I'm aware of the arguments for more restrictive li
 
 I understand that risk. I accept it. Here's why.
 
-RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- People, Content, Offers, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
+RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
 The MCP framework is the one piece worth naming carefully: `@revealui/mcp` — the hypervisor, the 14 first-party servers, and the adapter base class — is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
@@ -37,7 +37,7 @@ What MIT means practically: you can take RevealUI, strip the branding, deploy it
 
 If everything important is MIT, what's left to sell?
 
-Agents.
+Intelligence.
 
 RevealUI Pro includes:
 
@@ -91,7 +91,7 @@ A few things worth noting about this table.
 
 **The free tier is genuinely useful.** Unlimited admin collections, session-based auth, basic real-time sync, local AI inference (Inference Snaps / Ollama), and full source code access. You can build and run a real product on the free tier. I don't want "free" to mean "demo."
 
-**All four business primitives work on free.** People, Content, Offers, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
+**All four business primitives work on free.** Users, Content, Products, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
 
 **Pro will have a 7-day trial with no credit card required (coming soon).** The signup flow won't ask for payment information. You try it, you decide, you pay if it's worth it. If the product can't convince you in seven days, a payment wall on day one wasn't going to help.
 
@@ -177,7 +177,7 @@ I don't know if this model will work. MIT open source with a commercial AI tier 
 
 What I do know is that the alternative -- restrictive licensing, crippled free tiers, dark patterns in the upgrade flow -- might generate more short-term revenue but would make me build a product I don't want to use.
 
-RevealUI is the business stack I wanted when I started building software companies. People, content, offers, payments, and agents -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
+RevealUI is the business stack I wanted when I started building software companies. Users, content, products, payments, and intelligence -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
 
 The code is on [GitHub](https://github.com/RevealUIStudio/revealui). The license is MIT. The Pro features will have a free trial (coming soon). Everything I've described in this post is verifiable.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -15,7 +15,7 @@ author: Joshua Vaughn
 
 ---
 
-I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get people, content, offers, payments, and agents pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
+I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get users, content, products, payments, and intelligence pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
 
 But somewhere around the third month of building, I realized something that changed the architecture fundamentally: **the next wave of customers for software platforms are not human.**
 
@@ -306,6 +306,6 @@ The user interface for the future has yet to reveal itself. But we know one thin
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
 
 *Follow the project on [GitHub](https://github.com/RevealUIStudio/revealui).*

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 
-RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get people, content, offers, payments, and agents pre-wired and ready to deploy.
+RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get users, content, products, payments, and intelligence pre-wired and ready to deploy.
 
 This tutorial walks you through creating a real business application from scratch. By the end, you will have a working admin with typed collections, session-based authentication, a REST API with Swagger documentation, Stripe billing, license enforcement, and an admin dashboard  -  deployed to production on Vercel.
 
@@ -600,7 +600,7 @@ Stop the clock. With accounts pre-provisioned (NeonDB, Stripe, Vercel) and copy-
 - **An admin dashboard**  -  manage content, users, licenses, and settings from a single interface
 - **Deployed to production on Vercel**  -  global edge network, automatic SSL, zero-config scaling
 
-This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  people, content, offers, payments, and agents  -  is pre-wired and ready.
+This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  users, content, products, payments, and intelligence  -  is pre-wired and ready.
 
 ---
 
@@ -632,4 +632,4 @@ The pattern scales. Add products, orders, tickets, knowledge bases  -  each coll
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*


### PR DESCRIPTION
Marketing site-copy + mobile pass (5 commits, base 72e065a9).

## Copy
- Reconcile primitives to the corpus (Users/Content/Products/Payments/Intelligence) across the site and 6 blog posts; "agents" kept as an actor term only. `content.test.ts` contract updated.
- Pricing teaser: add the missing **Max** tier (was free/pro/enterprise, with Enterprise showing Max's feature set); now four tiers, correct Enterprise features, grid `sm:2 / lg:4`.
- Align AI model copy to Gemma 4 / Phi-4-mini; product count 7 → 8 (+RevMarket); vendor-sprawl cost reconciled to ~$1,200/mo across homepage + /pricing.
- Settle package map at 27 (21 MIT + 5 FSL + 1 internal); add `@revealui/tokens` to CLAUDE.md; MCP comment → 14.

## Mobile
- Vendor-sprawl comparison table card-stacks below `md` (removes deceptive overflow-x sidescroll that hid the RevealUI column); table at `md+`.
- ProductMockup admin + config.ts panel: code panel `overflow-x-auto` (no clipped lines), responsive screenshot heights.

## Nav
Verified correct against the real Tailwind v4 `lg` breakpoint (no `@config` → defaults apply); no change needed.

## Notes
- CI gate runs on this PR. Pricing here is **copy only** — source of truth (`packages/contracts/src/pricing.ts`, `apps/marketing/app/lib/pricing-fallbacks.ts`) untouched. Copy assumes $0/$49/$299/$1,499; keep in sync with live Stripe.
- Deferred (left as-is): `apps/marketing/app/content/primitives.ts:217` claims open models are "Apache 2.0" (Gemma = Gemma license, Phi-4 = MIT).
