### PR TITLE
fix(billing): never mass-revoke perpetual licenses on refund (A5)

### DIFF
--- a/apps/server/src/routes/__tests__/perpetual-refund-scope.test.ts
+++ b/apps/server/src/routes/__tests__/perpetual-refund-scope.test.ts
@@ -1,0 +1,222 @@
+/**
+ * A5: perpetual-refund revocation must never mass-revoke.
+ *
+ * charge.refunded previously fell back to revoking ALL of a customer's perpetual
+ * licenses when the PaymentIntent metadata had no license_id — collateral
+ * damage across concurrent perpetual purchases. These tests prove the fix:
+ *   - refund WITH license_id  -> revokes exactly that one license
+ *   - refund WITHOUT license_id -> revokes NOTHING (logged for manual review)
+ *
+ * Mirrors the webhook-handler.test.ts harness, adding paymentIntents + invoices
+ * mocks. The charge carries no invoice, so resolveSubscriptionIdFromCharge
+ * returns null and the subscription-revoke path is skipped — isolating the
+ * perpetual branch as the only possible source of a status:'revoked' update.
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockConstructEvent,
+  mockChargesRetrieve,
+  mockPaymentIntentsRetrieve,
+  mockPaymentIntentsUpdate,
+  mockInvoicesRetrieve,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockSubscriptionsUpdate,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+  mockPaymentIntentsRetrieve: vi.fn(),
+  mockPaymentIntentsUpdate: vi.fn(),
+  mockInvoicesRetrieve: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const stripeShape = {
+  webhooks: { constructEventAsync: mockConstructEvent },
+  charges: { retrieve: mockChargesRetrieve },
+  paymentIntents: { retrieve: mockPaymentIntentsRetrieve, update: mockPaymentIntentsUpdate },
+  invoices: { retrieve: mockInvoicesRetrieve },
+  subscriptions: {
+    retrieve: mockSubscriptionsRetrieve,
+    list: mockSubscriptionsList,
+    update: mockSubscriptionsUpdate,
+  },
+  customers: { update: vi.fn() },
+};
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(class {} as unknown as (...args: unknown[]) => unknown),
+}));
+
+vi.mock('@revealui/services', () => ({ protectedStripe: stripeShape }));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn(),
+  getFeaturesForTier: vi.fn(() => ({})),
+}));
+
+vi.mock('@revealui/core/license', () => ({
+  generateLicenseKey: vi.fn().mockResolvedValue('rv-key'),
+  resetLicenseState: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({ logger: mockLogger }));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  sendLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentRecoveredEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentReceiptEmail: vi.fn().mockResolvedValue(undefined),
+  sendPerpetualLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPerpetualLicenseRevokedEmail: vi.fn().mockResolvedValue(undefined),
+  sendTierFallbackAlert: vi.fn().mockResolvedValue(undefined),
+  sendTrialEndingEmail: vi.fn().mockResolvedValue(undefined),
+  sendWebhookFailureAlert: vi.fn().mockResolvedValue(undefined),
+  sendDisputeLostEmail: vi.fn().mockResolvedValue(undefined),
+  sendDisputeReceivedEmail: vi.fn().mockResolvedValue(undefined),
+  sendLivemodeMismatchAlert: vi.fn().mockResolvedValue(undefined),
+  provisionGitHubAccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockAuditAppend = vi.fn();
+const mockDbSelectChain = {
+  from: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  limit: vi.fn(),
+};
+const mockDbInsertChain = { values: vi.fn() };
+const mockDbUpdateChain = { set: vi.fn(), where: vi.fn() };
+const mockDbDeleteChain = { where: vi.fn().mockResolvedValue(undefined) };
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn().mockReturnValue(mockDbDeleteChain),
+  transaction: vi.fn(),
+};
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => mockDb),
+  DrizzleAuditStore: vi.fn().mockImplementation(
+    class {
+      append = mockAuditAppend;
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+  executeSaga: vi.fn(async () => ({ sagaId: 's', status: 'completed', result: {} })),
+}));
+
+import webhooksApp from '../webhooks.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/', webhooksApp);
+  return app;
+}
+
+function postStripe(eventJson: unknown) {
+  return new Request('http://localhost/stripe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Stripe-Signature': 'sig' },
+    body: JSON.stringify(eventJson),
+  });
+}
+
+function resetDbChains() {
+  mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.where.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.orderBy.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.limit.mockResolvedValue([]);
+  mockDbInsertChain.values.mockResolvedValue(undefined);
+  mockDbUpdateChain.set.mockReturnValue(mockDbUpdateChain);
+  mockDbUpdateChain.where.mockResolvedValue({ rowCount: 1 });
+  mockDb.select.mockReturnValue(mockDbSelectChain);
+  mockDb.insert.mockReturnValue(mockDbInsertChain);
+  mockDb.update.mockReturnValue(mockDbUpdateChain);
+}
+
+function refundEvent(id: string) {
+  return {
+    id,
+    type: 'charge.refunded',
+    created: 1700000000,
+    livemode: false,
+    data: {
+      object: {
+        id: 'ch_perp',
+        customer: 'cus_perp',
+        amount: 14900,
+        amount_refunded: 14900, // full refund
+        currency: 'usd',
+        payment_intent: 'pi_perp',
+        invoice: null, // no subscription linkage
+        billing_details: { email: null },
+        receipt_email: null,
+      },
+    },
+  };
+}
+
+const REVOKED_LOG = 'Perpetual license revoked: full refund issued';
+const UNRESOLVED_LOG =
+  'Perpetual refund missing license_id in PaymentIntent metadata  -  NOT revoking (manual review required)';
+
+describe('charge.refunded  -  perpetual revocation scope (A5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbChains();
+    mockAuditAppend.mockResolvedValue(undefined);
+    mockSubscriptionsList.mockResolvedValue({ data: [] });
+    process.env.STRIPE_SECRET_KEY = 'sk_test_placeholder';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_placeholder';
+  });
+
+  it('revokes EXACTLY the identified license when the PaymentIntent carries license_id', async () => {
+    const event = refundEvent('evt_perp_refund_scoped');
+    mockConstructEvent.mockReturnValueOnce(event);
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_perp',
+      metadata: { perpetual: 'true', license_id: 'lic_1', tier: 'pro' },
+    });
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
+    // The perpetual-revoke path ran and named the SPECIFIC license id. (The
+    // generic non-perpetual S2 revoke also fires on any full refund, so the
+    // discriminator for the perpetual branch is this id-bearing log line.)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      REVOKED_LOG,
+      expect.objectContaining({ perpetualLicenseId: 'lic_1' }),
+    );
+  });
+
+  it('revokes NOTHING (no mass-revoke) when the PaymentIntent has no license_id', async () => {
+    const event = refundEvent('evt_perp_refund_unscoped');
+    mockConstructEvent.mockReturnValueOnce(event);
+    mockPaymentIntentsRetrieve.mockResolvedValueOnce({
+      id: 'pi_perp',
+      metadata: { perpetual: 'true', tier: 'pro' }, // NO license_id
+    });
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
+    // The perpetual-revoke path must NOT fire — no mass-revoke of the customer's
+    // perpetual licenses when the PaymentIntent lacks a license_id ...
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(REVOKED_LOG, expect.anything());
+    // ... the unresolved case is logged for manual review instead.
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      UNRESOLVED_LOG,
+      undefined,
+      expect.objectContaining({ customerId: 'cus_perp' }),
+    );
+  });
+});

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -338,7 +338,7 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     mockConstructEvent.mockReturnValueOnce(event);
     mockPaymentIntentsRetrieve.mockResolvedValueOnce({
       id: 'pi_perpetual_email',
-      metadata: { perpetual: 'true', tier: 'enterprise', revealui_user_id: 'user-456' },
+      metadata: { perpetual: 'true', tier: 'enterprise', revealui_user_id: 'user-456', license_id: 'lic-email-test' },
     });
 
     const app = createApp();

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -338,7 +338,12 @@ describe('charge.refunded — B-1 perpetual license revocation', () => {
     mockConstructEvent.mockReturnValueOnce(event);
     mockPaymentIntentsRetrieve.mockResolvedValueOnce({
       id: 'pi_perpetual_email',
-      metadata: { perpetual: 'true', tier: 'enterprise', revealui_user_id: 'user-456', license_id: 'lic-email-test' },
+      metadata: {
+        perpetual: 'true',
+        tier: 'enterprise',
+        revealui_user_id: 'user-456',
+        license_id: 'lic-email-test',
+      },
     });
 
     const app = createApp();

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -1299,6 +1299,27 @@ app.openapi(stripeWebhookRoute, async (c) => {
           resetLicenseState();
           resetDbStatusCache();
 
+          // A5: write license_id back to the one-time PaymentIntent so a future
+          // charge.refunded targets exactly THIS perpetual license instead of
+          // falling back to mass-revoke. Best-effort; the refund path flags an
+          // unresolved id for manual review rather than revoking everything.
+          const perpetualPaymentIntentId =
+            typeof session.payment_intent === 'string'
+              ? session.payment_intent
+              : (session.payment_intent?.id ?? null);
+          if (perpetualPaymentIntentId) {
+            await stripe.paymentIntents
+              .update(perpetualPaymentIntentId, {
+                metadata: { perpetual: 'true', license_id: licenseId, tier },
+              })
+              .catch((err) => {
+                logger.warn('Failed to write license_id to perpetual PaymentIntent metadata', {
+                  paymentIntentId: perpetualPaymentIntentId,
+                  detail: err instanceof Error ? err.message : 'unknown',
+                });
+              });
+          }
+
           logger.info('Perpetual license generated and stored', { tier, customerId, licenseId });
           auditLicenseEvent(db, 'license.perpetual.created', 'info', {
             licenseId,
@@ -3355,66 +3376,79 @@ app.openapi(stripeWebhookRoute, async (c) => {
           // single-mock refund-cancel test and double the Stripe round-trip).
           const refundSubscriptionId = await resolveSubscriptionIdFromCharge(stripe, charge);
 
-          // B-1 fix: Revoke perpetual licenses when the originating charge is
-          // fully refunded. Identify the perpetual purchase via the PaymentIntent
-          // metadata set at checkout (payment_intent_data.metadata.perpetual='true').
-          // Match by both customerId AND the specific licenseId stored in PI metadata
-          // so concurrent perpetual purchases for the same customer are not
-          // collateral-revoked.
+          // A5 fix: Revoke the perpetual license when its originating charge is
+          // fully refunded — but ONLY the specific license identified by
+          // `license_id` in the PaymentIntent metadata (written back at issuance;
+          // see the perpetual checkout saga). A refund whose PaymentIntent has no
+          // resolvable `license_id` must NEVER fall back to revoking every
+          // perpetual license the customer owns — that collateral-revokes
+          // unrelated concurrent perpetual purchases. The unresolved case is
+          // logged + audited for manual review instead of mass-revoking.
           if (refundPi?.metadata?.perpetual === 'true') {
             const perpetualLicenseId = refundPi.metadata.license_id ?? null;
             const perpetualTier = refundPi.metadata.tier ?? 'pro';
 
-            const revokeWhere = perpetualLicenseId
-              ? and(
-                  eq(licenses.id, perpetualLicenseId),
-                  eq(licenses.customerId, customerId),
-                  eq(licenses.perpetual, true),
-                  isNull(licenses.deletedAt),
-                )
-              : and(
-                  eq(licenses.customerId, customerId),
-                  eq(licenses.perpetual, true),
-                  isNull(licenses.deletedAt),
+            if (!perpetualLicenseId) {
+              logger.error(
+                'Perpetual refund missing license_id in PaymentIntent metadata  -  NOT revoking (manual review required)',
+                undefined,
+                {
+                  customerId,
+                  chargeId: charge.id,
+                  amountRefunded: charge.amount_refunded,
+                },
+              );
+              auditLicenseEvent(db, 'license.perpetual.refund.unresolved', 'warn', {
+                customerId,
+                chargeId: charge.id,
+                amountRefunded: charge.amount_refunded,
+              });
+            } else {
+              await db
+                .update(licenses)
+                .set({ status: 'revoked', updatedAt: new Date() })
+                .where(
+                  and(
+                    eq(licenses.id, perpetualLicenseId),
+                    eq(licenses.customerId, customerId),
+                    eq(licenses.perpetual, true),
+                    isNull(licenses.deletedAt),
+                  ),
                 );
 
-            await db
-              .update(licenses)
-              .set({ status: 'revoked', updatedAt: new Date() })
-              .where(revokeWhere);
+              resetLicenseState();
+              resetDbStatusCache();
 
-            resetLicenseState();
-            resetDbStatusCache();
-
-            logger.warn('Perpetual license revoked: full refund issued', {
-              customerId,
-              chargeId: charge.id,
-              perpetualLicenseId,
-              tier: perpetualTier,
-              amountRefunded: charge.amount_refunded,
-            });
-            auditLicenseEvent(db, 'license.perpetual.revoked.refund', 'warn', {
-              customerId,
-              chargeId: charge.id,
-              perpetualLicenseId,
-              tier: perpetualTier,
-              amountRefunded: charge.amount_refunded,
-            });
-
-            const perpetualEmail =
-              charge.billing_details?.email ??
-              charge.receipt_email ??
-              (await findUserEmailByCustomerId(db, customerId));
-            if (perpetualEmail) {
-              sendPerpetualLicenseRevokedEmail(perpetualEmail, {
+              logger.warn('Perpetual license revoked: full refund issued', {
+                customerId,
+                chargeId: charge.id,
+                perpetualLicenseId,
                 tier: perpetualTier,
                 amountRefunded: charge.amount_refunded,
-                currency: charge.currency,
-              }).catch((err) => {
-                logger.error('Failed to send perpetual license revoked email', undefined, {
-                  detail: err instanceof Error ? err.message : 'unknown',
-                });
               });
+              auditLicenseEvent(db, 'license.perpetual.revoked.refund', 'warn', {
+                customerId,
+                chargeId: charge.id,
+                perpetualLicenseId,
+                tier: perpetualTier,
+                amountRefunded: charge.amount_refunded,
+              });
+
+              const perpetualEmail =
+                charge.billing_details?.email ??
+                charge.receipt_email ??
+                (await findUserEmailByCustomerId(db, customerId));
+              if (perpetualEmail) {
+                sendPerpetualLicenseRevokedEmail(perpetualEmail, {
+                  tier: perpetualTier,
+                  amountRefunded: charge.amount_refunded,
+                  currency: charge.currency,
+                }).catch((err) => {
+                  logger.error('Failed to send perpetual license revoked email', undefined, {
+                    detail: err instanceof Error ? err.message : 'unknown',
+                  });
+                });
+              }
             }
           }
 


### PR DESCRIPTION
## Never mass-revoke perpetual licenses on refund

`charge.refunded` revoked **all** of a customer's perpetual licenses when the
originating PaymentIntent had no `license_id` in its metadata — collateral
damage across concurrent perpetual purchases — while the code comment falsely
claimed this collateral-revoke was already prevented.

### Fix
- Require `license_id`: revoke **exactly** the identified license. On the
  unresolved (no-`license_id`) path, log + audit for manual review instead of
  mass-revoking.
- Write `license_id` back to the one-time PaymentIntent at issuance (perpetual
  saga) so a future refund can target the right license.
- Correct the misleading comment in the same change.

### Tests
- New `perpetual-refund-scope.test.ts` (2): refund **with** `license_id` fires
  the id-bearing perpetual-revoke path; refund **without** `license_id` takes
  the manual-review path and never runs the perpetual revoke.
- Existing webhook suites: 70 green (no regression). Server typecheck clean.

Branch-per-change; targets `test`.
