### PR TITLE
fix(admin): correct daemon license env var name on the account page

### DIFF
--- a/apps/admin/src/app/(frontend)/account/license/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/__tests__/page.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for the account license page's activation instructions.
+ *
+ * The critical behavior: the daemon activation block must name the env var the
+ * RevDev daemon actually reads — REVEALUI_LICENSE_KEY (one key, one var, both
+ * products). The page previously instructed REVDEV_LICENSE_KEY, which nothing
+ * reads: a buyer following that copy sets a dead var and the daemon silently
+ * runs as Free. The no-REVDEV_LICENSE_KEY assertion is the regression guard.
+ * (REVDEV_LICENSE_PUBLIC_KEY in the daemon-public-key block is a real,
+ * distinct daemon var and intentionally unaffected.)
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPush = vi.fn();
+
+vi.mock('@revealui/auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1', email: 'owner@example.com' } },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next/link', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Card: ({ children }: any) => <section>{children}</section>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  CardDescription: ({ children }: any) => <p>{children}</p>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  CardTitle: ({ children }: any) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/safe-stripe-redirect', () => ({
+  safeStripeRedirect: vi.fn(),
+}));
+
+import LicensePage from '../page';
+
+const TEST_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\ntest-pem\n-----END PUBLIC KEY-----';
+
+function jsonResponse(body: unknown): Pick<Response, 'ok' | 'json'> {
+  return { ok: true, json: () => Promise.resolve(body) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/billing/subscription')) {
+        return Promise.resolve(
+          jsonResponse({
+            tier: 'pro',
+            status: 'active',
+            expiresAt: null,
+            licenseKey: 'test-license-jwt',
+            perpetual: false,
+            supportExpiresAt: null,
+          }),
+        );
+      }
+      if (url.endsWith('/api/license/public-key')) {
+        return Promise.resolve(jsonResponse({ publicKey: TEST_PUBLIC_KEY }));
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('LicensePage activation instructions', () => {
+  it('instructs REVEALUI_LICENSE_KEY for both the framework and the daemon', async () => {
+    render(<LicensePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('test-license-jwt')).toBeDefined();
+    });
+
+    // Daemon block is present and names the var the daemon actually reads —
+    // one snippet for the framework .env, one for the daemon.
+    expect(document.body.textContent ?? '').toContain('The same key activates the RevDev daemon');
+    expect(screen.getAllByText('REVEALUI_LICENSE_KEY')).toHaveLength(1);
+    expect(screen.getAllByText('REVEALUI_LICENSE_KEY=your-key-here')).toHaveLength(2);
+  });
+
+  it('renders no REVDEV_LICENSE_KEY anywhere (the daemon never reads it)', async () => {
+    render(<LicensePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('test-license-jwt')).toBeDefined();
+    });
+
+    // The daemon-public-key block must still render (its REVDEV_LICENSE_PUBLIC_KEY
+    // is a real var and must not be caught by the regression check below).
+    expect(screen.getByText('REVDEV_LICENSE_PUBLIC_KEY')).toBeDefined();
+
+    expect(document.body.textContent ?? '').not.toContain('REVDEV_LICENSE_KEY');
+  });
+});

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -298,12 +298,12 @@ export default function LicensePage() {
                   The same key activates the RevDev daemon — one purchase, one license, both
                   products. Set it as{' '}
                   <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
-                    REVDEV_LICENSE_KEY
+                    REVEALUI_LICENSE_KEY
                   </code>
                   :
                 </p>
                 <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-2 text-xs font-mono dark:bg-zinc-900">
-                  REVDEV_LICENSE_KEY=your-key-here
+                  REVEALUI_LICENSE_KEY=your-key-here
                 </pre>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Corrects the daemon license env var name on the `/account/license` page to `REVEALUI_LICENSE_KEY` — the variable the RevDev daemon actually reads.

The daemon activation block instructed buyers to set the license as `REVDEV_LICENSE_KEY` (both the copy and the `.env` snippet). Nothing reads that variable: the daemon reads only `REVEALUI_LICENSE_KEY` (with a `REVEALUI_LICENSE_KEY_FILE` variant), so a buyer following the instructions set a dead var and the daemon silently ran as Free. The framework block on the same page already used the correct name; the "same key, both products" message is accurate and unchanged — one key, one var, both products.

The adjacent `REVDEV_LICENSE_PUBLIC_KEY` (daemon public key block) is a real daemon variable and is intentionally untouched.

## Changes

- `apps/admin/src/app/(frontend)/account/license/page.tsx` — both `REVDEV_LICENSE_KEY` occurrences in the daemon block → `REVEALUI_LICENSE_KEY` (copy + snippet).
- `apps/admin/src/app/(frontend)/account/license/__tests__/page.test.tsx` — new page test asserting the daemon block names `REVEALUI_LICENSE_KEY` and that **no** `REVDEV_LICENSE_KEY` string renders anywhere on the page (regression guard; also pins that `REVDEV_LICENSE_PUBLIC_KEY` still renders so the guard can't silently pass by the block vanishing).

## Verification

- New page tests green (2/2).
- Full `pnpm gate` PASS (quality + typecheck + tests + build).
- Grep: zero `REVDEV_LICENSE_KEY` remaining in apps/packages/docs.

## Flag — customer-facing prod copy

⚠️ This is customer-facing production copy: the wrong var name is likely already live on `main`. This fix should ride the **next `test→main` promotion** rather than wait for a feature batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
