### PR TITLE
fix(admin): sanitize editor-side embed URLs through the shared chokepoint

### DIFF
--- a/apps/admin/src/lib/features/embed/components/EmbedNodeComponent.tsx
+++ b/apps/admin/src/lib/features/embed/components/EmbedNodeComponent.tsx
@@ -1,4 +1,5 @@
 import { useLexicalComposerContext } from '@revealui/core/richtext/client';
+import { sanitizeUrl } from '@revealui/security/sanitize';
 import { $getNodeByKey } from 'lexical';
 import type React from 'react';
 import { useCallback, useMemo } from 'react';
@@ -49,6 +50,15 @@ export const EmbedNodeComponent = (props: Props) => {
     });
   }, [editor, nodeKey]);
 
+  // Route both URL sinks through the shared sanitizer (the same chokepoint
+  // CMSLink uses on the render path). A generic embed URL is author-controlled
+  // and `new URL()` accepts `javascript:`/`data:` schemes, so an unsanitized
+  // href here is the same XSS vector as the render path — neutralized to '#'.
+  const safeHref =
+    source.type === 'youtube'
+      ? sanitizeUrl(source.embedUrl, 'link')
+      : sanitizeUrl(source.url, 'link');
+
   return (
     <div className="embed-node shadow-sm p-3 pt-2 bg-gray-100 border border-gray-200 font-body mb-6 w-[560px]">
       <div className="embed-node__controls relative flex justify-between pb-1">
@@ -83,7 +93,7 @@ export const EmbedNodeComponent = (props: Props) => {
       {source.type === 'youtube' ? (
         <iframe
           className="w-full h-80"
-          src={source.embedUrl}
+          src={safeHref}
           title="YouTube video player"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           referrerPolicy="strict-origin-when-cross-origin"
@@ -91,7 +101,7 @@ export const EmbedNodeComponent = (props: Props) => {
         />
       ) : (
         <a
-          href={source.url}
+          href={safeHref}
           target="_blank"
           rel="noopener noreferrer"
           className="block p-4 bg-white rounded border border-gray-300 text-blue-600 hover:underline break-all"

--- a/apps/admin/src/lib/features/embed/components/__tests__/EmbedNodeComponent.test.tsx
+++ b/apps/admin/src/lib/features/embed/components/__tests__/EmbedNodeComponent.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * XSS-hardening tests for the editor-side EmbedNodeComponent.
+ *
+ * A generic embed URL is author-controlled and `new URL()` accepts
+ * `javascript:`/`data:` schemes, so the rendered <a href> is the same URL
+ * vector as the public render path. It must be neutralized through the shared
+ * sanitizeUrl chokepoint. Legitimate http(s) and YouTube embeds are unaffected.
+ *
+ * No regex authored (fleet posture): assertions use attribute equality.
+ */
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/richtext/client', () => ({
+  useLexicalComposerContext: () => [{ update: vi.fn(), dispatchCommand: vi.fn() }],
+}));
+
+// Avoid pulling the lexical DecoratorBlockNode internals into the test; only the
+// command symbol is referenced at runtime.
+vi.mock('../../nodes/EmbedNode', () => ({
+  OPEN_EMBED_DRAWER_COMMAND: { type: 'OPEN_EMBED_DRAWER_COMMAND' },
+}));
+
+import { EmbedNodeComponent } from '../EmbedNodeComponent';
+
+const renderEmbed = (url: string) =>
+  render(<EmbedNodeComponent data={{ url } as never} nodeKey="test-key" />);
+
+describe('EmbedNodeComponent', () => {
+  it('neutralizes a javascript: embed URL to # on the generic anchor', () => {
+    const { container } = renderEmbed('javascript:alert(document.cookie)');
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('#');
+  });
+
+  it('neutralizes a data:text/html embed URL to #', () => {
+    const { container } = renderEmbed('data:text/html,<script>alert(1)</script>');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('#');
+  });
+
+  it('preserves a legitimate https URL on the generic anchor', () => {
+    const { container } = renderEmbed('https://example.com/article');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com/article');
+  });
+
+  it('renders a YouTube watch URL as a youtube.com/embed iframe', () => {
+    const { container } = renderEmbed('https://www.youtube.com/watch?v=abc123');
+    const iframe = container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('src')).toBe('https://www.youtube.com/embed/abc123');
+    // No anchor in the youtube branch.
+    expect(container.querySelector('a')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Internal audit follow-up. `EmbedNodeComponent` (the editor-side embed renderer)
rendered a generic embed as `<a href={source.url}>` using the raw author URL.
`parseEmbedSource` parses with `new URL()`, which accepts `javascript:`/`data:`
schemes and falls them through to the generic branch — so the editor rendered an
unsanitized `href`, the same URL vector as the render path (author-to-self,
inside the editor).

## Change

Route both URL sinks through the shared `sanitizeUrl(url, 'link')` from
`@revealui/security/sanitize` — the same chokepoint `CMSLink` uses on the public
render path:
- generic anchor `href`
- the constructed YouTube iframe `src` (defense-in-depth; a valid https URL is
  returned unchanged)

Unsafe schemes neutralize to `'#'`; legitimate http(s) and YouTube embeds are
unaffected.

## Tests

`apps/admin/src/lib/features/embed/components/__tests__/EmbedNodeComponent.test.tsx`:
`javascript:` and `data:text/html` URLs render `href="#"`; a plain https URL is
preserved; a YouTube watch URL renders a `youtube.com/embed` iframe. 4 passing.
Admin typecheck clean.

## Review

Touches the embed render path (sanitize-adjacent). Holding for a recorded
security-review verdict before merge.
