### PR TITLE
fix(marketing): Phase A — honesty + currency pass (competitor reframe, vocab lock, metrics)

### DIFF
--- a/apps/marketing/app/content/__tests__/content.test.ts
+++ b/apps/marketing/app/content/__tests__/content.test.ts
@@ -10,9 +10,9 @@ import { METRICS, SITE } from '../site';
 // rules the marketing-overhaul lane established. Metric VALUES are enforced
 // separately against the codebase by scripts/validate/claim-drift.ts.
 
-// Canonical primitive contract (Joshua's methodology corpus): Users / Content /
-// Products / Payments / Intelligence. Body copy and footer reconcile to these.
-const FIVE_PRIMITIVES = ['Users', 'Content', 'Products', 'Payments', 'Intelligence'];
+// Canonical primitive contract (Joshua's methodology corpus): People / Content /
+// Offers / Payments / Agents. Body copy and footer reconcile to these.
+const FIVE_PRIMITIVES = ['People', 'Content', 'Offers', 'Payments', 'Agents'];
 
 describe('marketing content contracts', () => {
   describe('primitives', () => {

--- a/apps/marketing/app/content/capabilities.ts
+++ b/apps/marketing/app/content/capabilities.ts
@@ -18,7 +18,7 @@ export const CAPABILITIES_SECTION = {
   heading: "What's actually shipped.",
   body: 'Nine load-bearing primitives most platforms ship as separate products, or never ship at all. Each card links to the actual file.',
   footnote:
-    "Trust through specificity. Compare RevealUI to Convex, Supabase, or Payload and you'll see depth those competitors don't ship.",
+    'Trust through specificity. These are primitives most platforms ship as separate products, or never ship at all. Each card links to the actual file.',
 } as const;
 
 export const CAPABILITIES: readonly Capability[] = [

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -21,7 +21,7 @@ export const HOME_HERO = {
   subtitle: {
     lead: 'Stop renting your stack from a half-dozen vendors.',
     strong:
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host.',
+      'Auth, content, offers, and payments, pre-wired into one open-source runtime you self-host.',
     body: 'Ship one product, or stamp a branded, self-hosted copy for every client you serve. Your team and your AI agents work in it under the same permissions and the same tamper-evident audit trail. Build it yourself with',
     cliSuffix: 'or hire',
     agencyLabel: 'RevealUI Studio',
@@ -48,7 +48,7 @@ export const HOME_HERO = {
       {
         metric: `${METRICS.dbTables} database tables`,
         detail:
-          'Every table maps to a primitive: users, content, products, payments, or intelligence. See the [database reference](https://docs.revealui.com/database).',
+          'Every table maps to a primitive: people, content, offers, payments, or agents. See the [database reference](https://docs.revealui.com/database).',
       },
       {
         metric: `${METRICS.mcpServers} first-party MCP servers`,
@@ -122,13 +122,13 @@ export const HOME_PROBLEM = {
   rows: [
     {
       capability: 'Auth + RBAC + sessions',
-      sprawl: 'Clerk Pro ($25/seat)',
+      sprawl: 'A separate auth vendor, per seat',
       agentOnly: 'Bring your own',
       revealui: 'Built in',
     },
     {
       capability: 'CMS + admin UI',
-      sprawl: 'Payload + your team',
+      sprawl: 'A headless CMS, plus a team to wire it',
       agentOnly: 'Bring your own',
       revealui: 'Built in',
     },
@@ -146,13 +146,13 @@ export const HOME_PROBLEM = {
     },
     {
       capability: 'Tamper-evident audit log',
-      sprawl: 'Datadog + custom hashing',
+      sprawl: 'An observability vendor, plus custom hashing',
       agentOnly: 'Logs only',
       revealui: 'Hash-chained, in DB',
     },
     {
       capability: 'Cost (5 devs, mid-startup)',
-      sprawl: '~$1,200 / mo',
+      sprawl: '~$320 to $700+ / mo',
       agentOnly: '~$300 / mo + infra',
       revealui: '$49 / mo + infra',
     },
@@ -231,9 +231,10 @@ export const HOME_FAQ = {
   heading: 'Common questions.',
   items: [
     {
-      question: 'How is this different from Supabase, Convex, Clerk, or Trigger?',
+      question:
+        'How is this different from stitching together separate auth, database, CMS, and background-job services?',
       answer:
-        'Convex gives you real-time DB + functions. Supabase gives you Postgres + auth. Clerk gives you sessions. Trigger runs background jobs. Each one is a slice. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
+        'Each of those covers one slice: a real-time database, a Postgres-plus-auth backend, a session service, a jobs runner. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer governed by one RBAC policy and one tamper-evident audit chain. Self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
     },
     {
       question: 'Can I self-host?',

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -55,7 +55,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
 ] as const;
 
 export const FOOTER_TAGLINE =
-  'Agentic business runtime. Users, content, products, payments, and intelligence, pre-wired, open source, and ready to deploy.' as const;
+  'Agentic business runtime. People, content, offers, payments, and agents, pre-wired, open source, and ready to deploy.' as const;
 
 export const FOOTER_SOLO_OPERATOR_NOTE =
   'Built by one engineer in Tennessee. See Support for response SLAs.' as const;

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -23,7 +23,7 @@ export const PERSONA_CARD = {
   footer: {
     prefix: 'Also a fit for',
     sprawl: 'teams escaping backend-platform sprawl',
-    sprawlNote: '(Convex + Supabase + Clerk + Trigger), and',
+    sprawlNote: '(four or five separate backend services), and',
     studios: 'studios + consultancies',
     studiosNote:
       'white-labeling one runtime across N customers without re-licensing N SaaS stacks.',

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -6,7 +6,8 @@
 
 export const PERSONA_SECTION = {
   eyebrow: "Who it's for",
-  heading: 'For founders who need to ship fast, and still pass a security review.',
+  heading:
+    'For teams putting agents in front of customers who still have to pass a security review.',
 } as const;
 
 export const PERSONA_CARD = {

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -4,7 +4,7 @@
 //   - ProductsPrimitive: full forYou/forAgents/together/features deep-dive (used by ProductsPage.tsx)
 //   Both are canonical here. Phase 4 reconciles any copy redundancy.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4.
-// Intelligence primitive MCP count is sourced from METRICS.mcpServers
+// Agents primitive MCP count is sourced from METRICS.mcpServers
 // (currently 14, per docs/MARKETING_METRICS.md §1) — never hardcoded here.
 
 import { METRICS, SITE } from './site';
@@ -23,13 +23,13 @@ export interface HomePrimitive {
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login. One audit trail.',
   heading: "Everything a business needs. Nothing you don't.",
-  body: 'Users, content, products, payments, and intelligence: the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
+  body: 'People, content, offers, payments, and agents: the five things every product needs. Every action, whether it comes from a person or an AI agent, follows the same permission rules and lands in an audit trail you can prove was not tampered with.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 
 export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
   {
-    label: 'Users',
+    label: 'People',
     body: 'Auth, sessions, RBAC + ABAC. Same policy governs human and agent access.',
     color: 'emerald',
     iconPath:
@@ -43,7 +43,7 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
   },
   {
-    label: 'Products',
+    label: 'Offers',
     body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
     color: 'amber',
     iconPath:
@@ -57,8 +57,8 @@ export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
-    label: 'Intelligence',
-    body: 'Agents, MCP servers, CRDT memory. Bring-your-own-model; open-weight default.',
+    label: 'Agents',
+    body: 'Agents, MCP servers, persistent memory. Bring-your-own-model with an open-weight default.',
     color: 'violet',
     iconPath:
       'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',
@@ -88,7 +88,7 @@ export interface ProductsPrimitive {
 
 export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
   {
-    name: 'Users',
+    name: 'People',
     icon: 'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
     color: 'text-blue-600',
     bgColor: 'bg-blue-500/10',
@@ -148,7 +148,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Products',
+    name: 'Offers',
     icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
     color: 'text-purple-600',
     bgColor: 'bg-purple-500/10',
@@ -206,7 +206,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     ],
   },
   {
-    name: 'Intelligence',
+    name: 'Agents',
     icon: 'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z',
     color: 'text-violet-600',
     bgColor: 'bg-violet-500/10',
@@ -214,7 +214,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     forYou: {
       headline: 'AI agents that work on your business, no proprietary API keys',
       description:
-        'AI agents manage content, process tasks, and coordinate workflows. Runs on open models only (Apache 2.0) via Ubuntu Inference Snaps or Ollama. No vendor lock-in, no API bills.',
+        'AI agents manage content, process tasks, and coordinate workflows. Runs on open-weight models via Ubuntu Inference Snaps or Ollama. No vendor lock-in. Your own inference cost, not a per-token API tax.',
     },
     forAgents: {
       headline: 'A2A protocol, CRDT memory, and MCP servers',

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -106,7 +106,7 @@ export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
   version: 'v0.3.0',
   priceLabel: 'Free to self-host · Pro tier optional',
   tagline: 'The agentic business runtime',
-  body: 'Users, content, products, payments, and intelligence: pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
+  body: 'People, content, offers, payments, and agents: pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
   iconPath: 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5',
   facts: [
     { stat: String(METRICS.packages), label: 'packages' },

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -5,7 +5,7 @@ title: "Marketing Metrics — Pinned Truth"
 description: "Single source of truth for every metric, count, and status claim used in the marketing app and public-facing copy. Updated when the code changes; validated by claim-drift CI gate."
 category: internal
 audience: maintainer
-last-verified: 2026-05-18
+last-verified: 2026-06-22
 verified-via: pnpm tsx scripts/validate/claim-drift.ts
 ---
 
@@ -21,14 +21,14 @@ If a number appears in marketing copy, it MUST match the value below. If a value
 
 ## 1. Codebase metrics (validated by claim-drift CI gate)
 
-Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-05-18 (commit `b0c6bbc81`).
+Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-06-22 (commit `a5cf84240`).
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
 | Packages in `packages/` | **27** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **31** | `countWorkspaces()` (= 27 packages + 4 apps) | |
-| Test files | **912** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| Test files | **960** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **60** | `countUIComponents()` | Marketing copy says "60 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |


### PR DESCRIPTION
## Phase A — Marketing honesty + currency pass

First phase of the marketing program runbook. Small, mechanical, gates everything downstream. Base: `test`.

### What changed

**Competitor reframe (no vendor names, problems-we-solve framing)**
- `HOME_PROBLEM` sprawl cells: `Clerk Pro ($25/seat)` → `A separate auth vendor, per seat`; `Payload + your team` → `A headless CMS, plus a team to wire it`; `Datadog + custom hashing` → `An observability vendor, plus custom hashing`. `Stripe + your code` kept (shared payment rail, an integration).
- `HOME_PROBLEM` cost row: `~$1,200 / mo` → `~$320 to $700+ / mo` (sanctioned range; seeds the Phase D calculator).
- `HOME_FAQ` lead item: reframed away from named competitors to "stitching together separate auth, database, CMS, and background-job services."
- `persona.ts` sprawlNote + `capabilities.ts` footnote: drop named competitors.
- **Kept as integrations** (untouched): `marketplace.ts` Supabase connector, `pricing.ts` MCP-server list, deploy-target lists.

**Locked primitive vocab everywhere** (dead set Users/Content/Products/Payments/Intelligence → People/Content/Offers/Payments/Agents)
- `HOME_PRIMITIVES` + `PRODUCTS_PRIMITIVES` labels, section body, hero `subtitle.strong`, shipsToday DB-tables detail, `FOOTER_TAGLINE`, products flagship body.
- `content.test.ts` `FIVE_PRIMITIVES` contract updated to match (the HOME==PRODUCTS invariant forced the products-page label rename too).

**Soft-claim tighten**
- Agents primitive: dropped inaccurate "open models only (Apache 2.0)" and "no API bills"; now "open-weight models … your own inference cost, not a per-token API tax."

**Doc currency**
- `MARKETING_METRICS.md`: test files 912 → 960; `last-verified` + source-provenance bumped to 2026-06-22.

### Gates (all green)
- claim-drift: **0 mismatches** (83 claims, site.ts METRICS drift 0)
- marketing-voice: **0 new** violations
- em-dash: no em-dash additions in customer copy (repo-wide audit is warn-only baseline)
- `pnpm --filter marketing build`: green
- marketing tests: **73/73 pass**
- preview: home serves 200; built bundle embeds corrected vocab, no competitor/dead strings

### Scope notes for reviewer
- **Extensions beyond the literal runbook list** (all gate- or directive-forced): `PRODUCTS_PRIMITIVES` name labels + `content.test.ts` (the test invariant requires HOME and PRODUCTS labels to match); `FOOTER_TAGLINE` and products flagship body (verbatim dead-set in customer copy; "locked vocab everywhere" directive); `MARKETING_METRICS.md` source-provenance line (kept consistent with the bumped `last-verified`); home shipsToday DB-tables detail (dead-set, caught by the A2 grep).
- **Deferred / flagged, NOT in this PR**: two remaining dead-set sites in the **blog** surface — `app/lib/blog-posts.ts:127` (post excerpt) and `app/routes/BlogPostPage.tsx:155` (post CTA) — plus an `app/index.css:13` code comment. These sit outside the runbook's `app/content/`-scoped Phase A grep, and the blog post bodies likely need a coordinated vocab pass. Recommend a dedicated follow-up rather than rewriting published article copy here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
