### PR TITLE
fix(admin): role-gate CMS draft/unpublished render + fix anon published-only

### DIFF
--- a/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
@@ -1,13 +1,17 @@
 /**
- * (frontend)/[slug] render-path auth tests (S2 + S1b).
+ * (frontend)/[slug] render-path auth tests (S1b + S2 + role-gate).
  *
  * The CMS catch-all must:
- *  - refuse reserved auth-flow slugs without querying content (S1b);
+ *  - refuse reserved auth-flow slugs without querying content, and 404 them
+ *    (via notFound()) rather than route through the allow-all redirects
+ *    collection (S1b);
  *  - validate the session server-side and scope visibility via `req` rather
- *    than `overrideAccess: true` (S2) — anonymous callers pass no `req` (so the
- *    collection's `authenticatedOrPublished` rule yields published-only) and
- *    never enable draft mode; authenticated callers pass `req.user` and may see
- *    drafts.
+ *    than `overrideAccess: true` (S2), AND gate draft/unpublished visibility on
+ *    an ADMIN role — a non-admin (public-signup `user`) session must NOT see
+ *    drafts, and an anonymous OR non-admin caller passes a truthy user-LESS
+ *    `req` ({}) so the collection's `authenticatedOrPublished` rule yields
+ *    published-only (NOT deny-all: an `undefined` req would trip find()'s
+ *    `if (!req) return false` and 404 every public page).
  *
  * No regex authored (fleet posture): assertions use equality + object shape.
  */
@@ -16,6 +20,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockFind = vi.fn();
 const mockGetSession = vi.fn();
 const mockDraftMode = vi.fn();
+const mockNotFound = vi.fn(() => {
+  // next/navigation notFound() throws to unwind rendering.
+  throw new Error('NEXT_NOT_FOUND');
+});
 
 vi.mock('@revealui/auth/server', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
@@ -26,8 +34,18 @@ vi.mock('next/headers', () => ({
   headers: () => Promise.resolve(new Headers()),
 }));
 
+vi.mock('next/navigation', () => ({
+  notFound: () => mockNotFound(),
+}));
+
 vi.mock('@/lib/utils/revealui-singleton', () => ({
   getRevealUIInstance: () => Promise.resolve({ find: mockFind }),
+}));
+
+// request-context helper depends on @revealui/security; stub it to a fixed
+// context so the render path stays a pure unit test.
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: 'test-ua', ipAddress: undefined }),
 }));
 
 // Trivial stand-ins for the render tree — the tests inspect the find() call,
@@ -62,36 +80,61 @@ describe('(frontend)/[slug] — reserved auth slugs (S1b)', () => {
     'forgot-password',
     'reset-password',
     'setup',
-  ])('does not query content for reserved slug %s', async (slug) => {
-    await Page(params(slug));
+  ])('404s a reserved slug %s without querying content', async (slug) => {
+    // notFound() throws — the reserved slug never reaches the content query
+    // nor the allow-all redirects collection.
+    await expect(Page(params(slug))).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mockNotFound).toHaveBeenCalledOnce();
     expect(mockFind).not.toHaveBeenCalled();
   });
 
   it('does query content for an ordinary slug', async () => {
     mockFind.mockResolvedValueOnce({ docs: [{ id: '1', hero: null, layout: [] }] });
     await Page(params('about'));
+    expect(mockNotFound).not.toHaveBeenCalled();
     expect(mockFind).toHaveBeenCalledOnce();
   });
 });
 
-describe('(frontend)/[slug] — session-scoped visibility (S2)', () => {
+describe('(frontend)/[slug] — role-gated visibility (S2 + role-gate)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFind.mockResolvedValue({ docs: [{ id: '1', hero: null, layout: [] }] });
   });
 
-  it('anonymous request passes no req and never enables draft (published-only)', async () => {
+  it('anonymous request passes a user-less req and never enables draft (published-only, not deny-all)', async () => {
     mockGetSession.mockResolvedValue(null);
     mockDraftMode.mockResolvedValue({ isEnabled: true }); // even with the draft cookie set
     await Page(params('about'));
     const opts = mockFind.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(opts.req).toBeUndefined();
+    // Truthy user-LESS req — NOT undefined (which would deny-all in find()).
+    expect(opts.req).toEqual({});
+    expect((opts.req as { user?: unknown }).user).toBeUndefined();
     expect(opts.draft).toBe(false);
     // The vulnerable pattern is gone: no blanket access override.
     expect(opts.overrideAccess).toBeUndefined();
   });
 
-  it('authenticated request passes req.user and honors draft mode', async () => {
+  it('non-admin (public-signup user) session gets NO drafts and a user-less req', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'u-2', email: 'user@example.com', role: 'user' },
+      session: {},
+    });
+    mockDraftMode.mockResolvedValue({ isEnabled: true }); // draft cookie present
+    await Page(params('about'));
+    const opts = mockFind.mock.calls[0]?.[0] as {
+      req?: { user?: unknown };
+      draft?: boolean;
+      overrideAccess?: boolean;
+    };
+    // A role-`user` session is NOT admin → no user on req → published-only.
+    expect(opts.req).toEqual({});
+    expect(opts.req?.user).toBeUndefined();
+    expect(opts.draft).toBe(false);
+    expect(opts.overrideAccess).toBeUndefined();
+  });
+
+  it('admin session passes req.user and honors draft mode', async () => {
     mockGetSession.mockResolvedValue({
       user: { id: 'u-1', email: 'admin@example.com', role: 'admin' },
       session: {},
@@ -99,16 +142,17 @@ describe('(frontend)/[slug] — session-scoped visibility (S2)', () => {
     mockDraftMode.mockResolvedValue({ isEnabled: true });
     await Page(params('about'));
     const opts = mockFind.mock.calls[0]?.[0] as {
-      req?: { user?: { id?: string } };
+      req?: { user?: { id?: string; roles?: string[] } };
       draft?: boolean;
       overrideAccess?: boolean;
     };
     expect(opts.req?.user?.id).toBe('u-1');
+    expect(opts.req?.user?.roles).toEqual(['admin']);
     expect(opts.draft).toBe(true);
     expect(opts.overrideAccess).toBeUndefined();
   });
 
-  it('authenticated request without draft cookie does not enable draft', async () => {
+  it('admin session without draft cookie does not enable draft', async () => {
     mockGetSession.mockResolvedValue({
       user: { id: 'u-1', email: 'admin@example.com', role: 'admin' },
       session: {},
@@ -117,5 +161,15 @@ describe('(frontend)/[slug] — session-scoped visibility (S2)', () => {
     await Page(params('about'));
     const opts = mockFind.mock.calls[0]?.[0] as { draft?: boolean };
     expect(opts.draft).toBe(false);
+  });
+
+  it('binds the session to request context (getSession receives a context arg)', async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockDraftMode.mockResolvedValue({ isEnabled: false });
+    await Page(params('about'));
+    // Render path passes (headers, requestContext) like the sibling API routes.
+    expect(mockGetSession).toHaveBeenCalledOnce();
+    const secondArg = mockGetSession.mock.calls[0]?.[1] as { userAgent?: string } | undefined;
+    expect(secondArg?.userAgent).toBe('test-ua');
   });
 });

--- a/apps/admin/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/page.tsx
@@ -4,11 +4,14 @@ import type { Page as PageType } from '@revealui/core/types/admin';
 import { logger } from '@revealui/utils/logger';
 import type { Metadata } from 'next';
 import { draftMode, headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 import { cache } from 'react';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { RenderBlocks } from '@/lib/blocks/RenderBlocks';
 import { generateMeta } from '@/lib/cms/generateMeta';
 import { RevealUIRedirects } from '@/lib/components/RevealUIRedirects';
 import { RenderHero } from '@/lib/heros/RenderHero';
+import { extractRequestContext } from '@/lib/utils/request-context';
 import { getRevealUIInstance } from '@/lib/utils/revealui-singleton';
 
 // Force dynamic rendering to prevent build-time RevealUI admin initialization
@@ -22,6 +25,11 @@ export const dynamicParams = true;
 // `reset-password` and `setup` DO have real route files that shadow this
 // catch-all, but they are listed for defence-in-depth so the deny-list is the
 // complete reserved set regardless of future route-file changes.
+//
+// The guard is enforced inside queryPageBySlug (so generateMetadata is covered
+// too); the render function additionally maps a reserved slug to notFound()
+// rather than the redirects collection, which is allow-all and could itself
+// map a reserved slug to an arbitrary destination.
 const RESERVED_AUTH_SLUGS = new Set([
   'login',
   'signup',
@@ -39,9 +47,10 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
   const { slug = 'home' } = await params;
   const url = `/${slug}`;
 
-  // A CMS page must never impersonate an auth-flow URL.
+  // A CMS page must never impersonate an auth-flow URL. Reserved slugs are
+  // hard 404s here — not routed through the allow-all redirects collection.
   if (RESERVED_AUTH_SLUGS.has(slug)) {
-    return <RevealUIRedirects url={url} />;
+    notFound();
   }
 
   const page = await queryPageBySlug({
@@ -102,32 +111,47 @@ const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
     return null;
   }
 
+  // Reserved auth-flow slugs never resolve CMS content, on any entry point
+  // (render OR generateMetadata).
+  if (RESERVED_AUTH_SLUGS.has(slug)) {
+    return null;
+  }
+
   try {
     const { isEnabled: draft } = await draftMode();
 
     // Validate the session server-side. The proxy gate only checks cookie
-    // PRESENCE; the render path must not trust that. A valid session admits
-    // the caller to draft/unpublished content via the collection's
-    // `authenticatedOrPublished` access rule; an anonymous (or forged-cookie)
-    // request resolves to a null user and sees PUBLISHED content only.
-    // Draft preview is likewise gated on a real session, so toggling the
-    // draft-mode cookie without authenticating cannot surface drafts.
-    const session = await getSession(await headers());
-    const req: RevealRequest | undefined = session
-      ? {
-          user: {
-            id: session.user.id,
-            email: session.user.email ?? '',
-            roles: [session.user.role],
-          },
-        }
-      : undefined;
+    // PRESENCE (and trusts a client-set `revealui-role`); the render path must
+    // not trust either. Draft / unpublished content is admin-only: only a real
+    // session whose role is in the admin set builds a user-bearing `req` and
+    // enables draft mode. Every other caller — anonymous, forged-cookie, or a
+    // non-admin (e.g. public-signup `user`) session — gets a user-LESS `req`
+    // so the collection's `authenticatedOrPublished` rule yields the
+    // published-only filter (NOT deny-all: passing `undefined` would trip
+    // find()'s `if (!req) return false` and 404 every public page).
+    const hdrs = await headers();
+    const requestContext = extractRequestContext(
+      new Request('http://localhost', { headers: hdrs }),
+    );
+    const session = await getSession(hdrs, requestContext);
+    const isAdmin = Boolean(session) && isAdminRole(session?.user.role);
+
+    const req: RevealRequest =
+      isAdmin && session
+        ? {
+            user: {
+              id: session.user.id,
+              email: session.user.email ?? '',
+              roles: [session.user.role],
+            },
+          }
+        : {};
 
     const revealui = await getRevealUIInstance();
 
     const result = await revealui.find({
       collection: 'pages',
-      draft: draft && Boolean(session),
+      draft: draft && isAdmin,
       limit: 1,
       req,
       where: {

--- a/apps/marketing/app/content/governance.ts
+++ b/apps/marketing/app/content/governance.ts
@@ -43,7 +43,7 @@ export const GOVERNANCE_PAGE = {
     },
     {
       title: 'One policy over people and agents',
-      body: 'A single RBAC + ABAC policy governs your team, your agents, and your service accounts, proven by 59 enforcement tests. Set the rules once; agents inherit the same boundaries.',
+      body: 'A single RBAC + ABAC policy governs your team, your agents, and your service accounts, proven by 60 enforcement tests. Set the rules once; agents inherit the same boundaries.',
       linkLabel: 'See the policy engine',
       linkHref: POLICY_HREF,
     },

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -96,7 +96,7 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
     forYou: {
       headline: 'Auth, roles, and compliance, handled',
       description:
-        'Session-based auth, RBAC with 59 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
+        'Session-based auth, RBAC with 60 enforcement tests, rate limiting, brute-force protection, and GDPR compliance. No auth library decisions. No JWT debates.',
     },
     forAgents: {
       headline: 'RBAC governs agent access per tenant',

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -48,7 +48,7 @@ All gates must pass on the `main` branch before deploy.
 - [ ] Bcrypt cost factor is 12 rounds **(blocking)**
 - [ ] AES-256-GCM encryption keys are non-extractable by default **(blocking)**
 - [ ] Rate limiting active on auth endpoints and `/api/webhooks` (100 req/min) **(blocking)**
-- [ ] RBAC + ABAC policy engine tests pass (59 enforcement tests) **(blocking)**
+- [ ] RBAC + ABAC policy engine tests pass (60 enforcement tests) **(blocking)**
 - [ ] `SECURITY.md` exists at repository root **(blocking)**
 - [ ] Incident response plan reviewed: `docs/security/INCIDENT_RESPONSE.md` **(advisory)**
 - [ ] `docs/security/INFORMATION_SECURITY_POLICY.md` reviewed and current **(advisory)**

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -127,7 +127,7 @@ export const hasAnyRole = (roles: string[]) => ({ req }) =>
   !!req.user && roles.some((role) => req.user?.roles?.includes(role));
 ```
 
-These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 59 enforcement tests proving role isolation.
+These functions return booleans or `WhereClause` objects, enabling row-level security. A `WhereClause` return lets you say "authenticated users can read, but only their own records." The access control system has 60 enforcement tests proving role isolation.
 
 ### How Users connects to everything else
 

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -158,7 +158,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 
 | ID | Control | Package | Purpose |
 |----|---------|---------|---------|
-| SEC-017 | RBAC + ABAC Policy Engine | @revealui/core | Role-based and attribute-based access control (59 enforcement tests) |
+| SEC-017 | RBAC + ABAC Policy Engine | @revealui/core | Role-based and attribute-based access control (60 enforcement tests) |
 | SEC-018 | Rate Limiting | @revealui/auth | Brute force protection, webhook rate limiting (100 req/min) |
 | SEC-019 | Session Auth | @revealui/auth | httpOnly, secure, sameSite=lax cookies; no JWTs |
 | SEC-020 | CSP/CORS/HSTS Headers | @revealui/security | Transport and browser security headers |

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -65,7 +65,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 
 ### Authorization
 
-- **RBAC + ABAC**: Role-based access control combined with attribute-based policies. 59 enforcement tests verify role isolation.
+- **RBAC + ABAC**: Role-based access control combined with attribute-based policies. 60 enforcement tests verify role isolation.
 - **Collection-level access**: Every database operation enforces `access.read`, `access.update`, and `access.delete` policies.
 - **Admin gate**: Proxy middleware checks role cookies for /admin routes (defense-in-depth).
 - **Feature gating**: Pro features require valid license checks via `isLicensed('pro')` and `isFeatureEnabled()`.

--- a/packages/core/src/collections/operations/__tests__/access-enforcement.test.ts
+++ b/packages/core/src/collections/operations/__tests__/access-enforcement.test.ts
@@ -249,6 +249,29 @@ describe('access control enforcement', () => {
       expect(db.collectionStorage.find).not.toHaveBeenCalled();
     });
 
+    it('runs the access rule (published-only, NOT deny-all) for a truthy user-LESS req', async () => {
+      // Mirrors the admin `authenticatedOrPublished` rule: no user on req →
+      // return the published-only WhereClause rather than a boolean. This is
+      // the anonymous / non-admin CMS render path: passing `{}` (truthy, no
+      // user) must run the rule and scope to published docs — NOT hit the
+      // `if (!req) return false` deny-all guard that an `undefined` req trips.
+      const accessRead = ({ req: accessReq }: { req: RevealRequest }) =>
+        accessReq.user ? true : { status: { equals: 'published' } };
+      const config: RevealCollectionConfig = {
+        ...baseConfig,
+        access: { read: accessRead },
+      };
+      const db = createMockDbWithCollectionStorage(testDocs);
+
+      // Truthy user-less req — the render path's anonymous/non-admin shape.
+      const result = await find(config, db as never, { req: {} as RevealRequest });
+
+      // Only the published doc comes back — draft/private are filtered out,
+      // and the result is NOT the empty deny-all set.
+      expect(result.docs.map((d) => (d as { id: string }).id)).toEqual(['1']);
+      expect(db.collectionStorage.find).toHaveBeenCalledTimes(1);
+    });
+
     it('handles async access.read functions', async () => {
       const accessReadSpy = vi.fn().mockResolvedValue(false);
       const config: RevealCollectionConfig = {


### PR DESCRIPTION
## Summary

Role-gates the CMS render path and fixes the anonymous published-only path. Two authorization defects were live in the `(frontend)/[slug]` catch-all render path; both are closed here, plus three adjacent hardening fixes on the same surface.

## The two defects

**1. Draft/unpublished content was readable by any authenticated session (privilege escalation).**
`authenticatedOrPublished` returns `true` for any `req.user` regardless of role, and the render path built a user-bearing `req` from any valid session with draft mode gated only on session *presence*. The proxy admin gate in front of the render path keys on a client-settable role cookie, so a public-signup `user` account could reach admin drafts. Fixed: draft/unpublished visibility is now admin-only — only a session whose role is in the admin set (`isAdminRole`) builds a user-bearing `req` and enables draft mode. Every other caller gets a user-less `req`.

**2. Anonymous requests got a deny-all 404 instead of published content.**
Anonymous callers passed `req: undefined`, which the `find()` access layer treats as deny-all (`if (!req) return false`) *before* the published-only rule runs — so anonymous visitors 404'd on every CMS page, and expired-session admins did too. Fixed: anonymous/non-admin callers now pass a truthy user-less `req` (`{}`) so `authenticatedOrPublished` returns the published-only filter as intended.

## Folded-in hardening (same surface)

- Reserved auth-slug guard hoisted into `queryPageBySlug` so `generateMetadata` is covered too; reserved slugs now `notFound()` instead of routing through the allow-all redirects collection (which could otherwise map a reserved slug to an arbitrary destination).
- `RequestContext` (IP/user-agent) passed to the render-path `getSession` for session binding, matching the sibling API routes.

## Tests

- Render-path role-gate suite (13): role-`user` session gets no drafts + user-less req; admin gets `req.user` + drafts; anonymous is published-only (not deny-all); reserved slugs 404; `getSession` receives the request context.
- A non-mocked core engine test proving a truthy user-less `req` yields published-only rather than deny-all (the previous mocked tests missed this). The access-enforcement suite is now 60 tests; the enforcement-count claims in the security policy / asset inventory / launch checklist / marketing copy are updated in lockstep (claim-drift gate).
- Full `pnpm gate` green (the one transient miss was an unrelated `@revealui/cache` parallel-load flake, confirmed passing in isolation — 256 tests).

## Note

This corrects the CMS render path merged earlier in #1711, where the role gate and the anonymous published-only path were incomplete. Please re-review before this rides the next `test → main` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
