### PR TITLE
Mirror the hero trust strip into the operator view

### DIFF
--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -180,6 +180,16 @@ function NonTechnicalHero() {
           </a>
         </ButtonCVA>
       </div>
+
+      {/* Trust strip — mirror of TechnicalHero; same signals for the operator view. */}
+      <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm text-muted-foreground list-none p-0">
+        {['Open source', 'Self-hostable', 'Audit-ready'].map((signal) => (
+          <li key={signal} className="flex items-center gap-2">
+            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
+            {signal}
+          </li>
+        ))}
+      </ul>
     </>
   );
 }


### PR DESCRIPTION
Follow-up to #1550. The hero trust strip (Open source · Self-hostable · Audit-ready) landed in `TechnicalHero` only; the convergence spec left mirroring into the operator variant optional. This adds the same strip beneath the CTA in `NonTechnicalHero`, so the default `/` (non-technical) view also carries the trust signals.

Same markup as TechnicalHero — cobalt dot (`bg-primary`) + muted text, `list-none`. Verified: marketing typecheck clean; renders on the operator view (`/`).
