### PR TITLE
fix(admin): carry ?redirect= through MFA and rotate-password login flows

### DIFF
--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -18,7 +18,7 @@ import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
-import { safeInternalRedirect } from '@/lib/utils/safe-internal-redirect';
+import { buildAuthIntentQuery, readAuthIntent, resolveAuthDest } from '@/lib/utils/auth-redirect';
 
 export type OAuthProvider = 'github' | 'google' | 'vercel' | 'linkedin';
 
@@ -92,10 +92,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   );
   const messageKey = searchParams.get('message');
   const successMessage = messageKey ? SUCCESS_MESSAGES[messageKey] : undefined;
-  const rawUpgrade = searchParams.get('upgrade');
-  const upgrade: 'pro' | 'max' | null =
-    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
-  const redirect = safeInternalRedirect(searchParams.get('redirect'));
+  const { upgrade, redirect } = readAuthIntent(searchParams);
 
   const anyLoading = isLoading || isPasskeyLoading;
   const hasAlternates = oauthProviders.length > 0 || passkeySupported;
@@ -106,18 +103,18 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
 
     const result = await signIn({ email, password });
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
-      navigateAfterAuthChange('/rotate-password');
+      // Carry the intent through the rotation step so the destination survives it.
+      navigateAfterAuthChange(`/rotate-password${buildAuthIntentQuery({ upgrade, redirect })}`);
     } else if (result.success) {
-      const dest = upgrade
-        ? `/account/billing?upgrade=${upgrade}`
-        : redirect
-          ? redirect
-          : isAdminRole(result.user.role)
-            ? '/'
-            : '/welcome';
+      const dest = resolveAuthDest({
+        upgrade,
+        redirect,
+        fallback: isAdminRole(result.user.role) ? '/' : '/welcome',
+      });
       navigateAfterAuthChange(dest);
     } else if ('requiresMfa' in result && result.requiresMfa) {
-      navigateAfterAuthChange('/mfa');
+      // Carry the intent through the MFA step so the destination survives it.
+      navigateAfterAuthChange(`/mfa${buildAuthIntentQuery({ upgrade, redirect })}`);
     } else {
       const errorMessage = 'error' in result ? result.error : 'Failed to sign in';
       setError(errorMessage || 'Failed to sign in');
@@ -129,8 +126,7 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     const success = await passkeySignIn();
     if (success) {
       // Passkey sign-in returns no user object, so role-default falls back to '/'.
-      const dest = upgrade ? `/account/billing?upgrade=${upgrade}` : redirect ? redirect : '/';
-      navigateAfterAuthChange(dest);
+      navigateAfterAuthChange(resolveAuthDest({ upgrade, redirect, fallback: '/' }));
     }
   };
 

--- a/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
@@ -6,6 +6,9 @@
  * router.push. The App Router client cache still holds the logged-out RSC
  * payload for '/' (a redirect back to /login), so a soft push after sign-in
  * replays it and bounces the user straight back to /login.
+ *
+ * Also covers the ?redirect= / ?upgrade= intent: honored on direct success and
+ * carried through the /mfa and /rotate-password intermediate steps.
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -17,6 +20,8 @@ const mockNavigate = vi.fn();
 const mockPush = vi.fn();
 // Set per-test to render the passkey button.
 let mockPasskeySupported = false;
+// Set per-test to drive useSearchParams.
+let mockSearchParams: Record<string, string | null> = {};
 
 vi.mock('@revealui/auth/react', () => ({
   useSignIn: () => ({ signIn: mockSignIn, isLoading: false }),
@@ -30,7 +35,7 @@ vi.mock('@revealui/auth/react', () => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => ({ get: (k: string) => mockSearchParams[k] ?? null }),
 }));
 
 vi.mock('@/lib/utils/auth-navigation', () => ({
@@ -69,6 +74,7 @@ afterEach(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   mockPasskeySupported = false;
+  mockSearchParams = {};
 });
 
 function fillAndSubmit(): void {
@@ -112,6 +118,21 @@ describe('LoginForm post-sign-in navigation', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it('honors a ?redirect= over the role default on direct success', async () => {
+    mockSearchParams = { redirect: '/upgrade' };
+    mockSignIn.mockResolvedValue({
+      success: true,
+      user: { id: '2', email: 'subscriber@example.com', role: 'user' },
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/upgrade');
+    });
+  });
+
   it('full-navigates to /rotate-password when the account requires rotation', async () => {
     mockSignIn.mockResolvedValue({
       success: true,
@@ -128,6 +149,22 @@ describe('LoginForm post-sign-in navigation', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it('carries ?redirect= through the /rotate-password step', async () => {
+    mockSearchParams = { redirect: '/upgrade' };
+    mockSignIn.mockResolvedValue({
+      success: true,
+      user: { id: '1', email: 'owner@example.com' },
+      requiresPasswordRotation: true,
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/rotate-password?redirect=%2Fupgrade');
+    });
+  });
+
   it('full-navigates to /mfa when the server answers with an MFA challenge', async () => {
     mockSignIn.mockResolvedValue({ success: false, requiresMfa: true, mfaUserId: 'u-1' });
 
@@ -138,6 +175,18 @@ describe('LoginForm post-sign-in navigation', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/mfa');
     });
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('carries ?upgrade= and ?redirect= through the /mfa step', async () => {
+    mockSearchParams = { upgrade: 'pro', redirect: '/upgrade' };
+    mockSignIn.mockResolvedValue({ success: false, requiresMfa: true, mfaUserId: 'u-1' });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/mfa?upgrade=pro&redirect=%2Fupgrade');
+    });
   });
 
   it('shows the error and does not navigate on a failed sign-in', async () => {
@@ -162,6 +211,19 @@ describe('LoginForm post-sign-in navigation', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('honors ?redirect= after a successful passkey sign-in', async () => {
+    mockPasskeySupported = true;
+    mockSearchParams = { redirect: '/upgrade' };
+    mockPasskeySignIn.mockResolvedValue(true);
+
+    render(<LoginForm oauthProviders={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Passkey' }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/upgrade');
+    });
   });
 
   it('stays put when a passkey sign-in is cancelled or fails', async () => {

--- a/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
@@ -8,14 +8,38 @@ import {
   InputCVA as Input,
 } from '@revealui/presentation/server';
 import Link from 'next/link';
-import { type ChangeEvent, type FormEvent, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
+import { readAuthIntent, resolveAuthDest } from '@/lib/utils/auth-redirect';
 
 function filterDigits(value: string): string {
   return [...value].filter((c) => c >= '0' && c <= '9').join('');
 }
 
+function MFASkeleton() {
+  return (
+    <div className="w-full max-w-sm space-y-6">
+      <div className="h-7 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      <div className="space-y-4">
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-11 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+    </div>
+  );
+}
+
 export function MFAForm() {
+  return (
+    <Suspense fallback={<MFASkeleton />}>
+      <MFAContent />
+    </Suspense>
+  );
+}
+
+function MFAContent() {
+  const searchParams = useSearchParams();
+  const { upgrade, redirect } = readAuthIntent(searchParams);
   const { verify, verifyBackupCode, isLoading, error } = useMFAVerify();
   const [code, setCode] = useState('');
   const [useBackupCode, setUseBackupCode] = useState(false);
@@ -38,7 +62,8 @@ export function MFAForm() {
     const success = useBackupCode ? await verifyBackupCode(code.trim()) : await verify(code.trim());
 
     if (success) {
-      navigateAfterAuthChange('/');
+      // No user object from MFA verify, so the role-default falls back to '/'.
+      navigateAfterAuthChange(resolveAuthDest({ upgrade, redirect, fallback: '/' }));
     }
   };
 

--- a/apps/admin/src/app/(frontend)/mfa/__tests__/MFAForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/__tests__/MFAForm.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Tests for MFAForm's post-verify navigation — must be a full document
  * navigation so the App Router client cache from the pre-auth state is
- * discarded (same class as the LoginForm sign-in bounce).
+ * discarded (same class as the LoginForm sign-in bounce), and must honor the
+ * upgrade/redirect intent carried through the MFA step from login.
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -10,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockVerify = vi.fn();
 const mockVerifyBackupCode = vi.fn();
 const mockNavigate = vi.fn();
+// Set per-test to drive useSearchParams.
+let mockSearchParams: Record<string, string | null> = {};
 
 vi.mock('@revealui/auth/react', () => ({
   useMFAVerify: () => ({
@@ -18,6 +21,10 @@ vi.mock('@revealui/auth/react', () => ({
     isLoading: false,
     error: null,
   }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: (k: string) => mockSearchParams[k] ?? null }),
 }));
 
 vi.mock('@/lib/utils/auth-navigation', () => ({
@@ -43,6 +50,7 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSearchParams = {};
 });
 
 function submitCode(code: string): void {
@@ -53,6 +61,42 @@ function submitCode(code: string): void {
 
 describe('MFAForm post-verify navigation', () => {
   it('full-navigates home after a successful TOTP verification', async () => {
+    mockVerify.mockResolvedValue(true);
+
+    render(<MFAForm />);
+    submitCode('123456');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('honors a redirect carried through the MFA step', async () => {
+    mockSearchParams = { redirect: '/upgrade' };
+    mockVerify.mockResolvedValue(true);
+
+    render(<MFAForm />);
+    submitCode('123456');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/upgrade');
+    });
+  });
+
+  it('honors an upgrade intent carried through the MFA step (over redirect)', async () => {
+    mockSearchParams = { upgrade: 'pro', redirect: '/somewhere' };
+    mockVerify.mockResolvedValue(true);
+
+    render(<MFAForm />);
+    submitCode('123456');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/account/billing?upgrade=pro');
+    });
+  });
+
+  it('ignores an off-origin redirect and falls back home', async () => {
+    mockSearchParams = { redirect: '//evil.com' };
     mockVerify.mockResolvedValue(true);
 
     render(<MFAForm />);

--- a/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
+++ b/apps/admin/src/app/(frontend)/rotate-password/RotatePasswordForm.tsx
@@ -6,12 +6,38 @@ import {
   Heading,
   InputCVA as Input,
 } from '@revealui/presentation/server';
-import { type ChangeEvent, type FormEvent, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { type ChangeEvent, type FormEvent, Suspense, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
+import { readAuthIntent, resolveAuthDest } from '@/lib/utils/auth-redirect';
 import { apiFetch } from '@/lib/utils/csrf';
 
+function RotatePasswordSkeleton() {
+  return (
+    <div className="w-full max-w-md space-y-6">
+      <div className="h-7 w-56 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      <div className="space-y-4">
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="h-11 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+    </div>
+  );
+}
+
 export function RotatePasswordForm() {
+  return (
+    <Suspense fallback={<RotatePasswordSkeleton />}>
+      <RotatePasswordContent />
+    </Suspense>
+  );
+}
+
+function RotatePasswordContent() {
+  const searchParams = useSearchParams();
+  const { upgrade, redirect } = readAuthIntent(searchParams);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -54,7 +80,8 @@ export function RotatePasswordForm() {
         return;
       }
 
-      navigateAfterAuthChange('/');
+      // No user object from the rotation step, so the role-default falls back to '/'.
+      navigateAfterAuthChange(resolveAuthDest({ upgrade, redirect, fallback: '/' }));
     } catch {
       setError('An unexpected error occurred.');
     } finally {

--- a/apps/admin/src/app/(frontend)/rotate-password/__tests__/RotatePasswordForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/rotate-password/__tests__/RotatePasswordForm.test.tsx
@@ -2,7 +2,8 @@
  * Tests for RotatePasswordForm's post-rotation navigation — must be a full
  * document navigation so the App Router client cache from the
  * rotation-pending state is discarded (same class as the LoginForm sign-in
- * bounce).
+ * bounce), and must honor the upgrade/redirect intent carried through the
+ * rotation step from login.
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -10,9 +11,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockApiFetch = vi.fn();
 const mockNavigate = vi.fn();
+// Set per-test to drive useSearchParams.
+let mockSearchParams: Record<string, string | null> = {};
 
 vi.mock('@/lib/utils/csrf', () => ({
   apiFetch: (url: string, init?: RequestInit) => mockApiFetch(url, init),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: (k: string) => mockSearchParams[k] ?? null }),
 }));
 
 vi.mock('@/lib/utils/auth-navigation', () => ({
@@ -43,6 +50,7 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSearchParams = {};
 });
 
 function fillAndSubmit(): void {
@@ -65,6 +73,30 @@ describe('RotatePasswordForm post-rotation navigation', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('honors a redirect carried through the rotation step', async () => {
+    mockSearchParams = { redirect: '/upgrade' };
+    mockApiFetch.mockResolvedValue({ ok: true });
+
+    render(<RotatePasswordForm />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/upgrade');
+    });
+  });
+
+  it('honors an upgrade intent carried through the rotation step (over redirect)', async () => {
+    mockSearchParams = { upgrade: 'max', redirect: '/somewhere' };
+    mockApiFetch.mockResolvedValue({ ok: true });
+
+    render(<RotatePasswordForm />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/account/billing?upgrade=max');
     });
   });
 

--- a/apps/admin/src/lib/utils/__tests__/auth-redirect.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/auth-redirect.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAuthIntentQuery,
+  parseUpgrade,
+  readAuthIntent,
+  resolveAuthDest,
+} from '../auth-redirect';
+
+const reader = (params: Record<string, string | null>) => ({
+  get: (k: string) => params[k] ?? null,
+});
+
+describe('parseUpgrade', () => {
+  it('accepts the known checkout plans', () => {
+    expect(parseUpgrade('pro')).toBe('pro');
+    expect(parseUpgrade('max')).toBe('max');
+  });
+
+  it('rejects unknown values and null', () => {
+    expect(parseUpgrade('enterprise')).toBeNull();
+    expect(parseUpgrade('')).toBeNull();
+    expect(parseUpgrade(null)).toBeNull();
+  });
+});
+
+describe('resolveAuthDest', () => {
+  it('prefers upgrade over redirect and fallback', () => {
+    expect(resolveAuthDest({ upgrade: 'pro', redirect: '/somewhere', fallback: '/welcome' })).toBe(
+      '/account/billing?upgrade=pro',
+    );
+  });
+
+  it('uses the redirect when there is no upgrade', () => {
+    expect(resolveAuthDest({ upgrade: null, redirect: '/upgrade', fallback: '/welcome' })).toBe(
+      '/upgrade',
+    );
+  });
+
+  it('falls back when neither upgrade nor redirect is present', () => {
+    expect(resolveAuthDest({ upgrade: null, redirect: null, fallback: '/welcome' })).toBe(
+      '/welcome',
+    );
+  });
+});
+
+describe('buildAuthIntentQuery', () => {
+  it('returns an empty string when there is no intent', () => {
+    expect(buildAuthIntentQuery({ upgrade: null, redirect: null })).toBe('');
+  });
+
+  it('encodes upgrade and redirect into a query string', () => {
+    const qs = buildAuthIntentQuery({ upgrade: 'max', redirect: '/upgrade?ref=email' });
+    const parsed = new URLSearchParams(qs.slice(1));
+    expect(parsed.get('upgrade')).toBe('max');
+    expect(parsed.get('redirect')).toBe('/upgrade?ref=email');
+  });
+});
+
+describe('readAuthIntent', () => {
+  it('parses the upgrade and validates a same-origin redirect', () => {
+    expect(readAuthIntent(reader({ upgrade: 'pro', redirect: '/upgrade' }))).toEqual({
+      upgrade: 'pro',
+      redirect: '/upgrade',
+    });
+  });
+
+  it('drops an off-origin redirect and an invalid upgrade', () => {
+    expect(readAuthIntent(reader({ upgrade: 'bogus', redirect: '//evil.com' }))).toEqual({
+      upgrade: null,
+      redirect: null,
+    });
+  });
+
+  it('round-trips intent carried through an intermediate step', () => {
+    // buildAuthIntentQuery (login) -> readAuthIntent (/mfa, /rotate-password)
+    const qs = buildAuthIntentQuery({ upgrade: 'pro', redirect: '/upgrade?ref=email' });
+    expect(readAuthIntent(new URLSearchParams(qs.slice(1)))).toEqual({
+      upgrade: 'pro',
+      redirect: '/upgrade?ref=email',
+    });
+  });
+});

--- a/apps/admin/src/lib/utils/auth-redirect.ts
+++ b/apps/admin/src/lib/utils/auth-redirect.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { safeInternalRedirect } from '@/lib/utils/safe-internal-redirect';
+
+export type UpgradePlan = 'pro' | 'max';
+
+/** Narrow a raw ?upgrade= value to a known checkout plan, or null. */
+export function parseUpgrade(raw: string | null): UpgradePlan | null {
+  return raw === 'pro' || raw === 'max' ? raw : null;
+}
+
+/** A URLSearchParams-like reader (matches Next's useSearchParams() return). */
+interface ParamReader {
+  get(key: string): string | null;
+}
+
+/**
+ * Read the upgrade + validated same-origin redirect intent from a query reader.
+ * `redirect` is passed through safeInternalRedirect, so the result is always a
+ * safe internal path or null.
+ */
+export function readAuthIntent(searchParams: ParamReader): {
+  upgrade: UpgradePlan | null;
+  redirect: string | null;
+} {
+  return {
+    upgrade: parseUpgrade(searchParams.get('upgrade')),
+    redirect: safeInternalRedirect(searchParams.get('redirect')),
+  };
+}
+
+/**
+ * Resolve the post-auth destination with precedence upgrade > redirect > fallback.
+ * `upgrade` routes to the billing checkout entry; `redirect` must already be a
+ * validated same-origin path (see readAuthIntent / safeInternalRedirect).
+ */
+export function resolveAuthDest(opts: {
+  upgrade: UpgradePlan | null;
+  redirect: string | null;
+  fallback: string;
+}): string {
+  if (opts.upgrade) return `/account/billing?upgrade=${opts.upgrade}`;
+  if (opts.redirect) return opts.redirect;
+  return opts.fallback;
+}
+
+/**
+ * Build the query string ('' or '?...') that carries upgrade/redirect intent
+ * through an intermediate auth step (e.g. /mfa, /rotate-password) so the final
+ * destination survives the multi-step flow.
+ */
+export function buildAuthIntentQuery(opts: {
+  upgrade: UpgradePlan | null;
+  redirect: string | null;
+}): string {
+  const params = new URLSearchParams();
+  if (opts.upgrade) params.set('upgrade', opts.upgrade);
+  if (opts.redirect) params.set('redirect', opts.redirect);
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}


### PR DESCRIPTION
## Summary

Follow-up to #1632. That PR made login honor `?redirect=` (open-redirect-safe) in the **password** and **passkey** success branches, but flagged that the **MFA** and **rotate-password** branches still dropped it. This carries the intent through those two multi-step flows.

Both are intermediate steps: a user arriving from `/login?redirect=/upgrade` who then hits an MFA challenge or a forced password rotation should still land on `/upgrade` (or the `?upgrade=` checkout) after completing the step — not at login time.

## Changes

- **New `apps/admin/src/lib/utils/auth-redirect.ts`** — shared, no authored regex:
  - `parseUpgrade` — narrows `?upgrade=` to `'pro' | 'max' | null`
  - `readAuthIntent` — parses `upgrade` + validates `redirect` via the existing `safeInternalRedirect`
  - `resolveAuthDest` — precedence **`upgrade` > `redirect` > `fallback`**
  - `buildAuthIntentQuery` — carries intent forward as a query string through an intermediate step
- **`LoginForm.tsx`** — carries the intent into `/mfa` and `/rotate-password`; refactored onto `resolveAuthDest` for the password + passkey branches (behavior unchanged there, dedupes the precedence logic).
- **`MFAForm.tsx` / `RotatePasswordForm.tsx`** — read the carried intent (Suspense-wrapped for `useSearchParams`) and resolve the destination on success. Both fall back to `/` since neither step yields a user object for role-defaulting.

## Safety

Open-redirect-safe end to end: `redirect` is re-validated with `safeInternalRedirect` on **every hop** (login read, and again when each intermediate form reads it back). Off-origin / protocol-relative / backslash targets are dropped at each step.

## Verification

- `pnpm --filter admin typecheck` — clean
- `pnpm --filter admin lint` (Biome) — clean
- Affected tests — **30 passing**: new `auth-redirect` unit suite + carry-through cases across `LoginForm`, `MFAForm`, `RotatePasswordForm`

Changes confined to `apps/admin/src/`. Manual merge after CI green (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
