### PR TITLE
feat(claim-drift): gate x402/marketplace as-shipped claims + roadmap frontmatter exemption

### DIFF
--- a/docs/blog/02-http-402-payments.md
+++ b/docs/blog/02-http-402-payments.md
@@ -3,6 +3,7 @@ title: "Paying for AI API Calls with HTTP 402 and USDC"
 description: "_By Joshua Vaughn - RevealUI Studio_"
 visibility: public
 status: narrative
+roadmap: "Coming soon: x402 #93, agent marketplace #526"
 audience: user
 author: Joshua Vaughn
 ---

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -3,6 +3,7 @@ title: "Building for the Agent-First Internet"
 description: "*The web was built for browsers. The next web is being built for agents.*"
 visibility: public
 status: narrative
+roadmap: "Coming soon: x402 #93, agent marketplace #526"
 audience: user
 author: Joshua Vaughn
 ---

--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_COMMERCE_BLOCKLIST,
   CLI_TEMPLATE_CLAIM_PATTERNS,
   countCliTemplates,
   countDirs,
@@ -12,6 +13,7 @@ import {
   extractRevealuiPackages,
   findIncompleteProList,
   findLicenseSplitAntiPattern,
+  isRoadmapDeclaredFile,
   makeIgnoredPathPredicate,
   parseGitIgnoredOutput,
   WALK_EXCLUDED_DIRS,
@@ -403,5 +405,53 @@ describe('findLicenseSplitAntiPattern', () => {
     expect(findLicenseSplitAntiPattern('21 published + 5 private packages')).toBe(
       'N published + M private',
     );
+  });
+});
+
+describe('AGENT_COMMERCE_BLOCKLIST (x402 / marketplace presented as live)', () => {
+  const tokenFor = (needle: string): RegExp => {
+    const entry = AGENT_COMMERCE_BLOCKLIST.find((e) => e.label.includes(needle));
+    if (!entry) throw new Error(`no agent-commerce blocklist entry for ${needle}`);
+    return entry.token;
+  };
+  const x402 = tokenFor('x402');
+  const market = tokenFor('marketplace');
+
+  it('flags x402 presented as live but not neutral mentions', () => {
+    expect(x402.test('Big news: x402 is live today for every caller')).toBe(true);
+    expect(x402.test('x402 payments are available now')).toBe(true);
+    expect(x402.test('the x402 protocol, developed by Coinbase')).toBe(false);
+    expect(x402.test('## How x402 Works')).toBe(false);
+    expect(x402.test('the endpoints are code-complete behind X402_ENABLED=false')).toBe(false);
+    expect(
+      x402.test('x402 micropayments (USDC on Base) are designed but not transactable today'),
+    ).toBe(false);
+  });
+
+  it('flags the agent/MCP marketplace presented as live, not a template marketplace', () => {
+    expect(market.test('the agent marketplace is open for publishing')).toBe(true);
+    expect(market.test('RevMarket is live today')).toBe(true);
+    expect(market.test('the MCP marketplace discovery document lists every server')).toBe(false);
+    expect(market.test('a template marketplace is available for plugins')).toBe(false);
+  });
+});
+
+describe('isRoadmapDeclaredFile', () => {
+  const fm = (body: string): string => `---
+${body}
+---
+
+body text
+`;
+
+  it('exempts a file that declares roadmap status WITH a tracker', () => {
+    expect(isRoadmapDeclaredFile(fm('roadmap: "Coming soon: x402 #93"'))).toBe(true);
+    expect(isRoadmapDeclaredFile(fm('lifecycle: "roadmap, tracked in #526"'))).toBe(true);
+  });
+
+  it('does not exempt an unlinked declaration or a non-frontmatter file', () => {
+    expect(isRoadmapDeclaredFile(fm('roadmap: "Coming soon"'))).toBe(false);
+    expect(isRoadmapDeclaredFile('no frontmatter, roadmap: see #93')).toBe(false);
+    expect(isRoadmapDeclaredFile(fm('title: "no roadmap key here"'))).toBe(false);
   });
 });

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1259,6 +1259,52 @@ const BLOCKLIST: BlocklistEntry[] = [
 const QUALIFIER_PATTERN =
   /\((coming soon|planned|roadmap|in active development|forthcoming|will ship|in progress|TBD)\b[^)]*\)|\broadmap\b|(#\d+|\/(issues|pull|pulls)\/\d+|\bmilestones?\b|\.ya?ml\b)/i;
 
+/**
+ * Agent-commerce surfaces (x402 payments, the agent / MCP-server marketplace)
+ * are coming soon, NOT shipped. These tokens match only SHIPPED-CLAIM phrasing
+ * ("x402 is live", "the marketplace is open") -- never neutral mentions like
+ * "the x402 protocol", a glossary entry, or a "## How x402 Works" heading, so
+ * the design/explainer posts read normally. A shipped claim still passes if it
+ * carries a same-line qualifier (QUALIFIER_PATTERN), OR the whole file declares
+ * itself a roadmap post in frontmatter (isRoadmapDeclaredFile). The general
+ * BLOCKLIST (SSO / SLA / ...) is unaffected.
+ */
+export const AGENT_COMMERCE_BLOCKLIST: BlocklistEntry[] = [
+  {
+    token:
+      /\bx402\b[^.\n]{0,50}?\b(?:is|are)\s+(?:live|available|launched|in production|transacting|enabled today|working today)\b/i,
+    label: 'x402 (presented as live)',
+    why: 'x402 payments are coming soon, not live (X402_ENABLED=false); see #93',
+  },
+  {
+    token:
+      /\b(?:RevMarket|(?:agent(?: tool)?|MCP(?: server)?)[- ]marketplace)\b[^.\n]{0,50}?\b(?:is|are|now)\s+(?:live|open|available|launched)\b/i,
+    label: 'agent marketplace (presented as live)',
+    why: 'the agent / MCP-server marketplace is coming soon, not shipped; see #526',
+  },
+];
+
+/**
+ * A markdown file opts the AGENT_COMMERCE_BLOCKLIST tokens out by declaring
+ * itself a roadmap post in frontmatter, e.g.:
+ *   roadmap: "Coming soon: x402 #93, agent marketplace #526"
+ * The declaration MUST cite a tracker (issue / PR / milestone / workflow), so a
+ * roadmap exemption is never an unlinked "coming soon". The general BLOCKLIST
+ * (SSO / SLA / on-prem / ...) is unaffected and still enforced on every file.
+ */
+export function isRoadmapDeclaredFile(content: string): boolean {
+  if (!content.startsWith('---\n')) return false;
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) return false;
+  for (const raw of content.slice(4, end).split('\n')) {
+    const line = raw.trimStart();
+    if (line.startsWith('roadmap:') || line.startsWith('lifecycle:')) {
+      if (TRACKER_PATTERN.test(raw)) return true;
+    }
+  }
+  return false;
+}
+
 function scanForAspirationalFeatures(): AspirationalMatch[] {
   const matches: AspirationalMatch[] = [];
   const isIgnored = ignoredPathPredicateFor(ROOT);
@@ -1272,6 +1318,7 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
       return;
     }
     const isMarkdown = filePath.endsWith('.md');
+    const commerceExempt = isMarkdown && isRoadmapDeclaredFile(content);
     const lines = content.split('\n');
     let inFence = false;
     for (let i = 0; i < lines.length; i++) {
@@ -1303,6 +1350,23 @@ function scanForAspirationalFeatures(): AspirationalMatch[] {
           why: entry.why,
           text: line.trim(),
         });
+      }
+
+      // Agent-commerce tokens (x402 / agent marketplace) are coming soon, not
+      // shipped. Skip when the file declares itself a roadmap post in
+      // frontmatter; otherwise require a same-line qualifier like the rest.
+      if (!commerceExempt) {
+        for (const entry of AGENT_COMMERCE_BLOCKLIST) {
+          if (!entry.token.test(line)) continue;
+          if (QUALIFIER_PATTERN.test(line)) continue;
+          matches.push({
+            file: rel,
+            line: i + 1,
+            token: entry.label,
+            why: entry.why,
+            text: line.trim(),
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #1559: a durable CI gate so x402 and the agent / MCP marketplace cannot be presented as **live** in any scanned surface (blog, docs, landing), with a clean escape hatch for the dedicated roadmap posts.

## What it does

**`AGENT_COMMERCE_BLOCKLIST`** — two narrow tokens that match only *shipped-claim* phrasing:
- `x402 ... is/are live | available | launched | in production | transacting | enabled today`
- `(RevMarket | agent / MCP marketplace) ... is/are/now live | open | available | launched`

They deliberately do **not** fire on neutral mentions. I first tried bare `x402` / `marketplace` tokens and they produced **33 false positives** (the docs glossary listing "x402" as vocabulary, "## How x402 Works" headings, `X402_ENABLED=false`, "the x402 protocol"). Phrase-scoped tokens catch the real risk with zero false positives.

**`isRoadmapDeclaredFile`** — the frontmatter exemption. A post opts the agent-commerce tokens out by declaring, in frontmatter:

    roadmap: "Coming soon: x402 #93, agent marketplace #526"

The declaration **must cite a tracker** (issue / PR / milestone / workflow), so an exemption can never be an unlinked "coming soon". The general blocklist (`SSO` / `SLA` / `on-prem` / ...) is unaffected and still enforced on every file.

Applied the `roadmap:` frontmatter to the two coming-soon design posts (**02** http-402, **07** agent-first).

## Escape hatches (either one suffices)

1. A same-line qualifier — `(coming soon)`, `roadmap`, `#NNN` (existing behavior), or
2. A whole-file `roadmap:` frontmatter declaration (new) — mark the post once instead of per-line.

## Verification

End-to-end (a throwaway post, because proof beats assertion):
- `x402 is live today` with no frontmatter -> **fails** (gate catches it)
- the same line with `roadmap: "... #93"` -> **passes** (exemption works)

- `validate:claims`: 0 violations on the real tree
- claim-drift unit tests: **41 pass** (+4 new: token precision + exemption predicate)
- biome: clean

## Honest residual

Phrase tokens cannot catch every conceivable shipped-phrasing (e.g. "we turned x402 on last week"). They cover the common forms; the reframe plus review cover the rest. Broadening them later is a one-line change, and the `roadmap:` exemption is already there for any post that needs to discuss the feature freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
