### PR TITLE
fix(admission): scope the deployment-license user cap to self-hosted only

### DIFF
--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -107,14 +107,19 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Enforce user limit based on license tier (free: 3, pro: 25, enterprise: unlimited)
-    // Also track whether this is the first user  -  they get admin role automatically.
+    // The deployment-license user cap is a self-hosted (Forge) concept and must
+    // NOT gate hosted onboarding (it would cap the whole control plane at the
+    // free seat count). Mode detection mirrors apps/server validate-startup:
+    // license-signing-key presence ⇒ hosted multi-tenant deployment, where
+    // admission is governed per-account rather than by a deployment-global cap.
+    const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    // Track whether this is the first user  -  they get admin role automatically.
     let isFirstUser = false;
     try {
       await initializeLicense();
       const maxUsers = getMaxUsers();
       const db = getClient();
-      if (maxUsers !== Infinity) {
+      if (maxUsers !== Infinity && isSelfHostedForge) {
         // Check user limit. Prefer advisory lock inside a transaction to serialize
         // concurrent sign-up limit checks (prevents TOCTOU race). Falls back to a
         // non-atomic count when the driver doesn't support transactions (e.g. Neon HTTP).

--- a/apps/server/src/middleware/__tests__/resource-limits.test.ts
+++ b/apps/server/src/middleware/__tests__/resource-limits.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mock dependencies
@@ -149,6 +149,13 @@ describe('enforceSiteLimit', () => {
 // enforceUserLimit
 // ---------------------------------------------------------------------------
 describe('enforceUserLimit', () => {
+  // The deployment-license user cap is self-hosted (Forge) only; mode = forge
+  // when REVEALUI_LICENSE_PRIVATE_KEY is absent. Default every case to forge so
+  // the cap is active, except the explicit hosted case below.
+  beforeEach(() => {
+    delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+  });
+
   it('passes when under the user limit', async () => {
     mockedGetMaxUsers.mockReturnValue(25);
     const db = createMockDb(10);
@@ -180,6 +187,33 @@ describe('enforceUserLimit', () => {
     const res = await app.request('/users', { method: 'POST' });
 
     expect(res.status).toBe(201);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('still enforces the cap on self-hosted Forge (no signing key)', async () => {
+    mockedGetMaxUsers.mockReturnValue(3);
+    const db = createMockDb(3);
+
+    const app = createUserLimitApp(db);
+    const res = await app.request('/users', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    const body = await parseBody(res);
+    expect(body.error).toContain('User limit reached');
+  });
+
+  it('skips the cap on hosted SaaS (deployment mode = hosted)', async () => {
+    // Hosted mode is detected by REVEALUI_LICENSE_PRIVATE_KEY presence; the
+    // global deployment-license cap must not gate hosted onboarding.
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-signing-key';
+    mockedGetMaxUsers.mockReturnValue(3);
+    const db = createMockDb(9999); // far over any cap
+
+    const app = createUserLimitApp(db);
+    const res = await app.request('/users', { method: 'POST' });
+
+    expect(res.status).toBe(201);
+    // The global active-user count query must NOT run on hosted.
     expect(db.select).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/middleware/resource-limits.ts
+++ b/apps/server/src/middleware/resource-limits.ts
@@ -15,6 +15,7 @@ import { accountMemberships, type sites, type users } from '@revealui/db/schema'
 import { count, eq, inArray } from 'drizzle-orm';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 
 /**
  * Get all user IDs that belong to the same account as the given user.
@@ -95,6 +96,17 @@ export const enforceSiteLimit = (getSitesTable: () => typeof sites): MiddlewareH
  */
 export const enforceUserLimit = (getUsersTable: () => typeof users): MiddlewareHandler => {
   return async (c, next) => {
+    // The deployment-license user cap is a SELF-HOSTED (Forge) concept: a
+    // stamped kit is licensed for N seats. On a hosted multi-tenant deployment
+    // one process serves every tenant, so a global active-user count would cap
+    // the entire deployment rather than any one tenant. Hosted admission is
+    // governed per-account, not by a deployment-global seat count — so enforce
+    // this cap only in self-hosted (Forge) mode.
+    if (detectDeploymentMode(process.env as EnvMap) !== 'forge') {
+      await next();
+      return;
+    }
+
     const db = c.get('db') as DatabaseClient | undefined;
 
     if (!db) {

--- a/docs/runbooks/checkout-smoke-production.md
+++ b/docs/runbooks/checkout-smoke-production.md
@@ -47,6 +47,7 @@ vercel env ls --environment production | grep -E "STRIPE_|REVEALUI_|SENTRY_DSN|D
 - [ ] The checkout session creation code sets `metadata.tier` (see Failure Mode #4 — this is a **different** metadata bag from `revealui_tier` above)
 - [ ] `pnpm stripe:seed` has run against the **production** Stripe account at least once (idempotent; safe to re-run)
 - [ ] `STRIPE_LIVE_MODE=true` is set in Vercel production environment
+- [ ] **Signup is not capped.** The server must be in **hosted** mode so the deployment-license user cap is skipped on `/api/auth/signup`. Hosted mode is detected by `REVEALUI_LICENSE_PRIVATE_KEY` being set (env table above; `detectDeploymentMode` at `apps/server/src/lib/validate-startup.ts:128`). Verify a brand-new email can sign up even when ≥3 active users already exist — a `403 USER_LIMIT_REACHED` here means the server is mis-detected as self-hosted (signing key missing). The deployment-license seat cap is a self-hosted (Forge) concept and must not gate hosted onboarding.
 
 ### Health-check the server
 


### PR DESCRIPTION
## What

The active-user cap (`enforceUserLimit`) counts active users across the whole
deployment and blocks signup at `getMaxUsers()` (free tier = 3). That seat cap
models a single self-hosted install licensed for N seats; on a hosted
multi-tenant deployment one process serves all tenants, so it limited the
entire deployment instead of any one tenant.

## Change

Scope the cap to **self-hosted (Forge) mode only**, detected by the absence of
the license signing key (`detectDeploymentMode`,
`apps/server/src/lib/validate-startup.ts:128`). On hosted, signup admission is
per-account, not deployment-global. The admin sign-up cap gets the same
conditioning. Self-hosted kits are unchanged.

## Files

- `apps/server/src/middleware/resource-limits.ts` — `enforceUserLimit` skips on hosted
- `apps/admin/src/app/api/auth/sign-up/route.ts` — admin cap skips on hosted
- `apps/server/src/middleware/__tests__/resource-limits.test.ts` — hosted-skips + forge-still-enforces
- `docs/runbooks/checkout-smoke-production.md` — signup admission pre-flight check

## Validation

- `resource-limits.test.ts`: 9 passing (2 new — hosted skip, forge enforce).
- Biome clean; typecheck clean.

Base `test`, manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
