### PR TITLE
docs(packages): cite source for config/resilience/setup README claims

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,7 +112,7 @@ pnpm dev
 ## When to Use This
 
 - You're starting a new RevealUI project from scratch and want a guided setup
-- You need database, storage, and payment providers configured in one step
+- You need database, storage, and payment providers configured in one step (`generateEnvFile`, `packages/cli/src/generators/env-file.ts:23`)
 - You want Dev Container or Devbox configuration generated automatically
 - **Not** for adding RevealUI to an existing project  -  install individual packages instead
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -15,7 +15,7 @@ Environment configuration management for RevealUI - type-safe environment variab
 - **Type-safe**: Full TypeScript support with Zod validation
 - **Environment detection**: Automatically detects NODE_ENV
 - **Dotenv loading**: Loads `.env` files with priority
-- **Validation**: Validates all environment variables on load
+- **Validation**: Validates all environment variables on load (`packages/config/src/validator.ts:57`)
 - **MCP Configuration**: Configuration management for MCP servers
 - **RevealUI Config**: RevealUI-specific configuration
 
@@ -41,7 +41,7 @@ console.log(config.stripe.secretKey)
 console.log(config.storage.blobToken)
 ```
 
-The package also exports a lazy-proxy default export that validates on first property access:
+The package also exports a lazy-proxy default export (`packages/config/src/index.ts:217`) that validates on first property access:
 
 ```typescript
 import config from '@revealui/config'
@@ -74,7 +74,7 @@ const mcpConfig = getMcpConfig()
 
 ## Environment Variables
 
-The config package validates these environment variables:
+The config package validates these environment variables (schema: `packages/config/src/schema.ts:26`):
 
 ### Required Variables
 
@@ -156,7 +156,7 @@ pnpm --filter @revealui/config lint
 
 ## Design Principles
 
-- **Unified**: One config loader validates and types all environment variables across every app and package
+- **Unified**: One config loader (`getConfig`, `packages/config/src/index.ts:184`) validates and types all environment variables across every app and package
 - **Hermetic**: Validation runs at load time  -  invalid or missing variables fail fast, never leak into runtime
 
 ## Related Documentation

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -68,7 +68,7 @@ app.openapi(route, (c) => c.json({ id: '1', name: 'test' }, 201));
 ## Design Principles
 
 - **Unified**: Single schema definition drives validation, types, and OpenAPI spec
-- **Orthogonal**: Decoupled from business logic  -  validates at the boundary, not inside handlers
+- **Orthogonal**: Decoupled from business logic  -  validates at the boundary, not inside handlers (`zValidator`, `packages/openapi/src/zod-validator.ts:29`)
 - **Hermetic**: Request validation happens before handler execution, preventing invalid data from leaking through
 
 ## Contracts mirror — cross-language codegen pipeline (F8 Phase 3)

--- a/packages/resilience/README.md
+++ b/packages/resilience/README.md
@@ -8,7 +8,7 @@ audience: user
 
 # @revealui/resilience
 
-Resilience infrastructure for RevealUI applications. Implements circuit breaker, retry with exponential backoff, and bulkhead patterns for fault-tolerant service communication.
+Resilience infrastructure for RevealUI applications. Implements circuit breaker (`packages/resilience/src/circuit-breaker.ts:60`), retry with exponential backoff (`packages/resilience/src/retry.ts:55`), and bulkhead patterns (`packages/resilience/src/circuit-breaker.ts:561`) for fault-tolerant service communication.
 
 ## When to Use This
 

--- a/packages/setup/README.md
+++ b/packages/setup/README.md
@@ -129,7 +129,7 @@ Parses environment file content into key-value object.
 
 #### `validateEnv(required, env)`
 
-Validates environment variables against schema.
+Validates environment variables against schema (`packages/setup/src/validators/env.ts:32`).
 
 **Parameters:**
 - `required: EnvVariable[]` - Required variable definitions

--- a/scripts/validate/citation-baseline.json
+++ b/scripts/validate/citation-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Grandfathered uncited code-behaviour claims in gated docs. Regenerate via `citation-check.ts --update-baseline`. CI reports only NEW (file::claim) keys; shrinking this list = backfill progress. Citation VALIDITY is never baselined.",
-  "count": 52,
+  "count": 46,
   "keys": [
     "docs/ARCHITECTURE.md::**api level:** access control validates tenant membership",
     "docs/ARCHITECTURE.md::- **purpose**: revalidates footer global",
@@ -46,13 +46,7 @@
     "packages/ai/README.md::runs the inference, keeps cost + context control, and returns the result.",
     "packages/ai/README.md::the system enforces limits to prevent performance issues:",
     "packages/cli/README.md::- you need database, storage, and payment providers configured in one step",
-    "packages/config/README.md::- **unified**: one config loader validates and types all environment variables across every app and package",
-    "packages/config/README.md::- **validation**: validates all environment variables on load",
-    "packages/config/README.md::the config package validates these environment variables:",
-    "packages/config/README.md::the package also exports a lazy-proxy default export that validates on first property access:",
     "packages/openapi/README.md::- **orthogonal**: decoupled from business logic - validates at the boundary, not inside handlers",
-    "packages/resilience/README.md::description: \"resilience infrastructure for revealui applications. implements circuit breaker, retry with exponential backoff, and bulkhead patterns for fault-t",
-    "packages/resilience/README.md::resilience infrastructure for revealui applications. implements circuit breaker, retry with exponential backoff, and bulkhead patterns for fault-tolerant servic",
-    "packages/setup/README.md::validates environment variables against schema."
+    "packages/resilience/README.md::description: \"resilience infrastructure for revealui applications. implements circuit breaker, retry with exponential backoff, and bulkhead patterns for fault-t"
   ]
 }

--- a/scripts/validate/citation-baseline.json
+++ b/scripts/validate/citation-baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Grandfathered uncited code-behaviour claims in gated docs. Regenerate via `citation-check.ts --update-baseline`. CI reports only NEW (file::claim) keys; shrinking this list = backfill progress. Citation VALIDITY is never baselined.",
-  "count": 46,
+  "count": 44,
   "keys": [
     "docs/ARCHITECTURE.md::**api level:** access control validates tenant membership",
     "docs/ARCHITECTURE.md::- **purpose**: revalidates footer global",
@@ -45,8 +45,6 @@
     "packages/ai/README.md::- `updatecontext()`: validates then updates (cloning happens in workingmemory)",
     "packages/ai/README.md::runs the inference, keeps cost + context control, and returns the result.",
     "packages/ai/README.md::the system enforces limits to prevent performance issues:",
-    "packages/cli/README.md::- you need database, storage, and payment providers configured in one step",
-    "packages/openapi/README.md::- **orthogonal**: decoupled from business logic - validates at the boundary, not inside handlers",
     "packages/resilience/README.md::description: \"resilience infrastructure for revealui applications. implements circuit breaker, retry with exponential backoff, and bulkhead patterns for fault-t"
   ]
 }


### PR DESCRIPTION
Phase 2 of the doc-citation program (follow-up to #1532). Adds `path:line` Works-Cited citations grounding the flagged code-behaviour claims in three package READMEs, and shrinks `citation-baseline.json` from 52 to 46 coverage gaps.

- `@revealui/config` — 4 claims (validator, schema, lazy proxy, loader)
- `@revealui/resilience` — 1 body claim (circuit breaker / retry / bulkhead)
- `@revealui/setup` — 1 claim (`validateEnv`)

All citations resolve (0 validity errors); each cited line clears its coverage gap. Doc-only + baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
