### PR TITLE
fix(docs): repoint citations from signatures to implementing lines

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,7 +178,7 @@ That last exception is temporary, not a preferred pattern. It exists because the
 ### Type Safety Flow
 
 1. **Frontend** → Uses generated types for compile-time safety
-2. **API Routes** → Validates with contracts (runtime + compile-time) (`packages/openapi/src/zod-validator.ts:29`)
+2. **API Routes** → Validates with contracts (runtime + compile-time) (`packages/openapi/src/zod-validator.ts:63`)
 3. **Type Adapters** → Convert DB types ↔ RevealUI types
 4. **Database** → Drizzle ORM provides type-safe queries
 
@@ -668,7 +668,7 @@ hooks: {
 ### Tenant Isolation Guarantees
 
 1. **Database Level**: Queries filtered by tenant relationship
-2. **API Level**: Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:15`)
+2. **API Level**: Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:29`)
 3. **UI Level**: Admin panel shows only current tenant's data
 
 ### Testing Tenant Isolation
@@ -1252,7 +1252,7 @@ Customer-facing meters should map to business activity rather than upstream infr
 ### Tenant Security
 
 **Database Level:** Queries filtered by tenant relationship
-**API Level:** Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:15`)
+**API Level:** Access control validates tenant membership (`apps/admin/src/lib/access/tenants/checkTenantAccess.ts:29`)
 **UI Level:** Admin panel shows only current tenant's data
 
 ---

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1256,7 +1256,7 @@ catch (error) {
 
 ### Sentry Integration
 
-Sentry is configured in `apps/admin/next.config.mjs:204` and will automatically capture errors.
+Sentry is configured in `apps/admin/next.config.mjs:205` and will automatically capture errors.
 
 **Manual Error Capture:**
 ```typescript
@@ -2058,7 +2058,7 @@ To add new validation rules:
 
 ## Overview
 
-RevealUI has a comprehensive logging system already implemented in `@revealui/core` (`packages/core/src/utils/logger.ts:14`). This guide shows how to use it instead of `console.log`.
+RevealUI has a comprehensive logging system already implemented in `@revealui/core` (`packages/core/src/utils/logger-client.ts:70`). This guide shows how to use it instead of `console.log`.
 
 ## Quick Start
 
@@ -2937,7 +2937,7 @@ packages/
 
 ## CI/CD Integration
 
-The type system is validated in CI (`.github/workflows/ci.yml:186`) to prevent drift. The workflow runs on:
+The type system is validated in CI (`.github/workflows/ci.yml:227`) to prevent drift. The workflow runs on:
 - Pull requests touching schema or generated files
 - Pushes to main branch
 - Manual workflow dispatch

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -2736,7 +2736,7 @@ Receives Stripe webhook events for subscription lifecycle, license management, d
 
 **Submit a natural language task for an agent to execute**
 
-Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:95`)
+Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:93`)
 
 **Request body** (JSON)
 
@@ -2776,7 +2776,7 @@ Creates a ticket from the instruction, dispatches an AI agent with admin tools t
 
 **Submit a natural language task for an agent to execute**
 
-Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:95`)
+Creates a ticket from the instruction, dispatches an AI agent with admin tools to resolve it, and returns the result. (`apps/server/src/routes/agent-tasks.ts:93`)
 
 **Request body** (JSON)
 

--- a/docs/architecture/x402.md
+++ b/docs/architecture/x402.md
@@ -74,7 +74,7 @@ Agent                                  Server
   │ ◀─────────────────────────────────────│
 ```
 
-Verification lives in [`apps/server/src/middleware/x402.ts:202`](../../apps/server/src/middleware/x402.ts) (`verifyPayment`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed).
+Verification lives in [`apps/server/src/middleware/x402.ts:215`](../../apps/server/src/middleware/x402.ts) (`verifyPayment`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed).
 
 ## Payment requirements
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -6,7 +6,7 @@ status: verified
 audience: user
 ---
 
-RevealUI uses session-based authentication backed by database-stored sessions. There are no JWTs. The sole authentication mechanism is a `revealui-session` cookie containing a hashed token that maps to a row in the `sessions` table (`packages/auth/src/server/session.ts:124`).
+RevealUI uses session-based authentication backed by database-stored sessions. There are no JWTs. The sole authentication mechanism is a `revealui-session` cookie containing a hashed token that maps to a row in the `sessions` table (`packages/auth/src/server/session.ts:162`).
 
 **Package:** `@revealui/auth`
 
@@ -17,7 +17,7 @@ RevealUI uses session-based authentication backed by database-stored sessions. T
 1. User signs in with email/password or an OAuth provider
 2. A session row is created in the `sessions` table with a hashed token
 3. The raw token is set as an `HttpOnly`, `Secure`, `SameSite=Lax` cookie named `revealui-session`
-4. Every subsequent request validates the cookie against the hashed token in the database (`packages/auth/src/utils/token.ts:24`)
+4. Every subsequent request validates the cookie against the hashed token in the database (`packages/auth/src/utils/token.ts:35`)
 5. Sessions expire after a configurable TTL and are refreshed on activity
 
 No tokens are stored in `localStorage` or sent as `Authorization` headers.

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -120,7 +120,7 @@ Response:
 
 The endpoint:
 
-1. Validates the user session (`apps/server/src/routes/billing.ts:748`)
+1. Validates the user session (`apps/server/src/routes/billing.ts:749`)
 2. Finds or creates a Stripe customer (linked via `stripe_customer_id` in the users table)
 3. Creates a Checkout Session with the correct price
 4. Returns the Checkout URL (`apps/server/src/routes/billing.ts:856`)

--- a/docs/guides/collections.md
+++ b/docs/guides/collections.md
@@ -118,7 +118,7 @@ export default Posts;
 
 ## Field Types
 
-RevealUI supports these field types, with schemas defined in `@revealui/contracts` (`packages/contracts/src/admin/structure.ts:34`):
+RevealUI supports these field types, with schemas defined in `@revealui/contracts` (`packages/contracts/src/admin/structure.ts:373`):
 
 | Type | Description | Example |
 |------|-------------|---------|
@@ -401,7 +401,7 @@ Higher depth values increase query complexity. Use the minimum depth your use ca
 
 ## Registering Collections
 
-Collections are registered in the RevealUI configuration (`packages/core/src/config/index.ts:11`):
+Collections are registered in the RevealUI configuration (`packages/core/src/config/index.ts:45`):
 
 ```ts
 import { buildConfig } from '@revealui/core';

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -178,7 +178,7 @@ long-running operations stop instead of just being ignored.
 
 Some MCP servers need LLM capabilities without bundling a provider. The
 spec lets servers issue `sampling/createMessage` requests — the *client*
-runs the inference, keeps cost + context control, and returns the result (`packages/ai/src/tools/mcp-sampling.ts:175`).
+runs the inference, keeps cost + context control, and returns the result (`packages/ai/src/tools/mcp-sampling.ts:207`).
 On the Ubuntu reference stack, that means servers get LLM access via the
 developer's local Canonical Inference Snap — no cloud round-trip required.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -74,7 +74,7 @@ const mcpConfig = getMcpConfig()
 
 ## Environment Variables
 
-The config package validates these environment variables (schema: `packages/config/src/schema.ts:26`):
+The config package validates these environment variables (schema: `packages/config/src/schema.ts:187`):
 
 ### Required Variables
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -68,7 +68,7 @@ app.openapi(route, (c) => c.json({ id: '1', name: 'test' }, 201));
 ## Design Principles
 
 - **Unified**: Single schema definition drives validation, types, and OpenAPI spec
-- **Orthogonal**: Decoupled from business logic  -  validates at the boundary, not inside handlers (`zValidator`, `packages/openapi/src/zod-validator.ts:29`)
+- **Orthogonal**: Decoupled from business logic  -  validates at the boundary, not inside handlers (`zValidator`, `packages/openapi/src/zod-validator.ts:63`)
 - **Hermetic**: Request validation happens before handler execution, preventing invalid data from leaking through
 
 ## Contracts mirror — cross-language codegen pipeline (F8 Phase 3)


### PR DESCRIPTION
Two rounds of adversarial verification (32 + 15 independent skeptic agents) on the citations added in #1537/#1539/#1542 found 15 that **resolved** (validity passed) but landed on a function *signature*, a *barrel re-export*, or a *property* line rather than the line that implements the claim. This repoints each to the verified implementing line:

- `hashToken` -> `verifyToken` (the claim is about validating/comparing, not hashing)
- logger barrel re-export -> `createLogger` impl in `logger-client.ts`
- agent-tasks `method: 'post'` property -> the route handler
- partial `requiredSchema` -> the merged `envSchema`
- field-type *enum* -> the field *schemas*
- `zValidator` signature -> the `safeParseAsync` call; `checkTenantAccess` signature -> the `user.tenants` membership check; etc.

All re-verified to resolve (0 validity errors). A residual set of "could be even more precise" verdicts were left as-is: the two verification passes *contradicted each other* on the exact line (e.g. `x402.ts:202` vs `:215`), confirming that's subjective line-choice, not correctness — the citations point at the right implementing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
