### PR TITLE
ci(deploy): raise per-app deploy job timeout to 40m

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -94,7 +94,9 @@ jobs:
   deploy:
     name: Preview ${{ matrix.app }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Mirrors deploy.yml: api's Vercel server build runs ~19 min, which starved
+    # the deploy step and hit the 20-min wall. 40 = build + deploy + headroom.
+    timeout-minutes: 40
     needs: detect
     if: needs.detect.outputs.has-apps == 'true'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -318,7 +318,18 @@ jobs:
   deploy:
     name: Deploy ${{ matrix.app }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # api's Vercel build runs ~19 min on EVERY deploy: the turbo monorepo build
+    # is a remote-cache FULL TURBO hit (~4s), but Vercel's own @vercel/node
+    # compile of the Hono server (apps/server) takes ~19 min and is NOT turbo-
+    # cached — so this is not a cold-turbo-cache problem. At timeout-minutes: 20
+    # that build starved the `vercel deploy` step and GitHub cancelled the job
+    # mid-deploy at the 20-min wall (run 27769702651, 2026-06-18: Build 19m0s →
+    # Deploy cancelled 49s in). The deploy only "succeeded" because Vercel
+    # finishes the build server-side and aliases the domain independently of the
+    # GH job. 40 gives build (~19m) + deploy (~1-2m) + headroom so the job itself
+    # completes. (admin/marketing/docs build in 1-3.5 min; the wall is api-
+    # specific, but the limit is shared across the matrix.)
+    timeout-minutes: 40
     needs: [validate, migrate, detect]
     if: needs.detect.outputs.has-apps == 'true'
     environment:


### PR DESCRIPTION
## Problem

The `Deploy <app>` matrix job in `deploy.yml` (and the `Preview <app>` job in `deploy-test.yml`) had `timeout-minutes: 20`. The **api** app's Vercel build runs ~19 min on **every** deploy, which starves the `vercel deploy` step and GitHub cancels the job mid-deploy at the 20-min wall — the run concludes `cancelled`.

It "works" today only because Vercel finishes the build server-side and assigns the production alias independently of the GitHub job. The deploy succeeds by luck, not by the job finishing.

### Evidence — run 27769702651 (2026-06-18), Deploy api job

| Step | Window | Duration | Result |
|------|--------|----------|--------|
| Build | 15:47:49 → 16:06:47 | **19m 0s** | success (at the wire) |
| Deploy | 16:06:47 → 16:07:36 | 49s | **cancelled** (20-min job wall) |

admin / marketing / docs each deploy in 1–3.5 min; only api hits the wall.

### Root cause (revised from the original "cold turbo cache" hypothesis)

The turbo monorepo build is **already a remote-cache `FULL TURBO` hit (~4s)** — the build log shows `Remote caching enabled` and `15 successful, 15 total, Time: 4.068s >>> FULL TURBO`. The ~19 min is **Vercel's own `@vercel/node` compile of the Hono server** (`apps/server`), which is not turbo-cached and runs every deploy regardless of cache state (`Build Completed in .vercel/output [19m]`). So enabling turbo remote cache is a no-op here — it's already on and hitting.

## Fix

Raise both per-app deploy jobs from `timeout-minutes: 20` → `40`. That gives build (~19m) + deploy (~1–2m) + headroom so the job completes inside its budget instead of relying on Vercel's out-of-band completion.

- `deploy.yml` — production `Deploy <app>` matrix job
- `deploy-test.yml` — `Preview <app>` matrix job (same structure, same wall)

No Stripe/gating touched. No turbo/env changes.

## Follow-up (not in this PR)

The api Vercel build is intrinsically slow (~19 min) — the build log shows Vercel running a `tsc` pass over the whole graph (CLI templates included) that floods non-fatal `TS2307`/drizzle-overload errors. Speeding that up (scoping the server tsconfig / skipping the redundant type-check) is a separate, riskier change that warrants its own audit.

## Verify after merge

On the next test→main promotion that deploys api, confirm the **Deploy api** job concludes `success` (not `cancelled`) within the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
