### PR TITLE
fix(admin): remove duplicate Upgrade button from seat-limit warning

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -443,20 +443,12 @@ function BillingContent() {
               </div>
             )}
             {seats.max !== null && seats.active >= seats.max && (
-              <div className="flex items-center justify-between gap-3 rounded-lg bg-red-50 p-3 dark:bg-red-950/30">
+              <div className="rounded-lg bg-red-50 p-3 dark:bg-red-950/30">
                 <p className="text-xs text-red-600 dark:text-red-400">
                   {seats.tier === 'max'
                     ? "You've reached your seat limit. Contact us about Enterprise to add more members."
-                    : "You've reached your seat limit. Upgrade to add more members."}
+                    : 'You\'ve reached your seat limit. Use "Change plan" above to add more members.'}
                 </p>
-                {seats.tier !== 'max' && (
-                  <Link
-                    href={`/account/billing?upgrade=${seats.tier === 'free' ? 'pro' : 'max'}`}
-                    className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
-                  >
-                    Upgrade
-                  </Link>
-                )}
               </div>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary

- Removes the redundant "Upgrade" `<Link>` button from the Team Seats seat-limit warning block in `/account/billing`
- PR #1637 (billing-card-clarity) already added a universal "Change plan →" button to the Current Plan card, making this button duplicate
- Updates warning copy from `"Upgrade to add more members."` → `"Use \"Change plan\" above to add more members."`

## Why

Two upgrade entry points appeared simultaneously for a free user at their seat limit — the pre-existing Upgrade button in the Team Seats warning *and* the new "Change plan →" from #1637. Single entry point is cleaner and avoids confusion about which one to use.

## Test plan

- [ ] Navigate to `/account/billing` as a free user at seat limit — confirm only the "Change plan →" button appears in the Current Plan card, no second Upgrade button below
- [ ] Verify max-tier users still see the "Contact us about Enterprise" message (unchanged path)
- [ ] `pnpm --filter admin typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)