### PR TITLE
chore(ci): ignore TypeScript sub-6.x Dependabot proposals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,9 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Fleet is on TS 6.x (catalog ^6.0.3). Never downgrade below 6.
+      - dependency-name: "typescript"
+        versions: ["< 6.0.0"]
     # Allow automatic rebasing
     rebase-strategy: "auto"
 


### PR DESCRIPTION
## Summary

- Adds an explicit `ignore` entry in `.github/dependabot.yml` for `typescript` versions `< 6.0.0`
- Fleet is pinned to TS 6.x (catalog `^6.0.3`; engines/scripts `^6.0.2`; contracts peer `>=6.0.0`)
- Prevents Dependabot from repeatedly proposing a downgrade to the stable 5.x line (e.g. `^5.9.3`)

## Test plan

- [ ] Gate passes (CI will verify on push)
- [ ] Confirm no Dependabot PR targeting `typescript < 6.0.0` is recreated on next weekly run
- [ ] Existing TypeScript 6.x pins in catalog / packages unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)