### PR TITLE
feat(ai): capability-negotiated Reasoner port (P1a)

### DIFF
--- a/packages/ai/src/llm/providers/__tests__/capabilities.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/capabilities.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Reasoner capabilities() — transport-tier conformance (P2 seed, ADR 2026-06-25).
+ *
+ * Asserts each provider's golden capability profile, the purity/stability invariant
+ * (capabilities() is pure, deterministic, no network), and the cross-capability
+ * consistency invariants. Fully offline — capabilities() makes no network calls.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Reasoner, ReasonerCapabilities } from '../base.js';
+import { GroqProvider } from '../groq.js';
+import { InferenceSnapsProvider } from '../inference-snaps.js';
+import { OllamaProvider } from '../ollama.js';
+import { OpenAICompatProvider } from '../openai-compat.js';
+
+const TEST_URL = 'http://localhost:9999/v1';
+
+const cases: Array<{ name: string; reasoner: Reasoner; expected: ReasonerCapabilities }> = [
+  {
+    name: 'openai-compat',
+    reasoner: new OpenAICompatProvider({ apiKey: 'test', baseURL: TEST_URL }),
+    expected: {
+      providerTag: 'openai-compat',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'inference-snaps',
+    reasoner: new InferenceSnapsProvider({ baseURL: TEST_URL }),
+    expected: {
+      providerTag: 'inference-snaps',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'ollama',
+    reasoner: new OllamaProvider({}),
+    expected: {
+      providerTag: 'ollama',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'groq',
+    reasoner: new GroqProvider({ apiKey: 'test' }),
+    expected: {
+      providerTag: 'groq',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+];
+
+describe('Reasoner capabilities() — transport-tier conformance', () => {
+  for (const { name, reasoner, expected } of cases) {
+    describe(name, () => {
+      it('matches its golden capability profile', () => {
+        expect(reasoner.capabilities()).toEqual(expected);
+      });
+
+      it('is pure and stable (deterministic, no network)', () => {
+        const first = reasoner.capabilities();
+        for (let i = 0; i < 100; i++) {
+          expect(reasoner.capabilities()).toEqual(first);
+        }
+      });
+
+      it('satisfies the consistency invariants', () => {
+        const caps = reasoner.capabilities();
+        expect(caps.providerTag.length).toBeGreaterThan(0);
+        // parallelToolCalls ⇒ tools
+        if (caps.parallelToolCalls) {
+          expect(caps.tools).toBe(true);
+        }
+        // contextWindow, when declared, is a positive integer
+        if (caps.contextWindow !== undefined) {
+          expect(Number.isInteger(caps.contextWindow)).toBe(true);
+          expect(caps.contextWindow).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});

--- a/packages/ai/src/llm/providers/base.ts
+++ b/packages/ai/src/llm/providers/base.ts
@@ -1,7 +1,10 @@
 /**
  * LLM Provider Base Interface
  *
- * Abstract interface for all LLM providers (OpenAI, Anthropic, etc.)
+ * The agnostic Reasoner port (ADR 2026-06-25). Providers are negotiated by
+ * `capabilities()`, never by provider-name string. Vendor-shaped request knobs are
+ * tagged `@deprecated PROVIDER-EXTENSION` and excluded from the agnostic conformance
+ * contract; cross-provider usage (e.g. cache token stats) stays neutral.
  */
 
 /**
@@ -40,7 +43,16 @@ export interface Message {
   name?: string;
   toolCalls?: ToolCall[];
   toolCallId?: string;
-  /** Anthropic prompt caching - marks content for caching (5min TTL, 90% cost reduction) */
+  /**
+   * Neutral cache breakpoint hint (gated by the `promptCache` capability). An adapter
+   * that supports prompt caching maps this to its native cache-control; others ignore it.
+   */
+  cache?: boolean;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use `cache`. Anthropic-shaped request knob, retained
+   * transitionally for the cache-helper layer; excluded from the agnostic conformance
+   * contract. Callers migrate in P1b, then this is removed.
+   */
   cacheControl?: { type: 'ephemeral' };
 }
 
@@ -62,7 +74,11 @@ export interface LLMResponse {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
-    /** Anthropic cache stats */
+    /**
+     * Cross-provider cache usage (neutral; gated by `promptCache`). Populated by any
+     * caching provider  -  Anthropic cache tokens, OpenAI `cached_tokens`, Gemini
+     * `cachedContentTokenCount`. Read by the cost path; stays in neutral `usage`.
+     */
     cacheCreationTokens?: number;
     cacheReadTokens?: number;
   };
@@ -89,36 +105,93 @@ export interface LLMProviderConfig {
 }
 
 /**
- * Base interface for LLM providers
+ * Reasoning-depth hint (neutral, capability-gated by `reasoningEffort`).
+ *
+ * This is a *reasoning-depth* axis, NOT output entropy or length  -  adapters must never
+ * remap it to `temperature`/`maxTokens`. An adapter with a reasoning axis maps it to its
+ * native control (e.g. a thinking-token budget); an adapter without one advertises
+ * `reasoningEffort: false` and treats `effort` as a no-op.
  */
-export interface LLMProvider {
-  /**
-   * Chat completion
-   */
+export type ReasoningEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+/**
+ * Runtime-queryable capability record. The loop branches on these, never on a
+ * provider-name string. Conformance-tested (transport tier) so a provider cannot lie:
+ * advertise-true-but-not-wired fails the positive assertion; advertise-false-but-emits-a-
+ * native-field fails the inertness assertion.
+ */
+export interface ReasonerCapabilities {
+  /** Stable adapter id; also the only `providerOptions` namespace this adapter may read ('x-<tag>'). */
+  readonly providerTag: string;
+  readonly tools: boolean;
+  /** Implies `tools` (consistency invariant). */
+  readonly parallelToolCalls: boolean;
+  /** Implies the adapter accepts `ContentPart[]` message content. */
+  readonly vision: boolean;
+  readonly streaming: boolean;
+  readonly embeddings: boolean;
+  readonly reasoningEffort: boolean;
+  readonly promptCache: boolean;
+  readonly structuredOutput: boolean;
+  /** Max context window in tokens; undefined = unknown (loop budgets conservatively). */
+  readonly contextWindow?: number;
+}
+
+/**
+ * Namespaced opaque extension for genuinely unportable, request-shaped knobs.
+ *
+ * Core/loop code MUST pass this through and MUST NOT read any key  -  per-namespace schema
+ * lives in the owning adapter. A known-namespace registry (typed keys) rather than a bare
+ * `x-*` string convention, so a typo'd namespace fails loudly instead of silently no-opping.
+ */
+export interface ProviderOptions {
+  'x-anthropic'?: unknown;
+  'x-openai'?: unknown;
+  'x-google'?: unknown;
+}
+
+/**
+ * The Reasoner port  -  one swappable reasoning step plus the side capabilities
+ * (embeddings/streaming). The loop negotiates by `capabilities()`, never by name.
+ */
+export interface Reasoner {
+  /** Runtime-queryable, conformance-tested capability record. */
+  capabilities(): ReasonerCapabilities;
+
+  /** Chat completion. */
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse>;
 
-  /**
-   * Generate embeddings
-   */
+  /** Generate embeddings. */
   embed(text: string | string[], options?: LLMEmbedOptions): Promise<Embedding | Embedding[]>;
 
-  /**
-   * Stream chat completion
-   */
+  /** Stream chat completion. */
   stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk>;
 }
+
+/**
+ * @deprecated Use `Reasoner`. Alias retained one release cycle for external callers.
+ */
+export type LLMProvider = Reasoner;
 
 export interface LLMChatOptions {
   temperature?: number;
   maxTokens?: number;
   tools?: ToolDefinition[];
   toolChoice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
-  /** Enable prompt caching (Anthropic only) - caches system prompts and tools */
+  /** Neutral reasoning-depth hint (gated by `reasoningEffort`). No-op where unsupported. */
+  effort?: ReasoningEffort;
+  /** Neutral prompt-cache hint for the stable prefix  -  system + tools (gated by `promptCache`). */
+  cacheHint?: boolean;
+  /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
+  providerOptions?: ProviderOptions;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use `cacheHint`. Excluded from the agnostic
+   * conformance contract; callers migrate in P1b, then this is removed.
+   */
   enableCache?: boolean;
   /**
-   * Extended thinking token budget (Anthropic only).
-   * Enables Claude's internal reasoning before responding.
-   * Typical values: 512 (minimal) → 31999 (xhigh). 0 or undefined = disabled.
+   * @deprecated PROVIDER-EXTENSION  -  use `effort`. Vendor-shaped token budget; no provider
+   * reads it. Excluded from the agnostic conformance contract; callers migrate in P1b.
    */
   thinkingBudget?: number;
 }
@@ -131,7 +204,14 @@ export interface LLMStreamOptions {
   temperature?: number;
   maxTokens?: number;
   tools?: ToolDefinition[];
-  /** Enable prompt caching (Anthropic only) - caches system prompts and tools */
+  /** Neutral reasoning-depth hint (gated by `reasoningEffort`). No-op where unsupported. */
+  effort?: ReasoningEffort;
+  /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
+  providerOptions?: ProviderOptions;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use the `promptCache` capability + `cacheHint` on chat.
+   * Callers migrate in P1b, then this is removed.
+   */
   enableCache?: boolean;
 }
 

--- a/packages/ai/src/llm/providers/groq.ts
+++ b/packages/ai/src/llm/providers/groq.ts
@@ -16,6 +16,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -36,6 +37,21 @@ export class GroqProvider implements LLMProvider {
       baseURL: config.baseURL ?? 'https://api.groq.com/openai/v1',
       model: config.model ?? 'qwen/qwen3-32b',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (qwen/qwen3-32b). Groq exposes no embeddings endpoint.
+    return {
+      providerTag: 'groq',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/inference-snaps.ts
+++ b/packages/ai/src/llm/providers/inference-snaps.ts
@@ -35,6 +35,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -64,6 +65,22 @@ export class InferenceSnapsProvider implements LLMProvider {
       baseURL: config.baseURL,
       model: config.model ?? 'gemma3',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (gemma3, text-only). Per-model capability
+    // negotiation (e.g. qwen-vl vision, deepseek-r1 reasoningEffort) is a follow-up.
+    return {
+      providerTag: 'inference-snaps',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/ollama.ts
+++ b/packages/ai/src/llm/providers/ollama.ts
@@ -16,6 +16,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -45,6 +46,21 @@ export class OllamaProvider implements LLMProvider {
       baseURL,
       model: config.model ?? 'gemma4:e2b',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (gemma4:e2b, text-only).
+    return {
+      providerTag: 'ollama',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/openai-compat.ts
+++ b/packages/ai/src/llm/providers/openai-compat.ts
@@ -17,6 +17,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
   ToolCall,
 } from './base.js';
 
@@ -85,6 +86,22 @@ export class OpenAICompatProvider implements LLMProvider {
       );
     }
     this.baseURL = config.baseURL;
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Base OpenAI-compatible profile. Concrete providers (Groq, Ollama, inference-snaps)
+    // override per their endpoint and default model.
+    return {
+      providerTag: 'openai-compat',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   async chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {


### PR DESCRIPTION
Sharpens `@revealui/ai`'s `LLMProvider` into a capability-negotiated **Reasoner** port (per internal ADR 2026-06-25):

- `capabilities(): ReasonerCapabilities` — the agent loop branches on declared capabilities, never on a provider-name string. Implemented by all four providers (openai-compat, inference-snaps, ollama, groq).
- Neutral `ReasoningEffort` reasoning-depth hint and a namespaced opaque `providerOptions` channel (core passes through, never reads).
- `LLMProvider` retained as a deprecated alias of `Reasoner`.

**Purely additive — no caller changes.** Vendor-shaped request knobs (`thinkingBudget`/`enableCache`/`cacheControl`) are tagged `@deprecated` with neutral replacements alongside them (`effort`/`cacheHint`/`cache`); cross-provider cache token stats stay neutral in `usage` (so the existing cost readers are untouched). Migrating callers off the deprecated fields and consolidating the cost path are separate follow-ups.

Adds a transport-tier conformance test: golden capability profiles + purity/stability + consistency invariants for all four providers.

Validation: `pnpm turbo typecheck --filter=@revealui/ai` green; new conformance test 12/12; Biome clean on all changed files.
