### PR TITLE
feat(marketing): real analytics sink + audience-event consumer

### DIFF
--- a/apps/marketing/app/__tests__/analytics.test.ts
+++ b/apps/marketing/app/__tests__/analytics.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeDocumentStub() {
+  const listeners: Map<string, EventListenerOrEventListenerObject[]> = new Map();
+  return {
+    referrer: '',
+    addEventListener(type: string, handler: EventListenerOrEventListenerObject) {
+      const list = listeners.get(type) ?? [];
+      list.push(handler);
+      listeners.set(type, list);
+    },
+    dispatchEvent(event: Event) {
+      const list = listeners.get(event.type) ?? [];
+      for (const handler of list) {
+        if (typeof handler === 'function') {
+          handler(event);
+        } else {
+          handler.handleEvent(event);
+        }
+      }
+      return true;
+    },
+  };
+}
+
+beforeEach(() => {
+  const docStub = makeDocumentStub();
+  vi.stubGlobal('document', docStub);
+  vi.stubGlobal('navigator', {
+    sendBeacon: vi.fn(() => true),
+    doNotTrack: null,
+  });
+  vi.stubGlobal('window', {
+    location: { href: 'https://revealui.com/' },
+    doNotTrack: undefined,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('analytics sink', () => {
+  it('is dormant when VITE_ANALYTICS_DOMAIN is unset', async () => {
+    const { initAnalytics } = await import('../lib/analytics');
+    initAnalytics();
+    document.dispatchEvent(
+      new CustomEvent('revealui:audience', { detail: { audience: 'technical' } }),
+    );
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('sends an event when configured and the audience event fires', async () => {
+    vi.stubEnv('VITE_ANALYTICS_DOMAIN', 'revealui.com');
+    const { initAnalytics } = await import('../lib/analytics');
+    initAnalytics();
+
+    document.dispatchEvent(
+      new CustomEvent('revealui:audience', { detail: { audience: 'technical' } }),
+    );
+
+    expect(navigator.sendBeacon).toHaveBeenCalledOnce();
+
+    const [, blob] = (navigator.sendBeacon as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Blob,
+    ];
+    const text = await blob.text();
+    const payload = JSON.parse(text) as {
+      name: string;
+      domain: string;
+      props: { audience: string };
+    };
+
+    expect(payload.name).toBe('Audience Selected');
+    expect(payload.domain).toBe('revealui.com');
+    expect(payload.props.audience).toBe('technical');
+  });
+
+  it('does not send when DNT is enabled', async () => {
+    vi.stubEnv('VITE_ANALYTICS_DOMAIN', 'revealui.com');
+    vi.stubGlobal('navigator', {
+      sendBeacon: vi.fn(() => true),
+      doNotTrack: '1',
+    });
+
+    const { initAnalytics } = await import('../lib/analytics');
+    initAnalytics();
+
+    document.dispatchEvent(
+      new CustomEvent('revealui:audience', { detail: { audience: 'technical' } }),
+    );
+
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('track() never throws even when sendBeacon throws', async () => {
+    vi.stubEnv('VITE_ANALYTICS_DOMAIN', 'revealui.com');
+    vi.stubGlobal('navigator', {
+      sendBeacon: vi.fn(() => {
+        throw new Error('beacon failed');
+      }),
+      doNotTrack: null,
+    });
+
+    const { track } = await import('../lib/analytics');
+
+    expect(() => track('Test Event', { foo: 'bar' })).not.toThrow();
+  });
+
+  it('is idempotent: calling initAnalytics twice registers only one listener', async () => {
+    vi.stubEnv('VITE_ANALYTICS_DOMAIN', 'revealui.com');
+    const { initAnalytics } = await import('../lib/analytics');
+
+    initAnalytics();
+    initAnalytics();
+
+    document.dispatchEvent(
+      new CustomEvent('revealui:audience', { detail: { audience: 'non-technical' } }),
+    );
+
+    expect(navigator.sendBeacon).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/marketing/app/entry.client.tsx
+++ b/apps/marketing/app/entry.client.tsx
@@ -8,10 +8,13 @@ import { SpeedInsights } from '@vercel/speed-insights/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { initAnalytics } from './lib/analytics';
 import { initSentry } from './lib/sentry';
 
 // Initialise Sentry before mounting. No-op if VITE_SENTRY_DSN is absent.
 initSentry();
+// Initialise analytics sink. No-op if VITE_ANALYTICS_DOMAIN is absent or DNT is enabled.
+initAnalytics();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/apps/marketing/app/lib/analytics.ts
+++ b/apps/marketing/app/lib/analytics.ts
@@ -1,0 +1,102 @@
+// Product-analytics sink for the marketing site (Vite + React).
+//
+// Privacy posture:
+//   - Fully dormant when `VITE_ANALYTICS_DOMAIN` is absent. The module is shipped
+//     so events flow the moment the env var is set in Vercel, without redeploying.
+//   - Respects Do-Not-Track (DNT). All tracking is silently skipped for any visitor
+//     whose browser sends DNT=1 / DNT=yes.
+//   - No PII is collected. Payloads contain only the event name, domain, page URL,
+//     referring URL, and the named props passed by the caller — no user identifiers,
+//     no cookies, no fingerprints.
+//   - Transport: navigator.sendBeacon (fire-and-forget, survives page unload).
+//     Falls back to fetch with keepalive:true when sendBeacon is unavailable.
+//   - Payload format is Plausible-compatible so the endpoint can be Plausible Cloud,
+//     a self-hosted Plausible instance, or any compatible ingest server.
+//
+// Required follow-up before production:
+//   - CSP: add the analytics endpoint host to `connect-src` in apps/marketing/vercel.json.
+//   - Privacy disclosure: adding any analytics provider as a subprocessor requires
+//     an update to apps/marketing/app/content/legal/privacy.ts (owner/legal decision).
+
+const domain = import.meta.env.VITE_ANALYTICS_DOMAIN as string | undefined;
+const endpoint =
+  (import.meta.env.VITE_ANALYTICS_ENDPOINT as string | undefined) ??
+  'https://plausible.io/api/event';
+
+function isDntEnabled(): boolean {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false;
+  }
+  return (
+    navigator.doNotTrack === '1' ||
+    navigator.doNotTrack === 'yes' ||
+    (window as Window & { doNotTrack?: string }).doNotTrack === '1'
+  );
+}
+
+interface AnalyticsPayload {
+  name: string;
+  domain: string;
+  url: string;
+  referrer: string | null;
+  props?: Record<string, string | number | boolean>;
+}
+
+export function track(event: string, props?: Record<string, string | number | boolean>): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+  if (isDntEnabled()) {
+    return;
+  }
+  if (!domain) {
+    return;
+  }
+
+  const payload: AnalyticsPayload = {
+    name: event,
+    domain,
+    url: window.location.href,
+    referrer: document.referrer || null,
+    props,
+  };
+
+  try {
+    const body = JSON.stringify(payload);
+    if (typeof navigator.sendBeacon === 'function') {
+      navigator.sendBeacon(endpoint, new Blob([body], { type: 'application/json' }));
+    } else {
+      fetch(endpoint, {
+        method: 'POST',
+        keepalive: true,
+        headers: { 'content-type': 'application/json' },
+        body,
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional fire-and-forget; errors are swallowed by the outer try/catch
+      }).catch(() => {}); // empty-catch-ok: analytics fetch errors are intentionally silenced; the outer try/catch handles hard throws
+    }
+  } catch {
+    // Never propagate analytics errors to the caller.
+  }
+}
+
+let mounted = false;
+
+export function initAnalytics(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+  if (isDntEnabled()) {
+    return;
+  }
+  if (mounted) {
+    return;
+  }
+  mounted = true;
+
+  document.addEventListener('revealui:audience', (e: Event) => {
+    const audience = (e as CustomEvent<{ audience: string }>).detail?.audience;
+    if (audience) {
+      track('Audience Selected', { audience });
+    }
+  });
+}


### PR DESCRIPTION
## What

A **real** product-analytics sink for the marketing site, as a decoupled **consumer** of the `revealui:audience` DOM event that toggle PR4 (#1529) dispatches. Replaces the bare `CustomEvent` stub with an actual end-to-end pipeline.

- `apps/marketing/app/lib/analytics.ts` (new) — `track(event, props)` + `initAnalytics()`.
- `apps/marketing/app/entry.client.tsx` — one line: `initAnalytics()` after `initSentry()`.
- `apps/marketing/app/__tests__/analytics.test.ts` (new) — 5 tests.

## Why this shape (durable, not a stub)

The marketing app had **no analytics sink** (`hero-variant.ts:12` says so), and there are two consumers waiting on one: the audience toggle and the hero-variant A/B experiment. This adds the shared sink, mirroring the existing `sentry.ts` house pattern:

- **Dormant until configured** — no-op unless `VITE_ANALYTICS_DOMAIN` is set in Vercel env. The SDK ships so events flow the moment the env var lands, no redeploy (identical to how `sentry.ts` waits on `VITE_SENTRY_DSN`).
- **Privacy-first** — respects Do-Not-Track, no cookies, no PII (event name + domain + page/referrer URL + named props only). Cookieless, Plausible-compatible payload.
- **Provider-agnostic** — `VITE_ANALYTICS_ENDPOINT` overrides the default Plausible endpoint, so Plausible Cloud, a self-hosted instance, or any compatible ingest server all work.
- **Robust** — `sendBeacon` (fetch-keepalive fallback), wrapped so it never throws; SSR-safe; idempotent mount.

## Producer/consumer split

PR4 (#1529, merged) is the **producer** — its `useAudienceHead` hook dispatches `revealui:audience` on `document` with `detail.audience`. This PR is the **consumer** — `initAnalytics()` subscribes once and forwards `track('Audience Selected', { audience })`. The two are file-disjoint; this branch is rebased on top of #1529.

## Verification

- `vitest run analytics.test.ts` → 5/5 pass (dormant-when-unconfigured, configured-send payload, DNT, never-throws, idempotent-mount).
- Typecheck + Biome clean on the three files. Lockfile unchanged (native APIs only, no new deps).

## Required follow-ups before enabling in prod (owner-gated — intentionally NOT in this PR)

1. **CSP** — add the analytics endpoint host (default `https://plausible.io`) to `connect-src` in `apps/marketing/vercel.json`.
2. **Subprocessor disclosure** — naming the chosen analytics provider in `apps/marketing/app/content/legal/privacy.ts` is an owner/legal decision (mirrors the Sentry subprocessor entry).
3. Set `VITE_ANALYTICS_DOMAIN` (+ optional `VITE_ANALYTICS_ENDPOINT`) in Vercel env from revvault to activate.
