### PR TITLE
refactor(ai): consolidate cost tables onto one MODEL_PRICING (P1c)

### DIFF
--- a/packages/ai/src/llm/cache-utils.ts
+++ b/packages/ai/src/llm/cache-utils.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Message } from './providers/base.js';
+import { MODEL_PRICING } from './token-counter.js';
 
 /**
  * Mark a message for caching
@@ -179,33 +180,28 @@ export function createCachedConversation(config: {
   return result;
 }
 
+/** Look up a model's pricing, asserting presence (used only for known-present keys). */
+function requirePricing(model: string) {
+  const pricing = MODEL_PRICING[model];
+  if (!pricing) {
+    throw new Error(`No pricing entry for model: ${model}`);
+  }
+  return pricing;
+}
+
 /**
- * Pricing information for Anthropic Claude models (as of 2024)
- * Prices are per million tokens
+ * @deprecated Use `MODEL_PRICING` from `./token-counter.js`. Retained as a thin derived
+ * view (the Anthropic-with-cache subset) so existing importers keep one source of truth.
  */
 export const ANTHROPIC_PRICING = {
-  'claude-3-5-sonnet-20241022': {
-    input: 3.0,
-    output: 15.0,
-    cacheWrite: 3.75, // 25% markup for cache creation
-    cacheRead: 0.3, // 90% discount for cache hits
-  },
-  'claude-3-5-haiku-20241022': {
-    input: 1.0,
-    output: 5.0,
-    cacheWrite: 1.25,
-    cacheRead: 0.1,
-  },
-  'claude-3-opus-20240229': {
-    input: 15.0,
-    output: 75.0,
-    cacheWrite: 18.75,
-    cacheRead: 1.5,
-  },
+  'claude-3-5-sonnet-20241022': requirePricing('claude-3-5-sonnet-20241022'),
+  'claude-3-5-haiku-20241022': requirePricing('claude-3-5-haiku-20241022'),
+  'claude-3-opus-20240229': requirePricing('claude-3-opus-20240229'),
 } as const;
 
 /**
- * Calculate actual cost of a request with caching
+ * Calculate actual cost of a request with caching, using the unified MODEL_PRICING table.
+ * Unknown models price at zero (matching `estimateCost`).
  *
  * @example
  * ```ts
@@ -217,18 +213,23 @@ export const ANTHROPIC_PRICING = {
  *   cacheReadTokens: 5000,
  * })
  *
- * console.log(`Request cost: $${cost.toFixed(4)}`)
+ * console.log(`Request cost: $${cost.total.toFixed(4)}`)
  * console.log(`Savings vs no cache: $${cost.savings.toFixed(4)}`)
  * ```
  */
 export function calculateCacheCost(usage: {
-  model: keyof typeof ANTHROPIC_PRICING;
+  model: string;
   promptTokens: number;
   completionTokens: number;
   cacheCreationTokens?: number;
   cacheReadTokens?: number;
 }): { total: number; breakdown: Record<string, number>; savings: number } {
-  const pricing = ANTHROPIC_PRICING[usage.model];
+  const pricing = MODEL_PRICING[usage.model] ?? {
+    input: 0,
+    output: 0,
+    cacheWrite: 0,
+    cacheRead: 0,
+  };
   const uncachedTokens =
     usage.promptTokens - (usage.cacheCreationTokens || 0) - (usage.cacheReadTokens || 0);
 

--- a/packages/ai/src/llm/token-counter.ts
+++ b/packages/ai/src/llm/token-counter.ts
@@ -23,22 +23,43 @@ export interface CostEstimate {
   direction: 'input' | 'output';
 }
 
-// Cost per 1M tokens (USD)  -  input/output pricing
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // Anthropic
-  'claude-opus-4-6': { input: 15.0, output: 75.0 },
-  'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
-  'claude-haiku-4-5-20251001': { input: 0.25, output: 1.25 },
+/**
+ * Per-1M-token pricing (USD). Single source of truth for every cost path in the package:
+ * `estimateCost` (input/output) and `calculateCacheCost` (cache-utils, cacheWrite/cacheRead).
+ * Cache rates follow Anthropic's model (write ~125% of input, read ~10%); non-caching
+ * providers carry 0 (local models are free; cache cost is not modelled for hosted
+ * non-Anthropic providers here).
+ */
+export interface ModelPricing {
+  /** USD per 1M input tokens. */
+  input: number;
+  /** USD per 1M output tokens. */
+  output: number;
+  /** USD per 1M tokens written to the prompt cache (0 where unsupported/unmodelled). */
+  cacheWrite: number;
+  /** USD per 1M tokens read from the prompt cache (0 where unsupported/unmodelled). */
+  cacheRead: number;
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic (current)
+  'claude-opus-4-6': { input: 15.0, output: 75.0, cacheWrite: 18.75, cacheRead: 1.5 },
+  'claude-sonnet-4-6': { input: 3.0, output: 15.0, cacheWrite: 3.75, cacheRead: 0.3 },
+  'claude-haiku-4-5-20251001': { input: 0.25, output: 1.25, cacheWrite: 0.3125, cacheRead: 0.025 },
+  // Anthropic (legacy 2024  -  retained for cache-cost callers/examples)
+  'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0, cacheWrite: 3.75, cacheRead: 0.3 },
+  'claude-3-5-haiku-20241022': { input: 1.0, output: 5.0, cacheWrite: 1.25, cacheRead: 0.1 },
+  'claude-3-opus-20240229': { input: 15.0, output: 75.0, cacheWrite: 18.75, cacheRead: 1.5 },
   // OpenAI
-  'gpt-4o': { input: 5.0, output: 15.0 },
-  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4o': { input: 5.0, output: 15.0, cacheWrite: 0, cacheRead: 0 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6, cacheWrite: 0, cacheRead: 0 },
   // Groq (Qwen  -  Apache 2.0)
-  'qwen/qwen3-32b': { input: 0.59, output: 0.79 },
+  'qwen/qwen3-32b': { input: 0.59, output: 0.79, cacheWrite: 0, cacheRead: 0 },
   // Ollama (self-hosted  -  no cost)
-  'gemma4:e2b': { input: 0, output: 0 },
-  'gemma4:e4b': { input: 0, output: 0 },
-  'gemma4:26b': { input: 0, output: 0 },
-  'nomic-embed-text': { input: 0, output: 0 },
+  'gemma4:e2b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'gemma4:e4b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'gemma4:26b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'nomic-embed-text': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
 };
 
 function charsPerToken(model: string): number {


### PR DESCRIPTION
Stacked on #1625 (merges after it). Consolidates the two divergent cost tables into one source of truth.

Previously `token-counter.ts` (`MODEL_PRICING`: input/output, current models) and `cache-utils.ts` (`ANTHROPIC_PRICING`: with cache rates, legacy 2024 models) held separate, drift-prone numbers, with cost computed in multiple places. Now `MODEL_PRICING` is the single exported table — input/output + `cacheWrite`/`cacheRead` for every model — consumed by both `estimateCost` and `calculateCacheCost`. `ANTHROPIC_PRICING` is retained as a thin deprecated derived view so existing importers keep one set of numbers.

Validation: `turbo typecheck --filter=@revealui/ai` green; cost tests 25/25; Biome clean.
