### PR TITLE
docs: cite source for 22 claims across 8 docs (baseline 25->5)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,7 +178,7 @@ That last exception is temporary, not a preferred pattern. It exists because the
 ### Type Safety Flow
 
 1. **Frontend** → Uses generated types for compile-time safety
-2. **API Routes** → Validates with contracts (runtime + compile-time)
+2. **API Routes** → Validates with contracts (runtime + compile-time) (`packages/openapi/src/zod-validator.ts:29`)
 3. **Type Adapters** → Convert DB types ↔ RevealUI types
 4. **Database** → Drizzle ORM provides type-safe queries
 
@@ -288,7 +288,7 @@ Transactional REST API + Real-time Sync Source
 
 **NOT Stored:**
 
-- ⚠️ RAG document chunks (`rag_chunks`) — only when the optional Supabase sidecar is enabled. Everything else, including `agent_memories` (via `pgvector`), lives in NeonDB.
+- ⚠️ RAG document chunks (`rag_chunks`, `packages/db/src/schema/rag.ts:94`) — only when the optional Supabase sidecar is enabled. Everything else, including `agent_memories` (via `pgvector`), lives in NeonDB.
 
 ### Characteristics
 
@@ -547,7 +547,7 @@ const memories = await db
 
 ### Tenant Model
 
-RevealUI implements robust multi-tenancy using RevealUI admin 3.x, allowing multiple organizations to share the same application instance with complete data isolation.
+RevealUI implements robust multi-tenancy (`packages/db/src/schema/tenants.ts:3`) using RevealUI admin 3.x, allowing multiple organizations to share the same application instance with complete data isolation.
 
 ```typescript
 Tenants Collection {
@@ -668,7 +668,7 @@ hooks: {
 ### Tenant Isolation Guarantees
 
 1. **Database Level**: Queries filtered by tenant relationship
-2. **API Level**: Access control validates tenant membership
+2. **API Level**: Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:15`)
 3. **UI Level**: Admin panel shows only current tenant's data
 
 ### Testing Tenant Isolation
@@ -1252,7 +1252,7 @@ Customer-facing meters should map to business activity rather than upstream infr
 ### Tenant Security
 
 **Database Level:** Queries filtered by tenant relationship
-**API Level:** Access control validates tenant membership
+**API Level:** Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:15`)
 **UI Level:** Admin panel shows only current tenant's data
 
 ---

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1256,7 +1256,7 @@ catch (error) {
 
 ### Sentry Integration
 
-Sentry is configured in `apps/admin/next.config.mjs` and will automatically capture errors.
+Sentry is configured in `apps/admin/next.config.mjs:204` and will automatically capture errors.
 
 **Manual Error Capture:**
 ```typescript
@@ -2058,7 +2058,7 @@ To add new validation rules:
 
 ## Overview
 
-RevealUI has a comprehensive logging system already implemented in `@revealui/core`. This guide shows how to use it instead of `console.log`.
+RevealUI has a comprehensive logging system already implemented in `@revealui/core` (`packages/core/src/utils/logger.ts:14`). This guide shows how to use it instead of `console.log`.
 
 ## Quick Start
 
@@ -2937,7 +2937,7 @@ packages/
 
 ## CI/CD Integration
 
-The type system is validated in CI to prevent drift. The workflow runs on:
+The type system is validated in CI (`.github/workflows/ci.yml:186`) to prevent drift. The workflow runs on:
 - Pull requests touching schema or generated files
 - Pushes to main branch
 - Manual workflow dispatch

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -708,7 +708,7 @@ Accepts warn/error/fatal log entries from apps that cannot write to the DB direc
 
 **Verify a license key**
 
-Validates a JWT license key and returns the tier, features, and limits.
+Validates a JWT license key and returns the tier, features, and limits. (`apps/server/src/routes/license.ts:119`)
 
 **Request body** (JSON)
 
@@ -764,7 +764,7 @@ Returns which features are available at each license tier.
 
 **Verify a license key**
 
-Validates a JWT license key and returns the tier, features, and limits.
+Validates a JWT license key and returns the tier, features, and limits. (`apps/server/src/routes/license.ts:119`)
 
 **Request body** (JSON)
 
@@ -855,7 +855,7 @@ Creates a Stripe billing portal session for subscription management.
 
 **Get subscription status**
 
-Returns the current user's license tier, status, and expiration.
+Returns the current user's license tier, status, and expiration. (`apps/server/src/routes/billing.ts:907`)
 
 **Responses**
 
@@ -1054,7 +1054,7 @@ Creates a Stripe billing portal session for subscription management.
 
 **Get subscription status**
 
-Returns the current user's license tier, status, and expiration.
+Returns the current user's license tier, status, and expiration. (`apps/server/src/routes/billing.ts:907`)
 
 **Responses**
 
@@ -2736,7 +2736,7 @@ Receives Stripe webhook events for subscription lifecycle, license management, d
 
 **Submit a natural language task for an agent to execute**
 
-Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result.
+Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:95`)
 
 **Request body** (JSON)
 
@@ -2776,7 +2776,7 @@ Creates a ticket from the instruction, dispatches an AI agent with admin tools t
 
 **Submit a natural language task for an agent to execute**
 
-Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result.
+Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:95`)
 
 **Request body** (JSON)
 

--- a/docs/architecture/ai-stack.md
+++ b/docs/architecture/ai-stack.md
@@ -6,7 +6,7 @@ status: verified
 audience: user
 ---
 
-RevealUI's AI subsystem lives in `@revealui/ai` (Pro, Fair Source FSL-1.1-MIT). It provides open-model inference, agent orchestration, CRDT-based memory, RAG ingestion, and streaming runtime  -  all gated by tier. The default and recommended path is open-model inference (Ollama, Canonical Inference Snaps); cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible, Anthropic for prompt caching) are pluggable but opt-in via environment variables.
+RevealUI's AI subsystem lives in `@revealui/ai` (Pro, Fair Source FSL-1.1-MIT). It provides open-model inference, agent orchestration, CRDT-based memory, RAG ingestion, and streaming runtime  -  all gated by tier (`packages/ai/src/index.ts:1`). The default and recommended path is open-model inference (Ollama, Canonical Inference Snaps); cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible, Anthropic for prompt caching) are pluggable but opt-in via environment variables.
 
 ## Inference Abstraction
 

--- a/docs/architecture/x402.md
+++ b/docs/architecture/x402.md
@@ -31,7 +31,7 @@ x402 ships off by default. To activate, set the following in the deployment's en
 | `X402_PRICE_PER_TASK` | optional | Default per-task USDC price; used when `agentDef.pricing` not set. Defaults to `0.001`. |
 | `X402_FACILITATOR_URL` | optional | Defaults to `https://x402.org/facilitator`. Override only for self-hosted. |
 
-The boot validator (`apps/server/src/lib/validate-startup.ts`) enforces that when `X402_ENABLED=true`, `X402_RECEIVING_ADDRESS` is non-empty and matches the `0x` + 40-hex EVM format. Half-configured boots fail loudly rather than silently dropping payments to an empty `payTo`.
+The boot validator (`apps/server/src/lib/validate-startup.ts:435`) enforces that when `X402_ENABLED=true`, `X402_RECEIVING_ADDRESS` is non-empty and matches the `0x` + 40-hex EVM format. Half-configured boots fail loudly rather than silently dropping payments to an empty `payTo`.
 
 ### Secret sourcing
 
@@ -74,7 +74,7 @@ Agent                                  Server
   │ ◀─────────────────────────────────────│
 ```
 
-Verification lives in [`apps/server/src/middleware/x402.ts`](../../apps/server/src/middleware/x402.ts) (`verifyPayment`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed).
+Verification lives in [`apps/server/src/middleware/x402.ts:202`](../../apps/server/src/middleware/x402.ts) (`verifyPayment`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed).
 
 ## Payment requirements
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -6,7 +6,7 @@ status: verified
 audience: user
 ---
 
-RevealUI uses session-based authentication backed by database-stored sessions. There are no JWTs. The sole authentication mechanism is a `revealui-session` cookie containing a hashed token that maps to a row in the `sessions` table.
+RevealUI uses session-based authentication backed by database-stored sessions. There are no JWTs. The sole authentication mechanism is a `revealui-session` cookie containing a hashed token that maps to a row in the `sessions` table (`packages/auth/src/server/session.ts:124`).
 
 **Package:** `@revealui/auth`
 
@@ -17,7 +17,7 @@ RevealUI uses session-based authentication backed by database-stored sessions. T
 1. User signs in with email/password or an OAuth provider
 2. A session row is created in the `sessions` table with a hashed token
 3. The raw token is set as an `HttpOnly`, `Secure`, `SameSite=Lax` cookie named `revealui-session`
-4. Every subsequent request validates the cookie against the hashed token in the database
+4. Every subsequent request validates the cookie against the hashed token in the database (`packages/auth/src/utils/token.ts:24`)
 5. Sessions expire after a configurable TTL and are refreshed on activity
 
 No tokens are stored in `localStorage` or sent as `Authorization` headers.

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -120,10 +120,10 @@ Response:
 
 The endpoint:
 
-1. Validates the user session
+1. Validates the user session (`apps/server/src/routes/billing.ts:748`)
 2. Finds or creates a Stripe customer (linked via `stripe_customer_id` in the users table)
 3. Creates a Checkout Session with the correct price
-4. Returns the Checkout URL
+4. Returns the Checkout URL (`apps/server/src/routes/billing.ts:856`)
 
 ### Success and Cancel URLs
 

--- a/docs/guides/collections.md
+++ b/docs/guides/collections.md
@@ -118,7 +118,7 @@ export default Posts;
 
 ## Field Types
 
-RevealUI supports these field types, with schemas defined in `@revealui/contracts`:
+RevealUI supports these field types, with schemas defined in `@revealui/contracts` (`packages/contracts/src/admin/structure.ts:34`):
 
 | Type | Description | Example |
 |------|-------------|---------|
@@ -401,7 +401,7 @@ Higher depth values increase query complexity. Use the minimum depth your use ca
 
 ## Registering Collections
 
-Collections are registered in the RevealUI configuration:
+Collections are registered in the RevealUI configuration (`packages/core/src/config/index.ts:11`):
 
 ```ts
 import { buildConfig } from '@revealui/core';

--- a/scripts/validate/citation-baseline.json
+++ b/scripts/validate/citation-baseline.json
@@ -1,31 +1,11 @@
 {
   "note": "Grandfathered uncited code-behaviour claims in gated docs. Regenerate via `citation-check.ts --update-baseline`. CI reports only NEW (file::claim) keys; shrinking this list = backfill progress. Citation VALIDITY is never baselined.",
-  "count": 25,
+  "count": 5,
   "keys": [
-    "docs/ARCHITECTURE.md::**api level:** access control validates tenant membership",
-    "docs/ARCHITECTURE.md::- ⚠️ rag document chunks (`rag_chunks`) — only when the optional supabase sidecar is enabled. everything else, including `agent_memories` (via `pgvector`), live",
-    "docs/ARCHITECTURE.md::2. **api level**: access control validates tenant membership",
-    "docs/ARCHITECTURE.md::2. **api routes** → validates with contracts (runtime + compile-time)",
-    "docs/ARCHITECTURE.md::revealui implements robust multi-tenancy using revealui admin 3.x, allowing multiple organizations to share the same application instance with complete data iso",
     "docs/STANDARDS.md::- validates proper imports from drizzle-zod",
     "docs/STANDARDS.md::- validates staged files before commit",
-    "docs/STANDARDS.md::revealui has a comprehensive logging system already implemented in `@revealui/core`. this guide shows how to use it instead of `console.log`.",
-    "docs/STANDARDS.md::sentry is configured in `apps/admin/next.config.mjs` and will automatically capture errors.",
-    "docs/STANDARDS.md::the type system is validated in ci to prevent drift. the workflow runs on:",
     "docs/STANDARDS.md::this codebase follows the revfleet engineering postures defined in [`docs/methodology.md`](./methodology.md). three postures directly affect code standards:",
-    "docs/api/rest-api/README.md::creates a ticket from the instruction, dispatches an ai agent with admin tools to resolve it, and returns the result.",
-    "docs/api/rest-api/README.md::returns the current user's license tier, status, and expiration.",
-    "docs/api/rest-api/README.md::validates a jwt license key and returns the tier, features, and limits.",
     "docs/architecture/ADR-003-fair-source-licensing.md::all source code lives in the public repo. no gitignored packages. no private repo sync.",
-    "docs/architecture/ai-stack.md::revealui's ai subsystem lives in `@revealui/ai` (pro, fair source fsl-1.1-mit). it provides open-model inference, agent orchestration, crdt-based memory, rag in",
-    "docs/architecture/x402.md::the boot validator (`apps/server/src/lib/validate-startup.ts`) enforces that when `x402_enabled=true`, `x402_receiving_address` is non-empty and matches the `0x",
-    "docs/architecture/x402.md::verification lives in [`apps/server/src/middleware/x402.ts`](../../apps/server/src/middleware/x402.ts) (`verifypayment`): the `exact` scheme is checked against ",
-    "docs/guides/authentication.md::4. every subsequent request validates the cookie against the hashed token in the database",
-    "docs/guides/authentication.md::revealui uses session-based authentication backed by database-stored sessions. there are no jwts. the sole authentication mechanism is a `revealui-session` cook",
-    "docs/guides/billing.md::1. validates the user session",
-    "docs/guides/billing.md::4. returns the checkout url",
-    "docs/guides/collections.md::collections are registered in the revealui configuration:",
-    "docs/guides/collections.md::revealui supports these field types, with schemas defined in `@revealui/contracts`:",
     "docs/guides/deployment.md::- [ ] stripe webhook endpoint is registered in the stripe dashboard"
   ]
 }


### PR DESCRIPTION
Phase 2 backfill continuation (after #1537 + #1539 merged). Grounds 22 code-behaviour claims across 8 docs with `path:line` Works-Cited citations, each sourced via grep and **verified to resolve** (0 validity errors).

- `docs/ARCHITECTURE.md` (4) — contracts validation, rag_chunks schema, multi-tenancy, access-control (×2)
- `docs/STANDARDS.md` (3) — Sentry config, core logger, CI typecheck
- `docs/api/rest-api/README.md` (3) — license verify, license status, agent-tasks ticket route
- `docs/guides/{authentication,billing,collections}.md` (6)
- `docs/architecture/{x402,ai-stack}.md` (3)

`citation-baseline.json` 25 → **5**. The 5 remaining are non-code claims (a pre-commit hook, a methodology-doc pointer, a policy statement, an external Stripe-dashboard step) — correctly left baselined, not force-cited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
