### PR TITLE
feat(marketing): Phase F — governance surfaces

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -8,6 +8,7 @@ import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
 import { ForOperatorsHowItWorksPage } from './routes/ForOperatorsHowItWorksPage';
 import { ForOperatorsManagedPage } from './routes/ForOperatorsManagedPage';
+import { GovernancePage } from './routes/GovernancePage';
 import { HomePage } from './routes/HomePage';
 import { LocalAiPage } from './routes/LocalAiPage';
 import { NotFoundPage } from './routes/NotFoundPage';
@@ -43,6 +44,11 @@ export function App() {
         path: '/local-ai',
         component: LocalAiPage,
         meta: { title: 'Local-first AI | RevealUI' },
+      },
+      {
+        path: '/governance',
+        component: GovernancePage,
+        meta: { title: 'Provable agent governance | RevealUI' },
       },
       { path: '/pricing', component: PricingPage, meta: { title: 'Pricing | RevealUI' } },
       { path: '/blog', component: BlogIndexPage, meta: { title: 'Blog | RevealUI' } },

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,4 +1,5 @@
 import { ButtonCVA } from '@revealui/presentation';
+import { PROOF_GOVERNANCE } from '../../content/governance';
 import {
   PROOF_CI_SIGNALS,
   PROOF_LOCAL_AI,
@@ -183,6 +184,25 @@ export function Proof() {
               className="mt-4 inline-block text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
             >
               {PROOF_LOCAL_AI.linkLabel}
+            </a>
+          </div>
+        </div>
+
+        {/* Governance proof beat (Phase F): read every line + prove what agents did. */}
+        <div className="mx-auto mt-6 max-w-5xl">
+          <div className="rounded-2xl bg-primary/5 p-8 ring-1 ring-primary/20">
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+              {PROOF_GOVERNANCE.eyebrow}
+            </p>
+            <h3 className="mt-2 text-xl font-semibold text-foreground">
+              {PROOF_GOVERNANCE.heading}
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{PROOF_GOVERNANCE.body}</p>
+            <a
+              href={PROOF_GOVERNANCE.linkHref}
+              className="mt-4 inline-block text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+            >
+              {PROOF_GOVERNANCE.linkLabel}
             </a>
           </div>
         </div>

--- a/apps/marketing/app/content/governance.ts
+++ b/apps/marketing/app/content/governance.ts
@@ -1,0 +1,95 @@
+// Content for the standalone /governance page (GovernancePage.tsx) and the
+// home/products governance proof beat (PROOF_GOVERNANCE in proof.ts).
+//
+// Phase F (governance surfaces). Governance is NOT a third pillar (two-pillar
+// lock, 00-truth-source §1); it is the sharpened expression of the layer-1
+// ownership message ("One runtime you own, with agents you can prove").
+// Copy tracks the merged corpus: 06-copy-corpus §2 (sharpened lead) + §4.14
+// (governance block) + 00-truth-source §9 (governance capability claims).
+//
+// Honesty (truth-source §5/§9, binding): feature the CAPABILITY only. No SOC2 /
+// ISO / SSO / SCIM claims. No market-size figures. Locked vocab; no em dashes.
+// The §4(c) adopters are post-scrub (no Chinese-origin models) and are framed as
+// industry adopters of open/local models, NOT RevealUI customers.
+
+import { SITE } from './site';
+
+const AUDIT_HREF = `${SITE.urls.repo}/blob/main/packages/db/src/schema/audit-log.ts`;
+const POLICY_HREF = `${SITE.urls.repo}/blob/main/packages/security/src/authorization.ts`;
+
+export interface GovernanceCapability {
+  readonly title: string;
+  readonly body: string;
+  readonly linkLabel: string;
+  readonly linkHref: string;
+}
+
+export interface GovernanceAdopter {
+  readonly name: string;
+  readonly detail: string;
+  readonly source: string;
+}
+
+export const GOVERNANCE_PAGE = {
+  eyebrow: 'Provable agent governance',
+  h1: 'One runtime you own, with agents you can prove.',
+  lead: 'Put agents in front of customers and you get three hard questions: who could see this, who can stop an agent, and can you prove what it did. RevealUI answers all three from the record, not a promise.',
+  capabilities: [
+    {
+      title: 'A tamper-evident audit log',
+      body: 'Every action your People and your Agents take signs into a hash-chained (HMAC-SHA256) audit log. Alter one record and the chain breaks, so nothing gets quietly rewritten.',
+      linkLabel: 'See the schema',
+      linkHref: AUDIT_HREF,
+    },
+    {
+      title: 'One policy over people and agents',
+      body: 'A single RBAC + ABAC policy governs your team, your agents, and your service accounts, proven by 59 enforcement tests. Set the rules once; agents inherit the same boundaries.',
+      linkLabel: 'See the policy engine',
+      linkHref: POLICY_HREF,
+    },
+  ] as readonly GovernanceCapability[],
+  // Verbatim from corpus §4.14 (the sharpened layer-1 governance block).
+  block:
+    'Every action your People and your Agents take signs into a tamper-evident audit log you can prove was never edited. One set of permission rules governs your team, your agents, and your service accounts. So when a customer asks who could see this, who can stop an agent, and can you prove what it did, the answer is in the record, not a promise.',
+  proof: {
+    eyebrow: 'Why it matters',
+    heading: 'The operators who self-host their models need provable governance on top.',
+    body: 'Banks, defense programs, and other regulated operators already run open-weight models on their own infrastructure so data stays in-boundary. Their next question is always governance: who can act, and can you prove what happened. RevealUI is that layer.',
+    adopters: [
+      {
+        name: 'HSBC',
+        detail: 'is deploying self-hosted Mistral on its own internal systems in finance.',
+        source: 'HSBC, 2025-12-01',
+      },
+      {
+        name: 'Capital One',
+        detail: 'runs a production multi-agent assistant on fine-tuned Llama.',
+        source: 'Capital One tech blog, 2025-03-05',
+      },
+      {
+        name: 'Scale AI Defense Llama',
+        detail: 'fine-tunes Llama 3 for controlled government environments.',
+        source: 'Scale, 2024-11-04',
+      },
+    ] as readonly GovernanceAdopter[],
+    disclaimer:
+      'These are industry adopters of open and local models, not RevealUI customers. They show the shape of the buyer: self-host the model, then need provable governance on top.',
+  },
+  // Capability-not-certification honesty, framed positively (no cert name-drops).
+  honesty:
+    'Governance here is a technical capability your security team can read in the repo and verify line by line, not a certification you take on trust. RevealUI ships the audit chain and the policy engine; the proof is the code.',
+  cta: {
+    primary: { label: 'Start building', href: SITE.urls.signup },
+    secondary: { label: 'Read the docs', href: SITE.urls.docs },
+  },
+} as const;
+
+// Home/products governance proof beat. Pairs "their security team can read every
+// line" with "and prove what every agent did". Links onward to /governance.
+export const PROOF_GOVERNANCE = {
+  eyebrow: 'Provable governance',
+  heading: 'Read every line, and prove what every agent did.',
+  body: 'The whole runtime is open source in the repo, and every action by a person or an agent signs into a tamper-evident hash chain governed by one RBAC + ABAC policy. The answer to who did what is in the record, not a promise.',
+  linkLabel: 'See provable governance →',
+  linkHref: '/governance',
+} as const;

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -7,6 +7,7 @@ import type { NavLink } from './types';
 export const NAV_LINKS: readonly NavLink[] = [
   { label: 'Products', href: '/products' },
   { label: 'Local AI', href: '/local-ai' },
+  { label: 'Governance', href: '/governance' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: SITE.urls.docs },
   { label: 'Blog', href: '/blog' },
@@ -28,6 +29,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
     links: [
       { label: 'Products', href: '/products' },
       { label: 'Local AI', href: '/local-ai' },
+      { label: 'Governance', href: '/governance' },
       { label: 'Pricing', href: '/pricing' },
       { label: 'Documentation', href: SITE.urls.docs },
       { label: 'Blog', href: '/blog' },

--- a/apps/marketing/app/routes/GovernancePage.tsx
+++ b/apps/marketing/app/routes/GovernancePage.tsx
@@ -1,0 +1,112 @@
+import { ButtonCVA } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import { GOVERNANCE_PAGE } from '../content/governance';
+
+/**
+ * Standalone /governance page (Phase F). Pairs the governance CAPABILITY
+ * (tamper-evident audit + unified RBAC/ABAC over humans AND agents) with the
+ * §4(c) regulated-adopter proof. Governance is the sharpened expression of the
+ * layer-1 ownership lead, NOT a third pillar. Capability, not certification:
+ * no SOC2/ISO/SSO/SCIM claims. One primary CTA.
+ */
+export function GovernancePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-emerald-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            {GOVERNANCE_PAGE.eyebrow}
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+            {GOVERNANCE_PAGE.h1}
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">{GOVERNANCE_PAGE.lead}</p>
+        </div>
+      </section>
+
+      {/* The two governance capabilities. */}
+      <section className="px-6 py-16 sm:py-20 lg:px-8">
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
+          {GOVERNANCE_PAGE.capabilities.map((cap) => (
+            <div
+              key={cap.title}
+              className="flex flex-col rounded-2xl bg-card p-8 ring-1 ring-border"
+            >
+              <h2 className="text-lg font-semibold text-foreground">{cap.title}</h2>
+              <p className="mt-3 flex-1 text-sm leading-6 text-muted-foreground">{cap.body}</p>
+              <a
+                href={cap.linkHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-block self-start text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+              >
+                {cap.linkLabel}
+              </a>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* The governance block (sharpened layer-1 expression). */}
+      <section className="px-6 pb-16 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <blockquote className="rounded-2xl bg-primary/5 p-8 text-lg font-medium leading-8 text-foreground ring-1 ring-primary/20">
+            {GOVERNANCE_PAGE.block}
+          </blockquote>
+        </div>
+      </section>
+
+      {/* §4(c) regulated-adopter proof (industry adopters, not customers). */}
+      <section className="px-6 py-16 sm:py-20 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {GOVERNANCE_PAGE.proof.eyebrow}
+          </p>
+          <h2 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            {GOVERNANCE_PAGE.proof.heading}
+          </h2>
+          <p className="mt-4 text-base leading-7 text-muted-foreground">
+            {GOVERNANCE_PAGE.proof.body}
+          </p>
+          <ul className="mt-8 space-y-4 list-none p-0">
+            {GOVERNANCE_PAGE.proof.adopters.map((adopter) => (
+              <li key={adopter.name} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
+                <p className="text-base text-foreground">
+                  <span className="font-semibold">{adopter.name}</span> {adopter.detail}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">{adopter.source}</p>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm italic leading-6 text-muted-foreground">
+            {GOVERNANCE_PAGE.proof.disclaimer}
+          </p>
+        </div>
+      </section>
+
+      {/* Capability-not-certification honesty. */}
+      <section className="px-6 pb-16 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="border-t border-border pt-6 text-sm leading-6 text-muted-foreground">
+            {GOVERNANCE_PAGE.honesty}
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 pb-24 sm:pb-32 lg:px-8">
+        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+          <ButtonCVA asChild size="lg" variant="primary">
+            <a href={GOVERNANCE_PAGE.cta.primary.href}>{GOVERNANCE_PAGE.cta.primary.label}</a>
+          </ButtonCVA>
+          <ButtonCVA asChild size="lg" variant="outline">
+            <a href={GOVERNANCE_PAGE.cta.secondary.href} target="_blank" rel="noopener noreferrer">
+              {GOVERNANCE_PAGE.cta.secondary.label}
+            </a>
+          </ButtonCVA>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase F — provable agent governance (trust capstone, runbook §6b)

F3 surfaces. F1 (copy-corpus ownership lead) + F2 (truth-source §9 governance claims) already shipped in Phase B (#124/#125). **Governance is NOT a third pillar** — it sharpens the layer-1 ownership lead ("One runtime you own, with agents you can prove"). Base `test`.

### Surfaces
- **NEW `/governance` page** (`content/governance.ts` + `GovernancePage.tsx` + route + nav header/footer): pairs the **capability** (tamper-evident HMAC-SHA256 audit log + unified RBAC+ABAC over humans **and** agents, 59 enforcement tests, each linking to the source file) with the **§4(c) regulated-adopter proof** (HSBC/Mistral, Capital One/Llama, Scale Defense Llama — post-China-scrub, framed as industry adopters **not** customers). Carries the verbatim §4.14 governance block. One primary CTA.
- **Governance proof beat** (`PROOF_GOVERNANCE`, rendered in `Proof.tsx`): "read every line, and prove what every agent did" → links to `/governance`.
- **capabilities.ts** already leads with the audit + RBAC cards (human-and-agent pairing explicit), so F3(a) needed no change.

### Guardrails honored
Capability **not** certification — no SOC2/ISO/SSO/SCIM claims, no market-size figures, "the proof is the code." No Chinese-origin models. Locked vocab; no em dashes.

### Gates
typecheck clean · claim-drift **0** · marketing-voice **0 new** · no em-dash in copy · build green · **73/73** tests · `/governance` + `/local-ai` + `/` all **200** · content verified in the bundle.

### Notes for reviewer
- **`Proof.tsx` overlap with the still-open Phase D #1599:** #1599 adds the LIVE_METRICS badge at the **top** of the proof section; this PR adds the governance beat at the **bottom**. Additive, different regions — expect at most a trivial merge-order resolution.
- Built in an isolated git **worktree** off `origin/test` (a peer held the main checkout); verified in the main checkout after the peer released it. The peer's lane (#1602) was not disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)