### PR TITLE
fix(admin): honor ?redirect= after login + make /upgrade discoverable

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -196,9 +196,15 @@ function BillingContent() {
     };
   }, []);
 
-  // Auto-redirect to checkout on signup with ?upgrade=pro|max
+  // Auto-redirect to checkout on signup with ?upgrade=pro|max, and for churned
+  // users (expired/canceled) arriving with explicit upgrade intent. Never fires
+  // for active or trialing subscribers.
   useEffect(() => {
-    if (upgrade && subscription?.tier === 'free' && !actionLoading) {
+    const canAutoCheckout =
+      subscription?.tier === 'free' ||
+      subscription?.status === 'expired' ||
+      subscription?.status === 'canceled';
+    if (upgrade && canAutoCheckout && !actionLoading) {
       void handleCheckout(upgrade);
     }
   }, [upgrade, subscription, actionLoading, handleCheckout]);
@@ -496,6 +502,17 @@ function BillingContent() {
               {statusLabel}
             </span>
           </div>
+
+          {tier !== 'max' && (
+            <div className="flex items-center justify-end">
+              <Link
+                href="/upgrade"
+                className="text-sm font-medium text-[var(--tenant-brand,#2563eb)] underline hover:no-underline"
+              >
+                Change plan &rarr;
+              </Link>
+            </div>
+          )}
 
           {subscription?.expiresAt && (
             <div className="flex items-center justify-between">

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -18,6 +18,7 @@ import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
+import { safeInternalRedirect } from '@/lib/utils/safe-internal-redirect';
 
 export type OAuthProvider = 'github' | 'google' | 'vercel' | 'linkedin';
 
@@ -94,6 +95,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   const rawUpgrade = searchParams.get('upgrade');
   const upgrade: 'pro' | 'max' | null =
     rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
+  const redirect = safeInternalRedirect(searchParams.get('redirect'));
 
   const anyLoading = isLoading || isPasskeyLoading;
   const hasAlternates = oauthProviders.length > 0 || passkeySupported;
@@ -106,13 +108,13 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
       navigateAfterAuthChange('/rotate-password');
     } else if (result.success) {
-      const dest = isAdminRole(result.user.role)
-        ? upgrade
-          ? `/account/billing?upgrade=${upgrade}`
-          : '/'
-        : upgrade
-          ? `/account/billing?upgrade=${upgrade}`
-          : '/welcome';
+      const dest = upgrade
+        ? `/account/billing?upgrade=${upgrade}`
+        : redirect
+          ? redirect
+          : isAdminRole(result.user.role)
+            ? '/'
+            : '/welcome';
       navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {
       navigateAfterAuthChange('/mfa');
@@ -126,7 +128,9 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     setError(null);
     const success = await passkeySignIn();
     if (success) {
-      navigateAfterAuthChange('/');
+      // Passkey sign-in returns no user object, so role-default falls back to '/'.
+      const dest = upgrade ? `/account/billing?upgrade=${upgrade}` : redirect ? redirect : '/';
+      navigateAfterAuthChange(dest);
     }
   };
 

--- a/apps/admin/src/lib/utils/safe-internal-redirect.ts
+++ b/apps/admin/src/lib/utils/safe-internal-redirect.ts
@@ -1,0 +1,15 @@
+'use client';
+
+/** Validate a same-origin redirect path. Returns the safe path or null. */
+export function safeInternalRedirect(raw: string | null): string | null {
+  if (!raw) return null;
+  if (!raw.startsWith('/') || raw.startsWith('//')) return null; // reject protocol-relative //evil.com
+  if (raw.includes('\\')) return null; // browsers treat \ as / → /\evil.com
+  try {
+    const u = new URL(raw, window.location.origin);
+    if (u.origin !== window.location.origin) return null; // catch-all same-origin guard
+    return u.pathname + u.search + u.hash;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Two fixes to the LIVE-checkout discoverability path in `apps/admin`:

### Bug 1 — login dropped `?redirect=`
The login form read `error`/`message`/`upgrade` from the query string but never `redirect`. Expired sessions on `/upgrade` bounce to `/login?redirect=/upgrade`, but the success branch computed the destination only from role + `upgrade`, so users landed on `/` or `/welcome` and lost their place.

- New `safeInternalRedirect` validator (sibling to `safe-stripe-redirect.ts`): same-origin path check using string methods + the `URL` parser only — no authored regex. Rejects protocol-relative (`//evil.com`), backslash (`/\evil.com`), and cross-origin targets.
- Applied precedence **`upgrade` > `redirect` > role-default** in both the password and passkey success branches. (Passkey returns no user object, so its role-default stays `/`.)

### Bug 2 — `/upgrade` undiscoverable for existing subscribers
The billing page auto-redirected to checkout only when `tier === 'free'`, and nothing linked to `/upgrade` (the full pricing + checkout page), so trialing/expired/canceled subscribers had no path to change plans.

- Added a persistent **"Change plan →"** link to `/upgrade` in the current-plan card, shown for any subscription status and gated `tier !== 'max'`.
- Widened the auto-redirect to also fire for churned users (`status` `expired` or `canceled`) arriving with explicit `?upgrade=` intent — never for active or trialing subscribers. `/api/billing/checkout` already guards duplicate live subscriptions.

## Follow-up (out of scope)
The MFA and rotate-password success branches in `LoginForm` still drop `?redirect=`. Carrying the redirect through those multi-step flows is a separate change.

## Verification
- `pnpm --filter admin typecheck` — clean
- `pnpm --filter admin lint` (Biome) — clean, no fixes applied

Changes are confined to `apps/admin/src/`. Manual merge after CI green (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
