### PR TITLE
docs(metrics): fix §3 status table Track C (comingSoon false / In flight)

### DIFF
--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -98,7 +98,7 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 | Documentation Site | **Shipped** | docs.revealui.com. |
 | x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant. "Designed; gated on Stripe live." |
 | MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (14 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
-| Perpetual Licenses (Track C) | **Planned** | `comingSoon: true` in contracts. |
+| Perpetual Licenses (Track C) | **In flight** | `comingSoon: false` in contracts (asserted by `apps/server/src/routes/__tests__/pricing-accuracy.test.ts`); Stripe products seeded. Renders as available; live charging gated on the Stripe live-mode flip (same gate as subscriptions). |
 | Self-Hosted Docker Images (RevealUI Fleet) | **Planned** | Designed, not built. |
 | Visual Builder | **Planned** | Backlog. |
 | Enterprise SSO / SAML | **Planned** | Designed, not built. |


### PR DESCRIPTION
## What

Follow-up to #1533, which fixed the §2 Track C status line but **missed a sibling instance** in the same doc. `docs/MARKETING_METRICS.md` §3 (Status of marketing-relevant systems) still carried:

```
| Perpetual Licenses (Track C) | **Planned** | `comingSoon: true` in contracts. |
```

After #1533 this was self-contradictory: §2 now says the perpetual tiers render as available (`comingSoon: false`), while §3 still said `Planned` / `comingSoon: true`.

This corrects §3 to match:

- `comingSoon: false` (contract value; asserted by `apps/server/src/routes/__tests__/pricing-accuracy.test.ts`).
- Status **Planned → In flight**, consistent with the "Stripe live payments | In flight" row directly above and with #1533's §2 wording — the tiers are wired and seeded, gated only on the Stripe live-mode flip, not unbuilt like the other `Planned` rows (x402, MCP marketplace, Docker images).

## Why

The original pricing audit grepped dollar amounts, not `comingSoon`, so this second occurrence slipped through. No price values are affected — those remain in lockstep at the current canonical numbers. This is the last `comingSoon`/Track-C status drift in the doc (verified by grepping all occurrences).

## Notes

- Doc-only; no code touched.
- Preserves the live-mode caveat (no "payments live" overclaim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
