### PR TITLE
chore(db): remove deprecated 'vector' DatabaseType alias + fix stale Supabase doc comments (#1643, #1645)

### DIFF
--- a/packages/db/src/__tests__/client/connection-failures.test.ts
+++ b/packages/db/src/__tests__/client/connection-failures.test.ts
@@ -669,7 +669,7 @@ describe('database connection failures', () => {
       expect(() => getClient('rest')).toThrow('Database connection string not provided');
     });
 
-    it('throws when no connection string is available for vector client (aliased to rest)', async () => {
+    it('falls back to rest for the removed "vector" alias (throws with no connection string)', async () => {
       Reflect.deleteProperty(process.env, 'POSTGRES_URL');
       Reflect.deleteProperty(process.env, 'DATABASE_URL');
 
@@ -677,6 +677,9 @@ describe('database connection failures', () => {
       const { getClient, resetClient } = await import('../../client/index.js');
       resetClient();
 
+      // 'vector' is no longer a recognized DatabaseType (removed in #1643); as an
+      // unrecognized string it falls through to the default 'rest' client, which
+      // throws when no connection string is set.
       expect(() => getClient('vector')).toThrow('Database connection string not provided');
     });
   });

--- a/packages/db/src/__tests__/client/pool.test.ts
+++ b/packages/db/src/__tests__/client/pool.test.ts
@@ -247,10 +247,13 @@ describe('client/index  -  pool management', () => {
       expect(() => getClient('rest')).toThrow('Database connection string not provided');
     });
 
-    it('throws when no connection string is available for vector (aliased to rest)', () => {
+    it('falls back to rest for the removed "vector" alias (throws with no connection string)', () => {
       delete process.env.POSTGRES_URL;
       delete process.env.DATABASE_URL;
 
+      // 'vector' is no longer a recognized DatabaseType (removed in #1643); it falls
+      // through to the default 'rest' client, which throws when no connection string
+      // is set.
       expect(() => getClient('vector')).toThrow('Database connection string not provided');
     });
 

--- a/packages/db/src/cleanup/cross-db-cleanup.ts
+++ b/packages/db/src/cleanup/cross-db-cleanup.ts
@@ -3,10 +3,11 @@
  *
  * Removes orphaned vector data (agent memories + RAG documents/chunks) for
  * sites that have been soft-deleted in NeonDB. Runs against a single NeonDB
- * connection — historical "cross-DB" framing referred to a dual-DB (NeonDB +
- * Supabase) architecture that is being phased out; these tables now live on
- * the same database, but the soft-delete fanout is still needed because sites
- * use soft-delete (`deletedAt`) rather than hard-delete.
+ * connection — the "cross-DB" name is historical: it referred to a dual-DB
+ * (NeonDB + Supabase) architecture whose internal Supabase half was removed in
+ * May 2026. These tables now all live in the single Neon database, but the
+ * soft-delete fanout is still needed because sites use soft-delete (`deletedAt`)
+ * rather than hard-delete, so the FK cascade never fires for a soft-deleted site.
  *
  * Affected tables:
  * - agentMemories.siteId       -> sites.id

--- a/packages/db/src/client/__tests__/dual-client.test.ts
+++ b/packages/db/src/client/__tests__/dual-client.test.ts
@@ -1,8 +1,8 @@
 /**
  * Single Database Client Tests
  *
- * Tests that getClient('rest') and getClient('vector') both return the same
- * single Neon-primary client.
+ * Tests for the single Neon-primary client returned by getClient('rest').
+ * The legacy 'vector' alias was removed in #1643.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -37,15 +37,6 @@ describe('Single Database Client', () => {
   afterEach(() => {
     Reflect.deleteProperty(process.env, 'POSTGRES_URL');
     Reflect.deleteProperty(process.env, 'DATABASE_URL');
-  });
-
-  it('getClient("vector") returns the same client as getClient("rest")', () => {
-    const restClient = getClient('rest');
-    const vectorClient = getClient('vector');
-
-    expect(restClient).toBeDefined();
-    expect(vectorClient).toBeDefined();
-    expect(restClient).toBe(vectorClient);
   });
 
   it('returns same client instance for same type (singleton)', () => {

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -6,8 +6,9 @@
  * Uses node-postgres (pg Pool) with drizzle-orm/node-postgres for localhost / 127.0.0.1
  * connections (development and test environments).
  *
- * The 'vector' database type resolves to the same single client as 'rest' following Supabase
- * removal per docs/decisions/2026-05-01-supabase-removal.md (GAP-129 PR-C).
+ * A single 'rest' database type selects this client. The legacy 'vector' type
+ * (a holdover from the dual-DB Supabase era) was removed per
+ * docs/decisions/2026-05-01-supabase-removal.md (GAP-129 PR-C).
  *
  * Connection String Format:
  * - NeonDB: postgresql://...@neon.tech/...
@@ -60,9 +61,11 @@ let restSupportsTransactions = false;
 /**
  * Database type selector.
  * - 'rest': Neon-primary Postgres connection
- * - 'vector': deprecated alias for 'rest'; will be removed after 1-2 release cycles (GAP-129 PR-C)
+ *
+ * The legacy 'vector' alias (a holdover from the dual-DB Supabase era) was
+ * removed per GAP-129 PR-C; see docs/decisions/2026-05-01-supabase-removal.md.
  */
-export type DatabaseType = 'rest' | 'vector';
+export type DatabaseType = 'rest';
 
 /**
  * Database client type (Drizzle ORM client)
@@ -229,7 +232,6 @@ function registerPoolCleanup() {
  * Uses config module if available, otherwise falls back to process.env for backward compatibility.
  *
  * @param typeOrConnectionString - Database type ('rest') or connection string (legacy API).
- *   'vector' is a deprecated alias for 'rest' (GAP-129 PR-C); prefer 'rest' in new code.
  * @returns Database client instance
  *
  * @example
@@ -243,12 +245,11 @@ function registerPoolCleanup() {
  */
 // Note: DatabaseType | string union is intentional for backward compatibility (allows both type strings and connection strings)
 export function getClient(typeOrConnectionString?: DatabaseType | string): Database {
-  // Legacy API: If first argument is a string and not 'rest' or 'vector', treat as connection string
+  // Legacy API: If first argument is a string and not 'rest', treat as connection string
   if (typeOrConnectionString && typeof typeOrConnectionString === 'string') {
-    if (typeOrConnectionString === 'rest' || typeOrConnectionString === 'vector') {
+    if (typeOrConnectionString === 'rest') {
       // New API: Type specified
-      const type = typeOrConnectionString as DatabaseType;
-      return getClientByType(type);
+      return getClientByType();
     } else if (
       typeOrConnectionString.startsWith('postgresql://') ||
       typeOrConnectionString.startsWith('postgres://')
@@ -262,19 +263,13 @@ export function getClient(typeOrConnectionString?: DatabaseType | string): Datab
   }
 
   // Default to 'rest' for backward compatibility
-  return getClientByType('rest');
+  return getClientByType();
 }
 
 /**
- * Internal function to get client by type.
- * 'vector' is aliased to 'rest' (Supabase removed per GAP-129 PR-C).
+ * Internal function to get (or lazily create) the single 'rest' client.
  */
-function getClientByType(type: DatabaseType): Database {
-  if (type === 'vector') {
-    return getClientByType('rest');
-  }
-
-  // type === 'rest'
+function getClientByType(): Database {
   if (!restClient) {
     // Try to get from config module (ESM - lazy validation via Proxy)
     let url: string | undefined;
@@ -371,7 +366,7 @@ export function getRestPool(): Pool | null {
     const url = process.env.POSTGRES_URL || process.env.DATABASE_URL;
     if (!url) return null;
     try {
-      getClientByType('rest');
+      getClientByType();
     } catch {
       return null;
     }
@@ -454,7 +449,7 @@ export async function closeAllPools(): Promise<void> {
 /**
  * Asserts that the database supports transactions. Call at app startup to fail fast.
  *
- * @param dbType - Database type to check ('rest', or deprecated 'vector' alias)
+ * @param dbType - Database type to check ('rest')
  * @throws {Error} If the database driver does not support transactions
  *
  * @example

--- a/packages/db/src/schema/rag.ts
+++ b/packages/db/src/schema/rag.ts
@@ -1,9 +1,11 @@
 /**
  * RAG (Retrieval-Augmented Generation) Tables
  *
- * Stored on Supabase (vector database) because rag_chunks uses pgvector.
- * The ragDocuments → ragChunks FK cascade is enforced within Supabase.
- * The workspaceId → sites.id reference is cross-database (type-only, not enforced at runtime).
+ * Stored on Neon (Postgres) because rag_chunks uses the pgvector extension.
+ * The ragDocuments → ragChunks FK cascade is enforced within the same Neon database.
+ * The workspaceId → sites.id reference is a same-database FK; because sites are
+ * soft-deleted (deletedAt) rather than hard-deleted, orphaned rows are reclaimed by
+ * @revealui/db/cleanup rather than by the FK cascade.
  *
  * Embedding dimensions: 768 (nomic-embed-text via Ollama  -  policy default)
  */

--- a/packages/db/src/schema/vector.ts
+++ b/packages/db/src/schema/vector.ts
@@ -3,11 +3,11 @@
  *
  * Schemas for AI/vector operations that require pgvector.
  *
- * ARCHITECTURE NOTE: Despite the "vector" naming, `agentMemories` currently
- * lives in NeonDB (not Supabase) because its FK constraints reference
- * NeonDB's `sites` and `users` tables. Cross-database FKs are not possible.
- * The table is re-exported here for semantic grouping (it uses vector embeddings),
- * but its data resides in the REST (Neon) database.
+ * NAMING NOTE: the "vector" name refers to pgvector embeddings, not a separate
+ * vector database. Every table grouped here lives in the single Neon (Postgres)
+ * database alongside the rest of the schema. `agentMemories` is grouped here
+ * because it uses vector embeddings, and its FK constraints reference Neon's
+ * `sites` and `users` tables.
  *
  * RAG tables also require pgvector and follow the same pattern.
  */
@@ -19,9 +19,9 @@ export type {
   NewAgentMemory as NewAgentMemoryType,
 } from './agents.js';
 // Re-export table + types for convenience.
-// agentMemories lives in NeonDB (not Supabase) due to FK constraints on sites/users,
-// but is re-exported here because published @revealui/ai imports it from this path.
+// agentMemories lives in the Neon database; it is re-exported here because the
+// published @revealui/ai package imports it from this path.
 export { agentMemories } from './agents.js';
 
-// RAG tables (pgvector-backed, stored on Supabase)
+// RAG tables (pgvector-backed, stored on Neon)
 export * from './rag.js';

--- a/packages/scripts/database/connection.ts
+++ b/packages/scripts/database/connection.ts
@@ -13,7 +13,9 @@ import type { Pool, PoolClient } from 'pg';
 import { createLogger, detectDatabaseProvider, type Logger } from '../index.js';
 import { getSSLConfig } from './ssl-config.js';
 
-export type DatabaseType = 'rest' | 'vector';
+// The legacy 'vector' alias was removed per GAP-129 PR-C (Supabase removal);
+// see docs/decisions/2026-05-01-supabase-removal.md.
+export type DatabaseType = 'rest';
 
 export interface ConnectionConfig {
   connectionString: string;


### PR DESCRIPTION
## Summary

Removes the deprecated `'vector'` `DatabaseType` alias and fixes stale
"Stored on Supabase" doc comments. Both issues stem from the GAP-129 internal
Supabase removal: the RAG / vector tables now live on Neon (Postgres + pgvector),
and `'vector'` was only ever a deprecated alias of `'rest'`.

Closes #1643
Closes #1645

## #1643 — remove the `'vector'` DatabaseType alias

- Narrow `DatabaseType` to `'rest'` only in `@revealui/db`
  (`packages/db/src/client/index.ts`) and `@revealui/scripts`
  (`packages/scripts/database/connection.ts`).
- Drop the alias-resolution branches in `getClient` and `getClientByType`;
  `getClientByType` no longer needs a `type` parameter (the single `'rest'`
  client is the only option).
- Update the tests that referenced the alias:
  - `dual-client.test.ts` — drop the now-meaningless `getClient('vector') === getClient('rest')`
    equality test (and its unused import); the header notes the alias was removed.
  - `connection-failures.test.ts` / `pool.test.ts` — reword the two
    no-connection-string cases: `'vector'` is no longer a recognized type, so as an
    unrecognized string it falls through to the default `'rest'` client (which still
    throws when no connection string is set). Behavior is unchanged; the names/comments
    were stale.

No production call sites referenced `'vector'` (verified by grep across `packages` and `apps`).

## #1645 — fix stale Supabase doc comments

Internal Supabase was fully removed in May 2026; these comments still claimed the
RAG / vector data lived on Supabase.

- `schema/rag.ts` — header now says the tables live on Neon (pgvector), the FK
  cascade is enforced within the same Neon database, and orphan reclamation runs via
  `@revealui/db/cleanup` because sites are soft-deleted.
- `schema/vector.ts` — clarify that the `"vector"` name refers to pgvector embeddings,
  not a separate vector database; everything is on Neon.
- `cleanup/cross-db-cleanup.ts` — tighten the header: the dual-DB ("cross-DB") framing
  is historical (Supabase half removed May 2026). The soft-delete fanout is still
  required (the FK cascade never fires for a soft-deleted site), so the function stays.

## Out of scope

`packages/mcp/src/servers/supabase.ts` (customer-facing MCP adapter, intentionally
retained) is untouched.

## Verification

- `pnpm --filter @revealui/db test` — 52 files, 1170 passing (5 skipped)
- `pnpm --filter @revealui/db typecheck` — clean
- `pnpm --filter @revealui/scripts typecheck` — clean
- Pre-push gate (lint / coverage) — pass
