### PR TITLE
feat(ai): migrate callers to neutral Reasoner surface (P1b)

### DIFF
--- a/packages/ai/src/llm/__tests__/cache-utils.test.ts
+++ b/packages/ai/src/llm/__tests__/cache-utils.test.ts
@@ -27,7 +27,7 @@ describe('cache-utils', () => {
       expect(cached).toEqual({
         role: 'system',
         content: 'Test content',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
 
@@ -41,7 +41,7 @@ describe('cache-utils', () => {
       const cached = withCache(message);
 
       expect(cached.name).toBe('John');
-      expect(cached.cacheControl).toEqual({ type: 'ephemeral' });
+      expect(cached.cache).toBe(true);
     });
   });
 
@@ -52,7 +52,7 @@ describe('cache-utils', () => {
       expect(prompt).toEqual({
         role: 'system',
         content: 'You are a helpful assistant',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
   });
@@ -148,7 +148,7 @@ describe('cache-utils', () => {
       expect(conversation[0]).toEqual({
         role: 'system',
         content: 'You are helpful',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
 
@@ -159,10 +159,10 @@ describe('cache-utils', () => {
       });
 
       expect(conversation).toHaveLength(4);
-      expect(conversation[0].cacheControl).toBeUndefined();
-      expect(conversation[1].cacheControl).toBeUndefined();
-      expect(conversation[2].cacheControl).toEqual({ type: 'ephemeral' });
-      expect(conversation[3].cacheControl).toBeUndefined();
+      expect(conversation[0].cache).toBeUndefined();
+      expect(conversation[1].cache).toBeUndefined();
+      expect(conversation[2].cache).toBe(true);
+      expect(conversation[3].cache).toBeUndefined();
     });
 
     it('should include user messages without caching', () => {
@@ -175,7 +175,7 @@ describe('cache-utils', () => {
       });
 
       conversation.slice(-3).forEach((msg) => {
-        expect(msg.cacheControl).toBeUndefined();
+        expect(msg.cache).toBeUndefined();
       });
     });
   });

--- a/packages/ai/src/llm/__tests__/response-cache.test.ts
+++ b/packages/ai/src/llm/__tests__/response-cache.test.ts
@@ -52,16 +52,14 @@ describe('ResponseCache', () => {
       expect(key1).not.toBe(key2);
     });
 
-    it('should normalize messages (ignore cacheControl)', () => {
+    it('should normalize messages (ignore cache hint)', () => {
       const messages1: Message[] = [{ role: 'system', content: 'You are helpful' }];
-      const messages2: Message[] = [
-        { role: 'system', content: 'You are helpful', cacheControl: { type: 'ephemeral' } },
-      ];
+      const messages2: Message[] = [{ role: 'system', content: 'You are helpful', cache: true }];
 
       const key1 = cache.getCacheKey(messages1);
       const key2 = cache.getCacheKey(messages2);
 
-      // Should be same since cacheControl is not included in cache key
+      // Should be same since the cache hint is not included in the cache key
       expect(key1).toBe(key2);
     });
   });

--- a/packages/ai/src/llm/cache-utils.ts
+++ b/packages/ai/src/llm/cache-utils.ts
@@ -27,7 +27,7 @@ import type { Message } from './providers/base.js';
 export function withCache(message: Message): Message {
   return {
     ...message,
-    cacheControl: { type: 'ephemeral' },
+    cache: true,
   };
 }
 
@@ -89,7 +89,7 @@ export function estimateCacheSavings(
  *
  * @example
  * ```ts
- * const response = await client.chat(messages, { enableCache: true })
+ * const response = await client.chat(messages, { cacheHint: true })
  * const stats = formatCacheStats(response.usage)
  * console.log(stats)
  * // "Cache: 45% read (2,500 tokens), 10% created (500 tokens)"
@@ -146,7 +146,7 @@ export function shouldCache(content: string, minTokens = 1024): boolean {
  *   ],
  * })
  *
- * const response = await client.chat(conversation, { enableCache: true })
+ * const response = await client.chat(conversation, { cacheHint: true })
  * ```
  */
 export function createCachedConversation(config: {
@@ -168,7 +168,7 @@ export function createCachedConversation(config: {
       result.push({
         role: 'system',
         content: doc,
-        ...(isLast ? { cacheControl: { type: 'ephemeral' } } : {}),
+        ...(isLast ? { cache: true } : {}),
       });
     });
   }

--- a/packages/ai/src/llm/providers/base.ts
+++ b/packages/ai/src/llm/providers/base.ts
@@ -2,9 +2,10 @@
  * LLM Provider Base Interface
  *
  * The agnostic Reasoner port (ADR 2026-06-25). Providers are negotiated by
- * `capabilities()`, never by provider-name string. Vendor-shaped request knobs are
- * tagged `@deprecated PROVIDER-EXTENSION` and excluded from the agnostic conformance
- * contract; cross-provider usage (e.g. cache token stats) stays neutral.
+ * `capabilities()`, never by provider-name string. The control vocabulary is neutral
+ * and capability-gated (`effort`, `cache`/`cacheHint`); genuinely unportable knobs ride
+ * the namespaced opaque `providerOptions` channel; cross-provider usage (e.g. cache token
+ * stats) stays neutral in `LLMResponse.usage`.
  */
 
 /**
@@ -48,12 +49,6 @@ export interface Message {
    * that supports prompt caching maps this to its native cache-control; others ignore it.
    */
   cache?: boolean;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `cache`. Anthropic-shaped request knob, retained
-   * transitionally for the cache-helper layer; excluded from the agnostic conformance
-   * contract. Callers migrate in P1b, then this is removed.
-   */
-  cacheControl?: { type: 'ephemeral' };
 }
 
 export interface ToolCall {
@@ -184,16 +179,6 @@ export interface LLMChatOptions {
   cacheHint?: boolean;
   /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
   providerOptions?: ProviderOptions;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `cacheHint`. Excluded from the agnostic
-   * conformance contract; callers migrate in P1b, then this is removed.
-   */
-  enableCache?: boolean;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `effort`. Vendor-shaped token budget; no provider
-   * reads it. Excluded from the agnostic conformance contract; callers migrate in P1b.
-   */
-  thinkingBudget?: number;
 }
 
 export interface LLMEmbedOptions {
@@ -208,11 +193,6 @@ export interface LLMStreamOptions {
   effort?: ReasoningEffort;
   /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
   providerOptions?: ProviderOptions;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use the `promptCache` capability + `cacheHint` on chat.
-   * Callers migrate in P1b, then this is removed.
-   */
-  enableCache?: boolean;
 }
 
 export interface ToolDefinition {

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -7,7 +7,7 @@
 import { registerCleanupHandler } from '@revealui/core/monitoring';
 import { z } from 'zod/v4';
 import type { LLMClient } from '../llm/client.js';
-import type { Message } from '../llm/providers/base.js';
+import type { Message, ReasoningEffort } from '../llm/providers/base.js';
 import { estimateCost } from '../llm/token-counter.js';
 import type { AgentSkillProvider } from '../skills/integration/agent-skill-provider.js';
 import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
@@ -18,28 +18,12 @@ import { createWebSearchTool } from '../tools/web/duck-duck-go.js';
 import type { Agent, AgentResult, Task } from './agent.js';
 
 /**
- * Controls how much of the model's token budget is allocated to internal reasoning.
- * Applies to Anthropic Claude only  -  ignored by other providers.
- *
- * | Level   | Budget (tokens) | Use case                          |
- * |---------|-----------------|-----------------------------------|
- * | off     | 0               | Disabled (default)                |
- * | minimal | 512             | Simple tasks, cost-sensitive      |
- * | low     | 2 048           | Moderate complexity               |
- * | medium  | 8 000           | Multi-step reasoning              |
- * | high    | 16 000          | Complex planning                  |
- * | xhigh   | 31 999          | Maximum depth (expensive)         |
+ * Reasoning-depth hint for a task. Alias of the neutral `ReasoningEffort` — the agnostic
+ * Reasoner port's control vocabulary. Mapping a level to a provider's native control
+ * (e.g. a thinking-token budget) is the adapter's job; a provider that advertises
+ * `reasoningEffort: false` treats it as a no-op.
  */
-export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
-
-const THINKING_BUDGETS: Record<ThinkingLevel, number> = {
-  off: 0,
-  minimal: 512,
-  low: 2048,
-  medium: 8000,
-  high: 16000,
-  xhigh: 31999,
-};
+export type ThinkingLevel = ReasoningEffort;
 
 export interface RuntimeConfig {
   maxIterations?: number;
@@ -219,8 +203,8 @@ export class AgentRuntime {
       {
         role: 'system',
         content: agent.instructions,
-        // Cache agent instructions for cost savings (Anthropic only)
-        cacheControl: this.config.enableCache ? { type: 'ephemeral' } : undefined,
+        // Cache agent instructions for cost savings (effective where promptCache is supported)
+        cache: this.config.enableCache || undefined,
       },
       {
         role: 'user',
@@ -255,12 +239,6 @@ export class AgentRuntime {
           };
         }
 
-        // Resolve thinking budget if a level is configured
-        const thinkingBudget =
-          this.config.thinkingLevel && this.config.thinkingLevel !== 'off'
-            ? THINKING_BUDGETS[this.config.thinkingLevel]
-            : undefined;
-
         // Get LLM response (with caching for agent instructions and tools)
         const response = await llmClient.chat(messages, {
           tools: allTools.map((tool) => ({
@@ -271,8 +249,8 @@ export class AgentRuntime {
               parameters: z.toJSONSchema(tool.parameters) as Record<string, unknown>,
             },
           })),
-          enableCache: this.config.enableCache,
-          thinkingBudget,
+          cacheHint: this.config.enableCache,
+          effort: this.config.thinkingLevel,
         });
 
         // Accumulate token usage and cost

--- a/packages/ai/src/orchestration/streaming-runtime.ts
+++ b/packages/ai/src/orchestration/streaming-runtime.ts
@@ -118,12 +118,12 @@ export class StreamingAgentRuntime extends AgentRuntime {
       content: string;
       toolCalls?: unknown[];
       toolCallId?: string;
-      cacheControl?: { type: string };
+      cache?: boolean;
     }> = [
       {
         role: 'system',
         content: agent.instructions,
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       },
       {
         role: 'user',


### PR DESCRIPTION
Follows #1624 (now merged to `test`). Completes the Reasoner-port migration: removes the deprecated request knobs and moves every caller onto the neutral surface.

- `Message.cacheControl` → `Message.cache`; `LLMChatOptions.enableCache` → `cacheHint`; `thinkingBudget` → `effort`; `LLMStreamOptions.enableCache` removed.
- Callers migrated: the cache-helper utilities, the agent runtime, the streaming runtime, and tests.
- `ThinkingLevel` is now an alias of the neutral `ReasoningEffort`; the effort→budget table is dropped from the runtime (it relocates to a reasoning adapter when one lands).

No behavior change — these knobs were already inert at the wire (no provider read them); cross-provider cache token stats stay neutral in `usage`.

Validation: `turbo typecheck --filter=@revealui/ai` green; affected tests 72/72; Biome clean.
