### PR TITLE
chore(scripts): citation gate VALIDITY hard-fails

### DIFF
--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -285,13 +285,13 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
-        // Source-citation gate (CONTRIBUTING.md — Source citations). Warn-only on
-        // introduction (like docs import drift); flip to hard-fail on validity
-        // by dropping --warn once it has run green for a cycle.
-        name: 'Citation gate',
+        // Source-citation gate (CONTRIBUTING.md — Source citations). VALIDITY
+        // (every path:line citation must resolve and sit in-range) HARD-FAILS;
+        // COVERAGE stays warn-only + baseline-grandfathered (no --coverage-strict)
+        // until it is promoted in a later phase.
+        name: 'Citation gate (hard fail)',
         command: 'pnpm',
-        args: ['validate:citations', '--warn'],
-        warnOnly: true,
+        args: ['validate:citations'],
       },
       {
         name: 'Pro license validation',


### PR DESCRIPTION
Follow-up to #1532 (merged). Drops `--warn` / `warnOnly` from the "Citation gate" entry in `scripts/gates/ci-gate.ts` so an unresolved or out-of-range source citation **blocks** `pnpm gate` Phase 1 (citation rot). COVERAGE stays warn-only + baseline-grandfathered (no `--coverage-strict`) until a later phase.

Safe today: 0 validity errors across the 45 gated docs; `pnpm gate --phase=1` PASS with "Citation gate (hard fail)" green. One-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
