### PR TITLE
feat(marketing): non-technical landing is the default (toggle PR 2)

### DIFF
--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -1,16 +1,9 @@
-// Homepage audience fork — Phase 2 of the non-technical-lane spec.
-// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §4.3.
-// Decisions: §9.4 OQ-5 — Branch A stays on / (scroll-past); not a route change.
-//
-// Implementation note (Phase 2): placed AFTER <Hero /> in HomePage.tsx as a
-// separate component rather than INSIDE the existing Hero. This avoids
-// merge-conflict with peer PR #1141 which is editing HOME_HERO copy. The
-// spec's §4.3 ideal placement is "above the first scroll boundary" inside
-// the hero viewport; this implementation puts the fork as the next-band
-// after Hero, which is visible after a small scroll on most viewports.
-// Trade-off: marginally lower first-paint visibility for the fork in
-// exchange for zero collision with in-flight peer work. Revisit after #1141
-// lands if a stricter hero-internal placement is desired.
+// Homepage audience fork — the two technical-mode paths.
+// Branch B ("I want it built for me") was removed when the audience toggle
+// landed: "built for me" is now the non-technical mode itself (the in-hero
+// Technical/Non-technical switch), so this fork only carries the two technical
+// paths — build it yourself (A) and build it for your clients (C).
+// Original spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §4.3.
 
 import { HOME_FORK } from '../../content/home';
 
@@ -33,9 +26,9 @@ export function Fork() {
     <section id="homepage-fork" aria-label="Choose your path" className="bg-muted py-12 sm:py-16">
       <div className="mx-auto max-w-5xl px-6 lg:px-8">
         <p className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-6">
-          Three ways to use RevealUI
+          Two ways to build on RevealUI
         </p>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <button
             type="button"
             onClick={handleSelfBuildScroll}
@@ -49,19 +42,6 @@ export function Fork() {
               {HOME_FORK.branchA.cta}
             </p>
           </button>
-
-          <a
-            href={HOME_FORK.branchB.href}
-            className="group flex flex-col rounded-2xl border border-border bg-card p-6 text-left shadow-sm transition hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-          >
-            <h3 className="text-lg font-semibold leading-7 text-foreground">
-              {HOME_FORK.branchB.title}
-            </h3>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_FORK.branchB.body}</p>
-            <p className="mt-4 text-sm font-medium text-primary group-hover:underline underline-offset-4">
-              {HOME_FORK.branchB.cta}
-            </p>
-          </a>
 
           <a
             href={HOME_FORK.branchC.href}

--- a/apps/marketing/app/lib/audience.ts
+++ b/apps/marketing/app/lib/audience.ts
@@ -4,18 +4,18 @@
  * shareable, and SEO-clean. Mirrors selectHomeHero() in hero-variant.ts — the
  * same URL-param seam, generalized from "hero A/B" to "audience corpus".
  *
- * DEFAULT_AUDIENCE is the single place the default lives. It is 'technical'
- * during PR 1 (hero toggle only): the page body is still technical-only, so a
- * non-technical default would render a non-technical hero on a technical body.
- * It flips to 'non-technical' in PR 2, when the non-technical body lands — the
- * canonical-URL logic in audienceHref() inverts automatically off this constant.
+ * DEFAULT_AUDIENCE is the single place the default lives. It is 'non-technical':
+ * the broadest top-of-funnel audience, plain language, no terminal command in
+ * the first viewport. The bare canonical URL (`/`) serves non-technical;
+ * `/?for=technical` serves the developer corpus. audienceHref()'s canonical-URL
+ * logic inverts automatically off this constant.
  */
 
 export type Audience = 'technical' | 'non-technical';
 
 export const AUDIENCE_PARAM = 'for';
 
-export const DEFAULT_AUDIENCE: Audience = 'technical';
+export const DEFAULT_AUDIENCE: Audience = 'non-technical';
 
 export function selectAudience(search: string): Audience {
   const value = new URLSearchParams(search).get(AUDIENCE_PARAM);

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -1,4 +1,12 @@
+import { useLocation } from '@revealui/router';
 import { Footer } from '../components/Footer';
+import { ClosingCta } from '../components/for-operators/ClosingCta';
+import { DiscoveryScopeShip } from '../components/for-operators/DiscoveryScopeShip';
+import { EngagementPricing } from '../components/for-operators/EngagementPricing';
+import { Faq as OperatorFaq } from '../components/for-operators/Faq';
+import { HowWeDeliver } from '../components/for-operators/HowWeDeliver';
+import { Proof as OperatorProof } from '../components/for-operators/Proof';
+import { WhatYouGet } from '../components/for-operators/WhatYouGet';
 import { GetStarted } from '../components/GetStarted';
 import { Actors } from '../components/landing/Actors';
 import { Demo } from '../components/landing/Demo';
@@ -12,10 +20,12 @@ import { Primitives } from '../components/landing/Primitives';
 import { Problem } from '../components/landing/Problem';
 import { Proof } from '../components/landing/Proof';
 import { WhatsShipped } from '../components/landing/WhatsShipped';
+import { selectAudience } from '../lib/audience';
 
-export function HomePage() {
+/** Developer-facing landing — `/?for=technical`. */
+function TechnicalLanding() {
   return (
-    <div className="min-h-screen bg-background">
+    <>
       <Hero />
       <Actors />
       <Fork />
@@ -30,6 +40,39 @@ export function HomePage() {
       <Faq />
       <GetStarted />
       <Footer />
+    </>
+  );
+}
+
+/**
+ * Non-technical (operator) landing — the default `/`. Composes the existing
+ * `for-operators/*` section components inline. The shared <Hero/> self-selects
+ * the non-technical hero from the audience param, so it is not duplicated here.
+ * (The standalone /for-operators route still renders these too; it is retired
+ * and redirected here in PR 3.)
+ */
+function NonTechnicalLanding() {
+  return (
+    <>
+      <Hero />
+      <WhatYouGet />
+      <HowWeDeliver />
+      <EngagementPricing />
+      <DiscoveryScopeShip />
+      <OperatorProof />
+      <OperatorFaq />
+      <ClosingCta />
+      <Footer />
+    </>
+  );
+}
+
+export function HomePage() {
+  const { search } = useLocation();
+  const audience = selectAudience(search);
+  return (
+    <div className="min-h-screen bg-background">
+      {audience === 'non-technical' ? <NonTechnicalLanding /> : <TechnicalLanding />}
     </div>
   );
 }


### PR DESCRIPTION
## What

**PR 2 of the audience toggle** — the full-page corpus swap + default flip + Fork reconciliation. After this, the default homepage `/` *is* the non-technical (operator) landing, and `/?for=technical` is the developer landing.

## Changes

- **`lib/audience.ts`** — `DEFAULT_AUDIENCE` flipped `technical` → **`non-technical`**. Bare `/` now serves the operator corpus; `/?for=technical` serves the developer corpus. `audienceHref`'s canonical-URL logic inverts off the constant automatically (no other change needed).
- **`routes/HomePage.tsx`** — split into **TechnicalLanding** / **NonTechnicalLanding**, gated by `selectAudience(search)`. NonTechnicalLanding composes the existing `for-operators/*` section components inline (WhatYouGet, HowWeDeliver, EngagementPricing, DiscoveryScopeShip, Proof, Faq, ClosingCta). The shared `<Hero/>` self-selects the non-technical hero, so it isn't duplicated.
- **`components/landing/Fork.tsx`** — dropped **branch B** ("I want it built for me" — that's now the in-hero toggle). The fork carries only the two technical paths (build it yourself / build for your clients): 2-col grid, heading "Two ways to build on RevealUI". The #1515 `flex flex-col` vertical-align fix is preserved.

## Behavior after this PR
- `/` → non-technical operator landing (hero + WhatYouGet + HowWeDeliver + pricing + discovery + proof + faq + closing CTA).
- `/?for=technical` → the full developer landing (hero + actors + 2-way fork + problem + demo + objections + primitives + what's-shipped + persona + proof + pricing + faq + get-started).
- The in-hero toggle switches between them (real SSR navigation).

## Not in this PR
- **PR 3:** retire `/for-operators` route + nav label, 301-redirect `/for-operators` → `/?for=non-technical`. (The route stays live + duplicative until then — intentional, low-risk.)
- **PR 4:** SEO canonical/sitemap/OG per mode + analytics seam.

## Verification
- `pnpm --filter marketing test` → **55/55 pass** · typecheck clean · biome clean.
- `routes.test.ts` only asserts route *registration*, so the default flip is safe there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
