### PR TITLE
fix(ci): scope pre-push gate to pushed refs, not checked-out branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,6 +4,33 @@ if [ -z "$BASH_VERSION" ]; then
   exec bash -e "$0" "$@"
 fi
 
+# ── Gate scope: decided by the refs being pushed, not the checked-out branch ──
+# git feeds pre-push one "<local ref> <local sha> <remote ref> <remote sha>"
+# line per pushed ref on stdin. Tag pushes and ref deletions add no commits
+# to any branch, so they never gate; branch pushes gate on the remote branch
+# being pushed, regardless of which branch is checked out.
+ZERO_SHA=0000000000000000000000000000000000000000
+PROTECTED_BRANCH=""
+FEATURE_BRANCH=""
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+  [ -z "$remote_ref" ] && continue
+  [ "$local_sha" = "$ZERO_SHA" ] && continue # deletion: no local commits to validate
+  case "$remote_ref" in
+    refs/heads/main|refs/heads/test)
+      PROTECTED_BRANCH="${remote_ref#refs/heads/}"
+      ;;
+    refs/heads/*)
+      FEATURE_BRANCH="${remote_ref#refs/heads/}"
+      ;;
+  esac
+done
+
+if [ -z "$PROTECTED_BRANCH" ] && [ -z "$FEATURE_BRANCH" ]; then
+  echo ""
+  echo "No branch refs in this push (tags or deletions only); skipping CI gate."
+  exit 0
+fi
+
 # ── Sentinel file: signals to auto-commit hook that a gate is running ──
 GIT_DIR=$(git rev-parse --git-dir)
 GATE_SENTINEL="$GIT_DIR/gate-in-progress"
@@ -60,25 +87,21 @@ else
   echo "(Dirty file handling by coordinated push script)"
 fi
 
-# Branch-aware gate strictness
+# Branch-aware gate strictness, keyed to the pushed refs
 #   main/test: quality + typecheck (build + tests deferred to CI)
 #   feature/*: quality-only (local dev, no CI)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GATE_EXIT=0
-case "$BRANCH" in
-  main|test)
-    echo ""
-    echo "Running CI gate for protected branch '$BRANCH' (quality + typecheck; build + tests run in CI)..."
-    echo ""
-    pnpm gate --no-build --no-test || GATE_EXIT=$?
-    ;;
-  *)
-    echo ""
-    echo "Running quality checks for '$BRANCH'..."
-    echo ""
-    pnpm gate --phase=1 --changed || GATE_EXIT=$?
-    ;;
-esac
+if [ -n "$PROTECTED_BRANCH" ]; then
+  echo ""
+  echo "Running CI gate for protected branch '$PROTECTED_BRANCH' (quality + typecheck; build + tests run in CI)..."
+  echo ""
+  pnpm gate --no-build --no-test || GATE_EXIT=$?
+else
+  echo ""
+  echo "Running quality checks for '$FEATURE_BRANCH'..."
+  echo ""
+  pnpm gate --phase=1 --changed || GATE_EXIT=$?
+fi
 
 # Restore saved files (plain copy — never conflicts)
 if [ -n "$SAVE_DIR" ] && [ -f "$SAVE_DIR/manifest" ]; then


### PR DESCRIPTION
## Problem

The pre-push hook decided gate strictness from the currently checked-out branch (`git rev-parse --abbrev-ref HEAD`) and never read the refs actually being pushed. Any push made while `test` or `main` was checked out therefore ran the full protected-branch CI gate, including pushes that add no commits to any branch.

Observed 2026-07-04: `git push origin archive/rsc-poc-spike` (a tag-only push) from a `test` checkout printed "Running CI gate for protected branch 'test'" and ran `pnpm gate --no-build --no-test`, which died on cold-cache typecheck on a memory-constrained dev workstation; the tag had to go out with an owner-approved `--no-verify`.

## Fix

Parse the refs git feeds pre-push on stdin (one `<local ref> <local sha> <remote ref> <remote sha>` line per pushed ref):

- **Tag-only or delete-only pushes** exit before the gate, the gate sentinel, and the dirty-file save/restore. Nothing is being added to any branch, so there is nothing to validate.
- **Pushes touching `refs/heads/test` or `refs/heads/main`** run the protected gate (quality + typecheck) exactly as before, now regardless of which branch is checked out.
- **Other `refs/heads/*` pushes** keep the phase-1 quality gate, labeled with the pushed branch name instead of the checkout.

Deliberate behavior note: a deletion push (zero local sha) no longer gates even for protected refs. There are no local commits to validate, and deletion of protected branches is governed server-side by branch protection.

Implementation is prefix string matching only (`case` patterns + `${remote_ref#refs/heads/}`), no regex, POSIX-compatible within the hook's existing bash re-exec. `.husky/pre-push` is the single copy of this logic (husky `core.hooksPath` model; `scripts/git-hooks/push.sh` just triggers the hook via `git push`, so it inherits the fix).

## Evidence

New hook, synthetic stdin, `pnpm` stubbed so gate invocation is observable without running it. Checkout is `fix/pre-push-tag-scope` for every case, proving checkout independence:

```text
A: tag-only push
   No branch refs in this push (tags or deletions only); skipping CI gate.
   exit=0  (no gate invocation)

B: push refs/heads/test (checkout: fix/pre-push-tag-scope)
   Running CI gate for protected branch 'test' (quality + typecheck; build + tests run in CI)...
   [stub-gate] pnpm gate --no-build --no-test
   exit=0

C: push new feature branch (zero remote sha)
   Running quality checks for 'fix/pre-push-tag-scope'...
   [stub-gate] pnpm gate --phase=1 --changed
   exit=0

D: mixed push (tag + refs/heads/test)
   Running CI gate for protected branch 'test' ...
   [stub-gate] pnpm gate --no-build --no-test
   exit=0

E: branch-deletion-only push
   No branch refs in this push (tags or deletions only); skipping CI gate.
   exit=0

F: protected push, gate fails (stub exits 7)
   Running CI gate for protected branch 'test' ...
   [stub-gate] pnpm gate --no-build --no-test (simulated gate failure)
   exit=7  -> push still blocked on gate failure
```

Old hook (this branch's parent) run from a `test` checkout with the same tag-only stdin reproduces the reported bug:

```text
Running CI gate for protected branch 'test' (quality + typecheck; build + tests run in CI)...
[stub-gate] pnpm gate --no-build --no-test
```

Live, through real `git push` (new hook via the husky shim, no stubs):

```text
$ git push --dry-run origin tmp-prepush-scope-check        # temp tag
No branch refs in this push (tags or deletions only); skipping CI gate.
 * [new tag]             tmp-prepush-scope-check -> tmp-prepush-scope-check

$ git push -u origin fix/pre-push-tag-scope                # this branch
Running quality checks for 'fix/pre-push-tag-scope'...
[real phase-1 gate runs: 22 quality checks]
Result: PASS
 * [new branch]          fix/pre-push-tag-scope -> fix/pre-push-tag-scope
```

Manual merge only (no `--auto`); merge is the deployment, since the hook is the tracked file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
