### PR TITLE
fix(server): validate + root-bound terminal spawn cwd; operator-gate the PTY surface

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1192,8 +1192,10 @@ app.use('/api/v1/console-auth/*', routeLimit('terminal-auth'));
 app.route('/api/console-auth', terminalAuthRoute);
 
 // Terminal WebSocket bridge  -  daemon PTY sessions for remote access
-// Auth required: terminal sessions give PTY access to the server
+// Operator-gated: terminal sessions give PTY access to the server host, so
+// bare authentication is not enough — only owner/admin may reach the surface.
 app.use('/api/terminal/*', writeProtected);
+app.use('/api/terminal/*', requireRole('owner', 'admin'));
 app.use('/api/terminal/*', routeLimit('terminal-sessions'));
 export const terminalWs = createTerminalRoute();
 app.route('/api/terminal', terminalWs.app);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -52,7 +52,7 @@ import {
   validateStartup,
 } from './lib/validate-startup.js';
 import { auditMiddleware } from './middleware/audit.js';
-import { authMiddleware } from './middleware/auth.js';
+import { authMiddleware, requireRole } from './middleware/auth.js';
 import { requirePermission } from './middleware/authorization.js';
 import { bodyLimitGate } from './middleware/body-limits.js';
 import { noCacheCacheMiddleware, noStoreCacheMiddleware } from './middleware/cache-control.js';

--- a/apps/server/src/routes/__tests__/terminal-ws.test.ts
+++ b/apps/server/src/routes/__tests__/terminal-ws.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the terminal WebSocket bridge REST surface.
+ *
+ * Covers the PTY-spawn ingress hardening:
+ * - runtime (Zod) validation of the spawn body — previously a TS cast only;
+ * - cwd bounded to the terminal workspace root BEFORE any daemon RPC;
+ * - operator role gate composition on the mount (owner/admin only).
+ *
+ * The daemon socket is mocked to be unreachable: a request that passes
+ * validation must fail with the daemon error (proving it got past the guard)
+ * without ever spawning a real PTY — the dev machine may have a live daemon.
+ */
+
+import { EventEmitter } from 'node:events';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:net', () => ({
+  createConnection: vi.fn(() => {
+    const socket = new EventEmitter() as EventEmitter & { destroy: () => void };
+    socket.destroy = vi.fn();
+    queueMicrotask(() => socket.emit('error', new Error('ECONNREFUSED (test stub)')));
+    return socket;
+  }),
+}));
+
+import { requireRole } from '../../middleware/auth.js';
+import { createTerminalRoute, resolveWorkspaceCwd } from '../terminal-ws.js';
+
+const ROOT = '/srv/terminal-workspace';
+
+beforeEach(() => {
+  process.env.REVEALUI_TERMINAL_WORKSPACE_ROOT = ROOT;
+});
+
+afterEach(() => {
+  delete process.env.REVEALUI_TERMINAL_WORKSPACE_ROOT;
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkspaceCwd
+// ---------------------------------------------------------------------------
+describe('resolveWorkspaceCwd', () => {
+  it('defaults to the workspace root when no cwd is requested', () => {
+    expect(resolveWorkspaceCwd(undefined)).toBe(ROOT);
+  });
+
+  it('resolves a relative cwd under the root', () => {
+    expect(resolveWorkspaceCwd('projects/app')).toBe(`${ROOT}/projects/app`);
+  });
+
+  it('accepts the root itself and absolute paths inside it', () => {
+    expect(resolveWorkspaceCwd(ROOT)).toBe(ROOT);
+    expect(resolveWorkspaceCwd(`${ROOT}/nested`)).toBe(`${ROOT}/nested`);
+  });
+
+  it('rejects traversal escaping the root', () => {
+    expect(resolveWorkspaceCwd('../../etc')).toBeNull();
+    expect(resolveWorkspaceCwd('projects/../../../etc')).toBeNull();
+  });
+
+  it('rejects absolute paths outside the root', () => {
+    expect(resolveWorkspaceCwd('/etc')).toBeNull();
+    expect(resolveWorkspaceCwd('/')).toBeNull();
+  });
+
+  it('rejects sibling directories sharing the root as a string prefix', () => {
+    // startsWith(root) without the separator would wrongly admit this.
+    expect(resolveWorkspaceCwd(`${ROOT}-evil`)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /sessions — validation before daemon RPC
+// ---------------------------------------------------------------------------
+describe('POST /sessions', () => {
+  function createApp() {
+    return createTerminalRoute().app;
+  }
+
+  it('rejects a cwd outside the workspace root with 400, before any daemon call', async () => {
+    const app = createApp();
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: '/etc' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('workspace root');
+  });
+
+  it('rejects traversal cwd with 400', async () => {
+    const app = createApp();
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: '../../outside' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects malformed body values (schema, not cast)', async () => {
+    const app = createApp();
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cols: 'wide', rows: -5, cwd: 42 }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards a valid in-root cwd to the daemon (fails only at the socket here)', async () => {
+    const app = createApp();
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: 'projects/app', cols: 100, rows: 40 }),
+    });
+
+    // Past validation; the stubbed daemon socket refuses the connection.
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Daemon unreachable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mount composition — operator role gate
+// ---------------------------------------------------------------------------
+describe('terminal mount role gate', () => {
+  function createGatedApp(user: { id: string; role: string } | undefined) {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      if (user) c.set('user', user);
+      await next();
+    });
+    app.use('*', requireRole('owner', 'admin'));
+    app.route('/', createTerminalRoute().app);
+    return app;
+  }
+
+  it('403s an authenticated non-operator before any terminal route runs', async () => {
+    const app = createGatedApp({ id: 'user-1', role: 'viewer' });
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('401s when no user is present', async () => {
+    const app = createGatedApp(undefined);
+    const res = await app.request('/sessions', { method: 'GET' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('admits an admin through to the route handlers', async () => {
+    const app = createGatedApp({ id: 'admin-1', role: 'admin' });
+    const res = await app.request('/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: '/etc' }),
+    });
+
+    // Through the gate; rejected by the cwd bound (not by the role gate).
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -15,11 +15,50 @@
  */
 
 import { createConnection } from 'node:net';
+import { resolve, sep } from 'node:path';
 import type { ServerType } from '@hono/node-server';
 import { createNodeWebSocket } from '@hono/node-ws';
+import { zValidator } from '@revealui/openapi';
 import { Hono } from 'hono';
+import { z } from 'zod';
 
 const DAEMON_SOCKET = `${process.env.HOME ?? '/tmp'}/.local/share/revealui/harness.sock`;
+
+/**
+ * Runtime validation for the spawn body. The previous `c.req.json<{...}>()`
+ * was a TypeScript cast only — nothing constrained the values at runtime on a
+ * PTY-spawning (code-execution-adjacent) endpoint.
+ */
+const SpawnTerminalSessionSchema = z.object({
+  name: z.string().min(1).max(128).optional(),
+  cols: z.number().int().min(1).max(1024).optional(),
+  rows: z.number().int().min(1).max(1024).optional(),
+  cwd: z.string().min(1).max(4096).optional(),
+});
+
+/**
+ * Bound the requested PTY working directory to the terminal workspace root
+ * (REVEALUI_TERMINAL_WORKSPACE_ROOT, default $HOME — the daemon's own default).
+ *
+ * - omitted cwd → the root itself (matches the daemon's HOME fallback);
+ * - relative cwd → resolved under the root;
+ * - absolute cwd → admitted only when lexically inside the root;
+ * - anything escaping the root (traversal or foreign absolute path) → null.
+ *
+ * Lexical bound only (no realpath) — the daemon additionally stat()s the
+ * directory before spawning. Exported for direct unit testing.
+ */
+export function resolveWorkspaceCwd(requested: string | undefined): string | null {
+  const root = resolve(process.env.REVEALUI_TERMINAL_WORKSPACE_ROOT ?? process.env.HOME ?? '/tmp');
+  if (!requested) {
+    return root;
+  }
+  const target = resolve(root, requested);
+  if (target === root || target.startsWith(root + sep)) {
+    return target;
+  }
+  return null;
+}
 
 /** JSON-RPC call to the harness daemon over Unix socket. */
 function daemonRpc(method: string, params: Record<string, unknown>): Promise<unknown> {

--- a/apps/server/src/routes/terminal-ws.ts
+++ b/apps/server/src/routes/terminal-ws.ts
@@ -121,13 +121,15 @@ export function createTerminalRoute(): {
   });
 
   // ── REST: spawn session ────────────────────────────────────────────
-  app.post('/sessions', async (c) => {
-    const body = await c.req.json<{
-      name?: string;
-      cols?: number;
-      rows?: number;
-      cwd?: string;
-    }>();
+  app.post('/sessions', zValidator('json', SpawnTerminalSessionSchema), async (c) => {
+    const body = c.req.valid('json');
+
+    // Reject any cwd escaping the workspace root BEFORE the daemon RPC — the
+    // daemon only stat()s the directory; it does not bound the path itself.
+    const cwd = resolveWorkspaceCwd(body.cwd);
+    if (cwd === null) {
+      return c.json({ error: 'cwd is outside the terminal workspace root' }, 400);
+    }
 
     const name = body.name ?? `remote-${Date.now().toString(36)}`;
     try {
@@ -136,7 +138,7 @@ export function createTerminalRoute(): {
         backend: 'ClaudeCode',
         model: 'claude-opus-4-6',
         prompt: '',
-        cwd: body.cwd ?? null,
+        cwd,
         cols: body.cols ?? 120,
         rows: body.rows ?? 30,
       });


### PR DESCRIPTION
## What

Hardens the terminal PTY-spawn ingress (`/api/terminal/*`), which forwards into the harness daemon's `agent.spawn` RPC:

1. **Runtime validation** — the POST `/sessions` body was read via a TypeScript generic *cast* with no runtime checks. It now goes through a Zod schema (`zValidator`, matching the other routes).
2. **cwd bounded to a workspace root** — the client-supplied `cwd` was forwarded verbatim to the PTY spawn. It is now resolved against `REVEALUI_TERMINAL_WORKSPACE_ROOT` (default `$HOME`, the daemon's own fallback) and any path escaping the root — traversal or foreign absolute path — is rejected with 400 **before** the daemon RPC. Lexical bound; the daemon additionally `stat()`s the directory.
3. **Operator role gate** — the mount was gated only by `authMiddleware({ required: true })`, so ANY authenticated user (including free-tier) could direct where an interactive agent PTY is rooted. The mount now also requires `requireRole('owner', 'admin')`.

Surfaced by the internal security audit of 2026-07-02 (adversarially verified; severity high).

Daemon side confirmed as part of this change: the daemon's spawn handler only validates that `cwd` exists and is a directory — it does not bound the path itself (its signature gate is tracked separately) — so this server-side ingress check is the effective bound today.

## Verification

- New suite (13 tests): resolver unit cases incl. the `root-evil` shared-prefix trap; 400-before-RPC for out-of-root and malformed bodies; valid in-root cwd reaches the (stubbed-unreachable) daemon; role-gate composition — viewer 403, anonymous 401, admin passes through to the cwd bound. The daemon socket is mocked so no real PTY can spawn during tests.
- Full server package: 2816 tests green; typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
