### PR TITLE
feat(marketing): card-row centering + trust section reframe

### DIFF
--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -16,9 +16,14 @@ export function WhatYouGet() {
           </p>
         </div>
 
-        <ul className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0">
+        {/* flex-wrap + justify-center so a partial last row (e.g. 3 + 2) is
+            centered, not start-aligned. Card widths give 1 / 2 / 3 per row. */}
+        <ul className="mx-auto mt-16 flex max-w-5xl flex-wrap justify-center gap-6 list-none p-0">
           {FOR_OPERATORS_WHAT_YOU_GET.cards.map((card) => (
-            <li key={card.title} className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+            <li
+              key={card.title}
+              className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
+            >
               <h3 className="text-lg font-semibold leading-7 text-foreground">{card.title}</h3>
               <p className="mt-3 text-base leading-7 text-muted-foreground">{card.body}</p>
             </li>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -149,98 +149,23 @@ export function Proof() {
           </div>
 
           <div className="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-3">
-            <div className="rounded-2xl bg-primary/10 p-6 ring-1 ring-primary/20">
-              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
-                {PROOF_TRUST.cards[0].eyebrow}
-              </p>
-              <h4 className="mt-3 text-base font-semibold text-foreground">
-                {PROOF_TRUST.cards[0].heading}
-              </h4>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                {PROOF_TRUST.cards[0].body.prefix}{' '}
-                <a
-                  href={PROOF_TRUST.cards[0].body.licenseHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
-                >
-                  {PROOF_TRUST.cards[0].body.licenseLabel}
-                </a>{' '}
-                {PROOF_TRUST.cards[0].body.middle}{' '}
-                <a
-                  href={PROOF_TRUST.cards[0].body.explainerHref}
-                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
-                >
-                  {PROOF_TRUST.cards[0].body.explainerLabel}
-                </a>
-                {PROOF_TRUST.cards[0].body.suffix}
-              </p>
-            </div>
-
-            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
-              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
-                {PROOF_TRUST.cards[1].eyebrow}
-              </p>
-              <h4 className="mt-3 text-base font-semibold text-foreground">
-                {PROOF_TRUST.cards[1].heading}
-              </h4>
-              <pre
-                // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable code region — axe-core scrollable-region-focusable requires tabIndex=0 so keyboard users can scroll horizontally
-                tabIndex={0}
-                className="mt-3 overflow-x-auto rounded-lg bg-secondary px-3 py-2 font-mono text-[11px] leading-5 text-muted-foreground ring-1 ring-border"
+            {PROOF_TRUST.cards.map((card) => (
+              <div
+                key={card.title}
+                className="flex flex-col rounded-2xl bg-card p-6 ring-1 ring-border"
               >
-                {PROOF_TRUST.cards[1].codeSnippet}
-              </pre>
-              <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                <h4 className="text-base font-semibold text-foreground">{card.title}</h4>
+                <p className="mt-3 flex-1 text-sm leading-6 text-muted-foreground">{card.body}</p>
                 <a
-                  href={PROOF_TRUST.cards[1].fileHref}
+                  href={card.linkHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+                  className="mt-4 inline-block self-start text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
-                  {PROOF_TRUST.cards[1].fileLabel}
-                </a>{' '}
-                {PROOF_TRUST.cards[1].caption}
-              </p>
-            </div>
-
-            <div className="rounded-2xl bg-primary/10 p-6 ring-1 ring-primary/20">
-              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
-                {PROOF_TRUST.cards[2].eyebrow}
-              </p>
-              <h4 className="mt-3 text-base font-semibold text-foreground">
-                {PROOF_TRUST.cards[2].heading}
-              </h4>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                {PROOF_TRUST.cards[2].body.prefix}{' '}
-                <a
-                  href={PROOF_TRUST.cards[2].body.agencyHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
-                >
-                  {PROOF_TRUST.cards[2].body.agencyLabel}
-                </a>{' '}
-                {PROOF_TRUST.cards[2].body.middle}{' '}
-                <code className="rounded bg-card px-1 py-0.5 font-mono text-xs text-foreground ring-1 ring-primary/20">
-                  {PROOF_TRUST.cards[2].body.pkg1}
-                </code>{' '}
-                {PROOF_TRUST.cards[2].body.plus}{' '}
-                <code className="rounded bg-card px-1 py-0.5 font-mono text-xs text-foreground ring-1 ring-primary/20">
-                  {PROOF_TRUST.cards[2].body.pkg2}
-                </code>
-                {PROOF_TRUST.cards[2].body.suffix}{' '}
-                <a
-                  href={PROOF_TRUST.cards[2].body.sourceHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
-                >
-                  {PROOF_TRUST.cards[2].body.sourceLabel}
+                  {card.linkLabel}
                 </a>
-                {PROOF_TRUST.cards[2].body.end}
-              </p>
-            </div>
+              </div>
+            ))}
           </div>
         </div>
 

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -3,7 +3,7 @@
 // uses METRICS license split (21 MIT). Pre-Phase-3 audit had off-by-one count.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
 
-import { METRICS, SITE } from './site';
+import { SITE } from './site';
 
 export interface StackItem {
   readonly label: string;
@@ -61,52 +61,36 @@ export const PROOF_PORTABILITY = {
   dataNote: 'Standard Postgres, export anytime.',
 } as const;
 
+export interface TrustCard {
+  readonly title: string;
+  readonly body: string;
+  readonly linkLabel: string;
+  readonly linkHref: string;
+}
+
 export const PROOF_TRUST = {
-  eyebrow: 'Trust',
-  heading: 'Verifiable in three places.',
+  eyebrow: 'Proof, not promises',
+  heading: "Don't take our word for it. Neither will your customers.",
   cards: [
     {
-      eyebrow: 'In the repo',
-      heading: `${METRICS.licenseSplit.mit} of ${METRICS.packages} packages MIT, forever.`,
-      body: {
-        prefix: `The ${METRICS.licenseSplit.fsl} Pro packages ship under Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. View the`,
-        licenseLabel: 'LICENSE',
-        licenseHref: SITE.urls.repoLicense,
-        middle: 'or the',
-        explainerLabel: 'Fair Source explainer',
-        explainerHref: '/fair-source',
-        suffix: '.',
-      },
+      title: 'Their security team can read every line.',
+      body: 'The whole runtime is open source, MIT or Fair Source, sitting in the repo. No closed binary to explain away when procurement comes asking.',
+      linkLabel: 'Read the LICENSE',
+      linkHref: SITE.urls.repoLicense,
     },
     {
-      eyebrow: 'In the schema',
-      heading: 'Every mutation signs into a hash chain.',
-      codeSnippet: `// HMAC-SHA256 signature for tamper detection
-signature:         text('signature'),
-// Signature of the prior entry — the chain link
-previousSignature: text('previous_signature'),`,
-      fileLabel: 'packages/db/src/schema/audit-log.ts',
-      fileHref: `${SITE.urls.repo}/blob/main/packages/db/src/schema/audit-log.ts`,
-      caption: '(tampering breaks the chain).',
+      title: 'Prove what happened, by anyone or anything.',
+      body: 'Every change, by a person or an agent, signs into a tamper-evident chain. Alter one record and the chain breaks. Nothing gets quietly rewritten.',
+      linkLabel: 'See the schema',
+      linkHref: `${SITE.urls.repo}/blob/main/packages/db/src/schema/audit-log.ts`,
     },
     {
-      eyebrow: 'In production',
-      heading: 'This site runs on RevealUI.',
-      body: {
-        prefix: 'The marketing site you are reading and the agency site at',
-        agencyLabel: 'revealuistudio.com',
-        agencyHref: SITE.urls.agency,
-        middle: 'both run on',
-        pkg1: '@revealui/router',
-        plus: '+',
-        pkg2: '@revealui/presentation',
-        suffix: '. View the',
-        sourceLabel: 'marketing app source',
-        sourceHref: `${SITE.urls.repo}/tree/main/apps/marketing`,
-        end: '.',
-      },
+      title: 'We bet our own business on it.',
+      body: 'This site and our agency site both run on RevealUI, and the code, data, and infrastructure are yours to keep. If it breaks for you, it breaks for us first, and you are never stranded with a vendor.',
+      linkLabel: 'Read the source',
+      linkHref: `${SITE.urls.repo}/tree/main/apps/marketing`,
     },
-  ],
+  ] as readonly TrustCard[],
   changelogCta: {
     label: 'See what shipped this month →',
     href: SITE.urls.repoChangelog,

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -155,13 +155,18 @@ export function PricingPage() {
             </ul>
           </div>
 
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            {tiers.map((tier) => (
+          {/* flex-wrap + justify-center: 3 per row, partial last row centered.
+              A lone last tier (count % 3 === 1, e.g. Enterprise) goes wider and
+              stays centered; a remainder of 2 centers at card width. */}
+          <div className="flex flex-wrap justify-center gap-6">
+            {tiers.map((tier, index) => (
               <div
                 key={tier.id}
-                className={`relative flex flex-col rounded-2xl bg-card p-8 shadow-lg ${
-                  tier.highlighted ? 'ring-2 ring-primary' : 'ring-1 ring-border'
-                }`}
+                className={`relative flex w-full flex-col rounded-2xl bg-card p-8 shadow-lg sm:w-[calc(50%-0.75rem)] ${
+                  index === tiers.length - 1 && tiers.length % 3 === 1
+                    ? 'lg:w-2/3'
+                    : 'lg:w-[calc(33.333%-1rem)]'
+                } ${tier.highlighted ? 'ring-2 ring-primary' : 'ring-1 ring-border'}`}
               >
                 {tier.highlighted && (
                   <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-primary px-3 py-1.5 text-center text-sm font-semibold text-primary-foreground shadow-lg">


### PR DESCRIPTION
## What

Second landing-polish PR (after #1522): reusable card-row centering + the trust-section reframe. Fixes one of the two horizontal-scroll bugs.

## Changes

- **Card-row centering** — a reusable flex-wrap + `justify-center` pattern so a partial last row centers instead of left-aligning:
  - **WhatYouGet** (operator landing): 5 cards → 3 on top, **2 centered** below.
  - **Pricing subscription tiers**: 3 on top; a lone last tier (`count % 3 === 1`, e.g. **Enterprise**) goes **wider (2/3) and centered**; a remainder of 2 centers at card width.
- **Trust section reframe** (`Proof`) — one promise: **"Don't take our word for it. Neither will your customers."** Three uniform cards, each pairing a business outcome (read every line / prove what happened / we bet our business on it) with a clickable proof. **Dropped the license metric and the raw code snippet** — the snippet was a horizontal-scroll source, so this **fixes scroll bug #1**. New uniform `PROOF_TRUST` shape + clean map render; removed the now-unused `METRICS` import.

## Scroll bug #2 (the table)
The Problem-section comparison table is **already mobile-responsive** (stacked list on mobile, table only at `md+` inside `overflow-hidden`), so it is **not** a scroll culprit. If a horizontal scroll persists on mobile, point me at the section and I'll fix the actual source.

## Verification
- `pnpm --filter marketing test` → 55/55 · typecheck clean · biome clean.

## Follow-up
- "More fun than cards everywhere" — visual variety pass (separate).
- Extract a shared `CenteredCardGrid` so every >3-card layout inherits the centering rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
