### PR TITLE
chore(marketing): retire /for-operators, redirect to /?for=non-technical

### DIFF
--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -95,4 +95,20 @@ describe('marketing route registry', () => {
     expect(redirect?.destination).toBe('/roadmap');
     expect(redirect?.permanent).toBe(true);
   });
+
+  it('redirects the retired /for-operators path to /?for=non-technical', () => {
+    // /for-operators was a nav link that pre-dated the ?for= audience selector.
+    // The entry point is now the homepage with ?for=non-technical. A permanent
+    // edge redirect (vercel.json) preserves any bookmarks or indexed links.
+    const vercelConfig = JSON.parse(
+      readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8'),
+    ) as { redirects?: Array<{ source: string; destination: string; permanent?: boolean }> };
+    const redirect = vercelConfig.redirects?.find((entry) => entry.source === '/for-operators');
+    expect(
+      redirect,
+      'the /for-operators → /?for=non-technical redirect must be present',
+    ).toBeDefined();
+    expect(redirect?.destination).toBe('/?for=non-technical');
+    expect(redirect?.permanent).toBe(true);
+  });
 });

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -9,7 +9,6 @@ export const NAV_LINKS: readonly NavLink[] = [
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: SITE.urls.docs },
   { label: 'Blog', href: '/blog' },
-  { label: 'For Operators', href: '/for-operators' },
 ] as const;
 
 export const NAV_AUTH = {

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -60,6 +60,11 @@
       "has": [{ "type": "host", "value": "community.revealui.com" }],
       "destination": "https://github.com/RevealUIStudio/revealui/discussions",
       "permanent": true
+    },
+    {
+      "source": "/for-operators",
+      "destination": "/?for=non-technical",
+      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

- Removes the "For Operators" nav link from `NAV_LINKS` in `app/content/nav.ts`
- Adds a permanent edge redirect `/for-operators` → `/?for=non-technical` in `vercel.json` (permanent 308)
- Adds a vitest assertion in `routes.test.ts` guarding the redirect (mirrors the `/coming-soon` and `/marketplace` patterns)

## Why

`/?for=non-technical` is now the canonical non-technical audience landing (`DEFAULT_AUDIENCE = 'non-technical'` in `lib/audience.ts`). The standalone `/for-operators` path is redundant and a UX dead end; the nav link is gone and any bookmarks or indexed links redirect permanently.

## Test plan

- [x] `pnpm --filter marketing test` — all 56 tests pass (new redirect assertion included)
- [x] `pnpm gate:quick` — phase 1 clean (all hard-fail checks pass)
- [x] Pre-push gate passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)