### PR TITLE
refactor(admin): migrate mcp forms to Field-context + server-safe (Phase 4d)

### DIFF
--- a/apps/admin/src/app/(backend)/mcp/connect/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/connect/page.tsx
@@ -12,7 +12,7 @@
  * via the revvault-backed `McpOAuthProvider`.
  */
 
-import { ButtonCVA, Card } from '@revealui/presentation/server';
+import { ButtonCVA, Card, FormLabel, InputCVA } from '@revealui/presentation/server';
 
 type SearchParamValue = string | string[] | undefined;
 
@@ -74,20 +74,16 @@ export default async function ConnectMcpServerPage({
           <form method="GET" action="/api/mcp/oauth/initiate">
             <div className="grid gap-4">
               <div>
-                <label
-                  htmlFor="tenant"
-                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
-                >
+                <FormLabel htmlFor="tenant" required>
                   Tenant
-                </label>
-                <input
+                </FormLabel>
+                <InputCVA
                   id="tenant"
                   name="tenant"
                   type="text"
                   required
                   pattern="[A-Za-z0-9_-]{1,64}"
                   placeholder="acme"
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
                 <p className="mt-1 text-xs text-muted-foreground">
                   Identifier under which tokens are scoped in revvault. Alphanumeric, underscore,
@@ -96,20 +92,16 @@ export default async function ConnectMcpServerPage({
               </div>
 
               <div>
-                <label
-                  htmlFor="server"
-                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
-                >
+                <FormLabel htmlFor="server" required>
                   Server name
-                </label>
-                <input
+                </FormLabel>
+                <InputCVA
                   id="server"
                   name="server"
                   type="text"
                   required
                   pattern="[A-Za-z0-9_-]{1,64}"
                   placeholder="linear"
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
                 <p className="mt-1 text-xs text-muted-foreground">
                   Short identifier for this MCP server. Used as the revvault path segment.
@@ -117,19 +109,15 @@ export default async function ConnectMcpServerPage({
               </div>
 
               <div>
-                <label
-                  htmlFor="serverUrl"
-                  className="mb-1.5 block text-sm font-medium text-muted-foreground"
-                >
+                <FormLabel htmlFor="serverUrl" required>
                   Server URL
-                </label>
-                <input
+                </FormLabel>
+                <InputCVA
                   id="serverUrl"
                   name="serverUrl"
                   type="url"
                   required
                   placeholder="https://mcp.example.com"
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
                 <p className="mt-1 text-xs text-muted-foreground">
                   The MCP server&rsquo;s base URL. Must be HTTPS in production (localhost allowed

--- a/apps/admin/src/app/(backend)/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/page.tsx
@@ -16,6 +16,7 @@
 import {
   Badge,
   ButtonCVA,
+  Input,
   LinkButton,
   Table,
   TableBody,
@@ -24,7 +25,8 @@ import {
   TableHeader,
   TableRow,
 } from '@revealui/presentation';
-import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { Field, Label } from '@revealui/presentation/client';
+import { useCallback, useEffect, useState } from 'react';
 import { McpServerCard, type McpServerInfo } from '@/lib/components/agents/mcp-server-card';
 import { UsageDashboard } from '@/lib/components/mcp/usage-dashboard';
 import type { CollectionMcpSummary } from '@/lib/mcp/collections';
@@ -199,39 +201,32 @@ export default function McpCatalogPage() {
               onSubmit={handleLoadTenant}
               className="mb-8 rounded-lg border border-border bg-card p-4"
             >
-              <label
-                htmlFor="tenant-input"
-                className="mb-1.5 block text-sm font-medium text-muted-foreground"
-              >
-                Tenant
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  id="tenant-input"
-                  name="tenant"
-                  type="text"
-                  value={tenant}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => setTenant(e.target.value)}
-                  pattern="[A-Za-z0-9_-]{1,64}"
-                  placeholder="acme"
-                  className="w-64 rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-                <ButtonCVA
-                  type="submit"
-                  variant="outline"
-                  disabled={!tenant.trim() || state === 'loading'}
-                >
-                  {state === 'loading' ? 'Loading…' : 'Load'}
-                </ButtonCVA>
-                {activeTenant && state === 'ready' && (
-                  <span className="text-xs text-muted-foreground">
-                    Showing remote servers for{' '}
-                    <span className="font-mono text-muted-foreground">{activeTenant}</span>
-                  </span>
-                )}
-              </div>
+              <Field>
+                <Label>Tenant</Label>
+                <div className="flex items-center gap-3">
+                  <Input
+                    name="tenant"
+                    type="text"
+                    value={tenant}
+                    onChange={(e) => setTenant(e.target.value)}
+                    pattern="[A-Za-z0-9_-]{1,64}"
+                    placeholder="acme"
+                  />
+                  <ButtonCVA
+                    type="submit"
+                    variant="outline"
+                    disabled={!tenant.trim() || state === 'loading'}
+                  >
+                    {state === 'loading' ? 'Loading…' : 'Load'}
+                  </ButtonCVA>
+                  {activeTenant && state === 'ready' && (
+                    <span className="text-xs text-muted-foreground">
+                      Showing remote servers for{' '}
+                      <span className="font-mono text-muted-foreground">{activeTenant}</span>
+                    </span>
+                  )}
+                </div>
+              </Field>
             </form>
 
             {/* Remote servers (per tenant) */}

--- a/apps/admin/src/lib/components/mcp/elicitation-form.tsx
+++ b/apps/admin/src/lib/components/mcp/elicitation-form.tsx
@@ -14,7 +14,8 @@
 
 'use client';
 
-import { ButtonCVA } from '@revealui/presentation';
+import { ButtonCVA, Input, Select } from '@revealui/presentation';
+import { Description, Field, Label } from '@revealui/presentation/client';
 import { useState } from 'react';
 
 // ---------------------------------------------------------------------------
@@ -49,7 +50,6 @@ interface ArgumentFieldProps {
 }
 
 export function ArgumentField({ name, prop, required, value, onChange }: ArgumentFieldProps) {
-  const inputId = `arg-${name}`;
   const placeholder =
     prop.default !== undefined
       ? `default: ${JSON.stringify(prop.default)}`
@@ -58,43 +58,34 @@ export function ArgumentField({ name, prop, required, value, onChange }: Argumen
         : (prop.type ?? 'string');
 
   return (
-    <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-muted-foreground">
+    <Field>
+      <Label>
         {name}
         {required && <span className="ml-1 text-error">*</span>}
         <span className="ml-2 font-mono text-[10px] text-muted-foreground">
           {prop.type ?? 'string'}
         </span>
-      </label>
+      </Label>
       {prop.enum && prop.enum.length > 0 ? (
-        <select
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-        >
+        <Select value={value} onChange={(e) => onChange(e.target.value)}>
           <option value="">—</option>
           {prop.enum.map((opt) => (
             <option key={String(opt)} value={String(opt)}>
               {String(opt)}
             </option>
           ))}
-        </select>
+        </Select>
       ) : (
-        <input
-          id={inputId}
+        <Input
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           required={required}
-          className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
         />
       )}
-      {prop.description && (
-        <p className="mt-1 text-[11px] text-muted-foreground">{prop.description}</p>
-      )}
-    </div>
+      {prop.description && <Description>{prop.description}</Description>}
+    </Field>
   );
 }
 

--- a/apps/admin/src/lib/components/mcp/logs-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/logs-panel.tsx
@@ -9,7 +9,8 @@
 
 'use client';
 
-import { ButtonCVA } from '@revealui/presentation';
+import { ButtonCVA, Select } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface LogEntry {
@@ -139,22 +140,20 @@ export function LogsPanel({ tenant, server }: LogsPanelProps) {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
-        <label htmlFor="log-level" className="text-xs font-medium text-muted-foreground">
-          Level
-        </label>
-        <select
-          id="log-level"
-          value={level}
-          onChange={(e) => setLevel(e.target.value as Level)}
-          disabled={state === 'streaming' || state === 'connecting'}
-          className="rounded-md border border-border bg-muted px-2 py-1 font-mono text-xs text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
-        >
-          {LEVELS.map((l) => (
-            <option key={l} value={l}>
-              {l}
-            </option>
-          ))}
-        </select>
+        <Field>
+          <Label>Level</Label>
+          <Select
+            value={level}
+            onChange={(e) => setLevel(e.target.value as Level)}
+            disabled={state === 'streaming' || state === 'connecting'}
+          >
+            {LEVELS.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </Select>
+        </Field>
         {state === 'streaming' || state === 'connecting' ? (
           <ButtonCVA type="button" variant="outline" size="sm" onClick={stop}>
             Stop

--- a/apps/admin/src/lib/components/mcp/prompts-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/prompts-panel.tsx
@@ -10,7 +10,8 @@
 
 'use client';
 
-import { ButtonCVA } from '@revealui/presentation';
+import { ButtonCVA, Input } from '@revealui/presentation';
+import { Description, Field, Label } from '@revealui/presentation/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -217,8 +218,7 @@ function PromptArgumentField({
   value,
   onChange,
 }: PromptArgumentFieldProps) {
-  const inputId = `prompt-arg-${prompt}-${arg.name}`;
-  const listId = `${inputId}-suggestions`;
+  const listId = `prompt-arg-${prompt}-${arg.name}-suggestions`;
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -262,20 +262,18 @@ function PromptArgumentField({
   }, [value, prompt, arg.name, tenant, server]);
 
   return (
-    <div>
-      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-muted-foreground">
+    <Field>
+      <Label>
         {arg.name}
         {arg.required && <span className="ml-1 text-error">*</span>}
-      </label>
-      <input
-        id={inputId}
+      </Label>
+      <Input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         list={suggestions.length > 0 ? listId : undefined}
         required={arg.required}
         autoComplete="off"
-        className="w-full rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
       />
       {suggestions.length > 0 && (
         <datalist id={listId}>
@@ -284,10 +282,8 @@ function PromptArgumentField({
           ))}
         </datalist>
       )}
-      {arg.description && (
-        <p className="mt-1 text-[11px] text-muted-foreground">{arg.description}</p>
-      )}
-    </div>
+      {arg.description && <Description>{arg.description}</Description>}
+    </Field>
   );
 }
 


### PR DESCRIPTION
refactor(admin): migrate mcp forms to Field-context + server-safe (Phase 4d)

Primitive-adoption audit Phase 4, slice d (mcp forms). Two patterns by render context:

CLIENT (Field-context): elicitation-form, logs-panel, mcp/page, prompts-panel — each labeled
field -> <Field><Label/><headless Input|Select/><Description?/></Field>. Field/Label/Description
from /client; bare Input/Select from @revealui/presentation (headless, field-context-aware).
htmlFor/id dropped; value/onChange/required/list(datalist)/autoComplete/<option> preserved.

RSC (server-safe): mcp/connect — a native GET <form action> with uncontrolled inputs. Field
family is client-only, so used InputCVA + FormLabel from /server instead; kept name/required/
pattern/type + explicit htmlFor association + the uncontrolled native form.

Verified: admin typecheck + build green; usage-dashboard test 6/6; biome clean; connect stays a
clean RSC (no client-only imports).
