### PR TITLE
refactor(admin): backfill settings+marketplace forms to Field-context; retire biome inputComponents

### DIFF
--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge, ButtonCVA, Card, Select, Skeleton, Slider, Textarea } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -315,18 +316,16 @@ function ReviewsPanel({
                 ))}
               </div>
             </div>
-            <div className="mb-3">
-              <label className="block text-sm text-muted-foreground mb-1">
-                Comment (optional)
-                <Textarea
-                  value={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  rows={3}
-                  className="mt-1"
-                  placeholder="Share your experience..."
-                />
-              </label>
-            </div>
+            <Field className="mb-3">
+              <Label className="block text-sm text-muted-foreground mb-1">Comment (optional)</Label>
+              <Textarea
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                rows={3}
+                className="mt-1"
+                placeholder="Share your experience..."
+              />
+            </Field>
             <div className="flex gap-2">
               <ButtonCVA type="submit" disabled={submitting}>
                 {submitting ? 'Submitting...' : 'Submit Review'}
@@ -441,41 +440,36 @@ function SubmitTaskPanel({
       <h3 className="text-lg font-medium text-foreground mb-4">Submit a task to {agent.name}</h3>
 
       {/* Skill selection */}
-      <div className="mb-4">
-        {/* biome-ignore lint/a11y/noLabelWithoutControl: select is inside the conditional branch */}
-        <label className="block text-sm text-muted-foreground mb-1">
-          Skill
-          {skills.length === 0 ? (
-            <span className="block mt-1 text-muted-foreground">No skills available</span>
-          ) : (
-            <Select
-              value={selectedSkill}
-              onChange={(e) => setSelectedSkill(e.target.value)}
-              className="mt-1"
-            >
-              {skills.map((skill) => (
-                <option key={skill.id} value={skill.name}>
-                  {skill.name} - {skill.description}
-                </option>
-              ))}
-            </Select>
-          )}
-        </label>
-      </div>
+      <Field className="mb-4">
+        <Label className="block text-sm text-muted-foreground mb-1">Skill</Label>
+        {skills.length === 0 ? (
+          <span className="block mt-1 text-muted-foreground">No skills available</span>
+        ) : (
+          <Select
+            value={selectedSkill}
+            onChange={(e) => setSelectedSkill(e.target.value)}
+            className="mt-1"
+          >
+            {skills.map((skill) => (
+              <option key={skill.id} value={skill.name}>
+                {skill.name} - {skill.description}
+              </option>
+            ))}
+          </Select>
+        )}
+      </Field>
 
       {/* Input JSON */}
-      <div className="mb-4">
-        <label className="block text-sm text-muted-foreground mb-1">
-          Input (JSON)
-          <Textarea
-            value={inputJson}
-            onChange={(e) => setInputJson(e.target.value)}
-            rows={8}
-            className="mt-1 font-mono"
-            placeholder='{"key": "value"}'
-          />
-        </label>
-      </div>
+      <Field className="mb-4">
+        <Label className="block text-sm text-muted-foreground mb-1">Input (JSON)</Label>
+        <Textarea
+          value={inputJson}
+          onChange={(e) => setInputJson(e.target.value)}
+          rows={8}
+          className="mt-1 font-mono"
+          placeholder='{"key": "value"}'
+        />
+      </Field>
 
       {/* Priority */}
       <div className="mb-4">

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, EmptyState, InputCVA, LinkButton, Select, Skeleton } from '@revealui/presentation';
+import { Badge, EmptyState, Input, LinkButton, Select, Skeleton } from '@revealui/presentation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -102,8 +102,8 @@ export default function MarketplacePage() {
         {/* Search + Filters */}
         <div className="border-b border-border bg-muted px-6 py-4">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-            {/* Search */}
-            <InputCVA
+            {/* Search — no label; bare Input intentional for search-box pattern */}
+            <Input
               type="text"
               placeholder="Search agents..."
               value={search}
@@ -111,7 +111,7 @@ export default function MarketplacePage() {
               className="flex-1"
             />
 
-            {/* Category filter */}
+            {/* Category filter — no label; bare Select intentional */}
             <Select value={category} onChange={(e) => setCategory(e.target.value)}>
               {CATEGORIES.map((cat) => (
                 <option key={cat} value={cat}>
@@ -120,7 +120,7 @@ export default function MarketplacePage() {
               ))}
             </Select>
 
-            {/* Sort */}
+            {/* Sort filter — no label; bare Select intentional */}
             <Select value={sort} onChange={(e) => setSort(e.target.value as SortOption)}>
               <option value="rating">Highest Rated</option>
               <option value="tasks">Most Used</option>

--- a/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/publish/page.tsx
@@ -3,13 +3,14 @@
 import {
   ButtonCVA,
   Card,
-  InputCVA,
+  Input,
   Radio,
   RadioField,
   RadioGroup,
   Select,
   Textarea,
 } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -361,9 +362,9 @@ function StepBasicInfo({
     <div className="space-y-4">
       <h2 className="text-lg font-medium text-foreground">Basic Information</h2>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Agent Name</span>
-        <InputCVA
+      <Field>
+        <Label className="text-sm text-muted-foreground">Agent Name</Label>
+        <Input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -371,10 +372,10 @@ function StepBasicInfo({
           placeholder="Code Reviewer Pro"
         />
         {fieldError('name') && <p className="mt-1 text-xs text-error">{fieldError('name')}</p>}
-      </label>
+      </Field>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Description</span>
+      <Field>
+        <Label className="text-sm text-muted-foreground">Description</Label>
         <Textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -385,10 +386,10 @@ function StepBasicInfo({
         {fieldError('description') && (
           <p className="mt-1 text-xs text-error">{fieldError('description')}</p>
         )}
-      </label>
+      </Field>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Category</span>
+      <Field>
+        <Label className="text-sm text-muted-foreground">Category</Label>
         <Select value={category} onChange={(e) => setCategory(e.target.value)} className="mt-1">
           {CATEGORIES.map((cat) => (
             <option key={cat} value={cat}>
@@ -396,18 +397,18 @@ function StepBasicInfo({
             </option>
           ))}
         </Select>
-      </label>
+      </Field>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Tags (comma-separated)</span>
-        <InputCVA
+      <Field>
+        <Label className="text-sm text-muted-foreground">Tags (comma-separated)</Label>
+        <Input
           type="text"
           value={tags}
           onChange={(e) => setTags(e.target.value)}
           className="mt-1 w-full"
           placeholder="typescript, react, code-review"
         />
-      </label>
+      </Field>
 
       <div className="pt-4">
         <ButtonCVA type="button" onClick={onNext}>
@@ -467,9 +468,9 @@ function StepConfiguration({
         </RadioGroup>
       </div>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Base Price (USDC)</span>
-        <InputCVA
+      <Field>
+        <Label className="text-sm text-muted-foreground">Base Price (USDC)</Label>
+        <Input
           type="text"
           value={basePriceUsdc}
           onChange={(e) => setBasePriceUsdc(e.target.value)}
@@ -479,11 +480,11 @@ function StepConfiguration({
         {fieldError('basePriceUsdc') && (
           <p className="mt-1 text-xs text-error">{fieldError('basePriceUsdc')}</p>
         )}
-      </label>
+      </Field>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Max Execution Time (seconds)</span>
-        <InputCVA
+      <Field>
+        <Label className="text-sm text-muted-foreground">Max Execution Time (seconds)</Label>
+        <Input
           type="number"
           value={maxExecutionSecs}
           onChange={(e) => setMaxExecutionSecs(Number(e.target.value))}
@@ -491,10 +492,10 @@ function StepConfiguration({
           max={3600}
           className="mt-1 w-full"
         />
-      </label>
+      </Field>
 
-      <label className="block">
-        <span className="text-sm text-muted-foreground">Agent Definition (JSON)</span>
+      <Field>
+        <Label className="text-sm text-muted-foreground">Agent Definition (JSON)</Label>
         <Textarea
           value={definitionJson}
           onChange={(e) => setDefinitionJson(e.target.value)}
@@ -504,7 +505,7 @@ function StepConfiguration({
         {fieldError('definition') && (
           <p className="mt-1 text-xs text-error">{fieldError('definition')}</p>
         )}
-      </label>
+      </Field>
 
       <div className="flex gap-3 pt-4">
         <ButtonCVA type="button" variant="outline" onClick={onBack}>
@@ -567,9 +568,9 @@ function StepSkills({
             )}
           </div>
 
-          <label className="block">
-            <span className="text-xs text-muted-foreground">Name</span>
-            <InputCVA
+          <Field>
+            <Label className="text-xs text-muted-foreground">Name</Label>
+            <Input
               type="text"
               value={skill.name}
               onChange={(e) => updateSkill(i, 'name', e.target.value)}
@@ -579,11 +580,11 @@ function StepSkills({
             {fieldError(`skill-${i}-name`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-name`)}</p>
             )}
-          </label>
+          </Field>
 
-          <label className="block">
-            <span className="text-xs text-muted-foreground">Description</span>
-            <InputCVA
+          <Field>
+            <Label className="text-xs text-muted-foreground">Description</Label>
+            <Input
               type="text"
               value={skill.description}
               onChange={(e) => updateSkill(i, 'description', e.target.value)}
@@ -593,10 +594,10 @@ function StepSkills({
             {fieldError(`skill-${i}-description`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-description`)}</p>
             )}
-          </label>
+          </Field>
 
-          <label className="block">
-            <span className="text-xs text-muted-foreground">Input Schema (JSON)</span>
+          <Field>
+            <Label className="text-xs text-muted-foreground">Input Schema (JSON)</Label>
             <Textarea
               value={skill.inputSchema}
               onChange={(e) => updateSkill(i, 'inputSchema', e.target.value)}
@@ -606,10 +607,10 @@ function StepSkills({
             {fieldError(`skill-${i}-input`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-input`)}</p>
             )}
-          </label>
+          </Field>
 
-          <label className="block">
-            <span className="text-xs text-muted-foreground">Output Schema (JSON)</span>
+          <Field>
+            <Label className="text-xs text-muted-foreground">Output Schema (JSON)</Label>
             <Textarea
               value={skill.outputSchema}
               onChange={(e) => updateSkill(i, 'outputSchema', e.target.value)}
@@ -619,7 +620,7 @@ function StepSkills({
             {fieldError(`skill-${i}-output`) && (
               <p className="mt-1 text-xs text-error">{fieldError(`skill-${i}-output`)}</p>
             )}
-          </label>
+          </Field>
         </Card>
       ))}
 

--- a/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
+++ b/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { InputCVA } from '@revealui/presentation/server';
-import { useActionState, useEffect, useId, useState } from 'react';
+import { Input } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
+import { useActionState, useEffect, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
 import type { ChangePasswordState } from './actions';
 import { changePasswordAction } from './actions';
@@ -12,7 +13,6 @@ interface Props {
 }
 
 export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
-  const formId = useId();
   const [showCurrent, setShowCurrent] = useState(false);
   const [showNew, setShowNew] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -28,7 +28,7 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
   }, [state?.status, onSuccess]);
 
   return (
-    <form id={formId} action={action} className="mt-4 space-y-3">
+    <form action={action} className="mt-4 space-y-3">
       {/* Form-level error (wrong current password, server error) */}
       {state?.formError && (
         <div
@@ -39,86 +39,58 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
         </div>
       )}
 
-      <div>
-        <label
-          htmlFor={`${formId}-current`}
-          className="block text-xs font-medium text-zinc-400 mb-1"
-        >
-          Current password
-        </label>
+      <Field>
+        <Label className="block text-xs font-medium text-zinc-400 mb-1">Current password</Label>
         <PasswordInput visible={showCurrent} onToggle={() => setShowCurrent((v) => !v)}>
-          <InputCVA
-            id={`${formId}-current`}
+          <Input
             name="currentPassword"
             type={showCurrent ? 'text' : 'password'}
             autoComplete="current-password"
             required
             aria-invalid={!!state?.fieldErrors?.currentPassword}
-            aria-describedby={
-              state?.fieldErrors?.currentPassword ? `${formId}-current-error` : undefined
-            }
             className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.currentPassword && (
-          <p id={`${formId}-current-error`} className="mt-1 text-xs text-red-400">
-            {state.fieldErrors.currentPassword[0]}
-          </p>
+          <p className="mt-1 text-xs text-red-400">{state.fieldErrors.currentPassword[0]}</p>
         )}
-      </div>
+      </Field>
 
-      <div>
-        <label htmlFor={`${formId}-new`} className="block text-xs font-medium text-zinc-400 mb-1">
-          New password
-        </label>
+      <Field>
+        <Label className="block text-xs font-medium text-zinc-400 mb-1">New password</Label>
         <PasswordInput visible={showNew} onToggle={() => setShowNew((v) => !v)}>
-          <InputCVA
-            id={`${formId}-new`}
+          <Input
             name="newPassword"
             type={showNew ? 'text' : 'password'}
             autoComplete="new-password"
             required
             minLength={8}
             aria-invalid={!!state?.fieldErrors?.newPassword}
-            aria-describedby={state?.fieldErrors?.newPassword ? `${formId}-new-error` : undefined}
             className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.newPassword && (
-          <p id={`${formId}-new-error`} className="mt-1 text-xs text-red-400">
-            {state.fieldErrors.newPassword[0]}
-          </p>
+          <p className="mt-1 text-xs text-red-400">{state.fieldErrors.newPassword[0]}</p>
         )}
-      </div>
+      </Field>
 
-      <div>
-        <label
-          htmlFor={`${formId}-confirm`}
-          className="block text-xs font-medium text-zinc-400 mb-1"
-        >
-          Confirm new password
-        </label>
+      <Field>
+        <Label className="block text-xs font-medium text-zinc-400 mb-1">Confirm new password</Label>
         <PasswordInput visible={showConfirm} onToggle={() => setShowConfirm((v) => !v)}>
-          <InputCVA
-            id={`${formId}-confirm`}
+          <Input
             name="confirmPassword"
             type={showConfirm ? 'text' : 'password'}
             autoComplete="new-password"
             required
             minLength={8}
             aria-invalid={!!state?.fieldErrors?.confirmPassword}
-            aria-describedby={
-              state?.fieldErrors?.confirmPassword ? `${formId}-confirm-error` : undefined
-            }
             className="pr-10"
           />
         </PasswordInput>
         {state?.fieldErrors?.confirmPassword && (
-          <p id={`${formId}-confirm-error`} className="mt-1 text-xs text-red-400">
-            {state.fieldErrors.confirmPassword[0]}
-          </p>
+          <p className="mt-1 text-xs text-red-400">{state.fieldErrors.confirmPassword[0]}</p>
         )}
-      </div>
+      </Field>
 
       <div className="flex gap-2 pt-1">
         <button

--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -2,7 +2,8 @@
 
 const SAVED_FEEDBACK_MS = 2_000;
 
-import { InputCVA, Select } from '@revealui/presentation';
+import { Input, Select } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -142,32 +143,22 @@ export default function ApiKeysPage() {
 
             <div className="mt-5 flex flex-col gap-4">
               {/* Provider selector */}
-              <div>
-                <label
-                  htmlFor="provider-select"
-                  className="block text-xs font-medium text-muted-foreground mb-1.5"
-                >
+              <Field>
+                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
                   Provider
-                </label>
-                <Select
-                  id="provider-select"
-                  value={provider}
-                  onChange={(e) => setProvider(e.target.value as Provider)}
-                >
+                </Label>
+                <Select value={provider} onChange={(e) => setProvider(e.target.value as Provider)}>
                   {PROVIDERS.map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.label}
                     </option>
                   ))}
                 </Select>
-              </div>
+              </Field>
 
               {/* API key input */}
-              <div>
-                <label
-                  htmlFor="api-key-input"
-                  className="block text-xs font-medium text-muted-foreground mb-1.5"
-                >
+              <Field>
+                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
                   API Key
                   {activeProviderInfo && (
                     <a
@@ -179,10 +170,9 @@ export default function ApiKeysPage() {
                       Get key ↗
                     </a>
                   )}
-                </label>
+                </Label>
                 <div className="relative">
-                  <InputCVA
-                    id="api-key-input"
+                  <Input
                     type={showKey ? 'text' : 'password'}
                     value={apiKey}
                     onChange={(e) => setApiKey(e.target.value)}
@@ -197,7 +187,7 @@ export default function ApiKeysPage() {
                     {showKey ? 'hide' : 'show'}
                   </button>
                 </div>
-              </div>
+              </Field>
 
               {/* Actions */}
               <div className="flex items-center gap-2 pt-1">

--- a/apps/admin/src/app/(backend)/settings/security/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/security/page.tsx
@@ -4,13 +4,15 @@ const SUCCESS_DISMISS_MS = 5_000;
 const ERROR_DISMISS_MS = 8_000;
 
 import { useMFASetup, usePasskeyRegister } from '@revealui/auth/react';
+import { Input } from '@revealui/presentation';
 import {
   Dialog,
   DialogActions,
   DialogDescription,
   DialogTitle,
+  Field,
+  Label,
 } from '@revealui/presentation/client';
-import { InputCVA } from '@revealui/presentation/server';
 import { QRCodeSVG } from 'qrcode.react';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -517,16 +519,12 @@ function SecuritySettingsContent() {
                   </div>
 
                   {/* Verification */}
-                  <div>
-                    <label
-                      htmlFor="mfa-verify-code"
-                      className="text-xs font-medium text-muted-foreground"
-                    >
+                  <Field>
+                    <Label className="text-xs font-medium text-muted-foreground">
                       Enter a code from your authenticator app to verify
-                    </label>
+                    </Label>
                     <div className="mt-1 flex gap-2">
-                      <InputCVA
-                        id="mfa-verify-code"
+                      <Input
                         type="text"
                         inputMode="numeric"
                         autoComplete="one-time-code"
@@ -556,7 +554,7 @@ function SecuritySettingsContent() {
                         Cancel
                       </button>
                     </div>
-                  </div>
+                  </Field>
                 </div>
               )}
 
@@ -579,40 +577,38 @@ function SecuritySettingsContent() {
                       {/* Disable 2FA */}
                       {showDisableForm ? (
                         <div className="rounded-lg border border-border p-3">
-                          <label
-                            htmlFor="mfa-disable-password"
-                            className="text-xs font-medium text-muted-foreground"
-                          >
-                            Confirm your password to disable 2FA
-                          </label>
-                          <div className="mt-1.5 flex flex-wrap gap-2">
-                            <InputCVA
-                              id="mfa-disable-password"
-                              type="password"
-                              value={disablePassword}
-                              onChange={(e) => setDisablePassword(e.target.value)}
-                              placeholder="Password"
-                              className="w-full sm:w-48"
-                            />
-                            <button
-                              type="button"
-                              onClick={() => void handleDisableMFA()}
-                              disabled={disabling || !disablePassword.trim()}
-                              className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                              {disabling ? 'Disabling...' : 'Confirm'}
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setShowDisableForm(false);
-                                setDisablePassword('');
-                              }}
-                              className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
-                            >
-                              Cancel
-                            </button>
-                          </div>
+                          <Field>
+                            <Label className="text-xs font-medium text-muted-foreground">
+                              Confirm your password to disable 2FA
+                            </Label>
+                            <div className="mt-1.5 flex flex-wrap gap-2">
+                              <Input
+                                type="password"
+                                value={disablePassword}
+                                onChange={(e) => setDisablePassword(e.target.value)}
+                                placeholder="Password"
+                                className="w-full sm:w-48"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => void handleDisableMFA()}
+                                disabled={disabling || !disablePassword.trim()}
+                                className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
+                              >
+                                {disabling ? 'Disabling...' : 'Confirm'}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setShowDisableForm(false);
+                                  setDisablePassword('');
+                                }}
+                                className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </Field>
                         </div>
                       ) : (
                         <button
@@ -705,7 +701,7 @@ function SecuritySettingsContent() {
                         <div>
                           {renamingId === passkey.id ? (
                             <div className="flex gap-1.5">
-                              <InputCVA
+                              <Input
                                 type="text"
                                 value={renameValue}
                                 onChange={(e) => setRenameValue(e.target.value)}

--- a/biome.json
+++ b/biome.json
@@ -158,13 +158,7 @@
         "useSimplifiedLogicExpression": "warn"
       },
       "a11y": {
-        "recommended": true,
-        "noLabelWithoutControl": {
-          "level": "error",
-          "options": {
-            "inputComponents": ["Input", "InputCVA", "Textarea", "Select", "Slider", "Checkbox"]
-          }
-        }
+        "recommended": true
       }
     }
   },


### PR DESCRIPTION
refactor(admin): backfill settings+marketplace forms to Field-context; retire biome inputComponents

Final Phase-4 cleanup: bring the already-merged settings (4a) + marketplace (4b) forms onto the
same Field-context pattern as 4c-4f, so ALL admin forms use one consistent pattern, then retire
the lint band-aid that's no longer needed.

- 6 files (settings: PasswordChangeForm, api-keys, security; marketplace: publish, [agentId], page):
  raw <label> + InputCVA -> <Field><Label/><headless Input|Select|Textarea/></Field>. Field/Label
  from @revealui/presentation/client; headless controls from the main entry. RadioGroup/Slider left
  as-is (own field context); the search box + label-less marketplace filter selects left
  headless-only. PasswordInput wraps its Input child inside Field. value/onChange/required/pattern/
  inputMode/maxLength/autoComplete + <option> children all preserved.
- biome.json: REMOVE the noLabelWithoutControl.inputComponents option (added in 4b). No raw <label>
  wraps a design-system control anymore — verified 0 noLabelWithoutControl violations across
  admin/marketing/docs with the option removed — so the accommodation is retired.

Completes Phase 4: every admin/docs form is now on the durable Field-context pattern (or the
correct server-safe / core-ui variant), with association owned by the primitives.

Verified: admin typecheck + build green; settings tests 24/24; biome clean.
