### PR TITLE
fix(ci): defer tests to CI on main/test pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -68,9 +68,9 @@ GATE_EXIT=0
 case "$BRANCH" in
   main|test)
     echo ""
-    echo "Running CI gate for protected branch '$BRANCH' (quality + typecheck + affected tests)..."
+    echo "Running CI gate for protected branch '$BRANCH' (quality + typecheck; build + tests run in CI)..."
     echo ""
-    pnpm gate --no-build || GATE_EXIT=$?
+    pnpm gate --no-build --no-test || GATE_EXIT=$?
     ;;
   *)
     echo ""


### PR DESCRIPTION
## Problem

Pushes to `test`/`main` are rejected by the pre-push gate — **not by a failing test**, but by a 10-minute timeout on Phase 3. Every test suite that runs is green; the run is simply killed at the wall (`admin`/`server` — the two largest suites — never even start).

`.husky/pre-push` runs `pnpm gate --no-build` for the `main|test` case but omits `--no-test`, so the full affected suite runs locally. With `turbo.json` `test.cache=false` tests force-execute on every push, and on constrained hardware the serial run exceeds the gate's hard 600s Tests-phase cap (`scripts/gates/ci-gate.ts:474`). The hook's own comment (`.husky/pre-push:64`) already states tests should be "deferred to CI" — the command just didn't honor it.

## Fix

Add `--no-test` to the protected-branch path so the pre-push gate runs **quality + typecheck only**, matching the line-64 intent and the documented `--no-test` flag (`ci-gate.ts:15`, wired at `:103`/`:214`/`:472`). The echo is corrected to stop claiming "affected tests". CI remains the authoritative test gate and runs the full suite in the cloud (where it passes).

## Risk

Local-hook-only change; zero runtime/code impact — CI does not use husky hooks. The feature-branch pre-push path (`--phase=1 --changed`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
