### PR TITLE
fix(ci): make pre-push hook immune to mid-run rewrites of itself

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,6 +4,17 @@ if [ -z "$BASH_VERSION" ]; then
   exec bash -e "$0" "$@"
 fi
 
+# ── Execute from memory: the whole body is parsed before any of it runs ──
+# The dirty-save below reverts tracked files with `git checkout -- .` and
+# copies them back after the gate; when .husky/pre-push is itself dirty,
+# both steps rewrite this file on disk while it is executing (peer sessions
+# switching the shared checkout mid-push can do the same). A shell may
+# re-read a running script from disk between commands, so a mid-run rewrite
+# can corrupt execution, including the final gate exit status. Every code
+# path below exits inside this brace group, so the on-disk file is never
+# read again once the group has been parsed.
+{
+
 # ── Gate scope: decided by the refs being pushed, not the checked-out branch ──
 # git feeds pre-push one "<local ref> <local sha> <remote ref> <remote sha>"
 # line per pushed ref on stdin. Tag pushes and ref deletions add no commits
@@ -117,3 +128,4 @@ if [ -n "$SAVE_DIR" ] && [ -f "$SAVE_DIR/manifest" ]; then
 fi
 
 exit $GATE_EXIT
+}


### PR DESCRIPTION
Follow-up hardening to #1734 (merged): make the hook immune to mid-run rewrites of itself.

## Problem

The dirty-save in `.husky/pre-push` reverts tracked files with `git checkout -- .` before the gate and copies them back after; when `.husky/pre-push` is itself dirty, both steps rewrite the hook on disk while it is executing. A peer session switching a shared checkout mid-push rewrites it the same way. A shell may re-read a running script from disk between top-level commands, so a mid-run rewrite can corrupt execution, up to and including the final gate exit status that decides whether the push proceeds.

## Fix

Wrap the body (everything after the sh-to-bash re-exec) in a brace group. The shell parses the entire group before executing any of it, and every code path exits inside the group, so the on-disk file is never read again once execution starts. No behavior change; the diff is a comment block, `{`, and `}`.

## Evidence

Run with `.husky/pre-push` itself dirty (marker line inserted before the final exit), so the save/revert/restore cycle rewrites the running hook on disk mid-run:

```text
pre-run status:  M .husky/pre-push
Saving uncommitted files before gate...
  Saved 1 file(s)
Running CI gate for protected branch 'test' ...
[stub-gate] pnpm gate --no-build --no-test
Restoring saved files...
  Restored 1 file(s)
[dirty-marker] post-restore code still executing from the parsed-in-memory hook
exit=0
post-run status:  M .husky/pre-push    (dirty edit preserved)
```

Tag-only push with the dirty hook skips before the save dance ever starts:

```text
No branch refs in this push (tags or deletions only); skipping CI gate.
exit=0
```

The six-case scope matrix from #1734 (tag-only skip, protected fires from a non-test checkout, feature phase-1, mixed fires, delete-only skip, gate failure blocks with its exit code) was re-run on the armored hook with identical results, and pushing this branch ran the real phase-1 gate (PASS).

Manual merge only (no `--auto`); merge is the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
