### PR TITLE
Enforce adherence-lint on marketing + docs

### DIFF
--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -70,10 +70,13 @@ jobs:
       # hard failure across all apps.
       - name: Adherence lint (apps — report-only)
         run: node "$DS_DIR/scripts/adherence-lint.cjs" --warn apps
-      # Ratchet: enforce hard on surfaces already converged. Uncomment per app
-      # as each is cleaned, so cleaned surfaces can't regress.
-      # - name: Adherence lint (marketing — enforced)
-      #   run: node "$DS_DIR/scripts/adherence-lint.cjs" apps/marketing
+      # Ratchet: enforce hard on the surfaces already converged (PR #1550), so the
+      # cleaned apps can't regress while the rest stay report-only above. Add a
+      # line per app as each is cleaned.
+      - name: Adherence lint (marketing — enforced)
+        run: node "$DS_DIR/scripts/adherence-lint.cjs" apps/marketing
+      - name: Adherence lint (docs — enforced)
+        run: node "$DS_DIR/scripts/adherence-lint.cjs" apps/docs
 
   tokens-contract:
     name: tokens pack in sync


### PR DESCRIPTION
Follow-up to #1550. Now that **marketing** and **docs** are converged (0 adherence-lint errors), promote the DS adherence gate from report-only to **enforced** on those two apps so they can't regress. The `--warn apps` report-only sweep stays in place for the not-yet-converged surfaces (admin, server, …).

**Change** (`.github/workflows/ds.yml`): add two enforced steps — `adherence-lint apps/marketing` and `adherence-lint apps/docs` (no `--warn`) — alongside the existing `--warn apps` step.

Both apps are at 0 errors today, so this is green on merge. Only **errors** fail the gate; warnings (e.g. the checkmark-glyphs in docs tooling) stay non-blocking. Next ratchet step: clean + enforce the remaining apps one at a time.
