### PR TITLE
refactor(admin): adopt presentation primitives in the mcp area (Phase 3c)

### DIFF
--- a/apps/admin/src/app/(backend)/mcp/connect/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/connect/page.tsx
@@ -12,6 +12,8 @@
  * via the revvault-backed `McpOAuthProvider`.
  */
 
+import { ButtonCVA, Card } from '@revealui/presentation/server';
+
 type SearchParamValue = string | string[] | undefined;
 
 function firstString(value: SearchParamValue): string | undefined {
@@ -68,91 +70,84 @@ export default async function ConnectMcpServerPage({
           </div>
         )}
 
-        <form
-          method="GET"
-          action="/api/mcp/oauth/initiate"
-          className="rounded-lg border border-border bg-card p-6"
-        >
-          <div className="grid gap-4">
-            <div>
-              <label
-                htmlFor="tenant"
-                className="mb-1.5 block text-sm font-medium text-muted-foreground"
-              >
-                Tenant
-              </label>
-              <input
-                id="tenant"
-                name="tenant"
-                type="text"
-                required
-                pattern="[A-Za-z0-9_-]{1,64}"
-                placeholder="acme"
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Identifier under which tokens are scoped in revvault. Alphanumeric, underscore,
-                hyphen.
-              </p>
+        <Card className="p-6">
+          <form method="GET" action="/api/mcp/oauth/initiate">
+            <div className="grid gap-4">
+              <div>
+                <label
+                  htmlFor="tenant"
+                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
+                >
+                  Tenant
+                </label>
+                <input
+                  id="tenant"
+                  name="tenant"
+                  type="text"
+                  required
+                  pattern="[A-Za-z0-9_-]{1,64}"
+                  placeholder="acme"
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Identifier under which tokens are scoped in revvault. Alphanumeric, underscore,
+                  hyphen.
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="server"
+                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
+                >
+                  Server name
+                </label>
+                <input
+                  id="server"
+                  name="server"
+                  type="text"
+                  required
+                  pattern="[A-Za-z0-9_-]{1,64}"
+                  placeholder="linear"
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Short identifier for this MCP server. Used as the revvault path segment.
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="serverUrl"
+                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
+                >
+                  Server URL
+                </label>
+                <input
+                  id="serverUrl"
+                  name="serverUrl"
+                  type="url"
+                  required
+                  placeholder="https://mcp.example.com"
+                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  The MCP server&rsquo;s base URL. Must be HTTPS in production (localhost allowed
+                  for dev).
+                </p>
+              </div>
             </div>
 
-            <div>
-              <label
-                htmlFor="server"
-                className="mb-1.5 block text-sm font-medium text-muted-foreground"
-              >
-                Server name
-              </label>
-              <input
-                id="server"
-                name="server"
-                type="text"
-                required
-                pattern="[A-Za-z0-9_-]{1,64}"
-                placeholder="linear"
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Short identifier for this MCP server. Used as the revvault path segment.
-              </p>
+            <div className="mt-6 flex items-center gap-3">
+              <ButtonCVA type="submit">Authorize</ButtonCVA>
+              <span className="text-xs text-muted-foreground">
+                You&rsquo;ll be redirected to the server&rsquo;s consent screen.
+              </span>
             </div>
+          </form>
+        </Card>
 
-            <div>
-              <label
-                htmlFor="serverUrl"
-                className="mb-1.5 block text-sm font-medium text-muted-foreground"
-              >
-                Server URL
-              </label>
-              <input
-                id="serverUrl"
-                name="serverUrl"
-                type="url"
-                required
-                placeholder="https://mcp.example.com"
-                className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                The MCP server&rsquo;s base URL. Must be HTTPS in production (localhost allowed for
-                dev).
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-6 flex items-center gap-3">
-            <button
-              type="submit"
-              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-            >
-              Authorize
-            </button>
-            <span className="text-xs text-muted-foreground">
-              You&rsquo;ll be redirected to the server&rsquo;s consent screen.
-            </span>
-          </div>
-        </form>
-
-        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+        <Card className="mt-8 p-4">
           <h3 className="text-sm font-medium text-muted-foreground">How it works</h3>
           <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
             <li>
@@ -174,7 +169,7 @@ export default async function ConnectMcpServerPage({
               Refresh rotation is handled automatically by the MCP client on subsequent connections.
             </li>
           </ol>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/apps/admin/src/app/(backend)/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/page.tsx
@@ -13,6 +13,17 @@
 
 'use client';
 
+import {
+  Badge,
+  ButtonCVA,
+  LinkButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@revealui/presentation';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
 import { UsageDashboard } from '@/lib/components/mcp/usage-dashboard';
@@ -142,12 +153,9 @@ export default function McpCatalogPage() {
               Built-in and OAuth-authorized servers, content exposure, and per-meter usage
             </p>
           </div>
-          <a
-            href="/mcp/connect"
-            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90"
-          >
+          <LinkButton href="/mcp/connect" variant="default">
             Connect new server
-          </a>
+          </LinkButton>
         </div>
       </div>
 
@@ -210,13 +218,13 @@ export default function McpCatalogPage() {
                   placeholder="acme"
                   className="w-64 rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
-                <button
+                <ButtonCVA
                   type="submit"
+                  variant="outline"
                   disabled={!tenant.trim() || state === 'loading'}
-                  className="rounded-md bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {state === 'loading' ? 'Loading…' : 'Load'}
-                </button>
+                </ButtonCVA>
                 {activeTenant && state === 'ready' && (
                   <span className="text-xs text-muted-foreground">
                     Showing remote servers for{' '}
@@ -244,54 +252,48 @@ export default function McpCatalogPage() {
               )}
               {remotes.length > 0 && (
                 <div className="overflow-hidden rounded-lg border border-border">
-                  <table className="w-full text-sm">
-                    <thead className="bg-card">
-                      <tr>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          Server
-                        </th>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          Tenant
-                        </th>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          State
-                        </th>
-                        <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                          Actions
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableHeader>Server</TableHeader>
+                        <TableHeader>Tenant</TableHeader>
+                        <TableHeader>State</TableHeader>
+                        <TableHeader className="text-right">Actions</TableHeader>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
                       {remotes.map((r) => (
-                        <tr key={`${r.tenant}/${r.server}`} className="border-t border-border">
-                          <td className="px-4 py-3 font-mono text-muted-foreground">{r.server}</td>
-                          <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                        <TableRow key={`${r.tenant}/${r.server}`}>
+                          <TableCell className="font-mono text-muted-foreground">
+                            {r.server}
+                          </TableCell>
+                          <TableCell className="font-mono text-xs text-muted-foreground">
                             {r.tenant}
-                          </td>
-                          <td className="px-4 py-3">
-                            <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
-                              {r.connectionState}
-                            </span>
-                          </td>
-                          <td className="flex items-center justify-end gap-3 px-4 py-3 text-right">
-                            <a
-                              href={`/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
-                              className="text-xs font-medium text-success hover:text-success"
-                            >
-                              Inspect
-                            </a>
-                            <button
-                              type="button"
-                              onClick={() => void handleDisconnect(r.server)}
-                              className="text-xs font-medium text-error hover:text-error"
-                            >
-                              Disconnect
-                            </button>
-                          </td>
-                        </tr>
+                          </TableCell>
+                          <TableCell>
+                            <Badge color="success">{r.connectionState}</Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-3">
+                              <a
+                                href={`/mcp/inspect?tenant=${encodeURIComponent(r.tenant)}&server=${encodeURIComponent(r.server)}`}
+                                className="text-xs font-medium text-success hover:text-success"
+                              >
+                                Inspect
+                              </a>
+                              <button
+                                type="button"
+                                onClick={() => void handleDisconnect(r.server)}
+                                className="text-xs font-medium text-error hover:text-error"
+                              >
+                                Disconnect
+                              </button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
                       ))}
-                    </tbody>
-                  </table>
+                    </TableBody>
+                  </Table>
                 </div>
               )}
             </section>
@@ -317,42 +319,34 @@ export default function McpCatalogPage() {
                 </div>
               ) : (
                 <div className="overflow-hidden rounded-lg border border-border">
-                  <table className="w-full text-sm">
-                    <thead className="bg-card">
-                      <tr>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          Slug
-                        </th>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          Label
-                        </th>
-                        <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                          Exposure
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableHeader>Slug</TableHeader>
+                        <TableHeader>Label</TableHeader>
+                        <TableHeader>Exposure</TableHeader>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
                       {collections.map((c) => (
-                        <tr key={c.slug} className="border-t border-border">
-                          <td className="px-4 py-3 font-mono text-muted-foreground">{c.slug}</td>
-                          <td className="px-4 py-3 text-muted-foreground">
+                        <TableRow key={c.slug}>
+                          <TableCell className="font-mono text-muted-foreground">
+                            {c.slug}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
                             {c.labelPlural ?? c.label}
-                          </td>
-                          <td className="px-4 py-3">
+                          </TableCell>
+                          <TableCell>
                             {c.mcpResource ? (
-                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
-                                exposed
-                              </span>
+                              <Badge color="success">exposed</Badge>
                             ) : (
-                              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                                hidden
-                              </span>
+                              <Badge color="muted">hidden</Badge>
                             )}
-                          </td>
-                        </tr>
+                          </TableCell>
+                        </TableRow>
                       ))}
-                    </tbody>
-                  </table>
+                    </TableBody>
+                  </Table>
                 </div>
               )}
             </section>

--- a/apps/admin/src/lib/components/mcp/elicitation-form.tsx
+++ b/apps/admin/src/lib/components/mcp/elicitation-form.tsx
@@ -14,6 +14,7 @@
 
 'use client';
 
+import { ButtonCVA } from '@revealui/presentation';
 import { useState } from 'react';
 
 // ---------------------------------------------------------------------------
@@ -179,26 +180,25 @@ export function ElicitationForm({ message, requestedSchema, onSubmit }: Elicitat
         ))}
       </div>
       <div className="mt-3 flex items-center gap-2">
-        <button
-          type="submit"
-          className="rounded-md bg-success px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-success/90"
-        >
+        <ButtonCVA type="submit" variant="default" size="sm">
           Accept
-        </button>
-        <button
+        </ButtonCVA>
+        <ButtonCVA
           type="button"
+          variant="outline"
+          size="sm"
           onClick={() => void onSubmit('decline')}
-          className="rounded-md border border-border bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
         >
           Decline
-        </button>
-        <button
+        </ButtonCVA>
+        <ButtonCVA
           type="button"
+          variant="destructive"
+          size="sm"
           onClick={() => void onSubmit('cancel')}
-          className="rounded-md border border-error/30 bg-error/10 px-3 py-1.5 text-xs font-medium text-error transition-colors hover:bg-error/20"
         >
           Cancel
-        </button>
+        </ButtonCVA>
       </div>
     </form>
   );

--- a/apps/admin/src/lib/components/mcp/logs-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/logs-panel.tsx
@@ -9,6 +9,7 @@
 
 'use client';
 
+import { ButtonCVA } from '@revealui/presentation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface LogEntry {
@@ -155,30 +156,23 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
           ))}
         </select>
         {state === 'streaming' || state === 'connecting' ? (
-          <button
-            type="button"
-            onClick={stop}
-            className="rounded-md border border-border bg-muted px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted"
-          >
+          <ButtonCVA type="button" variant="outline" size="sm" onClick={stop}>
             Stop
-          </button>
+          </ButtonCVA>
         ) : (
-          <button
-            type="button"
-            onClick={() => void start()}
-            className="rounded-md bg-success px-3 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-success/90"
-          >
+          <ButtonCVA type="button" size="sm" onClick={() => void start()}>
             Start
-          </button>
+          </ButtonCVA>
         )}
-        <button
+        <ButtonCVA
           type="button"
+          variant="outline"
+          size="sm"
           onClick={() => setEntries([])}
           disabled={entries.length === 0}
-          className="rounded-md border border-border bg-muted px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
         >
           Clear
-        </button>
+        </ButtonCVA>
         <div className="ml-auto text-xs text-muted-foreground">
           {state === 'streaming' && (
             <span className="inline-flex items-center gap-1.5">

--- a/apps/admin/src/lib/components/mcp/prompts-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/prompts-panel.tsx
@@ -10,6 +10,7 @@
 
 'use client';
 
+import { ButtonCVA } from '@revealui/presentation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -183,13 +184,9 @@ function PromptCard({ prompt, tenant, server }: PromptCardProps) {
         ))}
 
         <div className="flex items-center gap-3 pt-2">
-          <button
-            type="submit"
-            disabled={submitting}
-            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <ButtonCVA type="submit" disabled={submitting}>
             {submitting ? 'Resolving…' : 'Resolve'}
-          </button>
+          </ButtonCVA>
           {error && <span className="text-xs text-error">{error}</span>}
         </div>
       </form>

--- a/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
+++ b/apps/admin/src/lib/components/mcp/streaming-tool-card.tsx
@@ -19,6 +19,7 @@
 
 'use client';
 
+import { ButtonCVA, Card } from '@revealui/presentation';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 import {
@@ -294,21 +295,13 @@ export function StreamingToolCard({ tool, tenant, server }: StreamingToolCardPro
         ))}
 
         <div className="flex items-center gap-3 pt-2">
-          <button
-            type="submit"
-            disabled={invoking}
-            className="rounded-md bg-success px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <ButtonCVA type="submit" disabled={invoking}>
             {invoking ? 'Invoking…' : 'Invoke'}
-          </button>
+          </ButtonCVA>
           {invoking && (
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted"
-            >
+            <ButtonCVA type="button" variant="outline" size="sm" onClick={handleCancel}>
               Cancel
-            </button>
+            </ButtonCVA>
           )}
         </div>
       </form>
@@ -346,7 +339,7 @@ function ProgressDisplay({
       ? Math.min(100, Math.round((progress.progress / progress.total) * 100))
       : undefined;
   return (
-    <div className="mt-4 rounded-md border border-border bg-card p-3">
+    <Card className="mt-4 p-3">
       <div className="mb-1.5 flex items-center justify-between text-[10px] text-muted-foreground">
         <span>{progress.message ?? 'Progress'}</span>
         <span className="font-mono">
@@ -363,7 +356,7 @@ function ProgressDisplay({
           }
         />
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
+++ b/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
@@ -8,6 +8,14 @@
 
 'use client';
 
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@revealui/presentation';
 import { useCallback, useEffect, useState } from 'react';
 
 type Range = '24h' | '7d' | '30d';
@@ -176,69 +184,65 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
       )}
 
       {state === 'ready' && data && data.meters.length > 0 && (
-        <div className="overflow-hidden rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-card">
-              <tr>
-                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Meter</th>
-                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Calls</th>
-                <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                  Outcome mix
-                </th>
-                <th className="px-4 py-3 text-right font-medium text-muted-foreground">p50</th>
-                <th className="px-4 py-3 text-right font-medium text-muted-foreground">p95</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.meters.map((m) => (
-                <tr key={m.meterName} className="border-t border-border align-middle">
-                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
-                    {m.meterName}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">{m.total.toLocaleString()}</td>
-                  <td className="min-w-48 px-4 py-3">
-                    <StackedBar
-                      successCount={m.successCount}
-                      errorCount={m.errorCount}
-                      unknownCount={m.unknownCount}
-                    />
-                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableHeader>Meter</TableHeader>
+              <TableHeader>Calls</TableHeader>
+              <TableHeader>Outcome mix</TableHeader>
+              <TableHeader className="text-right">p50</TableHeader>
+              <TableHeader className="text-right">p95</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.meters.map((m) => (
+              <TableRow key={m.meterName} className="align-middle">
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {m.meterName}
+                </TableCell>
+                <TableCell className="text-muted-foreground">{m.total.toLocaleString()}</TableCell>
+                <TableCell className="min-w-48">
+                  <StackedBar
+                    successCount={m.successCount}
+                    errorCount={m.errorCount}
+                    unknownCount={m.unknownCount}
+                  />
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                    <span>
+                      <span
+                        aria-hidden="true"
+                        className="mr-1 inline-block h-2 w-2 rounded-sm bg-success align-middle"
+                      />
+                      {m.successCount} ok
+                    </span>
+                    <span>
+                      <span
+                        aria-hidden="true"
+                        className="mr-1 inline-block h-2 w-2 rounded-sm bg-error align-middle"
+                      />
+                      {m.errorCount} err
+                    </span>
+                    {m.unknownCount > 0 && (
                       <span>
                         <span
                           aria-hidden="true"
-                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-success align-middle"
+                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-muted-foreground align-middle"
                         />
-                        {m.successCount} ok
+                        {m.unknownCount} unknown
                       </span>
-                      <span>
-                        <span
-                          aria-hidden="true"
-                          className="mr-1 inline-block h-2 w-2 rounded-sm bg-error align-middle"
-                        />
-                        {m.errorCount} err
-                      </span>
-                      {m.unknownCount > 0 && (
-                        <span>
-                          <span
-                            aria-hidden="true"
-                            className="mr-1 inline-block h-2 w-2 rounded-sm bg-muted-foreground align-middle"
-                          />
-                          {m.unknownCount} unknown
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono text-xs text-muted-foreground">
-                    {formatDuration(m.p50Ms)}
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono text-xs text-muted-foreground">
-                    {formatDuration(m.p95Ms)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs text-muted-foreground">
+                  {formatDuration(m.p50Ms)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs text-muted-foreground">
+                  {formatDuration(m.p95Ms)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       )}
 
       {state === 'ready' && data && (


### PR DESCRIPTION
refactor(admin): adopt presentation primitives in the mcp area (Phase 3c)

Primitive-adoption audit Phase 3, slice c (mcp pages + panels). App-level only — no package
dependency changes (tokens-only architecture).

Migrated 7 of 9 mcp files onto @revealui/presentation primitives, behavior preserved
(per-file import entry honored: mcp/connect is RSC -> /server, the rest -> main entry):
- ButtonCVA / LinkButton — buttons + CTAs across mcp page / connect / elicitation-form /
  streaming-tool-card / logs-panel / prompts-panel.
- Card — form/info/result panels (connect form, ProgressDisplay, etc.).
- Table family — mcp/page remote-servers + content-exposure tables, usage-dashboard meters table.
- Badge (tones muted/brand/warning/success/danger) — status/exposure pills.
- usage-dashboard: visible text/values preserved exactly; its RTL test passes 6/6.

Form inputs (<input>/<select>/<label>) left untouched for Phase 4 (boundary verified: input
counts unchanged, re-indent only under new Cards).

Files left unchanged: mcp/inspect (only tab strip + inline banners — both Phase-6 gaps) and
resources-panel (full-width selection-list buttons + title-less loading placeholders — no clean
primitive fit).

Handrolls LEFT (Phase-6 presentation gaps): Tab strips (Tab hardcodes border-blue/success);
inline status banners (Alert is modal-only); tinted cards/<details> disclosures (no Card
tint/collapsible); live/pulse + loading indicators (no Spinner); full-width selection-list button.

VISUAL DELTAS for review: Start (logs-panel) / Resolve (prompts-panel) / Invoke
(streaming-tool-card) action buttons were bg-success (green) and are now ButtonCVA
variant="default" (primary) — ButtonCVA has no success variant, so these normalize to the
primary CTA color. Flagged for sign-off; can be kept green via className if preferred.

Verified: admin typecheck + build green; biome clean; usage-dashboard test 6/6.
(Note: an unrelated pre-existing failure on `test` — auth-routes "403 when user limit reached" —
is NOT touched by this PR; appears tied to the recent auth/admission sign-up changes.)
