### PR TITLE
ci: raise Typecheck job timeout 15m → 25m for cold-install fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,14 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25m (not 15m): when the pnpm-store cache restore transiently misses
+    # (observed 2026-06-17 — Quality hit the cache warm in the same run while
+    # this job reported `reused 0`), the job falls back to a cold install of
+    # ~1.3k packages. On a degraded npm registry (large binaries sharp /
+    # rolldown / vercel-sdk seen at 18-30 KiB/s) that cold install alone can
+    # exceed 15m and cancel the job before typecheck runs. The headroom absorbs
+    # that fallback window; siblings already run 20-30m.
+    timeout-minutes: 25
     needs: quality
 
     steps:


### PR DESCRIPTION
## What

Raise the **Typecheck** job's `timeout-minutes` from **15 → 25** in `.github/workflows/ci.yml`.

## Why

PR #1515 (a 3-line `className` change) failed CI twice in a row — **both times the `Install dependencies` step hit the 15m cap and the job was canceled before typecheck ever ran** (the `Typecheck affected packages` step shows `-` / skipped). The actual typecheck work is fast: a third manual re-run later **passed in 46s** once the cache restored warm.

Root cause is the **cold-install fallback**, not a type error:
- In #1515's first run, **Quality hit the pnpm-store cache warm (42s)** while **Typecheck reported `reused 0`** in the *same* workflow with the *same* lockfile hash → its cache restore **transiently missed**.
- That forced a cold install of ~1.3k packages while the npm registry was degraded — the log shows large binaries (`sharp-libvips`, `@rolldown/binding`, `@vercel/sdk`) downloading at **18–30 KiB/s**.
- A cold install at that speed alone exceeds 15m.

15m was the **tightest** of the install+work jobs and left zero headroom for a cache-restore miss. Sibling jobs already run 20–30m.

## Change

```yaml
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25m (not 15m): cold-install fallback when the pnpm-store cache restore
+    # transiently misses, on a degraded registry. See commit body.
+    timeout-minutes: 25
     needs: quality
```

Comment in-file documents the incident + rationale.

## Scope / follow-up

Targeted to the job that actually flaked. Other install+work jobs still at 10–15m share the same cold-install risk in a bad registry window — a broader bump (or a dedicated cache-warming prep job that the rest `needs:`) is a possible follow-up if it recurs elsewhere. Not bundled here.

## Verification

This PR's own CI run exercises the new value (workflow changes apply to the PR head for `pull_request` events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
