### PR TITLE
ci(deploy): post-deploy invocation guard + GAP-252 verify (A6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -449,6 +449,32 @@ jobs:
           echo "::error::Admin health check failed after 2 minutes"
           exit 1
 
+      - name: Invocation guard — API (real function invocation)
+        # GAP-253: /health/ready can pass while real request handling fails with
+        # FUNCTION_INVOCATION_FAILED — readiness does not exercise the full route
+        # handler the way a real API request does, and public /api/* responses can
+        # be CDN-cached (a stale 200 masks a broken function). Hit an AUTHENTICATED
+        # route with NO auth: a healthy function returns 401 (the handler + auth
+        # middleware actually executed); a broken function config returns a 5xx
+        # Vercel runtime error. Cache-bust with the run id so the CDN cannot serve
+        # a stale response. A non-5xx proves the function invokes; 5xx (or no
+        # response) trips the existing `if: failure()` rollback below.
+        run: |
+          API_URL="${REVEALUI_API_URL:-https://api.revealui.com}"
+          PROBE="$API_URL/api/billing/subscription?_cb=${GITHUB_RUN_ID}"
+          echo "Invocation guard: GET $PROBE (expect a non-5xx, e.g. 401)..."
+          for i in $(seq 1 12); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' "$PROBE" 2>/dev/null || echo "000")
+            if [ "$CODE" -ge 200 ] && [ "$CODE" -lt 500 ]; then
+              echo "Invocation OK: function returned HTTP $CODE (handler executed)"
+              exit 0
+            fi
+            echo "Attempt $i/12 — got HTTP $CODE (function not invoking cleanly), waiting 10s..."
+            sleep 10
+          done
+          echo "::error::API invocation guard failed — /api/billing/subscription returned a 5xx (possible FUNCTION_INVOCATION_FAILED) after 2 minutes"
+          exit 1
+
       - name: Rollback on failure
         if: failure()
         # Per GAP-128: `vercel rollback` with no URL argument is a STATUS

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -492,7 +492,12 @@ jobs:
         # directly and doesn't go through the same team-scope validation.
         # Fix: route via --scope (team slug) instead of VERCEL_ORG_ID (team ID).
         run: |
-          set -uo pipefail
+          # GAP-252: use set +e so any individual grep/jq failure inside the
+          # loop does not abort the script early (GitHub Actions runs with
+          # set -eo pipefail by default; a grep that matches nothing exits 1
+          # and was aborting the loop on the first app, rolling back nothing).
+          # Failures are tracked via counters and surfaced at the end.
+          set +e
           echo "::warning::Smoke test failed — rolling back affected apps"
           pnpm add -g vercel@latest
           APP_LIST="${{ needs.detect.outputs.app-list }}"
@@ -502,7 +507,7 @@ jobs:
             # Look the project id up from the detect job's matrix (built from the
             # single-source .github/vercel-projects.json). This job has no checkout,
             # so it reuses the matrix via env rather than reading the file. Unknown -> skip.
-            PID=$(printf '%s' "$DETECT_MATRIX" | jq -r --arg a "$app" '.[] | select(.app == $a) | .["project-id"]')
+            PID=$(printf '%s' "$DETECT_MATRIX" | jq -r --arg a "$app" '.[] | select(.app == $a) | .["project-id"]' 2>/dev/null) || PID=""
             if [ -z "$PID" ]; then continue; fi
 
             echo ""
@@ -514,7 +519,7 @@ jobs:
               --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 || true)
             PREV_URL=$(printf '%s\n' "$DEPLOY_LIST" \
               | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
-              | sed -n '2p')
+              | sed -n '2p') || PREV_URL=""
 
             if [ -z "$PREV_URL" ]; then
               echo "::warning::No previous deployment found for $app — broken deploy is live, manual intervention required"
@@ -539,7 +544,7 @@ jobs:
             CURRENT_URL=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod \
               --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 \
               | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
-              | head -n 1)
+              | head -n 1) || CURRENT_URL=""
 
             if [ "$CURRENT_URL" = "$PREV_URL" ]; then
               echo "✅ Rollback verified: $app production now serving $CURRENT_URL"


### PR DESCRIPTION
## Summary

Closes GAP-252 and GAP-253 from the 2026-06-22 #1561 deploy incident (api FUNCTION_INVOCATION_FAILED → auto-rollback no-op → manual Vercel-API recovery).

**GAP-253** (commit 1): Invocation guard step in `smoke-test` that hits `/api/billing/subscription` (an authenticated endpoint) with no credentials. A healthy function returns 401 (handler + auth middleware ran); a broken function bundle returns 5xx. Cache-busted by `GITHUB_RUN_ID` to bypass CDN. A 5xx trips the existing `if: failure()` rollback.

**GAP-252** (commit 2): The rollback loop was opening with `set -uo pipefail`. GitHub Actions already runs with `set -eo pipefail` by default — combined, a `grep` that returns no match (exits 1) inside `$()` aborted the entire script before the loop could iterate the next app, rolling back nothing. Fix: `set +e` at the start of the rollback block so individual command failures don't abort the loop. Failures are tracked via counters (`ROLLBACK_FAILED`, `ROLLBACK_NO_HISTORY`) and surfaced in the exit at the end. Added `|| PREV_URL=""`, `|| CURRENT_URL=""`, and `|| PID=""` fallbacks on the grep/jq pipelines.

## Root cause of the 2026-06-22 incident

- #1549 added an `excludeFiles` entry to `apps/server/vercel.json` — syntactically valid, passed CI, then caused `FUNCTION_INVOCATION_FAILED` at runtime
- Auto-rollback fired but `grep` matched nothing on the first app (no prior `.vercel.app` URL in the listing format), exiting 1 with `set -e`, aborting the loop silently — every app was left on the broken deployment
- Manual Vercel-API rollback was required; revert followed as #1563

## Test plan

- [ ] Gate 22/22 — passed locally
- [ ] Smoke: deploy a known-bad api build (e.g. re-add the #1549 excludeFiles to a preview) — invocation guard should catch the 5xx and fail the job
- [ ] Smoke: confirm smoke-test rollback iterates ALL affected apps without aborting on the first one

🤖 Generated with [Claude Code](https://claude.com/claude-code)