### PR TITLE
refactor(admin): adopt presentation form primitives in marketplace (Phase 4b)

### DIFF
--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Badge, ButtonCVA, Card, Skeleton } from '@revealui/presentation';
+import { Badge, ButtonCVA, Card, Select, Skeleton, Slider, Textarea } from '@revealui/presentation';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { type ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -318,13 +318,11 @@ function ReviewsPanel({
             <div className="mb-3">
               <label className="block text-sm text-muted-foreground mb-1">
                 Comment (optional)
-                <textarea
+                <Textarea
                   value={comment}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => setComment(e.target.value)}
+                  onChange={(e) => setComment(e.target.value)}
                   rows={3}
-                  className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                  className="mt-1"
                   placeholder="Share your experience..."
                 />
               </label>
@@ -450,19 +448,17 @@ function SubmitTaskPanel({
           {skills.length === 0 ? (
             <span className="block mt-1 text-muted-foreground">No skills available</span>
           ) : (
-            <select
+            <Select
               value={selectedSkill}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => setSelectedSkill(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-border bg-card px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+              onChange={(e) => setSelectedSkill(e.target.value)}
+              className="mt-1"
             >
               {skills.map((skill) => (
                 <option key={skill.id} value={skill.name}>
                   {skill.name} - {skill.description}
                 </option>
               ))}
-            </select>
+            </Select>
           )}
         </label>
       </div>
@@ -471,13 +467,11 @@ function SubmitTaskPanel({
       <div className="mb-4">
         <label className="block text-sm text-muted-foreground mb-1">
           Input (JSON)
-          <textarea
+          <Textarea
             value={inputJson}
-            onChange={(
-              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-            ) => setInputJson(e.target.value)}
+            onChange={(e) => setInputJson(e.target.value)}
             rows={8}
-            className="mt-1 w-full font-mono rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+            className="mt-1 font-mono"
             placeholder='{"key": "value"}'
           />
         </label>
@@ -485,19 +479,15 @@ function SubmitTaskPanel({
 
       {/* Priority */}
       <div className="mb-4">
-        <label className="block text-sm text-muted-foreground mb-1">
-          Priority (1=low, 5=critical)
-          <input
-            type="range"
-            min={1}
-            max={5}
-            value={priority}
-            onChange={(
-              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-            ) => setPriority(Number(e.target.value))}
-            className="mt-1 w-full"
-          />
-        </label>
+        <Slider
+          label="Priority (1=low, 5=critical)"
+          min={1}
+          max={5}
+          step={1}
+          value={priority}
+          onChange={(value) => setPriority(value)}
+          className="mt-1"
+        />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>Low</span>
           <span>Normal</span>

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Badge, EmptyState, LinkButton, Skeleton } from '@revealui/presentation';
+import { Badge, EmptyState, InputCVA, LinkButton, Select, Skeleton } from '@revealui/presentation';
 import Link from 'next/link';
-import { type ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
 // =============================================================================
@@ -103,44 +103,30 @@ export default function MarketplacePage() {
         <div className="border-b border-border bg-muted px-6 py-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
             {/* Search */}
-            <input
+            <InputCVA
               type="text"
               placeholder="Search agents..."
               value={search}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => setSearch(e.target.value)}
-              className="flex-1 rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+              onChange={(e) => setSearch(e.target.value)}
+              className="flex-1"
             />
 
             {/* Category filter */}
-            <select
-              value={category}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => setCategory(e.target.value)}
-              className="rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
-            >
+            <Select value={category} onChange={(e) => setCategory(e.target.value)}>
               {CATEGORIES.map((cat) => (
                 <option key={cat} value={cat}>
                   {cat === 'all' ? 'All Categories' : cat.charAt(0).toUpperCase() + cat.slice(1)}
                 </option>
               ))}
-            </select>
+            </Select>
 
             {/* Sort */}
-            <select
-              value={sort}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => setSort(e.target.value as SortOption)}
-              className="rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
-            >
+            <Select value={sort} onChange={(e) => setSort(e.target.value as SortOption)}>
               <option value="rating">Highest Rated</option>
               <option value="tasks">Most Used</option>
               <option value="newest">Newest</option>
               <option value="price">Lowest Price</option>
-            </select>
+            </Select>
           </div>
         </div>
 

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -1,9 +1,18 @@
 'use client';
 
-import { ButtonCVA, Card } from '@revealui/presentation';
+import {
+  ButtonCVA,
+  Card,
+  InputCVA,
+  Radio,
+  RadioField,
+  RadioGroup,
+  Select,
+  Textarea,
+} from '@revealui/presentation';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { type ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -354,13 +363,11 @@ function StepBasicInfo({
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Agent Name</span>
-        <input
+        <InputCVA
           type="text"
           value={name}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setName(e.target.value)
-          }
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          onChange={(e) => setName(e.target.value)}
+          className="mt-1 w-full"
           placeholder="Code Reviewer Pro"
         />
         {fieldError('name') && <p className="mt-1 text-xs text-error">{fieldError('name')}</p>}
@@ -368,13 +375,11 @@ function StepBasicInfo({
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Description</span>
-        <textarea
+        <Textarea
           value={description}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setDescription(e.target.value)
-          }
+          onChange={(e) => setDescription(e.target.value)}
           rows={3}
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          className="mt-1"
           placeholder="An AI agent that reviews code for best practices, security issues, and performance..."
         />
         {fieldError('description') && (
@@ -384,30 +389,22 @@ function StepBasicInfo({
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Category</span>
-        <select
-          value={category}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setCategory(e.target.value)
-          }
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
-        >
+        <Select value={category} onChange={(e) => setCategory(e.target.value)} className="mt-1">
           {CATEGORIES.map((cat) => (
             <option key={cat} value={cat}>
               {cat.charAt(0).toUpperCase() + cat.slice(1)}
             </option>
           ))}
-        </select>
+        </Select>
       </label>
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Tags (comma-separated)</span>
-        <input
+        <InputCVA
           type="text"
           value={tags}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setTags(e.target.value)
-          }
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          onChange={(e) => setTags(e.target.value)}
+          className="mt-1 w-full"
           placeholder="typescript, react, code-review"
         />
       </label>
@@ -456,37 +453,27 @@ function StepConfiguration({
 
       <div>
         <span className="block text-sm text-muted-foreground mb-2">Pricing Model</span>
-        <div className="space-y-2">
+        <RadioGroup
+          name="pricingModel"
+          value={pricingModel}
+          onChange={(value) => setPricingModel(value)}
+        >
           {PRICING_MODELS.map((pm) => (
-            <label
-              key={pm.value}
-              className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 cursor-pointer hover:border-border transition-colors"
-            >
-              <input
-                type="radio"
-                name="pricingModel"
-                value={pm.value}
-                checked={pricingModel === pm.value}
-                onChange={(
-                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                ) => setPricingModel(e.target.value)}
-                className="accent-primary"
-              />
+            <RadioField key={pm.value}>
+              <Radio value={pm.value} />
               <span className="text-sm text-muted-foreground">{pm.label}</span>
-            </label>
+            </RadioField>
           ))}
-        </div>
+        </RadioGroup>
       </div>
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Base Price (USDC)</span>
-        <input
+        <InputCVA
           type="text"
           value={basePriceUsdc}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setBasePriceUsdc(e.target.value)
-          }
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          onChange={(e) => setBasePriceUsdc(e.target.value)}
+          className="mt-1 w-full"
           placeholder="0.10"
         />
         {fieldError('basePriceUsdc') && (
@@ -496,27 +483,23 @@ function StepConfiguration({
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Max Execution Time (seconds)</span>
-        <input
+        <InputCVA
           type="number"
           value={maxExecutionSecs}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setMaxExecutionSecs(Number(e.target.value))
-          }
+          onChange={(e) => setMaxExecutionSecs(Number(e.target.value))}
           min={10}
           max={3600}
-          className="mt-1 w-full rounded-lg border border-border bg-muted px-4 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          className="mt-1 w-full"
         />
       </label>
 
       <label className="block">
         <span className="text-sm text-muted-foreground">Agent Definition (JSON)</span>
-        <textarea
+        <Textarea
           value={definitionJson}
-          onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
-            setDefinitionJson(e.target.value)
-          }
+          onChange={(e) => setDefinitionJson(e.target.value)}
           rows={8}
-          className="mt-1 w-full font-mono rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none"
+          className="mt-1 font-mono"
         />
         {fieldError('definition') && (
           <p className="mt-1 text-xs text-error">{fieldError('definition')}</p>
@@ -586,13 +569,11 @@ function StepSkills({
 
           <label className="block">
             <span className="text-xs text-muted-foreground">Name</span>
-            <input
+            <InputCVA
               type="text"
               value={skill.name}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => updateSkill(i, 'name', e.target.value)}
-              className="mt-1 w-full rounded border border-border bg-muted px-3 py-1.5 text-sm text-foreground focus:border-ring focus:outline-none"
+              onChange={(e) => updateSkill(i, 'name', e.target.value)}
+              className="mt-1 w-full"
               placeholder="code-review"
             />
             {fieldError(`skill-${i}-name`) && (
@@ -602,13 +583,11 @@ function StepSkills({
 
           <label className="block">
             <span className="text-xs text-muted-foreground">Description</span>
-            <input
+            <InputCVA
               type="text"
               value={skill.description}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => updateSkill(i, 'description', e.target.value)}
-              className="mt-1 w-full rounded border border-border bg-muted px-3 py-1.5 text-sm text-foreground focus:border-ring focus:outline-none"
+              onChange={(e) => updateSkill(i, 'description', e.target.value)}
+              className="mt-1 w-full"
               placeholder="Reviews code for bugs, security issues, and best practices"
             />
             {fieldError(`skill-${i}-description`) && (
@@ -618,13 +597,11 @@ function StepSkills({
 
           <label className="block">
             <span className="text-xs text-muted-foreground">Input Schema (JSON)</span>
-            <textarea
+            <Textarea
               value={skill.inputSchema}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => updateSkill(i, 'inputSchema', e.target.value)}
+              onChange={(e) => updateSkill(i, 'inputSchema', e.target.value)}
               rows={3}
-              className="mt-1 w-full font-mono rounded border border-border bg-muted px-3 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none"
+              className="mt-1 font-mono text-xs"
             />
             {fieldError(`skill-${i}-input`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-input`)}</p>
@@ -633,13 +610,11 @@ function StepSkills({
 
           <label className="block">
             <span className="text-xs text-muted-foreground">Output Schema (JSON)</span>
-            <textarea
+            <Textarea
               value={skill.outputSchema}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => updateSkill(i, 'outputSchema', e.target.value)}
+              onChange={(e) => updateSkill(i, 'outputSchema', e.target.value)}
               rows={3}
-              className="mt-1 w-full font-mono rounded border border-border bg-muted px-3 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none"
+              className="mt-1 font-mono text-xs"
             />
             {fieldError(`skill-${i}-output`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-output`)}</p>

--- a/biome.json
+++ b/biome.json
@@ -158,7 +158,13 @@
         "useSimplifiedLogicExpression": "warn"
       },
       "a11y": {
-        "recommended": true
+        "recommended": true,
+        "noLabelWithoutControl": {
+          "level": "error",
+          "options": {
+            "inputComponents": ["Input", "InputCVA", "Textarea", "Select", "Slider", "Checkbox"]
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
refactor(admin): adopt presentation form primitives in marketplace (Phase 4b)

Primitive-adoption audit Phase 4, slice b (marketplace forms — the heaviest). App-level;
behavior parity preserved.

- publish/page.tsx: 7 inputs -> InputCVA, 4 textareas -> Textarea, category <select> -> native
  Select, pricing-model radios -> RadioGroup/RadioField/Radio (onChange lifted to group:
  (value)=>set). type=number/min/max + skill add/remove wiring preserved.
- [agentId]/page.tsx: 2 textareas -> Textarea, skill <select> -> native Select, priority
  <input type=range> -> Slider (onChange:(value:number); min/max/step preserved; uses Slider's
  `label` prop for proper htmlFor/id association — a11y).
- page.tsx: search input -> InputCVA; category + sort <select> -> native Select.

Selects use the NATIVE Select (select-headless), not the always-open SelectCVA composite.

biome: add `noLabelWithoutControl.inputComponents` (Input/InputCVA/Textarea/Select/Slider/
Checkbox) to root config. These design-system controls render nested native inputs, so a label
wrapping them IS associated at runtime — the option teaches biome to recognize them and unblocks
form-primitive adoption repo-wide (every form slice hits this). Low-risk: only relaxes the rule
for genuine controls.

Left handrolled: the 1-5 star-rating widget in ReviewsPanel (bespoke numeric buttons; the
`Rating` primitive could apply but is out of this slice's scope).

Verified: admin typecheck + build green; biome clean.
