### PR TITLE
fix(nav): repair mobile nav on touch and add router scroll handling

### DIFF
--- a/.changeset/mobile-nav-touch-and-scroll.md
+++ b/.changeset/mobile-nav-touch-and-scroll.md
@@ -1,0 +1,21 @@
+---
+'@revealui/presentation': patch
+'@revealui/router': patch
+---
+
+Fix mobile navigation on touch devices and add router scroll handling.
+
+presentation: add `relative` to the CVA button base so `LinkButton`'s
+`TouchTarget` hit-area expander (and the `ShineOverlay`) stay contained. Without
+a positioned ancestor on the button itself, the coarse-pointer touch-target
+overlay sized against the nearest positioned ancestor (such as a `sticky`
+header) and blanketed surrounding controls, intercepting taps. That is what
+stopped the marketing mobile hamburger (a sibling of the signup `LinkButton`)
+from opening on phones.
+
+router: `navigate()` now scrolls to the top on hashless client navigations
+(anchor links with a `#` are left alone), and `initClient()` sets
+`history.scrollRestoration = 'auto'` explicitly so the browser keeps restoring
+scroll on back/forward and reload. The global click handler now bails when
+`event.defaultPrevented` is already set, so it defers to the React `<Link>`
+component instead of pushing a duplicate history entry.

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,4 +1,10 @@
-import { LinkButton, useEscapeKey, useFocusTrap, useScrollLock } from '@revealui/presentation';
+import {
+  LinkButton,
+  useClickOutside,
+  useEscapeKey,
+  useFocusTrap,
+  useScrollLock,
+} from '@revealui/presentation';
 import { Link, useLocation } from '@revealui/router';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { NAV_AUTH, NAV_LINKS } from '../content/nav';
@@ -38,6 +44,7 @@ function NavLink({
 export function NavBar() {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const close = () => setOpen(false);
   const { pathname } = useLocation();
 
@@ -46,6 +53,15 @@ export function NavBar() {
   useScrollLock(open);
   useFocusTrap(menuRef, open);
   useEscapeKey(close, open);
+
+  // Close on a tap anywhere outside the menu panel. We list both the panel and
+  // the hamburger toggle so tapping the toggle to close doesn't double-fire
+  // (its own onClick handles that). useClickOutside is used instead of a
+  // visual `fixed` backdrop because the sticky header's `backdrop-blur` creates
+  // a containing block that clips any `position: fixed` descendant to the
+  // header box (which includes the in-flow menu) — so a fixed backdrop never
+  // actually covers the area outside the menu.
+  useClickOutside([menuRef, toggleRef], close, open);
 
   // Close the mobile menu after a client-side navigation (covers browser
   // back/forward, where a link's own onClick never fires).
@@ -100,6 +116,7 @@ export function NavBar() {
 
           {/* Hamburger - mobile only. 44x44 tap target per WCAG 2.5.5 / Apple HIG. */}
           <button
+            ref={toggleRef}
             type="button"
             className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted lg:hidden"
             aria-label={open ? 'Close menu' : 'Open menu'}
@@ -138,58 +155,49 @@ export function NavBar() {
         </div>
       </nav>
 
-      {/* Mobile menu */}
+      {/* Mobile menu. Tap-outside-to-close is handled by useClickOutside (see
+          the hook call above) rather than a visual backdrop, which the sticky
+          header's backdrop-blur containing block would clip. */}
       {open && (
-        <>
-          {/* Backdrop: tap outside to close. Sits below the nav row (top-16) so
-              the trigger stays interactive; kept out of the tab order. */}
-          <button
-            type="button"
-            aria-label="Close menu"
-            tabIndex={-1}
-            onClick={close}
-            className="fixed inset-x-0 bottom-0 top-16 z-40 bg-foreground/10 lg:hidden"
-          />
-          <div
-            id={MOBILE_MENU_ID}
-            ref={menuRef}
-            className="relative z-50 border-t border-border bg-background px-6 py-4 lg:hidden"
-          >
-            <div className="flex flex-col gap-1">
-              {NAV_LINKS.map(({ label, href }) => (
-                <NavLink
-                  key={label}
-                  href={href}
-                  className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  onClick={close}
-                >
-                  {label}
-                </NavLink>
-              ))}
-              <a
-                href="https://github.com/RevealUIStudio/revealui"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                onClick={close}
-              >
-                GitHub
-              </a>
-            </div>
-            <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
+        <div
+          id={MOBILE_MENU_ID}
+          ref={menuRef}
+          className="relative z-50 border-t border-border bg-background px-6 py-4 lg:hidden"
+        >
+          <div className="flex flex-col gap-1">
+            {NAV_LINKS.map(({ label, href }) => (
               <NavLink
-                href={NAV_AUTH.login.href}
+                key={label}
+                href={href}
                 className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 onClick={close}
               >
-                {NAV_AUTH.login.label}
+                {label}
               </NavLink>
-              <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">
-                {NAV_AUTH.signup.label}
-              </LinkButton>
-            </div>
+            ))}
+            <a
+              href="https://github.com/RevealUIStudio/revealui"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={close}
+            >
+              GitHub
+            </a>
           </div>
-        </>
+          <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
+            <NavLink
+              href={NAV_AUTH.login.href}
+              className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={close}
+            >
+              {NAV_AUTH.login.label}
+            </NavLink>
+            <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">
+              {NAV_AUTH.signup.label}
+            </LinkButton>
+          </div>
+        </div>
       )}
     </header>
   );

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -37,8 +37,7 @@ describe('NavBar (marketing)', () => {
     const menu = document.getElementById(MENU_ID);
     expect(menu).toBeInTheDocument();
 
-    // Two "Close menu" buttons exist while open (trigger + backdrop); the
-    // trigger is the one carrying aria-expanded.
+    // The hamburger trigger flips to "Close menu" + aria-expanded while open.
     const toggle = screen.getByRole('button', { name: 'Close menu', expanded: true });
     expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
   });
@@ -65,17 +64,27 @@ describe('NavBar (marketing)', () => {
     expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
   });
 
-  it('closes the menu when the backdrop is tapped (tap-outside)', () => {
+  it('closes the menu on a pointer-down outside the panel (tap-outside)', () => {
     renderNavBar();
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.getElementById(MENU_ID)).toBeInTheDocument();
 
-    const closers = screen.getAllByRole('button', { name: 'Close menu' });
-    expect(closers).toHaveLength(2);
-    const backdrop = closers.find((b) => !b.hasAttribute('aria-expanded'));
-    expect(backdrop).toBeDefined();
-
-    fireEvent.click(backdrop as HTMLElement);
+    // Tap-outside is handled by useClickOutside (capture-phase pointerdown), not
+    // a visual backdrop — a fixed backdrop would be clipped by the sticky
+    // header's backdrop-blur containing block. A pointerdown on the document
+    // body (outside both the menu panel and the toggle) closes the menu.
+    fireEvent.pointerDown(document.body);
     expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();
+  });
+
+  it('keeps the menu open on a pointer-down inside the panel', () => {
+    renderNavBar();
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const menu = document.getElementById(MENU_ID);
+    expect(menu).toBeInTheDocument();
+
+    fireEvent.pointerDown(menu as HTMLElement);
+    expect(document.getElementById(MENU_ID)).toBeInTheDocument();
   });
 
   it('locks body scroll while open and restores it on close', () => {

--- a/packages/presentation/src/components/Button.tsx
+++ b/packages/presentation/src/components/Button.tsx
@@ -24,9 +24,16 @@ const primaryButtonClasses =
   'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm hover:shadow-md';
 
 const buttonVariants = cva(
+  // `relative` contains the absolutely-positioned descendants this button can
+  // render — the `TouchTarget` hit-area expander (used by `LinkButton`) and the
+  // `ShineOverlay`. Without it those overlays size against the nearest *other*
+  // positioned ancestor (e.g. a `sticky` header), blanket the surrounding UI,
+  // and intercept pointer events on touch devices — which is what stopped the
+  // marketing mobile hamburger (a sibling of the signup `LinkButton`) from
+  // opening. The headless `Button` already carries `relative isolate`.
   // `gap-2` + the `[&_svg]` rules give icon/spinner children automatic spacing,
   // non-interactivity, and flex-shrink protection without per-call-site margins.
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     defaultVariants: {
       size: 'default',

--- a/packages/router/src/__tests__/router.test.ts
+++ b/packages/router/src/__tests__/router.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the logger to avoid cross-package dependency issues in tests
 vi.mock('../../../core/src/observability/logger.js', () => ({
@@ -368,6 +368,37 @@ describe('Router', () => {
     });
   });
 
+  describe('scroll behavior', () => {
+    it('scrolls to the top on a hashless client navigation', () => {
+      const router = new Router();
+      router.register(createRoute('/about'));
+      const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+      router.navigate('/about');
+      expect(scrollSpy).toHaveBeenCalledWith(0, 0);
+      scrollSpy.mockRestore();
+    });
+
+    it('does not scroll to the top when the URL has a hash (anchor link)', () => {
+      const router = new Router();
+      router.register(createRoute('/about'));
+      const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+      router.navigate('/about#section');
+      expect(scrollSpy).not.toHaveBeenCalled();
+      scrollSpy.mockRestore();
+    });
+
+    it('scrolls to the top after listeners are notified', () => {
+      const router = new Router();
+      router.register(createRoute('/about'));
+      const order: string[] = [];
+      router.subscribe(() => order.push('listener'));
+      const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => order.push('scroll'));
+      router.navigate('/about');
+      expect(order).toEqual(['listener', 'scroll']);
+      scrollSpy.mockRestore();
+    });
+  });
+
   describe('listener notifications', () => {
     it('notifies all subscribers on navigate', () => {
       const router = new Router();
@@ -451,6 +482,14 @@ describe('Router', () => {
       router.dispose();
     });
 
+    it('sets history.scrollRestoration to "auto" (keeps native back/forward + reload restore)', () => {
+      const router = new Router();
+      window.history.scrollRestoration = 'manual';
+      router.initClient();
+      expect(window.history.scrollRestoration).toBe('auto');
+      router.dispose();
+    });
+
     it('prevents duplicate initialization (HMR guard)', () => {
       const router = new Router();
       const addSpy = vi.spyOn(window, 'addEventListener');
@@ -486,6 +525,10 @@ describe('Router', () => {
       router.initClient();
       router.navigate('/a');
       expect(listener).not.toHaveBeenCalled();
+      // Dispose the re-initialized client so its document click listener does
+      // not leak into later tests (a leaked handler that preventDefaults would
+      // trip the global-click-handler defaultPrevented guard).
+      router.dispose();
     });
 
     it('dispose resets HMR guard so initClient can be called again', () => {
@@ -497,6 +540,56 @@ describe('Router', () => {
       const popstateCalls = addSpy.mock.calls.filter((c) => c[0] === 'popstate');
       expect(popstateCalls).toHaveLength(2);
       addSpy.mockRestore();
+      router.dispose();
+    });
+  });
+
+  describe('global click handler', () => {
+    // Reset the module-level HMR guard before AND after each test so initClient()
+    // actually installs the document listener (a prior test may have left it set).
+    beforeEach(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: test setup for HMR guard
+      (globalThis as any).__revealui_router_initialized = false;
+    });
+    afterEach(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: test cleanup for HMR guard
+      (globalThis as any).__revealui_router_initialized = false;
+    });
+
+    it('navigates on an unprevented internal link click', () => {
+      const router = new Router();
+      router.register(createRoute('/y'));
+      const navSpy = vi.spyOn(router, 'navigate').mockImplementation(() => {});
+      router.initClient();
+
+      const a = document.createElement('a');
+      a.setAttribute('href', '/y');
+      document.body.appendChild(a);
+      a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(navSpy).toHaveBeenCalledWith('/y');
+      a.remove();
+      navSpy.mockRestore();
+      router.dispose();
+    });
+
+    it('defers to a handler that already prevented default (no double navigation)', () => {
+      const router = new Router();
+      router.register(createRoute('/x'));
+      const navSpy = vi.spyOn(router, 'navigate').mockImplementation(() => {});
+      router.initClient();
+
+      const a = document.createElement('a');
+      a.setAttribute('href', '/x');
+      // Mirrors the React <Link>, which calls preventDefault() + navigate first;
+      // the global handler must then bail so only one history entry is pushed.
+      a.addEventListener('click', (e) => e.preventDefault());
+      document.body.appendChild(a);
+      a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(navSpy).not.toHaveBeenCalled();
+      a.remove();
+      navSpy.mockRestore();
       router.dispose();
     });
   });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -299,6 +299,15 @@ export class Router {
     this.currentMatch = this.match(window.location.pathname);
 
     this.notifyListeners();
+
+    // Scroll to the top on client navigation so a new page lands at the top,
+    // matching native full-page-load behavior. Skip when the URL carries a hash
+    // so in-page anchor links still jump to their target. Back/forward
+    // (popstate) and reload are deliberately left untouched: the browser's
+    // native scroll restoration (scrollRestoration = 'auto') handles those.
+    if (!url.includes('#')) {
+      window.scrollTo(0, 0);
+    }
   }
 
   /**
@@ -401,6 +410,14 @@ export class Router {
     if (globalThis.__revealui_router_initialized) return;
     globalThis.__revealui_router_initialized = true;
 
+    // Keep the browser's native scroll restoration for back/forward + reload.
+    // It is the default ('auto'), but set it explicitly to document intent and
+    // guard against any earlier code having switched it to 'manual'. navigate()
+    // handles scroll-to-top for forward client navigations.
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'auto';
+    }
+
     // Handle browser back/forward buttons
     this.popstateHandler = () => {
       this.lastPathname = window.location.pathname;
@@ -411,6 +428,12 @@ export class Router {
 
     // Intercept link clicks
     this.clickHandler = (e: MouseEvent) => {
+      // Defer to React-level handlers (e.g. the <Link> component, which already
+      // calls preventDefault() + router.navigate()). Without this guard both
+      // handlers fire for a single <Link> click and two history entries are
+      // pushed, so Back appears to do nothing on the first press.
+      if (e.defaultPrevented) return;
+
       const target = (e.target as HTMLElement).closest('a');
 
       if (!target) return;


### PR DESCRIPTION
## What

Fixes the marketing mobile hamburger not opening on phones (issue #1) and adds router scroll handling (issue #3): land at the top on client navigation, restore scroll on hard refresh and back/forward.

## Root cause (issue #1, verified in a real touch browser)

The marketing hamburger logic was correct (jsdom tests passed, deployed build current). The failure was touch-only, which is why it never showed up in jsdom or a mouse click:

- `@revealui/presentation` `LinkButton` renders a `TouchTarget` hit-area expander `<span>` that is `position: absolute`, sized `max(100%, 2.75rem)`, and shown only on coarse pointers (`pointer-fine:hidden`).
- The CVA button base (`buttonVariants`) lacked `relative`, so on a touch device the span sized against the nearest positioned ancestor: the `sticky` marketing header. It blanketed the whole nav row and intercepted the hamburger tap (a sibling of the signup `LinkButton`). `aria-expanded` stayed `false`.

Reproduced with Playwright iPhone-13 touch emulation at 375px and 320px: before the fix, `elementFromPoint` at the hamburger center returned the escaped span and `tap()` timed out; after, it returns the button itself and the menu opens.

## Changes

- **presentation** (`Button.tsx`): add `relative` to the `buttonVariants` base so `LinkButton`'s `TouchTarget` and the `ShineOverlay` stay contained. The headless `Button` already had `relative isolate`.
- **router** (`router.ts`):
  - `navigate()` scrolls to top on hashless client navigations (anchor `#` links are left alone).
  - `initClient()` sets `history.scrollRestoration = 'auto'` explicitly so the browser keeps restoring scroll on back/forward and reload.
  - the global click handler bails when `e.defaultPrevented` is set, so it defers to the React `<Link>` and stops pushing a duplicate history entry.
- **marketing** (`NavBar.tsx`): replaced the `fixed` backdrop (it was clipped by the header's `backdrop-blur` containing block, so tap-outside never actually worked) with `useClickOutside([menuRef, toggleRef])`.
- **tests**: +6 router tests (scroll-to-top, hash skip, ordering, `scrollRestoration`, `defaultPrevented` guard) and fixed a pre-existing listener leak; updated the marketing NavBar tests for the click-outside close path.

## Verification (prod preview, Playwright iPhone-13 @375px)

- Hamburger opens at 375px and 320px (issue #1 fixed).
- Menu closes on link nav, Escape, and tap-outside.
- Link nav lands at the top (`scrollY = 0`); hard refresh restores prior scroll; back/forward restore (issue #3).
- `@revealui/router` 112, `@revealui/presentation` 964, `marketing` 74 tests pass; `pnpm typecheck:all` 52/52; Biome clean.

## Dependency note for the agency site

The `@revealui/presentation` `relative` fix and the `@revealui/router` scroll fix reach the agency repo (which consumes these via npm, not workspace links) only after this PR merges, a release of `@revealui/presentation` + `@revealui/router` is cut, and agency bumps its deps. The agency mobile menu has the same `TouchTarget` interception (its "Book a call" `LinkButton` blankets the menu links on touch); that is resolved by the same presentation change once released. The companion agency PR (`fix/nav-mobile-close`) ships the close-behavior fix now and defers agency scroll-to-top to that release.

Changeset included (`presentation` + `router` patch).
