### PR TITLE
refactor(admin): extract StripeEntitySelect on @revealui/core/ui (Phase 4f)

### DIFF
--- a/apps/admin/src/lib/collections/Prices/ui/PricesSelect.tsx
+++ b/apps/admin/src/lib/collections/Prices/ui/PricesSelect.tsx
@@ -1,131 +1,25 @@
 'use client';
 
 import type { TextField } from '@revealui/core';
-import React from 'react';
-
-interface PriceOption {
-  label: string;
-  value: string;
-}
-
-const fetchStripePrices = async (): Promise<PriceOption[]> => {
-  const response = await fetch('/api/stripe/prices', {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  const data = await response.json();
-  if (data?.data) {
-    return data.data.reduce(
-      (acc: PriceOption[], item: { name: string; id: string }) => {
-        acc.push({
-          label: item.name || item.id,
-          value: item.id,
-        });
-        return acc;
-      },
-      [
-        {
-          label: 'Select a price',
-          value: '',
-        },
-      ],
-    );
-  }
-  return [];
-};
+import { StripeEntitySelect } from '@/lib/collections/_shared/StripeEntitySelect';
 
 const PricesSelect = (props: TextField) => {
   const { name, label, value, onChange } = props as TextField & {
     value?: string;
     onChange?: (value: string) => void;
   };
-  const [options, setOptions] = React.useState<PriceOption[]>([]);
-  const [loading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    const initializeOptions = async () => {
-      try {
-        const fetchedOptions = await fetchStripePrices();
-        setOptions(fetchedOptions);
-      } catch (_error) {
-        setOptions([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    initializeOptions();
-  }, []);
-
-  const stripeBaseUrl = `https://dashboard.stripe.com/${
-    import.meta.env.VITE_STRIPE_IS_TEST_KEY ? 'test/' : ''
-  }`;
 
   return (
-    <div>
-      <p style={{ marginBottom: '0' }}>{typeof label === 'string' ? label : 'Price'}</p>
-      <p
-        style={{
-          marginBottom: '0.75rem',
-          color: 'var(--theme-elevation-400)',
-        }}
-      >
-        {`Select the related Stripe price or `}
-        <a
-          href={`${stripeBaseUrl}products/create`}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'var(--theme-text)' }}
-        >
-          create a new one
-        </a>
-        {'.'}
-      </p>
-      <select
-        name={name}
-        value={(value as string) ?? ''}
-        onChange={(e) => onChange?.(e.target.value)}
-        disabled={loading}
-        style={{
-          width: '100%',
-          padding: '0.5rem',
-          borderRadius: '4px',
-          border: '1px solid var(--theme-elevation-150)',
-          background: 'var(--theme-input-bg, #fff)',
-          color: 'var(--theme-text)',
-          fontSize: '0.875rem',
-        }}
-      >
-        {loading ? (
-          <option value="">Loading prices...</option>
-        ) : options.length === 0 ? (
-          <option value="">No prices found</option>
-        ) : (
-          options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))
-        )}
-      </select>
-      {value && (
-        <div style={{ marginTop: '0.5rem', fontSize: '0.75rem' }}>
-          <a
-            href={`${stripeBaseUrl}prices/${value}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'var(--theme-elevation-400)' }}
-          >
-            View in Stripe Dashboard
-          </a>
-        </div>
-      )}
-    </div>
+    <StripeEntitySelect
+      name={name}
+      label={typeof label === 'string' ? label : 'Price'}
+      value={value}
+      onChange={onChange}
+      entityLabel="price"
+      apiPath="/api/stripe/prices"
+      dashboardViewPath={`prices/${value}`}
+      defaultOptionLabel="Select a price"
+    />
   );
 };
 

--- a/apps/admin/src/lib/collections/Products/ui/ProductSelect.tsx
+++ b/apps/admin/src/lib/collections/Products/ui/ProductSelect.tsx
@@ -1,42 +1,6 @@
 'use client';
 
-import React from 'react';
-
-interface ProductOption {
-  label: string;
-  value: string;
-}
-
-const fetchStripeProducts = async (): Promise<ProductOption[]> => {
-  const response = await fetch('/api/stripe/products', {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  const data = await response.json();
-  if (data?.data) {
-    return data.data.reduce(
-      (acc: ProductOption[], item: { name: string; id: string }) => {
-        acc.push({
-          label: item.name || item.id,
-          value: item.id,
-        });
-        return acc;
-      },
-      [
-        {
-          label: 'Select a product',
-          value: '',
-        },
-      ],
-    );
-  }
-  return [];
-};
+import { StripeEntitySelect } from '@/lib/collections/_shared/StripeEntitySelect';
 
 export const ProductSelect = (props: {
   name: string;
@@ -45,87 +9,17 @@ export const ProductSelect = (props: {
   onChange?: (value: string) => void;
 }) => {
   const { name, label, value, onChange } = props;
-  const [options, setOptions] = React.useState<ProductOption[]>([]);
-  const [loading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    const initializeOptions = async () => {
-      try {
-        const fetchedOptions = await fetchStripeProducts();
-        setOptions(fetchedOptions);
-      } catch (_error) {
-        setOptions([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    initializeOptions();
-  }, []);
-
-  const stripeBaseUrl = `https://dashboard.stripe.com/${
-    import.meta.env.VITE_STRIPE_IS_TEST_KEY ? 'test/' : ''
-  }`;
 
   return (
-    <div>
-      <p style={{ marginBottom: '0' }}>{typeof label === 'string' ? label : 'Product'}</p>
-      <p
-        style={{
-          marginBottom: '0.75rem',
-          color: 'var(--theme-elevation-400)',
-        }}
-      >
-        {`Select the related Stripe product or `}
-        <a
-          href={`${stripeBaseUrl}products/create`}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'var(--theme-text)' }}
-        >
-          create a new one
-        </a>
-        {'.'}
-      </p>
-      <select
-        name={name}
-        value={value ?? ''}
-        onChange={(e) => onChange?.(e.target.value)}
-        disabled={loading}
-        style={{
-          width: '100%',
-          padding: '0.5rem',
-          borderRadius: '4px',
-          border: '1px solid var(--theme-elevation-150)',
-          background: 'var(--theme-input-bg, #fff)',
-          color: 'var(--theme-text)',
-          fontSize: '0.875rem',
-        }}
-      >
-        {loading ? (
-          <option value="">Loading products...</option>
-        ) : options.length === 0 ? (
-          <option value="">No products found</option>
-        ) : (
-          options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))
-        )}
-      </select>
-      {value && (
-        <div style={{ marginTop: '0.5rem', fontSize: '0.75rem' }}>
-          <a
-            href={`${stripeBaseUrl}products/${value}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'var(--theme-elevation-400)' }}
-          >
-            View in Stripe Dashboard
-          </a>
-        </div>
-      )}
-    </div>
+    <StripeEntitySelect
+      name={name}
+      label={label}
+      value={value}
+      onChange={onChange}
+      entityLabel="product"
+      apiPath="/api/stripe/products"
+      dashboardViewPath={`products/${value}`}
+      defaultOptionLabel="Select a product"
+    />
   );
 };

--- a/apps/admin/src/lib/collections/_shared/StripeEntitySelect.tsx
+++ b/apps/admin/src/lib/collections/_shared/StripeEntitySelect.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { FieldLabel, SelectInput } from '@revealui/core/ui';
+import React from 'react';
+
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export interface StripeEntitySelectProps {
+  name: string;
+  label: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  entityLabel: string;
+  apiPath: string;
+  /** Full Stripe dashboard path for the selected entity, e.g. `prices/${value}`. Only rendered when value is truthy. */
+  dashboardViewPath: string;
+  defaultOptionLabel: string;
+}
+
+const fetchStripeEntities = async (
+  apiPath: string,
+  defaultOptionLabel: string,
+): Promise<SelectOption[]> => {
+  const response = await fetch(apiPath, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const data = await response.json();
+  if (data?.data) {
+    return data.data.reduce(
+      (acc: SelectOption[], item: { name: string; id: string }) => {
+        acc.push({
+          label: item.name || item.id,
+          value: item.id,
+        });
+        return acc;
+      },
+      [{ label: defaultOptionLabel, value: '' }],
+    );
+  }
+  return [];
+};
+
+export const StripeEntitySelect: React.FC<StripeEntitySelectProps> = ({
+  name,
+  label,
+  value,
+  onChange,
+  entityLabel,
+  apiPath,
+  dashboardViewPath,
+  defaultOptionLabel,
+}) => {
+  const [options, setOptions] = React.useState<SelectOption[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    const initializeOptions = async () => {
+      try {
+        const fetched = await fetchStripeEntities(apiPath, defaultOptionLabel);
+        setOptions(fetched);
+      } catch (_error) {
+        setOptions([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    initializeOptions();
+  }, [apiPath, defaultOptionLabel]);
+
+  const stripeBaseUrl = `https://dashboard.stripe.com/${
+    import.meta.env.VITE_STRIPE_IS_TEST_KEY ? 'test/' : ''
+  }`;
+
+  const resolvedOptions: SelectOption[] = loading
+    ? [{ label: `Loading ${entityLabel}s...`, value: '' }]
+    : options.length === 0
+      ? [{ label: `No ${entityLabel}s found`, value: '' }]
+      : options;
+
+  return (
+    <div>
+      <FieldLabel htmlFor={name} label={typeof label === 'string' ? label : entityLabel} />
+      <p
+        style={{
+          marginBottom: '0.75rem',
+          color: 'var(--theme-elevation-400)',
+        }}
+      >
+        {`Select the related Stripe ${entityLabel} or `}
+        <a
+          href={`${stripeBaseUrl}products/create`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'var(--theme-text)' }}
+        >
+          create a new one
+        </a>
+        {'.'}
+      </p>
+      <SelectInput
+        path={name}
+        value={value ?? ''}
+        options={resolvedOptions}
+        onChange={onChange}
+        disabled={loading}
+      />
+      {value && (
+        <div style={{ marginTop: '0.5rem', fontSize: '0.75rem' }}>
+          <a
+            href={`${stripeBaseUrl}${dashboardViewPath}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--theme-elevation-400)' }}
+          >
+            View in Stripe Dashboard
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
refactor(admin): extract StripeEntitySelect on @revealui/core/ui (Phase 4f)

Primitive-adoption audit Phase 4, slice f (admin custom-field selects). These are admin-engine
field components, so they adopt @revealui/core/ui (SelectInput + FieldLabel), NOT presentation —
app->core dep only, consistent with the tokens-only architecture (no presentation coupling).

- New shared apps/admin/src/lib/collections/_shared/StripeEntitySelect.tsx: config-driven
  (entityLabel/apiPath/dashboardViewPath/defaultOptionLabel + name/value/onChange); owns the
  Stripe fetch + loading/empty states + description/"create"/"view in dashboard" links. The
  raw <select> -> core/ui SelectInput (loading/empty mapped via options[] + disabled); the label
  <p> -> core/ui FieldLabel.
- PricesSelect (export default, TextField props) and ProductSelect (export const, plain props)
  collapse to thin wrappers over StripeEntitySelect — export shapes + signatures preserved exactly
  (they're registered in the admin collections config).

Verified: admin typecheck + build green; biome clean. (Fixed the wrapper imports from the
non-existent `~/` alias to admin's `@/` alias — typecheck caught it.)
