### PR TITLE
refactor(core): brand-token the rich-text editor UI (Phase 5b)

### DIFF
--- a/.changeset/core-richtext-tokens.md
+++ b/.changeset/core-richtext-tokens.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": patch
+---
+
+Brand-token the rich-text editor UI. 21 inline-hex/CSS colors across `client/richtext/RichTextEditor.tsx`, `client/richtext/components/ImageNodeComponent.tsx`, and the `richtext/exports/{server/rsc,client/rcc}.tsx` figcaptions now reference RevealUI brand tokens with the original hex as a literal fallback (e.g. `var(--rvui-brand, #3b82f6)`). No API/behavior change, no new dependency (token-only). The Lexical node-render plumbing structure is unchanged. `observability/alerts.ts` left as-is (its `#FFA500` is a Slack notification-channel color, not UI).

--- a/packages/core/src/client/richtext/RichTextEditor.tsx
+++ b/packages/core/src/client/richtext/RichTextEditor.tsx
@@ -395,7 +395,7 @@ export function RichTextEditor({
 
 export const richTextEditorStyles = `
 .revealui-rich-text-editor {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--rvui-border, #e2e8f0);
   border-radius: 8px;
   overflow: hidden;
   font-family: system-ui, -apple-system, sans-serif;
@@ -405,13 +405,13 @@ export const richTextEditorStyles = `
   display: flex;
   gap: 4px;
   padding: 8px;
-  border-bottom: 1px solid #e2e8f0;
-  background: #f8fafc;
+  border-bottom: 1px solid var(--rvui-border, #e2e8f0);
+  background: var(--rvui-surface-1, #f8fafc);
 }
 
 .editor-toolbar--floating {
   border-bottom: none;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--rvui-border, #e2e8f0);
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   background: white;
@@ -421,7 +421,7 @@ export const richTextEditorStyles = `
 
 .toolbar-btn {
   padding: 6px 10px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--rvui-border, #e2e8f0);
   border-radius: 4px;
   background: white;
   cursor: pointer;
@@ -430,13 +430,13 @@ export const richTextEditorStyles = `
 }
 
 .toolbar-btn:hover {
-  background: #f1f5f9;
+  background: var(--rvui-surface-2, #f1f5f9);
 }
 
 .toolbar-btn.active {
-  background: #3b82f6;
+  background: var(--rvui-brand, #3b82f6);
   color: white;
-  border-color: #3b82f6;
+  border-color: var(--rvui-brand, #3b82f6);
 }
 
 .editor-container {
@@ -454,7 +454,7 @@ export const richTextEditorStyles = `
   position: absolute;
   top: 16px;
   left: 16px;
-  color: #94a3b8;
+  color: var(--rvui-text-2, #94a3b8);
   pointer-events: none;
   user-select: none;
 }
@@ -471,24 +471,24 @@ export const richTextEditorStyles = `
 .editor-heading-h6 { font-size: 0.75em; font-weight: bold; margin: 0 0 8px 0; }
 
 .editor-quote {
-  border-left: 4px solid #e2e8f0;
+  border-left: 4px solid var(--rvui-border, #e2e8f0);
   padding-left: 16px;
   margin: 0 0 8px 0;
-  color: #64748b;
+  color: var(--rvui-text-2, #64748b);
 }
 
 .editor-list-ol { list-style: decimal; padding-left: 24px; margin: 0 0 8px 0; }
 .editor-list-ul { list-style: disc; padding-left: 24px; margin: 0 0 8px 0; }
 .editor-listitem { margin: 4px 0; }
 
-.editor-link { color: #3b82f6; text-decoration: underline; }
+.editor-link { color: var(--rvui-brand, #3b82f6); text-decoration: underline; }
 
 .editor-text-bold { font-weight: bold; }
 .editor-text-italic { font-style: italic; }
 .editor-text-underline { text-decoration: underline; }
 .editor-text-strikethrough { text-decoration: line-through; }
 .editor-text-code {
-  background: #f1f5f9;
+  background: var(--rvui-surface-2, #f1f5f9);
   padding: 2px 4px;
   border-radius: 4px;
   font-family: monospace;
@@ -497,8 +497,8 @@ export const richTextEditorStyles = `
 .editor-text-superscript { vertical-align: super; font-size: smaller; }
 
 .editor-code {
-  background: #1e293b;
-  color: #e2e8f0;
+  background: var(--rvui-text-0, #1e293b);
+  color: var(--rvui-border, #e2e8f0);
   padding: 16px;
   border-radius: 4px;
   font-family: monospace;

--- a/packages/core/src/client/richtext/components/ImageNodeComponent.tsx
+++ b/packages/core/src/client/richtext/components/ImageNodeComponent.tsx
@@ -104,7 +104,7 @@ export const ImageNodeComponent: React.FC<Props> = (props) => {
             style={{
               padding: '4px 8px',
               background: 'white',
-              border: '1px solid #e2e8f0',
+              border: `1px solid var(--rvui-border, #e2e8f0)`,
               borderRadius: '4px',
               cursor: 'pointer',
               fontSize: '12px',
@@ -121,7 +121,7 @@ export const ImageNodeComponent: React.FC<Props> = (props) => {
             style={{
               padding: '4px 8px',
               background: 'white',
-              border: '1px solid #e2e8f0',
+              border: `1px solid var(--rvui-border, #e2e8f0)`,
               borderRadius: '4px',
               cursor: 'pointer',
               fontSize: '12px',
@@ -152,7 +152,7 @@ export const ImageNodeComponent: React.FC<Props> = (props) => {
             width: '100%',
             marginTop: '8px',
             padding: '4px 8px',
-            border: '1px solid #e2e8f0',
+            border: `1px solid var(--rvui-border, #e2e8f0)`,
             borderRadius: '4px',
           }}
         />
@@ -162,7 +162,7 @@ export const ImageNodeComponent: React.FC<Props> = (props) => {
             style={{
               marginTop: '8px',
               fontSize: '14px',
-              color: '#64748b',
+              color: 'var(--rvui-text-2, #64748b)',
               fontStyle: 'italic',
             }}
           >

--- a/packages/core/src/richtext/exports/client/rcc.tsx
+++ b/packages/core/src/richtext/exports/client/rcc.tsx
@@ -244,7 +244,12 @@ function serializeNode(
         />
         {caption && (
           <figcaption
-            style={{ marginTop: '8px', fontSize: '14px', color: '#64748b', fontStyle: 'italic' }}
+            style={{
+              marginTop: '8px',
+              fontSize: '14px',
+              color: 'var(--rvui-text-2, #64748b)',
+              fontStyle: 'italic',
+            }}
           >
             {caption}
           </figcaption>

--- a/packages/core/src/richtext/exports/server/rsc.tsx
+++ b/packages/core/src/richtext/exports/server/rsc.tsx
@@ -357,7 +357,7 @@ function serializeNode(
             style={{
               marginTop: '8px',
               fontSize: '14px',
-              color: '#64748b',
+              color: 'var(--rvui-text-2, #64748b)',
               fontStyle: 'italic',
             }}
           >


### PR DESCRIPTION
refactor(core): brand-token the rich-text editor UI (Phase 5b)

Primitive-adoption audit Phase 5 (core, token-only), slice b — completes the core token-driving.
21 inline-hex/CSS colors -> var(--rvui-*, #hexFallback) across the richtext surface, keeping the
Lexical structure intact:
- client/richtext/RichTextEditor.tsx (15): toolbar/quote/code/link/placeholder chrome — border
  (--rvui-border), surfaces (--rvui-surface-1/2), brand (--rvui-brand), text (--rvui-text-0/2).
- client/richtext/components/ImageNodeComponent.tsx (4) + richtext/exports/{server/rsc,client/rcc}
  .tsx (1 each): button borders + figcaption colors (--rvui-border / --rvui-text-2).

Left raw (intentional): the onError SVG data-URI (URL-encoded blob, not CSS); observability/
alerts.ts #FFA500 (Slack channel color, non-UI); client/ui/index.tsx admin-engine --theme-* chrome.

TOKEN-ONLY: no @revealui/presentation import, NO new package dep. Review note: the .editor-code
block maps bg->--rvui-text-0 / text->--rvui-border (faithful to the original fixed-dark code block
via the hex fallbacks; a cleaner code-surface token is a Phase-6 refinement).

Verified: core typecheck + build green; richtext tests 166/166; biome clean.
