### PR TITLE
feat(core): execute field-level validate on collection create/update

### DIFF
--- a/packages/core/src/collections/operations/__tests__/fieldValidation.test.ts
+++ b/packages/core/src/collections/operations/__tests__/fieldValidation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Field Validation Executor Tests
+ *
+ * Covers runFieldValidators directly and its wiring into create()/update():
+ * a field's `validate` predicate now runs on ingress and rejects the write when
+ * it returns an error message.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DatabaseResult,
+  RevealCollectionConfig,
+  RevealCreateOptions,
+  RevealUpdateOptions,
+} from '../../../types/index.js';
+import { create } from '../create.js';
+import { runFieldValidators, ValidationError } from '../fieldValidation.js';
+import { findByID } from '../findById.js';
+import { update } from '../update.js';
+
+vi.mock('../findById', () => ({
+  findByID: vi.fn(),
+}));
+
+vi.mock('bcryptjs', () => ({
+  default: { hash: vi.fn() },
+}));
+
+/** A field's `validate` predicate, typed loosely to match the contracts signature. */
+type Validate = (value: unknown, args: unknown) => string | true | Promise<string | true>;
+
+const configWith = (validate: Validate): RevealCollectionConfig => ({
+  slug: 'test',
+  fields: [{ name: 'url', type: 'text', validate } as never],
+});
+
+describe('runFieldValidators', () => {
+  it('resolves when the predicate returns true', async () => {
+    await expect(
+      runFieldValidators(
+        configWith(() => true),
+        { url: 'https://ok.example' },
+        'create',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws ValidationError with the predicate message on a string return', async () => {
+    const config = configWith((v) =>
+      typeof v === 'string' && v.startsWith('javascript:') ? 'Unsafe URL scheme' : true,
+    );
+    const err = await runFieldValidators(config, { url: 'javascript:alert(1)' }, 'create').catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).message).toBe('Unsafe URL scheme');
+    expect((err as ValidationError).status).toBe(400);
+    expect((err as ValidationError).statusCode).toBe(400);
+    expect((err as ValidationError).field).toBe('url');
+  });
+
+  it('skips fields not present in the payload (partial update)', async () => {
+    const validate = vi.fn<Validate>(() => 'should not run');
+    await expect(
+      runFieldValidators(configWith(validate), { other: 'x' }, 'update'),
+    ).resolves.toBeUndefined();
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it('passes value, data, siblingData, operation and req to the predicate', async () => {
+    const validate = vi.fn<Validate>(() => true);
+    const req = { user: { id: 'u1' } } as never;
+    await runFieldValidators(configWith(validate), { url: 'https://x' }, 'update', req);
+    expect(validate).toHaveBeenCalledWith('https://x', {
+      value: 'https://x',
+      data: { url: 'https://x' },
+      siblingData: { url: 'https://x' },
+      operation: 'update',
+      req,
+    });
+  });
+
+  it('awaits async predicates', async () => {
+    const config = configWith((v) =>
+      v === 'bad' ? Promise.resolve('nope') : Promise.resolve(true),
+    );
+    await expect(runFieldValidators(config, { url: 'bad' }, 'create')).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+  });
+
+  it('runs validators on fields nested inside row/tabs containers', async () => {
+    const validate = vi.fn<Validate>(() => 'row field rejected');
+    const config: RevealCollectionConfig = {
+      slug: 'test',
+      fields: [
+        {
+          type: 'row',
+          fields: [{ name: 'nested', type: 'text', validate }],
+        } as never,
+      ],
+    };
+    await expect(runFieldValidators(config, { nested: 'v' }, 'create')).rejects.toThrow(
+      'row field rejected',
+    );
+    expect(validate).toHaveBeenCalledOnce();
+  });
+});
+
+describe('create()/update() wiring', () => {
+  const mockDb = { query: vi.fn() };
+
+  const config = configWith((v) =>
+    typeof v === 'string' && v.startsWith('javascript:') ? 'Unsafe URL scheme' : true,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Row present so update()'s existence check passes; create() ignores rows
+    // (it reads the created doc via the mocked findByID).
+    mockDb.query.mockResolvedValue({ rows: [{ id: 'id1' }] } as DatabaseResult);
+    vi.mocked(findByID).mockResolvedValue({ id: 'id1', url: 'https://ok' } as never);
+  });
+
+  it('create() rejects a document whose field validate fails', async () => {
+    const options: RevealCreateOptions = { data: { url: 'javascript:alert(1)' } };
+    await expect(create(config, mockDb as never, options)).rejects.toThrow('Unsafe URL scheme');
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it('create() proceeds when field validate passes', async () => {
+    const options: RevealCreateOptions = { data: { url: 'https://ok.example' } };
+    await expect(create(config, mockDb as never, options)).resolves.toBeTruthy();
+    expect(mockDb.query).toHaveBeenCalled();
+  });
+
+  it('update() rejects a patch whose field validate fails', async () => {
+    const options: RevealUpdateOptions = { id: 'id1', data: { url: 'javascript:alert(1)' } };
+    await expect(update(config, mockDb as never, options)).rejects.toThrow('Unsafe URL scheme');
+  });
+
+  it('update() proceeds when field validate passes', async () => {
+    const options: RevealUpdateOptions = { id: 'id1', data: { url: 'https://ok.example' } };
+    await expect(update(config, mockDb as never, options)).resolves.toBeTruthy();
+  });
+});

--- a/packages/core/src/collections/operations/create.ts
+++ b/packages/core/src/collections/operations/create.ts
@@ -17,6 +17,7 @@ import type {
 import { collectJsonFields, serializeValueForDatabase } from '../../utils/json-parsing.js';
 import { flattenFields, isJsonFieldType } from '../../utils/type-guards.js';
 import { runBeforeFieldHooks } from './fieldHooks.js';
+import { runFieldValidators } from './fieldValidation.js';
 import { findByID } from './findById.js';
 import { insertDocumentQuery } from './sqlAdapter.js';
 
@@ -106,6 +107,12 @@ export async function create(
       }
     }
   }
+
+  // Run field-level `validate` predicates after the built-in required/email
+  // checks and before beforeChange hooks (Payload's beforeValidate → validate →
+  // beforeChange ordering). Throws a ValidationError (HTTP 400) on the first
+  // failing field.
+  await runFieldValidators(config, data, 'create', options.req);
 
   // Run beforeChange field hooks after validation but before the DB write.
   await runBeforeFieldHooks(config, data, 'create', 'beforeChange', undefined, options.req);

--- a/packages/core/src/collections/operations/fieldValidation.ts
+++ b/packages/core/src/collections/operations/fieldValidation.ts
@@ -1,0 +1,103 @@
+/**
+ * Field Validation Execution
+ *
+ * Runs field-level `validate` predicates during create/update operations.
+ * Mirrors the fieldHooks.ts execution pattern: a single flattenFields traversal
+ * over the collection's fields.
+ *
+ * A field's `validate(value, { value, data, siblingData, operation, req })`
+ * returns `true` when the value is valid, or a non-empty string error message
+ * when it is not. On the first failure the engine throws a ValidationError
+ * (HTTP 400) carrying that message, so the write is rejected at ingress.
+ *
+ * Enforcement note: this is one of the engine's ingress checks and runs for
+ * EVERY collection written through create()/update(). For public page/post
+ * rich-text content it COMPLEMENTS — does not replace — the contracts walker
+ * (validateContent/validateBlocks, wired into the pages/posts write routes) and
+ * render-side sanitizeUrl. See docs/specs/2026-07-02-cms-render-path-hardening.md.
+ */
+
+import type { Field } from '@revealui/contracts/admin';
+import type { RevealCollectionConfig, RevealRequest } from '../../types/index.js';
+import { flattenFields } from '../../utils/type-guards.js';
+
+/**
+ * Thrown when a field's `validate` predicate rejects a value.
+ *
+ * Carries `status`/`statusCode` 400 so transports surface it as a client error
+ * with the validator's message intact (core `rest.ts` reads `status`; the
+ * server error middleware can branch on `name === 'ValidationError'`), rather
+ * than the generic 500 that a bare Error would produce.
+ */
+export class ValidationError extends Error {
+  readonly status = 400;
+  readonly statusCode = 400;
+  readonly field?: string;
+
+  constructor(message: string, field?: string) {
+    super(message);
+    this.name = 'ValidationError';
+    this.field = field;
+  }
+}
+
+/**
+ * Executes every field's `validate` predicate for the fields present in `data`.
+ *
+ * Called once per write, after the required-field / email-format checks and
+ * before the beforeChange field hooks — the same ordering Payload uses
+ * (beforeValidate hooks → validate → beforeChange hooks).
+ *
+ * A field is validated only when its name is present in `data`. This matches the
+ * engine's existing email check (which gates on `field.name in data`) and is
+ * correct for partial updates, where absent keys are untouched. Required-but-
+ * absent fields are still caught by the separate required-field check in the
+ * create operation.
+ *
+ * `flattenFields` recurses through `tabs`/`row` containers, whose child fields
+ * remain top-level keys in `data`, so `data[field.name]` and `siblingData: data`
+ * resolve correctly. `group`/`array`/`blocks` are validated as a single value
+ * (the whole sub-object), matching how the engine treats those JSON fields.
+ */
+export async function runFieldValidators(
+  config: RevealCollectionConfig,
+  data: Record<string, unknown>,
+  operation: 'create' | 'update',
+  req?: RevealRequest,
+): Promise<void> {
+  const fields = flattenFields(config.fields || []);
+
+  for (const field of fields as Field[]) {
+    if (!field.name) continue;
+
+    const validate = field.validate;
+    if (typeof validate !== 'function') continue;
+
+    // Only validate fields carried by this write payload.
+    if (!(field.name in data)) continue;
+
+    const value = data[field.name];
+    // `req` is required by FieldValidateArgs; ingress writes always carry one.
+    // Bootstrap/test paths may not — pass it through and let validators that
+    // depend on `req` fail loudly rather than silently skipping validation.
+    // Cast the args object to the predicate's own parameter type: core's
+    // RevealRequest and the contracts FieldValidateArgs.req generic differ only
+    // in their default user parameter, so the shape is identical.
+    const args = {
+      value,
+      data,
+      siblingData: data,
+      operation,
+      req,
+    } as Parameters<NonNullable<Field['validate']>>[1];
+    const result = await validate(value, args);
+
+    if (result !== true) {
+      const message =
+        typeof result === 'string' && result.length > 0
+          ? result
+          : `Field '${field.name}' failed validation`;
+      throw new ValidationError(message, field.name);
+    }
+  }
+}

--- a/packages/core/src/collections/operations/update.ts
+++ b/packages/core/src/collections/operations/update.ts
@@ -18,6 +18,7 @@ import type {
 import { collectJsonFields, serializeValueForDatabase } from '../../utils/json-parsing.js';
 import { flattenFields, isJsonFieldType } from '../../utils/type-guards.js';
 import { runBeforeFieldHooks } from './fieldHooks.js';
+import { runFieldValidators } from './fieldValidation.js';
 import { find } from './find.js';
 import { findByID } from './findById.js';
 import {
@@ -159,6 +160,11 @@ export async function update(
       }
     }
   }
+
+  // Run field-level `validate` predicates for the fields present in this patch,
+  // after the built-in email check and before beforeChange hooks. Throws a
+  // ValidationError (HTTP 400) on the first failing field.
+  await runFieldValidators(config, data, 'update', options.req);
 
   // Run beforeChange field hooks after validation but before the DB write.
   await runBeforeFieldHooks(config, data, 'update', 'beforeChange', undefined, options.req);


### PR DESCRIPTION
## Summary

Internal audit follow-up (defense-in-depth). The collection engine's `create()`
and `update()` operations ran only a required-field check and an email-format
check, then field hooks — they never invoked a field's `validate` predicate,
even though `validate` is a first-class field property plumbed through the field
types and the field-conversion utilities. A security-relevant `validate` on a
collection field was therefore silently dead code.

This wires a field-validate executor (`runFieldValidators`) into both operations
so `validate` runs on ingress, in Payload's `beforeValidate → validate →
beforeChange` order.

## Changes

- `packages/core/src/collections/operations/fieldValidation.ts` (new):
  `runFieldValidators` + a `ValidationError` (HTTP 400) that carries the
  predicate's message so transports surface it as a client error, not a generic
  500.
- `create.ts` / `update.ts`: call the executor after the required/email checks
  and before `beforeChange` hooks.
- Validates only the fields present in the write payload (consistent with the
  existing email check; correct for partial updates). `flattenFields` covers
  `row`/`tabs` containers whose children remain top-level `data` keys.

## Enforcement model

This **complements** — it does not replace — the two enforced render-path
layers: the contracts walker (`validateContent`/`validateBlocks`) at the
pages/posts write routes, and render-side `sanitizeUrl` in the core serializer.
It closes the gap where collections written through other paths get no
field-level ingress validation.

## Tests

`packages/core/src/collections/operations/__tests__/fieldValidation.test.ts` —
executor unit cases (pass / reject-with-message / skip-absent / args shape /
async / nested `row` container) plus create()+update() wiring (reject on failure,
proceed on pass). Full operations suite: 141 passing. `@revealui/core` typecheck
clean.

## Review

Touches `collections-operations` — a security-review-gated surface. Holding for
a recorded security-review verdict before merge.
