### PR TITLE
fix(auth,admin): stop bouncing signed-in non-admins to login; add verification resend

### DIFF
--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -76,4 +76,25 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
     const res = await proxy(req('/rotate-password', ADMIN_COOKIES));
     expect(redirectPath(res)).not.toBe('/');
   });
+
+  it('sends an authenticated non-admin off an admin route to /welcome, not /login', async () => {
+    // The bug: a signed-in user-role account hitting an admin route was bounced
+    // to /login (the form they just used) — a silent flash-and-reappear loop.
+    // Fix: redirect to /welcome with a ?denied=admin notice instead.
+    const res = await proxy(req('/settings', USER_COOKIES));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    const url = location ? new URL(location) : null;
+    expect(url?.pathname).toBe('/welcome');
+    expect(url?.pathname).not.toBe('/login');
+    expect(url?.searchParams.get('denied')).toBe('admin');
+  });
+
+  it('does not bounce an authenticated non-admin off /welcome (no loop)', async () => {
+    // /welcome is session-only, so the target of the deny redirect is itself
+    // reachable — guarantees the deny path terminates instead of looping.
+    const res = await proxy(req('/welcome', USER_COOKIES));
+    expect(redirectPath(res)).not.toBe('/login');
+    expect(redirectPath(res)).not.toBe('/welcome');
+  });
 });

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -106,13 +106,18 @@ describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => 
     expect(res.headers.get('location')).toContain('/login');
   });
 
-  it('still enforces the admin role on other backend pages (non-admin session redirects to /login)', async () => {
+  it('still enforces the admin role on other backend pages (non-admin session is sent to /welcome, not /login)', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/posts', {
         headers: { cookie: 'revealui-session=tok; revealui-role=user' },
       }),
     );
-    expect(res.headers.get('location')).toContain('/login');
+    // Admin role is still enforced: a non-admin cannot reach /posts. It now lands
+    // on /welcome (their session home) with a denial notice rather than being
+    // bounced to the login form they already used.
+    const location = res.headers.get('location');
+    expect(location).toContain('/welcome');
+    expect(location).not.toContain('/login');
   });
 
   it('lets an authenticated non-admin (subscriber) reach /account/billing without bouncing to /login', async () => {

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -40,6 +40,10 @@ const SUCCESS_MESSAGES: Record<string, string> = {
   already_verified: 'Your email is already verified — sign in to continue.',
 };
 
+// Sign-in error code (from the API `code` field) that the login form can
+// recover from in-place by offering to resend the verification email.
+const EMAIL_NOT_VERIFIED_CODE = 'EMAIL_NOT_VERIFIED';
+
 const OAUTH_META: Record<OAuthProvider, { label: string; href: string; Icon: typeof GitHubIcon }> =
   {
     github: { label: 'GitHub', href: '/api/auth/github', Icon: GitHubIcon },
@@ -90,6 +94,10 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   const [error, setError] = useState<string | null>(
     oauthError ? (OAUTH_ERROR_MESSAGES[oauthError] ?? 'Sign-in failed. Please try again.') : null,
   );
+  // When sign-in fails with EMAIL_NOT_VERIFIED, hold the address so the user can
+  // resend their verification link in-place instead of hitting a dead end.
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+  const [resendState, setResendState] = useState<'idle' | 'sending' | 'sent'>('idle');
   const messageKey = searchParams.get('message');
   const successMessage = messageKey ? SUCCESS_MESSAGES[messageKey] : undefined;
   const { upgrade, redirect } = readAuthIntent(searchParams);
@@ -100,6 +108,8 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    setUnverifiedEmail(null);
+    setResendState('idle');
 
     const result = await signIn({ email, password });
     if (result.success && 'requiresPasswordRotation' in result && result.requiresPasswordRotation) {
@@ -118,11 +128,33 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
     } else {
       const errorMessage = 'error' in result ? result.error : 'Failed to sign in';
       setError(errorMessage || 'Failed to sign in');
+      // Offer a self-service resend when the wall is an unverified email, so a
+      // never-delivered verification link is recoverable from the login screen.
+      const code = 'code' in result ? result.code : undefined;
+      setUnverifiedEmail(code === EMAIL_NOT_VERIFIED_CODE ? email : null);
     }
+  };
+
+  const handleResendVerification = async () => {
+    if (!unverifiedEmail) return;
+    setResendState('sending');
+    try {
+      await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: unverifiedEmail }),
+      });
+    } catch {
+      // The endpoint returns a constant accepted response by design (anti-
+      // enumeration), so even a transient failure shows the same confirmation.
+    }
+    setResendState('sent');
   };
 
   const handlePasskeySignIn = async () => {
     setError(null);
+    setUnverifiedEmail(null);
+    setResendState('idle');
     const success = await passkeySignIn();
     if (success) {
       // Passkey sign-in returns no user object, so role-default falls back to '/'.
@@ -151,6 +183,32 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
           className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400"
         >
           {error ?? passkeyError}
+        </div>
+      )}
+
+      {unverifiedEmail && (
+        <div
+          role="status"
+          className="rounded-md bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-300"
+        >
+          {resendState === 'sent' ? (
+            <p>
+              If that account exists and is unverified, a new verification link is on its way. Check
+              your inbox.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <p>Your email address is not verified yet.</p>
+              <button
+                type="button"
+                onClick={() => void handleResendVerification()}
+                disabled={resendState === 'sending'}
+                className="self-start rounded-md bg-amber-100 px-3 py-1.5 text-xs font-medium text-amber-900 ring-1 ring-amber-300 transition-colors hover:bg-amber-200 disabled:opacity-60 dark:bg-amber-900/40 dark:text-amber-200 dark:ring-amber-800"
+              >
+                {resendState === 'sending' ? 'Sending…' : 'Resend verification email'}
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/login/__tests__/LoginForm.test.tsx
@@ -200,6 +200,69 @@ describe('LoginForm post-sign-in navigation', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it('offers a verification resend when sign-in fails with EMAIL_NOT_VERIFIED', async () => {
+    mockSignIn.mockResolvedValue({
+      success: false,
+      error: 'Please verify your email address before signing in.',
+      code: 'EMAIL_NOT_VERIFIED',
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    // Friendly message shown (not the raw code), plus a recovery affordance.
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Please verify your email address before signing in.',
+    );
+    expect(screen.getByRole('button', { name: 'Resend verification email' })).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not offer a resend for a generic sign-in failure', async () => {
+    mockSignIn.mockResolvedValue({ success: false, error: 'Invalid email or password' });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    await screen.findByRole('alert');
+    expect(
+      screen.queryByRole('button', { name: 'Resend verification email' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('resends the verification email to the sign-in address and confirms', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ success: true }) });
+    vi.stubGlobal('fetch', fetchMock);
+    mockSignIn.mockResolvedValue({
+      success: false,
+      error: 'Please verify your email address before signing in.',
+      code: 'EMAIL_NOT_VERIFIED',
+    });
+
+    render(<LoginForm oauthProviders={[]} />);
+    fillAndSubmit();
+
+    const resendButton = await screen.findByRole('button', { name: 'Resend verification email' });
+    fireEvent.click(resendButton);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/auth/resend-verification',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ email: 'owner@example.com' }),
+        }),
+      );
+    });
+    expect(
+      await screen.findByText((content) => content.includes('verification link is on its way')),
+    ).toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
   it('full-navigates home after a successful passkey sign-in (no soft push)', async () => {
     mockPasskeySupported = true;
     mockPasskeySignIn.mockResolvedValue(true);

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -20,15 +20,22 @@ const CLI_INSTALL_COMMAND = 'pnpm create revealui my-app';
  * The success banner only renders when `?success=true` is in the URL —
  * direct visits (revisiting the page later) show the same three CTAs
  * without the celebratory framing.
+ *
+ * The `?denied=admin` banner renders when the proxy redirected an
+ * authenticated non-admin here from an admin-only route. It explains why they
+ * are not in the admin area instead of silently bouncing them to the login
+ * form they just used (see apps/admin/src/proxy.ts).
  */
 export default function WelcomePage() {
   const { tier } = useLicense();
   const [isPostPurchase, setIsPostPurchase] = useState(false);
+  const [deniedAdmin, setDeniedAdmin] = useState(false);
   const [cliCopied, setCliCopied] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     setIsPostPurchase(params.get('success') === 'true');
+    setDeniedAdmin(params.get('denied') === 'admin');
   }, []);
 
   const tierLabel = TIER_LABELS[tier] ?? 'Free';
@@ -47,6 +54,17 @@ export default function WelcomePage() {
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-12 lg:px-8">
+      {/* Access-denied notice: authenticated, but the admin area needs an admin role. */}
+      {deniedAdmin && (
+        <div
+          role="status"
+          className="mb-8 rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300"
+        >
+          You are signed in, but the admin area requires an admin role. Here is your account home.
+          If you need admin access, contact your workspace administrator.
+        </div>
+      )}
+
       {/* Hero */}
       <div className="text-center mb-12">
         {isPostPurchase && isPaidTier && (

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -185,10 +185,17 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     if (!SESSION_ONLY_PATHS.has(pathname)) {
       const role = request.cookies.get('revealui-role')?.value;
       if (role !== 'admin') {
-        // User is authenticated but not admin — redirect to login (no admin home for non-admins)
-        const loginUrl = request.nextUrl.clone();
-        loginUrl.pathname = '/login';
-        return NextResponse.redirect(loginUrl);
+        // Authenticated but not an admin. Redirect to /welcome (their session-only
+        // home), NOT /login. Bouncing an already-signed-in user to the login form
+        // they just used produces a silent flash-and-reappear loop with no feedback
+        // (a user-role account sent to an admin route via a ?redirect= intent).
+        // The `denied` param lets /welcome explain that the admin area needs an
+        // admin role.
+        const welcomeUrl = request.nextUrl.clone();
+        welcomeUrl.pathname = '/welcome';
+        welcomeUrl.search = '';
+        welcomeUrl.searchParams.set('denied', 'admin');
+        return NextResponse.redirect(welcomeUrl);
       }
     }
 

--- a/packages/auth/src/react/__tests__/useSignIn.test.tsx
+++ b/packages/auth/src/react/__tests__/useSignIn.test.tsx
@@ -66,6 +66,37 @@ describe('useSignIn', () => {
     }
   });
 
+  it('surfaces the human message for display and the machine code for branching', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(
+        {
+          error: 'EMAIL_NOT_VERIFIED',
+          message: 'Please verify your email address before signing in.',
+          code: 'EMAIL_NOT_VERIFIED',
+        },
+        403,
+      ),
+    );
+
+    const { result } = renderHook(() => useSignIn());
+
+    let signInResult: Awaited<ReturnType<typeof result.current.signIn>>;
+    await waitFor(async () => {
+      signInResult = await result.current.signIn({
+        email: 'unverified@example.com',
+        password: 'password123',
+      });
+    });
+
+    expect(signInResult!.success).toBe(false);
+    if (!signInResult!.success && 'error' in signInResult!) {
+      // Display copy is the human message, never the raw code.
+      expect(signInResult!.error).toBe('Please verify your email address before signing in.');
+      expect(signInResult!.code).toBe('EMAIL_NOT_VERIFIED');
+    }
+  });
+
   it('returns MFA challenge when required', async () => {
     vi.stubGlobal('fetch', mockFetch({ requiresMfa: true, mfaUserId: 'user-mfa-1' }));
 

--- a/packages/auth/src/react/useSignIn.ts
+++ b/packages/auth/src/react/useSignIn.ts
@@ -33,9 +33,14 @@ function toUser(validated: z.infer<typeof SignInUserSchema>): User {
   return validated as unknown as User;
 }
 
-// Validation schemas for sign-in response
+// Validation schemas for sign-in response. The error body carries both a
+// human-readable `message` and a machine `code` (see createApplicationErrorResponseData
+// in @revealui/core); `error` mirrors the code. All optional so a terse body
+// still parses.
 const SignInErrorResponseSchema = z.object({
   error: z.string().optional(),
+  message: z.string().optional(),
+  code: z.string().optional(),
 });
 
 const SignInSuccessResponseSchema = z.object({
@@ -52,7 +57,7 @@ export interface UseSignInResult {
     input: SignInInput,
   ) => Promise<
     | { success: true; user: User }
-    | { success: false; error: string }
+    | { success: false; error: string; code?: string }
     | { success: false; requiresMfa: true; mfaUserId: string }
   >;
   isLoading: boolean;
@@ -109,9 +114,14 @@ export function useSignIn(): UseSignInResult {
 
       if (!response.ok) {
         const errorData = SignInErrorResponseSchema.parse(json);
+        // Prefer the human-readable `message` for display; fall back to the
+        // machine `error` code, then a generic default. `code` (e.g.
+        // 'EMAIL_NOT_VERIFIED') lets callers branch — e.g. offer a
+        // resend-verification action — without string-matching display copy.
         return {
           success: false as const,
-          error: errorData.error || 'Failed to sign in',
+          error: errorData.message || errorData.error || 'Failed to sign in',
+          code: errorData.code,
         };
       }
 


### PR DESCRIPTION
## What

Two login-UX fixes to the same subsystem:

1. **Stop bouncing signed-in non-admins to the login form.** An authenticated user without the admin role who hit an admin-only route was redirected to `/login` (the form they had just used), producing a silent flash-and-reappear with no feedback. They are now sent to `/welcome` (their session-only home) with a notice explaining that the admin area requires an admin role.
2. **Make an unverified email recoverable from the login screen.** When sign-in fails because the address is unverified, the form now shows the human-readable reason and a "Resend verification email" action wired to the existing resend endpoint, instead of a dead end.

## Why

- Redirecting an already-authenticated user to a login form reads as a broken login: submit, flash, back to the same form. A `user`-role account reaching an admin route via a `?redirect=` intent hit exactly this loop.
- An unverified account whose original verification email never arrived had no in-product recovery path.
- As a side effect of (2), the sign-in hook now surfaces the friendly message plus a machine error code, so the raw code (e.g. the literal `EMAIL_NOT_VERIFIED`) no longer leaks into the UI.

## Change

- `apps/admin/src/proxy.ts`: authenticated non-admin on an admin route now redirects to `/welcome?denied=admin` (was `/login`).
- `apps/admin` welcome page: renders an "admin access required" notice when `?denied=admin` is present.
- `packages/auth` `useSignIn`: the failure result now carries `{ error: <friendly message>, code }`.
- `apps/admin` `LoginForm`: shows the friendly message and offers a verification resend on the unverified-email code.

## Verification

- Unit tests added/updated: proxy deny-to-`/welcome` (plus a no-loop guard), `useSignIn` message/code surfacing, `LoginForm` resend affordance, and a check that a generic failure offers no resend. `admin` + `auth` suites green.
- Biome and typecheck clean; full gate green.
