### PR TITLE
fix(admin): scope passkey + OAuth signup seat cap to self-hosted only

### DIFF
--- a/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
@@ -334,6 +334,67 @@ describe('GET /api/auth/callback/[provider] (OAuth callback)', () => {
     expect((res as MockRes).cookies.get('revealui-role')?.value).toBe('user');
   });
 
+  it('does NOT seat-cap hosted OAuth signup even at/over the free cap', async () => {
+    // Hosted mode: REVEALUI_LICENSE_PRIVATE_KEY present. The deployment-license
+    // seat cap must not gate hosted OAuth onboarding, so the global active-user
+    // count is never consulted and the flow proceeds to session creation.
+    setupHappyPath();
+    mockGetMaxUsers.mockReturnValueOnce(3);
+    mockCountActiveUsers.mockResolvedValueOnce(5); // over the free cap
+    const prevKey = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-signing-key';
+    try {
+      const GET = await loadRoute();
+      const res = await GET(
+        makeCallbackRequest({
+          searchParams: { code: 'auth-code', state: 'valid-state' },
+          stateCookie: 'valid-cookie',
+        }),
+        { params: Promise.resolve({ provider: 'github' }) },
+      );
+
+      expect((res as MockRes).url).not.toContain('user_limit_reached');
+      expect((res as MockRes).cookies.has('revealui-session')).toBe(true);
+      // Global active-user count must not even be queried on hosted.
+      expect(mockCountActiveUsers).not.toHaveBeenCalled();
+    } finally {
+      if (prevKey === undefined) {
+        delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+      } else {
+        process.env.REVEALUI_LICENSE_PRIVATE_KEY = prevKey;
+      }
+    }
+  });
+
+  it('still enforces the deployment-license cap on self-hosted (Forge) OAuth signup', async () => {
+    // Self-hosted (Forge) mode: no REVEALUI_LICENSE_PRIVATE_KEY. The seat cap is
+    // legitimate for a stamped kit and must still reject over-cap signups.
+    setupHappyPath();
+    mockGetMaxUsers.mockReturnValueOnce(3);
+    mockCountActiveUsers.mockResolvedValueOnce(5); // over the free cap
+    const prevKey = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    try {
+      const GET = await loadRoute();
+      const res = await GET(
+        makeCallbackRequest({
+          searchParams: { code: 'auth-code', state: 'valid-state' },
+          stateCookie: 'valid-cookie',
+        }),
+        { params: Promise.resolve({ provider: 'github' }) },
+      );
+
+      expect((res as MockRes).url).toContain('user_limit_reached');
+      expect((res as MockRes).cookies.has('revealui-session')).toBe(false);
+    } finally {
+      if (prevKey === undefined) {
+        delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+      } else {
+        process.env.REVEALUI_LICENSE_PRIVATE_KEY = prevKey;
+      }
+    }
+  });
+
   it('sets admin role cookie for admin users', async () => {
     setupHappyPath({ userRole: 'admin' });
 

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -103,12 +103,16 @@ export async function GET(
       return loginUrl('not_allowed');
     }
 
-    // Enforce user limit for new OAuth signups (CR5-2)
-    // Only check if this OAuth identity doesn't already map to a user
+    // Enforce user limit for new OAuth signups (CR5-2).
+    // Only check if this OAuth identity doesn't already map to a user. The
+    // deployment-license cap is a self-hosted (Forge) concept; hosted admission
+    // is per-account, so a deployment-global seat cap must not gate hosted OAuth
+    // onboarding (mirrors the password sign-up route + apps/server validate-startup).
+    const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
     try {
       await initializeLicense();
       const maxUsers = getMaxUsers();
-      if (maxUsers !== Infinity && !existingOAuth) {
+      if (maxUsers !== Infinity && !existingOAuth && isSelfHostedForge) {
         const activeCount = await countActiveUsers(db);
         if (activeCount >= maxUsers) {
           return loginUrl('user_limit_reached');

--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -52,10 +52,14 @@ vi.mock('@/lib/middleware/rate-limit', () => ({
   withRateLimit: vi.fn((handler: (request: NextRequest) => Promise<Response>) => handler),
 }));
 
+// Reassignable so individual tests can exercise the deployment-license seat cap.
+// Default: no limit, matching a hosted/unlicensed test environment.
+const mockGetMaxUsers = vi.fn(() => Infinity);
+
 // Mock license module  -  tests run without a license server, so report no limit
 vi.mock('@revealui/core/license', () => ({
   initializeLicense: vi.fn(() => Promise.resolve()),
-  getMaxUsers: vi.fn(() => Infinity),
+  getMaxUsers: () => mockGetMaxUsers(),
 }));
 
 // Mock drizzle-orm operators
@@ -506,6 +510,83 @@ describe('POST /api/auth/passkey/register-verify', () => {
     // Challenge cookie should be cleared
     const challengeCookie = response.cookies.get('passkey-challenge');
     expect(challengeCookie?.value).toBe('');
+  });
+
+  it('does NOT seat-cap hosted passkey signup even at/over the free cap', async () => {
+    // Hosted mode: REVEALUI_LICENSE_PRIVATE_KEY present. The deployment-license
+    // seat cap must be skipped entirely. Even with a finite getMaxUsers, the
+    // cap block (which would run db.transaction) must not execute. If the gate
+    // regressed, the route would hit the un-mocked db.transaction and 503;
+    // a 200 proves the block was correctly skipped on hosted.
+    const prevKey = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-signing-key';
+    mockGetMaxUsers.mockReturnValueOnce(3);
+    mockVerifyCookiePayload.mockReturnValue({
+      challenge: 'signup-challenge',
+      userId: 'temp-user-id',
+      email: 'hosted@example.com',
+      name: 'Hosted User',
+      expiresAt: Date.now() + 300000,
+    });
+    mockDb.limit.mockResolvedValue([]); // No existing user
+    mockDb.returning.mockResolvedValue([
+      { id: 'hosted-user-id', email: 'hosted@example.com', name: 'Hosted User', password: null },
+    ]);
+    mockVerifyRegistration.mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        fmt: 'none',
+        aaguid: '00000000-0000-0000-0000-000000000000',
+        credential: {
+          id: 'hosted-credential-id',
+          publicKey: new Uint8Array([7, 8, 9]),
+          counter: 0,
+          transports: ['internal'],
+        },
+        credentialType: 'public-key',
+        userVerified: true,
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+        attestationObject: new Uint8Array(),
+        origin: 'http://localhost:4000',
+      },
+    });
+    mockStorePasskey.mockResolvedValue({
+      id: 'passkey-id',
+      userId: 'hosted-user-id',
+      credentialId: 'hosted-credential-id',
+      deviceName: null,
+      createdAt: new Date(),
+    });
+    mockInitiateMFASetup.mockResolvedValue({
+      success: true,
+      secret: 'TOTP_SECRET',
+      uri: 'otpauth://totp/RevealUI:hosted@example.com',
+      backupCodes: ['b1', 'b2', 'b3'],
+    });
+    mockCreateSession.mockResolvedValue({
+      token: 'hosted-session-token',
+      session: { id: 'hosted-session-id' } as never,
+    });
+
+    try {
+      const request = createChallengeRequest(
+        'http://localhost:3000/api/auth/passkey/register-verify',
+        { attestationResponse: { id: 'cred-id', response: {} } },
+      );
+      const response = await handler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.user.email).toBe('hosted@example.com');
+    } finally {
+      if (prevKey === undefined) {
+        delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+      } else {
+        process.env.REVEALUI_LICENSE_PRIVATE_KEY = prevKey;
+      }
+    }
   });
 
   it('should reject sign-up when email is taken (race condition)', async () => {

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -114,11 +114,18 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
       // Sign-up flow: create user, store passkey, create session
       const db = getClient();
 
+      // The deployment-license user cap is a self-hosted (Forge) concept and must
+      // NOT gate hosted onboarding. A global active-user count would cap the whole
+      // control plane at the free seat count. Mirrors apps/server validate-startup
+      // and the password sign-up route: license-signing-key presence ⇒ hosted
+      // multi-tenant mode, where admission is governed per-account, not by a
+      // deployment-global seat count.
+      const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
       // Enforce user limit based on license tier (R5-H11 fix  -  was missing from passkey flow)
       try {
         await initializeLicense();
         const maxUsers = getMaxUsers();
-        if (maxUsers !== Infinity) {
+        if (maxUsers !== Infinity && isSelfHostedForge) {
           let limitExceeded = false;
           let limitMsg = '';
           await db.transaction(async (tx) => {


### PR DESCRIPTION
## What

Scope the deployment-license user cap to self-hosted (Forge) deployments on the two remaining admin signup entry points: passkey registration (`register-verify`) and the OAuth callback (`callback/[provider]`). The password sign-up route and the server API signup were already scoped this way; this brings passkey and OAuth into line.

## Why

The deployment-license seat cap answers "is THIS deployment licensed for N seats?" That is correct for a self-hosted, stamped kit, but wrong for hosted onboarding, where one process serves every tenant and admission is governed per-account. The passkey and OAuth admin signup routes still consulted the global active-user count unconditionally, so on a hosted deployment they would reject signups (`USER_LIMIT_REACHED` / `user_limit_reached`) once the free seat count was reached.

## Change

- `passkey/register-verify` and `callback/[provider]`: enforce the seat cap only when `REVEALUI_LICENSE_PRIVATE_KEY` is absent (Forge / self-hosted mode), mirroring the password sign-up route and `apps/server` startup mode detection.
- Tests: hosted signup is not seat-capped even at or over the free cap on both routes; self-hosted (Forge) still rejects over-cap OAuth signups.

## Verification

- `admin` unit tests green (passkey + OAuth suites, 37 passing).
- Biome and typecheck clean; full gate green.
