### PR TITLE
fix(contracts): allow data:image/ on image src at the write routes

### DIFF
--- a/packages/contracts/src/__tests__/content-validation.test.ts
+++ b/packages/contracts/src/__tests__/content-validation.test.ts
@@ -135,3 +135,50 @@ describe('validateBlocks — write-API surface', () => {
     expect(validateBlocks(blocks).valid).toBe(true);
   });
 });
+
+describe('validateContent — data:image/ on image src (render-contract parity)', () => {
+  function imageContent(src: string) {
+    return {
+      root: {
+        type: 'root',
+        children: [{ type: 'image', src, version: 1 }],
+      },
+    };
+  }
+
+  it('accepts a data:image/png src (the renderer allows it via sanitizeUrl image context)', () => {
+    const png =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==';
+    expect(validateContent(imageContent(png)).valid).toBe(true);
+  });
+
+  it('rejects a data:text/html src (not an image data URI)', () => {
+    const result = validateContent(imageContent('data:text/html,<script>alert(1)</script>'));
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toContain('Dangerous URL protocol');
+  });
+
+  it('rejects a javascript: src', () => {
+    expect(validateContent(imageContent('javascript:alert(1)')).valid).toBe(false);
+  });
+
+  it('rejects data:image/ on a link url (link context, not image)', () => {
+    const result = validateContent({
+      root: {
+        type: 'root',
+        children: [{ type: 'link', fields: { url: 'data:image/png;base64,AAAA' } }],
+      },
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects data:image/ on an href field (link context, not image)', () => {
+    const result = validateContent({
+      root: {
+        type: 'root',
+        children: [{ type: 'link', href: 'data:image/png;base64,AAAA' }],
+      },
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/contracts/src/content-validation.ts
+++ b/packages/contracts/src/content-validation.ts
@@ -4,7 +4,8 @@
  * Validates Lexical editor JSON content structure.
  * Rejects payloads with:
  * - javascript: URLs (XSS via link nodes)
- * - data: URLs (XSS via image/link nodes)
+ * - data: URLs (XSS via image/link nodes) — except `data:image/…` on an image
+ *   `src`, which the renderer allows via sanitizeUrl(url, 'image')
  * - vbscript: URLs
  * - Disallowed heading/list `tag` values (XSS via script-tagged element nodes)
  * - Excessively deep nesting (>20 levels)
@@ -75,14 +76,31 @@ const URL_FIELD_NAMES = new Set(['url', 'src', 'href']);
 const DANGEROUS_PROTOCOLS = ['javascript:', 'vbscript:', 'data:'];
 
 /**
+ * Image `src` fields may legitimately carry an inline `data:image/…` URI. The
+ * renderer allows exactly this shape via `isSafeUrl(url, 'image')`, so rejecting
+ * it at ingress would refuse a payload the renderer would safely display. Kept
+ * in lockstep with `SAFE_IMAGE_DATA_URI` in @revealui/security (contracts cannot
+ * import security — security depends on contracts, not the reverse).
+ */
+const SAFE_IMAGE_DATA_PREFIX = 'data:image/';
+
+/**
  * Tests whether a string value contains a dangerous URL protocol.
  * Strips whitespace and control characters before comparing, since browsers
  * normalize these away (e.g., `java\x00script:alert(1)` executes).
+ *
+ * Context-aware: an image `src` carrying a `data:image/…` URI is NOT dangerous
+ * (matches the renderer's image context). Every other field, and every other
+ * `data:` shape (`data:text/html`, `data:application/…`) plus `javascript:` /
+ * `vbscript:`, stays blocked.
  */
-function isDangerousUrl(value: string): boolean {
+function isDangerousUrl(value: string, field: string): boolean {
   // Strip all whitespace and ASCII control characters (0x00-0x1F, 0x7F)
   // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional -- strip control chars that browsers silently normalize
   const normalized = value.replace(/[\s\x00-\x1f\x7f]/g, '').toLowerCase();
+  if (field === 'src' && normalized.startsWith(SAFE_IMAGE_DATA_PREFIX)) {
+    return false;
+  }
   return DANGEROUS_PROTOCOLS.some((protocol) => normalized.startsWith(protocol));
 }
 
@@ -130,9 +148,10 @@ function walkNode(node: unknown, depth: number, path: string, errors: string[]):
     for (const key of Object.keys(obj)) {
       const value = obj[key];
 
-      // Check URL fields for dangerous protocols
+      // Check URL fields for dangerous protocols (context-aware by field name:
+      // an image `src` may carry a data:image/… URI the renderer allows)
       if (URL_FIELD_NAMES.has(key) && typeof value === 'string') {
-        if (isDangerousUrl(value)) {
+        if (isDangerousUrl(value, key)) {
           errors.push(`Dangerous URL protocol detected in field "${key}" at ${path}.${key}`);
         }
       }


### PR DESCRIPTION
## Summary

Internal audit follow-up (layer-agreement fix). The Lexical content-validation
walker (`packages/contracts/src/content-validation.ts`, wired into the
pages/posts write routes) blocked **all** `data:` URIs in `url`/`src`/`href`.
But the renderer allows `data:image/…` via `sanitizeUrl(url, 'image')`, and the
upload tests assert a `data:image/png` src renders. So a payload the renderer
would safely display was rejected at ingress — the two layers disagreed on
"safe image" (fail-closed, not a hole, but a real over-rejection).

## Change

`isDangerousUrl` is now context-aware by field name: an image `src` carrying a
`data:image/…` URI is accepted (matches the renderer's image context). Every
other field, and every other `data:` shape (`data:text/html`,
`data:application/…`), plus `javascript:`/`vbscript:`, stay blocked everywhere.

- No security import — `@revealui/security` depends on `contracts`, not the
  reverse; the `data:image/` prefix is kept in lockstep with
  `SAFE_IMAGE_DATA_URI` by comment.
- No new regex (the pre-existing control-char strip is unchanged).

## Tests

`data:image/png` src accepted; `data:text/html` and `javascript:` src rejected;
`data:image/` on a link `url`/`href` still rejected (link context). 27 passing.
Contracts typecheck clean.

## Review

Touches ingress validation (sanitize-adjacent). Holding for a recorded
security-review verdict before merge.
