### PR TITLE
feat(core): collectionStorage write-dispatch seam (F1 PR1/3)

### DIFF
--- a/packages/core/src/collections/operations/__tests__/create.test.ts
+++ b/packages/core/src/collections/operations/__tests__/create.test.ts
@@ -270,3 +270,62 @@ describe('create operation', () => {
     expect(insertCall[1]).not.toContain('hello');
   });
 });
+
+describe('create operation — typed-storage write seam', () => {
+  const seamConfig: RevealCollectionConfig = {
+    slug: 'pages',
+    fields: [{ name: 'title', type: 'text', required: true }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the adapter document and skips the dynamic SQL path when handled', async () => {
+    const handledDoc = { id: 'p1', title: 'Home' };
+    const db = {
+      query: vi.fn(),
+      collectionStorage: { create: vi.fn().mockResolvedValue(handledDoc) },
+    };
+
+    const result = await create(seamConfig, db as never, { data: { title: 'Home' } });
+
+    expect(result).toEqual(handledDoc);
+    expect(db.collectionStorage.create).toHaveBeenCalledWith(seamConfig, {
+      data: { title: 'Home' },
+    });
+    // The typed adapter owns the write — the dynamic-SQL path must not run.
+    expect(db.query).not.toHaveBeenCalled();
+    expect(findByID).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the dynamic SQL path when the adapter returns undefined', async () => {
+    const db = {
+      query: vi.fn().mockResolvedValue({ rows: [] } as DatabaseResult),
+      collectionStorage: { create: vi.fn().mockResolvedValue(undefined) },
+    };
+    const dynamicDoc = { id: 'p2', title: 'Home' };
+    vi.mocked(findByID).mockResolvedValue(dynamicDoc as never);
+
+    const result = await create(seamConfig, db as never, { data: { title: 'Home' } });
+
+    expect(db.collectionStorage.create).toHaveBeenCalled();
+    expect(db.query).toHaveBeenCalled(); // dynamic INSERT ran
+    expect(result).toEqual(dynamicDoc);
+  });
+
+  it('forwards req to the adapter when present', async () => {
+    const db = {
+      query: vi.fn(),
+      collectionStorage: { create: vi.fn().mockResolvedValue({ id: 'p3', title: 'Home' }) },
+    };
+    const req = { context: {} } as never;
+
+    await create(seamConfig, db as never, { data: { title: 'Home' }, req });
+
+    expect(db.collectionStorage.create).toHaveBeenCalledWith(seamConfig, {
+      data: { title: 'Home' },
+      req,
+    });
+  });
+});

--- a/packages/core/src/collections/operations/__tests__/delete.test.ts
+++ b/packages/core/src/collections/operations/__tests__/delete.test.ts
@@ -66,3 +66,38 @@ describe('delete operation', () => {
     expect(mockDb.query).not.toHaveBeenCalled();
   });
 });
+
+describe('deleteDocument — typed-storage write seam', () => {
+  const seamConfig: RevealCollectionConfig = { slug: 'pages', fields: [] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the adapter result and skips the dynamic delete when handled', async () => {
+    const handled = { id: 'p1' };
+    const db = {
+      query: vi.fn(),
+      collectionStorage: { delete: vi.fn().mockResolvedValue(handled) },
+    };
+
+    const result = await deleteDocument(seamConfig, db as never, { id: 'p1' });
+
+    expect(result).toEqual(handled);
+    expect(db.collectionStorage.delete).toHaveBeenCalledWith(seamConfig, { id: 'p1' });
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the dynamic delete when the adapter returns undefined', async () => {
+    const db = {
+      query: vi.fn().mockResolvedValue({ rows: [] } as DatabaseResult),
+      collectionStorage: { delete: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    const result = await deleteDocument(seamConfig, db as never, { id: 'p2' });
+
+    expect(db.collectionStorage.delete).toHaveBeenCalled();
+    expect(db.query).toHaveBeenCalled(); // dynamic DELETE ran
+    expect(result).toEqual({ id: 'p2' });
+  });
+});

--- a/packages/core/src/collections/operations/__tests__/update.test.ts
+++ b/packages/core/src/collections/operations/__tests__/update.test.ts
@@ -279,3 +279,51 @@ describe('update operation', () => {
     expect(updateCall[1]).toContain('new-title');
   });
 });
+
+describe('update operation — typed-storage write seam', () => {
+  const seamConfig: RevealCollectionConfig = {
+    slug: 'pages',
+    fields: [{ name: 'title', type: 'text' }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the adapter document and skips the dynamic SQL path when handled', async () => {
+    const handledDoc = { id: 'p1', title: 'Updated' };
+    const db = {
+      query: vi.fn(),
+      collectionStorage: { update: vi.fn().mockResolvedValue(handledDoc) },
+    };
+
+    const result = await update(seamConfig, db as never, { id: 'p1', data: { title: 'Updated' } });
+
+    expect(result).toEqual(handledDoc);
+    expect(db.collectionStorage.update).toHaveBeenCalledWith(seamConfig, {
+      id: 'p1',
+      data: { title: 'Updated' },
+    });
+    expect(db.query).not.toHaveBeenCalled();
+    expect(findByID).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the dynamic SQL path when the adapter returns undefined', async () => {
+    const db = {
+      query: vi.fn(),
+      collectionStorage: { update: vi.fn().mockResolvedValue(undefined) },
+    };
+    // No JSON fields → update verifies existence (rows[0] truthy) then runs UPDATE.
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 'p2' }] } as DatabaseResult) // existence check
+      .mockResolvedValueOnce({ rows: [] } as DatabaseResult); // UPDATE
+    const dynamicDoc = { id: 'p2', title: 'Updated' };
+    vi.mocked(findByID).mockResolvedValue(dynamicDoc as never);
+
+    const result = await update(seamConfig, db as never, { id: 'p2', data: { title: 'Updated' } });
+
+    expect(db.collectionStorage.update).toHaveBeenCalled();
+    expect(db.query).toHaveBeenCalled(); // dynamic UPDATE ran
+    expect(result).toEqual(dynamicDoc);
+  });
+});

--- a/packages/core/src/collections/operations/create.ts
+++ b/packages/core/src/collections/operations/create.ts
@@ -116,6 +116,21 @@ export async function create(
     data.password = await bcrypt.hash(data.password, saltRounds);
   }
 
+  // Typed-storage write seam: a registered collectionStorage adapter (e.g. the
+  // typed Drizzle bridge) may own this collection's writes. It receives the
+  // fully hook-processed `data` and returns the created document, or `undefined`
+  // to defer to the dynamic-SQL path below — same not-handled contract as the
+  // read seam in findById.ts / find.ts.
+  if (db?.collectionStorage?.create) {
+    const doc = await db.collectionStorage.create(config, {
+      data,
+      ...(options.req ? { req: options.req } : {}),
+    });
+    if (doc !== undefined) {
+      return doc;
+    }
+  }
+
   if (db?.query) {
     // Dynamic collection storage is quarantined in sqlAdapter.ts until this
     // layer is redesigned around typed tables that Drizzle can model directly.

--- a/packages/core/src/collections/operations/delete.ts
+++ b/packages/core/src/collections/operations/delete.ts
@@ -76,6 +76,21 @@ export async function deleteDocument(
     }
   }
 
+  // Typed-storage write seam: a registered collectionStorage adapter may own
+  // this collection's deletes (e.g. soft-delete semantics on a typed table). It
+  // returns the deleted document, throws for not-found, or returns `undefined`
+  // to defer to the dynamic-SQL path below (same not-handled contract as the
+  // read seam).
+  if (db?.collectionStorage?.delete) {
+    const result = await db.collectionStorage.delete(config, {
+      id,
+      ...(options.req ? { req: options.req } : {}),
+    });
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
   if (db?.query) {
     // Dynamic collection storage is quarantined in sqlAdapter.ts until this
     // layer is redesigned around typed tables that Drizzle can model directly.

--- a/packages/core/src/collections/operations/update.ts
+++ b/packages/core/src/collections/operations/update.ts
@@ -169,6 +169,22 @@ export async function update(
     data.password = await bcrypt.hash(data.password, saltRounds);
   }
 
+  // Typed-storage write seam: a registered collectionStorage adapter may own
+  // this collection's writes. It receives the hook-processed `data` and returns
+  // the updated document, throws for not-found / optimistic-lock 409, or returns
+  // `undefined` to defer to the dynamic-SQL path below (same not-handled
+  // contract as the read seam).
+  if (db?.collectionStorage?.update) {
+    const doc = await db.collectionStorage.update(config, {
+      id,
+      data,
+      ...(options.req ? { req: options.req } : {}),
+    });
+    if (doc !== undefined) {
+      return doc;
+    }
+  }
+
   if (db?.query) {
     // Dynamic collection storage is quarantined in sqlAdapter.ts until this
     // layer is redesigned around typed tables that Drizzle can model directly.

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -267,6 +267,34 @@ export interface CollectionStorageAdapter {
     collection: RevealCollectionConfig,
     options: RevealFindOptions,
   ) => Promise<RevealPaginatedResult | undefined>;
+  /**
+   * Typed create. Return `undefined` to signal "not handled by this adapter" —
+   * the caller falls through to the dynamic-SQL path. Return the created
+   * document on success; throw for a handled-but-failed write. Mirrors the
+   * `undefined` = not-handled contract used by `findByID`/`find`.
+   */
+  create?: (
+    collection: RevealCollectionConfig,
+    options: { data: RevealDataObject; req?: RevealRequest },
+  ) => Promise<RevealDocument | undefined>;
+  /**
+   * Typed update. `undefined` = not handled (fall through to dynamic SQL). A
+   * document = the updated row. Throw for handled-but-not-found or an
+   * optimistic-lock conflict (statusCode 409).
+   */
+  update?: (
+    collection: RevealCollectionConfig,
+    options: { id: string | number; data: RevealDataObject; req?: RevealRequest },
+  ) => Promise<RevealDocument | undefined>;
+  /**
+   * Typed delete. `undefined` = not handled (fall through to dynamic SQL). A
+   * document (at minimum `{ id }`) = the deleted row. Throw for
+   * handled-but-not-found.
+   */
+  delete?: (
+    collection: RevealCollectionConfig,
+    options: { id: string | number; req?: RevealRequest },
+  ) => Promise<RevealDocument | undefined>;
 }
 
 export interface QueryableDatabaseAdapter {


### PR DESCRIPTION
## PR1 of 3 — F1 Pages-model unification: engine write-dispatch seam

First of a phased sequence unifying the admin CMS `pages` collection onto the canonical site-scoped model (internal audit 2026-07-02, finding B1). This PR adds **only the engine seam** — no collection or behavior changes.

### What
- Extend `CollectionStorageAdapter` with optional `create` / `update` / `delete` methods.
- Dispatch to them from the `create` / `update` / `delete` operations, mirroring the existing `findByID` / `find` read seam: an adapter returns `undefined` to defer to the dynamic-SQL path, or the document to own the write. Throwing signals a handled-but-failed write (e.g. not-found, optimistic-lock 409).

### Why
The dynamic-SQL storage path cannot persist a site-scoped collection into a typed snake_case table: it derives column names verbatim from field names and **rejects camelCase identifiers**, never supplies `NOT NULL` columns like `site_id` / `path`, and routes content into a generic `_json` column instead of typed `jsonb` columns. A typed Drizzle bridge is the only viable write path, and it needs a create/update/delete dispatch hook in core — which today exists only for reads. This PR is that hook.

### Safety
Purely additive and guarded (`if (db?.collectionStorage?.create)` etc.). No adapter registers write methods in this PR, so **every existing collection continues on the dynamic path unchanged.**

### Tests
- 7 new seam tests per op: handled → adapter doc returned + dynamic path skipped; unhandled (`undefined`) → falls through to the dynamic path; `req` forwarded to the adapter.
- Full core operations suite green: **131 passed**. Typecheck + Biome clean.

### Sequence
- **PR1 (this)** — engine write-dispatch seam.
- **PR2** — `pages` typed handler + collection refit (canonical-direct: hero → Hero block; `blocks`/`seo` stored directly) + render-path refit.
- **PR3** — data migration + seed (Neon-branch dry-run first).
