### PR TITLE
feat(marketing): Phase D — interactive tables and snapshots

### DIFF
--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { HOME_COST_CALCULATOR as C } from '../../content/home';
+
+/**
+ * Interactive cost calculator. Replaces the former static HOME_PROBLEM cost row.
+ * The output is ALWAYS one of the sanctioned 00-truth-source §3 brackets (entry /
+ * growth / scale); the inputs only move you between sourced ranges, so the figure
+ * is never fabricated outside the §3 band. No vendor names. CSR-only (Vite SPA).
+ */
+function pickTier(products: number, vendors: number, mrr: number) {
+  const score = (products >= 3 ? 1 : 0) + (vendors >= 5 ? 1 : 0) + (mrr >= 20000 ? 1 : 0);
+  if (score >= 3) return C.tiers[2];
+  if (score === 2) return C.tiers[1];
+  return C.tiers[0];
+}
+
+function Slider({
+  label,
+  min,
+  max,
+  step,
+  value,
+  display,
+  onChange,
+}: {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  display: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="flex items-baseline justify-between">
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        <span className="font-mono text-sm text-primary">{display}</span>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="mt-2 w-full accent-primary"
+      />
+    </label>
+  );
+}
+
+export function CostCalculator() {
+  const [products, setProducts] = useState<number>(C.inputs.products.default);
+  const [vendors, setVendors] = useState<number>(C.inputs.vendors.default);
+  const [mrr, setMrr] = useState<number>(C.inputs.mrr.default);
+
+  const tier = pickTier(products, vendors, mrr);
+
+  return (
+    <section className="bg-background pb-24 sm:pb-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {C.eyebrow}
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {C.heading}
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{C.body}</p>
+        </div>
+
+        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
+          {/* Inputs */}
+          <div className="space-y-6 rounded-2xl bg-card p-8 ring-1 ring-border">
+            <Slider
+              label={C.inputs.products.label}
+              min={C.inputs.products.min}
+              max={C.inputs.products.max}
+              step={C.inputs.products.step}
+              value={products}
+              display={products >= C.inputs.products.max ? `${products}+` : String(products)}
+              onChange={setProducts}
+            />
+            <Slider
+              label={C.inputs.vendors.label}
+              min={C.inputs.vendors.min}
+              max={C.inputs.vendors.max}
+              step={C.inputs.vendors.step}
+              value={vendors}
+              display={String(vendors)}
+              onChange={setVendors}
+            />
+            <Slider
+              label={C.inputs.mrr.label}
+              min={C.inputs.mrr.min}
+              max={C.inputs.mrr.max}
+              step={C.inputs.mrr.step}
+              value={mrr}
+              display={
+                mrr >= C.inputs.mrr.max
+                  ? `$${(mrr / 1000).toFixed(0)}k+`
+                  : `$${(mrr / 1000).toFixed(0)}k`
+              }
+              onChange={setMrr}
+            />
+          </div>
+
+          {/* Output */}
+          <div className="flex flex-col justify-center gap-6 rounded-2xl bg-secondary p-8 ring-1 ring-border">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                {C.rentedLabel}
+              </p>
+              <p className="mt-1 text-3xl font-bold tracking-tight text-foreground">{tier.range}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{tier.note}</p>
+            </div>
+            <div className="border-t border-border pt-6">
+              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+                {C.revealui.label}
+              </p>
+              <p className="mt-1 text-3xl font-bold tracking-tight text-primary">
+                {C.revealui.value}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">{C.revealui.sub}</p>
+            </div>
+          </div>
+        </div>
+
+        <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">
+          {C.footnote}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/landing/FrontierPathway.tsx
+++ b/apps/marketing/app/components/landing/FrontierPathway.tsx
@@ -1,0 +1,31 @@
+import { FRONTIER_PATHWAY as F } from '../../content/local-ai';
+
+/**
+ * Frontier-pathway visual: a three-step progression (open-weight default -> add
+ * an adapter -> governed and audited) with a constant-governance footer. Static
+ * (no state); pairs with the interactive ProviderSwitch in the local-AI section.
+ */
+export function FrontierPathway() {
+  return (
+    <div className="mx-auto mt-12 max-w-4xl">
+      <div className="text-center">
+        <p className="text-xs font-semibold uppercase tracking-widest text-primary">{F.eyebrow}</p>
+        <h3 className="mt-2 text-xl font-semibold text-foreground">{F.heading}</h3>
+      </div>
+
+      <ol className="mt-8 grid grid-cols-1 gap-4 list-none p-0 sm:grid-cols-3">
+        {F.steps.map((step) => (
+          <li key={step.n} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 font-mono text-sm font-semibold text-primary">
+              {step.n}
+            </span>
+            <h4 className="mt-4 text-base font-semibold text-foreground">{step.title}</h4>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{step.body}</p>
+          </li>
+        ))}
+      </ol>
+
+      <p className="mt-4 text-center text-sm font-medium text-primary">{F.constant}</p>
+    </div>
+  );
+}

--- a/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
+++ b/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
@@ -1,0 +1,41 @@
+import { LIVE_METRICS as M } from '../../content/proof';
+
+/**
+ * Live-metrics snapshot badge. Renders the gate-pinned site.ts METRICS as a
+ * "live from the repo" strip and links to the claim-drift validator that
+ * enforces them. Static (the numbers are build-time constants pinned by CI).
+ */
+export function LiveMetricsBadge() {
+  return (
+    <div className="mx-auto mb-16 max-w-5xl rounded-2xl bg-secondary p-8 ring-1 ring-border">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-primary">
+            <span aria-hidden="true" className="h-2 w-2 animate-pulse rounded-full bg-primary" />
+            {M.eyebrow}
+          </p>
+          <h3 className="mt-2 text-xl font-semibold text-foreground">{M.heading}</h3>
+        </div>
+        <a
+          href={M.validatorHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+        >
+          {M.validatorLabel}
+        </a>
+      </div>
+
+      <dl className="mt-6 grid grid-cols-3 gap-4 sm:grid-cols-6">
+        {M.metrics.map((m) => (
+          <div key={m.label} className="text-center">
+            <dd className="text-3xl font-bold tracking-tight text-foreground">{m.value}</dd>
+            <dt className="mt-1 text-xs text-muted-foreground">{m.label}</dt>
+          </div>
+        ))}
+      </dl>
+
+      <p className="mt-6 text-sm leading-6 text-muted-foreground">{M.body}</p>
+    </div>
+  );
+}

--- a/apps/marketing/app/components/landing/LocalAi.tsx
+++ b/apps/marketing/app/components/landing/LocalAi.tsx
@@ -1,5 +1,7 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { LOCAL_AI_SECTION } from '../../content/local-ai';
+import { FrontierPathway } from './FrontierPathway';
+import { ProviderSwitch } from './ProviderSwitch';
 
 /**
  * Local-first AI home section. Sits between Primitives and Proof in the
@@ -51,6 +53,10 @@ export function LocalAi() {
             {LOCAL_AI_SECTION.snippet.caption}
           </p>
         </div>
+
+        {/* Provider-switch interactive + frontier-pathway visual (Phase D). */}
+        <ProviderSwitch />
+        <FrontierPathway />
 
         <div className="mx-auto mt-10 max-w-3xl space-y-3 text-center">
           <p className="text-sm leading-6 text-muted-foreground">{LOCAL_AI_SECTION.dogfood}</p>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -9,6 +9,7 @@ import {
   PROOF_STACK_PANEL,
   PROOF_TRUST,
 } from '../../content/proof';
+import { LiveMetricsBadge } from './LiveMetricsBadge';
 
 export function Proof() {
   return (
@@ -24,7 +25,12 @@ export function Proof() {
           <p className="mt-6 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
         </div>
 
-        <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Live-metrics snapshot badge (Phase D): gate-pinned counts + validator link. */}
+        <div className="mt-16">
+          <LiveMetricsBadge />
+        </div>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Repo signals */}
           <div className="rounded-2xl bg-secondary p-8 ring-1 ring-border">
             <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">

--- a/apps/marketing/app/components/landing/ProviderSwitch.tsx
+++ b/apps/marketing/app/components/landing/ProviderSwitch.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { PROVIDER_SWITCH as P } from '../../content/local-ai';
+
+/**
+ * Provider-switch interactive. Toggling Local <-> Frontier changes the model,
+ * data locus, cost model, and config line, while the governance/audit row stays
+ * fixed. Anchors the local-AI section; the frontier-pathway made tangible.
+ * CSR-only (Vite SPA).
+ */
+type Mode = 'local' | 'frontier';
+
+export function ProviderSwitch() {
+  const [mode, setMode] = useState<Mode>('local');
+  const active = P.modes[mode];
+
+  return (
+    <div className="mx-auto mt-12 max-w-3xl rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
+      <div className="text-center">
+        <p className="text-xs font-semibold uppercase tracking-widest text-primary">{P.eyebrow}</p>
+        <h3 className="mt-2 text-xl font-semibold text-foreground">{P.heading}</h3>
+      </div>
+
+      {/* Toggle */}
+      <div
+        className="mt-6 grid grid-cols-2 gap-1 rounded-xl bg-secondary p-1"
+        role="tablist"
+        aria-label="Provider mode"
+      >
+        {(['local', 'frontier'] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            role="tab"
+            aria-selected={mode === m}
+            onClick={() => setMode(m)}
+            className={`flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition ${
+              mode === m
+                ? 'bg-card text-foreground shadow-sm ring-1 ring-border'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {P.modes[m].label}
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary">
+              {P.modes[m].badge}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Changing attributes */}
+      <dl className="mt-6 divide-y divide-border">
+        {P.attributes.map((attr) => (
+          <div key={attr.key} className="flex items-baseline justify-between gap-4 py-3">
+            <dt className="text-sm text-muted-foreground">{attr.label}</dt>
+            <dd
+              className={`text-right text-sm font-medium text-foreground ${attr.key === 'config' ? 'font-mono text-primary' : ''}`}
+            >
+              {active[attr.key as keyof typeof active]}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Constant governance row */}
+      <div className="mt-4 rounded-xl bg-primary/5 p-4 ring-1 ring-primary/20">
+        <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+          {P.constant.label}
+        </p>
+        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 list-none p-0">
+          {P.constant.items.map((item) => (
+            <li key={item} className="text-sm text-foreground">
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -150,15 +150,56 @@ export const HOME_PROBLEM = {
       agentOnly: 'Logs only',
       revealui: 'Hash-chained, in DB',
     },
-    {
-      capability: 'Cost (5 devs, mid-startup)',
-      sprawl: '~$320 to $700+ / mo',
-      agentOnly: '~$300 / mo + infra',
-      revealui: '$49 / mo + infra',
-    },
   ] as readonly ProblemRow[],
   footnote:
-    'Sprawl prices reflect typical mid-startup invoices. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.',
+    'Capability comparison only; the monthly cost is the calculator below. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Cost calculator (interactive; replaces the former static cost row)
+// ---------------------------------------------------------------------------
+// Output is ALWAYS a sanctioned range from 00-truth-source §3 (entry ~$320-380,
+// climbing past $700-1,000+). The inputs move you between those sourced brackets;
+// the component never invents a precise figure outside the §3 band. No vendor
+// names. Honesty: sourced + time-sensitive + excludes payment processing +
+// RevealUI is self-hosted (you pay your own Postgres + compute).
+
+export interface CostTier {
+  readonly id: string;
+  readonly range: string;
+  readonly note: string;
+}
+
+export const HOME_COST_CALCULATOR = {
+  eyebrow: 'The rented stack',
+  heading: 'Add up what you would otherwise rent.',
+  body: 'A multi-product team rents auth, content, billing, observability, and background jobs from four to six vendors. Estimate the monthly bill for that rented stack, then compare it to one runtime you own.',
+  inputs: {
+    products: { label: 'Products you run', min: 1, max: 8, step: 1, default: 2 },
+    vendors: { label: 'Vendor services you would replace', min: 3, max: 6, step: 1, default: 5 },
+    mrr: { label: 'Monthly recurring revenue', min: 0, max: 50000, step: 5000, default: 10000 },
+  },
+  tiers: [
+    {
+      id: 'entry',
+      range: '$320 to $380 / month',
+      note: 'Entry tiers across four or five vendors.',
+    },
+    {
+      id: 'growth',
+      range: '$450 to $700 / month',
+      note: 'More products and seats push you up the published tiers.',
+    },
+    {
+      id: 'scale',
+      range: '$700 to $1,000+ / month',
+      note: 'Enterprise SSO, compliance tiers, or higher-tier auth enter.',
+    },
+  ] as const satisfies readonly CostTier[],
+  rentedLabel: 'The rented stack',
+  revealui: { label: 'RevealUI', value: '$49 / month', sub: '+ your own Postgres and compute' },
+  footnote:
+    'A sourced estimate from current 2026 published pricing, time-sensitive. It excludes payment processing, and RevealUI is self-hosted, so you still pay for your own Postgres and compute. Figures are ranges, not a quote.',
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -133,3 +133,76 @@ export const LOCAL_AI_PAGE = {
     secondary: { label: 'Read the docs', href: SITE.urls.docs },
   },
 } as const;
+
+// Provider-switch interactive (anchors the local-AI section). Toggling Local <->
+// Frontier changes the model, the data locus, and the cost model, while the
+// governance and audit row stays identical. The frontier-pathway made tangible.
+// Honesty: the local LLM_PROVIDER value is grep-accurate; frontier is described
+// as an opt-in adapter (the locked Pillar-2 framing), not a fabricated env value.
+export const PROVIDER_SWITCH = {
+  eyebrow: 'Local or frontier, same governance',
+  heading: 'Switch the model. The rules do not move.',
+  modes: {
+    local: {
+      label: 'Local',
+      badge: 'default',
+      model: 'gemma3, open-weight',
+      locus: 'Runs on your own box',
+      cost: 'Your inference cost, no per-token fee',
+      config: 'LLM_PROVIDER=inference-snaps',
+    },
+    frontier: {
+      label: 'Frontier',
+      badge: 'opt-in',
+      model: 'Claude, GPT, or Bedrock',
+      locus: 'Calls the vendor API you choose',
+      cost: 'Per-token vendor pricing',
+      config: 'add a frontier adapter, one config line',
+    },
+  },
+  attributes: [
+    { key: 'model', label: 'Model' },
+    { key: 'locus', label: 'Where it runs' },
+    { key: 'cost', label: 'Cost model' },
+    { key: 'config', label: 'Config' },
+  ],
+  constant: {
+    label: 'Constant either way',
+    items: [
+      'The same RBAC + ABAC permissions',
+      'The same tamper-evident audit log',
+      'The same MCP tools',
+    ],
+  },
+} as const;
+
+// Frontier-pathway visual: open-weight default -> add adapter -> governed and
+// audited, three steps, governance constant across all of them.
+export interface FrontierStep {
+  readonly n: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export const FRONTIER_PATHWAY = {
+  eyebrow: 'The frontier pathway',
+  heading: 'Start local. Escalate on purpose.',
+  steps: [
+    {
+      n: '1',
+      title: 'Open-weight default',
+      body: 'Agents run on an open-weight model on your own box. Zero config.',
+    },
+    {
+      n: '2',
+      title: 'Add an adapter',
+      body: 'When a task needs a frontier model, add the provider in one config line. Opt-in, never assumed.',
+    },
+    {
+      n: '3',
+      title: 'Governed and audited',
+      body: 'Whichever model runs, the same permissions govern it and the same audit log records it.',
+    },
+  ] as readonly FrontierStep[],
+  constant: 'Governance and audit stay identical across all three steps.',
+} as const;

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -9,6 +9,13 @@
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.
 //
+// Status re-verified 2026-06-23 (Phase D, against current per-product READMEs):
+// RevForge Beta → Alpha (README: stamped kits are reference/preview only, not
+// production-ready); RevCon Alpha → Active (MIT) (shipped MIT tool, no pre-1.0
+// marking). RevMarket STAYS Planned: MASTER_PLAN marks the infra complete, but
+// truth-source §5 binds the marketplace as not-yet-shipped to users and the hero
+// says it is "on the way" — the marketing guardrail wins over internal status.
+//
 // Conversion pass (2026-06-09): per the e-commerce-PDP optimization framework
 // (digitalapplied.com), three "test-first" wins applied to this product-family
 // page — (1) price/license transparency surfaced on every card via priceLabel
@@ -169,7 +176,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
       'Domain-locked, multi-tenant',
       'Self-hosted runtime instances',
     ],
-    status: 'Beta',
+    status: 'Alpha',
     priceLabel: 'Operator tool',
     iconPath:
       'M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766m-2.704 3.796-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z',
@@ -207,7 +214,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
       'Symlinked into every project',
       'Edit once, propagate fleet-wide',
     ],
-    status: 'Alpha',
+    status: 'Active (MIT)',
     priceLabel: 'Free · MIT',
     iconPath:
       'M6 13.5V3.75m0 9.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 3.75V16.5m12-3V3.75m0 9.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 3.75V16.5m-6-9V3.75m0 3.75a1.5 1.5 0 0 1 0 3m0-3a1.5 1.5 0 0 0 0 3m0 9.75V10.5',

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -3,7 +3,7 @@
 // uses METRICS license split (21 MIT). Pre-Phase-3 audit had off-by-one count.
 // Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
 
-import { SITE } from './site';
+import { METRICS, SITE } from './site';
 
 export interface StackItem {
   readonly label: string;
@@ -106,4 +106,28 @@ export const PROOF_LOCAL_AI = {
   body: 'In the default config, agents run on an open-weight model on infrastructure you own, so the content they read and write stays in your boundary. RevDev Studio, the harness the team uses to build RevealUI, runs the same local inference.',
   linkLabel: 'See local-first AI →',
   linkHref: '/local-ai',
+} as const;
+
+// Live-metrics snapshot badge. Every integer is read from site.ts METRICS, which
+// is pinned to the codebase by the claim-drift gate (build fails on drift). The
+// badge links to that validator so the "live from the repo" claim is checkable.
+export interface LiveMetric {
+  readonly value: number;
+  readonly label: string;
+}
+
+export const LIVE_METRICS = {
+  eyebrow: 'Live from the repo',
+  heading: 'Every number here is pinned to the codebase.',
+  body: 'These counts are validated on every PR by the claim-drift gate. If the code changes and a number drifts, the build fails before it can ship.',
+  metrics: [
+    { value: METRICS.packages, label: 'packages' },
+    { value: METRICS.apps, label: 'apps' },
+    { value: METRICS.testFiles, label: 'test files' },
+    { value: METRICS.uiComponents, label: 'UI components' },
+    { value: METRICS.mcpServers, label: 'MCP servers' },
+    { value: METRICS.dbTables, label: 'DB tables' },
+  ] as readonly LiveMetric[],
+  validatorLabel: 'See the validator →',
+  validatorHref: `${SITE.urls.repo}/blob/main/scripts/validate/claim-drift.ts`,
 } as const;

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -27,7 +27,7 @@ export const METRICS = {
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
   workspaces: 31,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
-  testFiles: 912,
+  testFiles: 960,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
   uiComponents: 60,
   /**

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -9,6 +9,7 @@ import { Proof as OperatorProof } from '../components/for-operators/Proof';
 import { WhatYouGet } from '../components/for-operators/WhatYouGet';
 import { GetStarted } from '../components/GetStarted';
 import { Actors } from '../components/landing/Actors';
+import { CostCalculator } from '../components/landing/CostCalculator';
 import { Demo } from '../components/landing/Demo';
 import { Faq } from '../components/landing/Faq';
 import { Fork } from '../components/landing/Fork';
@@ -33,6 +34,7 @@ function TechnicalLanding() {
       <Actors />
       <Fork />
       <Problem />
+      <CostCalculator />
       <Demo />
       <Objections />
       <Primitives />

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -1,5 +1,7 @@
 import { ButtonCVA } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
+import { FrontierPathway } from '../components/landing/FrontierPathway';
+import { ProviderSwitch } from '../components/landing/ProviderSwitch';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 
 /**
@@ -56,6 +58,12 @@ export function LocalAiPage() {
           </div>
           <p className="mt-3 text-sm text-muted-foreground">{LOCAL_AI_SECTION.snippet.caption}</p>
         </div>
+      </section>
+
+      {/* Provider-switch interactive + frontier-pathway visual (Phase D). */}
+      <section className="px-6 pb-8 lg:px-8">
+        <ProviderSwitch />
+        <FrontierPathway />
       </section>
 
       {/* §4(c) market proof: industry adopters of open/local models, not customers. */}

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Footer } from '../components/Footer';
 import { Faq } from '../components/landing/Faq';
 import { Proof } from '../components/landing/Proof';
@@ -10,6 +11,7 @@ import {
   PRODUCTS_PAGE_HERO,
   PRODUCTS_SISTERS,
   PRODUCTS_STATS_SECTION,
+  type ProductStatus,
 } from '../content/products';
 
 const ALL_PRODUCT_ANCHORS = [
@@ -17,7 +19,22 @@ const ALL_PRODUCT_ANCHORS = [
   ...PRODUCTS_SISTERS.map((p) => ({ slug: p.slug, name: p.name })),
 ] as const;
 
+// Filter chips for the fleet-products table. "All" plus each status, ordered
+// stability-descending to match the grid.
+const STATUS_FILTERS: readonly (ProductStatus | 'All')[] = [
+  'All',
+  'Beta',
+  'Alpha',
+  'Active (MIT)',
+  'Planned',
+];
+
 export function ProductsPage() {
+  const [filter, setFilter] = useState<ProductStatus | 'All'>('All');
+  const visibleSisters =
+    filter === 'All' ? PRODUCTS_SISTERS : PRODUCTS_SISTERS.filter((p) => p.status === filter);
+  const countFor = (f: ProductStatus | 'All') =>
+    f === 'All' ? PRODUCTS_SISTERS.length : PRODUCTS_SISTERS.filter((p) => p.status === f).length;
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
@@ -189,8 +206,36 @@ export function ProductsPage() {
             </p>
           </div>
 
-          <ul className="mt-14 grid grid-cols-1 gap-6 md:grid-cols-2">
-            {PRODUCTS_SISTERS.map((product) => {
+          {/* Status filter chips (Phase D, interactive). */}
+          <div
+            className="mt-10 flex flex-wrap items-center justify-center gap-2"
+            role="tablist"
+            aria-label="Filter products by status"
+          >
+            {STATUS_FILTERS.map((f) => {
+              const selected = filter === f;
+              return (
+                <button
+                  key={f}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  onClick={() => setFilter(f)}
+                  className={`inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-sm font-medium ring-1 transition ${
+                    selected
+                      ? 'bg-primary/10 text-primary ring-primary/30'
+                      : 'bg-card text-muted-foreground ring-border hover:text-foreground hover:ring-border/80'
+                  }`}
+                >
+                  {f}
+                  <span className="text-xs text-muted-foreground">{countFor(f)}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+            {visibleSisters.map((product) => {
               const status = PRODUCT_STATUS_STYLES[product.status];
               return (
                 <li


### PR DESCRIPTION
## Phase D — interactive tables/snapshots (runbook §5)

Five interactive/refreshed pieces. Base `test`. Branched off current `origin/test` (includes #1593/#1594/#125).

### Pieces
1. **Cost/value calculator** (`CostCalculator.tsx`) — **replaces the static `HOME_PROBLEM` cost row** (decision b). Inputs: # products, # vendors, MRR. Output is **always** a sanctioned truth-source §3 bracket (entry $320-380 / growth $450-700 / scale $700-1,000+) vs RevealUI $49/mo + own infra. Inputs only move you between sourced ranges — never an invented figure. **No vendor names.**
2. **Provider-switch** (`ProviderSwitch.tsx`) — Local (gemma3, your box) ↔ Frontier (add adapter) toggle; model + data-locus + cost change while the **RBAC/audit row stays identical**. Anchors both the home local-AI section and `/local-ai`. The frontier-pathway made tangible.
3. **Frontier-pathway visual** (`FrontierPathway.tsx`) — open-weight default → add adapter → governed/audited, governance constant.
4. **Live-metrics badge** (`LiveMetricsBadge.tsx`) — gate-pinned `site.ts` METRICS (27/4/960/60/14/85), "live from the repo" + validator link. Reconciles stale `testFiles` 912→960.
5. **Filterable fleet-products table** (ProductsPage) — status filter chips with counts. **Statuses re-verified against per-product READMEs:** RevForge Beta→Alpha, RevCon Alpha→Active (MIT). **RevMarket STAYS Planned** (truth-source §5 marketplace guardrail beats internal infra status).

### Guardrails honored
No Chinese-origin models (lead Gemma/Llama/Mistral/Phi); sourced cost **range** never a fixed number; locked vocab; no em dashes in copy; §5 honesty (no free/faster/turnkey).

### Gates
claim-drift **0** (testFiles 960) · marketing-voice **0 new** · no em-dash in copy · typecheck clean · build green · **73/73** tests · `/` + `/local-ai` + `/products` all **200** · each piece verified in the built bundle · static cost row removed.

### Flag (NOT Phase D — pre-existing, separate follow-up)
The marketing **blog** bundles `docs/blog/05-five-primitives.md`, which lists **DeepSeek-R1 / Qwen-VL** as installable Inference-Snaps models. This predates the 2026-06-23 China-derisk guardrail and is a different surface (blog/docs, factual "installable models" list, not a proof point/default). Recommend a separate pass — or an owner ruling on whether "installable option" listings are acceptable vs featured proof.

> ⏳ Preview screenshots of the calculator + provider-switch requested at pause — see PR comment / owner-review notes (CSR app; verified via dev-server 200 + bundle render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)