### PR TITLE
fix(contracts): rename Page publishAt -> scheduledAt to match db column

### DIFF
--- a/packages/contracts/src/__tests__/entities/page.test.ts
+++ b/packages/contracts/src/__tests__/entities/page.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { PageSchema, UpdatePageInputSchema } from '../../entities/page.js';
+
+// Regression for revealui#1639: the contracts Page field for scheduled-publish
+// time is named `scheduledAt`, matching the db column `scheduled_at`
+// (packages/db/src/schema/pages.ts). The field used to be named `publishAt`,
+// which never lined up with the db column, so a db row's scheduled-publish value
+// was silently dropped on a key-based round-trip through the contract layer.
+
+const SCHEDULED_AT = '2026-07-01T12:00:00.000Z';
+
+// Shaped like a db row → contract bridge would hand to PageSchema.parse(),
+// using the db (drizzle) property name `scheduledAt`.
+const dbShapedPage = {
+  id: 'page_123',
+  siteId: 'site_123',
+  title: 'Launch Announcement',
+  slug: 'launch-announcement',
+  path: '/launch-announcement',
+  status: 'scheduled' as const,
+  blocks: [],
+  scheduledAt: SCHEDULED_AT,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+describe('PageSchema scheduledAt (revealui#1639)', () => {
+  it('round-trips scheduledAt from a db-shaped row without dropping it', () => {
+    const parsed = PageSchema.parse(dbShapedPage);
+    expect(parsed.scheduledAt).toBe(SCHEDULED_AT);
+  });
+
+  it('treats the legacy publishAt key as unknown (stripped, not mapped)', () => {
+    const { scheduledAt, ...withoutScheduled } = dbShapedPage;
+    const legacy = { ...withoutScheduled, publishAt: SCHEDULED_AT } as Record<string, unknown>;
+    const parsed = PageSchema.parse(legacy);
+    // The renamed schema no longer carries the scheduled-publish value under the
+    // old key, and Zod strips the unknown `publishAt` — proving the old name was
+    // exactly the round-trip drift.
+    expect(parsed.scheduledAt).toBeUndefined();
+    expect('publishAt' in parsed).toBe(false);
+  });
+
+  it('allows scheduledAt to be omitted (optional)', () => {
+    const { scheduledAt, ...withoutScheduled } = dbShapedPage;
+    const parsed = PageSchema.parse(withoutScheduled);
+    expect(parsed.scheduledAt).toBeUndefined();
+  });
+});
+
+describe('UpdatePageInputSchema scheduledAt (revealui#1639)', () => {
+  it('accepts scheduledAt on update input', () => {
+    const parsed = UpdatePageInputSchema.parse({ scheduledAt: SCHEDULED_AT });
+    expect(parsed.scheduledAt).toBe(SCHEDULED_AT);
+  });
+});

--- a/packages/contracts/src/entities/page.ts
+++ b/packages/contracts/src/entities/page.ts
@@ -127,8 +127,8 @@ export const PageSchema = DualEntitySchema.extend({
   /** Sort order within parent */
   order: z.number().int().nonnegative().default(0),
 
-  /** Scheduled publish time */
-  publishAt: z.string().datetime().optional(),
+  /** Scheduled publish time (maps to db column `scheduled_at`) */
+  scheduledAt: z.string().datetime().optional(),
 
   /** Last published time */
   publishedAt: z.string().datetime().optional(),
@@ -383,7 +383,7 @@ export const UpdatePageInputSchema = z.object({
   blocks: z.array(BlockSchema).optional(),
   seo: PageSeoSchema.partial().optional(),
   order: z.number().int().nonnegative().optional(),
-  publishAt: z.string().datetime().optional(),
+  scheduledAt: z.string().datetime().optional(),
 });
 
 export type UpdatePageInput = z.infer<typeof UpdatePageInputSchema>;


### PR DESCRIPTION
Closes #1639

## Summary

The contracts Page schema exposed the scheduled-publish field as `publishAt`, but the database column is `scheduled_at` (drizzle property `scheduledAt`, `packages/db/src/schema/pages.ts:68`). The names never lined up, so a db row's scheduled-publish value was silently dropped on a key-based round-trip through the Page contract.

This renames the contracts field — in both `PageSchema` and `UpdatePageInputSchema` — from `publishAt` to `scheduledAt`, matching the db source of truth.

## Why rename (not bridge-map)

`publishAt` had **zero consumers** across the repo — `rg "publishAt"` returns only the two schema definitions. With no consumer blast radius, renaming to match the db column is the targeted fix the issue prefers over an explicit bridge map.

## Test

Adds `packages/contracts/src/__tests__/entities/page.test.ts`:
- a db-shaped row's `scheduledAt` survives `PageSchema.parse()` (the round-trip the issue asks for);
- the legacy `publishAt` key is now an unknown and Zod strips it — i.e. the old name *was* the drift;
- `scheduledAt` is optional and accepted on `UpdatePageInputSchema`.

## Verification

- `pnpm --filter @revealui/contracts build` — clean
- `pnpm --filter @revealui/contracts test` — 938/938 pass (+4 new)

## Out of scope (noted, not fixed)

The server route's *own* inline page schema (`apps/server/src/routes/content/pages.ts` `serializePage`) does not yet expose the scheduling field at all — a separate gap tracked under the re-audit's unwired-surface clusters (C11), not addressed here.

## Posture

Base `test`. Surfaced by the 2026-06-27 redundancy/wiring re-audit. No `--auto`, no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
