### PR TITLE
chore(deps): floor js-yaml@3 at ^3.15.0 for CVE-2026-53550

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "jsondiffpatch": ">=0.7.2",
       "markdown-it": ">=14.2.0",
       "js-yaml@4": ">=4.2.0",
+      "js-yaml@3": "^3.15.0",
       "minimatch": ">=10.2.4",
       "brace-expansion@5": ">=5.0.6",
       "rollup": ">=4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,7 @@ overrides:
   jsondiffpatch: '>=0.7.2'
   markdown-it: '>=14.2.0'
   js-yaml@4: '>=4.2.0'
+  js-yaml@3: ^3.15.0
   minimatch: '>=10.2.4'
   brace-expansion@5: '>=5.0.6'
   rollup: '>=4.59.0'
@@ -6353,8 +6354,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@5.0.0:
@@ -11443,7 +11444,7 @@ snapshots:
       '@yarnpkg/parsers': 3.0.3
       execa: 3.2.0
       fs-extra: 11.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       oxc-transform: 0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)
       path-to-regexp: 8.4.2
       resolve.exports: 2.0.3
@@ -11729,7 +11730,7 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
-      js-yaml: 5.0.0
+      js-yaml: 5.2.0
       minimatch: 10.2.5
       smol-toml: 1.7.0
       zod: 3.22.4
@@ -12024,7 +12025,7 @@ snapshots:
 
   '@yarnpkg/parsers@3.0.3':
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       tslib: 2.8.1
 
   abbrev@3.0.1: {}
@@ -13445,7 +13446,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -14708,7 +14709,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## Summary

Adds a major-scoped pnpm override `"js-yaml@3": "^3.15.0"` to close Dependabot alert #101 (CVE-2026-53550 / GHSA-h67p-54hq-rp68, medium): quadratic-complexity DoS in js-yaml merge-key handling via repeated aliases, affecting js-yaml < 3.15.0.

## Affected chain (all transitive, development scope)

- `vercel` CLI → `@vercel/backends@0.2.0` → `js-yaml@3.14.2` (direct, and via `@yarnpkg/parsers@3.0.3`)
- `@manypkg/get-packages@1.1.3` → `read-yaml-file@1.1.0` → `js-yaml@3.14.2`

## Why a caret-scoped override, and why now

- The existing `"js-yaml@4": ">=4.2.0"` override does not cover the 3.x consumers.
- A prior js-yaml 3.x alert was dismissed as tolerable risk because no patched 3.x release existed. js-yaml 3.15.0 is now published, so the 3.x line can be floored in place.
- The override is `^3.15.0` rather than an open `>=3.15.0` floor deliberately: an open floor lets the resolver jump the 3.x consumers to js-yaml 5.x, whose entrypoint drops the `safeLoad` API that `read-yaml-file` still calls (verified against the js-yaml 5.2.0 dist — zero `safeLoad` occurrences). That would break changesets tooling (`@manypkg/get-packages`) at runtime. `^3.15.0` keeps every 3.x consumer inside its own declared range on the first patched 3.x release.

## Verification

- Lockfile re-resolved with `pnpm install --lockfile-only`: `js-yaml@3.14.2` is gone; `@vercel/backends`, `@yarnpkg/parsers`, and `read-yaml-file` all resolve to `js-yaml@3.15.0`.
- Incidental same-major refresh: `@vercel/python-analysis` moved js-yaml 5.0.0 → 5.2.0, within its own declared range.
- Local phase-1 gate suite (pre-push hook) passed, including the security gate and dependency audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
