### PR TITLE
refactor(admin): adopt presentation form primitives in settings (Phase 4a)

### DIFF
--- a/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
+++ b/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { InputCVA } from '@revealui/presentation/server';
 import { useActionState, useEffect, useId, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import type { ChangePasswordState } from './actions';
@@ -46,7 +47,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
           Current password
         </label>
         <PasswordInput visible={showCurrent} onToggle={() => setShowCurrent((v) => !v)}>
-          <input
+          <InputCVA
             id={`${formId}-current`}
             name="currentPassword"
             type={showCurrent ? 'text' : 'password'}
@@ -56,7 +57,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
             aria-describedby={
               state?.fieldErrors?.currentPassword ? `${formId}-current-error` : undefined
             }
-            className="w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 pr-10 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none aria-invalid:border-red-700"
+            className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.currentPassword && (
@@ -71,7 +72,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
           New password
         </label>
         <PasswordInput visible={showNew} onToggle={() => setShowNew((v) => !v)}>
-          <input
+          <InputCVA
             id={`${formId}-new`}
             name="newPassword"
             type={showNew ? 'text' : 'password'}
@@ -80,7 +81,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
             minLength={8}
             aria-invalid={!!state?.fieldErrors?.newPassword}
             aria-describedby={state?.fieldErrors?.newPassword ? `${formId}-new-error` : undefined}
-            className="w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 pr-10 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none aria-invalid:border-red-700"
+            className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.newPassword && (
@@ -98,7 +99,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
           Confirm new password
         </label>
         <PasswordInput visible={showConfirm} onToggle={() => setShowConfirm((v) => !v)}>
-          <input
+          <InputCVA
             id={`${formId}-confirm`}
             name="confirmPassword"
             type={showConfirm ? 'text' : 'password'}
@@ -109,7 +110,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
             aria-describedby={
               state?.fieldErrors?.confirmPassword ? `${formId}-confirm-error` : undefined
             }
-            className="w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 pr-10 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none aria-invalid:border-red-700"
+            className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.confirmPassword && (

--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -2,7 +2,8 @@
 
 const SAVED_FEEDBACK_MS = 2_000;
 
-import { type ChangeEvent, useEffect, useState } from 'react';
+import { InputCVA, Select } from '@revealui/presentation';
+import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -148,20 +149,17 @@ export default function ApiKeysPage() {
                 >
                   Provider
                 </label>
-                <select
+                <Select
                   id="provider-select"
                   value={provider}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => setProvider(e.target.value as Provider)}
-                  className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+                  onChange={(e) => setProvider(e.target.value as Provider)}
                 >
                   {PROVIDERS.map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.label}
                     </option>
                   ))}
-                </select>
+                </Select>
               </div>
 
               {/* API key input */}
@@ -183,15 +181,13 @@ export default function ApiKeysPage() {
                   )}
                 </label>
                 <div className="relative">
-                  <input
+                  <InputCVA
                     id="api-key-input"
                     type={showKey ? 'text' : 'password'}
                     value={apiKey}
-                    onChange={(
-                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                    ) => setApiKey(e.target.value)}
+                    onChange={(e) => setApiKey(e.target.value)}
                     placeholder={activeProviderInfo?.placeholder ?? ''}
-                    className="w-full rounded-lg border border-border bg-muted px-3 py-2 pr-16 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none font-mono"
+                    className="pr-16 font-mono"
                   />
                   <button
                     type="button"

--- a/apps/admin/src/app/(backend)/settings/security/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/security/page.tsx
@@ -10,8 +10,9 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@revealui/presentation/client';
+import { InputCVA } from '@revealui/presentation/server';
 import { QRCodeSVG } from 'qrcode.react';
-import { type ChangeEvent, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
 // =============================================================================
@@ -524,20 +525,20 @@ function SecuritySettingsContent() {
                       Enter a code from your authenticator app to verify
                     </label>
                     <div className="mt-1 flex gap-2">
-                      <input
+                      <InputCVA
                         id="mfa-verify-code"
                         type="text"
                         inputMode="numeric"
                         autoComplete="one-time-code"
                         maxLength={6}
                         value={verifyCode}
-                        onChange={(
-                          e: ChangeEvent<
-                            HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                          >,
-                        ) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
+                        onChange={(e) =>
+                          setVerifyCode(
+                            [...e.target.value].filter((c) => c >= '0' && c <= '9').join(''),
+                          )
+                        }
                         placeholder="000000"
-                        className="w-32 rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                        className="w-32"
                       />
                       <button
                         type="button"
@@ -585,17 +586,13 @@ function SecuritySettingsContent() {
                             Confirm your password to disable 2FA
                           </label>
                           <div className="mt-1.5 flex flex-wrap gap-2">
-                            <input
+                            <InputCVA
                               id="mfa-disable-password"
                               type="password"
                               value={disablePassword}
-                              onChange={(
-                                e: ChangeEvent<
-                                  HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                                >,
-                              ) => setDisablePassword(e.target.value)}
+                              onChange={(e) => setDisablePassword(e.target.value)}
                               placeholder="Password"
-                              className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none sm:w-48"
+                              className="w-full sm:w-48"
                             />
                             <button
                               type="button"
@@ -708,19 +705,15 @@ function SecuritySettingsContent() {
                         <div>
                           {renamingId === passkey.id ? (
                             <div className="flex gap-1.5">
-                              <input
+                              <InputCVA
                                 type="text"
                                 value={renameValue}
-                                onChange={(
-                                  e: ChangeEvent<
-                                    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                                  >,
-                                ) => setRenameValue(e.target.value)}
+                                onChange={(e) => setRenameValue(e.target.value)}
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter') void submitRename(passkey.id);
                                   if (e.key === 'Escape') cancelRename();
                                 }}
-                                className="w-36 rounded border border-border bg-muted px-2 py-0.5 text-sm text-foreground focus:border-ring focus:outline-none"
+                                className="w-36"
                               />
                               <button
                                 type="button"


### PR DESCRIPTION
refactor(admin): adopt presentation form primitives in settings (Phase 4a)

Primitive-adoption audit Phase 4, slice a (settings forms). App-level only; behavior parity
preserved (controlled value/onChange, validation, autoComplete all intact).

- settings/account/PasswordChangeForm.tsx: 3 password inputs -> InputCVA (autoComplete
  current-password/new-password, required, minLength, aria-* preserved).
- settings/api-keys/page.tsx: API-key input -> InputCVA (pr-16 font-mono kept); provider
  <select> -> native Select (value/onChange + options preserved).
- settings/security/page.tsx: 3 inputs (MFA code, disable password, passkey rename) -> InputCVA;
  inputMode/autoComplete=one-time-code/maxLength preserved.

No-regex fix (M2): settings/security MFA-code onChange `value.replace(/\D/g, '')` ->
`[...value].filter((c) => c >= '0' && c <= '9').join('')`.

Primitive choice note: used the NATIVE Select (select-headless) for the provider dropdown, NOT
the SelectCVA composite — the composite has no open/close state (SelectContent always renders),
so it's an always-open list, not a real dropdown (pre-existing; tracked for Phase 6). InputCVA
is the direct native <input> (className lands on the input), so layout padding is preserved.

Verified: admin typecheck + build green; settings tests 24/24; biome clean.
