### PR TITLE
refactor(admin): adopt presentation primitives in marketplace + refunds (Phase 3b)

### DIFF
--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, ButtonCVA, Card, Skeleton } from '@revealui/presentation';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { type ChangeEvent, useEffect, useState } from 'react';
@@ -89,11 +90,11 @@ export default function MarketplaceAgentDetailPage() {
     return (
       <div className="min-h-screen">
         <div className="border-b border-border bg-card px-6 py-4">
-          <div className="h-5 w-48 animate-pulse rounded bg-muted" />
+          <Skeleton className="h-5 w-48" />
         </div>
         <div className="p-6">
-          <div className="h-4 w-96 animate-pulse rounded bg-muted" />
-          <div className="mt-3 h-3 w-64 animate-pulse rounded bg-muted" />
+          <Skeleton className="h-4 w-96" />
+          <Skeleton className="mt-3 h-3 w-64" />
         </div>
       </div>
     );
@@ -136,7 +137,7 @@ export default function MarketplaceAgentDetailPage() {
                   {agent.rating.toFixed(1)} ({agent.reviewCount} reviews)
                 </span>
                 <span>{agent.taskCount} tasks completed</span>
-                <span className="rounded bg-muted px-2 py-0.5">{agent.category}</span>
+                <Badge color="muted">{agent.category}</Badge>
                 <span className="text-muted-foreground">v{agent.version}</span>
               </div>
             </div>
@@ -210,7 +211,7 @@ function SkillsPanel({ skills }: { skills: AgentSkill[] }) {
   return (
     <div className="space-y-4">
       {skills.map((skill) => (
-        <div key={skill.id} className="rounded-lg border border-border bg-card p-4">
+        <Card key={skill.id} className="p-4">
           <h3 className="font-medium text-foreground">{skill.name}</h3>
           <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>
           {skill.inputSchema && (
@@ -233,7 +234,7 @@ function SkillsPanel({ skills }: { skills: AgentSkill[] }) {
               </pre>
             </details>
           )}
-        </div>
+        </Card>
       ))}
     </div>
   );
@@ -289,69 +290,54 @@ function ReviewsPanel({
     <div>
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-medium text-muted-foreground">{reviews.length} Reviews</h3>
-        <button
-          type="button"
-          onClick={() => setShowForm(!showForm)}
-          className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          Write Review
-        </button>
+        <ButtonCVA onClick={() => setShowForm(!showForm)}>Write Review</ButtonCVA>
       </div>
 
       {showForm && (
-        <form
-          onSubmit={handleSubmitReview}
-          className="mb-6 rounded-lg border border-border bg-card p-4"
-        >
-          <div className="mb-3">
-            <span className="block text-sm text-muted-foreground mb-1">Rating</span>
-            <div className="flex gap-1" role="radiogroup" aria-label="Rating">
-              {[1, 2, 3, 4, 5].map((n) => (
-                <button
-                  key={n}
-                  type="button"
-                  onClick={() => setRating(n)}
-                  className={`h-8 w-8 rounded transition-colors ${
-                    n <= rating
-                      ? 'bg-warning text-warning-foreground'
-                      : 'bg-muted text-muted-foreground'
-                  }`}
-                >
-                  {n}
-                </button>
-              ))}
+        <form onSubmit={handleSubmitReview}>
+          <Card className="mb-6 p-4">
+            <div className="mb-3">
+              <span className="block text-sm text-muted-foreground mb-1">Rating</span>
+              <div className="flex gap-1" role="radiogroup" aria-label="Rating">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setRating(n)}
+                    className={`h-8 w-8 rounded transition-colors ${
+                      n <= rating
+                        ? 'bg-warning text-warning-foreground'
+                        : 'bg-muted text-muted-foreground'
+                    }`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="mb-3">
-            <label className="block text-sm text-muted-foreground mb-1">
-              Comment (optional)
-              <textarea
-                value={comment}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) => setComment(e.target.value)}
-                rows={3}
-                className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
-                placeholder="Share your experience..."
-              />
-            </label>
-          </div>
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              disabled={submitting}
-              className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
-            >
-              {submitting ? 'Submitting...' : 'Submit Review'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowForm(false)}
-              className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
+            <div className="mb-3">
+              <label className="block text-sm text-muted-foreground mb-1">
+                Comment (optional)
+                <textarea
+                  value={comment}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => setComment(e.target.value)}
+                  rows={3}
+                  className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                  placeholder="Share your experience..."
+                />
+              </label>
+            </div>
+            <div className="flex gap-2">
+              <ButtonCVA type="submit" disabled={submitting}>
+                {submitting ? 'Submitting...' : 'Submit Review'}
+              </ButtonCVA>
+              <ButtonCVA type="button" variant="outline" onClick={() => setShowForm(false)}>
+                Cancel
+              </ButtonCVA>
+            </div>
+          </Card>
         </form>
       )}
 
@@ -362,7 +348,7 @@ function ReviewsPanel({
       ) : (
         <div className="space-y-3">
           {reviews.map((review) => (
-            <div key={review.id} className="rounded-lg border border-border bg-card p-4">
+            <Card key={review.id} className="p-4">
               <div className="flex items-center gap-2">
                 <div className="flex gap-0.5">
                   {Array.from({ length: 5 }, (_, i) => (
@@ -375,11 +361,7 @@ function ReviewsPanel({
                     </span>
                   ))}
                 </div>
-                {review.verified === 1 && (
-                  <span className="rounded bg-success/10 px-2 py-0.5 text-xs text-success">
-                    Verified
-                  </span>
-                )}
+                {review.verified === 1 && <Badge color="success">Verified</Badge>}
                 <span className="text-xs text-muted-foreground">
                   {new Date(review.createdAt).toLocaleDateString()}
                 </span>
@@ -387,7 +369,7 @@ function ReviewsPanel({
               {review.comment && (
                 <p className="mt-2 text-sm text-muted-foreground">{review.comment}</p>
               )}
-            </div>
+            </Card>
           ))}
         </div>
       )}
@@ -524,12 +506,12 @@ function SubmitTaskPanel({
       </div>
 
       {/* Cost estimate */}
-      <div className="mb-6 rounded-lg border border-border bg-card p-3">
+      <Card className="mb-6 p-3">
         <p className="text-sm text-muted-foreground">
           Estimated cost:{' '}
           <span className="font-medium text-foreground">${agent.basePriceUsdc} USDC</span>
         </p>
-      </div>
+      </Card>
 
       {error && (
         <div className="mb-4 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error">
@@ -537,13 +519,9 @@ function SubmitTaskPanel({
         </div>
       )}
 
-      <button
-        type="submit"
-        disabled={submitting || skills.length === 0}
-        className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
-      >
+      <ButtonCVA type="submit" disabled={submitting || skills.length === 0}>
         {submitting ? 'Submitting...' : 'Submit Task'}
-      </button>
+      </ButtonCVA>
     </form>
   );
 }

--- a/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
@@ -1,5 +1,18 @@
 'use client';
 
+import {
+  Badge,
+  EmptyState,
+  LinkButton,
+  Skeleton,
+  Stat,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@revealui/presentation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -75,12 +88,7 @@ export default function AnalyticsPage() {
                 Performance metrics and version history for your agents
               </p>
             </div>
-            <Link
-              href="/marketplace/publish"
-              className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Publish New Agent
-            </Link>
+            <LinkButton href="/marketplace/publish">Publish New Agent</LinkButton>
           </div>
         </div>
 
@@ -96,21 +104,21 @@ export default function AnalyticsPage() {
             <>
               {/* Overview cards */}
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-                <MetricCard
+                <Stat
                   label="Published"
                   value={String(published)}
-                  sublabel={`${drafts} drafts`}
+                  description={`${drafts} drafts`}
                 />
-                <MetricCard label="Total Tasks" value={String(totalTasks)} sublabel="completed" />
-                <MetricCard
+                <Stat label="Total Tasks" value={String(totalTasks)} description="completed" />
+                <Stat
                   label="Revenue"
                   value={`$${totalRevenue.toFixed(2)}`}
-                  sublabel="USDC earned"
+                  description="USDC earned"
                 />
-                <MetricCard
+                <Stat
                   label="Avg Rating"
                   value={avgRating.toFixed(1)}
-                  sublabel={`across ${agents.length} agents`}
+                  description={`across ${agents.length} agents`}
                 />
               </div>
 
@@ -118,105 +126,72 @@ export default function AnalyticsPage() {
               <h2 className="text-lg font-medium text-foreground mb-4">Your Agents</h2>
 
               {agents.length === 0 ? (
-                <div className="flex flex-col items-center py-12 text-center">
-                  <p className="text-muted-foreground">No agents yet</p>
-                  <Link
-                    href="/marketplace/publish"
-                    className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
-                  >
-                    Publish Your First Agent
-                  </Link>
-                </div>
+                <EmptyState
+                  title="No agents yet"
+                  action={
+                    <LinkButton href="/marketplace/publish">Publish Your First Agent</LinkButton>
+                  }
+                />
               ) : (
-                <div className="overflow-x-auto rounded-lg border border-border">
-                  <table className="w-full text-left text-sm">
-                    <thead className="bg-card text-muted-foreground">
-                      <tr>
-                        <th className="px-4 py-3 font-medium">Agent</th>
-                        <th className="px-4 py-3 font-medium">Status</th>
-                        <th className="px-4 py-3 font-medium">Version</th>
-                        <th className="px-4 py-3 font-medium text-right">Tasks</th>
-                        <th className="px-4 py-3 font-medium text-right">Rating</th>
-                        <th className="px-4 py-3 font-medium text-right">Revenue</th>
-                        <th className="px-4 py-3 font-medium">Created</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border">
-                      {agents.map((agent) => {
-                        const revenue = agent.taskCount * Number.parseFloat(agent.basePriceUsdc);
-                        return (
-                          <tr key={agent.id} className="bg-muted hover:bg-card transition-colors">
-                            <td className="px-4 py-3">
-                              <Link
-                                href={`/marketplace/${agent.id}`}
-                                className="font-medium text-foreground hover:text-primary transition-colors"
-                              >
-                                {agent.name}
-                              </Link>
-                              <p className="text-xs text-muted-foreground">{agent.category}</p>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span
-                                className={`rounded px-2 py-0.5 text-xs ${
-                                  agent.status === 'published'
-                                    ? 'bg-success/10 text-success'
-                                    : agent.status === 'draft'
-                                      ? 'bg-warning/15 text-warning-foreground'
-                                      : 'bg-muted text-muted-foreground'
-                                }`}
-                              >
-                                {agent.status}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-muted-foreground">v{agent.version}</td>
-                            <td className="px-4 py-3 text-right text-foreground">
-                              {agent.taskCount}
-                            </td>
-                            <td className="px-4 py-3 text-right">
-                              <span className="text-warning-foreground">★</span>{' '}
-                              <span className="text-foreground">{agent.rating.toFixed(1)}</span>
-                              <span className="text-muted-foreground"> ({agent.reviewCount})</span>
-                            </td>
-                            <td className="px-4 py-3 text-right text-foreground">
-                              ${revenue.toFixed(2)}
-                            </td>
-                            <td className="px-4 py-3 text-muted-foreground">
-                              {new Date(agent.createdAt).toLocaleDateString()}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableHeader>Agent</TableHeader>
+                      <TableHeader>Status</TableHeader>
+                      <TableHeader>Version</TableHeader>
+                      <TableHeader>Tasks</TableHeader>
+                      <TableHeader>Rating</TableHeader>
+                      <TableHeader>Revenue</TableHeader>
+                      <TableHeader>Created</TableHeader>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {agents.map((agent) => {
+                      const revenue = agent.taskCount * Number.parseFloat(agent.basePriceUsdc);
+                      return (
+                        <TableRow key={agent.id}>
+                          <TableCell>
+                            <Link
+                              href={`/marketplace/${agent.id}`}
+                              className="font-medium text-foreground hover:text-primary transition-colors"
+                            >
+                              {agent.name}
+                            </Link>
+                            <p className="text-xs text-muted-foreground">{agent.category}</p>
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              color={
+                                agent.status === 'published'
+                                  ? 'success'
+                                  : agent.status === 'draft'
+                                    ? 'warning'
+                                    : 'muted'
+                              }
+                            >
+                              {agent.status}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>v{agent.version}</TableCell>
+                          <TableCell>{agent.taskCount}</TableCell>
+                          <TableCell>
+                            <span className="text-warning-foreground">★</span>{' '}
+                            <span className="text-foreground">{agent.rating.toFixed(1)}</span>
+                            <span className="text-muted-foreground"> ({agent.reviewCount})</span>
+                          </TableCell>
+                          <TableCell>${revenue.toFixed(2)}</TableCell>
+                          <TableCell>{new Date(agent.createdAt).toLocaleDateString()}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
               )}
             </>
           )}
         </div>
       </div>
     </LicenseGate>
-  );
-}
-
-// =============================================================================
-// Metric Card
-// =============================================================================
-
-function MetricCard({
-  label,
-  value,
-  sublabel,
-}: {
-  label: string;
-  value: string;
-  sublabel: string;
-}) {
-  return (
-    <div className="rounded-lg border border-border bg-card p-5">
-      <p className="text-sm text-muted-foreground">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-foreground">{value}</p>
-      <p className="mt-0.5 text-xs text-muted-foreground">{sublabel}</p>
-    </div>
   );
 }
 
@@ -230,15 +205,11 @@ function AnalyticsSkeleton() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
         {Array.from({ length: 4 }, (_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-          <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
-            <div className="h-3 w-16 rounded bg-foreground/10" />
-            <div className="mt-2 h-7 w-20 rounded bg-foreground/10" />
-            <div className="mt-1 h-2.5 w-12 rounded bg-foreground/10" />
-          </div>
+          <Skeleton key={i} className="h-28 rounded-lg" />
         ))}
       </div>
-      <div className="h-5 w-28 rounded bg-foreground/10 mb-4" />
-      <div className="animate-pulse rounded-lg border border-border bg-card h-64" />
+      <Skeleton className="h-5 w-28 mb-4" />
+      <Skeleton className="h-64 rounded-lg" />
     </>
   );
 }

--- a/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, Card, EmptyState, Skeleton, Stat } from '@revealui/presentation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -90,41 +91,36 @@ export default function EarningsDashboardPage() {
             <>
               {/* Summary cards */}
               <div className="grid gap-4 sm:grid-cols-3 mb-8">
-                <SummaryCard
+                <Stat
                   label="Total Earnings"
                   value={`$${summary.totalEarningsUsdc.toFixed(2)}`}
-                  sublabel="USDC"
+                  description="USDC"
                 />
-                <SummaryCard
+                <Stat
                   label="Tasks Completed"
                   value={String(summary.totalTasks)}
-                  sublabel="across all agents"
+                  description="across all agents"
                 />
-                <SummaryCard
+                <Stat
                   label="Published Agents"
                   value={String(summary.agentCount)}
-                  sublabel="active in marketplace"
+                  description="active in marketplace"
                 />
               </div>
 
               {/* Agent earnings breakdown */}
               <h2 className="text-lg font-medium text-foreground mb-4">Earnings by Agent</h2>
               {summary.agents.length === 0 ? (
-                <div className="flex flex-col items-center py-12 text-center">
-                  <p className="text-muted-foreground">No published agents yet</p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Publish an agent to start earning
-                  </p>
-                </div>
+                <EmptyState
+                  title="No published agents yet"
+                  description="Publish an agent to start earning"
+                />
               ) : (
                 <div className="space-y-3">
                   {summary.agents.map((agent) => {
                     const earnings = agent.taskCount * Number.parseFloat(agent.basePriceUsdc);
                     return (
-                      <div
-                        key={agent.id}
-                        className="flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-3"
-                      >
+                      <Card key={agent.id} className="flex items-center gap-4 px-4 py-3">
                         <div className="flex-1">
                           <Link
                             href={`/marketplace/${agent.id}`}
@@ -137,15 +133,9 @@ export default function EarningsDashboardPage() {
                               ★ {agent.rating.toFixed(1)} ({agent.reviewCount})
                             </span>
                             <span>{agent.taskCount} tasks</span>
-                            <span
-                              className={`rounded px-2 py-0.5 text-xs ${
-                                agent.status === 'published'
-                                  ? 'bg-success/10 text-success'
-                                  : 'bg-muted text-muted-foreground'
-                              }`}
-                            >
+                            <Badge color={agent.status === 'published' ? 'success' : 'muted'}>
                               {agent.status}
-                            </span>
+                            </Badge>
                           </div>
                         </div>
                         <div className="text-right">
@@ -156,7 +146,7 @@ export default function EarningsDashboardPage() {
                             ${agent.basePriceUsdc}/task
                           </p>
                         </div>
-                      </div>
+                      </Card>
                     );
                   })}
                 </div>
@@ -170,28 +160,6 @@ export default function EarningsDashboardPage() {
 }
 
 // =============================================================================
-// Summary Card
-// =============================================================================
-
-function SummaryCard({
-  label,
-  value,
-  sublabel,
-}: {
-  label: string;
-  value: string;
-  sublabel: string;
-}) {
-  return (
-    <div className="rounded-lg border border-border bg-card p-5">
-      <p className="text-sm text-muted-foreground">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-foreground">{value}</p>
-      <p className="mt-0.5 text-xs text-muted-foreground">{sublabel}</p>
-    </div>
-  );
-}
-
-// =============================================================================
 // Skeleton
 // =============================================================================
 
@@ -201,26 +169,14 @@ function EarningsSkeleton() {
       <div className="grid gap-4 sm:grid-cols-3 mb-8">
         {Array.from({ length: 3 }, (_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-          <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
-            <div className="h-3 w-20 rounded bg-foreground/10" />
-            <div className="mt-2 h-7 w-24 rounded bg-foreground/10" />
-            <div className="mt-1 h-2.5 w-16 rounded bg-foreground/10" />
-          </div>
+          <Skeleton key={i} className="h-28 rounded-lg" />
         ))}
       </div>
-      <div className="h-5 w-32 rounded bg-foreground/10 mb-4" />
+      <Skeleton className="h-5 w-32 mb-4" />
       <div className="space-y-3">
         {Array.from({ length: 3 }, (_, i) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-            key={i}
-            className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
-          >
-            <div className="flex items-center gap-4">
-              <div className="h-4 w-40 rounded bg-foreground/10" />
-              <div className="ml-auto h-4 w-16 rounded bg-foreground/10" />
-            </div>
-          </div>
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+          <Skeleton key={i} className="h-14 rounded-lg" />
         ))}
       </div>
     </>

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, EmptyState, LinkButton, Skeleton } from '@revealui/presentation';
 import Link from 'next/link';
 import { type ChangeEvent, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -87,24 +88,13 @@ export default function MarketplacePage() {
               </p>
             </div>
             <div className="flex gap-2">
-              <Link
-                href="/marketplace/tasks"
-                className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
-              >
+              <LinkButton href="/marketplace/tasks" variant="outline" size="sm">
                 My Tasks
-              </Link>
-              <Link
-                href="/marketplace/analytics"
-                className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
-              >
+              </LinkButton>
+              <LinkButton href="/marketplace/analytics" variant="outline" size="sm">
                 Analytics
-              </Link>
-              <Link
-                href="/marketplace/publish"
-                className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
-              >
-                Publish Agent
-              </Link>
+              </LinkButton>
+              <LinkButton href="/marketplace/publish">Publish Agent</LinkButton>
             </div>
           </div>
         </div>
@@ -163,12 +153,10 @@ export default function MarketplacePage() {
               Failed to load agents: {error}
             </div>
           ) : agents.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <p className="text-lg text-muted-foreground">No agents found</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {search ? 'Try a different search term' : 'No agents published yet'}
-              </p>
-            </div>
+            <EmptyState
+              title="No agents found"
+              description={search ? 'Try a different search term' : 'No agents published yet'}
+            />
           ) : (
             <>
               <p className="mb-4 text-sm text-muted-foreground">
@@ -204,18 +192,16 @@ function MarketplaceAgentCard({ agent }: { agent: MarketplaceAgent }) {
           </h3>
           <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{agent.description}</p>
         </div>
-        <span className="ml-3 rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
-          {agent.category}
-        </span>
+        <Badge color="muted">{agent.category}</Badge>
       </div>
 
       {/* Tags */}
       {agent.tags.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
           {agent.tags.slice(0, 4).map((tag) => (
-            <span key={tag} className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            <Badge key={tag} color="muted">
               {tag}
-            </span>
+            </Badge>
           ))}
           {agent.tags.length > 4 && (
             <span className="text-xs text-muted-foreground">+{agent.tags.length - 4}</span>
@@ -247,15 +233,7 @@ function AgentGridSkeleton() {
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }, (_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-        <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
-          <div className="h-4 w-2/3 rounded bg-foreground/10" />
-          <div className="mt-2 h-3 w-full rounded bg-foreground/10" />
-          <div className="mt-1 h-3 w-4/5 rounded bg-foreground/10" />
-          <div className="mt-4 flex gap-4">
-            <div className="h-3 w-16 rounded bg-foreground/10" />
-            <div className="h-3 w-12 rounded bg-foreground/10" />
-          </div>
-        </div>
+        <Skeleton key={i} className="h-40 rounded-lg" />
       ))}
     </div>
   );

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ButtonCVA, Card } from '@revealui/presentation';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useState } from 'react';
@@ -412,13 +413,9 @@ function StepBasicInfo({
       </label>
 
       <div className="pt-4">
-        <button
-          type="button"
-          onClick={onNext}
-          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
+        <ButtonCVA type="button" onClick={onNext}>
           Next: Configuration
-        </button>
+        </ButtonCVA>
       </div>
     </div>
   );
@@ -527,20 +524,12 @@ function StepConfiguration({
       </label>
 
       <div className="flex gap-3 pt-4">
-        <button
-          type="button"
-          onClick={onBack}
-          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
-        >
+        <ButtonCVA type="button" variant="outline" onClick={onBack}>
           Back
-        </button>
-        <button
-          type="button"
-          onClick={onNext}
-          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
+        </ButtonCVA>
+        <ButtonCVA type="button" onClick={onNext}>
           Next: Skills
-        </button>
+        </ButtonCVA>
       </div>
     </div>
   );
@@ -571,33 +560,27 @@ function StepSkills({
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-medium text-foreground">Skills</h2>
-        <button
-          type="button"
-          onClick={addSkill}
-          className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
-        >
+        <ButtonCVA type="button" variant="outline" onClick={addSkill}>
           + Add Skill
-        </button>
+        </ButtonCVA>
       </div>
       <p className="text-sm text-muted-foreground">
         Define the capabilities your agent offers. Each skill has an input and output schema.
       </p>
 
       {skills.map((skill, i) => (
-        <div
-          key={skill.name || `skill-${i}`}
-          className="rounded-lg border border-border bg-card p-4 space-y-3"
-        >
+        <Card key={skill.name || `skill-${i}`} className="p-4 space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-medium text-foreground">Skill {i + 1}</h3>
             {skills.length > 1 && (
-              <button
+              <ButtonCVA
                 type="button"
+                variant="ghost"
                 onClick={() => removeSkill(i)}
                 className="text-xs text-error hover:text-error"
               >
                 Remove
-              </button>
+              </ButtonCVA>
             )}
           </div>
 
@@ -662,24 +645,16 @@ function StepSkills({
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-output`)}</p>
             )}
           </label>
-        </div>
+        </Card>
       ))}
 
       <div className="flex gap-3 pt-4">
-        <button
-          type="button"
-          onClick={onBack}
-          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
-        >
+        <ButtonCVA type="button" variant="outline" onClick={onBack}>
           Back
-        </button>
-        <button
-          type="button"
-          onClick={onNext}
-          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
+        </ButtonCVA>
+        <ButtonCVA type="button" onClick={onNext}>
           Next: Review
-        </button>
+        </ButtonCVA>
       </div>
     </div>
   );
@@ -721,7 +696,7 @@ function StepReview({
       <h2 className="text-lg font-medium text-foreground">Review & Publish</h2>
 
       {/* Summary */}
-      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <Card className="p-4 space-y-3">
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div>
             <span className="text-muted-foreground">Name:</span>{' '}
@@ -754,7 +729,7 @@ function StepReview({
             <span className="text-foreground">{skills.filter((s) => s.name).length}</span>
           </div>
         </div>
-      </div>
+      </Card>
 
       {/* Skills summary */}
       <div>
@@ -787,21 +762,12 @@ function StepReview({
 
       {/* Actions */}
       <div className="flex gap-3 pt-2">
-        <button
-          type="button"
-          onClick={onBack}
-          className="rounded-lg border border-border px-6 py-2.5 text-sm text-foreground hover:bg-muted transition-colors"
-        >
+        <ButtonCVA type="button" variant="outline" onClick={onBack}>
           Back
-        </button>
-        <button
-          type="button"
-          onClick={onPublish}
-          disabled={submitting}
-          className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
-        >
+        </ButtonCVA>
+        <ButtonCVA type="button" onClick={onPublish} disabled={submitting}>
           {submitting ? 'Publishing...' : 'Publish Agent'}
-        </button>
+        </ButtonCVA>
       </div>
 
       <p className="text-xs text-muted-foreground">

--- a/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, Card, EmptyState, LinkButton, Skeleton } from '@revealui/presentation';
 import type { TaskSubmissionRecord } from '@revealui/sync';
 import { useTaskSubmissions } from '@revealui/sync';
 import Link from 'next/link';
@@ -20,13 +21,13 @@ interface TaskProgress {
 
 type StatusFilter = 'all' | 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
 
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-warning/10 text-warning-foreground',
-  queued: 'bg-primary/10 text-primary',
-  running: 'bg-primary/10 text-primary',
-  completed: 'bg-success/10 text-success',
-  failed: 'bg-error/10 text-error',
-  cancelled: 'bg-muted text-muted-foreground',
+const STATUS_BADGE_COLORS: Record<string, 'warning' | 'brand' | 'success' | 'danger' | 'muted'> = {
+  pending: 'warning',
+  queued: 'brand',
+  running: 'brand',
+  completed: 'success',
+  failed: 'danger',
+  cancelled: 'muted',
 };
 
 // =============================================================================
@@ -113,18 +114,13 @@ export default function TaskDashboardPage() {
               Failed to load tasks: {error.message}
             </div>
           ) : filteredTasks.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <p className="text-lg text-muted-foreground">No tasks found</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {filter !== 'all' ? 'Try a different filter' : 'Submit a task from the marketplace'}
-              </p>
-              <Link
-                href="/marketplace"
-                className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
-              >
-                Browse Agents
-              </Link>
-            </div>
+            <EmptyState
+              title="No tasks found"
+              description={
+                filter !== 'all' ? 'Try a different filter' : 'Submit a task from the marketplace'
+              }
+              action={<LinkButton href="/marketplace">Browse Agents</LinkButton>}
+            />
           ) : (
             <div className="space-y-3">
               {filteredTasks.map((task) => (
@@ -184,19 +180,15 @@ function TaskRow({
     };
   }, [apiUrl, task.id, task.status]);
 
-  const statusClass = STATUS_COLORS[task.status] ?? 'bg-muted text-muted-foreground';
-
   return (
-    <div className="rounded-lg border border-border bg-card">
+    <Card>
       {/* Row header */}
       <button
         type="button"
         onClick={onToggle}
         className="flex w-full items-center gap-4 px-4 py-3 text-left hover:bg-muted transition-colors"
       >
-        <span className={`rounded px-2.5 py-0.5 text-xs font-medium ${statusClass}`}>
-          {task.status}
-        </span>
+        <Badge color={STATUS_BADGE_COLORS[task.status] ?? 'muted'}>{task.status}</Badge>
         <span className="flex-1 text-sm text-foreground truncate">{task.skill_name}</span>
         <span className="text-xs text-muted-foreground">P{task.priority}</span>
         {task.cost_usdc && <span className="text-xs text-muted-foreground">${task.cost_usdc}</span>}
@@ -288,7 +280,7 @@ function TaskRow({
           )}
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 
@@ -300,17 +292,8 @@ function TaskTableSkeleton() {
   return (
     <div className="space-y-3">
       {Array.from({ length: 5 }, (_, i) => (
-        <div
-          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-          key={i}
-          className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
-        >
-          <div className="flex items-center gap-4">
-            <div className="h-5 w-16 rounded bg-muted" />
-            <div className="h-4 w-48 rounded bg-muted" />
-            <div className="ml-auto h-3 w-20 rounded bg-muted" />
-          </div>
-        </div>
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+        <Skeleton key={i} className="h-12 rounded-lg" />
       ))}
     </div>
   );

--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -1,5 +1,16 @@
 'use client';
 
+import {
+  Badge,
+  ButtonCVA,
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@revealui/presentation';
 import { type ChangeEvent, useEffect, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -95,6 +106,14 @@ function reducer(state: State, action: Action): State {
       return { ...state, user: null, userLoading: false };
   }
 }
+
+const REFUND_STATUS_COLORS: Record<string, 'success' | 'warning' | 'danger' | 'muted' | 'brand'> = {
+  succeeded: 'success',
+  pending: 'warning',
+  failed: 'danger',
+  canceled: 'muted',
+  requires_action: 'brand',
+};
 
 // =============================================================================
 // Page
@@ -271,148 +290,148 @@ function RefundsDashboard() {
 
       <div className="mx-auto max-w-4xl p-6">
         {/* Refund Form */}
-        <form
-          onSubmit={(e) => void handleSubmit(e)}
-          className="rounded-lg border border-border bg-card p-6"
-        >
-          <h2 className="mb-4 text-lg font-medium text-foreground">Issue Refund</h2>
+        <form onSubmit={(e) => void handleSubmit(e)}>
+          <Card className="p-6">
+            <h2 className="mb-4 text-lg font-medium text-foreground">Issue Refund</h2>
 
-          {/* Status Message */}
-          {message && (
-            <div
-              role="alert"
-              className={`mb-4 flex items-center justify-between rounded-lg border p-3 text-sm ${
-                submitStatus === 'success'
-                  ? 'border-success/30 bg-success/10 text-success'
-                  : 'border-error/30 bg-error/10 text-error'
-              }`}
-            >
-              <span>{message}</span>
-              <button
-                type="button"
-                onClick={() => dispatch({ type: 'DISMISS_MESSAGE' })}
-                className="ml-3 shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Dismiss message"
+            {/* Status Message */}
+            {message && (
+              <div
+                role="alert"
+                className={`mb-4 flex items-center justify-between rounded-lg border p-3 text-sm ${
+                  submitStatus === 'success'
+                    ? 'border-success/30 bg-success/10 text-success'
+                    : 'border-error/30 bg-error/10 text-error'
+                }`}
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
+                <span>{message}</span>
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: 'DISMISS_MESSAGE' })}
+                  className="ml-3 shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Dismiss message"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-          )}
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            {/* Payment Intent / Charge ID */}
-            <div className="sm:col-span-2">
-              <label
-                htmlFor="refund-identifier"
-                className="mb-1.5 block text-sm font-medium text-foreground"
-              >
-                Payment Intent or Charge ID
-              </label>
-              <input
-                id="refund-identifier"
-                type="text"
-                value={identifier}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
-                placeholder="pi_abc123 or ch_abc123"
-                required
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Prefix determines type: pi_ for payment intents, ch_ for charges
-              </p>
-            </div>
-
-            {/* Amount */}
-            <div>
-              <label
-                htmlFor="refund-amount"
-                className="mb-1.5 block text-sm font-medium text-foreground"
-              >
-                Amount (USD)
-              </label>
-              <input
-                id="refund-amount"
-                type="number"
-                value={amountInput}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
-                placeholder="Leave empty for full refund"
-                min="0.01"
-                step="0.01"
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Optional. Omit for a full refund.
-              </p>
-            </div>
-
-            {/* Reason */}
-            <div>
-              <label
-                htmlFor="refund-reason"
-                className="mb-1.5 block text-sm font-medium text-foreground"
-              >
-                Reason
-              </label>
-              <select
-                id="refund-reason"
-                value={reason}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) =>
-                  dispatch({
-                    type: 'SET_REASON',
-                    value: e.target.value as State['reason'],
-                  })
-                }
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              >
-                <option value="requested_by_customer">Requested by customer</option>
-                <option value="duplicate">Duplicate charge</option>
-                <option value="fraudulent">Fraudulent</option>
-              </select>
-            </div>
-          </div>
-
-          {/* Submit */}
-          <div className="mt-6 flex items-center gap-3">
-            <button
-              type="submit"
-              disabled={submitStatus === 'submitting' || !identifier.trim()}
-              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {submitStatus === 'submitting' ? (
-                <span className="flex items-center gap-2">
-                  <span
-                    className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground"
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
                     aria-hidden="true"
-                  />
-                  Processing...
-                </span>
-              ) : (
-                'Issue Refund'
-              )}
-            </button>
-            {submitStatus === 'submitting' && (
-              <span className="text-xs text-muted-foreground">This may take a few seconds...</span>
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
             )}
-          </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {/* Payment Intent / Charge ID */}
+              <div className="sm:col-span-2">
+                <label
+                  htmlFor="refund-identifier"
+                  className="mb-1.5 block text-sm font-medium text-foreground"
+                >
+                  Payment Intent or Charge ID
+                </label>
+                <input
+                  id="refund-identifier"
+                  type="text"
+                  value={identifier}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
+                  placeholder="pi_abc123 or ch_abc123"
+                  required
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Prefix determines type: pi_ for payment intents, ch_ for charges
+                </p>
+              </div>
+
+              {/* Amount */}
+              <div>
+                <label
+                  htmlFor="refund-amount"
+                  className="mb-1.5 block text-sm font-medium text-foreground"
+                >
+                  Amount (USD)
+                </label>
+                <input
+                  id="refund-amount"
+                  type="number"
+                  value={amountInput}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
+                  placeholder="Leave empty for full refund"
+                  min="0.01"
+                  step="0.01"
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Optional. Omit for a full refund.
+                </p>
+              </div>
+
+              {/* Reason */}
+              <div>
+                <label
+                  htmlFor="refund-reason"
+                  className="mb-1.5 block text-sm font-medium text-foreground"
+                >
+                  Reason
+                </label>
+                <select
+                  id="refund-reason"
+                  value={reason}
+                  onChange={(
+                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+                  ) =>
+                    dispatch({
+                      type: 'SET_REASON',
+                      value: e.target.value as State['reason'],
+                    })
+                  }
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                >
+                  <option value="requested_by_customer">Requested by customer</option>
+                  <option value="duplicate">Duplicate charge</option>
+                  <option value="fraudulent">Fraudulent</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Submit */}
+            <div className="mt-6 flex items-center gap-3">
+              <ButtonCVA
+                type="submit"
+                disabled={submitStatus === 'submitting' || !identifier.trim()}
+              >
+                {submitStatus === 'submitting' ? (
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground"
+                      aria-hidden="true"
+                    />
+                    Processing...
+                  </span>
+                ) : (
+                  'Issue Refund'
+                )}
+              </ButtonCVA>
+              {submitStatus === 'submitting' && (
+                <span className="text-xs text-muted-foreground">
+                  This may take a few seconds...
+                </span>
+              )}
+            </div>
+          </Card>
         </form>
 
         {/* Refund History (session-local) */}
@@ -422,59 +441,49 @@ function RefundsDashboard() {
               Recent Refunds{' '}
               <span className="text-sm font-normal text-muted-foreground">(this session)</span>
             </h2>
-            <div className="overflow-x-auto rounded-lg border border-border">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border bg-card">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Refund ID
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Status
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Amount
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Source
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Reason
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Time</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {history.map((record) => (
-                    <tr key={record.id} className="border-b border-border last:border-b-0">
-                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
-                        {record.id}
-                      </td>
-                      <td className="px-4 py-3">
-                        <RefundStatusBadge status={record.status} />
-                      </td>
-                      <td className="px-4 py-3 text-foreground">
-                        {formatAmount(record.amount, record.currency)}
-                      </td>
-                      <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
-                        {record.paymentIntentId ?? record.chargeId ?? '-'}
-                      </td>
-                      <td className="px-4 py-3 text-muted-foreground">
-                        {formatReason(record.reason)}
-                      </td>
-                      <td className="px-4 py-3 text-xs text-muted-foreground">
-                        {new Date(record.createdAt).toLocaleTimeString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableHeader>Refund ID</TableHeader>
+                  <TableHeader>Status</TableHeader>
+                  <TableHeader>Amount</TableHeader>
+                  <TableHeader>Source</TableHeader>
+                  <TableHeader>Reason</TableHeader>
+                  <TableHeader>Time</TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {history.map((record) => (
+                  <TableRow key={record.id}>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {record.id}
+                    </TableCell>
+                    <TableCell>
+                      <Badge color={REFUND_STATUS_COLORS[record.status] ?? 'muted'}>
+                        {record.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-foreground">
+                      {formatAmount(record.amount, record.currency)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {record.paymentIntentId ?? record.chargeId ?? '-'}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatReason(record.reason)}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {new Date(record.createdAt).toLocaleTimeString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           </div>
         )}
 
         {/* Help text */}
-        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+        <Card className="mt-8 p-4">
           <h3 className="text-sm font-medium text-foreground">Notes</h3>
           <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
             <li>
@@ -498,26 +507,10 @@ function RefundsDashboard() {
               .
             </li>
           </ul>
-        </div>
+        </Card>
       </div>
     </div>
   );
-}
-
-// =============================================================================
-// Components
-// =============================================================================
-
-function RefundStatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    succeeded: 'bg-success/10 text-success',
-    pending: 'bg-warning/15 text-warning-foreground',
-    failed: 'bg-error/10 text-error',
-    canceled: 'bg-muted text-muted-foreground',
-    requires_action: 'bg-primary/10 text-primary',
-  };
-  const color = colors[status] ?? 'bg-muted text-muted-foreground';
-  return <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>{status}</span>;
 }
 
 // =============================================================================


### PR DESCRIPTION
refactor(admin): adopt presentation primitives in marketplace + refunds (Phase 3b)

Primitive-adoption audit Phase 3, slice b (marketplace pages + refunds). App-level only —
no package dependency changes (tokens-only architecture).

Migrated 7 pages onto @revealui/presentation primitives, behavior preserved:
- ButtonCVA / LinkButton — buttons + link-buttons across marketplace page/[agentId]/publish/
  tasks/analytics + refunds (Issue Refund, keeping its spinner markup).
- Card — content/section panels (skill cards, review cards, cost estimate, refund form/notes,
  earnings rows, task rows, publish step-3/4 cards).
- Table family (Table/TableHead/TableBody/TableRow/TableHeader/TableCell) — refunds history
  table + analytics agents table.
- Stat — analytics MetricCard (4 tiles) and earnings SummaryCard (3 tiles).
- Badge (tones muted/brand/warning/success/danger) — status pills across tasks/analytics/
  earnings/refunds (replaced ad-hoc STATUS_COLORS maps with tone maps).
- Skeleton / SkeletonText — loaders; EmptyState — empty states (with LinkButton actions).

Form inputs (<input>/<select>/<textarea>/<label>, incl. type=range/radio in publish + [agentId])
were deliberately LEFT untouched — they belong to Phase 4. (Inputs re-indent in the diff only
because their container became a Card; the controls themselves are unchanged.)

Handrolls LEFT (same presentation gaps tracked for Phase 6, plus this slice's extras):
- Tab strips (Tab hardcodes border-blue-600); inline status banners (Alert is modal-only);
  loading spinners (no Spinner primitive); access-denied tinted panels.
- publish step stepper (custom Stepper state); [agentId] 1-5 rating picker (interactive
  selector, not action buttons); publish pricing-model radio-label-as-card.
- Minor visual delta: analytics rows lose their custom bg-muted/hover:bg-card tint in favor of
  TableRow's built-in row treatment.

Verified: admin typecheck + build green; biome clean.
