### PR TITLE
fix(server): drop overbroad api function-trace excludeFiles

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -6,8 +6,7 @@
     "api/**": {
       "memory": 512,
       "maxDuration": 30,
-      "includeFiles": "dist/index_bg.wasm",
-      "excludeFiles": "**/*.{ts,tsx,mts,cts}"
+      "includeFiles": "dist/index_bg.wasm"
     }
   },
   "crons": [{ "path": "/api/cron/dispatch", "schedule": "0 6 * * *" }],


### PR DESCRIPTION
The `excludeFiles: "**/*.{ts,tsx,mts,cts}"` glob in `apps/server/vercel.json` excluded runtime-required modules from the api serverless function bundle, causing it to fail at invocation (FUNCTION_INVOCATION_FAILED). Reverts to the prior includeFiles-only trace config so the api function bundles correctly.