### PR TITLE
fix(marketing): /local-ai review fixes + lean Western open-weight

### DIFF
--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -51,7 +51,7 @@ export const LOCAL_AI_SECTION = {
     lines: [
       {
         code: 'LLM_PROVIDER=inference-snaps',
-        note: 'gemma3 on your box, port 9090 (zero-config default)',
+        note: 'gemma3 on your box, port 9090 (default runner)',
       },
       { code: 'LLM_PROVIDER=ollama', note: 'gemma4 on your box, port 11434' },
     ],
@@ -98,7 +98,7 @@ export const LOCAL_AI_PAGE = {
     adopters: [
       {
         name: 'HSBC',
-        detail: 'self-hosts Mistral on its own systems in finance.',
+        detail: 'is deploying self-hosted Mistral on its own internal systems in finance.',
         source: 'HSBC, 2025-12-01',
       },
       {
@@ -108,13 +108,14 @@ export const LOCAL_AI_PAGE = {
         source: 'Capital One tech blog, 2025-03-05',
       },
       {
-        name: '300+ hospitals',
-        detail: 'run private, on-site DeepSeek inside their clinical systems.',
-        source: 'Int. J. Surgery, 2025-06-21',
+        name: 'Goldman Sachs and Shopify',
+        detail:
+          'run Llama in production, with Shopify serving tens of millions of inferences a day.',
+        source: 'Meta AI, 2024-08-29',
       },
       {
         name: 'Scale AI Defense Llama',
-        detail: 'fine-tunes Llama on doctrine and policy for controlled government environments.',
+        detail: 'fine-tunes Llama 3 on doctrine and policy for controlled government environments.',
         source: 'Scale, 2024-11-04',
       },
     ] as readonly LocalAdopter[],
@@ -128,7 +129,7 @@ export const LOCAL_AI_PAGE = {
   },
   honesty: LOCAL_AI_SECTION.honesty,
   cta: {
-    primary: { label: 'Start free', href: SITE.urls.signup },
+    primary: { label: 'Start building', href: SITE.urls.signup },
     secondary: { label: 'Read the docs', href: SITE.urls.docs },
   },
 } as const;


### PR DESCRIPTION
## Phase C review follow-up (#1593 already merged, so this lands on `test` directly)

Adversarial review of the merged Phase C `/local-ai` page, plus an owner directive to de-emphasize Chinese-origin models on customer surfaces.

### Changes (`content/local-ai.ts`)
- **Adopter accuracy/tense:** HSBC → "is deploying self-hosted Mistral … internal systems" (the Dec-2025 source is a signed forward commitment, not live production); Scale → "Llama **3**" (matches Scale's own announcement).
- **Lean Western open-weight:** dropped the "300+ Chinese hospitals / DeepSeek" adopter; substituted a Western Llama adopter (**Goldman Sachs + Shopify**, Meta AI 2024-08-29). The runtime stays provider-agnostic — operators may self-host any open-weight model — this is a **marketing-proof** change, not a capability restriction.
- **Honesty:** snippet note "(zero-config default)" → "(default runner)" ("zero-config" read turnkey, contradicting the honesty line).
- **CTA:** `/local-ai` primary "Start free" → "Start building" (this surface argues cost honesty; "free" stays correct on the pricing page).

### Kept (per review rulings)
- Hero "Local-first AI" trust chip (owner directive; trust-signal, not a pillar reorder).
- The page's `honesty` line (the "missing" flag was a false positive — it already renders).
- The truth-source-sourced "Frontier API prices have moved up" pillar line.

### Gates
- claim-drift **0**, marketing-voice **0 new**, no em-dash in copy, build green, **73/73** marketing tests, `/local-ai` renders **200**.

> Companion corpus PR (truth-source §4 Chinese-model scrub + 2 accuracy fixes) follows in an internal repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)