### PR TITLE
refactor(admin): migrate agents forms to the Field-context pattern (Phase 4c)

### DIFF
--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import type { A2AAgentCard } from '@revealui/contracts';
-import { Badge, Breadcrumb, ButtonCVA, Card, LinkButton } from '@revealui/presentation';
+import {
+  Badge,
+  Breadcrumb,
+  ButtonCVA,
+  Card,
+  Input,
+  LinkButton,
+  Textarea,
+} from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, use, useEffect, useState } from 'react';
 import { AgentContexts } from '@/lib/components/agents/agent-contexts';
@@ -188,63 +197,39 @@ export default function AgentDetailPage({ params }: PageProps) {
                 <Card className="p-5">
                   {isEditing ? (
                     <div className="flex flex-col gap-4">
-                      <div>
-                        <label
-                          htmlFor="edit-name"
-                          className="block text-xs font-medium text-muted-foreground mb-1.5"
-                        >
-                          Name
-                        </label>
-                        <input
-                          id="edit-name"
+                      <Field>
+                        <Label>Name</Label>
+                        <Input
+                          name="editName"
                           type="text"
                           value={editName}
-                          onChange={(
-                            e: ChangeEvent<
-                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                            >,
-                          ) => setEditName(e.target.value)}
-                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            setEditName(e.target.value)
+                          }
                         />
-                      </div>
-                      <div>
-                        <label
-                          htmlFor="edit-description"
-                          className="block text-xs font-medium text-muted-foreground mb-1.5"
-                        >
-                          Description
-                        </label>
-                        <input
-                          id="edit-description"
+                      </Field>
+                      <Field>
+                        <Label>Description</Label>
+                        <Input
+                          name="editDescription"
                           type="text"
                           value={editDescription}
-                          onChange={(
-                            e: ChangeEvent<
-                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                            >,
-                          ) => setEditDescription(e.target.value)}
-                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            setEditDescription(e.target.value)
+                          }
                         />
-                      </div>
-                      <div>
-                        <label
-                          htmlFor="edit-system-prompt"
-                          className="block text-xs font-medium text-muted-foreground mb-1.5"
-                        >
-                          System Prompt
-                        </label>
-                        <textarea
-                          id="edit-system-prompt"
+                      </Field>
+                      <Field>
+                        <Label>System Prompt</Label>
+                        <Textarea
+                          name="editSystemPrompt"
                           rows={7}
                           value={editSystemPrompt}
-                          onChange={(
-                            e: ChangeEvent<
-                              HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-                            >,
-                          ) => setEditSystemPrompt(e.target.value)}
-                          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
+                          onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                            setEditSystemPrompt(e.target.value)
+                          }
                         />
-                      </div>
+                      </Field>
                       {/* Inline save error — Alert primitive is a modal dialog, not applicable */}
                       {saveError && (
                         <div

--- a/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
@@ -14,7 +14,8 @@
 
 'use client';
 
-import { Breadcrumb, ButtonCVA, Card } from '@revealui/presentation';
+import { Breadcrumb, ButtonCVA, Card, Select, Textarea } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { type ChangeEvent, use, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -67,38 +68,32 @@ export default function AgentRunPage({ params }: PageProps) {
 
         <Card className="p-4">
           <form onSubmit={handleStart} className="space-y-3">
-            <label
-              htmlFor="instruction"
-              className="block text-sm font-medium text-muted-foreground"
-            >
-              Instruction
-            </label>
-            <textarea
-              id="instruction"
-              value={instruction}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-              ) => setInstruction(e.target.value)}
-              disabled={stream.isStreaming}
-              rows={4}
-              placeholder="What would you like the agent to do?"
-              className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
-            />
+            <Field>
+              <Label>Instruction</Label>
+              <Textarea
+                name="instruction"
+                value={instruction}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setInstruction(e.target.value)}
+                disabled={stream.isStreaming}
+                rows={4}
+                placeholder="What would you like the agent to do?"
+              />
+            </Field>
             <div className="flex items-center gap-3">
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                <span>Mode</span>
-                <select
+              <Field>
+                <Label>Mode</Label>
+                <Select
+                  name="mode"
                   value={mode}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => setMode(e.target.value as 'admin' | 'coding')}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                    setMode(e.target.value as 'admin' | 'coding')
+                  }
                   disabled={stream.isStreaming}
-                  className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
                 >
                   <option value="admin">admin</option>
                   <option value="coding">coding</option>
-                </select>
-              </label>
+                </Select>
+              </Field>
               <div className="flex-1" />
               {!stream.isStreaming && (
                 <ButtonCVA type="submit" disabled={!instruction.trim()} variant="default" size="sm">

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { Badge, Breadcrumb, ButtonCVA, Card, LinkButton } from '@revealui/presentation';
+import {
+  Badge,
+  Breadcrumb,
+  ButtonCVA,
+  Card,
+  Input,
+  LinkButton,
+  Textarea,
+} from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useReducer } from 'react';
@@ -288,24 +297,19 @@ export default function NewAgentPage() {
                   2. Configure agent
                 </h2>
 
-                {/* Agent Name */}
-                <div>
-                  <label
-                    htmlFor="agent-name"
-                    className="block text-sm font-medium text-muted-foreground mb-1.5"
-                  >
+                <Field>
+                  <Label>
                     Name <span className="text-error">*</span>
-                  </label>
-                  <input
-                    id="agent-name"
+                  </Label>
+                  <Input
+                    name="name"
                     type="text"
                     required
                     value={name}
-                    onChange={(
-                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                    ) => handleNameChange(e.target.value)}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      handleNameChange(e.target.value)
+                    }
                     placeholder={`e.g. ${tpl?.label ?? 'My Agent'}`}
-                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                   />
                   {name.trim() && (
                     <p className="mt-1 text-xs text-muted-foreground">
@@ -319,47 +323,33 @@ export default function NewAgentPage() {
                       </code>
                     </p>
                   )}
-                </div>
+                </Field>
 
-                {/* Description */}
-                <div>
-                  <label
-                    htmlFor="agent-desc"
-                    className="block text-sm font-medium text-muted-foreground mb-1.5"
-                  >
-                    Description
-                  </label>
-                  <input
-                    id="agent-desc"
+                <Field>
+                  <Label>Description</Label>
+                  <Input
+                    name="description"
                     type="text"
                     value={description}
-                    onChange={(
-                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                    ) => dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      dispatch({ type: 'SET_DESCRIPTION', value: e.target.value })
+                    }
                     placeholder={tpl?.description ?? 'What does this agent do?'}
-                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
                   />
-                </div>
+                </Field>
 
-                {/* System Prompt */}
-                <div>
-                  <label
-                    htmlFor="agent-prompt"
-                    className="block text-sm font-medium text-muted-foreground mb-1.5"
-                  >
-                    System Prompt
-                  </label>
-                  <textarea
-                    id="agent-prompt"
+                <Field>
+                  <Label>System Prompt</Label>
+                  <Textarea
+                    name="systemPrompt"
                     rows={6}
                     value={systemPrompt}
-                    onChange={(
-                      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                    ) => dispatch({ type: 'SET_SYSTEM_PROMPT', value: e.target.value })}
+                    onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                      dispatch({ type: 'SET_SYSTEM_PROMPT', value: e.target.value })
+                    }
                     placeholder="Describe the agent's role, personality, and constraints..."
-                    className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
                   />
-                </div>
+                </Field>
 
                 {/* Model info (read-only) */}
                 <Card className="px-4 py-3 text-xs text-muted-foreground">

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { A2ATask } from '@revealui/contracts';
-import { Badge, ButtonCVA } from '@revealui/presentation';
+import { Badge, ButtonCVA, Textarea } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import { useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -112,22 +113,18 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
 
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <label
-          htmlFor="instruction"
-          className="block text-sm font-medium text-muted-foreground mb-1.5"
-        >
+      <Field>
+        <Label>
           Send a task to <span className="text-foreground">{agentName}</span>
-        </label>
-        <textarea
-          id="instruction"
+        </Label>
+        <Textarea
+          name="instruction"
           rows={4}
           value={instruction}
           onChange={(e) => setInstruction(e.target.value)}
           placeholder={`Tell ${agentName} what to do...`}
-          className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none resize-none"
         />
-      </div>
+      </Field>
 
       <ButtonCVA
         type="button"


### PR DESCRIPTION
refactor(admin): migrate agents forms to the Field-context pattern (Phase 4c)

Primitive-adoption audit Phase 4, slice c — the FIRST slice on the durable Field-context pattern
(enabled by foundation #1680). App-level; behavior parity preserved.

Restructured every labeled field in agents/new, agents/[agentId], agents/[agentId]/run, and
task-tester into <Field><Label>…</Label><headless control/></Field>:
- inputs -> headless Input, textareas -> headless Textarea, mode <select> -> native Select
  (all field-context-aware; Field auto-wires id + aria-labelledby/describedby).
- Dropped manual htmlFor/id and raw control styling; value/onChange/required/rows/placeholder/
  disabled and <option> children preserved.
- Field/Label from @revealui/presentation/client; bare Input/Select/Textarea from
  @revealui/presentation (NOT the CVA variants — those don't read field context).

Reference pattern for 4d/4e/4f + the 4a/4b backfill.

Verified: admin typecheck + build green; agents tests 19/19; biome clean.
