### PR TITLE
feat(auth): provision a personal account + owner membership at signup (hosted)

### DIFF
--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -68,6 +68,8 @@ vi.mock('@revealui/db/client', () => ({
 vi.mock('@revealui/db/schema', () => ({
   users: { email: 'email', id: 'id' },
   oauthAccounts: { providerEmail: 'providerEmail', id: 'id' },
+  accounts: { id: 'id', slug: 'slug' },
+  accountMemberships: { id: 'id', accountId: 'accountId', userId: 'userId' },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -355,6 +357,35 @@ describe('auth', () => {
   // signUp
   // =========================================================================
   describe('signUp', () => {
+    // Personal-account provisioning at signup is hosted-only (license signing
+    // key present). Default to absent (Forge) so existing cases are unaffected;
+    // the hosted case sets it explicitly.
+    beforeEach(() => {
+      delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    });
+
+    it('provisions a personal account + owner membership on hosted SaaS', async () => {
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-signing-key';
+      mockLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await signUp('acct@example.com', 'StrongPass1', 'Acct User');
+      expect(result.success).toBe(true);
+
+      const valueCalls = mockInsertValues.mock.calls.map((c) => c[0]);
+      // account insert (Workspace name + slug) + owner membership insert
+      expect(
+        valueCalls.some(
+          (v) =>
+            typeof v.name === 'string' &&
+            v.name.includes('Workspace') &&
+            typeof v.slug === 'string',
+        ),
+      ).toBe(true);
+      expect(
+        valueCalls.some((v) => v.role === 'owner' && v.status === 'active' && Boolean(v.accountId)),
+      ).toBe(true);
+    });
+
     it('creates user and returns session token on success', async () => {
       // First limit call: user lookup (no existing)
       // Second limit call: OAuth check (no existing)

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -7,7 +7,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db/client';
-import { oauthAccounts, users } from '@revealui/db/schema';
+import { accountMemberships, accounts, oauthAccounts, users } from '@revealui/db/schema';
 import bcrypt from 'bcryptjs';
 import { and, eq, isNull } from 'drizzle-orm';
 import type { SignInResult, SignUpResult, User } from '../types.js';
@@ -440,6 +440,42 @@ export async function signUp(
         success: false,
         error: 'Failed to create session',
       };
+    }
+
+    // Provision a personal billing account + owner membership so a hosted tenant
+    // exists from signup. Best-effort: the Stripe billing webhook
+    // (ensureHostedAccount) is idempotent on an active membership and backfills
+    // this if it fails here, so a transient error never blocks signup. Skipped on
+    // self-hosted (Forge) deployments — single-tenant, no per-user accounts (mode
+    // detected by the license signing key, as in apps/server validate-startup).
+    if (process.env.REVEALUI_LICENSE_PRIVATE_KEY) {
+      try {
+        const accountId = crypto.randomUUID();
+        const now = new Date();
+        await db.insert(accounts).values({
+          id: accountId,
+          name: `${user.name || 'RevealUI'} Workspace`,
+          slug: `acct-${accountId}`,
+          status: 'active',
+          createdAt: now,
+          updatedAt: now,
+        });
+        await db.insert(accountMemberships).values({
+          id: crypto.randomUUID(),
+          accountId,
+          userId: user.id,
+          role: 'owner',
+          status: 'active',
+          createdAt: now,
+          updatedAt: now,
+        });
+      } catch {
+        logger.error(
+          'Failed to provision personal account at signup (billing webhook will backfill)',
+          undefined,
+          { userId: user.id },
+        );
+      }
     }
 
     // Return the raw (unhashed) token so the caller can include it in the


### PR DESCRIPTION
## What

Hosted `signUp` created only a `users` row — a tenant (`account` +
`account_membership`) existed only after the first Stripe billing webhook. This
makes signup provision a **personal billing account + owner membership at t0**,
so a per-account boundary exists from the moment a user signs up.

## Why it's safe

- **Best-effort + non-fatal:** wrapped in `try/catch`; a failure logs and
  continues — signup still succeeds.
- **Idempotent backstop:** `apps/server` `ensureHostedAccount` (the Stripe
  webhook path) is idempotent on an active membership, so it **reuses** the
  signup-created account (no duplicate) and **backfills** if provisioning failed
  here. No transaction/cleanup fragility on the onboarding path.
- **Hosted-gated:** skipped on self-hosted (Forge) deployments — single-tenant,
  no per-user accounts. Detected by the license signing key, as in
  `apps/server/src/lib/validate-startup.ts`.

## Files

- `packages/auth/src/server/auth.ts` — create `account` + owner
  `account_membership` after session creation (hosted only).
- `packages/auth/src/server/__tests__/auth.test.ts` — new hosted-provisioning
  test; existing Forge-mode cases unaffected (provisioning skipped without the
  signing key).

## Validation

- `auth.test.ts`: 36 passing (1 new). Typecheck + Biome clean.

Base `test`, manual merge. (Independent of the Part-1 admission PR — different files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
