### PR TITLE
fix(presentation): brand-tokenize Tab + Callout; add inline status role to Callout

### DIFF
--- a/.changeset/tab-callout-brand-tokens.md
+++ b/.changeset/tab-callout-brand-tokens.md
@@ -1,0 +1,8 @@
+---
+"@revealui/presentation": minor
+---
+
+Brand-tokenize `Tab` and `Callout`, and make `Callout` usable as an inline status banner.
+
+- `Tab`/`TabList`: replace the hardcoded `blue-*`/`zinc-*` palette with semantic tokens (`border-primary`/`text-primary` active, `text-muted-foreground`/`border-border` rest, `outline-ring` focus), and move the consumer `className` to last in the merge so the active color can be overridden.
+- `Callout`: replace the per-variant raw palette (`blue/amber/red/green/violet`) with brand tokens (`primary`/`warning`/`error`/`success`/`accent`); title→`text-foreground`, body→`text-muted-foreground`. Add a `role` prop (`'note' | 'status' | 'alert'`, default `'note'`) so it can serve as an inline status/alert banner — the modal `Alert` remains modal-only.

--- a/packages/presentation/src/components/callout.tsx
+++ b/packages/presentation/src/components/callout.tsx
@@ -5,28 +5,28 @@ type CalloutVariant = 'info' | 'warning' | 'error' | 'success' | 'tip';
 
 const variantStyles: Record<CalloutVariant, { wrapper: string; icon: string; iconChar: string }> = {
   info: {
-    wrapper: 'bg-blue-50 ring-blue-200 dark:bg-blue-950/30 dark:ring-blue-800',
-    icon: 'text-blue-600 dark:text-blue-400',
+    wrapper: 'bg-primary/10 ring-primary/20',
+    icon: 'text-primary',
     iconChar: 'i',
   },
   warning: {
-    wrapper: 'bg-amber-50 ring-amber-200 dark:bg-amber-950/30 dark:ring-amber-800',
-    icon: 'text-amber-600 dark:text-amber-400',
+    wrapper: 'bg-warning/10 ring-warning/20',
+    icon: 'text-warning-foreground',
     iconChar: '!',
   },
   error: {
-    wrapper: 'bg-red-50 ring-red-200 dark:bg-red-950/30 dark:ring-red-800',
-    icon: 'text-red-600 dark:text-red-400',
+    wrapper: 'bg-error/10 ring-error/20',
+    icon: 'text-error',
     iconChar: '✕',
   },
   success: {
-    wrapper: 'bg-green-50 ring-green-200 dark:bg-green-950/30 dark:ring-green-800',
-    icon: 'text-green-600 dark:text-green-400',
+    wrapper: 'bg-success/10 ring-success/20',
+    icon: 'text-success',
     iconChar: '✓',
   },
   tip: {
-    wrapper: 'bg-violet-50 ring-violet-200 dark:bg-violet-950/30 dark:ring-violet-800',
-    icon: 'text-violet-600 dark:text-violet-400',
+    wrapper: 'bg-accent/10 ring-accent/20',
+    icon: 'text-accent-foreground',
     iconChar: '★',
   },
 };
@@ -35,28 +35,29 @@ export function Callout({
   variant = 'info',
   title,
   icon,
+  role = 'note',
   className,
   children,
 }: {
   variant?: CalloutVariant;
   title?: string;
   icon?: React.ReactNode;
+  /** ARIA role. Default 'note'; use 'status'/'alert' for live status banners. */
+  role?: 'note' | 'status' | 'alert';
   className?: string;
   children: React.ReactNode;
 }) {
   const styles = variantStyles[variant];
 
   return (
-    <div role="note" className={cn('rounded-xl p-4 ring-1', styles.wrapper, className)}>
+    <div role={role} className={cn('rounded-xl p-4 ring-1', styles.wrapper, className)}>
       <div className="flex gap-3">
         <span className={cn('mt-0.5 shrink-0 text-sm font-bold', styles.icon)} aria-hidden="true">
           {icon ?? styles.iconChar}
         </span>
         <div className="min-w-0 flex-1">
-          {title && <p className="text-sm font-semibold text-zinc-950 dark:text-white">{title}</p>}
-          <div className={cn('text-sm text-zinc-700 dark:text-zinc-300', title && 'mt-1')}>
-            {children}
-          </div>
+          {title && <p className="text-sm font-semibold text-foreground">{title}</p>}
+          <div className={cn('text-sm text-muted-foreground', title && 'mt-1')}>{children}</div>
         </div>
       </div>
     </div>

--- a/packages/presentation/src/components/tabs.tsx
+++ b/packages/presentation/src/components/tabs.tsx
@@ -80,7 +80,7 @@ export function TabList({
       ref={listRef}
       role="tablist"
       onKeyDown={handleKeyDown}
-      className={cn('flex border-b border-zinc-200 dark:border-zinc-700', className)}
+      className={cn('flex border-b border-border', className)}
     >
       {children}
     </div>
@@ -109,11 +109,11 @@ export function Tab({
       tabIndex={isActive ? 0 : -1}
       onClick={() => setActiveTab(id)}
       className={cn(
-        className,
-        'relative -mb-px border-b-2 px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+        'relative -mb-px border-b-2 px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
         isActive
-          ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-          : 'border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200',
+          ? 'border-primary text-primary'
+          : 'border-transparent text-muted-foreground hover:text-foreground',
+        className,
       )}
     >
       {children}


### PR DESCRIPTION
fix(presentation): brand-tokenize Tab + Callout; add inline status role to Callout

Fixes the two primitive gaps surfaced by the Phase 3 admin adoption sweep (consumers were
handrolling tab strips + status banners to avoid these):

- Tab / TabList: replace hardcoded blue-*/zinc-* with semantic tokens (border-primary/
  text-primary active; text-muted-foreground/border-border rest; outline-ring focus) and move
  the consumer `className` last in the cn() merge so the active color is overridable.
- Callout (the inline status-banner primitive): replace per-variant raw palette
  (blue/amber/red/green/violet) with brand tokens (primary/warning/error/success/accent);
  title -> text-foreground, body -> text-muted-foreground. Add a `role` prop
  ('note' | 'status' | 'alert', default 'note') so it can serve as an inline status/alert
  banner. The modal `Alert` is correct as-is and is unchanged.

Changeset: @revealui/presentation minor. Visual impact: existing Callout consumers (7 marketing
pages + docs showcase) and Tab consumers (docs + marketing ProductMockup) shift from raw palette
to brand tokens — the intended consistency fix; worth a visual glance on review.

Verified: presentation typecheck + build; admin / marketing / docs typecheck + build all green.
