### PR TITLE
feat(marketing): in-hero audience toggle — technical / non-technical (toggle PR 1)

### DIFF
--- a/apps/marketing/app/components/landing/AudienceToggle.tsx
+++ b/apps/marketing/app/components/landing/AudienceToggle.tsx
@@ -1,0 +1,42 @@
+import { Link, useLocation } from '@revealui/router';
+import { type Audience, audienceHref } from '../../lib/audience';
+
+// Non-technical first: it is the broader audience and the eventual default.
+const OPTIONS: ReadonlyArray<{ value: Audience; label: string }> = [
+  { value: 'non-technical', label: 'Non-technical' },
+  { value: 'technical', label: 'Technical' },
+];
+
+/**
+ * Audience switch in the hero (it replaces the former eyebrow pill). Each option
+ * is a router Link to `/?for=…`, so switching is a real SSR navigation — the
+ * served corpus matches the URL with no client-only state and no flash. Rendered
+ * as a <nav> landmark: it is navigation between two views of the page.
+ */
+export function AudienceToggle({ current }: { current: Audience }) {
+  const { search } = useLocation();
+  return (
+    <nav
+      aria-label="Choose your view"
+      className="inline-flex items-center gap-1 rounded-full bg-secondary p-1 ring-1 ring-border"
+    >
+      {OPTIONS.map((option) => {
+        const active = option.value === current;
+        return (
+          <Link
+            key={option.value}
+            to={audienceHref(search, option.value)}
+            aria-current={active ? 'true' : undefined}
+            className={
+              active
+                ? 'rounded-full bg-primary px-4 py-1.5 text-sm font-semibold text-primary-foreground'
+                : 'rounded-full px-4 py-1.5 text-sm font-medium text-muted-foreground transition hover:text-foreground'
+            }
+          >
+            {option.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -1,7 +1,10 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { useLocation } from '@revealui/router';
+import { FOR_OPERATORS_HERO } from '../../content/for-operators';
 import { SITE } from '../../content/site';
+import { selectAudience } from '../../lib/audience';
 import { selectHomeHero } from '../../lib/hero-variant';
+import { AudienceToggle } from './AudienceToggle';
 
 const backgroundPrimitives = [
   {
@@ -49,8 +52,155 @@ const backgroundPrimitives = [
   },
 ];
 
+const ArrowIcon = () => (
+  <svg
+    className="h-4 w-4"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <title>Arrow</title>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+  </svg>
+);
+
+/** Technical hero — the canonical developer-facing pitch (CLI, GitHub, ships-today). */
+function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
+  return (
+    <>
+      <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+        {hero.h1}
+      </h1>
+
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+        <strong className="text-foreground">
+          {hero.subtitle.lead} {hero.subtitle.strong}
+        </strong>{' '}
+        {hero.subtitle.body}{' '}
+        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
+          {SITE.cli.create}
+        </code>{' '}
+        {hero.subtitle.cliSuffix}{' '}
+        <a
+          href={hero.subtitle.agencyHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary hover:underline"
+        >
+          {hero.subtitle.agencyLabel}
+        </a>{' '}
+        {hero.subtitle.agencySuffix}
+      </p>
+
+      <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <ButtonCVA asChild size="lg" className="w-full sm:w-auto gap-2">
+          <a href={hero.cta.primary.href}>
+            {hero.cta.primary.label}
+            <ArrowIcon />
+          </a>
+        </ButtonCVA>
+        <ButtonCVA asChild variant="outline" size="lg" className="w-full sm:w-auto gap-2">
+          <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <title>GitHub</title>
+              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+            </svg>
+            {hero.cta.secondary.label}
+          </a>
+        </ButtonCVA>
+      </div>
+
+      <p className="mt-6 text-sm text-muted-foreground">
+        {hero.agencyCta.prefix}{' '}
+        <a
+          href={hero.agencyCta.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary hover:underline"
+        >
+          {hero.agencyCta.label}
+        </a>
+      </p>
+
+      <div className="mt-10 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10">
+        <span className="select-none text-background/50">$</span>
+        <span className="text-emerald-400">npx</span>
+        <span className="text-background">create-revealui@latest</span>
+        <span className="text-blue-300">my-app</span>
+      </div>
+
+      <p className="mt-4 text-sm text-muted-foreground">{hero.cliCaption}</p>
+
+      <div className="mt-16 border-t border-border pt-10">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-6">
+          {hero.shipsToday.heading}
+        </h2>
+        <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
+          {hero.shipsToday.items.map((item) => (
+            <li key={item.metric} className="flex gap-3">
+              <svg
+                className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                aria-hidden="true"
+              >
+                <title>Check</title>
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div>
+                <p className="text-sm font-medium text-foreground">{item.metric}</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">{item.detail}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Non-technical hero — the operator-facing pitch. Reuses the /for-operators hero
+ * copy and deliberately omits the developer-only surfaces (CLI block, GitHub
+ * CTA, ships-today). The full non-technical body lands in PR 2.
+ */
+function NonTechnicalHero() {
+  const hero = FOR_OPERATORS_HERO;
+  return (
+    <>
+      <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+        {hero.h1Lines.map((line) => (
+          <span key={line} className="block">
+            {line}
+          </span>
+        ))}
+      </h1>
+
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+        {hero.subtitle}
+      </p>
+
+      <div className="mt-10 flex justify-center">
+        <ButtonCVA asChild size="lg" className="w-full sm:w-auto gap-2">
+          <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
+            {hero.primaryCta.label}
+            <ArrowIcon />
+          </a>
+        </ButtonCVA>
+      </div>
+    </>
+  );
+}
+
 export function Hero() {
   const { search } = useLocation();
+  const audience = selectAudience(search);
   const hero = selectHomeHero(search);
 
   return (
@@ -77,116 +227,12 @@ export function Hero() {
 
       <div className="relative mx-auto max-w-7xl">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle mr-2 animate-pulse" />
-            {hero.eyebrow}
-          </p>
-
-          <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-            {hero.h1}
-          </h1>
-
-          <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-            <strong className="text-foreground">
-              {hero.subtitle.lead} {hero.subtitle.strong}
-            </strong>{' '}
-            {hero.subtitle.body}{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-base text-foreground">
-              {SITE.cli.create}
-            </code>{' '}
-            {hero.subtitle.cliSuffix}{' '}
-            <a
-              href={hero.subtitle.agencyHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary hover:underline"
-            >
-              {hero.subtitle.agencyLabel}
-            </a>{' '}
-            {hero.subtitle.agencySuffix}
-          </p>
-
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <ButtonCVA asChild size="lg" className="w-full sm:w-auto gap-2">
-              <a href={hero.cta.primary.href}>
-                {hero.cta.primary.label}
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                >
-                  <title>Arrow</title>
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
-                  />
-                </svg>
-              </a>
-            </ButtonCVA>
-            <ButtonCVA asChild variant="outline" size="lg" className="w-full sm:w-auto gap-2">
-              <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
-                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <title>GitHub</title>
-                  <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-                </svg>
-                {hero.cta.secondary.label}
-              </a>
-            </ButtonCVA>
+          {/* Audience switch — replaces the former eyebrow pill. */}
+          <div className="mb-8 flex justify-center">
+            <AudienceToggle current={audience} />
           </div>
 
-          <p className="mt-6 text-sm text-muted-foreground">
-            {hero.agencyCta.prefix}{' '}
-            <a
-              href={hero.agencyCta.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary hover:underline"
-            >
-              {hero.agencyCta.label}
-            </a>
-          </p>
-
-          <div className="mt-10 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10">
-            <span className="select-none text-background/50">$</span>
-            <span className="text-emerald-400">npx</span>
-            <span className="text-background">create-revealui@latest</span>
-            <span className="text-blue-300">my-app</span>
-          </div>
-
-          <p className="mt-4 text-sm text-muted-foreground">{hero.cliCaption}</p>
-
-          <div className="mt-16 border-t border-border pt-10">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-6">
-              {hero.shipsToday.heading}
-            </h2>
-            <ul className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-3 list-none">
-              {hero.shipsToday.items.map((item) => (
-                <li key={item.metric} className="flex gap-3">
-                  <svg
-                    className="mt-0.5 h-4 w-4 shrink-0 text-primary"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                    aria-hidden="true"
-                  >
-                    <title>Check</title>
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  <div>
-                    <p className="text-sm font-medium text-foreground">{item.metric}</p>
-                    <p className="mt-0.5 text-sm text-muted-foreground">{item.detail}</p>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {audience === 'technical' ? <TechnicalHero hero={hero} /> : <NonTechnicalHero />}
         </div>
       </div>
     </section>

--- a/apps/marketing/app/lib/audience.test.ts
+++ b/apps/marketing/app/lib/audience.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { type Audience, audienceHref, DEFAULT_AUDIENCE, selectAudience } from './audience';
+
+const OTHER: Audience = DEFAULT_AUDIENCE === 'technical' ? 'non-technical' : 'technical';
+
+describe('selectAudience', () => {
+  it('falls back to the default for missing or unknown params', () => {
+    expect(selectAudience('')).toBe(DEFAULT_AUDIENCE);
+    expect(selectAudience('?for=bogus')).toBe(DEFAULT_AUDIENCE);
+    expect(selectAudience('?hero=foundation')).toBe(DEFAULT_AUDIENCE);
+  });
+
+  it('reads explicit audiences', () => {
+    expect(selectAudience('?for=technical')).toBe('technical');
+    expect(selectAudience('?for=non-technical')).toBe('non-technical');
+  });
+});
+
+describe('audienceHref', () => {
+  it('omits the param for the default audience (canonical URL)', () => {
+    expect(audienceHref('', DEFAULT_AUDIENCE)).toBe('/');
+  });
+
+  it('sets the param for the non-default audience', () => {
+    expect(audienceHref('', OTHER)).toBe(`/?for=${OTHER}`);
+  });
+
+  it('preserves other query params', () => {
+    const href = audienceHref('?hero=foundation', OTHER);
+    expect(href).toContain('hero=foundation');
+    expect(href).toContain(`for=${OTHER}`);
+  });
+});

--- a/apps/marketing/app/lib/audience.ts
+++ b/apps/marketing/app/lib/audience.ts
@@ -1,0 +1,39 @@
+/**
+ * Landing-page audience selector. Reads `?for=technical|non-technical` from the
+ * URL search string, so the choice is SSR-rendered per request (no flash),
+ * shareable, and SEO-clean. Mirrors selectHomeHero() in hero-variant.ts — the
+ * same URL-param seam, generalized from "hero A/B" to "audience corpus".
+ *
+ * DEFAULT_AUDIENCE is the single place the default lives. It is 'technical'
+ * during PR 1 (hero toggle only): the page body is still technical-only, so a
+ * non-technical default would render a non-technical hero on a technical body.
+ * It flips to 'non-technical' in PR 2, when the non-technical body lands — the
+ * canonical-URL logic in audienceHref() inverts automatically off this constant.
+ */
+
+export type Audience = 'technical' | 'non-technical';
+
+export const AUDIENCE_PARAM = 'for';
+
+export const DEFAULT_AUDIENCE: Audience = 'technical';
+
+export function selectAudience(search: string): Audience {
+  const value = new URLSearchParams(search).get(AUDIENCE_PARAM);
+  return value === 'technical' || value === 'non-technical' ? value : DEFAULT_AUDIENCE;
+}
+
+/**
+ * Href for a given audience, preserving any other query params. The default
+ * audience gets the bare canonical URL (param omitted); the non-default audience
+ * carries `?for=…`. Inverts automatically when DEFAULT_AUDIENCE flips.
+ */
+export function audienceHref(search: string, audience: Audience): string {
+  const params = new URLSearchParams(search);
+  if (audience === DEFAULT_AUDIENCE) {
+    params.delete(AUDIENCE_PARAM);
+  } else {
+    params.set(AUDIENCE_PARAM, audience);
+  }
+  const qs = params.toString();
+  return qs ? `/?${qs}` : '/';
+}


### PR DESCRIPTION
## What

**PR 1 of the landing-page audience toggle.** Introduces an in-hero **Technical / Non-technical** switch (replacing the eyebrow "pill"), on the URL-param mechanism the rest of the toggle will build on. Hero-only scope.

This is the first slice of replacing the buried `/for-operators` nav link (and the "operators" jargon) with an obvious, first-class in-hero toggle that anyone reading English understands.

## Changes

- **`lib/audience.ts`** — `selectAudience(search)` reads `?for=technical|non-technical`; URL-param driven so the choice is **SSR-rendered per request** (no flash), shareable, SEO-clean. Mirrors the existing `selectHomeHero()` seam. `DEFAULT_AUDIENCE` centralizes the default in one place; `audienceHref()` preserves other params and keeps the default audience on the bare canonical URL.
- **`AudienceToggle.tsx`** — a `<nav>` of two router `Link`s; replaces the former eyebrow pill. Switching is a real SSR navigation, not client-only state.
- **`Hero.tsx`** — branches **TechnicalHero** (canonical dev pitch: CLI block, GitHub CTA, ships-today) vs **NonTechnicalHero** (reuses the `/for-operators` hero copy; omits the developer-only surfaces). The toggle sits above both.
- **`audience.test.ts`** — covers `selectAudience` + `audienceHref`, written default-agnostic (via `DEFAULT_AUDIENCE`) so the suite stays correct when the default flips in PR 2.

## Deliberate sequencing

**Default stays `technical` in this PR.** A non-technical default today would render the non-technical hero on a still-technical page body. The default flips to `non-technical` in **PR 2**, together with the full non-technical body — `DEFAULT_AUDIENCE` makes that a one-line change and `audienceHref` inverts off it automatically.

## Not in this PR (per the plan)

- PR 2: full-page corpus swap (non-technical body folded in) + default flip + Fork reconciliation (technical keeps branches A+C, drops B; non-technical has no Fork).
- PR 3: retire `/for-operators` route + nav label + redirect.
- PR 4: SEO (canonical/sitemap/OG per mode) + analytics seam.

## Verification

- `pnpm --filter marketing test` → **55/55 pass** (5 new) · typecheck clean · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
