### PR TITLE
docs(blog): refresh component claims, add 5 codebase-grounded posts

### DIFF
--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -31,6 +31,51 @@ interface PostMeta {
 
 const POST_METADATA: PostMeta[] = [
   {
+    slug: 'revfleet-product-family',
+    title: 'One Runtime, Eight Products: The RevFleet Family',
+    excerpt:
+      'You do not adopt a framework, you adopt a fleet. RevealUI is the flagship runtime, and seven sister products extend it, from an encrypted secret vault to an agent tool marketplace.',
+    publishedAt: '2026-06-18T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '11-revfleet-product-family.md',
+  },
+  {
+    slug: 'dashboard-agent-chat',
+    title: 'Run Your Admin by Talking to It',
+    excerpt:
+      'Open the admin, type what you want done, and watch the agent do it, with streaming output, full tool visibility, and the same access control your users get.',
+    publishedAt: '2026-06-17T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '15-dashboard-agent-chat.md',
+  },
+  {
+    slug: 'own-your-secrets',
+    title: "Your Secrets Don't Belong in a .env File",
+    excerpt:
+      'The default bargain puts your credentials in a vendor dashboard or a plaintext .env file. RevVault keeps them age-encrypted on hardware you control, never as plaintext on disk.',
+    publishedAt: '2026-06-16T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '12-own-your-secrets.md',
+  },
+  {
+    slug: 'zero-regex',
+    title: 'Building a Codebase With Zero Hand-Written Regex',
+    excerpt:
+      'We banned hand-written regular expressions across the entire fleet. Here is what we use instead, and why it makes the code safer and easier to read.',
+    publishedAt: '2026-06-15T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '13-zero-regex.md',
+  },
+  {
+    slug: 'claim-drift',
+    title: 'The Marketing Site That Fails CI When It Lies',
+    excerpt:
+      'Every number on revealui.com is checked against the code on every push. When a stat drifts from reality, the build breaks before the lie ships.',
+    publishedAt: '2026-06-14T12:00:00.000Z',
+    author: 'RevealUI Team',
+    file: '14-claim-drift.md',
+  },
+  {
     slug: 'component-library',
     title: '60 Components, One Dependency',
     excerpt:

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -231,7 +231,7 @@ Some numbers on what's actually shipped:
 
 - **31 workspaces** across the monorepo (4 apps + 27 packages — 21 MIT, 5 Fair Source, 1 internal)
 - **85 database tables** via Drizzle ORM on NeonDB (Postgres)
-- **60 UI components** in `@revealui/presentation` (80 counting the admin engine) — zero external UI dependencies, just Tailwind v4, clsx, and CVA
+- **60 UI components** in `@revealui/presentation` — one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **14 first-party MCP servers** in `@revealui/mcp`
 - **Extensive test coverage** across unit, integration, and E2E layers (run `pnpm test` for the current count)
 - **Full OpenAPI spec** with Swagger UI at `/docs`

--- a/docs/blog/09-component-library.md
+++ b/docs/blog/09-component-library.md
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 Open the `package.json` of a typical React app and trace the dependency tree under your UI. A component library. The headless-primitive library it sits on. An icon set. A class-merging utility. A variants helper. A few polyfills the library pulls in. Every one of those is a version you have to track, a breaking change you have to absorb on someone else's schedule, and a styling opinion you have to work around.
 
-RevealUI's UI layer, `@revealui/presentation`, has exactly one runtime dependency. Not one UI framework. One package: `tailwind-merge`. Everything else, the 60 components and the machinery that powers them, is in the box and MIT licensed.
+RevealUI's UI layer, `@revealui/presentation`, has exactly one third-party runtime dependency. Not one UI framework. One npm package: `tailwind-merge`. Its design tokens come from a sibling in-house package, `@revealui/tokens`. Everything else, the 60 components and the machinery that powers them, is in the box and MIT licensed.
 
 This post is about why a component library should be something you own outright, and how this one is built.
 
@@ -29,7 +29,7 @@ The set is meant to cover real business software, not just a demo: `accordion`, 
 
 The dependency story is the headline:
 
-- **One runtime dependency:** `tailwind-merge`, for safely merging Tailwind class lists.
+- **One third-party runtime dependency:** `tailwind-merge`, for safely merging Tailwind class lists. Design tokens come from the in-house `@revealui/tokens` package, not from npm.
 - **React is a peer dependency**, not a bundled copy. The package works on React 18 or 19; RevealUI runs it on 19.
 - **Tailwind v4** for styling.
 
@@ -90,7 +90,7 @@ Because the tokens are semantic rather than literal, a component never says "blu
 
 ## The trade-off
 
-Here is the honest version. A from-scratch component layer trades away two real things: the ecosystem breadth of a Radix or an MUI, and the millions of hours of edge-case hardening that a widely used library accumulates. If you need an exotic widget that is not among the 59, you build it, on the same primitives, rather than `npm install`-ing it in an afternoon.
+Here is the honest version. A from-scratch component layer trades away two real things: the ecosystem breadth of a Radix or an MUI, and the millions of hours of edge-case hardening that a widely used library accumulates. If you need an exotic widget that is not among the 60, you build it, on the same primitives, rather than `npm install`-ing it in an afternoon.
 
 What you get back is ownership. No major-version migrations dictated by someone else's roadmap. No dependency that can change behavior under you. No styling you cannot reach. For business software, where the component needs are broad but not exotic, that is the trade I want, and it is the one RevealUI makes by default.
 

--- a/docs/blog/11-revfleet-product-family.md
+++ b/docs/blog/11-revfleet-product-family.md
@@ -1,0 +1,65 @@
+---
+title: "One Runtime, Eight Products: The RevFleet Family"
+description: "You do not adopt a framework, you adopt a fleet. RevealUI is the flagship runtime, and seven sister products extend it."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+Most tools sell you a library. You install it, wire it into one corner of your app, and move on. RevealUI is built the other way around. It is a runtime that an entire family of products sits on top of, each one solving a problem you hit the moment you start running software for real.
+
+We call the family RevFleet. RevealUI is the flagship: the agentic business runtime that gives you users, content, products, payments, and intelligence pre-wired into one deployable system. The other seven products are the tools we built to operate it, and we ship every one of them.
+
+This post is the map. It is also honest about where each product is, because "shipping" means different things at different stages, and you deserve to know which is which before you build on it.
+
+## How we label maturity
+
+Every product carries one of four status badges. They mean exactly what they say:
+
+- **Beta** -- production-ready code, dogfooded daily, limited real users.
+- **Alpha** -- works and ships, development-preview quality, may break.
+- **Active (MIT)** -- a released, free, open library with no SLA.
+- **Planned** -- code-complete or scaffolded, not yet shipped to users.
+
+No product on this page hides behind a vaguer word than that.
+
+## The flagship: RevealUI
+
+**RevealUI** (Beta) is the foundation everything else builds on. The five primitives, users, content, products, payments, and intelligence, are pre-wired into a single runtime that your team and your AI agents share through one open protocol. Standard Postgres for data, S3-compatible object storage, real-time sync, a typed REST API with an OpenAPI spec, session auth, and feature gating, all in the box.
+
+You can run a real business on the open-source core today. Start here. Add the rest of the fleet as you grow into it.
+
+```bash
+npx create-revealui@latest my-app
+```
+
+## The seven sister products
+
+Each of these came out of operating RevealUI ourselves. We needed them, so we built them, then made them products.
+
+**RevVault** (Beta) is an age-encrypted secret vault. A Rust CLI plus a Tauri desktop app keep your credentials encrypted on hardware you control, never in a vendor dashboard and never as plaintext on disk. It is the canonical secret store for every project in the fleet. There is a whole post on why your secrets do not belong in a `.env` file.
+
+**RevForge** (Beta) is a white-label stamping tool for operators. It generates branded, domain-locked RevealUI trial kits as self-hosted runtime instances, so an agency or platform can hand a customer their own deployment without forking anything by hand.
+
+**RevDev** (Alpha) is a multi-agent IDE harness: a desktop Studio, a terminal Console, and a Node daemon that coordinate AI coding agents across a multi-repo workspace. It speaks to Claude, Cursor, and Copilot through a shared coordination layer. Alpha means it works and we use it, not that it is bulletproof yet.
+
+**RevCon** (Alpha) is editor config sync. One source of truth for Zed, VS Code, and Cursor settings, symlinked into every project, so you edit a config once and it propagates fleet-wide.
+
+**RevSkills** (Active, MIT) is a library of Claude Code skills: auth flows, schema patterns, test scaffolds, and more, ready to drop into any agent. Free, open, importable.
+
+**RevKit** (Active, MIT) is a portable developer environment. Profile-based bootstrap with parameterized templates and tier-aware configs, so a new machine comes up reproducible instead of hand-assembled.
+
+**RevMarket** (Planned) is the agent tool marketplace. The runtime already ships a catalog of first-party integrations out of the box; RevMarket is the planned layer where third-party developers publish and discover MCP servers and agent capabilities. It is designed, not yet open to outside publishers, and we say so plainly on the roadmap.
+
+## Why a fleet instead of one big product
+
+The temptation, building this, was to fold everything into one monolith and call it a platform. We did the opposite on purpose.
+
+Each product is useful on its own. RevVault secures secrets for any project, RevealUI runtime or not. RevSkills drops into any Claude Code setup. RevKit bootstraps any developer machine. Bundling them would have made each one worse, locked behind a runtime you may not want yet.
+
+So they compose instead of couple. You can take exactly the piece you need today, and the rest is there when you need it. One foundation, eight products, no all-or-nothing.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. See the whole RevFleet lineup and current status at [revealui.com/products](https://revealui.com/products), or start with the runtime: `npx create-revealui`.*

--- a/docs/blog/12-own-your-secrets.md
+++ b/docs/blog/12-own-your-secrets.md
@@ -1,0 +1,60 @@
+---
+title: "Your Secrets Don't Belong in a .env File"
+description: "The default bargain puts your credentials in a vendor dashboard or a plaintext .env file. RevVault keeps them age-encrypted on hardware you control."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+The `.env` file is where security quietly rots.
+
+It starts innocently. You paste a Stripe key into `.env.local` to get a feature working. A teammate copies it into Slack to unblock themselves. CI needs it, so it goes into the provider dashboard too. Six months later your most sensitive credentials exist in plaintext in four places, none of them encrypted, and nobody remembers all four. The day one of them leaks, you find out from a billing alert.
+
+RevealUI refuses that bargain. Every project in the fleet keeps its secrets in **RevVault**, an age-encrypted local secret store, and nothing lives in plaintext on disk.
+
+## What RevVault is
+
+RevVault is a Rust command-line tool plus a Tauri desktop app. It encrypts your secrets with [age](https://age-encryption.org/), keeps them on your own filesystem, and never phones home. The encrypted store is git-friendly, so a team can version it like any other file, and it is compatible with the `passage` format, so you are not locked into a bespoke vault you cannot leave.
+
+The model is simple. Secrets are encrypted at rest. They are decrypted on demand, in memory, by a key that stays on your machine. They are never written back to disk in the clear, and they never transit a third-party server you do not control.
+
+```bash
+# Store a secret (prompts for the value, never echoed)
+revvault set my-project/stripe/secret-key
+
+# Read it back
+revvault get my-project/stripe/secret-key
+
+# Load a whole namespace into your shell environment
+revvault export-env my-project > /dev/null   # used by .envrc, not a file
+```
+
+## How a RevealUI project actually uses it
+
+The point of RevVault is that you stop thinking about secrets day to day, and they are still never exposed.
+
+Every RevealUI project ships an `.envrc` that calls RevVault at shell entry. When you `cd` into the project, your credentials are decrypted into the environment for that session, used by the running process, and gone when the shell exits. No `.env.local` full of live keys sits on disk waiting to be committed by accident.
+
+```bash
+# .envrc
+eval "$(revvault export-env my-project)"
+```
+
+Contrast that with the standard pattern: secrets in a provider's secret manager, secrets in a `.env` checked into a "private" repo, secrets pasted into a CI settings page. All three hand values that should only exist on hardware you control to someone else, and all three are one misconfiguration away from public.
+
+## The desktop app, for when the CLI is not enough
+
+Not everyone wants to live in a terminal. The RevVault desktop app gives you a visual view of your namespaces, lets you add and rotate secrets without memorizing commands, and keeps the same age-encrypted store underneath. The CLI and the app are two front doors to one vault, not two systems to keep in sync.
+
+## The honest part
+
+RevVault is Beta. It is what the entire fleet runs on every day, which is the strongest test we can give it, but a few things are worth knowing before you adopt it.
+
+You hold the age identity key. That is the whole point, and it is also a responsibility: lose the key with no backup and you lose the secrets it protects, exactly as it should be for something nobody else can decrypt. The CLI is intentionally conservative about destructive operations, so renaming and bulk deletion are deliberate rather than one keystroke away. And like the rest of RevFleet, it is open, so you can read precisely what it does with your data before you trust it with any.
+
+The trade you are making is real surface area, your own key and your own store, in exchange for the one thing a vendor dashboard can never give you: secrets that only ever exist where you put them.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. RevVault is part of the RevFleet family; read the source and get started on [GitHub](https://github.com/RevealUIStudio/revvault).*

--- a/docs/blog/13-zero-regex.md
+++ b/docs/blog/13-zero-regex.md
@@ -1,0 +1,66 @@
+---
+title: "Building a Codebase With Zero Hand-Written Regex"
+description: "We banned authored regex across the fleet. Here is what we use instead, and why it made the code safer and easier to read."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+There is a rule across the entire RevFleet codebase that surprises people: no hand-written regular expressions. Not "use them sparingly." Zero authored regex, enforced in CI.
+
+This sounds like an aesthetic preference. It is actually a security and maintainability decision, and it has paid for itself many times over.
+
+## Why regex is a liability, not a tool
+
+A regular expression is write-only code. You write one that works on your three test cases, ship it, and a year later nobody on the team, including the author, can say with confidence what it accepts and what it rejects. Bugs hide in the gap between what you meant and what the pattern actually matches.
+
+Worse, some regex patterns are a denial-of-service vector. Catastrophic backtracking lets a short, innocent-looking input pin a CPU core for seconds:
+
+```js
+// A classic ReDoS pattern. Feed it "aaaaaaaaaaaaaaaaaaaaaaaa!"
+// and watch one CPU core melt.
+const looksValid = /^(a+)+$/;
+looksValid.test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"); // hangs
+```
+
+That pattern is the kind of thing that ends up in an input validator, looks fine in review, passes the tests, and becomes an outage the first time an attacker sends a crafted string. Banning the whole category removes the foot-gun instead of hoping every reviewer spots it.
+
+## What we use instead
+
+For every job regex usually does, there is a clearer, safer tool that says what it means:
+
+- **Parsing structured text** uses real parsers. `URL` for URLs, `JSON.parse` for JSON, `Date.parse` for dates. These are battle-tested, spec-compliant, and they reject malformed input correctly instead of approximately.
+- **Walking code and markup** uses AST walkers. We use `mdast` for Markdown, the Lexical tree for rich text, and `@typescript-eslint` for TypeScript. An AST knows the difference between a string literal and an identifier; a regex only sees characters.
+- **Membership and lookup** uses `Set` and `Map`. "Is this one of the allowed values" is a `Set.has`, not an alternation you have to keep escaping.
+- **Splitting human text** uses `Intl.Segmenter`, which understands graphemes and word boundaries across languages, where a regex quietly mangles anything outside ASCII.
+- **Simple shape checks** use typed predicates: `startsWith`, `endsWith`, `includes`, and small hand-written functions that a human can read in one pass.
+
+Library APIs that happen to wrap a tested pattern are fine. Zod's `.email()` is a typed contract, not a regex you maintain. The line is about regex you author and own, because that is the regex that bites you.
+
+## The one exception, kept on a short leash
+
+Some third-party tools only accept configuration as a regex string: a linter ignore pattern, a scanner allowlist. We do not pretend those away. Each one is marked with a `// REGEX-CONFIG-BOUNDARY` comment, kept as small as possible, and isolated so it is obvious it is a boundary with someone else's API, not logic we wrote.
+
+## How the rule pays off in practice
+
+The most satisfying proof is the tooling that enforces our own claims. The validator that keeps our marketing numbers honest has to count things in the repo, like how many test cases live in a suite. The obvious implementation is a regex over the file. Ours is not:
+
+```ts
+for (const line of content.split('\n')) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith('it(') || trimmed.startsWith('test(')) count++;
+}
+```
+
+Anyone can read that and know exactly what it counts. There is no pattern to misremember, no edge case lurking in a quantifier, and nothing for a malicious input to exploit. We have an AST-based analyzer in CI that hunts for the dangerous patterns regex tends to hide, command injection, time-of-check-to-time-of-use races, and ReDoS, and the no-regex rule means it has far less to hunt for.
+
+## The trade-off
+
+The honest cost is line count. A typed predicate or a small parser-driven function is sometimes longer than the one-liner regex it replaces. We take that trade every time, because the longer version is the one a teammate can read at 11pm before a launch and actually trust.
+
+Readable, reviewable, and safe beats clever and opaque. For code you intend to run for years, that is not a close call.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. Read how we build it in the [docs](https://docs.revealui.com).*

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -1,0 +1,64 @@
+---
+title: "The Marketing Site That Fails CI When It Lies"
+description: "Every number on revealui.com is checked against the code on every push. When a stat drifts from reality, the build breaks before the lie ships."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+Marketing numbers rot. A landing page says "60 components," the team ships three more, and now the page is wrong and nobody notices, because the page and the code live in different worlds and no one is paid to keep them in sync.
+
+On revealui.com, that cannot happen. Every count we publish is checked against the actual code on every push, and if a number drifts from the truth, the build fails before the change can merge. The marketing site is not allowed to lie.
+
+## The problem with hand-written stats
+
+Pick any developer-facing site and you will find stale numbers. "Over 200 integrations" when it has been 340 for a year. "12 supported languages" when two were removed. The numbers were true once, typed by hand into a hero section, and then reality moved and the copy did not.
+
+It is not malice, it is structure. The claim and the thing it describes have no connection. Keeping them aligned depends on someone remembering, and someone always forgets.
+
+## One canonical source, imported everywhere
+
+The first half of the fix is a single source of truth. Every number the marketing site can state lives in one typed object, and no page is allowed to hardcode the integer anywhere else.
+
+```ts
+export const METRICS = {
+  packages: 27,        // workspace packages
+  uiComponents: 60,    // components in @revealui/presentation
+  mcpServers: 14,      // first-party MCP servers
+  dbTables: 85,        // Drizzle table declarations
+  // ...
+} as const;
+```
+
+A page that wants to say "60 UI components" imports `METRICS.uiComponents`. It never types `60`. Change the underlying number in one place and the copy follows automatically, on the marketing site, in the docs, and in the product roadmap, with no copy edit at all.
+
+## The validator that does the counting
+
+The second half is a check that proves those numbers are real. On every push, a claim-drift validator walks the docs and the marketing content, finds every place a number sits next to a noun it recognizes, and counts the real thing in the repository. The counts come straight from the source: it reads the components directory, the MCP servers directory, the database schema, and the test suites, and compares each published claim against the live count.
+
+If they match, the build is green. If they do not, it fails loudly with the exact mismatch:
+
+```
+claim-drift: docs/blog/09-component-library.md
+  UI components: claims 59, actual 60 (UNDERSTATED)
+  -> fix the copy or fix the count, but they must agree
+```
+
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 27 packages, 60 UI components, 14 first-party MCP servers, 85 database tables, 59 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+
+## The validator practices what we preach
+
+There is a detail worth calling out. The fleet has a rule against hand-written regular expressions, and the claim-drift validator obeys it. It does not scan files with clever patterns. It splits text into lines, trims them, and uses plain string checks and real parsers to find claims and count code. It even skips fenced code blocks, so the example error message above does not trip the validator on this very page.
+
+So the tool that keeps our marketing honest is itself built to the same standard it enforces: readable, reviewable, and impossible to quietly fool.
+
+## Why bother
+
+This is more discipline than most marketing sites accept, and that is exactly why it is worth writing about. A number you can verify is a number you can trust, and a company that wires "verify before you claim" into its build pipeline is telling you something about how it writes the rest of its code too.
+
+We would rather break our own build than ship a stat we cannot stand behind.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. Every claim on this site is checked against the source; read it for yourself in the [docs](https://docs.revealui.com).*

--- a/docs/blog/15-dashboard-agent-chat.md
+++ b/docs/blog/15-dashboard-agent-chat.md
@@ -1,0 +1,53 @@
+---
+title: "Run Your Admin by Talking to It"
+description: "Open the RevealUI admin, type what you want done, and watch the agent do it, with streaming output and full tool visibility."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+The fastest admin interface is a sentence.
+
+"Draft a post about our Q2 launch and save it as a draft." "How many users signed up last week?" "Mark every ticket from the demo account as resolved." In the RevealUI admin, you type that into a chat panel and the agent does it, in front of you, with every step it takes visible as it happens.
+
+This is Dashboard Agent Chat, and it ships today in the admin dashboard.
+
+## What it does
+
+The agent lives inside the admin you already use. From the chat panel it can create and edit content, query your data, manage collections, and run multi-step workflows, all through natural language. You get streaming responses so you see the work as it unfolds, full visibility into which tools it called, and a conversation history so you can pick up where you left off.
+
+It is not a chatbot bolted onto a sidebar that can only answer questions. It operates your business, on the same data, through the same API your team uses.
+
+## Why it works: collections are already tools
+
+The reason this needed almost no new surface area is the architecture underneath. In RevealUI, every collection you define is automatically exposed as a tool an agent can call. Define a `Posts` collection and you get a REST API, an admin UI, and an agent-callable tool, simultaneously, from one definition.
+
+So when you ask the agent to draft a post, it is not reaching through a special integration. It is calling the exact same create-post operation a human triggers from the dashboard. There is no separate "agent path" to keep in sync with the real one, which means the agent cannot do anything your own access control does not already allow.
+
+That last part matters. Every action the agent takes is governed by the same RBAC and ABAC rules that govern your users, and every operation is attributed in the audit log. The agent does not get a backstage pass. It gets a seat with the same permissions as the account it is acting for.
+
+## It runs on your models, not someone's API
+
+The agent streams its work over Server-Sent Events, and the inference behind it is yours to choose. RevealUI auto-detects the inference path at runtime, preferring a local Ubuntu Inference Snap and falling back to Ollama, both running open-weight models on your own hardware.
+
+```ts
+// The runtime picks the available local backend automatically.
+const llmClient = createLLMClientFromEnv(); // snap, else Ollama
+```
+
+No proprietary API key. No per-token cloud bill. No customer data leaving your machine to reach a frontier model. If you would rather point it at a cloud-compatible endpoint, that is a single environment variable, but it is opt-in, never the default.
+
+## The honest scope
+
+Dashboard Agent Chat is a Pro-tier feature. The AI engine that powers it loads only for licensed deployments, so a free-tier install never pulls the agent code into memory at all.
+
+And because it runs on open-weight models by design, set your expectations accordingly. These models are excellent at the structured work an admin is full of: drafting and editing content, querying and summarizing data, filling fields, orchestrating a sequence of API calls. They are not a frontier reasoning engine, and we would rather you know that than be surprised by it. For the daily operation of a business, structured and reliable is exactly the right trade.
+
+## Try it
+
+Spin up a RevealUI instance, open the admin, and ask it to do something. Watching your admin act on a plain-English instruction, with every tool call shown and every permission respected, is the moment the "agentic business runtime" stops being a tagline and starts being a tool you reach for.
+
+---
+
+*RevealUI is the open runtime for businesses that run their own AI. See what the admin can do in the [docs](https://docs.revealui.com), or compare tiers on the [pricing page](https://revealui.com/pricing).*


### PR DESCRIPTION
## Summary

Audit and refresh of the marketing blog, plus 5 new posts grounded in the current codebase.

Source of truth: post content lives in `docs/blog/*.md`; the blog index reads metadata from `apps/marketing/app/lib/blog-posts.ts`.

## Audit result: no posts removed

All 10 existing posts are current or carry accurate forward-looking caveats. The things that would make a post stale are absent or already corrected: x402 and the MCP marketplace are honestly flagged as dormant/planned, the only "Supabase" references are the intentionally-retained MCP adapter or explicit "mid-migration off Supabase" framing, and storage already reflects Cloudflare R2 as canonical with Vercel Blob marked legacy. Nothing crossed the "no longer applies" line.

## Updates (2 posts)

Both fix the same drift: `@revealui/presentation` now depends on `@revealui/tokens` + `tailwind-merge`, and `cva`/`cn` are vendored in-package rather than installed.

- **09-component-library**: "one dependency" -> "one third-party dependency" (`tailwind-merge`), with design tokens from `@revealui/tokens`; fixed a stray "59" that contradicted the "60 components" used everywhere else in the post.
- **01-why-we-built-revealui**: corrected the component/deps bullet (dropped the unverifiable "80 counting the admin engine" and the inaccurate "clsx, and CVA" deps).

## New posts (5)

| File | Title | Grounded in |
|------|-------|-------------|
| 11 | One Runtime, Eight Products: The RevFleet Family | `content/products.ts` product roster + statuses |
| 12 | Your Secrets Do Not Belong in a .env File | RevVault (age-encrypted vault) + revvault-first methodology |
| 13 | Building a Codebase With Zero Hand-Written Regex | the no-regex engineering rule + the no-regex claim-drift scanner |
| 14 | The Marketing Site That Fails CI When It Lies | `scripts/validate/claim-drift.ts` + canonical `METRICS` |
| 15 | Run Your Admin by Talking to It | shipped Dashboard Agent Chat + agent-stream + collections-as-MCP-tools |

All numeric claims in the new posts use the canonical `METRICS` values, so claim-drift stays green. (Post 14 caught two of its own draft errors during validation, which was a fitting test of the feature it describes.)

## Validation

- `validate:claims` (claim-drift): 0 mismatches
- `validate:marketing-voice`: clean
- `validate:citations`: 0 new uncited claims
- marketing `typecheck`: clean
- marketing `test`: 73 passed
- biome format + lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
