### PR TITLE
refactor(admin): adopt presentation primitives in the agents area (Phase 3a)

### DIFF
--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { A2AAgentCard } from '@revealui/contracts';
-import { Breadcrumb } from '@revealui/presentation/client';
+import { Badge, Breadcrumb, ButtonCVA, Card, LinkButton } from '@revealui/presentation';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, use, useEffect, useState } from 'react';
 import { AgentContexts } from '@/lib/components/agents/agent-contexts';
@@ -170,6 +170,7 @@ export default function AgentDetailPage({ params }: PageProps) {
             </div>
           )}
 
+          {/* Inline error banner — Alert primitive is a modal dialog, not applicable */}
           {error && (
             <div
               role="alert"
@@ -184,7 +185,7 @@ export default function AgentDetailPage({ params }: PageProps) {
               {/* Left: Agent metadata */}
               <div className="flex flex-col gap-6">
                 {/* Identity */}
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   {isEditing ? (
                     <div className="flex flex-col gap-4">
                       <div>
@@ -244,6 +245,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                           className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
                         />
                       </div>
+                      {/* Inline save error — Alert primitive is a modal dialog, not applicable */}
                       {saveError && (
                         <div
                           role="alert"
@@ -253,22 +255,24 @@ export default function AgentDetailPage({ params }: PageProps) {
                         </div>
                       )}
                       <div className="flex gap-2 pt-1">
-                        <button
+                        <ButtonCVA
                           type="button"
                           onClick={handleSave}
                           disabled={saving || !editName.trim()}
-                          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                          variant="default"
+                          size="sm"
                         >
                           {saving ? 'Saving...' : 'Save'}
-                        </button>
-                        <button
+                        </ButtonCVA>
+                        <ButtonCVA
                           type="button"
                           onClick={handleEditCancel}
                           disabled={saving}
-                          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                          variant="outline"
+                          size="sm"
                         >
                           Cancel
-                        </button>
+                        </ButtonCVA>
                       </div>
                     </div>
                   ) : (
@@ -276,17 +280,16 @@ export default function AgentDetailPage({ params }: PageProps) {
                       <div className="flex items-start justify-between gap-3">
                         <h1 className="text-xl font-semibold text-foreground">{card.name}</h1>
                         <div className="flex shrink-0 items-center gap-2">
-                          <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
-                            v{card.version}
-                          </span>
-                          <button
+                          <Badge color="success">v{card.version}</Badge>
+                          <ButtonCVA
                             type="button"
                             onClick={handleEditStart}
                             disabled={loadingDef}
-                            className="rounded-lg border border-border px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                            variant="outline"
+                            size="sm"
                           >
                             {loadingDef ? '...' : 'Edit'}
-                          </button>
+                          </ButtonCVA>
                         </div>
                       </div>
                       <p className="mt-2 text-sm text-muted-foreground">{card.description}</p>
@@ -297,10 +300,10 @@ export default function AgentDetailPage({ params }: PageProps) {
                       )}
                     </>
                   )}
-                </div>
+                </Card>
 
                 {/* Capabilities */}
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Capabilities
                   </h2>
@@ -338,10 +341,10 @@ export default function AgentDetailPage({ params }: PageProps) {
                       <dd className="text-muted-foreground">{card.defaultInputModes.join(', ')}</dd>
                     </div>
                   </dl>
-                </div>
+                </Card>
 
                 {/* Skills */}
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Skills ({card.skills.length})
                   </h2>
@@ -358,29 +361,27 @@ export default function AgentDetailPage({ params }: PageProps) {
                         {skill.tags && skill.tags.length > 0 && (
                           <div className="mt-1.5 flex flex-wrap gap-1">
                             {skill.tags.map((tag) => (
-                              <span
-                                key={tag}
-                                className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
-                              >
+                              <Badge key={tag} color="muted">
                                 {tag}
-                              </span>
+                              </Badge>
                             ))}
                           </div>
                         )}
                       </li>
                     ))}
                   </ul>
-                </div>
+                </Card>
 
                 {/* Agent Card JSON link */}
-                <a
+                <LinkButton
                   href={`${apiUrl}/.well-known/agents/${agentId}/agent.json`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="rounded-lg border border-border bg-muted px-4 py-2.5 text-center text-sm text-muted-foreground transition-colors hover:bg-muted/80"
+                  external
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-center"
                 >
                   View Agent Card JSON ↗
-                </a>
+                </LinkButton>
 
                 {/* Danger zone  -  built-in agents are protected */}
                 {!BUILTIN_AGENTS.has(agentId) && (
@@ -392,6 +393,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                           Retire <strong className="text-foreground">{card.name}</strong>? This
                           removes the agent from the registry. This action cannot be undone.
                         </p>
+                        {/* Inline retire error — Alert primitive is a modal dialog, not applicable */}
                         {retireError && (
                           <div
                             role="alert"
@@ -401,25 +403,27 @@ export default function AgentDetailPage({ params }: PageProps) {
                           </div>
                         )}
                         <div className="flex gap-2">
-                          <button
+                          <ButtonCVA
                             type="button"
                             onClick={handleRetire}
                             disabled={retiring}
-                            className="rounded-lg bg-error px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
+                            variant="destructive"
+                            size="sm"
                           >
                             {retiring ? 'Retiring...' : 'Confirm Retire'}
-                          </button>
-                          <button
+                          </ButtonCVA>
+                          <ButtonCVA
                             type="button"
                             onClick={() => {
                               setIsConfirmingRetire(false);
                               setRetireError(null);
                             }}
                             disabled={retiring}
-                            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                            variant="outline"
+                            size="sm"
                           >
                             Cancel
-                          </button>
+                          </ButtonCVA>
                         </div>
                       </div>
                     ) : (
@@ -427,13 +431,15 @@ export default function AgentDetailPage({ params }: PageProps) {
                         <p className="text-sm text-muted-foreground">
                           Remove this agent from the registry permanently.
                         </p>
-                        <button
+                        <ButtonCVA
                           type="button"
                           onClick={() => setIsConfirmingRetire(true)}
-                          className="shrink-0 rounded-lg border border-error/30 px-3 py-1.5 text-sm font-medium text-error transition-colors hover:border-error/50 hover:text-error"
+                          variant="outline"
+                          size="sm"
+                          className="shrink-0 border-error/30 text-error hover:border-error/50 hover:text-error"
                         >
                           Retire Agent
-                        </button>
+                        </ButtonCVA>
                       </div>
                     )}
                   </div>
@@ -442,27 +448,29 @@ export default function AgentDetailPage({ params }: PageProps) {
 
               {/* Right: Task tester + history */}
               <div className="flex flex-col gap-6">
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <div className="mb-4 flex items-center justify-between gap-2">
                     <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                       Task Tester
                     </h2>
-                    <a
+                    <LinkButton
                       href={`/agents/${encodeURIComponent(agentId)}/run`}
-                      className="rounded-md border border-success/30 bg-success/10 px-3 py-1.5 text-xs font-medium text-success transition-colors hover:bg-success/20"
+                      variant="outline"
+                      size="sm"
+                      className="border-success/30 bg-success/10 text-success hover:bg-success/20"
                       title="Stream agent execution live (Stage 5 surface)"
                     >
                       Watch live ↗
-                    </a>
+                    </LinkButton>
                   </div>
                   <TaskTester
                     agentId={agentId}
                     agentName={card.name}
                     onComplete={() => setTaskRefreshKey((k) => k + 1)}
                   />
-                </div>
+                </Card>
 
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Agent Memory
                     <span className="ml-2 text-xs font-normal normal-case text-muted-foreground">
@@ -470,16 +478,16 @@ export default function AgentDetailPage({ params }: PageProps) {
                     </span>
                   </h2>
                   <AgentMemory agentId={agentId} />
-                </div>
+                </Card>
 
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Task History
                   </h2>
                   <TaskHistory agentId={agentId} refreshKey={taskRefreshKey} />
-                </div>
+                </Card>
 
-                <div className="rounded-xl border border-border bg-card p-5">
+                <Card className="p-5">
                   <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                     Agent Contexts
                     <span className="ml-2 text-xs font-normal normal-case text-muted-foreground">
@@ -487,7 +495,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                     </span>
                   </h2>
                   <AgentContexts agentId={agentId} />
-                </div>
+                </Card>
               </div>
             </div>
           )}

--- a/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
@@ -14,7 +14,7 @@
 
 'use client';
 
-import { Breadcrumb } from '@revealui/presentation/client';
+import { Breadcrumb, ButtonCVA, Card } from '@revealui/presentation';
 import Link from 'next/link';
 import { type ChangeEvent, use, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -65,69 +65,65 @@ export default function AgentRunPage({ params }: PageProps) {
           </p>
         </header>
 
-        <form
-          onSubmit={handleStart}
-          className="space-y-3 rounded-lg border border-border bg-card p-4"
-        >
-          <label htmlFor="instruction" className="block text-sm font-medium text-muted-foreground">
-            Instruction
-          </label>
-          <textarea
-            id="instruction"
-            value={instruction}
-            onChange={(
-              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-            ) => setInstruction(e.target.value)}
-            disabled={stream.isStreaming}
-            rows={4}
-            placeholder="What would you like the agent to do?"
-            className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
-          />
-          <div className="flex items-center gap-3">
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span>Mode</span>
-              <select
-                value={mode}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) => setMode(e.target.value as 'admin' | 'coding')}
-                disabled={stream.isStreaming}
-                className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
-              >
-                <option value="admin">admin</option>
-                <option value="coding">coding</option>
-              </select>
+        <Card className="p-4">
+          <form onSubmit={handleStart} className="space-y-3">
+            <label
+              htmlFor="instruction"
+              className="block text-sm font-medium text-muted-foreground"
+            >
+              Instruction
             </label>
-            <div className="flex-1" />
-            {!stream.isStreaming && (
-              <button
-                type="submit"
-                disabled={!instruction.trim()}
-                className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Start agent
-              </button>
-            )}
-            {stream.isStreaming && (
-              <button
-                type="button"
-                onClick={stream.abort}
-                className="rounded-md border border-error/30 bg-error/10 px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/15"
-              >
-                Cancel
-              </button>
-            )}
-            {!stream.isStreaming && stream.chunks.length > 0 && (
-              <button
-                type="button"
-                onClick={stream.reset}
-                className="rounded-md border border-border bg-muted px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-foreground/10"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-        </form>
+            <textarea
+              id="instruction"
+              value={instruction}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+              ) => setInstruction(e.target.value)}
+              disabled={stream.isStreaming}
+              rows={4}
+              placeholder="What would you like the agent to do?"
+              className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+            />
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span>Mode</span>
+                <select
+                  value={mode}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => setMode(e.target.value as 'admin' | 'coding')}
+                  disabled={stream.isStreaming}
+                  className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+                >
+                  <option value="admin">admin</option>
+                  <option value="coding">coding</option>
+                </select>
+              </label>
+              <div className="flex-1" />
+              {!stream.isStreaming && (
+                <ButtonCVA type="submit" disabled={!instruction.trim()} variant="default" size="sm">
+                  Start agent
+                </ButtonCVA>
+              )}
+              {stream.isStreaming && (
+                <ButtonCVA
+                  type="button"
+                  onClick={stream.abort}
+                  variant="outline"
+                  size="sm"
+                  className="border-error/30 bg-error/10 text-error hover:bg-error/15"
+                >
+                  Cancel
+                </ButtonCVA>
+              )}
+              {!stream.isStreaming && stream.chunks.length > 0 && (
+                <ButtonCVA type="button" onClick={stream.reset} variant="ghost" size="sm">
+                  Clear
+                </ButtonCVA>
+              )}
+            </div>
+          </form>
+        </Card>
 
         <StatusBar
           isStreaming={stream.isStreaming}
@@ -156,10 +152,10 @@ export default function AgentRunPage({ params }: PageProps) {
         )}
 
         {stream.text && (
-          <section className="rounded-lg border border-border bg-card p-4">
+          <Card className="p-4">
             <h2 className="mb-2 text-sm font-medium text-muted-foreground">Agent output</h2>
             <pre className="whitespace-pre-wrap text-sm text-foreground">{stream.text}</pre>
-          </section>
+          </Card>
         )}
 
         {stream.chunks.length > 0 && (
@@ -219,6 +215,7 @@ function StatusBar({ isStreaming, sessionId, chunkCount, error }: StatusBarProps
 
 // ---------------------------------------------------------------------------
 // Elicitation card — wraps the shared ElicitationForm with namespace label
+// Border uses primary/30 tint (not Card's border-border) — left as handroll
 // ---------------------------------------------------------------------------
 
 interface ElicitationCardProps {
@@ -252,6 +249,7 @@ function ElicitationCard({ namespace, requestedSchema, message, onSubmit }: Elic
 
 // ---------------------------------------------------------------------------
 // Chunk row — per-event rendering for the event log
+// Log rows use tinted borders per event type — not generic Card
 // ---------------------------------------------------------------------------
 
 function ChunkRow({ chunk, index }: { chunk: AgentStreamChunk; index: number }) {

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Breadcrumb } from '@revealui/presentation/client';
+import { Badge, Breadcrumb, ButtonCVA, Card, LinkButton } from '@revealui/presentation';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useReducer } from 'react';
@@ -268,17 +268,12 @@ export default function NewAgentPage() {
                     <p className="text-xs text-muted-foreground leading-relaxed">{t.description}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {t.capabilities.slice(0, 2).map((cap) => (
-                        <span
-                          key={cap}
-                          className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-                        >
+                        <Badge key={cap} color="muted">
                           {cap}
-                        </span>
+                        </Badge>
                       ))}
                       {t.capabilities.length > 2 && (
-                        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                          +{t.capabilities.length - 2}
-                        </span>
+                        <Badge color="muted">+{t.capabilities.length - 2}</Badge>
                       )}
                     </div>
                   </button>
@@ -367,16 +362,16 @@ export default function NewAgentPage() {
                 </div>
 
                 {/* Model info (read-only) */}
-                <div className="rounded-lg border border-border bg-card px-4 py-3 text-xs text-muted-foreground">
+                <Card className="px-4 py-3 text-xs text-muted-foreground">
                   <span className="font-medium text-foreground">Model:</span> {tpl?.model}
                   &nbsp;·&nbsp;
                   <span className="font-medium text-foreground">Temp:</span> {tpl?.temperature}
                   &nbsp;·&nbsp;
                   <span className="font-medium text-foreground">Max tokens:</span>{' '}
                   {tpl?.maxTokens?.toLocaleString()}
-                </div>
+                </Card>
 
-                {/* Error */}
+                {/* Error — inline banner; Alert primitive is a modal dialog, not applicable */}
                 {error && (
                   <div
                     role="alert"
@@ -388,19 +383,17 @@ export default function NewAgentPage() {
 
                 {/* Actions */}
                 <div className="flex gap-3 pt-2">
-                  <button
+                  <ButtonCVA
                     type="submit"
                     disabled={submitting || !name.trim()}
-                    className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                    variant="default"
+                    size="sm"
                   >
                     {submitting ? 'Creating...' : 'Create Agent'}
-                  </button>
-                  <Link
-                    href="/agents"
-                    className="rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-                  >
+                  </ButtonCVA>
+                  <LinkButton as={Link} href="/agents" variant="outline" size="sm">
                     Cancel
-                  </Link>
+                  </LinkButton>
                 </div>
               </section>
             )}

--- a/apps/admin/src/app/(backend)/agents/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { A2AAgentCard } from '@revealui/contracts';
+import { EmptyState, LinkButton, Skeleton, SkeletonText } from '@revealui/presentation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { AgentCard } from '@/lib/components/agents/agent-card';
@@ -28,7 +29,7 @@ export default function AgentsPage() {
           </p>
         </div>
 
-        {/* Tabs */}
+        {/* Tab strip — left as handroll: Tab primitive hard-codes border-blue-600 (not border-primary) */}
         <div className="border-b border-border bg-muted px-6">
           <nav className="flex gap-1 -mb-px">
             {(['agents', 'mcp'] as Tab[]).map((t) => (
@@ -70,7 +71,6 @@ function AgentCardsPanel() {
     fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' })
       .then((r) => r.json())
       .then((data: { agents: A2AAgentCard[] }) => {
-        // Derive agentId from skills[0].id or fallback to slugified name
         const withIds: AgentWithId[] = (data.agents ?? []).map((card) => ({
           card,
           agentId: card.name
@@ -93,16 +93,10 @@ function AgentCardsPanel() {
     return (
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
-            key={i}
-            className="animate-pulse rounded-lg border border-border bg-card p-4"
-          >
-            <div className="mb-3 h-5 w-2/3 rounded bg-foreground/10" />
-            <div className="space-y-2">
-              <div className="h-3 w-full rounded bg-foreground/10" />
-              <div className="h-3 w-4/5 rounded bg-foreground/10" />
-            </div>
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+          <div key={i} className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="mb-3 h-5 w-2/3" />
+            <SkeletonText lines={2} />
           </div>
         ))}
       </div>
@@ -124,17 +118,14 @@ function AgentCardsPanel() {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <p className="text-sm text-muted-foreground">{agents.length} agent(s) registered</p>
-        <Link
-          href="/agents/new"
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
+        <LinkButton as={Link} href="/agents/new" variant="default" size="sm">
           + New Agent
-        </Link>
+        </LinkButton>
       </div>
 
       {agents.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border px-6 py-16 text-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <EmptyState
+          icon={
             <svg
               className="size-6"
               fill="none"
@@ -149,18 +140,15 @@ function AgentCardsPanel() {
                 d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09ZM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456Z"
               />
             </svg>
-          </div>
-          <h3 className="text-sm font-semibold text-foreground">No agents registered</h3>
-          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            Create your first AI agent to get started with automated tasks and workflows.
-          </p>
-          <Link
-            href="/agents/new"
-            className="mt-6 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Create Agent
-          </Link>
-        </div>
+          }
+          title="No agents registered"
+          description="Create your first AI agent to get started with automated tasks and workflows."
+          action={
+            <LinkButton as={Link} href="/agents/new" variant="default" size="sm">
+              Create Agent
+            </LinkButton>
+          }
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {agents.map(({ card, agentId }) => (
@@ -198,16 +186,10 @@ function McpServersPanel() {
     return (
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
-            key={i}
-            className="animate-pulse rounded-lg border border-border bg-card p-4"
-          >
-            <div className="mb-3 h-5 w-1/2 rounded bg-foreground/10" />
-            <div className="space-y-2">
-              <div className="h-3 w-full rounded bg-foreground/10" />
-              <div className="h-3 w-3/5 rounded bg-foreground/10" />
-            </div>
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+          <div key={i} className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="mb-3 h-5 w-1/2" />
+            <SkeletonText lines={2} />
           </div>
         ))}
       </div>
@@ -239,8 +221,8 @@ function McpServersPanel() {
       </div>
 
       {servers.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border px-6 py-16 text-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <EmptyState
+          icon={
             <svg
               className="size-6"
               fill="none"
@@ -255,15 +237,15 @@ function McpServersPanel() {
                 d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"
               />
             </svg>
-          </div>
-          <h3 className="text-sm font-semibold text-foreground">No MCP servers connected</h3>
-          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            Start your development environment with MCP support to connect servers.
-          </p>
-          <code className="mt-4 rounded-lg bg-muted px-3 py-1.5 font-mono text-xs text-muted-foreground">
-            revealui dev up --include mcp
-          </code>
-        </div>
+          }
+          title="No MCP servers connected"
+          description="Start your development environment with MCP support to connect servers."
+          action={
+            <code className="rounded-lg bg-muted px-3 py-1.5 font-mono text-xs text-muted-foreground">
+              revealui dev up --include mcp
+            </code>
+          }
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {servers.map((server) => (

--- a/apps/admin/src/lib/components/agents/agent-card.tsx
+++ b/apps/admin/src/lib/components/agents/agent-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { A2AAgentCard } from '@revealui/contracts';
-import { Badge } from '@revealui/presentation/client';
+import { Badge, Card, LinkButton } from '@revealui/presentation';
 import Link from 'next/link';
 
 interface AgentCardProps {
@@ -15,42 +15,18 @@ interface AgentCardProps {
  */
 export function AgentCard({ card, agentId }: AgentCardProps) {
   return (
-    <div
-      className="flex flex-col gap-4 rounded-xl border p-5 transition-colors"
-      style={{
-        backgroundColor: 'var(--rvui-surface-1, oklch(0.18 0.006 225))',
-        borderColor: 'var(--rvui-border-subtle, oklch(0.28 0.006 222 / 0.4))',
-        borderRadius: 'var(--rvui-radius-lg, 16px)',
-        transition:
-          'border-color var(--rvui-duration-normal, 200ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
-      }}
-    >
+    <Card className="flex flex-col gap-4 p-5">
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3
-            className="truncate font-semibold"
-            style={{ color: 'var(--rvui-text-0, oklch(0.95 0.002 210))' }}
-          >
-            {card.name}
-          </h3>
-          <p
-            className="mt-0.5 text-xs"
-            style={{ color: 'var(--rvui-text-2, oklch(0.55 0.012 218))' }}
-          >
-            v{card.version}
-          </p>
+          <h3 className="truncate font-semibold text-foreground">{card.name}</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">v{card.version}</p>
         </div>
-        <Badge color="emerald">active</Badge>
+        <Badge color="success">active</Badge>
       </div>
 
       {/* Description */}
-      <p
-        className="line-clamp-2 text-sm"
-        style={{ color: 'var(--rvui-text-2, oklch(0.55 0.012 218))' }}
-      >
-        {card.description}
-      </p>
+      <p className="line-clamp-2 text-sm text-muted-foreground">{card.description}</p>
 
       {/* Capabilities */}
       <div className="flex flex-wrap gap-1.5">
@@ -66,34 +42,20 @@ export function AgentCard({ card, agentId }: AgentCardProps) {
       {/* Skills */}
       {card.skills.length > 0 && (
         <div>
-          <p
-            className="mb-2 text-xs font-medium uppercase tracking-wide"
-            style={{ color: 'var(--rvui-text-2, oklch(0.55 0.012 218))' }}
-          >
+          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Skills ({card.skills.length})
           </p>
           <ul className="space-y-1">
             {card.skills.slice(0, 3).map((skill) => (
               <li key={skill.id} className="flex items-start gap-2">
-                <span
-                  className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: 'var(--rvui-text-2, oklch(0.55 0.012 218))' }}
-                />
-                <span
-                  className="text-xs leading-relaxed"
-                  style={{ color: 'var(--rvui-text-1, oklch(0.75 0.01 215))' }}
-                >
+                <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground" />
+                <span className="text-xs leading-relaxed text-muted-foreground">
                   {skill.description}
                 </span>
               </li>
             ))}
             {card.skills.length > 3 && (
-              <li
-                className="text-xs"
-                style={{ color: 'var(--rvui-text-2, oklch(0.55 0.012 218))' }}
-              >
-                +{card.skills.length - 3} more
-              </li>
+              <li className="text-xs text-muted-foreground">+{card.skills.length - 3} more</li>
             )}
           </ul>
         </div>
@@ -101,32 +63,25 @@ export function AgentCard({ card, agentId }: AgentCardProps) {
 
       {/* Actions */}
       <div className="mt-auto flex gap-2 pt-1">
-        <Link
+        <LinkButton
+          as={Link}
           href={`/agents/${agentId}`}
-          className="flex-1 rounded-lg px-3 py-2 text-center text-sm font-medium transition-colors"
-          style={{
-            backgroundColor: 'var(--rvui-surface-2, oklch(0.22 0.008 222))',
-            color: 'var(--rvui-text-1, oklch(0.75 0.01 215))',
-            borderRadius: 'var(--rvui-radius-md, 10px)',
-          }}
+          variant="secondary"
+          size="sm"
+          className="flex-1 justify-center"
         >
           Test Agent
-        </Link>
-        <a
+        </LinkButton>
+        <LinkButton
           href={card.url.replace('/a2a', `/.well-known/agents/${agentId}/agent.json`)}
-          target="_blank"
-          rel="noreferrer"
-          className="rounded-lg px-3 py-2 text-sm font-medium transition-colors"
-          style={{
-            backgroundColor: 'var(--rvui-surface-2, oklch(0.22 0.008 222))',
-            color: 'var(--rvui-text-1, oklch(0.75 0.01 215))',
-            borderRadius: 'var(--rvui-radius-md, 10px)',
-          }}
+          external
+          variant="secondary"
+          size="sm"
           title="View Agent Card JSON"
         >
           JSON
-        </a>
+        </LinkButton>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/apps/admin/src/lib/components/agents/agent-contexts.tsx
+++ b/apps/admin/src/lib/components/agents/agent-contexts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@revealui/presentation';
 import { useAgentContexts } from '@revealui/sync';
 
 interface AgentContextsProps {
@@ -59,9 +60,7 @@ export function AgentContexts({ agentId }: AgentContextsProps) {
       {agentContexts.map((ctx) => (
         <li key={ctx.id} className="rounded-lg border border-border p-3">
           <div className="mb-1.5 flex items-center gap-2">
-            <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-              priority {ctx.priority}
-            </span>
+            <Badge color="muted">priority {ctx.priority}</Badge>
             <span className="text-xs text-muted-foreground">
               {formatRelativeTime(ctx.created_at)}
             </span>

--- a/apps/admin/src/lib/components/agents/agent-memory.tsx
+++ b/apps/admin/src/lib/components/agents/agent-memory.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ButtonCVA } from '@revealui/presentation';
 import { useAgentMemory } from '@revealui/sync';
 import { useState } from 'react';
 
@@ -104,7 +105,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
 
   return (
     <div>
-      {/* Filter tabs */}
+      {/* Filter chips — Tabs primitive not applicable: "All" requires null active value */}
       <div className="mb-4 flex items-center gap-2">
         <button
           type="button"
@@ -156,6 +157,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <div className="mb-1.5 flex items-center gap-2">
+                    {/* Memory type pills use accent/warning tones not in Badge — left as handroll */}
                     <span
                       className={`rounded px-1.5 py-0.5 text-xs font-medium ${memory.typeInfo.color}`}
                     >
@@ -170,11 +172,13 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
                   </div>
                   <p className="text-sm text-muted-foreground line-clamp-3">{memory.content}</p>
                 </div>
-                <button
+                <ButtonCVA
                   type="button"
                   onClick={() => handleRemove(memory.id)}
                   disabled={removingId === memory.id}
-                  className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-error group-hover:opacity-100 disabled:opacity-50"
+                  variant="ghost"
+                  size="icon"
+                  className="shrink-0 opacity-0 group-hover:opacity-100 hover:text-error disabled:opacity-50"
                   title="Delete memory"
                   aria-label="Delete memory"
                 >
@@ -190,7 +194,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
                       clipRule="evenodd"
                     />
                   </svg>
-                </button>
+                </ButtonCVA>
               </div>
             </li>
           ))}

--- a/apps/admin/src/lib/components/agents/mcp-server-card.tsx
+++ b/apps/admin/src/lib/components/agents/mcp-server-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, ButtonCVA, Card } from '@revealui/presentation';
 import { useState } from 'react';
 
 export interface McpServerInfo {
@@ -23,20 +24,20 @@ interface McpServerCardProps {
   server: McpServerInfo;
 }
 
+const STATUS_BADGE_COLOR = {
+  configured: 'warning',
+  active: 'success',
+  unavailable: 'danger',
+} as const satisfies Record<McpServerInfo['status'], 'warning' | 'success' | 'danger'>;
+
 /**
  * Displays an MCP server and its available tools in the MCP UI panel.
  */
 export function McpServerCard({ server }: McpServerCardProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const statusColors = {
-    configured: 'bg-warning/15 text-warning-foreground',
-    active: 'bg-success/10 text-success',
-    unavailable: 'bg-error/10 text-error',
-  };
-
   return (
-    <div className="rounded-xl border border-border bg-card p-5">
+    <Card className="p-5">
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -45,11 +46,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
             {server.packageName ?? server.remoteUrl ?? server.id}
           </p>
         </div>
-        <span
-          className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[server.status]}`}
-        >
-          {server.status}
-        </span>
+        <Badge color={STATUS_BADGE_COLOR[server.status]}>{server.status}</Badge>
       </div>
 
       {/* Description */}
@@ -59,12 +56,9 @@ export function McpServerCard({ server }: McpServerCardProps) {
       {server.envRequired.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
           {server.envRequired.map((envVar) => (
-            <span
-              key={envVar}
-              className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
-            >
+            <Badge key={envVar} color="muted" className="font-mono">
               {envVar}
-            </span>
+            </Badge>
           ))}
         </div>
       )}
@@ -72,10 +66,13 @@ export function McpServerCard({ server }: McpServerCardProps) {
       {/* Tools toggle */}
       {server.tools.length > 0 && (
         <div className="mt-4">
-          <button
+          <ButtonCVA
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            className="flex w-full items-center justify-between rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-foreground/10"
+            variant="ghost"
+            size="sm"
+            className="flex w-full items-center justify-between"
+            aria-expanded={expanded}
           >
             <span>{server.tools.length} tools</span>
             <svg
@@ -88,7 +85,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
-          </button>
+          </ButtonCVA>
 
           {expanded && (
             <ul className="mt-2 space-y-1">
@@ -115,6 +112,6 @@ export function McpServerCard({ server }: McpServerCardProps) {
           )}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 
 interface AgentActionRow {
@@ -19,6 +20,12 @@ interface TaskHistoryProps {
   /** Increment to trigger a refresh */
   refreshKey?: number;
 }
+
+const STATUS_BADGE_COLOR = {
+  completed: 'success',
+  failed: 'danger',
+  cancelled: 'muted',
+} as const satisfies Record<string, 'success' | 'danger' | 'muted'>;
 
 /**
  * Displays the last 20 completed A2A tasks for an agent.
@@ -114,13 +121,8 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    completed: 'bg-success/10 text-success',
-    failed: 'bg-error/10 text-error',
-    cancelled: 'bg-muted text-muted-foreground',
-  };
-  const color = colors[status] ?? 'bg-muted text-muted-foreground';
-  return <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>{status}</span>;
+  const color = (STATUS_BADGE_COLOR as Record<string, string>)[status] ?? 'muted';
+  return <Badge color={color as 'success' | 'danger' | 'muted'}>{status}</Badge>;
 }
 
 /** Pull the user text from the tasks/send params */

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { A2ATask } from '@revealui/contracts';
+import { Badge, ButtonCVA } from '@revealui/presentation';
 import { useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -11,6 +12,26 @@ interface TaskTesterProps {
 }
 
 type TesterState = 'idle' | 'submitting' | 'polling' | 'done' | 'error';
+
+const TASK_STATE_BADGE_COLOR = {
+  submitted: 'muted',
+  working: 'brand',
+  'input-required': 'warning',
+  completed: 'success',
+  canceled: 'muted',
+  failed: 'danger',
+  unknown: 'muted',
+} as const satisfies Record<string, 'muted' | 'brand' | 'warning' | 'success' | 'danger'>;
+
+const TASK_STATE_LABEL: Record<string, string> = {
+  submitted: 'Submitted',
+  working: 'Working',
+  'input-required': 'Input Required',
+  completed: 'Completed',
+  canceled: 'Canceled',
+  failed: 'Failed',
+  unknown: 'Unknown',
+};
 
 /**
  * Interactive task tester for an A2A agent.
@@ -108,14 +129,16 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
         />
       </div>
 
-      <button
+      <ButtonCVA
         type="button"
         onClick={submit}
         disabled={state === 'submitting' || state === 'polling' || !instruction.trim()}
-        className="self-start rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        variant="default"
+        size="sm"
+        className="self-start"
       >
         {state === 'submitting' ? 'Sending...' : state === 'polling' ? 'Working...' : 'Send Task'}
-      </button>
+      </ButtonCVA>
 
       {/* Status badge */}
       {task && (
@@ -129,7 +152,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
         </div>
       )}
 
-      {/* Response */}
+      {/* Response — bg-muted (not bg-card); Card would apply bg-card, behavioral mismatch */}
       {responseText && (
         <div className="rounded-lg border border-border bg-muted p-4">
           <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -139,7 +162,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
         </div>
       )}
 
-      {/* Error */}
+      {/* Inline error — Alert primitive is a modal dialog, not applicable */}
       {errorMsg && (
         <div role="alert" className="rounded-lg border border-error/30 bg-error/10 p-4">
           <p className="text-sm text-error">{errorMsg}</p>
@@ -150,17 +173,7 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
 }
 
 function TaskStateBadge({ state }: { state: string }) {
-  const configs: Record<string, { label: string; color: string }> = {
-    submitted: { label: 'Submitted', color: 'bg-muted text-muted-foreground' },
-    working: { label: 'Working', color: 'bg-primary/10 text-primary' },
-    'input-required': { label: 'Input Required', color: 'bg-warning/15 text-warning-foreground' },
-    completed: { label: 'Completed', color: 'bg-success/10 text-success' },
-    canceled: { label: 'Canceled', color: 'bg-muted text-muted-foreground' },
-    failed: { label: 'Failed', color: 'bg-error/10 text-error' },
-    unknown: { label: 'Unknown', color: 'bg-muted text-muted-foreground' },
-  };
-  const cfg = configs[state] ?? { label: state, color: 'bg-muted text-muted-foreground' };
-  return (
-    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${cfg.color}`}>{cfg.label}</span>
-  );
+  const color = TASK_STATE_BADGE_COLOR[state as keyof typeof TASK_STATE_BADGE_COLOR] ?? 'muted';
+  const label = TASK_STATE_LABEL[state] ?? state;
+  return <Badge color={color}>{label}</Badge>;
 }


### PR DESCRIPTION
refactor(admin): adopt presentation primitives in the agents area (Phase 3a)

Primitive-adoption audit Phase 3, slice a (agents pages + feature panels). App-level
only — no package dependency changes (consistent with the tokens-only architecture).

Migrated 10 files onto @revealui/presentation primitives, behavior preserved
(onClick/disabled/type/aria/href intact):
- ButtonCVA / LinkButton — raw <button> and <Link>-styled-as-button across the
  agents / new / [agentId] / run pages + mcp-server-card / task-tester / agent-memory.
- Card — panel/section divs, incl. agent-card's 8 inline-oklch literals -> Card + tokens.
- Badge (semantic tones muted/brand/warning/success/danger) — status pills across
  agent-card / mcp-server-card / task-tester / task-history / agent-contexts
  (raw color="emerald" -> color="success").
- Skeleton / SkeletonText — animate-pulse loaders; EmptyState — empty-state blocks.

Intentionally LEFT as handrolls — presentation primitive gaps, deferred to Phase 6 rather
than forced into a lossy swap:
- Tab strips: presentation `Tab` hardcodes border-blue-600/text-blue-600 for the active
  indicator (off-token, appended after the consumer className so it cannot be overridden)
  -> needs a token-driven Tab before adoption.
- Inline status banners: presentation `Alert` is an alertdialog modal (portal/focus-trap/
  scroll-lock), not an inline banner -> needs an inline Alert/Callout variant.
- Tinted cards/rows (border-primary/10; per-row success/error/accent tints) and bg-muted
  panels: `Card` hardcodes border-border/bg-card -> needs a tone/tint prop (EXTEND).
- Memory-type pill needing a bg-accent tone, the "All"=null filter chip, and selected-card
  inputs: no matching Badge tone / Tabs(null) / selectable-card primitive.

Verified: admin typecheck + build green; biome clean.
