### PR TITLE
Marketing: load brand fonts

### DIFF
--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -68,7 +68,7 @@ export function PricingTeaser() {
                 }`}
               >
                 {t.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary-foreground">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-semibold uppercase tracking-widest text-primary-foreground">
                     Recommended
                   </div>
                 )}

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -18,6 +18,9 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inter+Tight:wght@700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="RevealUI | Your business grows with you, and stays at the frontier." />


### PR DESCRIPTION
## Summary

- Load Inter, Inter Tight, and JetBrains Mono from Google Fonts in `apps/marketing/index.html` — identical `<link>` block to the one already in `apps/docs/index.html`. Without this, display headings silently fell back to a system face even though the CSS uses `font-display` (Inter Tight).
- Align the "Recommended" badge on `PricingTeaser` from `tracking-wider` → `tracking-widest` to match every other uppercase eyebrow on the site.

## Test plan

- [ ] Run `pnpm --filter @revealui/marketing dev`, open the homepage
- [ ] DevTools → Network → filter "font" — confirm Inter Tight loads from fonts.googleapis.com
- [ ] DevTools → Elements → select hero `<h1>` → Computed → font-family resolves to `"Inter Tight"`
- [ ] Hero headline looks heavier/tighter than before the change
- [ ] Pricing section "Recommended" badge spacing matches section eyebrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)