### PR TITLE
fix(contracts): allow 'archived' in ProductStatusSchema to match db CHECK

### DIFF
--- a/packages/contracts/src/entities/product.ts
+++ b/packages/contracts/src/entities/product.ts
@@ -94,7 +94,9 @@ export type StripePriceList = z.infer<typeof StripePriceListSchema>;
 // Product Status
 // =============================================================================
 
-export const ProductStatusSchema = z.enum(['draft', 'published']);
+// Mirrors the db CHECK constraint (packages/db/src/schema/products.ts PRODUCT_STATUSES);
+// 'archived' must be included or archived rows throw on ProductSchema.parse().
+export const ProductStatusSchema = z.enum(['draft', 'published', 'archived']);
 export type ProductStatus = z.infer<typeof ProductStatusSchema>;
 
 // =============================================================================


### PR DESCRIPTION
Closes #1638

## Summary

`ProductStatusSchema` in `@revealui/contracts` allowed only `['draft', 'published']`, but the database CHECK constraint (`packages/db/src/schema/products.ts` `PRODUCT_STATUSES`) allows `['draft', 'published', 'archived']`. Any archived product row failed `ProductSchema.parse()`, so archived products could not round-trip from the db through the contract layer.

Adds `'archived'` to the enum so contracts matches the db source of truth.

## Consumer audit (before widening)

- `rg ProductStatusSchema|ProductStatus` — contracts-internal `_status` usages (`product.ts:175,208`) treat it as a plain enum; no 2-value assumption.
- The marketing app has its own unrelated `ProductStatus` type (`Beta|Alpha|...`), not imported from contracts.

## Verification

- `pnpm --filter @revealui/contracts build` — clean
- `pnpm --filter @revealui/contracts test` — 934/934 pass

## Posture

Base `test`. Surfaced by the 2026-06-27 redundancy/wiring re-audit. No `--auto`, no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
