### PR TITLE
fix(security): stop broadcasting revvault secrets into global shell env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -26,23 +26,28 @@ watch_file flake.nix
 watch_file flake.lock
 
 # Load .envrc.local early — it provides REVVAULT_IDENTITY and REVVAULT_STORE
-# which revvault needs to decrypt secrets. Must come before the revvault block.
+# which revvault needs to decrypt secrets. Must come before any revvault calls.
 source_env_if_exists .envrc.local
 
 # =============================================================================
-# Revvault: load secrets from age-encrypted vault (optional)
+# Secrets: point-of-use only — NOT broadcast into the global shell
 # =============================================================================
-if [[ -x "$HOME/.local/bin/revvault" ]]; then
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/core 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/license 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/stripe 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/supabase 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/services 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/cron 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/admin 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/admin-url 2>/dev/null)"
-  eval "$("$HOME/.local/bin/revvault" export-env revealui/env/npm 2>/dev/null)"
-fi
+# Secrets are NOT loaded here. Broadcasting them into direnv's exported env
+# exposes every secret (including REVEALUI_KEK and studio DB credentials)
+# to every child process — editors, Claude Code, ACP launchers, all tools.
+#
+# Use the with-secrets wrapper to scope secrets to the process that needs them:
+#
+#   with-secrets stripe -- pnpm dev:api
+#   with-secrets core stripe supabase -- pnpm test:integration
+#   with-secrets npm -- pnpm changeset:publish
+#   with-secrets core -- pnpm kek:rotate
+#
+# Available namespaces: core, license, stripe, supabase, services, cron,
+#                       admin, admin-url, npm
+#
+# with-secrets is defined in revkit/shell/shellrc.d/45-with-secrets.sh and
+# loaded automatically in managed shell sessions (REVEALUI_MODE=managed).
 
 # Load environment files (for secrets and local config)
 # .env overrides vault values — useful for local dev tweaks.


### PR DESCRIPTION
## Summary

- Remove 9 `eval "$(revvault export-env ...)"` lines from `.envrc` that broadcast all revvault namespaces (core, license, stripe, supabase, services, cron, admin, admin-url, npm) into the global direnv-exported environment on every shell entry
- This broadcast exposed REVEALUI_KEK and studio DB credentials to every child process — editors, Claude Code, ACP launchers, tools
- Replace with point-of-use pattern using the `with-secrets` wrapper (defined in revkit)

## How to use secrets now

```bash
with-secrets stripe -- pnpm dev:api
with-secrets core stripe supabase -- pnpm test:integration
with-secrets npm -- pnpm changeset:publish
with-secrets core -- pnpm kek:rotate
```

## Test plan

- [ ] `printenv | grep -E 'REVEALUI_KEK|FORGE_DATABASE_URL'` in a fresh dev shell returns nothing
- [ ] `with-secrets stripe -- printenv | grep STRIPE` shows Stripe vars in subprocess only
- [ ] `pnpm dev` still works (uses local Postgres defaults from flake.nix, no secrets needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)