### PR TITLE
feat(ai): agnostic Reasoner port — capability surface + provider-neutral migration (P1a-c + P2a/b)

### DIFF
--- a/packages/ai/src/llm/__tests__/cache-utils.test.ts
+++ b/packages/ai/src/llm/__tests__/cache-utils.test.ts
@@ -27,7 +27,7 @@ describe('cache-utils', () => {
       expect(cached).toEqual({
         role: 'system',
         content: 'Test content',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
 
@@ -41,7 +41,7 @@ describe('cache-utils', () => {
       const cached = withCache(message);
 
       expect(cached.name).toBe('John');
-      expect(cached.cacheControl).toEqual({ type: 'ephemeral' });
+      expect(cached.cache).toBe(true);
     });
   });
 
@@ -52,7 +52,7 @@ describe('cache-utils', () => {
       expect(prompt).toEqual({
         role: 'system',
         content: 'You are a helpful assistant',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
   });
@@ -148,7 +148,7 @@ describe('cache-utils', () => {
       expect(conversation[0]).toEqual({
         role: 'system',
         content: 'You are helpful',
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       });
     });
 
@@ -159,10 +159,10 @@ describe('cache-utils', () => {
       });
 
       expect(conversation).toHaveLength(4);
-      expect(conversation[0].cacheControl).toBeUndefined();
-      expect(conversation[1].cacheControl).toBeUndefined();
-      expect(conversation[2].cacheControl).toEqual({ type: 'ephemeral' });
-      expect(conversation[3].cacheControl).toBeUndefined();
+      expect(conversation[0].cache).toBeUndefined();
+      expect(conversation[1].cache).toBeUndefined();
+      expect(conversation[2].cache).toBe(true);
+      expect(conversation[3].cache).toBeUndefined();
     });
 
     it('should include user messages without caching', () => {
@@ -175,7 +175,7 @@ describe('cache-utils', () => {
       });
 
       conversation.slice(-3).forEach((msg) => {
-        expect(msg.cacheControl).toBeUndefined();
+        expect(msg.cache).toBeUndefined();
       });
     });
   });

--- a/packages/ai/src/llm/__tests__/response-cache.test.ts
+++ b/packages/ai/src/llm/__tests__/response-cache.test.ts
@@ -52,16 +52,14 @@ describe('ResponseCache', () => {
       expect(key1).not.toBe(key2);
     });
 
-    it('should normalize messages (ignore cacheControl)', () => {
+    it('should normalize messages (ignore cache hint)', () => {
       const messages1: Message[] = [{ role: 'system', content: 'You are helpful' }];
-      const messages2: Message[] = [
-        { role: 'system', content: 'You are helpful', cacheControl: { type: 'ephemeral' } },
-      ];
+      const messages2: Message[] = [{ role: 'system', content: 'You are helpful', cache: true }];
 
       const key1 = cache.getCacheKey(messages1);
       const key2 = cache.getCacheKey(messages2);
 
-      // Should be same since cacheControl is not included in cache key
+      // Should be same since the cache hint is not included in the cache key
       expect(key1).toBe(key2);
     });
   });

--- a/packages/ai/src/llm/cache-utils.ts
+++ b/packages/ai/src/llm/cache-utils.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Message } from './providers/base.js';
+import { MODEL_PRICING } from './token-counter.js';
 
 /**
  * Mark a message for caching
@@ -179,33 +180,28 @@ export function createCachedConversation(config: {
   return result;
 }
 
+/** Look up a model's pricing, asserting presence (used only for known-present keys). */
+function requirePricing(model: string) {
+  const pricing = MODEL_PRICING[model];
+  if (!pricing) {
+    throw new Error(`No pricing entry for model: ${model}`);
+  }
+  return pricing;
+}
+
 /**
- * Pricing information for Anthropic Claude models (as of 2024)
- * Prices are per million tokens
+ * @deprecated Use `MODEL_PRICING` from `./token-counter.js`. Retained as a thin derived
+ * view (the Anthropic-with-cache subset) so existing importers keep one source of truth.
  */
 export const ANTHROPIC_PRICING = {
-  'claude-3-5-sonnet-20241022': {
-    input: 3.0,
-    output: 15.0,
-    cacheWrite: 3.75, // 25% markup for cache creation
-    cacheRead: 0.3, // 90% discount for cache hits
-  },
-  'claude-3-5-haiku-20241022': {
-    input: 1.0,
-    output: 5.0,
-    cacheWrite: 1.25,
-    cacheRead: 0.1,
-  },
-  'claude-3-opus-20240229': {
-    input: 15.0,
-    output: 75.0,
-    cacheWrite: 18.75,
-    cacheRead: 1.5,
-  },
+  'claude-3-5-sonnet-20241022': requirePricing('claude-3-5-sonnet-20241022'),
+  'claude-3-5-haiku-20241022': requirePricing('claude-3-5-haiku-20241022'),
+  'claude-3-opus-20240229': requirePricing('claude-3-opus-20240229'),
 } as const;
 
 /**
- * Calculate actual cost of a request with caching
+ * Calculate actual cost of a request with caching, using the unified MODEL_PRICING table.
+ * Unknown models price at zero (matching `estimateCost`).
  *
  * @example
  * ```ts
@@ -217,18 +213,23 @@ export const ANTHROPIC_PRICING = {
  *   cacheReadTokens: 5000,
  * })
  *
- * console.log(`Request cost: $${cost.toFixed(4)}`)
+ * console.log(`Request cost: $${cost.total.toFixed(4)}`)
  * console.log(`Savings vs no cache: $${cost.savings.toFixed(4)}`)
  * ```
  */
 export function calculateCacheCost(usage: {
-  model: keyof typeof ANTHROPIC_PRICING;
+  model: string;
   promptTokens: number;
   completionTokens: number;
   cacheCreationTokens?: number;
   cacheReadTokens?: number;
 }): { total: number; breakdown: Record<string, number>; savings: number } {
-  const pricing = ANTHROPIC_PRICING[usage.model];
+  const pricing = MODEL_PRICING[usage.model] ?? {
+    input: 0,
+    output: 0,
+    cacheWrite: 0,
+    cacheRead: 0,
+  };
   const uncachedTokens =
     usage.promptTokens - (usage.cacheCreationTokens || 0) - (usage.cacheReadTokens || 0);
 

--- a/packages/ai/src/llm/cache-utils.ts
+++ b/packages/ai/src/llm/cache-utils.ts
@@ -27,7 +27,7 @@ import type { Message } from './providers/base.js';
 export function withCache(message: Message): Message {
   return {
     ...message,
-    cacheControl: { type: 'ephemeral' },
+    cache: true,
   };
 }
 
@@ -89,7 +89,7 @@ export function estimateCacheSavings(
  *
  * @example
  * ```ts
- * const response = await client.chat(messages, { enableCache: true })
+ * const response = await client.chat(messages, { cacheHint: true })
  * const stats = formatCacheStats(response.usage)
  * console.log(stats)
  * // "Cache: 45% read (2,500 tokens), 10% created (500 tokens)"
@@ -146,7 +146,7 @@ export function shouldCache(content: string, minTokens = 1024): boolean {
  *   ],
  * })
  *
- * const response = await client.chat(conversation, { enableCache: true })
+ * const response = await client.chat(conversation, { cacheHint: true })
  * ```
  */
 export function createCachedConversation(config: {
@@ -168,7 +168,7 @@ export function createCachedConversation(config: {
       result.push({
         role: 'system',
         content: doc,
-        ...(isLast ? { cacheControl: { type: 'ephemeral' } } : {}),
+        ...(isLast ? { cache: true } : {}),
       });
     });
   }

--- a/packages/ai/src/llm/providers/__tests__/capabilities.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/capabilities.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Reasoner capabilities() — transport-tier conformance (P2 seed, ADR 2026-06-25).
+ *
+ * Asserts each provider's golden capability profile, the purity/stability invariant
+ * (capabilities() is pure, deterministic, no network), and the cross-capability
+ * consistency invariants. Fully offline — capabilities() makes no network calls.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Reasoner, ReasonerCapabilities } from '../base.js';
+import { GroqProvider } from '../groq.js';
+import { InferenceSnapsProvider } from '../inference-snaps.js';
+import { OllamaProvider } from '../ollama.js';
+import { OpenAICompatProvider } from '../openai-compat.js';
+
+const TEST_URL = 'http://localhost:9999/v1';
+
+const cases: Array<{ name: string; reasoner: Reasoner; expected: ReasonerCapabilities }> = [
+  {
+    name: 'openai-compat',
+    reasoner: new OpenAICompatProvider({ apiKey: 'test', baseURL: TEST_URL }),
+    expected: {
+      providerTag: 'openai-compat',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'inference-snaps',
+    reasoner: new InferenceSnapsProvider({ baseURL: TEST_URL }),
+    expected: {
+      providerTag: 'inference-snaps',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'ollama',
+    reasoner: new OllamaProvider({}),
+    expected: {
+      providerTag: 'ollama',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+  {
+    name: 'groq',
+    reasoner: new GroqProvider({ apiKey: 'test' }),
+    expected: {
+      providerTag: 'groq',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    },
+  },
+];
+
+describe('Reasoner capabilities() — transport-tier conformance', () => {
+  for (const { name, reasoner, expected } of cases) {
+    describe(name, () => {
+      it('matches its golden capability profile', () => {
+        expect(reasoner.capabilities()).toEqual(expected);
+      });
+
+      it('is pure and stable (deterministic, no network)', () => {
+        const first = reasoner.capabilities();
+        for (let i = 0; i < 100; i++) {
+          expect(reasoner.capabilities()).toEqual(first);
+        }
+      });
+
+      it('satisfies the consistency invariants', () => {
+        const caps = reasoner.capabilities();
+        expect(caps.providerTag.length).toBeGreaterThan(0);
+        // parallelToolCalls ⇒ tools
+        if (caps.parallelToolCalls) {
+          expect(caps.tools).toBe(true);
+        }
+        // contextWindow, when declared, is a positive integer
+        if (caps.contextWindow !== undefined) {
+          expect(Number.isInteger(caps.contextWindow)).toBe(true);
+          expect(caps.contextWindow).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});

--- a/packages/ai/src/llm/providers/__tests__/conformance.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/conformance.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Reasoner conformance — transport tier (P2b, ADR 2026-06-25).
+ *
+ * The anti-lying property: for every capability flag the suite runs the POSITIVE
+ * assertion iff `capabilities()[flag] === true`, else the INERTNESS assertion. A
+ * provider that advertises a capability it doesn't wire fails the positive check;
+ * one that advertises false but emits a native field fails the inertness check.
+ *
+ * This tier is offline + deterministic: `fetch` is stubbed and the outbound request
+ * (or the parsed response) is inspected via a request-capture spy. The golden
+ * capability-profile snapshots, purity, and consistency invariants live in the
+ * sibling `capabilities.test.ts`. Behavioral assertions (does prompt-cache actually
+ * cache, does the model actually reason) are non-deterministic and belong to the
+ * env-gated live tier (Tier 2) / the Claude adapter's external tier (Tier 3) — not here.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ToolDefinition } from '../base.js';
+import { GroqProvider } from '../groq.js';
+import { OpenAICompatProvider } from '../openai-compat.js';
+
+type CapturedCall = { url: string; body: Record<string, unknown> };
+
+/** Stub global fetch to capture outbound requests and return a canned JSON response. */
+function stubJsonFetch(responseBody: unknown): CapturedCall[] {
+  const calls: CapturedCall[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const body =
+        typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+      calls.push({ url: String(url), body });
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }),
+  );
+  return calls;
+}
+
+const CHAT_RESPONSE = {
+  choices: [{ message: { content: 'hi' }, finish_reason: 'stop' }],
+  usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+};
+
+const TOOL: ToolDefinition = {
+  type: 'function',
+  function: { name: 'search', description: 'Search the web', parameters: { type: 'object' } },
+};
+
+const newProvider = () =>
+  new OpenAICompatProvider({ apiKey: 'test', baseURL: 'http://localhost:9999/v1' });
+
+describe('Reasoner conformance — transport tier (openai-compat)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('tools', () => {
+    it('positive: advertises tools and forwards them on the wire', async () => {
+      const calls = stubJsonFetch(CHAT_RESPONSE);
+      const p = newProvider();
+      expect(p.capabilities().tools).toBe(true);
+      await p.chat([{ role: 'user', content: 'hi' }], { tools: [TOOL] });
+      expect(calls[0]?.body.tools).toBeDefined();
+    });
+  });
+
+  describe('reasoningEffort (inertness)', () => {
+    it('advertises false and emits no native reasoning field even when effort is set', async () => {
+      const calls = stubJsonFetch(CHAT_RESPONSE);
+      const p = newProvider();
+      expect(p.capabilities().reasoningEffort).toBe(false);
+      await p.chat([{ role: 'user', content: 'hi' }], { effort: 'high' });
+      const body = calls[0]?.body ?? {};
+      expect(body.thinking).toBeUndefined();
+      expect(body.reasoning).toBeUndefined();
+      expect(body.reasoning_effort).toBeUndefined();
+    });
+  });
+
+  describe('promptCache (inertness)', () => {
+    it('advertises false and emits no cache-control even when cacheHint/cache are set', async () => {
+      const calls = stubJsonFetch(CHAT_RESPONSE);
+      const p = newProvider();
+      expect(p.capabilities().promptCache).toBe(false);
+      await p.chat([{ role: 'system', content: 'sys', cache: true }], { cacheHint: true });
+      const serialized = JSON.stringify(calls[0]?.body ?? {});
+      expect(serialized).not.toContain('cache_control');
+      expect(serialized).not.toContain('cacheControl');
+    });
+
+    it('does not surface cache usage fields when promptCache is false', async () => {
+      const calls = stubJsonFetch({
+        choices: [{ message: { content: 'hi' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+          cache_read_input_tokens: 7,
+        },
+      });
+      const p = newProvider();
+      const res = await p.chat([{ role: 'user', content: 'hi' }]);
+      expect(res.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+      expect(res.usage?.cacheReadTokens).toBeUndefined();
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  describe('providerOptions (opaque isolation)', () => {
+    it('never leaks a foreign namespace payload onto the wire', async () => {
+      const calls = stubJsonFetch(CHAT_RESPONSE);
+      const p = newProvider();
+      await p.chat([{ role: 'user', content: 'hi' }], {
+        providerOptions: { 'x-anthropic': { sentinel: 'LEAK_ME_NOT' } },
+      });
+      expect(JSON.stringify(calls[0]?.body ?? {})).not.toContain('LEAK_ME_NOT');
+    });
+  });
+
+  describe('embeddings', () => {
+    it('positive: openai-compat advertises embeddings and returns a vector', async () => {
+      stubJsonFetch({ data: [{ embedding: [0.1, 0.2, 0.3], model: 'm' }] });
+      const p = newProvider();
+      expect(p.capabilities().embeddings).toBe(true);
+      const e = await p.embed('hello');
+      expect(Array.isArray(e)).toBe(false);
+      expect((e as { vector: number[] }).vector).toEqual([0.1, 0.2, 0.3]);
+    });
+
+    it('inertness: groq advertises no embeddings and throws on embed()', () => {
+      const g = new GroqProvider({ apiKey: 'test' });
+      expect(g.capabilities().embeddings).toBe(false);
+      expect(() => g.embed('hello')).toThrow();
+    });
+  });
+
+  describe('streaming', () => {
+    it('positive: advertises streaming, yields content chunks then a terminal done', async () => {
+      const sse =
+        'data: {"choices":[{"delta":{"content":"he"}}]}\n' +
+        'data: {"choices":[{"delta":{"content":"llo"}}]}\n' +
+        'data: [DONE]\n';
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(sse));
+              controller.close();
+            },
+          });
+          return new Response(stream, { status: 200 });
+        }),
+      );
+      const p = newProvider();
+      expect(p.capabilities().streaming).toBe(true);
+
+      let text = '';
+      let sawDone = false;
+      for await (const chunk of p.stream([{ role: 'user', content: 'hi' }])) {
+        text += chunk.content;
+        if (chunk.done) sawDone = true;
+      }
+      expect(text).toBe('hello');
+      expect(sawDone).toBe(true);
+    });
+  });
+});

--- a/packages/ai/src/llm/providers/base.ts
+++ b/packages/ai/src/llm/providers/base.ts
@@ -2,9 +2,10 @@
  * LLM Provider Base Interface
  *
  * The agnostic Reasoner port (ADR 2026-06-25). Providers are negotiated by
- * `capabilities()`, never by provider-name string. Vendor-shaped request knobs are
- * tagged `@deprecated PROVIDER-EXTENSION` and excluded from the agnostic conformance
- * contract; cross-provider usage (e.g. cache token stats) stays neutral.
+ * `capabilities()`, never by provider-name string. The control vocabulary is neutral
+ * and capability-gated (`effort`, `cache`/`cacheHint`); genuinely unportable knobs ride
+ * the namespaced opaque `providerOptions` channel; cross-provider usage (e.g. cache token
+ * stats) stays neutral in `LLMResponse.usage`.
  */
 
 /**
@@ -48,12 +49,6 @@ export interface Message {
    * that supports prompt caching maps this to its native cache-control; others ignore it.
    */
   cache?: boolean;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `cache`. Anthropic-shaped request knob, retained
-   * transitionally for the cache-helper layer; excluded from the agnostic conformance
-   * contract. Callers migrate in P1b, then this is removed.
-   */
-  cacheControl?: { type: 'ephemeral' };
 }
 
 export interface ToolCall {
@@ -184,16 +179,6 @@ export interface LLMChatOptions {
   cacheHint?: boolean;
   /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
   providerOptions?: ProviderOptions;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `cacheHint`. Excluded from the agnostic
-   * conformance contract; callers migrate in P1b, then this is removed.
-   */
-  enableCache?: boolean;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use `effort`. Vendor-shaped token budget; no provider
-   * reads it. Excluded from the agnostic conformance contract; callers migrate in P1b.
-   */
-  thinkingBudget?: number;
 }
 
 export interface LLMEmbedOptions {
@@ -208,11 +193,6 @@ export interface LLMStreamOptions {
   effort?: ReasoningEffort;
   /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
   providerOptions?: ProviderOptions;
-  /**
-   * @deprecated PROVIDER-EXTENSION  -  use the `promptCache` capability + `cacheHint` on chat.
-   * Callers migrate in P1b, then this is removed.
-   */
-  enableCache?: boolean;
 }
 
 export interface ToolDefinition {

--- a/packages/ai/src/llm/providers/base.ts
+++ b/packages/ai/src/llm/providers/base.ts
@@ -1,7 +1,10 @@
 /**
  * LLM Provider Base Interface
  *
- * Abstract interface for all LLM providers (OpenAI, Anthropic, etc.)
+ * The agnostic Reasoner port (ADR 2026-06-25). Providers are negotiated by
+ * `capabilities()`, never by provider-name string. Vendor-shaped request knobs are
+ * tagged `@deprecated PROVIDER-EXTENSION` and excluded from the agnostic conformance
+ * contract; cross-provider usage (e.g. cache token stats) stays neutral.
  */
 
 /**
@@ -40,7 +43,16 @@ export interface Message {
   name?: string;
   toolCalls?: ToolCall[];
   toolCallId?: string;
-  /** Anthropic prompt caching - marks content for caching (5min TTL, 90% cost reduction) */
+  /**
+   * Neutral cache breakpoint hint (gated by the `promptCache` capability). An adapter
+   * that supports prompt caching maps this to its native cache-control; others ignore it.
+   */
+  cache?: boolean;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use `cache`. Anthropic-shaped request knob, retained
+   * transitionally for the cache-helper layer; excluded from the agnostic conformance
+   * contract. Callers migrate in P1b, then this is removed.
+   */
   cacheControl?: { type: 'ephemeral' };
 }
 
@@ -62,7 +74,11 @@ export interface LLMResponse {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
-    /** Anthropic cache stats */
+    /**
+     * Cross-provider cache usage (neutral; gated by `promptCache`). Populated by any
+     * caching provider  -  Anthropic cache tokens, OpenAI `cached_tokens`, Gemini
+     * `cachedContentTokenCount`. Read by the cost path; stays in neutral `usage`.
+     */
     cacheCreationTokens?: number;
     cacheReadTokens?: number;
   };
@@ -89,36 +105,93 @@ export interface LLMProviderConfig {
 }
 
 /**
- * Base interface for LLM providers
+ * Reasoning-depth hint (neutral, capability-gated by `reasoningEffort`).
+ *
+ * This is a *reasoning-depth* axis, NOT output entropy or length  -  adapters must never
+ * remap it to `temperature`/`maxTokens`. An adapter with a reasoning axis maps it to its
+ * native control (e.g. a thinking-token budget); an adapter without one advertises
+ * `reasoningEffort: false` and treats `effort` as a no-op.
  */
-export interface LLMProvider {
-  /**
-   * Chat completion
-   */
+export type ReasoningEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+/**
+ * Runtime-queryable capability record. The loop branches on these, never on a
+ * provider-name string. Conformance-tested (transport tier) so a provider cannot lie:
+ * advertise-true-but-not-wired fails the positive assertion; advertise-false-but-emits-a-
+ * native-field fails the inertness assertion.
+ */
+export interface ReasonerCapabilities {
+  /** Stable adapter id; also the only `providerOptions` namespace this adapter may read ('x-<tag>'). */
+  readonly providerTag: string;
+  readonly tools: boolean;
+  /** Implies `tools` (consistency invariant). */
+  readonly parallelToolCalls: boolean;
+  /** Implies the adapter accepts `ContentPart[]` message content. */
+  readonly vision: boolean;
+  readonly streaming: boolean;
+  readonly embeddings: boolean;
+  readonly reasoningEffort: boolean;
+  readonly promptCache: boolean;
+  readonly structuredOutput: boolean;
+  /** Max context window in tokens; undefined = unknown (loop budgets conservatively). */
+  readonly contextWindow?: number;
+}
+
+/**
+ * Namespaced opaque extension for genuinely unportable, request-shaped knobs.
+ *
+ * Core/loop code MUST pass this through and MUST NOT read any key  -  per-namespace schema
+ * lives in the owning adapter. A known-namespace registry (typed keys) rather than a bare
+ * `x-*` string convention, so a typo'd namespace fails loudly instead of silently no-opping.
+ */
+export interface ProviderOptions {
+  'x-anthropic'?: unknown;
+  'x-openai'?: unknown;
+  'x-google'?: unknown;
+}
+
+/**
+ * The Reasoner port  -  one swappable reasoning step plus the side capabilities
+ * (embeddings/streaming). The loop negotiates by `capabilities()`, never by name.
+ */
+export interface Reasoner {
+  /** Runtime-queryable, conformance-tested capability record. */
+  capabilities(): ReasonerCapabilities;
+
+  /** Chat completion. */
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse>;
 
-  /**
-   * Generate embeddings
-   */
+  /** Generate embeddings. */
   embed(text: string | string[], options?: LLMEmbedOptions): Promise<Embedding | Embedding[]>;
 
-  /**
-   * Stream chat completion
-   */
+  /** Stream chat completion. */
   stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk>;
 }
+
+/**
+ * @deprecated Use `Reasoner`. Alias retained one release cycle for external callers.
+ */
+export type LLMProvider = Reasoner;
 
 export interface LLMChatOptions {
   temperature?: number;
   maxTokens?: number;
   tools?: ToolDefinition[];
   toolChoice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
-  /** Enable prompt caching (Anthropic only) - caches system prompts and tools */
+  /** Neutral reasoning-depth hint (gated by `reasoningEffort`). No-op where unsupported. */
+  effort?: ReasoningEffort;
+  /** Neutral prompt-cache hint for the stable prefix  -  system + tools (gated by `promptCache`). */
+  cacheHint?: boolean;
+  /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
+  providerOptions?: ProviderOptions;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use `cacheHint`. Excluded from the agnostic
+   * conformance contract; callers migrate in P1b, then this is removed.
+   */
   enableCache?: boolean;
   /**
-   * Extended thinking token budget (Anthropic only).
-   * Enables Claude's internal reasoning before responding.
-   * Typical values: 512 (minimal) → 31999 (xhigh). 0 or undefined = disabled.
+   * @deprecated PROVIDER-EXTENSION  -  use `effort`. Vendor-shaped token budget; no provider
+   * reads it. Excluded from the agnostic conformance contract; callers migrate in P1b.
    */
   thinkingBudget?: number;
 }
@@ -131,7 +204,14 @@ export interface LLMStreamOptions {
   temperature?: number;
   maxTokens?: number;
   tools?: ToolDefinition[];
-  /** Enable prompt caching (Anthropic only) - caches system prompts and tools */
+  /** Neutral reasoning-depth hint (gated by `reasoningEffort`). No-op where unsupported. */
+  effort?: ReasoningEffort;
+  /** Opaque, namespaced provider extension. Core never reads it; the adapter owns the schema. */
+  providerOptions?: ProviderOptions;
+  /**
+   * @deprecated PROVIDER-EXTENSION  -  use the `promptCache` capability + `cacheHint` on chat.
+   * Callers migrate in P1b, then this is removed.
+   */
   enableCache?: boolean;
 }
 

--- a/packages/ai/src/llm/providers/groq.ts
+++ b/packages/ai/src/llm/providers/groq.ts
@@ -16,6 +16,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -36,6 +37,21 @@ export class GroqProvider implements LLMProvider {
       baseURL: config.baseURL ?? 'https://api.groq.com/openai/v1',
       model: config.model ?? 'qwen/qwen3-32b',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (qwen/qwen3-32b). Groq exposes no embeddings endpoint.
+    return {
+      providerTag: 'groq',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/inference-snaps.ts
+++ b/packages/ai/src/llm/providers/inference-snaps.ts
@@ -35,6 +35,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -64,6 +65,22 @@ export class InferenceSnapsProvider implements LLMProvider {
       baseURL: config.baseURL,
       model: config.model ?? 'gemma3',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (gemma3, text-only). Per-model capability
+    // negotiation (e.g. qwen-vl vision, deepseek-r1 reasoningEffort) is a follow-up.
+    return {
+      providerTag: 'inference-snaps',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/ollama.ts
+++ b/packages/ai/src/llm/providers/ollama.ts
@@ -16,6 +16,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
@@ -45,6 +46,21 @@ export class OllamaProvider implements LLMProvider {
       baseURL,
       model: config.model ?? 'gemma4:e2b',
     });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Profile for the default model (gemma4:e2b, text-only).
+    return {
+      providerTag: 'ollama',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/providers/openai-compat.ts
+++ b/packages/ai/src/llm/providers/openai-compat.ts
@@ -17,6 +17,7 @@ import type {
   LLMResponse,
   LLMStreamOptions,
   Message,
+  ReasonerCapabilities,
   ToolCall,
 } from './base.js';
 
@@ -85,6 +86,22 @@ export class OpenAICompatProvider implements LLMProvider {
       );
     }
     this.baseURL = config.baseURL;
+  }
+
+  capabilities(): ReasonerCapabilities {
+    // Base OpenAI-compatible profile. Concrete providers (Groq, Ollama, inference-snaps)
+    // override per their endpoint and default model.
+    return {
+      providerTag: 'openai-compat',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
   }
 
   async chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {

--- a/packages/ai/src/llm/token-counter.ts
+++ b/packages/ai/src/llm/token-counter.ts
@@ -23,22 +23,43 @@ export interface CostEstimate {
   direction: 'input' | 'output';
 }
 
-// Cost per 1M tokens (USD)  -  input/output pricing
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // Anthropic
-  'claude-opus-4-6': { input: 15.0, output: 75.0 },
-  'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
-  'claude-haiku-4-5-20251001': { input: 0.25, output: 1.25 },
+/**
+ * Per-1M-token pricing (USD). Single source of truth for every cost path in the package:
+ * `estimateCost` (input/output) and `calculateCacheCost` (cache-utils, cacheWrite/cacheRead).
+ * Cache rates follow Anthropic's model (write ~125% of input, read ~10%); non-caching
+ * providers carry 0 (local models are free; cache cost is not modelled for hosted
+ * non-Anthropic providers here).
+ */
+export interface ModelPricing {
+  /** USD per 1M input tokens. */
+  input: number;
+  /** USD per 1M output tokens. */
+  output: number;
+  /** USD per 1M tokens written to the prompt cache (0 where unsupported/unmodelled). */
+  cacheWrite: number;
+  /** USD per 1M tokens read from the prompt cache (0 where unsupported/unmodelled). */
+  cacheRead: number;
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic (current)
+  'claude-opus-4-6': { input: 15.0, output: 75.0, cacheWrite: 18.75, cacheRead: 1.5 },
+  'claude-sonnet-4-6': { input: 3.0, output: 15.0, cacheWrite: 3.75, cacheRead: 0.3 },
+  'claude-haiku-4-5-20251001': { input: 0.25, output: 1.25, cacheWrite: 0.3125, cacheRead: 0.025 },
+  // Anthropic (legacy 2024  -  retained for cache-cost callers/examples)
+  'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0, cacheWrite: 3.75, cacheRead: 0.3 },
+  'claude-3-5-haiku-20241022': { input: 1.0, output: 5.0, cacheWrite: 1.25, cacheRead: 0.1 },
+  'claude-3-opus-20240229': { input: 15.0, output: 75.0, cacheWrite: 18.75, cacheRead: 1.5 },
   // OpenAI
-  'gpt-4o': { input: 5.0, output: 15.0 },
-  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4o': { input: 5.0, output: 15.0, cacheWrite: 0, cacheRead: 0 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6, cacheWrite: 0, cacheRead: 0 },
   // Groq (Qwen  -  Apache 2.0)
-  'qwen/qwen3-32b': { input: 0.59, output: 0.79 },
+  'qwen/qwen3-32b': { input: 0.59, output: 0.79, cacheWrite: 0, cacheRead: 0 },
   // Ollama (self-hosted  -  no cost)
-  'gemma4:e2b': { input: 0, output: 0 },
-  'gemma4:e4b': { input: 0, output: 0 },
-  'gemma4:26b': { input: 0, output: 0 },
-  'nomic-embed-text': { input: 0, output: 0 },
+  'gemma4:e2b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'gemma4:e4b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'gemma4:26b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  'nomic-embed-text': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
 };
 
 function charsPerToken(model: string): number {

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -7,7 +7,7 @@
 import { registerCleanupHandler } from '@revealui/core/monitoring';
 import { z } from 'zod/v4';
 import type { LLMClient } from '../llm/client.js';
-import type { Message } from '../llm/providers/base.js';
+import type { Message, ReasoningEffort } from '../llm/providers/base.js';
 import { estimateCost } from '../llm/token-counter.js';
 import type { AgentSkillProvider } from '../skills/integration/agent-skill-provider.js';
 import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
@@ -18,28 +18,12 @@ import { createWebSearchTool } from '../tools/web/duck-duck-go.js';
 import type { Agent, AgentResult, Task } from './agent.js';
 
 /**
- * Controls how much of the model's token budget is allocated to internal reasoning.
- * Applies to Anthropic Claude only  -  ignored by other providers.
- *
- * | Level   | Budget (tokens) | Use case                          |
- * |---------|-----------------|-----------------------------------|
- * | off     | 0               | Disabled (default)                |
- * | minimal | 512             | Simple tasks, cost-sensitive      |
- * | low     | 2 048           | Moderate complexity               |
- * | medium  | 8 000           | Multi-step reasoning              |
- * | high    | 16 000          | Complex planning                  |
- * | xhigh   | 31 999          | Maximum depth (expensive)         |
+ * Reasoning-depth hint for a task. Alias of the neutral `ReasoningEffort` — the agnostic
+ * Reasoner port's control vocabulary. Mapping a level to a provider's native control
+ * (e.g. a thinking-token budget) is the adapter's job; a provider that advertises
+ * `reasoningEffort: false` treats it as a no-op.
  */
-export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
-
-const THINKING_BUDGETS: Record<ThinkingLevel, number> = {
-  off: 0,
-  minimal: 512,
-  low: 2048,
-  medium: 8000,
-  high: 16000,
-  xhigh: 31999,
-};
+export type ThinkingLevel = ReasoningEffort;
 
 export interface RuntimeConfig {
   maxIterations?: number;
@@ -219,8 +203,8 @@ export class AgentRuntime {
       {
         role: 'system',
         content: agent.instructions,
-        // Cache agent instructions for cost savings (Anthropic only)
-        cacheControl: this.config.enableCache ? { type: 'ephemeral' } : undefined,
+        // Cache agent instructions for cost savings (effective where promptCache is supported)
+        cache: this.config.enableCache || undefined,
       },
       {
         role: 'user',
@@ -255,12 +239,6 @@ export class AgentRuntime {
           };
         }
 
-        // Resolve thinking budget if a level is configured
-        const thinkingBudget =
-          this.config.thinkingLevel && this.config.thinkingLevel !== 'off'
-            ? THINKING_BUDGETS[this.config.thinkingLevel]
-            : undefined;
-
         // Get LLM response (with caching for agent instructions and tools)
         const response = await llmClient.chat(messages, {
           tools: allTools.map((tool) => ({
@@ -271,8 +249,8 @@ export class AgentRuntime {
               parameters: z.toJSONSchema(tool.parameters) as Record<string, unknown>,
             },
           })),
-          enableCache: this.config.enableCache,
-          thinkingBudget,
+          cacheHint: this.config.enableCache,
+          effort: this.config.thinkingLevel,
         });
 
         // Accumulate token usage and cost

--- a/packages/ai/src/orchestration/streaming-runtime.ts
+++ b/packages/ai/src/orchestration/streaming-runtime.ts
@@ -118,12 +118,12 @@ export class StreamingAgentRuntime extends AgentRuntime {
       content: string;
       toolCalls?: unknown[];
       toolCallId?: string;
-      cacheControl?: { type: string };
+      cache?: boolean;
     }> = [
       {
         role: 'system',
         content: agent.instructions,
-        cacheControl: { type: 'ephemeral' },
+        cache: true,
       },
       {
         role: 'user',

--- a/scripts/validate/boundary.ts
+++ b/scripts/validate/boundary.ts
@@ -339,6 +339,62 @@ function checkPublicRepoProDependencies(): string[] {
 }
 
 // =============================================================================
+// Check 5: Runtime packages must not import vendor LLM SDKs
+// =============================================================================
+
+// The fleet runtime reaches AI only via the Reasoner port / MCP  -  never a vendor
+// SDK (ADR 2026-06-25). Bans static, dynamic import(), and require() of these in
+// every packages/** source file. Enforces an already-true posture, machine-checked.
+const BANNED_RUNTIME_SDKS = ['@anthropic-ai/sdk', 'openai'];
+
+function importsBannedSdk(content: string, sdk: string): boolean {
+  // Match import/export ... from, dynamic import(), and require() of the exact
+  // package or a subpath, in single or double quotes. The closing quote / slash
+  // anchor avoids false positives like the local './openai-compat.js' module.
+  return (
+    content.includes(`from '${sdk}'`) ||
+    content.includes(`from "${sdk}"`) ||
+    content.includes(`from '${sdk}/`) ||
+    content.includes(`from "${sdk}/`) ||
+    content.includes(`import('${sdk}')`) ||
+    content.includes(`import("${sdk}")`) ||
+    content.includes(`import('${sdk}/`) ||
+    content.includes(`import("${sdk}/`) ||
+    content.includes(`require('${sdk}')`) ||
+    content.includes(`require("${sdk}")`) ||
+    content.includes(`require('${sdk}/`) ||
+    content.includes(`require("${sdk}/`)
+  );
+}
+
+function checkVendorSdkBoundary(): string[] {
+  const violations: string[] = [];
+  const allPackageNames = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+
+  for (const pkgName of allPackageNames) {
+    const srcDir = join(PACKAGES_DIR, pkgName, 'src');
+    const files = collectSourceFiles(srcDir);
+
+    for (const file of files) {
+      const content = readFileSync(file, 'utf8');
+      const relPath = relative(REPO_ROOT, file);
+
+      for (const sdk of BANNED_RUNTIME_SDKS) {
+        if (importsBannedSdk(content, sdk)) {
+          violations.push(
+            `  ${relPath}: imports banned vendor SDK '${sdk}'  -  the runtime must reach AI only via the Reasoner port / MCP`,
+          );
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+// =============================================================================
 // Main
 // =============================================================================
 
@@ -384,6 +440,15 @@ function main(): void {
   } else {
     for (const v of publicRepoViolations) console.log(v);
     allViolations.push(...publicRepoViolations);
+  }
+
+  console.log('\n→ Check 5: Runtime packages do not import vendor LLM SDKs');
+  const vendorSdkViolations = checkVendorSdkBoundary();
+  if (vendorSdkViolations.length === 0) {
+    console.log('  ✓ No banned vendor SDK imports in packages/**');
+  } else {
+    for (const v of vendorSdkViolations) console.log(v);
+    allViolations.push(...vendorSdkViolations);
   }
 
   console.log(`\n${Sep}`);


### PR DESCRIPTION
## Summary

- **P1a** — capability-negotiated Reasoner port: `capabilities()`/`ReasoningEffort`/`ProviderOptions` on `LLMProvider`; `LLMProvider` deprecated alias.
- **P1b** — migrate all callers off deprecated fields (`thinkingBudget→effort`, `enableCache→cacheHint`, `cacheControl→cache`) across `runtime.ts`, `cache-utils`, `streaming-runtime`, tests.
- **P1c** — consolidate token-counter and cache-utils cost tables onto a single `MODEL_PRICING` source.
- **P2a** — CI boundary: ban `@anthropic-ai/sdk` and `openai` direct imports in `packages/**` (Check 5).
- **P2b** — transport-tier conformance suite verifying provider-neutral invariants.

## Test plan

- [ ] `turbo typecheck --filter=@revealui/ai` green
- [ ] Capabilities test 12/12
- [ ] Biome clean
- [ ] Promote to main via merge commit (no squash)