### PR TITLE
fix(server): remove dead terminal-ws output poll timer, document the gap

### DIFF
--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -134,30 +134,16 @@ export function createTerminalRoute(): {
     upgradeWebSocket((c) => {
       const sessionId = c.req.param('id');
 
-      // Poll daemon for output via a persistent socket connection
-      let outputSocket: ReturnType<typeof createConnection> | null = null;
-      let closed = false;
+      // NOTE: output streaming is not yet implemented on this remote bridge.
+      // Desktop clients receive agent output via the Tauri event system; the
+      // remote WebSocket path needs the daemon to expose an output stream
+      // (SSE / JSON-RPC subscription), which it does not have yet. Until then
+      // this bridge forwards INPUT (keystrokes + resize) and leaves session
+      // lifecycle to the REST endpoints. A previous 100ms output-poll timer
+      // here did no work and burned CPU per open connection, so it was removed.
+      // Real output streaming is tracked in revealui#1650.
 
       return {
-        onOpen(_event, _ws) {
-          // Subscribe to agent output by polling daemon
-          // The daemon emits 'output' events  -  we poll via a long-lived connection
-          // For now, use periodic RPC polling until daemon supports event streaming
-          const pollInterval = setInterval(async () => {
-            if (closed) {
-              clearInterval(pollInterval);
-              return;
-            }
-            // Output streaming is handled by the Tauri event system for desktop.
-            // For remote WebSocket, the daemon's HTTP gateway SSE endpoint
-            // would be the proper source. For now, the WebSocket bridge
-            // forwards input and handles session lifecycle.
-          }, 100);
-
-          // Clean up on close
-          outputSocket = null; // placeholder for future event stream
-        },
-
         onMessage(event, ws) {
           try {
             const msg = JSON.parse(
@@ -193,14 +179,6 @@ export function createTerminalRoute(): {
             }
           } catch {
             ws.send(JSON.stringify({ type: 'error', message: 'Invalid message' }));
-          }
-        },
-
-        onClose() {
-          closed = true;
-          if (outputSocket) {
-            outputSocket.destroy();
-            outputSocket = null;
           }
         },
       };


### PR DESCRIPTION
Closes #1641

## Summary

The terminal WebSocket route (`apps/server/src/routes/terminal-ws.ts`) started a 100 ms `setInterval` whose callback only checked a `closed` flag and otherwise did nothing — the output-streaming RPC was never implemented. Every open connection burned a 100 ms timer for no work, and no agent output ever reached the client. The **input** path (keystrokes + resize) was unaffected.

## Approach (interim, option b)

Per the issue, this is the interim fix, not the full output stream:

- Remove the dead `setInterval`, the unused `outputSocket` placeholder, the now-dead `closed` flag, and the `onClose` handler that only tore those down.
- The handler now forwards input and leaves session lifecycle to the REST endpoints, with a comment documenting that remote output streaming is not yet implemented.

The real fix — a daemon SSE / JSON-RPC output subscription forwarded to the WebSocket client — is tracked as a follow-up in **#1650**.

## Diff shape

`1 file changed, 8 insertions(+), 30 deletions(-)` — net deletion of dead code.

## Verification

- `pnpm --filter server typecheck` — passes clean (exit 0) after building workspace deps.

## Posture

Base `test`. Surfaced by the 2026-06-27 redundancy/wiring re-audit. No `--auto`, no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
