### PR TITLE
chore(cli): remove deprecated `revealui shell` top-level alias

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -11,6 +11,13 @@ describe('cli', () => {
     expect(commandNames).toContain('db');
     expect(commandNames).toContain('dev');
     expect(commandNames).toContain('migrate');
-    expect(commandNames).toContain('shell');
+  });
+
+  it('no longer exposes the deprecated top-level `shell` alias', () => {
+    const cli = createCli();
+    const commandNames = cli.commands.map((command) => command.name());
+
+    // Removed at #1642 — replaced by `revealui dev shell` (and `revealui dev up`).
+    expect(commandNames).not.toContain('shell');
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -378,22 +378,5 @@ export function createCli(): Command {
       await runMigrateCommand(options);
     });
 
-  // TODO(v1.0.0): remove deprecated `revealui shell` top-level alias.
-  // Migration path: users should run `revealui dev shell` (or `revealui dev up`).
-  // See §4.18 Phase A audit (.jv/docs/audits/legacy-sweep-2026-04-27.md §2.3).
-  program
-    .command('shell')
-    .description('Deprecated alias for `revealui dev shell` — will be removed at v1.0.0')
-    .option('--ensure', 'Initialize/start the local DB when possible', false)
-    .option('--json', 'Output machine-readable JSON', false)
-    .option('--inside', 'Internal flag used after re-entering nix develop', false)
-    .action(async (options: { ensure?: boolean; json?: boolean; inside?: boolean }) => {
-      await runDevUpCommand({
-        ensure: options.ensure,
-        json: options.json,
-        inside: options.inside,
-      });
-    });
-
   return program;
 }


### PR DESCRIPTION
## What

Removes the deprecated top-level `revealui shell` command. It was an alias for `revealui dev shell` / `revealui dev up`, carrying an in-code TODO targeting removal at v1.0.0. The replacement `dev` subcommands are fully wired, so the alias is now dropped.

## Changes

- **`packages/cli/src/cli.ts`** — delete the deprecated top-level `shell` command block (the one carrying the `TODO(v1.0.0)` comment). The `revealui dev shell` subcommand and `revealui dev up` are untouched.
- **`packages/cli/src/__tests__/cli.test.ts`** — flip the `expect(commandNames).toContain('shell')` assertion to a dedicated case asserting the top-level `shell` command is **no longer** registered, so coverage proves the removal rather than merely dropping the check.

## Verification

- `pnpm --filter @revealui/cli test` — 20 files / 213 tests pass.
- Built-binary smoke: top-level `shell` is absent from `revealui --help`; `revealui dev shell` and `revealui dev up` still resolve under `revealui dev --help`.
- Grepped docs/examples/scripts — nothing else invoked the bare `revealui shell` (only the now-removed TODO comment referenced it).

Closes #1642