### PR TITLE
refactor(contracts): derive webhook event count from array (A8)

### DIFF
--- a/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
+++ b/packages/contracts/src/__tests__/stripe-webhook-events.test.ts
@@ -6,8 +6,12 @@ import {
 } from '../stripe-webhook-events.js';
 
 describe('stripe-webhook-events', () => {
-  it('exposes exactly RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT events', () => {
-    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toHaveLength(RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT);
+  it('exposes exactly the expected number of events (literal drift guard)', () => {
+    // The literal lives HERE, not in a hand-maintained module constant: a change
+    // to the array forces a deliberate update to this expectation. The exported
+    // COUNT is derived from the array, so it tracks automatically — assert they agree.
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENTS).toHaveLength(15);
+    expect(RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT).toBe(15);
   });
 
   it('has no duplicates', () => {

--- a/packages/contracts/src/stripe-webhook-events.ts
+++ b/packages/contracts/src/stripe-webhook-events.ts
@@ -65,7 +65,8 @@ export const RELEVANT_STRIPE_WEBHOOK_EVENTS = [
 export type RelevantStripeWebhookEvent = (typeof RELEVANT_STRIPE_WEBHOOK_EVENTS)[number];
 
 /**
- * Expected event count — acts as a coarse drift detector for reviewers.
- * If you're adjusting the array above, update this too.
+ * Event count, derived from the array so the two can never drift. The literal
+ * drift guard for reviewers (assert the array length against the expected
+ * number) lives in the unit test, not in a hand-maintained constant here.
  */
-export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = 15;
+export const RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT = RELEVANT_STRIPE_WEBHOOK_EVENTS.length;


### PR DESCRIPTION
## Derive the webhook event count from the array

`RELEVANT_STRIPE_WEBHOOK_EVENT_COUNT` was a hand-maintained `15` that could
drift from `RELEVANT_STRIPE_WEBHOOK_EVENTS`. Derive it from the array length so
they can never disagree; move the literal drift guard into the unit test
(asserts the array length is 15 and that the derived count agrees). 5/5 green.

Branch-per-change; targets `test`.
