### PR TITLE
ci(citations): enforce citation gate in CI + coverage hard-fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
         # apps/docs/scripts/check-links.ts.
         run: pnpm --filter docs check:links
 
+      - name: Citation gate (hard fail, validity + coverage-strict)
+        # Every code-behaviour claim in gated docs must cite a source:line that
+        # resolves and sits in range (VALIDITY, zero baseline), and must not add
+        # a NEW uncited claim beyond the grandfathered baseline (COVERAGE, via
+        # --coverage-strict, Phase 3). Mirrors the local pnpm gate citation step
+        # in scripts/gates/ci-gate.ts. See CONTRIBUTING.md "Source citations".
+        run: pnpm validate:citations --coverage-strict
+
   # ---------------------------------------------------------------------------
   # Phase 1.5: Drizzle migration apply (all branches)
   #

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -287,11 +287,12 @@ async function gate(): Promise<void> {
       {
         // Source-citation gate (CONTRIBUTING.md — Source citations). VALIDITY
         // (every path:line citation must resolve and sit in-range) HARD-FAILS;
-        // COVERAGE stays warn-only + baseline-grandfathered (no --coverage-strict)
-        // until it is promoted in a later phase.
+        // COVERAGE is now hard-fail too via --coverage-strict (Phase 3): NEW
+        // uncited code-behaviour claims beyond the grandfathered baseline fail.
+        // Mirrored in CI by the Quality job step in .github/workflows/ci.yml.
         name: 'Citation gate (hard fail)',
         command: 'pnpm',
-        args: ['validate:citations'],
+        args: ['validate:citations', '--coverage-strict'],
       },
       {
         name: 'Pro license validation',


### PR DESCRIPTION
## What

The source-citation gate (`pnpm validate:citations`) previously ran only in the
local pre-push gate (`pnpm gate` / `scripts/gates/ci-gate.ts`). It was not wired
into any CI workflow, so PRs that skip the local hook (web merge, `--no-verify`,
fork PRs) bypassed it entirely.

This PR:
- Adds `pnpm validate:citations --coverage-strict` as a hard-fail step in the
  **Quality** job of `.github/workflows/ci.yml`. It now runs on every PR via the
  existing required `Quality` check.
- Flips the local `ci-gate.ts` citation step to `--coverage-strict` so the
  pre-push gate matches CI.

## Enforcement scope

- **VALIDITY** (zero baseline): every `path:line` citation in gated docs must
  resolve and sit in range. Already hard-failed locally; now also in CI.
- **COVERAGE** (`--coverage-strict`): a NEW uncited code-behaviour claim beyond
  the grandfathered baseline (`scripts/validate/citation-baseline.json`) fails
  the build. Existing baselined claims are unaffected.

No branch-protection change is required: folding the step into the existing
required `Quality` check enforces it on every PR without adding a new required
status context (which, with no matching check job, would block the merge queue).

## Pre-flight

`pnpm validate:citations --coverage-strict` on the base branch reports
`0 validity errors, 0 NEW coverage gaps (5 baselined)` and exits 0, so wiring
the hard-fail in does not block existing PRs.
