### PR TITLE
refactor(admin,docs): migrate refunds/Agent/docs forms to Field-context (Phase 4e)

### DIFF
--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -4,6 +4,8 @@ import {
   Badge,
   ButtonCVA,
   Card,
+  Input,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -11,7 +13,8 @@ import {
   TableHeader,
   TableRow,
 } from '@revealui/presentation';
-import { type ChangeEvent, useEffect, useReducer } from 'react';
+import { Description, Field, Label } from '@revealui/presentation/client';
+import { useEffect, useReducer } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -331,80 +334,51 @@ function RefundsDashboard() {
 
             <div className="grid gap-4 sm:grid-cols-2">
               {/* Payment Intent / Charge ID */}
-              <div className="sm:col-span-2">
-                <label
-                  htmlFor="refund-identifier"
-                  className="mb-1.5 block text-sm font-medium text-foreground"
-                >
-                  Payment Intent or Charge ID
-                </label>
-                <input
-                  id="refund-identifier"
+              <Field className="sm:col-span-2">
+                <Label>Payment Intent or Charge ID</Label>
+                <Input
                   type="text"
                   value={identifier}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
+                  onChange={(e) => dispatch({ type: 'SET_IDENTIFIER', value: e.target.value })}
                   placeholder="pi_abc123 or ch_abc123"
                   required
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
-                <p className="mt-1 text-xs text-muted-foreground">
+                <Description>
                   Prefix determines type: pi_ for payment intents, ch_ for charges
-                </p>
-              </div>
+                </Description>
+              </Field>
 
               {/* Amount */}
-              <div>
-                <label
-                  htmlFor="refund-amount"
-                  className="mb-1.5 block text-sm font-medium text-foreground"
-                >
-                  Amount (USD)
-                </label>
-                <input
-                  id="refund-amount"
+              <Field>
+                <Label>Amount (USD)</Label>
+                <Input
                   type="number"
                   value={amountInput}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
+                  onChange={(e) => dispatch({ type: 'SET_AMOUNT', value: e.target.value })}
                   placeholder="Leave empty for full refund"
                   min="0.01"
                   step="0.01"
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 />
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Optional. Omit for a full refund.
-                </p>
-              </div>
+                <Description>Optional. Omit for a full refund.</Description>
+              </Field>
 
               {/* Reason */}
-              <div>
-                <label
-                  htmlFor="refund-reason"
-                  className="mb-1.5 block text-sm font-medium text-foreground"
-                >
-                  Reason
-                </label>
-                <select
-                  id="refund-reason"
+              <Field>
+                <Label>Reason</Label>
+                <Select
                   value={reason}
-                  onChange={(
-                    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
-                  ) =>
+                  onChange={(e) =>
                     dispatch({
                       type: 'SET_REASON',
                       value: e.target.value as State['reason'],
                     })
                   }
-                  className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
                 >
                   <option value="requested_by_customer">Requested by customer</option>
                   <option value="duplicate">Duplicate charge</option>
                   <option value="fraudulent">Fraudulent</option>
-                </select>
-              </div>
+                </Select>
+              </Field>
             </div>
 
             {/* Submit */}

--- a/apps/admin/src/lib/components/Agent/index.tsx
+++ b/apps/admin/src/lib/components/Agent/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Select, Textarea } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
@@ -895,22 +897,21 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
               Coding
             </button>
           </div>
-          <label htmlFor="model-select" className="text-xs text-muted-foreground">
-            Model
-          </label>
-          <select
-            id="model-select"
-            value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
-            disabled={stream.isStreaming}
-            className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
-          >
-            {MODEL_OPTIONS.map((opt) => (
-              <option key={opt.id} value={opt.id}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+          <Field className="flex items-center gap-2">
+            <Label className="text-xs text-muted-foreground">Model</Label>
+            <Select
+              value={selectedModel}
+              onChange={(e) => setSelectedModel(e.target.value)}
+              disabled={stream.isStreaming}
+              className="rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+            >
+              {MODEL_OPTIONS.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          </Field>
           {selectedModel !== 'auto' && (
             <span className="hidden text-xs text-muted-foreground sm:inline">
               {MODEL_OPTIONS.find((m) => m.id === selectedModel)?.model || 'default'}
@@ -918,7 +919,7 @@ export default function AgentChat({ conversationId, onConversationCreated }: Age
           )}
         </div>
         <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl items-end gap-2 sm:gap-3">
-          <textarea
+          <Textarea
             ref={textareaRef}
             className="flex-1 resize-none rounded-xl border border-border bg-muted px-3 py-2.5 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20 sm:px-4 sm:py-3"
             value={input}

--- a/apps/docs/app/components/SearchBar.tsx
+++ b/apps/docs/app/components/SearchBar.tsx
@@ -5,6 +5,7 @@
  * Supports Cmd+K / Ctrl+K keyboard shortcut to focus.
  */
 
+import { Input } from '@revealui/presentation';
 import { useNavigate } from '@revealui/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SearchResult } from '../lib/search-index';
@@ -127,7 +128,7 @@ export function SearchBar() {
   return (
     <div className="relative w-full">
       <div className="relative">
-        <input
+        <Input
           ref={inputRef}
           type="search"
           placeholder="Search docs..."
@@ -144,7 +145,7 @@ export function SearchBar() {
           className="w-full rounded-lg border border-border bg-surface py-2 pr-10 pl-3 font-sans text-[0.8125rem] text-text-primary transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-bg)] focus:outline-none"
         />
         <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-xs text-text-muted">
-          {'\u2318'}K
+          {'⌘'}K
         </span>
       </div>
 

--- a/apps/docs/app/components/showcase/PropPanel.tsx
+++ b/apps/docs/app/components/showcase/PropPanel.tsx
@@ -1,3 +1,5 @@
+import { Input, Select } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import type { PropControls } from './types.js';
 
 interface PropPanelProps {
@@ -16,88 +18,100 @@ export function PropPanel({ controls, values, onChange }: PropPanelProps) {
         Props
       </h3>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {entries.map(([key, control]) => (
-          <div key={key} className="flex flex-col gap-1">
-            <label htmlFor={`prop-${key}`} className="text-xs font-medium text-text-secondary">
-              {key}
-            </label>
-            {control.type === 'select' && (
-              <select
-                id={`prop-${key}`}
-                value={values[key] as string}
-                onChange={(e) => onChange(key, e.target.value)}
-                className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-ink outline-none focus:ring-2 focus:ring-accent"
-              >
-                {control.options.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
-            )}
-            {control.type === 'boolean' && (
-              <button
-                type="button"
-                id={`prop-${key}`}
-                role="switch"
-                aria-checked={values[key] as boolean}
-                onClick={() => onChange(key, !(values[key] as boolean))}
-                className={`relative h-6 w-10 rounded-full transition-colors ${
-                  values[key] ? 'bg-accent' : 'bg-border'
-                }`}
-              >
-                <span
-                  className={`absolute top-0.5 left-0.5 size-5 rounded-full bg-white shadow transition-transform ${
-                    values[key] ? 'translate-x-4' : 'translate-x-0'
-                  }`}
+        {entries.map(([key, control]) => {
+          if (control.type === 'select') {
+            return (
+              <Field key={key}>
+                <Label className="text-xs font-medium text-text-secondary">{key}</Label>
+                <Select
+                  value={values[key] as string}
+                  onChange={(e) => onChange(key, e.target.value)}
+                  className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-ink outline-none focus:ring-2 focus:ring-accent"
+                >
+                  {control.options.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+            );
+          }
+
+          if (control.type === 'text') {
+            return (
+              <Field key={key}>
+                <Label className="text-xs font-medium text-text-secondary">{key}</Label>
+                <Input
+                  type="text"
+                  value={values[key] as string}
+                  placeholder={control.placeholder}
+                  onChange={(e) => onChange(key, e.target.value)}
+                  className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-ink outline-none focus:ring-2 focus:ring-accent"
                 />
-              </button>
-            )}
-            {control.type === 'text' && (
-              <input
-                id={`prop-${key}`}
-                type="text"
-                value={values[key] as string}
-                placeholder={control.placeholder}
-                onChange={(e) => onChange(key, e.target.value)}
-                className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-ink outline-none focus:ring-2 focus:ring-accent"
-              />
-            )}
-            {(control.type === 'number' || control.type === 'range') && (
-              <div className="flex items-center gap-2">
-                <input
+              </Field>
+            );
+          }
+
+          return (
+            <div key={key} className="flex flex-col gap-1">
+              <label htmlFor={`prop-${key}`} className="text-xs font-medium text-text-secondary">
+                {key}
+              </label>
+              {control.type === 'boolean' && (
+                <button
+                  type="button"
                   id={`prop-${key}`}
-                  type="range"
-                  value={values[key] as number}
-                  min={control.min}
-                  max={control.max}
-                  step={control.step ?? 1}
-                  onChange={(e) => onChange(key, Number(e.target.value))}
-                  className="h-1.5 flex-1 appearance-none rounded-full bg-border accent-accent"
-                />
-                <span className="min-w-[2rem] text-right text-xs tabular-nums text-text-muted">
-                  {values[key] as number}
-                </span>
-              </div>
-            )}
-            {control.type === 'color' && (
-              <div className="flex flex-wrap gap-1">
-                {control.options.map((color) => (
-                  <button
-                    key={color}
-                    type="button"
-                    title={color}
-                    onClick={() => onChange(key, color)}
-                    className={`size-5 rounded-full border-2 transition-transform hover:scale-110 ${
-                      values[key] === color ? 'border-accent scale-110' : 'border-transparent'
+                  role="switch"
+                  aria-checked={values[key] as boolean}
+                  onClick={() => onChange(key, !(values[key] as boolean))}
+                  className={`relative h-6 w-10 rounded-full transition-colors ${
+                    values[key] ? 'bg-accent' : 'bg-border'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 size-5 rounded-full bg-white shadow transition-transform ${
+                      values[key] ? 'translate-x-4' : 'translate-x-0'
                     }`}
-                    style={{ backgroundColor: `var(--color-${color}-500, ${color})` }}
                   />
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
+                </button>
+              )}
+              {(control.type === 'number' || control.type === 'range') && (
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`prop-${key}`}
+                    type="range"
+                    value={values[key] as number}
+                    min={control.min}
+                    max={control.max}
+                    step={control.step ?? 1}
+                    onChange={(e) => onChange(key, Number(e.target.value))}
+                    className="h-1.5 flex-1 appearance-none rounded-full bg-border accent-accent"
+                  />
+                  <span className="min-w-[2rem] text-right text-xs tabular-nums text-text-muted">
+                    {values[key] as number}
+                  </span>
+                </div>
+              )}
+              {control.type === 'color' && (
+                <div className="flex flex-wrap gap-1">
+                  {control.options.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      title={color}
+                      onClick={() => onChange(key, color)}
+                      className={`size-5 rounded-full border-2 transition-transform hover:scale-110 ${
+                        values[key] === color ? 'border-accent scale-110' : 'border-transparent'
+                      }`}
+                      style={{ backgroundColor: `var(--color-${color}-500, ${color})` }}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
refactor(admin,docs): migrate refunds/Agent/docs forms to Field-context (Phase 4e)

Primitive-adoption audit Phase 4, slice e. Field-context pattern where it fits; headless-only
where a labeled field would be wrong.

- refunds/page.tsx: 2 inputs + 1 select -> <Field><Label/><Input|Select/><Description/></Field>
  (hint <p> -> Description; controlled useReducer/submit/validation preserved).
- Agent/index.tsx: model <select> -> Field+Select; chat composer <textarea> -> headless Textarea
  WITHOUT Field/Label (it's a composer, not a labeled field — preserves Enter-to-send /
  Escape-abort / streaming-disabled / ref auto-resize / placeholder-as-label).
- docs PropPanel.tsx: text input + select -> Field pattern (Vite app: no RSC split, Field family
  works without 'use client'). Slider/Switch/color controls left for later (reported).
- docs SearchBar.tsx: search box -> headless Input only (placeholder + type=search + ⌘K convey
  intent; a visible Label would break the compact search UX).

Field/Label/Description imported from @revealui/presentation/client (the CONTEXT Label — the
bare Label on the main entry is the simple non-context label and would NOT auto-associate inside
<Field>); headless Input/Select/Textarea from @revealui/presentation.

Verified: admin + docs typecheck + build green; agents tests 19/19; biome clean.
