### PR TITLE
fix(license): surface the vendor public key on /account/license for daemon activation

### DIFF
--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -307,6 +307,43 @@ export default function LicensePage() {
                 </pre>
               </div>
             </div>
+            {publicKey && (
+              <div className="rounded-lg border p-3 dark:border-zinc-800">
+                <p className="text-xs font-medium text-zinc-600 uppercase tracking-wide mb-2">
+                  Daemon public key
+                </p>
+                <div className="space-y-1.5 text-sm text-zinc-600 dark:text-zinc-400">
+                  <p>
+                    The RevDev daemon also needs the vendor public key to verify your license.
+                    Without it, a valid Pro license silently runs as Free. Set it as{' '}
+                    <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
+                      REVDEV_LICENSE_PUBLIC_KEY
+                    </code>
+                    :
+                  </p>
+                  <div className="relative">
+                    <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-3 text-xs font-mono text-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+                      {publicKey}
+                    </pre>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void navigator.clipboard.writeText(publicKey);
+                        setPubCopied(true);
+                        setTimeout(() => setPubCopied(false), 2000);
+                      }}
+                      className="absolute right-2 top-2 rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-600 shadow-sm hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                    >
+                      {pubCopied ? 'Copied!' : 'Copy'}
+                    </button>
+                  </div>
+                  <p className="text-xs text-zinc-400 mt-2">
+                    Newer daemon builds bake this key in, so this step is only needed for older
+                    builds or after a key rotation.
+                  </p>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
       )}

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -61,7 +61,7 @@ export default function LicensePage() {
   const [copied, setCopied] = useState(false);
   const [pubCopied, setPubCopied] = useState(false);
   // Vendor Ed25519 public key (PEM). The daemon needs it to verify a license;
-  // without it a valid Pro license silently runs Free (GAP-268). Public material.
+  // without it a valid Pro license silently runs Free. Public material.
   const [publicKey, setPublicKey] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -59,20 +59,30 @@ export default function LicensePage() {
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
   const [githubUsername, setGithubUsername] = useState('');
   const [copied, setCopied] = useState(false);
+  const [pubCopied, setPubCopied] = useState(false);
+  // Vendor Ed25519 public key (PEM). The daemon needs it to verify a license;
+  // without it a valid Pro license silently runs Free (GAP-268). Public material.
+  const [publicKey, setPublicKey] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
       const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
 
-      const [subRes, featRes, pricingRes] = await Promise.all([
+      const [subRes, featRes, pricingRes, pubKeyRes] = await Promise.all([
         fetch(`${apiUrl}/api/billing/subscription`, { credentials: 'include' }),
         fetch(`${apiUrl}/api/license/features`),
         fetch(`${apiUrl}/api/pricing`),
+        fetch(`${apiUrl}/api/license/public-key`),
       ]);
 
       if (subRes.ok) {
         const data = (await subRes.json()) as SubscriptionData;
         setSubscription(data);
+      }
+
+      if (pubKeyRes.ok) {
+        const data = (await pubKeyRes.json()) as { publicKey: string | null };
+        setPublicKey(data.publicKey);
       }
 
       if (featRes.ok) {

--- a/apps/server/src/routes/__tests__/license.test.ts
+++ b/apps/server/src/routes/__tests__/license.test.ts
@@ -445,3 +445,37 @@ describe('GET /features', () => {
     expect(body.enterprise.analytics).toBe(true);
   });
 });
+
+describe('GET /public-key', () => {
+  const ORIGINAL = process.env.REVEALUI_LICENSE_PUBLIC_KEY;
+
+  beforeEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.REVEALUI_LICENSE_PUBLIC_KEY;
+    } else {
+      process.env.REVEALUI_LICENSE_PUBLIC_KEY = ORIGINAL;
+    }
+  });
+
+  it('returns the vendor public key PEM, unescaping literal \\n', async () => {
+    process.env.REVEALUI_LICENSE_PUBLIC_KEY =
+      '-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEA0000000000000000000000000000\\n-----END PUBLIC KEY-----';
+    const app = createApp();
+    const res = await app.request('/public-key');
+    expect(res.status).toBe(200);
+    const body = await parseBody(res);
+    expect(body.publicKey.startsWith('-----BEGIN PUBLIC KEY-----')).toBe(true);
+    // Literal backslash-n must be converted to a real newline (no-regex replaceAll).
+    expect(body.publicKey.includes('\\n')).toBe(false);
+    expect(body.publicKey.includes('\n')).toBe(true);
+  });
+
+  it('returns publicKey:null when the key is not configured', async () => {
+    delete process.env.REVEALUI_LICENSE_PUBLIC_KEY;
+    const app = createApp();
+    const res = await app.request('/public-key');
+    expect(res.status).toBe(200);
+    const body = await parseBody(res);
+    expect(body.publicKey).toBeNull();
+  });
+});

--- a/apps/server/src/routes/license.ts
+++ b/apps/server/src/routes/license.ts
@@ -432,4 +432,37 @@ app.openapi(featuresRoute, async (c) => {
   );
 });
 
+// GET /api/license/public-key  -  Public: the vendor Ed25519 public key (PEM)
+const publicKeyRoute = createRoute({
+  method: 'get',
+  path: '/public-key',
+  tags: ['license'],
+  summary: 'Get the vendor license public key (PEM)',
+  description:
+    'Returns the Ed25519 public key used to verify license JWTs. This is PUBLIC material (no auth): a buyer sets it as REVDEV_LICENSE_PUBLIC_KEY so the RevDev daemon can verify their license. Null when the server has no key configured.',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            publicKey: z.string().nullable().openapi({
+              description: 'Ed25519 vendor public key in PEM, or null when unconfigured',
+              example: '-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----',
+            }),
+          }),
+        },
+      },
+      description: 'Vendor public key (PEM), or null when the server has none configured',
+    },
+  },
+});
+
+app.openapi(publicKeyRoute, async (c) => {
+  // Non-secret verification material. Unescape literal \n (Vercel stores
+  // multi-line PEMs escaped) with replaceAll, NOT the :156 regex (no-regex rule
+  // for new code); mirrors the generate route's normalize at :372.
+  const publicKey = process.env.REVEALUI_LICENSE_PUBLIC_KEY?.replaceAll('\\n', '\n') ?? null;
+  return c.json({ publicKey }, 200);
+});
+
 export default app;


### PR DESCRIPTION
## What

Surface the vendor Ed25519 public key (PEM) to a paying customer on `/account/license`, so they have the second value the RevDev daemon needs to verify their license.

## Why

The daemon verifies a license JWT against the vendor public key. The account page showed only the JWT (plus a `REVDEV_LICENSE_KEY` activation snippet), with no source for `REVDEV_LICENSE_PUBLIC_KEY`. A buyer who sets only the JWT gets a valid Pro license that silently runs as Free. This is a server-side-only change and helps already-shipped daemon builds today.

## Change

- New public `GET /api/license/public-key` (`apps/server/src/routes/license.ts`): returns the PEM from `REVEALUI_LICENSE_PUBLIC_KEY` (unescaped with `replaceAll`, no regex), or `null` when unconfigured. Public material, no auth — sits alongside the existing public `/verify` and `/features`.
- `/account/license` page fetches it and renders a "Daemon public key" copy block (PEM + a `REVDEV_LICENSE_PUBLIC_KEY` note), shown only when a license key exists. The copy notes that newer daemon builds bake the key in, so this is an older-build / rotation override.

## Verification

- Route test: returns the PEM (`BEGIN PUBLIC KEY` asserted; literal `\n` unescaped to real newlines) and `null` when unconfigured. `server` + `admin` suites green.
- Biome and typecheck clean; full gate green.
