### PR TITLE
feat(billing): catalog-completeness gate on checkout (A2)

### DIFF
--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -34,7 +34,7 @@ export interface BillingCatalogRow {
  * two lists are intentionally separate. A test in
  * `__tests__/validate-startup.test.ts` asserts they stay in sync.
  */
-const EXPECTED_LIVE_PLAN_IDS = [
+export const EXPECTED_LIVE_PLAN_IDS = [
   'subscription:pro',
   'subscription:max',
   'subscription:enterprise',
@@ -45,6 +45,31 @@ const EXPECTED_LIVE_PLAN_IDS = [
   'credits:standard',
   'credits:scale',
 ] as const;
+
+/**
+ * Compute which expected live-mode billing-catalog plans are absent (no row at
+ * all) or incomplete (row present but `stripe_price_id` is null). Shared by the
+ * boot-time validator (`validateBillingCatalogAtStartup`, run only by the Fly
+ * worker) AND the per-cold-instance checkout gate in `routes/billing.ts`, so the
+ * two enforcement points cannot drift — both derive the expected set from
+ * `EXPECTED_LIVE_PLAN_IDS` and apply the identical missing/incomplete predicate.
+ */
+export function findBillingCatalogGaps(rows: BillingCatalogRow[]): {
+  missing: string[];
+  incomplete: string[];
+} {
+  const byPlanId = new Map<string, string | null>(rows.map((r) => [r.planId, r.stripePriceId]));
+  const missing: string[] = [];
+  const incomplete: string[] = [];
+  for (const planId of EXPECTED_LIVE_PLAN_IDS) {
+    if (!byPlanId.has(planId)) {
+      missing.push(planId);
+    } else if (!byPlanId.get(planId)) {
+      incomplete.push(planId);
+    }
+  }
+  return { missing, incomplete };
+}
 
 /**
  * Where this RevealUI deployment runs.
@@ -600,11 +625,12 @@ export async function validateLicenseAtStartup(env: EnvMap = process.env as EnvM
 }
 
 /**
- * Default fetcher: queries `billing_catalog` via the shared Drizzle client.
- * Extracted so `validateBillingCatalogAtStartup` can take an injectable
- * fetcher in tests (avoids mocking the DB module).
+ * Fetch the live-mode `billing_catalog` rows via the shared Drizzle client.
+ * Exported so BOTH the boot-time validator (injectable for tests) AND the
+ * checkout gate in `routes/billing.ts` issue the identical query — checking the
+ * live-mode rows specifically (test rows may be partially seeded before cutover).
  */
-async function defaultFetchBillingCatalogRows(): Promise<BillingCatalogRow[]> {
+export async function fetchLiveBillingCatalogRows(): Promise<BillingCatalogRow[]> {
   const db = getClient();
   return (
     db
@@ -645,7 +671,7 @@ async function defaultFetchBillingCatalogRows(): Promise<BillingCatalogRow[]> {
  */
 export async function validateBillingCatalogAtStartup(
   env: EnvMap = process.env as EnvMap,
-  fetchRows: () => Promise<BillingCatalogRow[]> = defaultFetchBillingCatalogRows,
+  fetchRows: () => Promise<BillingCatalogRow[]> = fetchLiveBillingCatalogRows,
 ): Promise<void> {
   if (env.SKIP_ENV_VALIDATION === 'true') return;
   if (env.NODE_ENV !== 'production') return;
@@ -653,17 +679,7 @@ export async function validateBillingCatalogAtStartup(
   if (env.STRIPE_LIVE_MODE !== 'true') return;
 
   const rows = await fetchRows();
-  const byPlanId = new Map<string, string | null>(rows.map((r) => [r.planId, r.stripePriceId]));
-
-  const missing: string[] = [];
-  const incomplete: string[] = [];
-  for (const planId of EXPECTED_LIVE_PLAN_IDS) {
-    if (!byPlanId.has(planId)) {
-      missing.push(planId);
-    } else if (!byPlanId.get(planId)) {
-      incomplete.push(planId);
-    }
-  }
+  const { missing, incomplete } = findBillingCatalogGaps(rows);
 
   if (missing.length === 0 && incomplete.length === 0) return;
 

--- a/apps/server/src/routes/__tests__/billing-catalog-gate.test.ts
+++ b/apps/server/src/routes/__tests__/billing-catalog-gate.test.ts
@@ -1,0 +1,97 @@
+/**
+ * A2: per-cold-instance live-catalog completeness gate on POST /api/billing/checkout.
+ *
+ * Asserts the checkout gate fails fast with a precise NAMED error when an
+ * expected live price row is missing or null — the failure mode that, post-flip,
+ * boots a Vercel cold instance clean and then 500s the first real checkout (the
+ * boot-time validator only runs on the Fly worker). The gate and the Fly
+ * validator share findBillingCatalogGaps + EXPECTED_LIVE_PLAN_IDS, so a single
+ * predicate is exercised here and at startup.
+ */
+
+import { HTTPException } from 'hono/http-exception';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { assertLiveCatalogComplete, resetLiveCatalogGateForTests } from '../billing.js';
+
+interface Row {
+  planId: string;
+  stripePriceId: string | null;
+}
+
+const EXPECTED = [
+  'subscription:pro',
+  'subscription:max',
+  'subscription:enterprise',
+  'perpetual:pro',
+  'perpetual:max',
+  'perpetual:enterprise',
+  'credits:starter',
+  'credits:standard',
+  'credits:scale',
+];
+
+function completeRows(): Row[] {
+  return EXPECTED.map((planId) => ({ planId, stripePriceId: `price_live_${planId}` }));
+}
+
+/** Run the gate and return the thrown HTTPException, or fail if it did not throw. */
+async function catchGate(promise: Promise<void>): Promise<HTTPException> {
+  try {
+    await promise;
+  } catch (e) {
+    return e as HTTPException;
+  }
+  throw new Error('expected assertLiveCatalogComplete to throw, but it resolved');
+}
+
+describe('assertLiveCatalogComplete (A2 checkout gate)', () => {
+  beforeEach(() => resetLiveCatalogGateForTests());
+
+  it('throws a named 503 naming a null live price row', async () => {
+    const rows = completeRows().map((r) =>
+      r.planId === 'subscription:max' ? { ...r, stripePriceId: null } : r,
+    );
+    const err = await catchGate(assertLiveCatalogComplete('live', async () => rows));
+    expect(err).toBeInstanceOf(HTTPException);
+    expect(err.status).toBe(503);
+    expect(err.message).toContain('Billing catalog incomplete');
+    expect(err.message).toContain('null stripe_price_id');
+    expect(err.message).toContain('subscription:max');
+  });
+
+  it('throws naming a missing plan row', async () => {
+    const rows = completeRows().filter((r) => r.planId !== 'credits:scale');
+    const err = await catchGate(assertLiveCatalogComplete('live', async () => rows));
+    expect(err.status).toBe(503);
+    expect(err.message).toContain('missing rows');
+    expect(err.message).toContain('credits:scale');
+  });
+
+  it('resolves when every expected live plan has a non-null price', async () => {
+    await expect(
+      assertLiveCatalogComplete('live', async () => completeRows()),
+    ).resolves.toBeUndefined();
+  });
+
+  it('caches success: a later incomplete catalog is not re-fetched once verified', async () => {
+    await assertLiveCatalogComplete('live', async () => completeRows());
+    // Even a now-broken catalog + a fetcher that would throw is short-circuited.
+    const throwingFetch = vi.fn(async (): Promise<Row[]> => {
+      throw new Error('fetcher must not be called after success is cached');
+    });
+    await expect(assertLiveCatalogComplete('live', throwingFetch)).resolves.toBeUndefined();
+    expect(throwingFetch).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op in test mode even when the catalog is incomplete', async () => {
+    const incomplete = async (): Promise<Row[]> => [
+      { planId: 'subscription:pro', stripePriceId: null },
+    ];
+    await expect(assertLiveCatalogComplete('test', incomplete)).resolves.toBeUndefined();
+  });
+});

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -29,16 +29,16 @@ import { getServices, type ProtectedStripe } from '../lib/services-loader.js';
 import { getHostedLimitsForTier } from '../lib/tier-limits.js';
 import { MRR_TIER_PRICE_FALLBACK_CENTS } from '../lib/tier-pricing.js';
 import {
+  type BillingCatalogRow,
+  fetchLiveBillingCatalogRows,
+  findBillingCatalogGaps,
+} from '../lib/validate-startup.js';
+import {
   sendDowngradeConfirmationEmail,
   sendUpgradeConfirmationEmail,
 } from '../lib/webhook-emails.js';
 import { assertAccountOwner } from '../middleware/account-owner.js';
 import { resetDbStatusCache, resetSupportExpiryCache } from '../middleware/license.js';
-import {
-  type BillingCatalogRow,
-  fetchLiveBillingCatalogRows,
-  findBillingCatalogGaps,
-} from '../lib/validate-startup.js';
 
 /** Default trial period for new subscriptions (overridable via env) */
 const TRIAL_PERIOD_DAYS = Number.parseInt(process.env.REVEALUI_TRIAL_DAYS ?? '7', 10);

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -34,9 +34,69 @@ import {
 } from '../lib/webhook-emails.js';
 import { assertAccountOwner } from '../middleware/account-owner.js';
 import { resetDbStatusCache, resetSupportExpiryCache } from '../middleware/license.js';
+import {
+  type BillingCatalogRow,
+  fetchLiveBillingCatalogRows,
+  findBillingCatalogGaps,
+} from '../lib/validate-startup.js';
 
 /** Default trial period for new subscriptions (overridable via env) */
 const TRIAL_PERIOD_DAYS = Number.parseInt(process.env.REVEALUI_TRIAL_DAYS ?? '7', 10);
+
+/**
+ * Per-cold-instance live-catalog completeness gate (A2).
+ *
+ * Vercel cold starts deliberately skip `validateBillingCatalogAtStartup`
+ * (apps/server/src/index.ts) to avoid a DB round-trip on the request path, so
+ * only the Fly worker validates the catalog at boot. The hole: a live deploy
+ * with a missing/null `stripe_price_id` row boots clean on Vercel, then 500s the
+ * FIRST real checkout deep inside the Stripe price lookup with an opaque
+ * "catalog is not configured" error mid-customer-transaction.
+ *
+ * This gate runs the SAME completeness check the Fly validator runs at boot —
+ * derived from the SAME `EXPECTED_LIVE_PLAN_IDS` + `findBillingCatalogGaps` +
+ * `fetchLiveBillingCatalogRows`, so the two enforcement points cannot drift —
+ * once per cold instance, and fails the checkout up front with a precise named
+ * error listing the offending plan ids. Only enforced in live mode (the
+ * post-flip risk); test-mode catalogs may be partially seeded and resolve
+ * lazily per request as before.
+ *
+ * Caches SUCCESS only: re-seeding the live catalog recovers without a redeploy
+ * (a still-incomplete catalog re-checks on the next request until it passes).
+ */
+let liveCatalogVerified = false;
+
+/** Test-only: clear the per-instance success cache between cases. */
+export function resetLiveCatalogGateForTests(): void {
+  liveCatalogVerified = false;
+}
+
+export async function assertLiveCatalogComplete(
+  mode: 'live' | 'test' = getConfiguredStripeMode(),
+  fetchRows: () => Promise<BillingCatalogRow[]> = fetchLiveBillingCatalogRows,
+): Promise<void> {
+  if (liveCatalogVerified) return;
+  if (mode !== 'live') return;
+
+  const { missing, incomplete } = findBillingCatalogGaps(await fetchRows());
+  if (missing.length === 0 && incomplete.length === 0) {
+    liveCatalogVerified = true;
+    return;
+  }
+
+  const details: string[] = [];
+  if (missing.length > 0) details.push(`missing rows: ${missing.join(', ')}`);
+  if (incomplete.length > 0) details.push(`null stripe_price_id: ${incomplete.join(', ')}`);
+  logger.error('Checkout blocked: live billing catalog incomplete', undefined, {
+    missing,
+    incomplete,
+  });
+  throw new HTTPException(503, {
+    message:
+      `Billing catalog incomplete (live mode): ${details.join('; ')}. ` +
+      'Checkout is temporarily disabled until the live Stripe catalog is re-seeded.',
+  });
+}
 
 /** Gate automatic_tax on Stripe Tax being active in this account (#828) */
 const isStripeTaxEnabled = process.env.STRIPE_TAX_ENABLED === 'true';
@@ -750,6 +810,12 @@ app.openapi(checkoutRoute, async (c) => {
     throw new HTTPException(401, { message: 'Authentication required' });
   }
   assertAccountOwner(c);
+
+  // A2: fail fast with a precise, named error if the LIVE catalog is incomplete,
+  // rather than 500ing deep inside the Stripe price lookup on the first real
+  // checkout (Vercel cold starts skip the boot-time validator). Cached per cold
+  // instance; no-op in test mode.
+  await assertLiveCatalogComplete();
 
   const { priceId, tier } = c.req.valid('json');
   const resolvedTier = tier ?? 'pro';


### PR DESCRIPTION
## Catalog-completeness gate on `POST /api/billing/checkout`

Closes a cold-start gap in billing-catalog validation.

### Problem
`validateBillingCatalogAtStartup` runs only on the Fly worker; the Vercel
serverless entrypoint deliberately skips it (it's a per-cold-start DB round-trip
we don't want on the request path). So a deploy whose `billing_catalog` is
missing a row or has a null `stripe_price_id` for an expected plan boots clean
on Vercel and then **500s the first real checkout** deep inside the Stripe price
lookup with an opaque "catalog is not configured" error — mid customer
transaction.

### Fix
Add `assertLiveCatalogComplete`, a per-cold-instance gate at the top of the
checkout handler. It runs the **same** completeness check the startup validator
runs, derived from the **same** `EXPECTED_LIVE_PLAN_IDS` + `findBillingCatalogGaps`
+ live-rows query — so the two enforcement points cannot drift — and fails
checkout up front with a precise named error listing the offending plan ids.

- Enforced in live mode only; test-mode catalogs (which may be partially seeded)
  resolve lazily per request as before.
- Caches success only, so re-seeding the catalog recovers without a redeploy.

To make this drift-proof, the missing/incomplete predicate and the live-rows
fetcher were extracted from `validate-startup.ts` and shared (no behavior change
to the startup validator — covered by its existing tests, still green).

### Tests
- New `billing-catalog-gate.test.ts` (5): null price row → named 503; missing
  row → named 503; complete catalog → resolves; success cached (no re-fetch);
  no-op in test mode.
- Existing `validate-startup` + `billing` suites: 153 green (no regression).
- Server typecheck clean.

Branch-per-change; targets `test`.
