### PR TITLE
docs(go-live): reconcile runbooks to shipped code (A7)

### DIFF
--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -111,7 +111,7 @@ Refer to `docs/ENVIRONMENT-VARIABLES-GUIDE.md` for the full reference.
 - [ ] `REVEALUI_PUBLIC_SERVER_URL` set **(blocking)**
 - [ ] `NEXT_PUBLIC_SERVER_URL` set **(blocking)**
 - [ ] `POSTGRES_URL` set (NeonDB connection string) **(blocking)**
-- [ ] `BLOB_READ_WRITE_TOKEN` set (Vercel Blob Storage) **(blocking)**
+- [ ] `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` set (Cloudflare R2 object storage, revvault `revealui/prod/r2/*`) **(blocking)**
 - [ ] `STRIPE_SECRET_KEY` set (live key, not `sk_test_*`) **(blocking)**
 - [ ] `STRIPE_WEBHOOK_SECRET` set (live webhook signing secret) **(blocking)**
 - [ ] `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` set (live key, not `pk_test_*`) **(blocking)**

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -82,7 +82,7 @@ All gates must pass on the `main` branch before deploy.
 - [ ] NeonDB production database provisioned and accessible **(blocking)**
 - [ ] pgvector extension enabled on NeonDB (`CREATE EXTENSION IF NOT EXISTS vector`) **(blocking)**
 - [ ] ElectricSQL sync proxy running and connected to NeonDB **(blocking)**
-- [ ] Vercel Blob Storage configured (`BLOB_READ_WRITE_TOKEN`) **(blocking)**
+- [ ] Cloudflare R2 object storage configured (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` / `R2_ACCOUNT_ID`; creds in revvault `revealui/prod/r2/*`) **(blocking)**
 
 ---
 

--- a/docs/runbooks/checkout-smoke-production.md
+++ b/docs/runbooks/checkout-smoke-production.md
@@ -75,13 +75,13 @@ Expected: every row has `state = 'closed'` and `failure_count = 0`. If any row i
 
 > Use a **real card** in **live mode**. The test card numbers (`4242 4242 4242 4242`) only work in test mode and won't exercise the live webhook path. Use a personal card and refund the charge in §Rollback below.
 
-1. **Sign in** at `https://revealui.com/sign-in` as an account that does NOT currently hold a Pro license (verify in admin: user row's `tier = 'free'`).
+1. **Sign in** at `https://admin.revealui.com/sign-in` as an account that does NOT currently hold a Pro license (verify in admin: user row's `tier = 'free'`).
 2. Navigate to the **pricing page** at `https://revealui.com/pricing`.
 3. Click **Get Pro** (the $49/mo subscription tier). 📸 **Screenshot:** the pricing page before clicking, to capture the rendered tier list.
 4. The frontend POSTs to the checkout-session creation endpoint, which builds a Stripe checkout session with `metadata = { tier: 'pro', revealui_user_id: <your user id> }` and returns the Stripe-hosted URL. Browser redirects to `https://checkout.stripe.com/...`.
 5. **Stripe Checkout (hosted page)** — enter your real card. 📸 **Screenshot:** the Stripe checkout page before submitting (mask the card number — keep last 4 digits visible).
 6. Submit. Stripe processes the charge and fires `checkout.session.completed` to your webhook endpoint.
-7. Browser redirects back to `https://revealui.com/checkout/success` (the configured `success_url`). 📸 **Screenshot:** the success page.
+7. Browser redirects back to `https://admin.revealui.com/welcome?success=true` (the configured `success_url` — `${adminUrl}/welcome?success=true&tier=<tier>`, see `apps/server/src/routes/billing.ts`). 📸 **Screenshot:** the `/welcome` page.
 8. Navigate to `https://app.revealui.com/` (or wherever the post-checkout app lives). Confirm a Pro-gated feature is now accessible (e.g., the AI agents panel that requires `isLicensed('pro')`). 📸 **Screenshot:** the Pro feature rendering.
 
 **Wall-clock budget:** end-to-end (steps 1-8) should complete in **under 30 seconds** on a healthy production. If step 8 doesn't show Pro features within 60 seconds, jump to the failure-mode triage below.

--- a/docs/runbooks/stripe-go-live-cutover.md
+++ b/docs/runbooks/stripe-go-live-cutover.md
@@ -69,9 +69,11 @@ revvault sync vercel --manifest scripts/sync/revvault-vercel.toml   # or the pnp
 
 `STRIPE_LIVE_MODE` is in the manifest `skip` list, so the sync does **not** touch it — you flip it explicitly in step 4. Confirm the secret-key + webhook vars now resolve to live (the sync reports each var).
 
-## 3. Re-seed billing_catalog with LIVE price IDs
+## 3. Seed the LIVE-mode billing_catalog rows
 
-The prod `billing_catalog` currently holds **test** price IDs from Gate-5. Re-seed against the **live** Stripe account so it holds live price IDs. The seed picks live/test by key prefix and prints a 5-second LIVE warning — this is intentional.
+The `billing_catalog` is **mode-keyed** (ADR Layer 1 — `mode` column on `accounts.ts`; `sync-billing-catalog.ts` writes the row's mode). Live and test rows **coexist** (unique on `(plan_id, mode)`), so this step does **not** re-seed over / replace the test rows — it seeds the **live-mode** rows alongside them. The flip in step 4 (`STRIPE_LIVE_MODE`) changes which mode the runtime reads (`getConfiguredStripeMode`); it does not move catalog data.
+
+Seed the live-mode rows with the **live** Stripe key (the seed picks live/test by key prefix and prints a 5-second LIVE warning — intentional). The live rows must exist before the flip: the Fly startup validator and the per-cold-instance checkout gate both fail-fast if an expected live price row is missing. (Owner-gated — this is the Gate 1c live re-seed.)
 
 ```bash
 cd ~/revfleet/revealui


### PR DESCRIPTION
## Reconcile stale go-live runbooks to shipped code (A7)

Three revealui go-live docs corrected to match shipped behavior:

- **checkout-smoke-production.md** — sign-in host -> `admin.revealui.com`; the post-checkout `success_url` is `${adminUrl}/welcome?success=true` (per `apps/server/src/routes/billing.ts`), not `/checkout/success`.
- **stripe-go-live-cutover.md** — reframed step 3 + the env table to the **mode-keyed** `billing_catalog` (ADR Layer 1): live and test rows coexist (unique on `(plan_id, mode)`), so the flip switches which mode the runtime reads rather than re-seeding over a single-mode catalog. The live rows must exist before the flip (the Fly validator + the per-cold-instance checkout gate fail-fast otherwise).
- **LAUNCH-CHECKLIST.md** — Vercel Blob -> Cloudflare R2 (creds in revvault `revealui/prod/r2/*`).

Verify: `grep /checkout/success docs/runbooks/` and `grep "Vercel Blob" docs/runbooks/ docs/LAUNCH-CHECKLIST.md` both return nothing.

The .jv portion (stripe-pre-flip lane + OWNER_ACTIONS renewal-price rows) is a separate .jv change. Branch-per-change; targets `test`.
