### PR TITLE
docs(metrics): correct Track C perpetual status to comingSoon false

### DIFF
--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -69,7 +69,7 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 | Agency Perpetual | $8,499 | $799/yr |
 | Enterprise Perpetual | $42,999 | $3,999/yr |
 
-**Status:** marked `comingSoon: true` in `packages/contracts/src/pricing.ts`. Marketing must label Track C "Coming soon" at H2 weight (no corner badges).
+**Status:** `comingSoon: false` in `packages/contracts/src/pricing.ts` (all three Track C tiers; asserted by `apps/server/src/routes/__tests__/pricing-accuracy.test.ts`). Marketing must NOT label Track C "Coming soon" — the perpetual tiers render as available. Live charging is still gated on the Stripe live-mode flip (see §3).
 
 ### Track D — Professional Services
 


### PR DESCRIPTION
## What

`docs/MARKETING_METRICS.md` §2 (Track C — Perpetual licenses) carried a stale **status** line claiming the perpetual tiers are `comingSoon: true` and instructing marketing to label Track C "Coming soon."

That is no longer accurate:

- `packages/contracts/src/pricing.ts` ships `comingSoon: false` for all three perpetual tiers (Pro / Agency / Enterprise Perpetual).
- `apps/server/src/routes/__tests__/pricing-accuracy.test.ts` asserts all three are enabled (`comingSoon: false`) and that none is marked coming soon.

This corrects the doc to match the contract and its enforcing test, and removes the outdated "Coming soon" labeling instruction.

## Why

Surfaced during a pricing audit. All **price values** across the lockstep surfaces (server fallback, MRR fallback, marketing fallback, Stripe seed cents, contracts, the agency ladder, and §2 of this doc) are consistent with the current canonical numbers — this `comingSoon` status line was the only drift found.

## Notes

- Doc-only change; no code touched.
- Preserves the Stripe live-mode caveat (perpetual tiers *render* as available, but live charging stays gated on the live-mode flip — points to §3). No "payments live" overclaim is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
