### PR TITLE
ci(e2e): scope e2e jobs via npx playwright (Playwright 1.61 -- arg-parse fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,7 @@ jobs:
           (echo "::error::Servers failed to start within 240s" && exit 1)
 
       - name: Run E2E smoke tests
-        run: pnpm test:e2e -- --project=chromium e2e/smoke.e2e.ts
+        run: npx playwright test --project=chromium e2e/smoke.e2e.ts
         env:
           CI: "true"
           SKIP_ENV_VALIDATION: "true"
@@ -605,7 +605,7 @@ jobs:
           done
 
       - name: Run accessibility tests (fail on critical violations)
-        run: pnpm test:e2e -- --project=chromium e2e/accessibility.e2e.ts
+        run: npx playwright test --project=chromium e2e/accessibility.e2e.ts
         env:
           CI: "true"
           SKIP_ENV_VALIDATION: "true"

--- a/.github/workflows/electric-e2e.yml
+++ b/.github/workflows/electric-e2e.yml
@@ -79,7 +79,7 @@ jobs:
           echo "Electric health probe: HTTP $STATUS — proceeding"
 
       - name: Run Electric E2E tests
-        run: pnpm test:e2e -- --project=chromium e2e/electric.e2e.ts
+        run: npx playwright test --project=chromium e2e/electric.e2e.ts
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: ${{ secrets.ELECTRIC_E2E_ADMIN_URL }}


### PR DESCRIPTION
## Problem

The Playwright **1.60 → 1.61** bump in the bundle changed `--` argument
parsing. As a result, the `pnpm test:e2e -- --project=chromium e2e/<file>`
indirection used by three CI jobs **no longer forwards its scoping args**
to playwright. Those jobs silently ran the **full ~390-test suite** instead
of their single scoped file. The auth + electric specs in that suite need a
test DB that CI doesn't seed, so the jobs failed — even though the
marketing/accessibility tests themselves pass.

Affected jobs:
- **E2E Smoke** (`ci.yml`)
- **Accessibility (E2E)** (`ci.yml`)
- **Electric E2E** (`electric-e2e.yml`)

## Root cause (proven, audit-first)

With Playwright 1.61, `pnpm test:e2e -- --list --project=chromium e2e/<file>`
drops the forwarded args entirely — playwright boots the webServer and runs
in full execute mode (unscoped). The direct `npx playwright test --list
--project=chromium e2e/<file>` form honors `--list` and the file scope.

## Fix

Switch the three scoped jobs to the repo's known-good direct invocation
(`npx playwright test --project=chromium e2e/<file>`), matching the
**visual-snapshots** job in `ci.yml` which already bypasses the pnpm-script
`--` indirection. Each job now runs **only** its scoped file
(smoke / accessibility / electric), not the auth-DB suite.

Diff is exactly three lines; no other behavior changes.

## Impact

Restores scoped e2e and **unblocks promotion #1595**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
