### PR TITLE
perf(server): exclude TS source from api Vercel function trace

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -6,7 +6,8 @@
     "api/**": {
       "memory": 512,
       "maxDuration": 30,
-      "includeFiles": "dist/index_bg.wasm"
+      "includeFiles": "dist/index_bg.wasm",
+      "excludeFiles": "**/*.{ts,tsx,mts,cts}"
     }
   },
   "crons": [{ "path": "/api/cron/dispatch", "schedule": "0 6 * * *" }],


### PR DESCRIPTION
## Summary

The `api` (`apps/server`) production Vercel build runs **~19 min on every deploy** and is the long pole — admin/marketing/docs build in 1–3.5 min. #1544 raised the deploy job `timeout-minutes` 20→40 so the job stops getting cancelled (symptom fix). **This PR fixes the root cause.**

## Root cause

The turbo monorepo build is a remote-cache `FULL TURBO` hit (~4s) — not the problem. The ~19 min is `@vercel/node`'s post-build function step:

- It traces the function with `@vercel/nft` (`ts: true`). For every `.ts`/`.tsx` file it reads, it runs an in-process, ts-node-style type-check (`register()` → `getSemanticDiagnostics`).
- `register({ files: true })` preserves the resolved tsconfig's `include`, and the trace pulls in workspace source, so the TypeScript program ends up spanning the **entire monorepo** — `apps/admin`, `apps/marketing`, `apps/docs`, `packages/ai`, `packages/cli/templates`.
- That produces **~2,900 non-fatal type errors** (`TS2307` unresolved `@revealui/*`, etc.) and burns ~18 min. The errors don't fail the build (`noEmitOnError` is unset), so it is pure wasted wall-clock.

This type-check is **redundant**: the CI gate type-checks the whole repo before merge and `turbo build` type-checks the packages. The function runs the **prebuilt `dist/` bundle (plain JS)** plus its traced `node_modules` deps — no TypeScript source is needed at runtime.

## Fix

Add `excludeFiles` to the `api/**` function so `@vercel/nft` never reads TS source. With no `.ts`/`.tsx` traced, `register()` never fires and the whole-repo type-check is skipped.

```json
"functions": {
  "api/**": {
    "memory": 512,
    "maxDuration": 30,
    "includeFiles": "dist/index_bg.wasm",
    "excludeFiles": "**/*.{ts,tsx,mts,cts}"
  }
}
```

## Verification

Local `vercel build --prod` with vercel `54.14.2` (the CI version) against the api project:

| | Before | After |
|---|---|---|
| Build | ~19 min (run `27769702651`) | **46s** |
| `Using TypeScript` whole-repo type-check | ~2,900 errors | **none** |

Function output is unchanged: handler (`apps/server/api/index.js`) + all 112 `dist` chunks + every `@revealui` workspace dep + `pg`/`stripe`/`jose`/`drizzle`/`@neondatabase` traced; **0 `.ts` in the bundle**.

## Notes
- No change to the turbo remote cache, `TURBO_TOKEN`/`TURBO_TEAM`, or any Stripe gating.
- `excludeFiles` only matches TypeScript source, never `.js`/`.wasm`/`.json`, so the runtime bundle is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
