### PR TITLE
fix(admin): validate draft-preview session + reserved-slug metadata test

### DIFF
--- a/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/__tests__/page.test.tsx
@@ -58,7 +58,7 @@ vi.mock('@revealui/utils/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
-import Page from '../page';
+import Page, { generateMetadata } from '../page';
 
 function params(slug: string) {
   return { params: Promise.resolve({ slug }) };
@@ -171,5 +171,37 @@ describe('(frontend)/[slug] — role-gated visibility (S2 + role-gate)', () => {
     expect(mockGetSession).toHaveBeenCalledOnce();
     const secondArg = mockGetSession.mock.calls[0]?.[1] as { userAgent?: string } | undefined;
     expect(secondArg?.userAgent).toBe('test-ua');
+  });
+});
+
+describe('(frontend)/[slug] — generateMetadata reserved slugs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDraftMode.mockResolvedValue({ isEnabled: false });
+    mockGetSession.mockResolvedValue(null);
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it.each([
+    'login',
+    'signup',
+    'mfa',
+    'rotate-password',
+    'forgot-password',
+    'reset-password',
+    'setup',
+  ])('does not query content from generateMetadata for reserved slug %s', async (slug) => {
+    // The reserved-slug guard lives in queryPageBySlug, the shared entry point
+    // for both Page() and generateMetadata(), so the metadata path must skip
+    // the content query too — a future refactor moving the guard back into
+    // Page() would re-open reserved-slug metadata queries; this pins it.
+    await generateMetadata(params(slug));
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('queries content from generateMetadata for an ordinary slug', async () => {
+    mockFind.mockResolvedValueOnce({ docs: [{ id: '1', hero: null, layout: [] }] });
+    await generateMetadata(params('ordinary-meta'));
+    expect(mockFind).toHaveBeenCalledOnce();
   });
 });

--- a/apps/admin/src/app/(frontend)/next/preview/__tests__/route.test.ts
+++ b/apps/admin/src/app/(frontend)/next/preview/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+/**
+ * (frontend)/next/preview route — draft-mode enable is admin-only.
+ *
+ * The draft-mode enabler must validate the session server-side (not trust
+ * cookie presence) and require an admin role before enabling draft mode,
+ * mirroring the (frontend)/[slug] render path. A forged/absent cookie or a
+ * non-admin session must get 403 with draft mode never enabled.
+ *
+ * No regex authored (fleet posture): assertions use equality + call counts.
+ */
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockEnable = vi.fn();
+const mockRedirect = vi.fn();
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+vi.mock('@/lib/utils/request-context', () => ({
+  extractRequestContext: () => ({ userAgent: 'test-ua', ipAddress: undefined }),
+}));
+
+vi.mock('next/headers', () => ({
+  draftMode: () => Promise.resolve({ enable: mockEnable }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+import { GET } from '../route';
+
+function req(path: string | null) {
+  const url =
+    path === null
+      ? 'http://localhost/next/preview'
+      : `http://localhost/next/preview?path=${encodeURIComponent(path)}`;
+  return new NextRequest(url);
+}
+
+describe('(frontend)/next/preview — draft-mode enable is admin-only', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('404s when no path is provided', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'a', email: 'a@example.com', role: 'admin' },
+      session: {},
+    });
+    const res = await GET(req(null));
+    expect(res.status).toBe(404);
+    expect(mockEnable).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('403 and never enables draft when the session is invalid/absent (forged cookie)', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(req('/about'));
+    expect(res.status).toBe(403);
+    expect(mockEnable).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('403 and never enables draft for a non-admin (public-signup user) session', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'u', email: 'u@example.com', role: 'user' },
+      session: {},
+    });
+    const res = await GET(req('/about'));
+    expect(res.status).toBe(403);
+    expect(mockEnable).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('enables draft and redirects for an admin session', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'a', email: 'a@example.com', role: 'admin' },
+      session: {},
+    });
+    await GET(req('/about'));
+    expect(mockEnable).toHaveBeenCalledOnce();
+    expect(mockRedirect).toHaveBeenCalledWith('/about');
+  });
+});

--- a/apps/admin/src/app/(frontend)/next/preview/route.ts
+++ b/apps/admin/src/app/(frontend)/next/preview/route.ts
@@ -1,12 +1,14 @@
+import { getSession } from '@revealui/auth/server';
 import { draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { NextRequest } from 'next/server';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
+import { extractRequestContext } from '@/lib/utils/request-context';
 
 // Force dynamic rendering to prevent build-time RevealUI admin initialization
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest): Promise<Response> {
-  const session = req.cookies.get('revealui-session')?.value;
   const { searchParams } = new URL(req.url);
   const path = searchParams.get('path');
 
@@ -14,7 +16,15 @@ export async function GET(req: NextRequest): Promise<Response> {
     return new Response('No path provided', { status: 404 });
   }
 
-  if (!session) {
+  // Draft preview is admin-only. Validate the session server-side and check the
+  // role — the old gate trusted mere PRESENCE of a `revealui-session` cookie
+  // value (forgeable/stale), the same anti-pattern the render path dropped in
+  // (frontend)/[slug]/page.tsx. Without this, any authenticated (even a
+  // public-signup `user`) or forged-cookie caller could flip the app-wide
+  // draft-mode cookie. The render path re-gates draft CONTENT on an admin
+  // session, but the enabler must fail closed here too (defence-in-depth).
+  const session = await getSession(req.headers, extractRequestContext(req));
+  if (!session || !isAdminRole(session.user.role)) {
     return new Response('You are not allowed to preview this page', {
       status: 403,
     });


### PR DESCRIPTION
## Summary

Follow-up to the CMS render-path auth hardening (#1714, internal audit 2026-07-02). Closes the two review items left open on that PR.

## Changes

1. **`(frontend)/next/preview/route.ts`** — the draft-mode enabler validated only cookie *presence*. It now validates the session server-side (`getSession` + `extractRequestContext`) and requires an admin role before `draft.enable()`, mirroring the render path. The render path already re-gates draft *content* on an admin session, so there was no draft-content leak, but the enabler now fails closed too. New route test covers no-path (404), invalid/absent session (403), non-admin session (403), and admin (enable + redirect).
2. **`(frontend)/[slug]/__tests__/page.test.tsx`** — add `generateMetadata` reserved-slug coverage. The reserved-slug guard lives in `queryPageBySlug` (shared by `Page` and `generateMetadata`); the new cases pin that the metadata path also skips the content query for reserved slugs, so a future refactor can't silently re-open it.

## Verification

Both affected test files pass locally (25/25). No new `next/*` couplings; no regex authored. (Local admin `tsc` surfaces only pre-existing unbuilt-`@revealui/ai` module-resolution errors, unrelated to these files — CI builds the workspace and runs the full gate.)
