### PR TITLE
docs(automation): lead Claude Code install with native installer

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -20,14 +20,26 @@ What's left here, and what this doc covers, is just two things: agent integratio
 
 ## Claude Code Integration
 
-[Claude Code](https://docs.anthropic.com/claude/docs/claude-code) is Anthropic's agentic CLI. It's the primary AI agent surface for this repo (alongside Zed's ACP integration).
+[Claude Code](https://code.claude.com/docs/en/setup) is Anthropic's agentic CLI. It's the primary AI agent surface for this repo (alongside Zed's ACP integration).
 
 ### Install
 
+Anthropic's recommended install is the **native installer**, a self-updating native binary that needs no Node.js. It updates itself in the background.
+
 ```bash
-pnpm add -g @anthropic-ai/claude-code
-# or, if you prefer not to install globally:
-pnpm dlx @anthropic-ai/claude-code
+# macOS / Linux / WSL
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+```powershell
+# Windows PowerShell
+irm https://claude.ai/install.ps1 | iex
+```
+
+Secondary (advanced): the npm package. It requires Node.js 18+ and ships the same native binary through per-platform optional dependencies, so your package manager must be configured to allow optional dependencies.
+
+```bash
+npm install -g @anthropic-ai/claude-code
 ```
 
 ### Run from the repo root
@@ -36,7 +48,7 @@ pnpm dlx @anthropic-ai/claude-code
 claude
 ```
 
-Project conventions are loaded from [`CLAUDE.md`](../CLAUDE.md) at the repo root. The agent's allowed permissions are defined in a local `.claude/settings.local.json` (not committed); see Anthropic's [Claude Code settings reference](https://docs.anthropic.com/claude/docs/claude-code-settings) for the format. Per-rule conventions and commands under `.claude/rules/` and `.claude/commands/` may be locally symlinked from `~/revfleet/revcon/profiles/revealui/claude/`, but neither directory is tracked in this repo.
+Project conventions are loaded from [`CLAUDE.md`](../CLAUDE.md) at the repo root. The agent's allowed permissions are defined in a local `.claude/settings.local.json` (not committed); see Anthropic's [Claude Code settings reference](https://code.claude.com/docs/en/settings) for the format. Per-rule conventions and commands under `.claude/rules/` and `.claude/commands/` may be locally symlinked from `~/revfleet/revcon/profiles/revealui/claude/`, but neither directory is tracked in this repo.
 
 ### MCP servers
 


### PR DESCRIPTION
## What

Updates the stale Claude Code install guidance in `docs/AUTOMATION.md` to match Anthropic's current recommendations (as of 2026-06).

### Install section
- **Leads with the native installer** (Anthropic's primary recommended method), a self-updating native binary that needs no Node.js:
  - macOS / Linux / WSL: `curl -fsSL https://claude.ai/install.sh | bash`
  - Windows PowerShell: `irm https://claude.ai/install.ps1 | iex`
- Keeps `npm install -g @anthropic-ai/claude-code` as a clearly-labelled **secondary** option, noting it requires Node.js 18+ and that the package manager must allow optional dependencies (the npm package delivers the same native binary via per-platform optional deps).
- **Drops the `pnpm dlx` line.** With optional-dependency delivery, `pnpm dlx` is not documented to reliably resolve the platform-specific native binary; the official docs only document `npm install -g`.

### Stale doc links
Refreshes the two `docs.anthropic.com/claude/docs/claude-code...` links to the current canonical `code.claude.com` pages, both confirmed to resolve:
- intro link -> https://code.claude.com/docs/en/setup
- settings reference -> https://code.claude.com/docs/en/settings

## Source of truth
Commands and requirements verified against https://code.claude.com/docs/en/setup.

## Local verification
- `citation-check --coverage-strict`: pass (0 new uncited claims)
- `claim-drift`: pass (0 mismatches)

Docs-only change. Base branch: `test`.
