### PR TITLE
fix(billing): unified license — surface JWT for framework + daemon (A9)

### DIFF
--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -284,6 +284,17 @@ export default function LicensePage() {
                   </code>{' '}
                   at startup.
                 </p>
+                <p className="mt-3">
+                  The same key activates the RevDev daemon — one purchase, one license, both
+                  products. Set it as{' '}
+                  <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
+                    REVDEV_LICENSE_KEY
+                  </code>
+                  :
+                </p>
+                <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-2 text-xs font-mono dark:bg-zinc-900">
+                  REVDEV_LICENSE_KEY=your-key-here
+                </pre>
               </div>
             </div>
           </CardContent>

--- a/apps/server/src/routes/__tests__/billing.test.ts
+++ b/apps/server/src/routes/__tests__/billing.test.ts
@@ -624,7 +624,14 @@ describe('GET /subscription', () => {
     expect(body.expiresAt).toBeNull();
   });
 
-  it('prefers request-scoped account entitlements over legacy license lookup', async () => {
+  it('takes tier/status from request-scoped entitlements but still surfaces the license key (A9)', async () => {
+    // The entitlement path short-circuits tier/status resolution, but the license
+    // JWT must still be surfaced — a paying hosted customer needs the key to
+    // activate a self-hosted framework deploy AND the RevDev daemon (one license,
+    // both products). Previously this path returned licenseKey:null.
+    _selectResult = [
+      { tier: 'pro', status: 'active', expiresAt: null, licenseKey: 'rv-entitlement-key' },
+    ];
     const app = createApp(MOCK_USER, {
       accountId: 'acct_123',
       tier: 'max',
@@ -634,11 +641,10 @@ describe('GET /subscription', () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
-    expect(body.tier).toBe('max');
+    expect(body.tier).toBe('max'); // tier/status still from entitlements
     expect(body.status).toBe('past_due');
     expect(body.expiresAt).toBeNull();
-    expect(body.licenseKey).toBeNull();
-    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(body.licenseKey).toBe('rv-entitlement-key'); // license key now surfaced
   });
 
   it('returns revoked license status', async () => {

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -922,6 +922,27 @@ const subscriptionRoute = createRoute({
   },
 });
 
+/**
+ * The user's most-recent active (non-deleted) license JWT, or null (A9).
+ *
+ * Surfaced on the hosted entitlement + snapshot short-circuit paths below so a
+ * paying customer can always retrieve the key they need to activate a
+ * self-hosted framework deploy AND the RevDev daemon — one Ed25519-signed JWT
+ * that both accept. Previously those paths returned licenseKey:null even after
+ * the checkout webhook had issued and stored a license (the webhook's
+ * syncHostedSubscriptionState creates the hosted rows that trigger the
+ * short-circuit), so a hosted subscriber could never see their key.
+ */
+async function getUserLicenseKey(userId: string): Promise<string | null> {
+  const [row] = await getClient()
+    .select({ licenseKey: licenses.licenseKey })
+    .from(licenses)
+    .where(and(eq(licenses.userId, userId), isNull(licenses.deletedAt)))
+    .orderBy(desc(licenses.createdAt))
+    .limit(1);
+  return row?.licenseKey ?? null;
+}
+
 app.openapi(subscriptionRoute, async (c) => {
   const user = c.get('user');
   if (!user) {
@@ -935,7 +956,7 @@ app.openapi(subscriptionRoute, async (c) => {
         tier: requestEntitlements.tier,
         status: requestEntitlements.subscriptionStatus ?? 'active',
         expiresAt: null,
-        licenseKey: null,
+        licenseKey: await getUserLicenseKey(user.id),
       },
       200,
     );
@@ -948,7 +969,7 @@ app.openapi(subscriptionRoute, async (c) => {
         tier: hostedSubscription.tier,
         status: hostedSubscription.status,
         expiresAt: null,
-        licenseKey: null,
+        licenseKey: await getUserLicenseKey(user.id),
         graceUntil: hostedSubscription.graceUntil,
       },
       200,


### PR DESCRIPTION
## Unified license: surface the JWT so a hosted customer can activate both products

One purchase issues one Ed25519-signed license JWT that **both** the self-hosted
framework and the RevDev daemon accept (they already share the signing key, so
the framework-issued token verifies against the daemon's public key — verified by
the round-trip test in #1613 and a daemon-side cross-issuer test in revdev).

### The gap (surfaced by the paid-path e2e in #1613)
`GET /api/billing/subscription` returned `licenseKey: null` on the hosted
entitlement + snapshot short-circuit paths. The checkout webhook's
`syncHostedSubscriptionState` always creates the hosted rows that trigger those
short-circuits, so a paying hosted customer could **never** retrieve the key
shown on `/account/license` — breaking self-hosted + daemon activation.

### Fix
- `billing.ts`: add `getUserLicenseKey` and surface the most-recent active
  license on both hosted paths (null only when there genuinely is no license).
- `/account/license`: label the key for the daemon too — set it as
  `REVDEV_LICENSE_KEY`; "one purchase, one license, both products".
- `billing.test.ts`: the entitlements path now takes tier/status from
  entitlements **and** surfaces the license key (was: asserted null + no DB
  lookup). 47/47 green; server typecheck clean.

Pairs with #1613 (paid-path proof). Branch-per-change; targets `test`.
