### PR TITLE
feat(marketing): break up card grids — thesis band + Primitives zigzag

### DIFF
--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -33,30 +33,40 @@ export function Primitives() {
           </p>
         </div>
 
-        <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
-          {HOME_PRIMITIVES.map((p) => (
-            <div
-              key={p.label}
-              className="flex flex-col items-start rounded-2xl bg-card p-6 ring-1 ring-border transition hover:ring-border/80"
-            >
+        {/* Alternating feature rows (a zigzag), not a card grid — gives the page
+            rhythm. Each primitive is a generous row with a large accent icon that
+            alternates sides; the copy hugs toward it. */}
+        <div className="mx-auto mt-16 max-w-4xl space-y-10 sm:space-y-14">
+          {HOME_PRIMITIVES.map((p, index) => {
+            const flipped = index % 2 === 1;
+            return (
               <div
-                className={`mb-5 flex h-10 w-10 items-center justify-center rounded-xl ring-1 ${accentBg[p.color]}`}
+                key={p.label}
+                className={`flex flex-col gap-5 sm:items-center sm:gap-10 ${
+                  flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
+                }`}
               >
-                <svg
-                  className="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.75}
-                  stroke="currentColor"
+                <div
+                  className={`flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl ring-1 ${accentBg[p.color]}`}
                 >
-                  <title>{p.label}</title>
-                  <path strokeLinecap="round" strokeLinejoin="round" d={p.iconPath} />
-                </svg>
+                  <svg
+                    className="h-10 w-10"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <title>{p.label}</title>
+                    <path strokeLinecap="round" strokeLinejoin="round" d={p.iconPath} />
+                  </svg>
+                </div>
+                <div className={`flex-1 ${flipped ? 'sm:text-right' : ''}`}>
+                  <h3 className="text-xl font-semibold text-foreground">{p.label}</h3>
+                  <p className="mt-2 text-base leading-7 text-muted-foreground">{p.body}</p>
+                </div>
               </div>
-              <h3 className="text-base font-semibold text-foreground">{p.label}</h3>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">{p.body}</p>
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         <div className="mt-12 text-center">

--- a/apps/marketing/app/components/landing/ThesisBand.tsx
+++ b/apps/marketing/app/components/landing/ThesisBand.tsx
@@ -1,0 +1,21 @@
+import { HOME_THESIS_BAND } from '../../content/home';
+
+/**
+ * Full-width thesis band — a no-card pacing break between the Primitives and
+ * What's-shipped card grids. The contrasting `bg-secondary` surface makes it
+ * read as a deliberate beat, not another section of cards.
+ */
+export function ThesisBand() {
+  return (
+    <section className="bg-secondary py-20 sm:py-24">
+      <div className="mx-auto max-w-4xl px-6 text-center lg:px-8">
+        <p className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          {HOME_THESIS_BAND.line}
+        </p>
+        <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-muted-foreground">
+          {HOME_THESIS_BAND.sub}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -90,6 +90,13 @@ export const HOME_HERO_FOUNDATION = {
   h1: 'The foundation your business runs on.',
 } as const;
 
+// Full-width thesis band — a no-card rhythm break between the Primitives and
+// What's-shipped grids. One bold line + a short contrast sub.
+export const HOME_THESIS_BAND = {
+  line: 'You bring the business. The runtime handles the rest.',
+  sub: 'Not a starter kit, and not glue between five SaaS tools. One system, already wired together.',
+} as const;
+
 // ---------------------------------------------------------------------------
 // Problem (comparison table)
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -19,6 +19,7 @@ import { PricingTeaser } from '../components/landing/PricingTeaser';
 import { Primitives } from '../components/landing/Primitives';
 import { Problem } from '../components/landing/Problem';
 import { Proof } from '../components/landing/Proof';
+import { ThesisBand } from '../components/landing/ThesisBand';
 import { WhatsShipped } from '../components/landing/WhatsShipped';
 import { selectAudience } from '../lib/audience';
 
@@ -33,6 +34,7 @@ function TechnicalLanding() {
       <Demo />
       <Objections />
       <Primitives />
+      <ThesisBand />
       <WhatsShipped />
       <Persona />
       <Proof />


### PR DESCRIPTION
## What

"More fun than cards everywhere" pass — adds rhythm to the grid-heavy landing stretch.

- **Primitives** → alternating feature rows (zigzag) instead of a 5-card grid: a large accent icon alternates sides, copy hugs toward it. Keeps the dark-mode-safe `accentBg`.
- **New `ThesisBand`** → a full-width, no-card pacing break ("You bring the business. The runtime handles the rest.") on a contrasting `bg-secondary` surface, placed between Primitives and What's-shipped in the technical landing.

## Verification
- `pnpm --filter marketing test` → 55/55 · typecheck clean · biome clean.

## Follow-up
- Extract a shared `CenteredCardGrid` (deferred); retire /for-operators route (toggle PR3); SEO per audience mode (toggle PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)