### PR TITLE
feat(presentation): canonical Field-context family + brand-token form controls

### DIFF
--- a/.changeset/field-family-exports.md
+++ b/.changeset/field-family-exports.md
@@ -1,0 +1,9 @@
+---
+"@revealui/presentation": minor
+---
+
+Make the Field-context form family canonical and fully consumable, brand-tokenize the field + headless-control internals.
+
+- Exports (additive, non-breaking): the full field-context family (`Field`/`Description`/`ErrorMessage`/`Fieldset`/`Legend`/`FieldGroup` + the context `Label`) is now reachable from the main entry and `/client`; the context-aware `Label` is the canonical bare `Label` on `/client` (mirrors the `Text`/`Heading` Catalyst precedent). The simple label is also exported everywhere as `ControlLabel`, and as `FieldLabel` (context label) from the main entry. Bare `Label` on `.`/`/server` remains the simple, server-safe label, so existing standalone `Label`/`FormLabel`/`FormField` consumers are unchanged. `FieldsetLabel` retained as a `/client` back-compat alias.
+- Tokens: `fieldset` (Legend/Label/Description/ErrorMessage) and `form-field` (description/error) + the headless control internals (`input`/`select`/`textarea`-headless) move off raw `zinc`/`blue`/`red` onto brand bridge tokens (`text-foreground`/`text-muted-foreground`/`text-destructive`/`ring`/`border`), matching the Card/Text migration.
+- Canonical form pattern is now `<Field><Label/><headless Input|Select|Textarea/><Description/><ErrorMessage/></Field>` (context-driven id/aria). The standalone `FormLabel`/`FormField` + CVA controls are kept for the styled-control path.

--- a/apps/docs/app/showcase/fieldset.showcase.tsx
+++ b/apps/docs/app/showcase/fieldset.showcase.tsx
@@ -5,9 +5,9 @@ import {
   FieldGroup,
   Fieldset,
   FieldsetLabel,
+  Input,
   Legend,
 } from '@revealui/presentation/client';
-import { InputCVA } from '@revealui/presentation/server';
 import type { ShowcaseStory } from '@/components/showcase/types.js';
 
 const story: ShowcaseStory = {
@@ -27,12 +27,12 @@ const story: ShowcaseStory = {
       <FieldGroup>
         <Field>
           <FieldsetLabel>Full Name</FieldsetLabel>
-          <InputCVA placeholder="Jane Doe" />
+          <Input placeholder="Jane Doe" />
         </Field>
         <Field>
           <FieldsetLabel>Email</FieldsetLabel>
           <Description>We&apos;ll never share your email.</Description>
-          <InputCVA type="email" placeholder="jane@example.com" />
+          <Input type="email" placeholder="jane@example.com" />
         </Field>
       </FieldGroup>
     </Fieldset>
@@ -47,7 +47,7 @@ const story: ShowcaseStory = {
           <FieldGroup>
             <Field>
               <FieldsetLabel>Password</FieldsetLabel>
-              <InputCVA type="password" placeholder="••••••••" />
+              <Input type="password" placeholder="••••••••" />
               <ErrorMessage>Password must be at least 8 characters.</ErrorMessage>
             </Field>
           </FieldGroup>

--- a/packages/presentation/src/client.ts
+++ b/packages/presentation/src/client.ts
@@ -74,12 +74,14 @@ export {
   Field,
   FieldGroup,
   Fieldset,
+  Label,
   Label as FieldsetLabel,
   Legend,
 } from './components/fieldset.js';
 export { Heading, Subheading } from './components/heading.js';
 export { Input, InputGroup } from './components/input-headless.js';
 export { Kbd, KbdShortcut } from './components/kbd.js';
+export { Label as ControlLabel, type LabelProps } from './components/Label.js';
 export {
   LinkButton,
   type LinkButtonOwnProps,

--- a/packages/presentation/src/components/fieldset.tsx
+++ b/packages/presentation/src/components/fieldset.tsx
@@ -34,7 +34,7 @@ export function Legend({
       {...props}
       className={cn(
         className,
-        'text-base/6 font-semibold text-zinc-950 data-disabled:opacity-50 sm:text-sm/6 dark:text-white',
+        'text-base/6 font-semibold text-foreground data-disabled:opacity-50 sm:text-sm/6',
       )}
     />
   );
@@ -85,7 +85,7 @@ export function Label({
       {...props}
       className={cn(
         className,
-        'text-base/6 text-zinc-950 select-none data-disabled:opacity-50 sm:text-sm/6 dark:text-white',
+        'text-base/6 text-foreground select-none data-disabled:opacity-50 sm:text-sm/6',
       )}
     />
   );
@@ -104,7 +104,7 @@ export function Description({
       {...props}
       className={cn(
         className,
-        'text-base/6 text-zinc-500 data-disabled:opacity-50 sm:text-sm/6 dark:text-zinc-400',
+        'text-base/6 text-muted-foreground data-disabled:opacity-50 sm:text-sm/6',
       )}
     />
   );
@@ -123,7 +123,7 @@ export function ErrorMessage({
       {...props}
       className={cn(
         className,
-        'text-base/6 text-red-600 data-disabled:opacity-50 sm:text-sm/6 dark:text-red-500',
+        'text-base/6 text-destructive data-disabled:opacity-50 sm:text-sm/6',
       )}
     />
   );

--- a/packages/presentation/src/components/form-field.tsx
+++ b/packages/presentation/src/components/form-field.tsx
@@ -38,12 +38,12 @@ function FormField({
       </FormLabel>
       {children}
       {description && !error && (
-        <p id={descriptionId} className="text-xs text-zinc-500 dark:text-zinc-400">
+        <p id={descriptionId} className="text-xs text-muted-foreground">
           {description}
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="text-xs text-red-600 dark:text-red-400">
+        <p id={errorId} role="alert" className="text-xs text-destructive">
           {error}
         </p>
       )}

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -61,13 +61,21 @@ export {
 } from './dropdown.js';
 export { EmptyState } from './empty-state.js';
 export { FormLabel, type FormLabelProps } from './FormLabel.js';
-export { Field, FieldGroup, Fieldset, Legend } from './fieldset.js';
+export {
+  Description,
+  ErrorMessage,
+  Field,
+  FieldGroup,
+  Fieldset,
+  Label as FieldLabel,
+  Legend,
+} from './fieldset.js';
 export { FormField, type FormFieldProps } from './form-field.js';
 export { Heading, Subheading } from './heading.js';
 export { Input as InputCVA, type InputProps } from './Input.js';
 export { Input, InputGroup } from './input-headless.js';
 export { Kbd, KbdShortcut } from './kbd.js';
-export { Label, type LabelProps } from './Label.js';
+export { Label, Label as ControlLabel, type LabelProps } from './Label.js';
 export {
   type LinkBehavior,
   LinkButton,

--- a/packages/presentation/src/components/input-headless.tsx
+++ b/packages/presentation/src/components/input-headless.tsx
@@ -12,7 +12,7 @@ export function InputGroup({ children }: React.ComponentPropsWithoutRef<'span'>)
         'has-[[data-slot=icon]:first-child]:[&_input]:pl-10 has-[[data-slot=icon]:last-child]:[&_input]:pr-10 sm:has-[[data-slot=icon]:first-child]:[&_input]:pl-8 sm:has-[[data-slot=icon]:last-child]:[&_input]:pr-8',
         '*:data-[slot=icon]:pointer-events-none *:data-[slot=icon]:absolute *:data-[slot=icon]:top-3 *:data-[slot=icon]:z-10 *:data-[slot=icon]:size-5 sm:*:data-[slot=icon]:top-2.5 sm:*:data-[slot=icon]:size-4',
         '[&>[data-slot=icon]:first-child]:left-3 sm:[&>[data-slot=icon]:first-child]:left-2.5 [&>[data-slot=icon]:last-child]:right-3 sm:[&>[data-slot=icon]:last-child]:right-2.5',
-        '*:data-[slot=icon]:text-zinc-500 dark:*:data-[slot=icon]:text-zinc-400',
+        '*:data-[slot=icon]:text-muted-foreground',
       )}
     >
       {children}
@@ -43,13 +43,13 @@ export function Input({ className, disabled, invalid, ref, ...props }: InputProp
         // Basic layout
         'relative block w-full',
         // Background color + shadow applied to inset pseudo element, so shadow blends with border in light mode
-        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm',
+        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-card before:shadow-sm',
         // Background color is moved to control and shadow is removed in dark mode so hide `before` pseudo
         'dark:before:hidden',
         // Focus ring
-        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500',
+        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-ring',
         // Disabled state
-        'has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none',
+        'has-data-disabled:opacity-50 has-data-disabled:before:bg-muted has-data-disabled:before:shadow-none',
       ])}
     >
       <input
@@ -80,17 +80,17 @@ export function Input({ className, disabled, invalid, ref, ...props }: InputProp
           // Basic layout
           'relative block w-full appearance-none rounded-lg px-[calc(--spacing(3.5)-1px)] py-[calc(--spacing(2.5)-1px)] sm:px-[calc(--spacing(3)-1px)] sm:py-[calc(--spacing(1.5)-1px)]',
           // Typography
-          'text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white',
+          'text-base/6 text-foreground placeholder:text-muted-foreground sm:text-sm/6',
           // Border
-          'border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20',
+          'border border-input data-hover:border-input',
           // Background color
           'bg-transparent dark:bg-white/5',
           // Hide default focus styles
           'focus:outline-hidden',
           // Invalid state
-          'data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-600 dark:data-invalid:data-hover:border-red-600',
+          'data-invalid:border-destructive data-invalid:data-hover:border-destructive',
           // Disabled state
-          'data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/2.5 dark:data-hover:data-disabled:border-white/15',
+          'data-disabled:border-border data-hover:data-disabled:border-border dark:data-disabled:bg-white/2.5',
           // System icons
           'dark:scheme-dark',
         ])}

--- a/packages/presentation/src/components/select-headless.tsx
+++ b/packages/presentation/src/components/select-headless.tsx
@@ -23,13 +23,13 @@ export function Select({ className, multiple, disabled, invalid, ref, ...props }
         // Basic layout
         'group relative block w-full',
         // Background color + shadow applied to inset pseudo element, so shadow blends with border in light mode
-        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm',
+        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-card before:shadow-sm',
         // Background color is moved to control and shadow is removed in dark mode so hide `before` pseudo
         'dark:before:hidden',
         // Focus ring
-        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset has-data-focus:after:ring-2 has-data-focus:after:ring-blue-500',
+        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset has-data-focus:after:ring-2 has-data-focus:after:ring-ring',
         // Disabled state
-        'has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none',
+        'has-data-disabled:opacity-50 has-data-disabled:before:bg-muted has-data-disabled:before:shadow-none',
       ])}
     >
       <select
@@ -51,23 +51,23 @@ export function Select({ className, multiple, disabled, invalid, ref, ...props }
           // Options (multi-select)
           '[&_optgroup]:font-semibold',
           // Typography
-          'text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white dark:*:text-white',
+          'text-base/6 text-foreground placeholder:text-muted-foreground sm:text-sm/6 dark:*:text-white',
           // Border
-          'border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20',
+          'border border-input data-hover:border-input',
           // Background color
           'bg-transparent dark:bg-white/5 dark:*:bg-zinc-800',
           // Hide default focus styles
           'focus:outline-hidden',
           // Invalid state
-          'data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-600 dark:data-invalid:data-hover:border-red-600',
+          'data-invalid:border-destructive data-invalid:data-hover:border-destructive',
           // Disabled state
-          'data-disabled:border-zinc-950/20 data-disabled:opacity-100 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/2.5 dark:data-hover:data-disabled:border-white/15',
+          'data-disabled:border-border data-disabled:opacity-100 data-hover:data-disabled:border-border dark:data-disabled:bg-white/2.5',
         ])}
       />
       {!multiple && (
         <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
           <svg
-            className="size-5 stroke-zinc-500 group-has-data-disabled:stroke-zinc-600 sm:size-4 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText]"
+            className="size-5 stroke-muted-foreground group-has-data-disabled:stroke-muted-foreground sm:size-4 forced-colors:stroke-[CanvasText]"
             viewBox="0 0 16 16"
             aria-hidden="true"
             fill="none"

--- a/packages/presentation/src/components/textarea-headless.tsx
+++ b/packages/presentation/src/components/textarea-headless.tsx
@@ -30,13 +30,13 @@ export function Textarea({
         // Basic layout
         'relative block w-full',
         // Background color + shadow applied to inset pseudo element, so shadow blends with border in light mode
-        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm',
+        'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-card before:shadow-sm',
         // Background color is moved to control and shadow is removed in dark mode so hide `before` pseudo
         'dark:before:hidden',
         // Focus ring
-        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500',
+        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-ring',
         // Disabled state
-        'has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none',
+        'has-data-disabled:opacity-50 has-data-disabled:before:bg-muted has-data-disabled:before:shadow-none',
       ])}
     >
       <textarea
@@ -51,17 +51,17 @@ export function Textarea({
           // Basic layout
           'relative block h-full w-full appearance-none rounded-lg px-[calc(--spacing(3.5)-1px)] py-[calc(--spacing(2.5)-1px)] sm:px-[calc(--spacing(3)-1px)] sm:py-[calc(--spacing(1.5)-1px)]',
           // Typography
-          'text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white',
+          'text-base/6 text-foreground placeholder:text-muted-foreground sm:text-sm/6',
           // Border
-          'border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20',
+          'border border-input data-hover:border-input',
           // Background color
           'bg-transparent dark:bg-white/5',
           // Hide default focus styles
           'focus:outline-hidden',
           // Invalid state
-          'data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-600 dark:data-invalid:data-hover:border-red-600',
+          'data-invalid:border-destructive data-invalid:data-hover:border-destructive',
           // Disabled state
-          'disabled:border-zinc-950/20 dark:disabled:border-white/15 dark:disabled:bg-white/2.5 dark:data-hover:disabled:border-white/15',
+          'disabled:border-border data-hover:disabled:border-border dark:disabled:bg-white/2.5',
           // Resizable
           resizable ? 'resize-y' : 'resize-none',
         ])}

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -32,7 +32,7 @@ export { EmptyState } from './components/empty-state.js';
 export { FormLabel, type FormLabelProps } from './components/FormLabel.js';
 export { FormField, type FormFieldProps } from './components/form-field.js';
 export { Input as InputCVA, type InputProps } from './components/Input.js';
-export { Label, type LabelProps } from './components/Label.js';
+export { Label, Label as ControlLabel, type LabelProps } from './components/Label.js';
 export {
   Pagination,
   PaginationContent,


### PR DESCRIPTION
feat(presentation): canonical Field-context family + brand-token form controls

Foundation for primitive-adoption Phase 4 (Field-context forms). Additive, non-breaking.

Exports: the full field-context family (Field/Description/ErrorMessage/Fieldset/Legend/FieldGroup
+ context Label) is now reachable from the main entry; the context-aware Label is the canonical
bare `Label` on /client (mirrors the Text/Heading Catalyst precedent). The simple label is also
exported as `ControlLabel` everywhere + `FieldLabel` (context) from the main entry; bare `Label`
on `.`/`/server` stays the simple server-safe label, so all existing Label/FormLabel/FormField
consumers are unchanged. FieldsetLabel retained as a /client alias. FormLabel/FormField kept.

Tokens: fieldset (Legend/Label/Description/ErrorMessage), form-field (description/error), and the
headless control internals (input/select/textarea-headless) move off raw zinc/blue/red onto brand
bridge tokens (text-foreground / text-muted-foreground / text-destructive / ring / border-input).
Raw kept only where no token cascades: precision alpha fills + OS-rendered <option> colors.

Fix: the docs fieldset.showcase composed <Field> with InputCVA (which doesn't read field context
— silent missing ARIA); switched to the headless Input.

Changeset: @revealui/presentation 0.9.1 -> 0.10.0.
Verified: presentation typecheck + build + tests (964 pass); admin + marketing + docs typecheck + build green.
