### PR TITLE
feat(marketing): SEO per ?for= audience mode

### DIFF
--- a/apps/marketing/app/__tests__/use-audience-head.test.ts
+++ b/apps/marketing/app/__tests__/use-audience-head.test.ts
@@ -1,0 +1,152 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Audience } from '../lib/audience';
+import { useAudienceHead } from '../lib/use-audience-head';
+
+function addMeta(selector: string, attrName: string, attrValue: string): void {
+  const el = document.createElement('meta');
+  const openBracket = selector.indexOf('[');
+  const closeBracket = selector.lastIndexOf(']');
+  if (openBracket !== -1 && closeBracket !== -1) {
+    const inner = selector.slice(openBracket + 1, closeBracket);
+    const eqIdx = inner.indexOf('=');
+    if (eqIdx !== -1) {
+      el.setAttribute(inner.slice(0, eqIdx), inner.slice(eqIdx + 1).replaceAll('"', ''));
+    }
+  }
+  el.setAttribute(attrName, attrValue);
+  document.head.appendChild(el);
+}
+
+beforeEach(() => {
+  document.head.innerHTML = '';
+  const canonical = document.createElement('link');
+  canonical.rel = 'canonical';
+  canonical.href = 'https://revealui.com';
+  document.head.appendChild(canonical);
+
+  addMeta('meta[name="description"]', 'content', '');
+  addMeta('meta[property="og:title"]', 'content', '');
+  addMeta('meta[property="og:description"]', 'content', '');
+  addMeta('meta[property="og:image"]', 'content', '');
+  addMeta('meta[name="twitter:title"]', 'content', '');
+  addMeta('meta[name="twitter:description"]', 'content', '');
+  addMeta('meta[name="twitter:image"]', 'content', '');
+});
+
+afterEach(() => {
+  delete document.documentElement.dataset.audience;
+});
+
+describe('useAudienceHead — non-technical audience', () => {
+  it('sets document.title to the non-technical headline', () => {
+    renderHook(() => useAudienceHead('non-technical'));
+    expect(document.title).toBe(
+      'RevealUI | Your business grows with you, and stays at the frontier.',
+    );
+  });
+
+  it('does not mutate link[rel=canonical]', () => {
+    const before = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href;
+    renderHook(() => useAudienceHead('non-technical'));
+    expect(document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href).toBe(before);
+  });
+
+  it('sets og:title to the non-technical title', () => {
+    renderHook(() => useAudienceHead('non-technical'));
+    expect(document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.content).toBe(
+      'RevealUI | Your business grows with you, and stays at the frontier.',
+    );
+  });
+
+  it('sets document.documentElement.dataset.audience to non-technical', () => {
+    renderHook(() => useAudienceHead('non-technical'));
+    expect(document.documentElement.dataset.audience).toBe('non-technical');
+  });
+
+  it('dispatches revealui:audience CustomEvent with correct detail', () => {
+    const handler = vi.fn();
+    document.addEventListener('revealui:audience', handler);
+    renderHook(() => useAudienceHead('non-technical'));
+    expect(handler).toHaveBeenCalledOnce();
+    expect((handler.mock.calls[0]?.[0] as CustomEvent | undefined)?.detail).toEqual({
+      audience: 'non-technical',
+    });
+    document.removeEventListener('revealui:audience', handler);
+  });
+});
+
+describe('useAudienceHead — technical audience', () => {
+  it('sets document.title to the technical headline', () => {
+    renderHook(() => useAudienceHead('technical'));
+    expect(document.title).toBe('RevealUI | Run your whole business on one runtime you own.');
+  });
+
+  it('does not mutate link[rel=canonical]', () => {
+    const before = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href;
+    renderHook(() => useAudienceHead('technical'));
+    expect(document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href).toBe(before);
+  });
+
+  it('sets og:description to the technical description', () => {
+    renderHook(() => useAudienceHead('technical'));
+    expect(
+      document.querySelector<HTMLMetaElement>('meta[property="og:description"]')?.content,
+    ).toBe(
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+    );
+  });
+
+  it('sets document.documentElement.dataset.audience to technical', () => {
+    renderHook(() => useAudienceHead('technical'));
+    expect(document.documentElement.dataset.audience).toBe('technical');
+  });
+
+  it('dispatches revealui:audience CustomEvent with correct detail', () => {
+    const handler = vi.fn();
+    document.addEventListener('revealui:audience', handler);
+    renderHook(() => useAudienceHead('technical'));
+    expect(handler).toHaveBeenCalledOnce();
+    expect((handler.mock.calls[0]?.[0] as CustomEvent | undefined)?.detail).toEqual({
+      audience: 'technical',
+    });
+    document.removeEventListener('revealui:audience', handler);
+  });
+});
+
+describe('useAudienceHead — audience switch', () => {
+  it('updates title and dataset when audience changes', () => {
+    const { rerender } = renderHook(
+      ({ audience }: { audience: Audience }) => useAudienceHead(audience),
+      { initialProps: { audience: 'non-technical' as Audience } },
+    );
+
+    expect(document.title).toBe(
+      'RevealUI | Your business grows with you, and stays at the frontier.',
+    );
+
+    act(() => {
+      rerender({ audience: 'technical' });
+    });
+
+    expect(document.title).toBe('RevealUI | Run your whole business on one runtime you own.');
+    expect(document.documentElement.dataset.audience).toBe('technical');
+  });
+
+  it('does not mutate canonical on either variant', () => {
+    const before = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href;
+
+    const { rerender } = renderHook(
+      ({ audience }: { audience: Audience }) => useAudienceHead(audience),
+      { initialProps: { audience: 'non-technical' as Audience } },
+    );
+
+    expect(document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href).toBe(before);
+
+    act(() => {
+      rerender({ audience: 'technical' });
+    });
+
+    expect(document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href).toBe(before);
+  });
+});

--- a/apps/marketing/app/lib/use-audience-head.ts
+++ b/apps/marketing/app/lib/use-audience-head.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import type { Audience } from './audience';
+
+interface AudienceSeo {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogImage: string;
+  twitterTitle: string;
+  twitterDescription: string;
+  twitterImage: string;
+}
+
+const SEO: Record<Audience, AudienceSeo> = {
+  'non-technical': {
+    title: 'RevealUI | Your business grows with you, and stays at the frontier.',
+    description:
+      'Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves.',
+    ogTitle: 'RevealUI | Your business grows with you, and stays at the frontier.',
+    ogDescription:
+      'Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves.',
+    ogImage:
+      'https://api.revealui.com/api/og?title=RevealUI&description=Your%20business%2C%20delivered%20and%20yours%20to%20own.',
+    twitterTitle: 'RevealUI | Your business grows with you, and stays at the frontier.',
+    twitterDescription:
+      'Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves.',
+    twitterImage:
+      'https://api.revealui.com/api/og?title=RevealUI&description=Your%20business%2C%20delivered%20and%20yours%20to%20own.',
+  },
+  technical: {
+    title: 'RevealUI | Run your whole business on one runtime you own.',
+    description:
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+    ogTitle: 'RevealUI | Run your whole business on one runtime you own.',
+    ogDescription:
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+    ogImage:
+      'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
+    twitterTitle: 'RevealUI | Run your whole business on one runtime you own.',
+    twitterDescription:
+      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+    twitterImage:
+      'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
+  },
+};
+
+function setMeta(selector: string, attr: string, value: string): void {
+  document.querySelector<HTMLElement>(selector)?.setAttribute(attr, value);
+}
+
+export function useAudienceHead(audience: Audience): void {
+  useEffect(() => {
+    const seo = SEO[audience];
+
+    document.title = seo.title;
+
+    setMeta('meta[name="description"]', 'content', seo.description);
+    setMeta('meta[property="og:title"]', 'content', seo.ogTitle);
+    setMeta('meta[property="og:description"]', 'content', seo.ogDescription);
+    setMeta('meta[property="og:image"]', 'content', seo.ogImage);
+    setMeta('meta[name="twitter:title"]', 'content', seo.twitterTitle);
+    setMeta('meta[name="twitter:description"]', 'content', seo.twitterDescription);
+    setMeta('meta[name="twitter:image"]', 'content', seo.twitterImage);
+
+    document.documentElement.dataset.audience = audience;
+
+    document.dispatchEvent(
+      new CustomEvent('revealui:audience', { detail: { audience }, bubbles: false }),
+    );
+  }, [audience]);
+}

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -22,6 +22,7 @@ import { Proof } from '../components/landing/Proof';
 import { ThesisBand } from '../components/landing/ThesisBand';
 import { WhatsShipped } from '../components/landing/WhatsShipped';
 import { selectAudience } from '../lib/audience';
+import { useAudienceHead } from '../lib/use-audience-head';
 
 /** Developer-facing landing — `/?for=technical`. */
 function TechnicalLanding() {
@@ -72,6 +73,7 @@ function NonTechnicalLanding() {
 export function HomePage() {
   const { search } = useLocation();
   const audience = selectAudience(search);
+  useAudienceHead(audience);
   return (
     <div className="min-h-screen bg-background">
       {audience === 'non-technical' ? <NonTechnicalLanding /> : <TechnicalLanding />}

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -9,8 +9,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RevealUI | Run your whole business on one runtime you own.</title>
-    <meta name="description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
+    <title>RevealUI | Your business grows with you, and stays at the frontier.</title>
+    <meta name="description" content="Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves." />
     <meta name="keywords" content="open source, self-hostable, multi-tenant, white-label, business runtime, auth, content, products, payments, billing, admin dashboard, AI agents, MCP, Stripe, RevealUI, RevVault, RevKit" />
     <meta name="author" content="RevealUI Studio" />
     <link rel="canonical" href="https://revealui.com" />
@@ -20,19 +20,19 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="RevealUI | Run your whole business on one runtime you own." />
-    <meta property="og:description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
+    <meta property="og:title" content="RevealUI | Your business grows with you, and stays at the frontier." />
+    <meta property="og:description" content="Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves." />
     <meta property="og:url" content="https://revealui.com" />
     <meta property="og:site_name" content="RevealUI" />
-    <meta property="og:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own." />
+    <meta property="og:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Your%20business%2C%20delivered%20and%20yours%20to%20own." />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="RevealUI | Run your whole business on one runtime you own." />
+    <meta property="og:image:alt" content="RevealUI | Your business grows with you, and stays at the frontier." />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="RevealUI | Run your whole business on one runtime you own." />
-    <meta name="twitter:description" content="Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client." />
-    <meta name="twitter:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own." />
+    <meta name="twitter:title" content="RevealUI | Your business grows with you, and stays at the frontier." />
+    <meta name="twitter:description" content="Running a business is hard enough without racing to keep up with AI. We build your software with AI built in, yours to own, and keep it current as the world moves." />
+    <meta name="twitter:image" content="https://api.revealui.com/api/og?title=RevealUI&description=Your%20business%2C%20delivered%20and%20yours%20to%20own." />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -11,7 +11,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://revealui.com/marketplace</loc>
+    <loc>https://revealui.com/philosophy</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -34,6 +34,16 @@
     <loc>https://revealui.com/fair-source</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://revealui.com/for-operators/how-it-works</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://revealui.com/for-operators/managed</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>https://revealui.com/roadmap</loc>


### PR DESCRIPTION
## Toggle PR4 — SEO per ?for= audience mode (direction A: consolidated canonical)

### What changed

**`apps/marketing/index.html`** — static default copy is now non-technical  
Title, description, og:title/description/image, and twitter:title/description/image default to the non-technical audience. The canonical `https://revealui.com` is unchanged (single canonical for the site).

**`apps/marketing/app/lib/use-audience-head.ts`** — new hook  
`useAudienceHead(audience)` swaps dynamic head tags per audience (title, og:title, og:description, og:image, twitter:*) without touching `link[rel=canonical]`. Also sets `document.documentElement.dataset.audience` for analytics and fires `CustomEvent('revealui:audience', { detail: { audience } })`.

**`apps/marketing/app/routes/HomePage.tsx`** — hook wired  
Calls `useAudienceHead(audience)` immediately after `selectAudience`.

**`apps/marketing/public/sitemap.xml`** — reconciled vs App.tsx routes  
- Removed stale `/marketplace` (redirects to /roadmap, no route)
- Added missing `/philosophy`
- Added missing `/for-operators/how-it-works`
- Added missing `/for-operators/managed`

**`apps/marketing/app/__tests__/use-audience-head.test.ts`** — 12 new tests  
`renderHook` + `act` via @testing-library/react. Asserts: title changes per audience, og:title/description set correctly, `dataset.audience` set, `CustomEvent` fires with correct detail, canonical is NOT mutated for either variant.

### SEO invariant

Both `https://revealui.com` and `https://revealui.com/?for=technical` share the same canonical: `https://revealui.com`. The `?for=` parameter is a UX affordance, not a separate SEO target.

### Test results

68 tests passing. Typecheck clean. Gate: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
