### PR TITLE
docs(blog): mark marketplace/x402 coming-soon; wire blog into claim-drift gate

### DIFF
--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -151,7 +151,7 @@ const POST_METADATA: PostMeta[] = [
     slug: 'http-402-payments',
     title: 'Paying for AI API Calls with HTTP 402 and USDC',
     excerpt:
-      'How the x402 protocol enables agent-native micropayments without accounts or subscriptions.',
+      'Coming soon: how the x402 protocol will enable agent-native micropayments without accounts or subscriptions. This post is the design.',
     publishedAt: '2026-03-21T12:00:00.000Z',
     author: 'RevealUI Team',
     file: '02-http-402-payments.md',

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -150,7 +150,7 @@ const featureTierMap: Record<keyof FeatureFlags, LicenseTier> = {
 };
 ```
 
-Free tier gets the full runtime engine, auth, the REST API, and local AI inference (Inference Snaps or Ollama — no API key, no cloud bill). Pro unlocks AI agents, payments, sync, MCP, and the monitoring dashboard. Max adds AI memory, advanced inference configuration, and audit logging. Enterprise adds multi-tenant management and RevealUI Fleet — branded white-label deployment for your own customers (managed setup via RevForge). White-label and SSO are designed but not yet shipped, so the code forces those flags to `false` rather than advertise features that don't exist.
+Free tier gets the full runtime engine, auth, the REST API, and local AI inference (Inference Snaps or Ollama — no API key, no cloud bill). Pro unlocks AI agents, payments, sync, MCP, and the monitoring dashboard. Max adds AI memory, advanced inference configuration, and audit logging. Enterprise adds multi-tenant management and RevealUI Fleet — branded white-label deployment for your own customers (managed setup via RevForge). White-label and SSO are on the roadmap, designed but not yet shipped (SSO tracked in [#449](https://github.com/RevealUIStudio/revealui/issues/449)), so the code forces those flags to `false` rather than advertise features that don't exist.
 
 ### Pricing served from a single source, not hardcoded
 

--- a/docs/blog/02-http-402-payments.md
+++ b/docs/blog/02-http-402-payments.md
@@ -7,7 +7,7 @@ audience: user
 author: Joshua Vaughn
 ---
 
-> **Status note (updated 2026-05-26):** The x402 integration in RevealUI is **designed and code-complete but dormant** today. The feature flag `X402_ENABLED=false` is the default; the endpoints exist but won't transact. Live agent payments are gated on the Stripe live-keys flip and the billing-readiness audit — see [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status). This post explains the design and how to wire it; it does not claim x402 payments are currently transactable through RevealUI in production.
+> **Coming soon, not yet live (roadmap, tracked in [#93](https://github.com/RevealUIStudio/revealui/issues/93)):** x402 payments in RevealUI are **designed and code-complete but dormant** today. The feature flag `X402_ENABLED=false` is the default; the endpoints exist but won't transact. Live agent payments are gated on the Stripe live-keys flip and the billing-readiness audit — see [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status). This post explains the design and how to wire it; it does not claim x402 payments are currently transactable through RevealUI in production.
 
 ---
 
@@ -22,7 +22,7 @@ That model works fine for most APIs. But it breaks down for AI agent systems, wh
 - You want granular per-call pricing, not flat subscriptions
 - Payment is better handled at the protocol level than the application level
 
-The [x402 protocol](https://x402.org)  -  developed by Coinbase  -  finally gives 402 a real use. Here's how we implemented it in RevealUI, and why it's the right model for AI-native APIs.
+The [x402 protocol](https://x402.org)  -  developed by Coinbase  -  finally gives 402 a real use. Here's the design we have built in RevealUI and how it will work once x402 ships, and why it's the right model for AI-native APIs.
 
 ---
 
@@ -175,7 +175,7 @@ One line of setup. The SDK intercepts 402 responses, pays on-chain, retries. The
 
 ## The MCP Marketplace
 
-The cleaner application of x402 in RevealUI is the MCP Marketplace.
+The cleaner application of x402 in RevealUI is the MCP Marketplace (coming soon, tracked in [#526](https://github.com/RevealUIStudio/revealui/issues/526)).
 
 Developers publish Model Context Protocol servers to the marketplace with a per-call USDC price. Callers invoke them through RevealUI's proxy  -  which handles payment verification and SSRF protection  -  and the developer earns 80% of each call.
 
@@ -223,7 +223,7 @@ This is early. The tooling is still rough. Not every developer wants to deal wit
 
 ## Activating It
 
-In RevealUI, x402 is off by default. Enable it with two environment variables:
+When x402 ships, it will be off by default. You will enable it with a few environment variables:
 
 ```bash
 X402_ENABLED=true

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -11,7 +11,7 @@ RevealUI is open source today; the commercial side is pre-launch. Before we talk
 
 This is a solo-founder project. I don't have a VC board to answer to or a growth team optimizing conversion funnels. I have a business model I believe in, and I'd rather explain it plainly than have you discover the trade-offs later.
 
-> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (third-party publishing + 80/20 revenue share) and **x402 agent payments** — are **planned, not shipped**. The first-party MCP catalog (14 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
+> **Status note (updated 2026-05-26):** Two revenue surfaces described later in this post — the **MCP Marketplace** (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526); third-party publishing + 80/20 revenue share) and **x402 agent payments** (coming soon, [#93](https://github.com/RevealUIStudio/revealui/issues/93)) — are **planned, not shipped**. The first-party MCP catalog (14 servers under `packages/mcp/src/servers/`) does ship today; third-party publishing, marketplace discovery UI, billing rails, and developer payouts are unbuilt. x402 is designed and code-complete behind `X402_ENABLED=false`. Stripe runs in test mode until a billing-readiness audit closes. See [What Works Today](../WHAT_WORKS_TODAY.md) for the current shipping status of every commercial surface.
 
 ---
 
@@ -84,7 +84,7 @@ Pro packages are published to npm as compiled distributions. You can install the
 | **Audit logging** | -- | -- | Yes | Yes |
 | **Multi-tenant** | -- | -- | -- | Yes |
 | **White-label** | -- | -- | -- | Yes (planned) |
-| **Support** | Community | Email (48h) | Email (24h) | Slack (4h SLA) |
+| **Support** | Community | Email (48h) | Email (24h) | Slack (planned) |
 | **Source code** | Full | Full | Full | Full |
 
 A few things worth noting about this table.
@@ -129,7 +129,7 @@ The model works like this:
 
 2. **Pro AI features convert power users.** Teams that outgrow the free tier -- more sites, more users, AI automation -- upgrade to Pro. The conversion happens because the product is genuinely more capable, not because we crippled the free version.
 
-3. **Marketplace commissions create ecosystem revenue.** Developers publish MCP servers to our marketplace, set their own pricing, and earn 80% of revenue. We take 20% for hosting, discovery, and billing infrastructure. More developers building servers means more capability for agent users, which means more demand for agent tasks.
+3. **Marketplace commissions will create ecosystem revenue (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)).** Developers will publish MCP servers to our marketplace, set their own pricing, and earn 80% of revenue. We take 20% for hosting, discovery, and billing infrastructure. More developers building servers means more capability for agent users, which means more demand for agent tasks.
 
 I'm not going to share revenue projections here. That's not the point. The point is transparency: here's exactly what's free, what's paid, and why. You can decide whether the trade-off makes sense for your team.
 
@@ -139,13 +139,13 @@ I'm not going to share revenue projections here. That's not the point. The point
 
 RevealUI isn't just a framework you install. It's an open runtime for businesses that run their own AI, with an ecosystem strategy.
 
-**MCP Marketplace (in preview).** Developers will be able to publish MCP servers -- tools that AI agents use to interact with external services -- with per-call pricing via the x402 payment protocol. Server authors earn 80% of revenue. The publish/list/invoke/onboard endpoints are wired today; payouts open with the billing-readiness audit. We handle discovery, billing, and the agent routing infrastructure. The goal is a self-sustaining marketplace where developers build specialized integrations and get paid for their work.
+**MCP Marketplace (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)).** Developers will be able to publish MCP servers -- tools that AI agents use to interact with external services -- with per-call pricing via the x402 payment protocol. Server authors earn 80% of revenue. The publish/list/invoke/onboard endpoints are wired today; payouts open with the billing-readiness audit. We handle discovery, billing, and the agent routing infrastructure. The goal is a self-sustaining marketplace where developers build specialized integrations and get paid for their work.
 
 **"Built with RevealUI" badge.** Completely opt-in. If you display the badge, you get 500 bonus agent tasks per month. If you don't want it, don't use it. We will never require attribution. MIT means MIT.
 
 **Template marketplace.** Starter projects on Vercel that showcase RevealUI for specific use cases -- SaaS boilerplates, e-commerce setups, documentation sites, internal tools. These lower the barrier to getting started and demonstrate what's possible.
 
-**Community discussions.** Free support for everyone through community forums. Pro and above get priority support with SLA-backed response times. The community is where we build trust, gather feedback, and help people succeed -- regardless of what tier they're on.
+**Community discussions.** Free support for everyone through community forums. Pro and above get priority support with faster response times. The community is where we build trust, gather feedback, and help people succeed -- regardless of what tier they're on.
 
 **The flywheel.** More developers using RevealUI means more MCP servers published to the marketplace. More MCP servers means agents can do more things. More capable agents means more demand for agent tasks. More demand means more developers building servers. Each layer reinforces the others.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -11,7 +11,7 @@ author: Joshua Vaughn
 
 ---
 
-> **Status note (updated 2026-05-18):** This post discusses the **agent-first future** RevealUI is building toward. Specifically: x402 micropayments (USDC on Base) and the per-call MCP server marketplace are **designed but not transactable today**. The x402 endpoints are code-complete behind `X402_ENABLED=false`; the marketplace ships its first-party catalog (14 MCP servers) but third-party publishing, payment proxying, and per-call billing are unbuilt. The Agent Card endpoint (`/.well-known/agent.json`) ships today; `payment-methods.json` ships with an `X402_ENABLED=false` empty-payments shape. See [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status of every system mentioned below.
+> **Status note (updated 2026-05-18):** This post discusses the **agent-first future** RevealUI is building toward. Specifically: x402 micropayments (USDC on Base) (coming soon, [#93](https://github.com/RevealUIStudio/revealui/issues/93)) and the per-call MCP server marketplace (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)) are **designed but not transactable today**. The x402 endpoints are code-complete behind `X402_ENABLED=false`; the marketplace ships its first-party catalog (14 MCP servers) but third-party publishing, payment proxying, and per-call billing are unbuilt. The Agent Card endpoint (`/.well-known/agent.json`) ships today; `payment-methods.json` ships with an `X402_ENABLED=false` empty-payments shape. See [What Works Today](../WHAT_WORKS_TODAY.md) for current shipping status of every system mentioned below.
 
 ---
 
@@ -211,7 +211,7 @@ Agent                          RevealUI Marketplace             MCP Server
 
 The payment is verified by Coinbase's public facilitator at `x402.org/facilitator`. No API key required for verification. The entire flow is stateless from the agent's perspective -- pay, prove, get access.
 
-RevealUI's marketplace uses x402 as the payment rail for all per-call MCP server invocations. The default price is $0.001 USDC per call, but each server sets its own price.
+RevealUI's marketplace will use x402 as the payment rail for all per-call MCP server invocations (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)). The default price will be $0.001 USDC per call, but each server sets its own price.
 
 ### OpenAPI: The foundation layer
 
@@ -244,7 +244,7 @@ curl -X POST https://api.example.com/api/marketplace/servers \
 
 **The economics:** Developers earn 80% of each call's revenue. RevealUI takes 20%. Payouts happen via Stripe Connect -- developers onboard once, and transfers are batched automatically. At $0.001 per call, a server handling 100,000 calls per month generates $80 for the developer and $20 for the platform. At $0.005 per call, those numbers are $400 and $100.
 
-This is the first combined MCP + A2A registry. Smithery, mcpt, OpenTools, and Glama.ai list MCP servers. The a2a-registry.org lists A2A agents. RevealUI's marketplace is the first to combine both -- agents that are discoverable via A2A *and* tools that are invocable via MCP, with a payment layer that lets the economics work without manual billing integration. Registration on external registries (a2a-registry.org, Smithery, mcpt, OpenTools, Glama.ai) is planned for hard launch.
+This will be the first combined MCP + A2A registry (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)). Smithery, mcpt, OpenTools, and Glama.ai list MCP servers. The a2a-registry.org lists A2A agents. RevealUI's marketplace is the first to combine both -- agents that are discoverable via A2A *and* tools that are invocable via MCP, with a payment layer that lets the economics work without manual billing integration. Registration on external registries (a2a-registry.org, Smithery, mcpt, OpenTools, Glama.ai) is planned for hard launch.
 
 The marketplace is secured against common attack vectors. Developer-supplied MCP server URLs are validated against an SSRF guard that blocks loopback, link-local, and private RFC-1918 ranges. Proxied requests have a 30-second timeout. Rate limiting prevents probe abuse (30 invocations per minute per caller). And the x402 payment itself acts as an economic rate limiter -- every call costs real money, which naturally deters spam.
 
@@ -258,7 +258,7 @@ If you deploy a RevealUI instance today, you get agent-native infrastructure wit
 
 **Feature gating works for both audiences.** When a human user hits a Pro feature, they see the billing page and can upgrade. When an agent hits a Pro feature without a license, it gets a structured JSON error with the pricing URL. When x402 is enabled, agents can pay per-call instead of subscribing -- the same feature, two access patterns.
 
-**You can earn money from MCP servers while you sleep.** Publish an MCP server to the marketplace, set a per-call price, onboard with Stripe Connect, and agent calls generate passive revenue. The marketplace handles discovery, payment verification, proxying, transaction recording, and developer payouts.
+**You will be able to earn money from MCP servers while you sleep (coming soon, [#526](https://github.com/RevealUIStudio/revealui/issues/526)).** Publish an MCP server to the marketplace, set a per-call price, onboard with Stripe Connect, and agent calls generate passive revenue. The marketplace handles discovery, payment verification, proxying, transaction recording, and developer payouts.
 
 **The same code serves both audiences.** This is the key architectural insight. You do not build a "human API" and an "agent API." You build one API with Zod schemas and OpenAPI definitions. Humans consume it via the admin dashboard. Agents consume it via the OpenAPI spec and A2A protocol. The code is identical.
 

--- a/docs/blog/11-revfleet-product-family.md
+++ b/docs/blog/11-revfleet-product-family.md
@@ -19,7 +19,7 @@ Every product carries one of four status badges. They mean exactly what they say
 
 - **Beta** -- production-ready code, dogfooded daily, limited real users.
 - **Alpha** -- works and ships, development-preview quality, may break.
-- **Active (MIT)** -- a released, free, open library with no SLA.
+- **Active (MIT)** -- a released, free, open library, no support guarantees.
 - **Planned** -- code-complete or scaffolded, not yet shipped to users.
 
 No product on this page hides behind a vaguer word than that.

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1184,6 +1184,9 @@ const ASPIRATIONAL_SCAN_FILES = [
   'apps/docs/public/docs-pro/inference/index.md',
   'apps/docs/public/docs-pro/mcp/index.md',
   'apps/docs/public/docs-pro/editors/index.md',
+  // Blog posts (wired 2026-06-19): CONTRIBUTING.md (Future-tense claims)
+  // explicitly covers blog drafts; long-form, but the same blocklist applies.
+  'docs/blog',
 ];
 
 interface BlocklistEntry {


### PR DESCRIPTION
## Summary

Follow-up to #1557: present the agent marketplace and x402 payments as **coming soon, not shipped**, with each mention tracked to a real issue, and close the CI gap that let blog posts make unqualified aspirational claims.

## Reframe (the three posts that lean on unshipped surfaces)

- **02 (http-402-payments)** → a coming-soon design preview. The top note leads with "Coming soon, not yet live (roadmap, #93)"; the intro, "Activating It", and the marketplace section move to future tense; the blog-index excerpt signals coming-soon.
- **06 (open-source-and-pro)** → MCP Marketplace (#526) and x402 (#93) marked coming-soon in the status note, the Ecosystem Play section, and the flywheel.
- **07 (agent-first-future)** → x402 (#93) and the marketplace (#526) marked coming-soon in the status note and the marketplace claims.

## Close the CI gap

Wired `docs/blog` into claim-drift's `ASPIRATIONAL_SCAN_FILES`, so blog posts are now held to the same honesty bar as the docs and landing pages: the blocklist terms (`SSO`, `SLA`, `on-prem`, `air-gapped`, `RAG`, `managed hosting`, `auto-scaling`, `dunning`) must carry a qualifier (`(planned)`, `roadmap`, or a tracker). This was previously unenforced on the blog (`CONTRIBUTING.md` §Future-tense claims says the convention covers "blog drafts", but the scanner never included them). Fixed the 4 violations it surfaced:

- **01**: `SSO` → "on the roadmap … (SSO tracked in #449)"
- **06**: `Slack (4h SLA)` → `Slack (planned)`; "SLA-backed response times" → "faster response times"
- **11**: "with no SLA" → "no support guarantees"

**Scope note:** `x402`/`marketplace` are deliberately not blocklist tokens (a bare token would break the legitimate long-form x402 design post, which mentions x402 dozens of times). So their coming-soon framing here is editorial + tracker-cited (markers cite #93/#526) rather than auto-gated. A hard gate on "x402/marketplace presented as live" would need a frontmatter roadmap-exemption plus tokens in claim-drift; happy to do that as a follow-up if you want it enforced.

## Validation

- `validate:claims`: 0 mismatches, 0 unqualified aspirational (scan now covers `docs/blog`)
- claim-drift unit tests: 37 passed
- marketing `typecheck`: clean
- marketing `test`: 73 passed
- biome: clean (`claim-drift.ts` + `blog-posts.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
