### PR TITLE
fix(marketing): meet WCAG AA contrast on the pricing "Save 20%" badge

### DIFF
--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -199,7 +199,7 @@ export function PricingPage() {
                   }`}
                 >
                   Annually
-                  <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-700 dark:text-green-400">
+                  <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-800 dark:text-green-400">
                     Save 20%
                   </span>
                 </button>


### PR DESCRIPTION
## Summary

Fixes a **pre-existing** WCAG 2.1 AA color-contrast violation on the marketing pricing page that is currently failing the **Accessibility (E2E)** gate (and is already red on `main`).

The annual-discount **"Save 20%"** badge (`apps/marketing/app/routes/PricingPage.tsx:202`) rendered `text-green-700` on the translucent `bg-green-500/15` pill — **3.96:1** contrast, below the **4.5:1** AA floor for 12px text. axe flags it as a serious `color-contrast` violation.

## Fix

`text-green-700` → `text-green-800` (light mode only). On the same background this computes to **~5.7:1** — comfortably above 4.5:1. The `dark:text-green-400` variant is untouched (the dark pairing was not flagged).

Contrast verified by hand against the exact colors axe reported (the method reproduces axe's 3.96:1 for the old color before predicting 5.7:1 for the new). The Accessibility (E2E) job re-runs on this PR and proves it.

## Why now

This violation is the **only** thing blocking the `test → main` promotion PR (#1634), which carries the live-checkout login/redirect fixes (#1632/#1633) needed to unblock the Gate 6 live-Stripe smoke. Landing this on `test` lets #1634 go green.

## Verification

- `pnpm --filter marketing typecheck` — clean (after building workspace deps)
- Biome — no new warnings (5 pre-existing marketing warnings unchanged)
- Accessibility (E2E) — re-run by CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
