### PR TITLE
fix(setup): make BLOB_READ_WRITE_TOKEN optional (R2 migration)

### DIFF
--- a/packages/setup/src/validators/env.ts
+++ b/packages/setup/src/validators/env.ts
@@ -135,8 +135,11 @@ export const REQUIRED_ENV_VARS: EnvVariable[] = [
   },
   {
     name: 'BLOB_READ_WRITE_TOKEN',
-    description: 'Vercel Blob storage token',
-    required: true,
+    // Legacy Vercel Blob token — being retired in favor of Cloudflare R2 (GAP-208).
+    // Optional to match the config schema (packages/config/src/schema.ts), so a
+    // fresh R2-only deploy does not fail validation on a token it no longer needs.
+    description: 'Vercel Blob storage token (legacy; optional — superseded by R2)',
+    required: false,
   },
   {
     name: 'STRIPE_SECRET_KEY',


### PR DESCRIPTION
Closes #1640

## Summary

The setup env validator marked `BLOB_READ_WRITE_TOKEN` as **required**, but the config schema (`packages/config/src/schema.ts:45`) marks the same variable `.optional()` and labels it legacy — being retired in favor of Cloudflare R2 (GAP-208).

A fresh R2-only deployment that calls `setupEnvironment()` without explicit overrides failed validation on a token it no longer needs. This flips the setup validator entry to `required: false` so setup agrees with config.

## Verification

- `pnpm --filter @revealui/setup build` — clean
- `pnpm --filter @revealui/setup test` — 79/79 pass (no test asserted the token as required)

## Posture

Base `test`. Surfaced by the 2026-06-27 redundancy/wiring re-audit. No `--auto`, no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
