### PR TITLE
feat(marketing): Phase C — local-AI amplification surfaces

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -9,6 +9,7 @@ import { FairSourcePage } from './routes/FairSourcePage';
 import { ForOperatorsHowItWorksPage } from './routes/ForOperatorsHowItWorksPage';
 import { ForOperatorsManagedPage } from './routes/ForOperatorsManagedPage';
 import { HomePage } from './routes/HomePage';
+import { LocalAiPage } from './routes/LocalAiPage';
 import { NotFoundPage } from './routes/NotFoundPage';
 import { PhilosophyPage } from './routes/PhilosophyPage';
 import { PricingPage } from './routes/PricingPage';
@@ -37,6 +38,11 @@ export function App() {
         path: '/philosophy',
         component: PhilosophyPage,
         meta: { title: 'Why RevealUI exists | RevealUI' },
+      },
+      {
+        path: '/local-ai',
+        component: LocalAiPage,
+        meta: { title: 'Local-first AI | RevealUI' },
       },
       { path: '/pricing', component: PricingPage, meta: { title: 'Pricing | RevealUI' } },
       { path: '/blog', component: BlogIndexPage, meta: { title: 'Blog | RevealUI' } },

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -6,6 +6,12 @@ import { selectAudience } from '../../lib/audience';
 import { selectHomeHero } from '../../lib/hero-variant';
 import { AudienceToggle } from './AudienceToggle';
 
+// Shared trust strip (the signals the retired eyebrow pill used to carry).
+// Rendered above BOTH hero H1 variants and for both audiences, so the
+// "Local-first AI" chip lands without forking the ?hero=foundation A/B or
+// adding a third hero variant (positioning decision d).
+const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Audit-ready', 'Local-first AI'] as const;
+
 const ArrowIcon = () => (
   <svg
     className="h-4 w-4"
@@ -90,7 +96,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
 
       {/* Trust strip — the signals the retired eyebrow pill used to carry. */}
       <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {['Open source', 'Self-hostable', 'Audit-ready'].map((signal) => (
+        {TRUST_SIGNALS.map((signal) => (
           <li key={signal} className="flex items-center gap-2">
             <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
             {signal}
@@ -183,7 +189,7 @@ function NonTechnicalHero() {
 
       {/* Trust strip — mirror of TechnicalHero; same signals for the operator view. */}
       <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {['Open source', 'Self-hostable', 'Audit-ready'].map((signal) => (
+        {TRUST_SIGNALS.map((signal) => (
           <li key={signal} className="flex items-center gap-2">
             <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
             {signal}

--- a/apps/marketing/app/components/landing/LocalAi.tsx
+++ b/apps/marketing/app/components/landing/LocalAi.tsx
@@ -1,0 +1,68 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { LOCAL_AI_SECTION } from '../../content/local-ai';
+
+/**
+ * Local-first AI home section. Sits between Primitives and Proof in the
+ * technical landing. Four beats (sovereignty, economics, pathway, governance),
+ * a grep-accurate one-config-line provider snippet, the RevDev dogfood proof,
+ * and the required honesty line. Copy is locked to content/local-ai.ts, which
+ * tracks the merged Phase B corpus. Ownership stays the lead; this section is
+ * its local-AI proof, so it links onward to /local-ai rather than re-leading.
+ */
+export function LocalAi() {
+  return (
+    <section className="bg-background py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {LOCAL_AI_SECTION.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {LOCAL_AI_SECTION.heading}
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{LOCAL_AI_SECTION.body}</p>
+        </div>
+
+        <div className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 sm:grid-cols-2">
+          {LOCAL_AI_SECTION.beats.map((beat) => (
+            <div key={beat.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <h3 className="text-base font-semibold text-foreground">{beat.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{beat.body}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* One-config-line provider snippet (grep-accurate to packages/ai). */}
+        <div className="mx-auto mt-10 max-w-4xl">
+          <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
+            <ul className="space-y-2 font-mono text-sm list-none p-0">
+              {LOCAL_AI_SECTION.snippet.lines.map((line) => (
+                <li
+                  key={line.code}
+                  className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
+                >
+                  <code className="text-emerald-400">{line.code}</code>
+                  <span className="text-background/60"># {line.note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className="mt-3 text-center text-sm text-muted-foreground">
+            {LOCAL_AI_SECTION.snippet.caption}
+          </p>
+        </div>
+
+        <div className="mx-auto mt-10 max-w-3xl space-y-3 text-center">
+          <p className="text-sm leading-6 text-muted-foreground">{LOCAL_AI_SECTION.dogfood}</p>
+          <p className="text-sm leading-6 text-muted-foreground">{LOCAL_AI_SECTION.honesty}</p>
+        </div>
+
+        <div className="mt-10 text-center">
+          <ButtonCVA asChild variant="outline" size="lg">
+            <a href={LOCAL_AI_SECTION.cta.href}>{LOCAL_AI_SECTION.cta.label}</a>
+          </ButtonCVA>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,6 +1,7 @@
 import { ButtonCVA } from '@revealui/presentation';
 import {
   PROOF_CI_SIGNALS,
+  PROOF_LOCAL_AI,
   PROOF_PORTABILITY,
   PROOF_REPO_SIGNALS,
   PROOF_SECTION,
@@ -166,6 +167,23 @@ export function Proof() {
                 </a>
               </div>
             ))}
+          </div>
+        </div>
+
+        {/* Local-AI proof beat: in-boundary by default, dogfooded by RevDev. */}
+        <div className="mx-auto mt-16 max-w-5xl">
+          <div className="rounded-2xl bg-secondary p-8 ring-1 ring-border">
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+              {PROOF_LOCAL_AI.eyebrow}
+            </p>
+            <h3 className="mt-2 text-xl font-semibold text-foreground">{PROOF_LOCAL_AI.heading}</h3>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{PROOF_LOCAL_AI.body}</p>
+            <a
+              href={PROOF_LOCAL_AI.linkHref}
+              className="mt-4 inline-block text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+            >
+              {PROOF_LOCAL_AI.linkLabel}
+            </a>
           </div>
         </div>
 

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -1,0 +1,134 @@
+// Content for the Local-first AI home section (LocalAi.tsx) and the standalone
+// /local-ai page (LocalAiPage.tsx).
+//
+// Copy is locked to the merged Phase B corpus:
+//   - docs/marketing/06-copy-corpus.md §4.11 (frontier pathway), §4.12 (local-first AI)
+//   - docs/marketing/00-truth-source.md §8 (local-first AI grounding), §4(c) (named adopters)
+// If this file drifts from the corpus, this file is wrong and gets fixed here
+// first (corpus §0 authority rule).
+//
+// Honesty guardrails (truth-source §5, binding): open-model-first is framed on
+// cost + sovereignty + good-enough-for-most-work economics, NEVER on parity,
+// "free", "turnkey", or "faster". Frontier stays the opt-in escalation. The
+// provider snippet is grep-accurate to packages/ai/src/llm/client.ts
+// (LLM_PROVIDER; inference-snaps default gemma3 :9090, ollama gemma4 :11434).
+// Positioning guardrail (Phase C): ownership stays the lead; local AI is its proof.
+
+import { SITE } from './site';
+
+export interface LocalAiBeat {
+  readonly title: string;
+  readonly body: string;
+}
+
+// Shared home-section content. Four beats per the corpus §4.12 lead.
+export const LOCAL_AI_SECTION = {
+  eyebrow: 'Local-first AI',
+  heading: 'Your agents run on models you own.',
+  body: 'Your Agents run on open-weight models on your own infrastructure by default. The content they read and write never leaves your boundary, your AI bill is your own inference cost, and the same permissions and audit log cover every action.',
+  beats: [
+    {
+      title: 'Sovereignty',
+      body: 'The content your agents read and write never leaves your boundary. In the default config, inference runs on infrastructure you own.',
+    },
+    {
+      title: 'Economics',
+      body: 'Your AI bill is your own inference cost, not a per-token tax that grows with every customer.',
+    },
+    {
+      title: 'Pathway',
+      body: 'When you want a frontier model, add it in one config line: opt-in, never assumed.',
+    },
+    {
+      title: 'Governance',
+      body: 'Either way, the same permissions govern every action and the same audit log records it.',
+    },
+  ] as readonly LocalAiBeat[],
+  // Grep-accurate to packages/ai/src/llm/client.ts createLLMClientFromEnv().
+  snippet: {
+    caption:
+      'One line picks your model runner. Frontier providers stay opt-in adapters, never the default.',
+    lines: [
+      {
+        code: 'LLM_PROVIDER=inference-snaps',
+        note: 'gemma3 on your box, port 9090 (zero-config default)',
+      },
+      { code: 'LLM_PROVIDER=ollama', note: 'gemma4 on your box, port 11434' },
+    ],
+  },
+  dogfood:
+    'RevDev Studio, the harness the team uses to build RevealUI, ships a local-inference cockpit that installs and runs Inference Snaps and Ollama. The team that maintains RevealUI runs local inference.',
+  honesty:
+    'Local inference needs an open-weight model runner (Ollama or Ubuntu Inference Snaps) and adequate hardware. Frontier models still lead the hardest work, which is why they are one config line away.',
+  cta: { label: 'See local-first AI', href: '/local-ai' },
+} as const;
+
+export interface LocalAdopter {
+  readonly name: string;
+  readonly detail: string;
+  readonly source: string;
+}
+
+// Standalone /local-ai page. Consolidates the scattered strong lines plus the
+// §4(c) named-adopter MARKET proof (industry adopters of open/local models, NOT
+// RevealUI customers) and the air-gap roadmap. The opencode pathway is gated to
+// Phase E (corpus §4.13) and is intentionally omitted until those docs ship.
+export const LOCAL_AI_PAGE = {
+  eyebrow: 'Local-first AI',
+  h1: 'Run your AI on infrastructure you own.',
+  lead: 'RevealUI is open-model first. The runtime needs no hosted model API: it runs on open-weight models by default, and a frontier provider is one opt-in config line, never assumed. Ownership is the lead. Local AI is how you prove it.',
+  pillars: [
+    {
+      title: 'Your data stays in your boundary',
+      body: 'In the default config, agents run on an open-weight model on your own infrastructure, so the content they read and write never leaves your boundary. No hosted model API sits between your code and your business logic.',
+    },
+    {
+      title: 'Your inference cost, not a per-token tax',
+      body: 'You pay for your own inference and compute, not a per-token fee that grows with every customer you add. Frontier API prices have moved up; commodity and local inference keep falling.',
+    },
+    {
+      title: 'Frontier is one opt-in line away',
+      body: 'Start fully on open weights running locally. When a task needs a frontier model, add the provider as an opt-in adapter, never the default. The same permissions govern every action and the same audit log records it, whichever model runs.',
+    },
+  ],
+  marketProof: {
+    eyebrow: 'Why local-first matters',
+    heading: 'Open and local models already run where data cannot leave.',
+    body: 'Across regulated, high-stakes industries, teams already self-host open-weight models so sensitive data stays inside their boundary. RevealUI adds the governance layer on top: one permission model over people and agents, and a tamper-evident audit on every action.',
+    adopters: [
+      {
+        name: 'HSBC',
+        detail: 'self-hosts Mistral on its own systems in finance.',
+        source: 'HSBC, 2025-12-01',
+      },
+      {
+        name: 'Capital One',
+        detail:
+          'runs a production multi-agent assistant on fine-tuned Llama, with dealers reporting up to 55% more engagement.',
+        source: 'Capital One tech blog, 2025-03-05',
+      },
+      {
+        name: '300+ hospitals',
+        detail: 'run private, on-site DeepSeek inside their clinical systems.',
+        source: 'Int. J. Surgery, 2025-06-21',
+      },
+      {
+        name: 'Scale AI Defense Llama',
+        detail: 'fine-tunes Llama on doctrine and policy for controlled government environments.',
+        source: 'Scale, 2024-11-04',
+      },
+    ] as readonly LocalAdopter[],
+    disclaimer:
+      'These are industry adopters of open and local models, not RevealUI customers. They show where the runtime fits: where good enough and yours beats best and rented.',
+  },
+  roadmap: {
+    heading: 'On the roadmap',
+    body: 'An air-gapped, container-image deployment path for fully disconnected environments. Not shipped yet, tracked on the roadmap.',
+    href: '/roadmap',
+  },
+  honesty: LOCAL_AI_SECTION.honesty,
+  cta: {
+    primary: { label: 'Start free', href: SITE.urls.signup },
+    secondary: { label: 'Read the docs', href: SITE.urls.docs },
+  },
+} as const;

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -6,6 +6,7 @@ import type { NavLink } from './types';
 
 export const NAV_LINKS: readonly NavLink[] = [
   { label: 'Products', href: '/products' },
+  { label: 'Local AI', href: '/local-ai' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: SITE.urls.docs },
   { label: 'Blog', href: '/blog' },
@@ -26,6 +27,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
     heading: 'Product',
     links: [
       { label: 'Products', href: '/products' },
+      { label: 'Local AI', href: '/local-ai' },
       { label: 'Pricing', href: '/pricing' },
       { label: 'Documentation', href: SITE.urls.docs },
       { label: 'Blog', href: '/blog' },

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -212,9 +212,9 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     bgColor: 'bg-violet-500/10',
     ringColor: 'ring-violet-500/20',
     forYou: {
-      headline: 'AI agents that work on your business, no proprietary API keys',
+      headline: 'Agents on open-weight models you run yourself',
       description:
-        'AI agents manage content, process tasks, and coordinate workflows. Runs on open-weight models via Ubuntu Inference Snaps or Ollama. No vendor lock-in. Your own inference cost, not a per-token API tax.',
+        'Agents manage content, process tasks, and coordinate workflows on open-weight models running on infrastructure you own, via Ubuntu Inference Snaps or Ollama. Add a frontier provider in one config line: opt-in, never assumed. Your own inference cost, not a per-token API tax.',
     },
     forAgents: {
       headline: 'A2A protocol, CRDT memory, and MCP servers',

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -96,3 +96,14 @@ export const PROOF_TRUST = {
     href: SITE.urls.repoChangelog,
   },
 } as const;
+
+// Local-AI proof beat. The default config keeps content in-boundary and the
+// team's own harness (RevDev) runs the same local inference, so the open-model
+// claim is dogfooded, not asserted. Links onward to the /local-ai surface.
+export const PROOF_LOCAL_AI = {
+  eyebrow: 'Local-first AI',
+  heading: 'The AI runs on your box, not a vendor cloud.',
+  body: 'In the default config, agents run on an open-weight model on infrastructure you own, so the content they read and write stays in your boundary. RevDev Studio, the harness the team uses to build RevealUI, runs the same local inference.',
+  linkLabel: 'See local-first AI →',
+  linkHref: '/local-ai',
+} as const;

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -13,6 +13,7 @@ import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
 import { Fork } from '../components/landing/Fork';
 import { Hero } from '../components/landing/Hero';
+import { LocalAi } from '../components/landing/LocalAi';
 import { Objections } from '../components/landing/Objections';
 import { Persona } from '../components/landing/Persona';
 import { PricingTeaser } from '../components/landing/PricingTeaser';
@@ -38,6 +39,7 @@ function TechnicalLanding() {
       <ThesisBand />
       <WhatsShipped />
       <Persona />
+      <LocalAi />
       <Proof />
       <PricingTeaser />
       <Faq />

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -1,0 +1,130 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
+
+/**
+ * Standalone /local-ai page (positioning decision c: standalone, not folded in).
+ * Consolidates the economics, in-boundary sovereignty, and frontier-pathway
+ * lines, the §4(c) named-adopter MARKET proof (industry adopters of open/local
+ * models, not RevealUI customers), and the air-gap roadmap. The opencode pathway
+ * is gated to Phase E (corpus §4.13) and ships there, not here. One primary CTA.
+ * Guardrail: ownership stays the lead; local AI is its proof, not a reordering of
+ * the locked positioning stack.
+ */
+export function LocalAiPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            {LOCAL_AI_PAGE.eyebrow}
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+            {LOCAL_AI_PAGE.h1}
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{LOCAL_AI_PAGE.lead}</p>
+        </div>
+      </section>
+
+      {/* Three pillars: sovereignty, economics, pathway. */}
+      <section className="px-6 py-16 sm:py-20 lg:px-8">
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
+          {LOCAL_AI_PAGE.pillars.map((pillar) => (
+            <div key={pillar.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <h2 className="text-lg font-semibold text-foreground">{pillar.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">{pillar.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* One-config-line provider snippet, shared with the home section. */}
+      <section className="px-6 pb-8 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
+            <ul className="space-y-2 font-mono text-sm list-none p-0">
+              {LOCAL_AI_SECTION.snippet.lines.map((line) => (
+                <li
+                  key={line.code}
+                  className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
+                >
+                  <code className="text-emerald-400">{line.code}</code>
+                  <span className="text-background/60"># {line.note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className="mt-3 text-sm text-muted-foreground">{LOCAL_AI_SECTION.snippet.caption}</p>
+        </div>
+      </section>
+
+      {/* §4(c) market proof: industry adopters of open/local models, not customers. */}
+      <section className="px-6 py-16 sm:py-20 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {LOCAL_AI_PAGE.marketProof.eyebrow}
+          </p>
+          <h2 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            {LOCAL_AI_PAGE.marketProof.heading}
+          </h2>
+          <p className="mt-4 text-base leading-7 text-muted-foreground">
+            {LOCAL_AI_PAGE.marketProof.body}
+          </p>
+          <ul className="mt-8 space-y-4 list-none p-0">
+            {LOCAL_AI_PAGE.marketProof.adopters.map((adopter) => (
+              <li key={adopter.name} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
+                <p className="text-base text-foreground">
+                  <span className="font-semibold">{adopter.name}</span> {adopter.detail}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">{adopter.source}</p>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm italic leading-6 text-muted-foreground">
+            {LOCAL_AI_PAGE.marketProof.disclaimer}
+          </p>
+        </div>
+      </section>
+
+      {/* Dogfood proof + honesty qualification + air-gap roadmap. */}
+      <section className="px-6 pb-16 lg:px-8">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <p className="text-base leading-7 text-muted-foreground">{LOCAL_AI_SECTION.dogfood}</p>
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+              {LOCAL_AI_PAGE.roadmap.heading}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {LOCAL_AI_PAGE.roadmap.body}{' '}
+              <a
+                href={LOCAL_AI_PAGE.roadmap.href}
+                className="font-medium text-primary hover:underline"
+              >
+                See the roadmap
+              </a>
+              .
+            </p>
+          </div>
+          <p className="border-t border-border pt-6 text-sm leading-6 text-muted-foreground">
+            {LOCAL_AI_PAGE.honesty}
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 pb-24 sm:pb-32 lg:px-8">
+        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+          <ButtonCVA asChild size="lg" variant="primary">
+            <a href={LOCAL_AI_PAGE.cta.primary.href}>{LOCAL_AI_PAGE.cta.primary.label}</a>
+          </ButtonCVA>
+          <ButtonCVA asChild size="lg" variant="outline">
+            <a href={LOCAL_AI_PAGE.cta.secondary.href} target="_blank" rel="noopener noreferrer">
+              {LOCAL_AI_PAGE.cta.secondary.label}
+            </a>
+          </ButtonCVA>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase C — Local-AI amplification surfaces

Copy pulled verbatim from the merged Phase B corpus (`06-copy-corpus` §4.11/§4.12, `00-truth-source` §8/§4(c)). Base: `test`. **Ownership stays the lead; local AI is its proof** (positioning stack not reordered).

### Surfaces
- **Hero chip** — "Local-first AI" added to the shared trust strip (extracted to a `TRUST_SIGNALS` const used by both hero variants). No `?hero=foundation` fork, no third hero variant (decision d).
- **Home section** — `content/local-ai.ts` + `components/landing/LocalAi.tsx`, inserted between Persona and Proof in the technical landing. Four beats (sovereignty / economics / pathway / governance) + a grep-accurate one-config-line provider snippet (`LLM_PROVIDER`) + RevDev dogfood proof + required honesty line.
- **Standalone `/local-ai` page** (decision c) — `routes/LocalAiPage.tsx` + `App.tsx` route + nav (header + footer). Carries the economics/sovereignty/frontier-pathway pillars, the §4(c) named-adopter **market** proof (HSBC, Capital One, 300+ hospitals, Scale AI Defense Llama), the air-gap roadmap note, and one primary CTA.
- **Agents primitive card** — leads with local ("Agents on open-weight models you run yourself. Add a frontier provider in one line.").
- **proof.ts / Proof.tsx** — local-AI proof beat (in-boundary by default, dogfooded by RevDev).

### Scope guardrails honored
- **Provider-switch interactive is Phase D** — only a static snippet here, not the interactive toggle.
- **opencode pathway is gated to Phase E** (corpus §4.13, `git grep opencode` = 0) — omitted from `/local-ai` until those docs ship.
- Locked positioning stack not reordered.

### Gates
- claim-drift **0**, marketing-voice **0 new**, no em-dash in customer copy
- typecheck clean, build green, **73/73** marketing tests
- preview: `/` and `/local-ai` both **200**; bundle verified to contain the hero chip, page h1, provider snippet, adopter proof, proof beat, route + nav link

### Honesty note for reviewer
The §4(c) adopters carry **source attributions** (publisher + date, e.g. "HSBC, 2025-12-01"), the same format the verified research block (`wf_5c4bb639`) provided. Per-adopter clickable **URLs were not in that block**, so none were fabricated. If you want live links, they need to come from the research output. The adopters are explicitly framed as industry adopters of open/local models, **not** RevealUI customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)