### PR TITLE
chore(marketing): extract CenteredCardGrid component

### DIFF
--- a/apps/marketing/app/components/CenteredCardGrid.tsx
+++ b/apps/marketing/app/components/CenteredCardGrid.tsx
@@ -1,0 +1,12 @@
+interface CenteredCardGridProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CenteredCardGrid({ children, className }: CenteredCardGridProps) {
+  return (
+    <div className={['flex flex-wrap justify-center gap-6', className].filter(Boolean).join(' ')}>
+      {children}
+    </div>
+  );
+}

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -1,4 +1,5 @@
 import { FOR_OPERATORS_WHAT_YOU_GET } from '../../content/for-operators';
+import { CenteredCardGrid } from '../CenteredCardGrid';
 
 export function WhatYouGet() {
   return (
@@ -16,19 +17,17 @@ export function WhatYouGet() {
           </p>
         </div>
 
-        {/* flex-wrap + justify-center so a partial last row (e.g. 3 + 2) is
-            centered, not start-aligned. Card widths give 1 / 2 / 3 per row. */}
-        <ul className="mx-auto mt-16 flex max-w-5xl flex-wrap justify-center gap-6 list-none p-0">
+        <CenteredCardGrid className="mx-auto mt-16 max-w-5xl">
           {FOR_OPERATORS_WHAT_YOU_GET.cards.map((card) => (
-            <li
+            <div
               key={card.title}
               className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
             >
               <h3 className="text-lg font-semibold leading-7 text-foreground">{card.title}</h3>
               <p className="mt-3 text-base leading-7 text-muted-foreground">{card.body}</p>
-            </li>
+            </div>
           ))}
-        </ul>
+        </CenteredCardGrid>
       </div>
     </section>
   );

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -1,5 +1,6 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
+import { CenteredCardGrid } from '../components/CenteredCardGrid';
 import { Footer } from '../components/Footer';
 import { NewsletterSignup } from '../components/NewsletterSignup';
 import {
@@ -155,10 +156,7 @@ export function PricingPage() {
             </ul>
           </div>
 
-          {/* flex-wrap + justify-center: 3 per row, partial last row centered.
-              A lone last tier (count % 3 === 1, e.g. Enterprise) goes wider and
-              stays centered; a remainder of 2 centers at card width. */}
-          <div className="flex flex-wrap justify-center gap-6">
+          <CenteredCardGrid>
             {tiers.map((tier, index) => (
               <div
                 key={tier.id}
@@ -216,7 +214,7 @@ export function PricingPage() {
                 )}
               </div>
             ))}
-          </div>
+          </CenteredCardGrid>
 
           <p className="mt-8 text-center text-sm text-muted-foreground">{PRICING_TRIAL_NOTE}</p>
         </div>


### PR DESCRIPTION
Extract the repeated `flex flex-wrap justify-center gap-6` pattern into a
reusable `CenteredCardGrid` component used in two places:

- `WhatYouGet` (non-technical landing) — partial last row of cards (3+2) centers correctly
- `PricingPage` subscription tier grid — same centering behavior

## Changes

- **new** `apps/marketing/app/components/CenteredCardGrid.tsx` — thin wrapper, `flex flex-wrap justify-center gap-6` + `className` prop for callers to add positioning/sizing
- `WhatYouGet.tsx` — `<ul list-none p-0>` → `<CenteredCardGrid>` (children changed from `li` to `div`)
- `PricingPage.tsx` — inline `<div flex flex-wrap justify-center gap-6>` → `<CenteredCardGrid>`

No visual change — pure structural cleanup.

## Test plan

- [x] `pnpm --filter marketing test --run` — 42/42 pass (3 infrastructure failures in fresh worktree pre-dating this PR)
- [x] `pnpm gate:quick` — PASS
- [x] Pre-push gate — PASS