### PR TITLE
fix(admin): harden CMS preview/render path auth

### DIFF
--- a/apps/admin/src/__tests__/api/proxy-routes.test.ts
+++ b/apps/admin/src/__tests__/api/proxy-routes.test.ts
@@ -18,9 +18,13 @@ const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 // Mock auth  -  proxy routes now require a valid session
+import { getSession } from '@revealui/auth/server';
+
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn().mockResolvedValue({ userId: 'test-user', token: 'tok' }),
 }));
+
+const mockGetSession = vi.mocked(getSession);
 
 vi.mock('@/lib/utils/request-context', () => ({
   extractRequestContext: vi.fn().mockReturnValue({}),
@@ -309,6 +313,80 @@ describe('DELETE /api/collections/[collection]/[id]', () => {
       params: Promise.resolve({ collection: 'posts', id: 'gone' }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests  -  fail-closed session gate (S3): unauthenticated requests never
+// reach the content API. Covers the two proxies that previously lacked the
+// gate — collections/[id] and globals/[slug] — plus the collections list.
+// ---------------------------------------------------------------------------
+
+describe('session gate — no session → 401, no upstream forward', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('collections/[id] GET rejects a request with no session (401, no fetch)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/collections/pages/p-1');
+    const res = await collectionItemGet(req, {
+      params: Promise.resolve({ collection: 'pages', id: 'p-1' }),
+    });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('collections/[id] PATCH rejects a request with no session (401, no fetch)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/collections/pages/p-1', {
+      method: 'PATCH',
+      body: '{}',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await collectionItemPatch(req, {
+      params: Promise.resolve({ collection: 'pages', id: 'p-1' }),
+    });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('collections/[id] DELETE rejects a request with no session (401, no fetch)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/collections/pages/p-1', {
+      method: 'DELETE',
+    });
+    const res = await collectionItemDelete(req, {
+      params: Promise.resolve({ collection: 'pages', id: 'p-1' }),
+    });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('globals/[slug] GET rejects a request with no session (401, no fetch)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/globals/nav');
+    const res = await globalsGet(req, { params: Promise.resolve({ slug: 'nav' }) });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('globals/[slug] POST rejects a request with no session (401, no fetch)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const req = new NextRequest('http://localhost/api/globals/nav', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await globalsPost(req, { params: Promise.resolve({ slug: 'nav' }) });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('forwards to upstream when a session is present (gate open)', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ title: 'Nav' }));
+    const req = new NextRequest('http://localhost/api/globals/nav');
+    const res = await globalsGet(req, { params: Promise.resolve({ slug: 'nav' }) });
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -98,3 +98,31 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
     expect(redirectPath(res)).not.toBe('/welcome');
   });
 });
+
+describe('admin proxy — /forgot-password is not public (S1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+  });
+
+  it('redirects an UNAUTHENTICATED /forgot-password request to /login (no longer whitelisted public)', async () => {
+    // /forgot-password was in PUBLIC_PATHS but has no route — it fell through to
+    // the (frontend)/[slug] CMS catch-all unauthenticated. It is now protected;
+    // an anonymous request is bounced to /login (with the original path preserved).
+    const res = await proxy(req('/forgot-password'));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    const url = location ? new URL(location) : null;
+    expect(url?.pathname).toBe('/login');
+    expect(url?.searchParams.get('redirect')).toBe('/forgot-password');
+  });
+
+  it('still treats /reset-password as public (recovery flow entry point)', async () => {
+    const res = await proxy(req('/reset-password'));
+    // Public path → no auth redirect to /login.
+    expect(redirectPath(res)).not.toBe('/login');
+  });
+});

--- a/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * (frontend)/[slug] render-path auth tests (S2 + S1b).
+ *
+ * The CMS catch-all must:
+ *  - refuse reserved auth-flow slugs without querying content (S1b);
+ *  - validate the session server-side and scope visibility via `req` rather
+ *    than `overrideAccess: true` (S2) — anonymous callers pass no `req` (so the
+ *    collection's `authenticatedOrPublished` rule yields published-only) and
+ *    never enable draft mode; authenticated callers pass `req.user` and may see
+ *    drafts.
+ *
+ * No regex authored (fleet posture): assertions use equality + object shape.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFind = vi.fn();
+const mockGetSession = vi.fn();
+const mockDraftMode = vi.fn();
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('next/headers', () => ({
+  draftMode: () => mockDraftMode(),
+  headers: () => Promise.resolve(new Headers()),
+}));
+
+vi.mock('@/lib/utils/revealui-singleton', () => ({
+  getRevealUIInstance: () => Promise.resolve({ find: mockFind }),
+}));
+
+// Trivial stand-ins for the render tree — the tests inspect the find() call,
+// not the emitted markup.
+vi.mock('@/lib/blocks/RenderBlocks', () => ({ RenderBlocks: () => null }));
+vi.mock('@/lib/heros/RenderHero', () => ({ RenderHero: () => null }));
+vi.mock('@/lib/components/RevealUIRedirects', () => ({ RevealUIRedirects: () => null }));
+vi.mock('@/lib/cms/generateMeta', () => ({ generateMeta: () => ({}) }));
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import Page from '../page';
+
+function params(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe('(frontend)/[slug] — reserved auth slugs (S1b)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDraftMode.mockResolvedValue({ isEnabled: false });
+    mockGetSession.mockResolvedValue(null);
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it.each([
+    'login',
+    'signup',
+    'mfa',
+    'rotate-password',
+    'forgot-password',
+    'reset-password',
+    'setup',
+  ])('does not query content for reserved slug %s', async (slug) => {
+    await Page(params(slug));
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('does query content for an ordinary slug', async () => {
+    mockFind.mockResolvedValueOnce({ docs: [{ id: '1', hero: null, layout: [] }] });
+    await Page(params('about'));
+    expect(mockFind).toHaveBeenCalledOnce();
+  });
+});
+
+describe('(frontend)/[slug] — session-scoped visibility (S2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [{ id: '1', hero: null, layout: [] }] });
+  });
+
+  it('anonymous request passes no req and never enables draft (published-only)', async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockDraftMode.mockResolvedValue({ isEnabled: true }); // even with the draft cookie set
+    await Page(params('about'));
+    const opts = mockFind.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts.req).toBeUndefined();
+    expect(opts.draft).toBe(false);
+    // The vulnerable pattern is gone: no blanket access override.
+    expect(opts.overrideAccess).toBeUndefined();
+  });
+
+  it('authenticated request passes req.user and honors draft mode', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'u-1', email: 'admin@example.com', role: 'admin' },
+      session: {},
+    });
+    mockDraftMode.mockResolvedValue({ isEnabled: true });
+    await Page(params('about'));
+    const opts = mockFind.mock.calls[0]?.[0] as {
+      req?: { user?: { id?: string } };
+      draft?: boolean;
+      overrideAccess?: boolean;
+    };
+    expect(opts.req?.user?.id).toBe('u-1');
+    expect(opts.draft).toBe(true);
+    expect(opts.overrideAccess).toBeUndefined();
+  });
+
+  it('authenticated request without draft cookie does not enable draft', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'u-1', email: 'admin@example.com', role: 'admin' },
+      session: {},
+    });
+    mockDraftMode.mockResolvedValue({ isEnabled: false });
+    await Page(params('about'));
+    const opts = mockFind.mock.calls[0]?.[0] as { draft?: boolean };
+    expect(opts.draft).toBe(false);
+  });
+});

--- a/apps/admin/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { getSession } from '@revealui/auth/server';
+import type { RevealRequest } from '@revealui/core';
 import type { Page as PageType } from '@revealui/core/types/admin';
 import { logger } from '@revealui/utils/logger';
 import type { Metadata } from 'next';
-import { draftMode } from 'next/headers';
+import { draftMode, headers } from 'next/headers';
 import { cache } from 'react';
 import { RenderBlocks } from '@/lib/blocks/RenderBlocks';
 import { generateMeta } from '@/lib/cms/generateMeta';
@@ -13,6 +15,23 @@ import { getRevealUIInstance } from '@/lib/utils/revealui-singleton';
 export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 
+// Auth-flow slugs are owned by dedicated route files (login/signup/mfa/…) or,
+// in the case of `forgot-password`, by no route at all. This catch-all must
+// never resolve a CMS page that claims one of them — otherwise a page authored
+// with such a slug would impersonate the auth UI at an unauthenticated URL.
+// `reset-password` and `setup` DO have real route files that shadow this
+// catch-all, but they are listed for defence-in-depth so the deny-list is the
+// complete reserved set regardless of future route-file changes.
+const RESERVED_AUTH_SLUGS = new Set([
+  'login',
+  'signup',
+  'mfa',
+  'rotate-password',
+  'forgot-password',
+  'reset-password',
+  'setup',
+]);
+
 // Removed generateStaticParams to prevent build-time initialization
 // Pages will be generated on-demand at request time
 
@@ -20,7 +39,10 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
   const { slug = 'home' } = await params;
   const url = `/${slug}`;
 
-  // let page: PageType | null;
+  // A CMS page must never impersonate an auth-flow URL.
+  if (RESERVED_AUTH_SLUGS.has(slug)) {
+    return <RevealUIRedirects url={url} />;
+  }
 
   const page = await queryPageBySlug({
     slug,
@@ -82,13 +104,32 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
 
   try {
     const { isEnabled: draft } = await draftMode();
+
+    // Validate the session server-side. The proxy gate only checks cookie
+    // PRESENCE; the render path must not trust that. A valid session admits
+    // the caller to draft/unpublished content via the collection's
+    // `authenticatedOrPublished` access rule; an anonymous (or forged-cookie)
+    // request resolves to a null user and sees PUBLISHED content only.
+    // Draft preview is likewise gated on a real session, so toggling the
+    // draft-mode cookie without authenticating cannot surface drafts.
+    const session = await getSession(await headers());
+    const req: RevealRequest | undefined = session
+      ? {
+          user: {
+            id: session.user.id,
+            email: session.user.email ?? '',
+            roles: [session.user.role],
+          },
+        }
+      : undefined;
+
     const revealui = await getRevealUIInstance();
 
     const result = await revealui.find({
       collection: 'pages',
-      draft,
+      draft: draft && Boolean(session),
       limit: 1,
-      overrideAccess: true,
+      req,
       where: {
         slug: {
           equals: slug,

--- a/apps/admin/src/app/api/collections/[collection]/[id]/route.ts
+++ b/apps/admin/src/app/api/collections/[collection]/[id]/route.ts
@@ -1,6 +1,8 @@
+import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
+import { extractRequestContext } from '@/lib/utils/request-context';
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -16,6 +18,16 @@ async function proxyRequest(
   { params }: RouteParams,
   method: string,
 ): Promise<NextResponse> {
+  // Fail-closed session gate, mirroring the sibling list proxy
+  // (app/api/collections/[collection]/route.ts). The api server enforces
+  // per-collection permissions on the forwarded cookie, but this proxy must
+  // not forward at all without a validated session — defence-in-depth so an
+  // unauthenticated request never reaches the content API.
+  const session = await getSession(request.headers, extractRequestContext(request));
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { collection, id } = await params;
 
   const headers = await apiForwardHeaders(request);

--- a/apps/admin/src/app/api/globals/[slug]/route.ts
+++ b/apps/admin/src/app/api/globals/[slug]/route.ts
@@ -1,5 +1,7 @@
+import { getSession } from '@revealui/auth/server';
 import { type NextRequest, NextResponse } from 'next/server';
 import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
+import { extractRequestContext } from '@/lib/utils/request-context';
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
@@ -30,6 +32,14 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
+  // Fail-closed session gate, mirroring the collections list proxy. The api
+  // server enforces per-global permissions on the forwarded cookie, but this
+  // proxy must not forward at all without a validated session.
+  const session = await getSession(request.headers, extractRequestContext(request));
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { slug } = await params;
   const { searchParams } = new URL(request.url);
 
@@ -52,6 +62,11 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
+  const session = await getSession(request.headers, extractRequestContext(request));
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { slug } = await params;
   const body = await request.json();
 

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -37,12 +37,19 @@ const allowedOrigins = process.env.REVEALUI_CORS_ORIGINS
 // Public paths in the (frontend) route group: no session required.
 // Any (backend) page resolves to a path that is NOT in this set and is NOT
 // internal (`/api/`, `/_next/`), so the auth gate kicks in.
+//
+// NOTE: `/forgot-password` is deliberately NOT here. No route renders it —
+// the password-recovery flow starts at `/reset-password` (linked from the
+// login form). Whitelisting it as public meant the request fell through to
+// the `(frontend)/[slug]` CMS catch-all UNAUTHENTICATED, so a CMS page with
+// slug `forgot-password` would render publicly. Dropping it makes the auth
+// gate treat it as protected; the catch-all also refuses reserved auth slugs
+// (see RESERVED_AUTH_SLUGS in app/(frontend)/[slug]/page.tsx).
 const PUBLIC_PATHS = new Set([
   '/login',
   '/signup',
   '/mfa',
   '/rotate-password',
-  '/forgot-password',
   '/reset-password',
   '/setup',
 ]);
@@ -149,7 +156,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
 
   // Already-authenticated admins have no reason to see the login/signup screens.
   // Redirect them to the dashboard. Scoped to /login + /signup ONLY — /setup,
-  // /rotate-password, /forgot-password, /reset-password, /mfa stay reachable for an
+  // /rotate-password, /reset-password, /mfa stay reachable for an
   // authenticated or partially-authenticated user (forced rotation, MFA enrollment,
   // etc.). The `revealui-role` cookie is normalized to 'admin' | 'user' at sign-in
   // (defense-in-depth UI hint), and this predicate matches the auth gate's admit


### PR DESCRIPTION
## Summary

Auth hardening on the admin CMS render/proxy path, ahead of upcoming live-preview content-editing work. Three defence-in-depth fixes from an internal audit (2026-07-02); the render path currently leans on client-supplied signals, and this tightens it before draft/preview surfaces are built.

## Changes

1. **Reserved auth-flow slugs.** `/forgot-password` is removed from the proxy's public-path allowlist — no route renders it (the recovery flow starts at `/reset-password`, linked from the login form), so it was falling through to the `(frontend)/[slug]` CMS catch-all. The catch-all now also refuses the full reserved auth-slug set (`login`, `signup`, `mfa`, `rotate-password`, `forgot-password`, `reset-password`, `setup`), so CMS content can never claim an auth URL.

2. **Server-side session validation on the render path.** `(frontend)/[slug]/page.tsx` validates the session and scopes content visibility through the request's user (via the collection's `authenticatedOrPublished` access rule) instead of a blanket access override. Unauthenticated requests get published content only; draft preview requires a real session.

3. **Fail-closed session gate on the content proxies that lacked one.** `api/collections/[collection]/[id]` and `api/globals/[slug]` now require a validated session before forwarding, matching the collections-list proxy. The API server already enforces per-collection permissions on the forwarded cookie; this makes the admin proxy layer refuse unauthenticated requests outright.

> Note: the audit scoped fix (3) to the collection-item proxy; while verifying against current code I found the globals proxy had the identical gap, so both are gated here. Both were previously backstopped only by the API server's permission check.

## Tests

- Render path: reserved slugs are refused without a content query; authenticated requests pass the user and honor draft mode, anonymous requests do neither.
- Proxy: `/forgot-password` is treated as protected; `/reset-password` stays public.
- Each previously-ungated proxy method returns 401 with no upstream fetch when the session is absent.
- Full admin suite green (1841 passed), `tsc --noEmit` clean. No regex authored.

Ref: internal audit 2026-07-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
