### PR TITLE
docs: currency sweep — retire Supabase/Railway references, fix GitHub posture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,7 +243,7 @@ graph TB
     NeonDB -.optional RAG.-> Supabase
 ```
 
-> **Note on `agent_memories`:** Despite the historical "vector database" framing, `agent_memories` lives in **NeonDB** (not Supabase) because of FK constraints on `sites` / `users`. NeonDB supports `pgvector`. See [`packages/db/src/schema/vector.ts`](https://github.com/RevealUIStudio/revealui/blob/main/packages/db/src/schema/vector.ts) for the canonical comment. The Supabase sidecar today is used for RAG chunk embeddings only; the Phase 7 consolidation goal is to move RAG onto NeonDB pgvector and retire the Supabase sidecar entirely.
+> **Note on `agent_memories`:** Despite the historical "vector database" framing, `agent_memories` lives in **NeonDB** (not Supabase) because of FK constraints on `sites` / `users`. NeonDB supports `pgvector`. See [`packages/db/src/schema/vector.ts`](https://github.com/RevealUIStudio/revealui/blob/main/packages/db/src/schema/vector.ts) for the canonical comment. RAG chunk embeddings likewise live on NeonDB `pgvector`; the historical Supabase RAG sidecar was retired for internal use per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md). Legacy Supabase code remains in tree during phase-out, and new features must not depend on Supabase-specific behavior.
 
 ### When to enable each layer
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,11 +253,11 @@ graph TB
 - Supports `pgvector` for vector embeddings inline with relational data.
 - Serverless / scale-to-zero for variable workload.
 
-#### Supabase RAG sidecar (optional)
+#### Supabase RAG sidecar (retired — legacy)
 
-- Only enable when ingesting large document corpora for retrieval-augmented agent contexts.
-- Today's role per [`memory: project_supabase_usage_minimal`](../../.jv/memory): RAG chunks + a duplicate billing copy (legacy). Auth/storage/realtime/RLS/edge-fn are NOT used.
-- Phase 7 plan: consolidate onto NeonDB pgvector and retire this sidecar.
+- RAG chunk embeddings now live on NeonDB `pgvector` (see NeonDB above); the standalone Supabase RAG sidecar was retired for internal use per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md). Auth/storage/realtime/RLS/edge-fn were never used.
+- Legacy Supabase code remains in tree during phase-out; new features must not depend on Supabase-specific behavior.
+- The customer-facing Supabase MCP adapter (`packages/mcp/src/servers/supabase.ts`) is a separate, retained integration for customers who run Supabase — distinct from RevealUI's own (removed) sidecar usage.
 
 #### ElectricSQL sync (optional)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1311,9 +1311,9 @@ Customer-facing meters should map to business activity rather than upstream infr
 - **Supabase RAG sidecar**: retired for internal use — `rag_chunks` and `agent_memories` now live on NeonDB `pgvector` (per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md)). Legacy Supabase code remains in tree during phase-out; auth / storage / realtime / RLS / edge-functions were never used.
 - **ElectricSQL**: optional sync layer; service connects to NeonDB. Agent tables (`agent_contexts`, `agent_memories`, `conversations`) can be electrified when sync is enabled. Off by default.
 
-### Phase 7: Consolidate RAG onto NeonDB (planned)
+### Phase 7: Consolidate RAG onto NeonDB (RAG cutover landed; legacy phase-out ongoing)
 
-Direction: **Supabase → NeonDB** (move RAG embeddings off the optional sidecar and onto Postgres-primary, retire the Supabase dependency for RAG entirely).
+Direction: **Supabase → NeonDB** (move RAG embeddings off the optional sidecar and onto Postgres-primary, retire the Supabase dependency for RAG entirely). The RAG cutover has landed — `rag_chunks` and `agent_memories` are served from NeonDB `pgvector`; the remaining work is removing legacy Supabase code from the tree. The historical phase order is preserved below for reference.
 
 Phase order (ship-order, not calendar):
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,7 +233,7 @@ graph TB
 
     subgraph Server[Server Database Layer]
         NeonDB[(NeonDB - primary<br/>POSTGRES_URL<br/>REST + agent_memories<br/>via pgvector)]
-        Supabase[(Supabase - optional<br/>SUPABASE_DATABASE_URL<br/>RAG chunk embeddings)]
+        Supabase[(Supabase - legacy sidecar<br/>retired for internal use<br/>RAG now on Neon pgvector)]
     end
 
     React --> ElectricClient

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1308,7 +1308,7 @@ Customer-facing meters should map to business activity rather than upstream infr
 ### Current Status
 
 - **NeonDB primary**: source of truth for everything, including `agent_memories` (NeonDB pgvector)
-- **Supabase RAG sidecar**: optional; today used only for `rag_chunks` plus a legacy duplicate billing copy. Auth / storage / realtime / RLS / edge-functions are unused.
+- **Supabase RAG sidecar**: retired for internal use — `rag_chunks` and `agent_memories` now live on NeonDB `pgvector` (per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md)). Legacy Supabase code remains in tree during phase-out; auth / storage / realtime / RLS / edge-functions were never used.
 - **ElectricSQL**: optional sync layer; service connects to NeonDB. Agent tables (`agent_contexts`, `agent_memories`, `conversations`) can be electrified when sync is enabled. Off by default.
 
 ### Phase 7: Consolidate RAG onto NeonDB (planned)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,7 +70,7 @@ RevealUI is a Postgres-primary stack with comprehensive type safety, optional si
 ### Core Systems
 
 1. **NeonDB (POSTGRES_URL — primary)**: Transactional REST API source. Houses 85 tables including `agent_memories` and other vector-typed tables (NeonDB supports `pgvector`). Source of truth for the application.
-2. **Supabase (SUPABASE_DATABASE_URL — optional RAG sidecar)**: Hosts `rag_chunks` and related embedding tables when an Ollama/cloud RAG path is wired. Phase 7 (in roadmap) consolidates RAG embeddings onto NeonDB pgvector and retires the Supabase sidecar; current usage is minimal.
+2. **Supabase (legacy RAG sidecar — retired for internal use)**: Historically hosted `rag_chunks` and related embedding tables; RAG embeddings now live on NeonDB `pgvector` and the sidecar was retired for internal use per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md). Legacy Supabase code remains in tree during phase-out.
 3. **ElectricSQL (optional sync layer)**: Real-time synchronization for agent contexts and conversations when enabled (env vars are off by default).
 4. **Vercel AI SDK**: Streaming AI completions with React hooks
 5. **Cloudflare R2 (S3-compatible)**: Media and file storage — the sole object-storage backend (GAP-208)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,7 +240,7 @@ graph TB
     ElectricClient --> LocalCache
     ElectricClient <--> ElectricService
     ElectricService <--> NeonDB
-    NeonDB -.optional RAG.-> Supabase
+    NeonDB -.legacy RAG.-> Supabase
 ```
 
 > **Note on `agent_memories`:** Despite the historical "vector database" framing, `agent_memories` lives in **NeonDB** (not Supabase) because of FK constraints on `sites` / `users`. NeonDB supports `pgvector`. See [`packages/db/src/schema/vector.ts`](https://github.com/RevealUIStudio/revealui/blob/main/packages/db/src/schema/vector.ts) for the canonical comment. RAG chunk embeddings likewise live on NeonDB `pgvector`; the historical Supabase RAG sidecar was retired for internal use per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md). Legacy Supabase code remains in tree during phase-out, and new features must not depend on Supabase-specific behavior.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -63,7 +63,7 @@ The older `pnpm db:*` scripts still exist and remain useful as lower-level build
 
 | Command              | Description                                     | File                                   | Environment Variables Required                             |
 | -------------------- | ----------------------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `pnpm db:init`       | Initialize database connection and verify setup | `scripts/setup/database.ts`            | `POSTGRES_URL`, `DATABASE_URL`, or `SUPABASE_DATABASE_URI` |
+| `pnpm db:init`       | Initialize database connection and verify setup | `scripts/setup/database.ts`            | `POSTGRES_URL`, `DATABASE_URL` (or the legacy `SUPABASE_DATABASE_URI`) |
 | `pnpm db:migrate`    | Run Drizzle migrations                          | `scripts/setup/migrations.ts`          | `POSTGRES_URL` or `DATABASE_URL`                           |
 | `pnpm db:reset`      | Drop all tables and recreate schema             | `scripts/setup/reset-database.ts`      | Same as init                                               |
 | `pnpm db:seed`       | Seed the database — composite of the three seeders below | `apps/admin/src/seed.ts`, `scripts/seed-fleet-marketing-site.ts`, `scripts/setup/seed-billing.ts` | Same as init                          |

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -130,7 +130,7 @@ pnpm revealui dev up
 
 - `DATABASE_URL` (primary)
 - `POSTGRES_URL` (fallback)
-- `SUPABASE_DATABASE_URI` (Supabase-specific)
+- `SUPABASE_DATABASE_URI` (Supabase-specific — legacy, being retired; see the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md))
 
 **Usage:**
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -311,7 +311,7 @@ pnpm db:status
 
 - `DATABASE_URL` - PostgreSQL connection string
 - `POSTGRES_URL` - Alternative name (Neon convention)
-- `SUPABASE_DATABASE_URI` - Supabase-specific
+- `SUPABASE_DATABASE_URI` - Supabase-specific (legacy, being retired)
 
 **Format:**
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -9,7 +9,7 @@ audience: developer
 
 This guide describes the RevealUI database workflow and the underlying database scripts it orchestrates across different development environments.
 
-**Last Updated:** 2026-01-31
+**Last Updated:** 2026-07-04
 
 ---
 
@@ -755,7 +755,7 @@ pnpm db:restore backup.json
 
 ---
 
-**Last Updated:** 2026-01-31
+**Last Updated:** 2026-07-04
 **Part of:** Development Guide consolidation
 
 ---

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -353,8 +353,8 @@ Update the deployment step in `.github/workflows/staging-performance.yml`:
     # Vercel
     npx vercel --prod=false
 
-    # Railway
-    railway deploy
+    # Fly.io (Railway was the retired origin — dropped per ADR 2026-05-18)
+    flyctl deploy
 
     # Render
     # Configure webhook deployment

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -18,7 +18,7 @@ latency on shape queries via the worker's Hono app surface).
 | Fly app | Purpose | Status |
 |---------|---------|--------|
 | `revealui-worker` | apps/server long-running subset (alerting, Yjs collab WS, agent-collab WS, terminal-ws Forge-gated, RVMarket executor flag-gated) | Phase 3 — scaffolded, first deploy pending |
-| `revealui-electric` | ElectricSQL sync service, replicates from Neon | Phase 5 — Electric cutover from Railway |
+| `revealui-electric` | ElectricSQL sync service, replicates from Neon | Phase 5 — Electric cutover from the retired Railway host (ADR 2026-05-18) |
 
 ## First deploy (one-time setup)
 

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -166,6 +166,6 @@ unhealthy. Investigate via `flyctl logs --app revealui-worker`.
 ElectricSQL Fly setup lives in a separate `fly.electric.toml`
 (landing in Phase 5 of the infra-consolidation lane). Same region
 (iad), same Fly account. Connects to the same Neon `POSTGRES_URL`
-the worker uses. The cutover from Railway-hosted Electric to
-Fly-hosted Electric is the load-bearing piece of Phase 5 — see the
-lane plan for sequencing.
+the worker uses. The cutover from the retired Railway-hosted Electric
+(dropped per ADR 2026-05-18) to Fly-hosted Electric is the load-bearing
+piece of Phase 5 — see the lane plan for sequencing.

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -81,14 +81,20 @@ Each vendor is evaluated against the following criteria:
 
 ---
 
-### 3.2 Supabase (Secondary Database — legacy, phasing out)
+### 3.2 Supabase — DECOMMISSIONED (internal datastore usage removed)
 
-> **Status note (2026-05-29):** Supabase is a *legacy secondary* store being phased out per ADR [`2026-05-01-supabase-removal`](https://github.com/RevealUIStudio/revealui/blob/main/docs/decisions/2026-05-01-supabase-removal.md) (target: NeonDB-primary + ElectricSQL). It remains in service during phase-out, so this assessment stays in force; new features must not add Supabase dependencies. The retained Supabase MCP adapter is a customer-facing integration, separate from internal usage.
+> **Decommissioned (internal usage) per ADR [`2026-05-01-supabase-removal`](https://github.com/RevealUIStudio/revealui/blob/main/docs/decisions/2026-05-01-supabase-removal.md).** RevealUI's internal Supabase datastore dependency has been removed: RAG chunk embeddings and vector tables now live on NeonDB `pgvector`, and auth/storage/realtime/RLS/edge-fn were never used. Legacy Supabase code remains in tree during phase-out (final code removal tracked separately); no new features may depend on Supabase.
+>
+> The customer-facing Supabase **MCP adapter** (`packages/mcp/src/servers/supabase.ts`) is a *retained customer integration* — it is not a RevealUI vendor data dependency and is out of scope for this assessment.
+>
+> The vendor assessment below is retained as a **historical** record for the audit trail. RevealUI holds no active Supabase data dependency, so there is no forward review date.
 
 **Vendor:** Supabase Inc.
-**Service:** Managed PostgreSQL + pgvector, Auth (legacy secondary — phase-out in progress)
+**Service:** Managed PostgreSQL + pgvector, Auth (decommissioned as an internal RevealUI datastore)
 **Asset ID:** DS-002, TP-006 (see Asset Inventory)
-**Data classification:** Confidential (vector embeddings, OAuth linkage)
+**Data classification:** Confidential (historical — vector embeddings, OAuth linkage)
+
+_Historical assessment (retained for audit trail):_
 
 | Category | Assessment | Notes |
 |----------|-----------|-------|
@@ -105,19 +111,18 @@ Each vendor is evaluated against the following criteria:
 | Data portability | Standard PostgreSQL + pg_dump | Standard migration path |
 | Backup/Recovery | Daily snapshots (provider-managed) | RPO: 24 hours, RTO: hours |
 
-**Data shared with Supabase:**
-- Vector embeddings for RAG functionality
+**Data formerly shared with Supabase:**
+- Vector embeddings for RAG functionality (now on NeonDB `pgvector`)
 - OAuth account linkage records
-- Auth session data (where Supabase Auth is used)
+- Auth session data (where Supabase Auth was used)
 
-**Compensating controls:**
+**Historical compensating controls:**
 - Service role keys restricted to server-side use only
 - Anon keys have RLS policies enforced
 - Cross-DB cleanup (`@revealui/db/cleanup`) handles orphaned data after site deletion
 - Supabase imports restricted to permitted paths via `supabase-boundary.js` hook
 
-**Risk rating:** Low
-**Next review:** 2026-07-12
+**Status:** Decommissioned as an internal datastore (ADR 2026-05-01) — RAG/vectors migrated to NeonDB `pgvector`; legacy code phase-out tracked separately. No forward review.
 
 ---
 

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -302,3 +302,4 @@ A vendor replacement is triggered if:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-12 | RevealUI Studio | Initial vendor risk assessments for all five vendors. |
+| 2026-07-04 | RevealUI Studio | Internal audit (2026-07-03): Supabase (§3.2 + Risk Summary) marked decommissioned — internal datastore usage removed per ADR 2026-05-01 (RAG/vectors on NeonDB `pgvector`); customer-facing MCP adapter noted as a retained, out-of-scope integration. Corrected GitHub posture to a single-owner **User** account (account-level access controls / 2FA / security log), not a GitHub Organization. |

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -217,9 +217,9 @@ Each vendor is evaluated against the following criteria:
 | DPA | In effect | GitHub DPA covers npm (TP-004) as well |
 | Encryption at rest | AES-256 | Repository data, secrets encrypted |
 | Encryption in transit | TLS 1.2+ | All GitHub traffic encrypted |
-| Access controls | Organization RBAC, branch protection, CODEOWNERS | Meets requirements |
-| MFA | Required for all org members | Enforced at organization level |
-| Audit logging | Organization audit log | Available for security events |
+| Access controls | Account-level permissions, branch protection + required status checks (public repos), CODEOWNERS | Single-owner **User** account (not a GitHub Organization) |
+| MFA | Enabled on the account owner | Account-level 2FA (single-owner User account) |
+| Audit logging | Account security log | Org-level audit log not applicable (User account) |
 | Incident response | Documented | Status page at githubstatus.com |
 | Breach notification | Per DPA terms | Timely notification committed |
 | SLA uptime | 99.9% | Meets requirements |

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -235,7 +235,7 @@ Each vendor is evaluated against the following criteria:
 - Security scanning results (CodeQL, Dependabot, Gitleaks)
 
 **Compensating controls:**
-- Two-factor authentication required for organization membership
+- Two-factor authentication enabled on the account owner (single-owner User account)
 - Branch protection on `main` and `test` (require CI pass before merge)
 - npm publishing uses OIDC trusted publishing (no long-lived NPM_TOKEN)
 - SLSA Build Level 2 provenance attestations on published packages

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -254,7 +254,7 @@ _Historical assessment (retained for audit trail):_
 | Vendor | Asset IDs | Risk Rating | Key Strengths | Watchlist Items |
 |--------|-----------|-------------|---------------|-----------------|
 | Neon | DS-001, TP-005 | Low | SOC 2 Type II, PITR, standard PostgreSQL | Monitor for pricing changes, verify DPA annually |
-| Supabase (legacy, phasing out) | DS-002, TP-006 | Low | SOC 2 Type II, RLS, pgvector | Phase-out in progress (ADR 2026-05-01) → NeonDB pgvector; no new Supabase dependencies; verify DPA while in service |
+| ~~Supabase~~ (DECOMMISSIONED — internal datastore usage removed) | DS-002, TP-006 | n/a | _(historical)_ SOC 2 Type II, RLS, pgvector | Decommissioned as an internal datastore (ADR 2026-05-01) → RAG/vectors on NeonDB pgvector; legacy code phase-out tracked separately; customer-facing MCP adapter retained separately (not a RevealUI data dependency) |
 | Vercel | TP-001 | Low | SOC 2 Type II, 99.99% SLA, instant rollback | Monitor for env var handling changes |
 | Stripe | TP-002 | Low | PCI DSS L1, SOC 2 Type II, no card data exposure | Monitor test-to-live mode transition readiness |
 | GitHub | TP-003, TP-004 | Low | SOC 2 Type II, OIDC publishing, secret scanning | Monitor for Actions pricing changes, audit log retention |


### PR DESCRIPTION
## Doc currency sweep (internal audit, 2026-07-03)

Second of two file-disjoint doc-only PRs from an internal audit (2026-07-03). Refreshes tracked docs that still described retired infrastructure as current. No code changes; served twins under `apps/docs/` are untracked build output and are not touched.

### Changes
- **`docs/ARCHITECTURE.md`** — RAG described as running on the retired Supabase sidecar; rewritten to Neon/pgvector per the 2026-05-01 Supabase-removal ADR. The retained customer-facing Supabase MCP adapter is kept distinct from the removed internal datastore usage. *Scope note:* the edit extends beyond the originally-flagged lines to resolve same-file self-contradiction (mermaid node/edge, migration-strategy status, Core Systems list) so the doc is internally consistent.
- **`docs/DATABASE.md`** — refreshed `Last Updated` to 2026-07-04; demoted `SUPABASE_DATABASE_URI` to a legacy note across the env table, priority-order list, and primary datastore list (with ADR link).
- **`docs/PERFORMANCE.md`** — deploy example switched from Railway (dropped per ADR 2026-05-18) to Fly.io, with Railway noted as the retired origin.
- **`docs/deployment/fly.md`** — Electric references clarified as a cutover from the retired Railway host (ADR 2026-05-18).
- **`docs/security/VENDOR_RISK_ASSESSMENTS.md`** — corrected GitHub posture to an account-level single-owner User account (RevealUIStudio is a User on Free, not an Organization), including the compensating-control note; marked the Supabase vendor entry **DECOMMISSIONED** (internal datastore usage removed), preserving the historical assessment and flagging the retained MCP adapter as out of scope. *Convention note:* decommission is marked in-place (matching the RevealCoin precedent in this file) rather than physically relocating the section, to avoid anchor/cross-ref churn. Change-log entry added.

### Follow-up (out of scope for this PR)
- Sibling docs `docs/security/ASSET_INVENTORY.md` and `docs/security/SOC2_AUDIT_TRACK.md` (both dated 2026-05-29) still describe Supabase as "phasing out / in service" — they drift from the decommission recorded here and should be reconciled in a later pass.

File-disjoint from the leak-scrub PR (#1731, merged).
