### PR TITLE
refactor(admin): adopt presentation primitives in chat + coordination (Phase 3d)

### DIFF
--- a/apps/admin/src/app/(backend)/chat/page.tsx
+++ b/apps/admin/src/app/(backend)/chat/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ButtonCVA, EmptyState, Skeleton } from '@revealui/presentation';
 import { useConversations } from '@revealui/sync';
 import { useState } from 'react';
 import AgentChat from '@/lib/components/Agent';
@@ -49,13 +50,9 @@ export default function ChatPage() {
             <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
               Conversations
             </span>
-            <button
-              type="button"
-              onClick={handleNewChat}
-              className="rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700"
-            >
+            <ButtonCVA type="button" variant="default" size="sm" onClick={handleNewChat}>
               New
-            </button>
+            </ButtonCVA>
           </div>
           <div className="flex-1 overflow-y-auto">
             {sidebarLoading ? (
@@ -64,12 +61,9 @@ export default function ChatPage() {
                   <div
                     // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
                     key={i}
-                    className="animate-pulse rounded-md px-3 py-2.5"
+                    className="rounded-md px-3 py-2.5"
                   >
-                    <div
-                      className="h-4 rounded bg-zinc-200 dark:bg-zinc-700"
-                      style={{ width: `${60 + (i % 3) * 15}%` }}
-                    />
+                    <Skeleton className="h-4" style={{ width: `${60 + (i % 3) * 15}%` }} />
                   </div>
                 ))}
               </div>
@@ -80,24 +74,27 @@ export default function ChatPage() {
                 </p>
               </div>
             ) : conversations.length === 0 ? (
-              <div className="flex flex-col items-center px-3 py-8">
-                <svg
-                  className="mb-2 size-6 text-zinc-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 01-.825-.242m9.345-8.334a2.126 2.126 0 00-.476-.095 48.64 48.64 0 00-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0011.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
-                  />
-                </svg>
-                <p className="text-center text-xs text-zinc-400">No conversations yet</p>
-                <p className="mt-1 text-center text-xs text-zinc-500">Start a new chat to begin</p>
-              </div>
+              <EmptyState
+                icon={
+                  <svg
+                    className="size-6 text-zinc-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 01-.825-.242m9.345-8.334a2.126 2.126 0 00-.476-.095 48.64 48.64 0 00-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0011.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
+                    />
+                  </svg>
+                }
+                title="No conversations yet"
+                description="Start a new chat to begin"
+                className="border-0 py-8"
+              />
             ) : null}
             {!(sidebarLoading || sidebarError) &&
               conversations.map((conv) => (
@@ -137,7 +134,7 @@ export default function ChatPage() {
           className="flex w-6 shrink-0 items-center justify-center border-r border-zinc-200 bg-zinc-50 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
           aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
         >
-          {sidebarOpen ? '\u2039' : '\u203A'}
+          {sidebarOpen ? '‹' : '›'}
         </button>
 
         {/* Chat area */}

--- a/apps/admin/src/app/(backend)/coordination/page.tsx
+++ b/apps/admin/src/app/(backend)/coordination/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, Card, EmptyState, Skeleton } from '@revealui/presentation';
 import type { CoordinationSessionRecord } from '@revealui/sync';
 import { useCoordinationSessions } from '@revealui/sync';
 import { useState } from 'react';
@@ -26,12 +27,6 @@ function isStaleSession(record: CoordinationSessionRecord): boolean {
 // =============================================================================
 // Helpers
 // =============================================================================
-
-const STATUS_COLORS: Record<string, string> = {
-  active: 'bg-success/10 text-success',
-  ended: 'bg-muted text-muted-foreground',
-  crashed: 'bg-error/10 text-error',
-};
 
 function formatAge(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -135,12 +130,12 @@ function CoordinationDashboard() {
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
                 key={i}
-                className="animate-pulse rounded-lg border border-border bg-card px-4 py-3"
+                className="rounded-lg border border-border bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <div className="h-5 w-16 rounded-full bg-foreground/10" />
-                  <div className="h-4 flex-1 rounded bg-foreground/10" />
-                  <div className="h-3 w-32 rounded bg-foreground/10" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                  <Skeleton className="h-4 flex-1" />
+                  <Skeleton className="h-3 w-32" />
                 </div>
               </div>
             ))}
@@ -153,7 +148,30 @@ function CoordinationDashboard() {
             {error.message}
           </div>
         ) : displayed.length === 0 ? (
-          <EmptyState scope={scope} />
+          <EmptyState
+            icon={
+              <svg
+                className="h-6 w-6 text-muted-foreground"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+                />
+              </svg>
+            }
+            title={scope === 'active' ? 'No active sessions' : 'No sessions found'}
+            description={
+              scope === 'active'
+                ? 'No active coordination sessions. The daemon writes here when started with POSTGRES_URL set; sessions appear within seconds of session.register.'
+                : 'No coordination sessions found. Either no daemons have run with POSTGRES_URL set, or all sessions have ended.'
+            }
+          />
         ) : (
           <>
             <div className="mb-3 text-xs text-muted-foreground">
@@ -206,15 +224,6 @@ function StatPill({
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
-  const color = STATUS_COLORS[status] ?? 'bg-muted text-muted-foreground';
-  return (
-    <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
-      {status}
-    </span>
-  );
-}
-
 function SessionRow({
   session,
   expanded,
@@ -227,8 +236,15 @@ function SessionRow({
   const age = ageSeconds(session.started_at);
   const stale = isStaleSession(session);
 
+  const statusColor = (status: string) => {
+    if (status === 'active') return 'success' as const;
+    if (status === 'ended') return 'muted' as const;
+    if (status === 'crashed') return 'danger' as const;
+    return 'muted' as const;
+  };
+
   return (
-    <div className="rounded-lg border border-border bg-card transition-colors hover:border-ring">
+    <Card className="hover:border-ring transition-colors">
       <button
         type="button"
         onClick={onToggle}
@@ -236,7 +252,7 @@ function SessionRow({
         aria-expanded={expanded}
       >
         <div className="flex items-center gap-3">
-          <StatusBadge status={session.status} />
+          <Badge color={statusColor(session.status)}>{session.status}</Badge>
           <span className="truncate font-mono text-sm text-muted-foreground">
             {session.agent_id}
           </span>
@@ -247,12 +263,9 @@ function SessionRow({
             {formatAge(age)}
           </span>
           {stale && (
-            <span
-              title="Session has not ended after 7+ days — likely a stale row"
-              className="shrink-0 rounded-full bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning-foreground"
-            >
+            <Badge color="warning" title="Session has not ended after 7+ days — likely a stale row">
               stale
-            </span>
+            </Badge>
           )}
           <ChevronIcon expanded={expanded} />
         </div>
@@ -275,12 +288,11 @@ function SessionRow({
                 <h4 className="mb-1 text-xs font-medium text-muted-foreground">Tool counters</h4>
                 <div className="flex flex-wrap gap-2">
                   {Object.entries(session.tools).map(([tool, n]) => (
-                    <span
-                      key={tool}
-                      className="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground"
-                    >
-                      {tool}: {n}
-                    </span>
+                    <Badge key={tool} color="muted">
+                      <span className="font-mono">
+                        {tool}: {n}
+                      </span>
+                    </Badge>
                   ))}
                 </div>
               </div>
@@ -288,7 +300,7 @@ function SessionRow({
           </div>
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 
@@ -312,34 +324,5 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
     >
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
     </svg>
-  );
-}
-
-function EmptyState({ scope }: { scope: Scope }) {
-  const message =
-    scope === 'active'
-      ? 'No active coordination sessions. The daemon writes here when started with POSTGRES_URL set; sessions appear within seconds of session.register.'
-      : 'No coordination sessions found. Either no daemons have run with POSTGRES_URL set, or all sessions have ended.';
-
-  return (
-    <div className="flex flex-col items-center py-16">
-      <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-        <svg
-          className="h-6 w-6 text-muted-foreground"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
-          />
-        </svg>
-      </div>
-      <p className="max-w-md text-center text-sm text-muted-foreground">{message}</p>
-    </div>
   );
 }


### PR DESCRIPTION
refactor(admin): adopt presentation primitives in chat + coordination (Phase 3d)

Primitive-adoption audit Phase 3, final slice d (chat + coordination). App-level only — no
package dependency changes.

coordination/page.tsx (clean fit):
- Badge — StatusBadge (active->success, ended->muted, crashed->danger), the stale pill
  (->warning), and tool-counter pills (->muted); STATUS_COLORS map removed.
- Card — SessionRow wrapper (hover:border-ring passed through className).
- Skeleton — loading shimmer rows; EmptyState — both scope variants (icon slot + title/description).

chat/page.tsx (sidebar page on raw zinc-* — adopted only what cleanly fits; Sidebar layout +
token sweep deliberately left for Phase 6):
- ButtonCVA — the "New" button (dropping raw bg-blue-600 for the primary token).
- Skeleton — conversation-list loaders; EmptyState — "No conversations yet" (border-0 to sit
  inside the sidebar chrome).

Left handrolled (Phase-6): chat sidebar collapse toggle + conversation list-item buttons
(Sidebar chrome), all zinc-*/blue-50 surfaces (token sweep); coordination StatPill (no compact
Stat variant), scope tab strip (Tab hardcodes blue), inline error banners (Alert is modal-only).

Verified: admin typecheck + build green (Compiled successfully, 37/37 static pages); biome clean.
The build-time "Invalid URL" logs for /api/shapes/* are pre-existing ElectricSQL-sync prerender
fallbacks, unrelated to this UI change.
