### PR TITLE
fix(marketing): make Primitives accent icons dark-mode-aware

### DIFF
--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -1,12 +1,20 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 
+// Accent chips must be surface-relative so they adapt under the token-based
+// theme (dark-first; light via system pref OR a manual [data-theme] override).
+// Translucent bg/ring tint whatever the adaptive card surface is in either
+// mode — mirroring the emerald row's bg-primary/10 + text-primary + ring-
+// primary/20. We deliberately do NOT use Tailwind `dark:` variants: those are
+// media-based and would desync from a manual [data-theme] toggle. emerald rides
+// the adaptive brand token; the other four keep their distinct accent hues at
+// /10–/20 opacity with a mid-tone icon that reads in both modes.
 const accentBg: Record<string, string> = {
   emerald: 'bg-primary/10 text-primary ring-primary/20',
-  blue: 'bg-blue-50 text-blue-700 ring-blue-200',
-  amber: 'bg-amber-50 text-amber-700 ring-amber-200',
-  cyan: 'bg-cyan-50 text-cyan-700 ring-cyan-200',
-  violet: 'bg-violet-50 text-violet-700 ring-violet-200',
+  blue: 'bg-blue-500/10 text-blue-500 ring-blue-500/20',
+  amber: 'bg-amber-500/10 text-amber-500 ring-amber-500/20',
+  cyan: 'bg-cyan-500/10 text-cyan-500 ring-cyan-500/20',
+  violet: 'bg-violet-500/10 text-violet-500 ring-violet-500/20',
 };
 
 export function Primitives() {


### PR DESCRIPTION
## What

Fix dark/light-mode handling of the accent icons in the **"Everything a business needs. Nothing you don't."** section (`Primitives.tsx`). Only the first icon adapted to dark mode; the other four stayed light-mode colored.

## Root cause

`Primitives.tsx` maps each primitive's accent color through `accentBg`. The icon `<svg>` strokes via `currentColor`, so it inherits the chip's `text-*`:

- **emerald** (first card): `bg-primary/10 text-primary ring-primary/20` — `primary` is an adaptive CSS-variable token → flips with the theme ✅
- **blue / amber / cyan / violet**: `bg-blue-50 text-blue-700 ring-blue-200`, … — **static, single-value Tailwind swatches with no theme handling** → on the dark card surface they render as pale `*-50` chips with dark `*-700` icons ❌

## Fix (`accentBg`)

Make all four **surface-relative**, mirroring the working emerald row — translucent `/10` backgrounds + `/20` rings that tint whatever the adaptive card surface is in either mode, plus a mid-tone hue icon. Distinct accent hues preserved.

```js
emerald: 'bg-primary/10 text-primary ring-primary/20',      // unchanged
blue:    'bg-blue-500/10  text-blue-500  ring-blue-500/20',
amber:   'bg-amber-500/10 text-amber-500 ring-amber-500/20',
cyan:    'bg-cyan-500/10  text-cyan-500  ring-cyan-500/20',
violet:  'bg-violet-500/10 text-violet-500 ring-violet-500/20',
```

## Why not Tailwind `dark:` variants

The theme is **token-based and dark-first** (`@revealui/presentation/tokens.css`): light mode is reached via **system `@media (prefers-color-scheme: light)`** *and* a manual **`[data-theme="light"]`** override (highest priority). Tailwind's `dark:` is media-based, so it would **desync from the manual `[data-theme]` toggle**. Surface-relative opacity adapts correctly under both mechanisms.

## Note / possible follow-up

`blue/amber/cyan/violet` are intentionally un-tokenized "multi-hue accents" (`index.css` comment), so a single mid-tone `*-500` icon is a both-modes compromise rather than a per-mode-optimal value. If we ever want per-mode-tuned accents, the clean path is adaptive accent tokens in `tokens.css` (out of scope here).

## Verification

- `pnpm --filter marketing test` → **50/50 pass**
- `pnpm --filter marketing typecheck` → clean · Biome → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
