### PR TITLE
ci: enforce react RSC CVE floor (resolve >=19.2.4, lockstep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Version policy validation
         run: pnpm validate:versions
 
+      - name: React RSC CVE floor validation (hard fail)
+        # react / react-dom / react-server-dom-webpack must each RESOLVE at
+        # >=19.2.4 (final fix for the Dec-2025 React RSC CVE series:
+        # CVE-2025-55182 "React2Shell" RCE, CVE-2025-55184/55183,
+        # CVE-2025-67779) and in lockstep: version skew between react and
+        # its server-dom binding is an RSC flight-protocol failure mode.
+        # Reads resolved versions (pnpm virtual store), not declared ranges;
+        # absent packages pass, so the guard engages automatically when
+        # @revealui/router 0.4.0 adds react-server-dom-webpack. Mirrors the
+        # local gate step in scripts/gates/ci-gate.ts.
+        run: pnpm validate:react-floor
+
       - name: Boundary validation (hard fail)
         run: pnpm validate:boundary
 

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",
     "validate:brand-bridge": "tsx scripts/validate/brand-bridge.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",
+    "validate:react-floor": "tsx scripts/validate/react-rsc-floor.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
     "validate:citations": "tsx scripts/validate/citation-check.ts",
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -273,6 +273,16 @@ async function gate(): Promise<void> {
         args: ['validate:versions'],
       },
       {
+        // Dec-2025 React RSC CVE series (CVE-2025-55182 "React2Shell" +
+        // follow-ups; final fix 19.2.4): react / react-dom /
+        // react-server-dom-webpack must RESOLVE >=19.2.4 and in lockstep.
+        // Absent packages pass. Mirrored in CI by the Quality job step in
+        // .github/workflows/ci.yml.
+        name: 'React RSC CVE floor (hard fail)',
+        command: 'pnpm',
+        args: ['validate:react-floor'],
+      },
+      {
         name: 'Catalog changeset check',
         command: 'pnpm',
         args: ['validate:catalog'],

--- a/scripts/validate/__tests__/react-rsc-floor.test.ts
+++ b/scripts/validate/__tests__/react-rsc-floor.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectResolvedVersions,
+  compareVersions,
+  evaluateFloor,
+  LOCKSTEP_PACKAGES,
+  parseVersion,
+  REACT_RSC_FLOOR,
+} from '../react-rsc-floor';
+
+function resolvedMap(entries: Record<string, readonly string[]>): Map<string, readonly string[]> {
+  return new Map(Object.entries(entries));
+}
+
+describe('parseVersion', () => {
+  it('parses a stable release', () => {
+    expect(parseVersion('19.2.7')).toEqual({ major: 19, minor: 2, patch: 7, prerelease: null });
+  });
+
+  it('parses a pre-release suffix', () => {
+    expect(parseVersion('19.2.4-canary-abc123')).toEqual({
+      major: 19,
+      minor: 2,
+      patch: 4,
+      prerelease: 'canary-abc123',
+    });
+  });
+
+  it('ignores build metadata', () => {
+    expect(parseVersion('19.2.4+build.5')).toEqual({
+      major: 19,
+      minor: 2,
+      patch: 4,
+      prerelease: null,
+    });
+  });
+
+  it('rejects cores that are not exactly three segments', () => {
+    expect(parseVersion('19.2')).toBeNull();
+    expect(parseVersion('19.2.4.1')).toBeNull();
+    expect(parseVersion('')).toBeNull();
+  });
+
+  it('rejects non-numeric segments', () => {
+    expect(parseVersion('19.2.x')).toBeNull();
+    expect(parseVersion('19.2.7a')).toBeNull();
+    expect(parseVersion('workspace:*')).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  function mustParseForTest(version: string) {
+    const parsed = parseVersion(version);
+    if (!parsed) throw new Error(`test version must parse: ${version}`);
+    return parsed;
+  }
+
+  function cmp(a: string, b: string): number {
+    return compareVersions(mustParseForTest(a), mustParseForTest(b));
+  }
+
+  it('orders by major, minor, patch', () => {
+    expect(cmp('18.9.9', '19.0.0')).toBeLessThan(0);
+    expect(cmp('19.1.9', '19.2.0')).toBeLessThan(0);
+    expect(cmp('19.2.3', '19.2.4')).toBeLessThan(0);
+    expect(cmp('19.3.0', '19.2.4')).toBeGreaterThan(0);
+  });
+
+  it('treats identical stable versions as equal', () => {
+    expect(cmp('19.2.4', '19.2.4')).toBe(0);
+  });
+
+  it('orders a pre-release BEFORE its stable release (the semver rule the floor depends on)', () => {
+    expect(cmp('19.2.4-canary-1', '19.2.4')).toBeLessThan(0);
+    expect(cmp('19.2.4', '19.2.4-canary-1')).toBeGreaterThan(0);
+  });
+});
+
+describe('evaluateFloor', () => {
+  it('pins the floor constant to the final fix of the Dec-2025 CVE series', () => {
+    // Lowering this constant is a security decision, not a refactor: the
+    // test forces any such change to touch this file and say why.
+    expect(REACT_RSC_FLOOR).toBe('19.2.4');
+    expect([...LOCKSTEP_PACKAGES]).toEqual(['react', 'react-dom', 'react-server-dom-webpack']);
+  });
+
+  it('passes when all three resolve lockstep above the floor', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.7'],
+        'react-dom': ['19.2.7'],
+        'react-server-dom-webpack': ['19.2.7'],
+      }),
+    );
+    expect(report.violations).toEqual([]);
+  });
+
+  it('passes at exactly the floor (boundary)', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.4'],
+        'react-dom': ['19.2.4'],
+        'react-server-dom-webpack': ['19.2.4'],
+      }),
+    );
+    expect(report.violations).toEqual([]);
+  });
+
+  it('passes with react-server-dom-webpack absent (pre-router-0.4.0 state) and says so', () => {
+    const report = evaluateFloor(
+      resolvedMap({ react: ['19.2.7'], 'react-dom': ['19.2.7'], 'react-server-dom-webpack': [] }),
+    );
+    expect(report.violations).toEqual([]);
+    const skipLine = report.summary.find((line) => line.startsWith('react-server-dom-webpack'));
+    expect(skipLine).toContain('absent');
+  });
+
+  it('passes vacuously when none of the three are installed (absence is not exposure)', () => {
+    expect(evaluateFloor(new Map<string, string[]>()).violations).toEqual([]);
+  });
+
+  it('fails every resolution below the floor and names the CVE series', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.3'],
+        'react-dom': ['19.2.3'],
+        'react-server-dom-webpack': ['19.2.3'],
+      }),
+    );
+    const belowFloor = report.violations.filter((violation) => violation.rule === 'below-floor');
+    expect(belowFloor).toHaveLength(3);
+    expect(belowFloor[0]?.detail).toContain('CVE-2025-55182');
+  });
+
+  it('fails a pre-release of the floor version (19.2.4-canary is below 19.2.4)', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.4'],
+        'react-dom': ['19.2.4'],
+        'react-server-dom-webpack': ['19.2.4-canary-abc'],
+      }),
+    );
+    expect(report.violations.map((violation) => violation.rule)).toContain('below-floor');
+  });
+
+  it('fails lockstep skew even when every version clears the floor', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.7'],
+        'react-dom': ['19.2.6'],
+        'react-server-dom-webpack': ['19.2.7'],
+      }),
+    );
+    expect(report.violations).toHaveLength(1);
+    expect(report.violations[0]?.rule).toBe('version-skew');
+    expect(report.violations[0]?.detail).toContain('react-dom=19.2.6');
+  });
+
+  it('fails when one package resolves to multiple versions (skew within a package)', () => {
+    const report = evaluateFloor(
+      resolvedMap({
+        react: ['19.2.7', '19.3.0'],
+        'react-dom': ['19.2.7'],
+        'react-server-dom-webpack': [],
+      }),
+    );
+    expect(report.violations.map((violation) => violation.rule)).toContain('version-skew');
+  });
+
+  it('fails closed on an unparseable resolved version', () => {
+    const report = evaluateFloor(resolvedMap({ react: ['not-semver'] }));
+    expect(report.violations.map((violation) => violation.rule)).toContain('unparseable-version');
+  });
+});
+
+describe('collectResolvedVersions', () => {
+  it('reads react from the real pnpm virtual store (pnpm-layout drift guard)', () => {
+    // If the .pnpm directory layout ever changes shape, the collector would
+    // report every package absent and the floor would pass vacuously. react
+    // is always installed in this repo, so an empty result means collector
+    // drift, not a react-free workspace.
+    const resolved = collectResolvedVersions();
+    const reactVersions = resolved.get('react') ?? [];
+    expect(reactVersions.length).toBeGreaterThan(0);
+    for (const version of reactVersions) {
+      expect(parseVersion(version)).not.toBeNull();
+    }
+  });
+
+  it('throws (fail-closed) when the virtual store is missing', () => {
+    expect(() => collectResolvedVersions('scripts/validate/__tests__/no-such-root')).toThrow(
+      'pnpm install',
+    );
+  });
+});

--- a/scripts/validate/react-rsc-floor.ts
+++ b/scripts/validate/react-rsc-floor.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env tsx
+
+/**
+ * React RSC CVE Floor Validation
+ *
+ * Enforces the resolved-version security floor for the December-2025 React
+ * RSC CVE series: CVE-2025-55182 "React2Shell" (CVSS 10.0 unauthenticated
+ * RCE via flight-protocol deserialization at Server Function endpoints),
+ * CVE-2025-55184 (DoS) + CVE-2025-55183 (source exposure), and
+ * CVE-2025-67779 (follow-up for the incomplete DoS fix). The final fixed
+ * floor is 19.2.4 (react.dev advisories 2025-12-03 and 2025-12-11).
+ *
+ * Rules:
+ *   1. react, react-dom, and react-server-dom-webpack must each RESOLVE at
+ *      >=19.2.4. Resolved versions come from node_modules/.pnpm metadata,
+ *      not declared ranges, so catalog drift or a pnpm override below the
+ *      floor is caught.
+ *   2. All resolved copies of the three must be ONE identical version:
+ *      skew between react and its server-dom binding is itself a failure
+ *      mode for the RSC flight protocol.
+ *   3. A package absent from the dependency graph passes (absence is not
+ *      exposure). react-server-dom-webpack is not a dependency today; it
+ *      arrives with @revealui/router 0.4.0 RSC mode and this check starts
+ *      guarding it automatically.
+ *
+ * Source: internal RSC-router design re-audit (2026-07-04), finding F8.
+ *
+ * @dependencies
+ * - node:fs - File system operations
+ * - node:path - Path manipulation
+ * - node:url - import.meta.url to filesystem path
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Final fixed version for the Dec-2025 React RSC CVE series. */
+export const REACT_RSC_FLOOR = '19.2.4';
+
+/** The flight-protocol trio that must clear the floor in lockstep. */
+export const LOCKSTEP_PACKAGES = ['react', 'react-dom', 'react-server-dom-webpack'] as const;
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Pre-release suffix (e.g. "canary-abc"), null for stable releases. */
+  prerelease: string | null;
+}
+
+function isAllDigits(segment: string): boolean {
+  if (segment.length === 0) return false;
+  for (const char of segment) {
+    if (char < '0' || char > '9') return false;
+  }
+  return true;
+}
+
+/**
+ * Structured semver parse (no regex, per repo convention): strip build
+ * metadata (+) and pre-release (-), then require exactly three numeric
+ * dot-separated core segments.
+ */
+export function parseVersion(version: string): ParsedVersion | null {
+  const plusIndex = version.indexOf('+');
+  const withoutBuild = plusIndex === -1 ? version : version.slice(0, plusIndex);
+  const dashIndex = withoutBuild.indexOf('-');
+  const core = dashIndex === -1 ? withoutBuild : withoutBuild.slice(0, dashIndex);
+  const prerelease = dashIndex === -1 ? null : withoutBuild.slice(dashIndex + 1);
+
+  const segments = core.split('.');
+  if (segments.length !== 3) return null;
+  const [majorRaw, minorRaw, patchRaw] = segments;
+  if (majorRaw === undefined || minorRaw === undefined || patchRaw === undefined) return null;
+  if (!(isAllDigits(majorRaw) && isAllDigits(minorRaw) && isAllDigits(patchRaw))) return null;
+
+  return {
+    major: Number.parseInt(majorRaw, 10),
+    minor: Number.parseInt(minorRaw, 10),
+    patch: Number.parseInt(patchRaw, 10),
+    prerelease,
+  };
+}
+
+/**
+ * Compare parsed versions. A pre-release orders BEFORE its stable release
+ * (19.2.4-canary < 19.2.4) per semver, which the floor check depends on.
+ * Ordering BETWEEN two pre-releases of the same core is plain string
+ * comparison; floor and lockstep verdicts never depend on it.
+ */
+export function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+  if (a.prerelease === null && b.prerelease === null) return 0;
+  if (a.prerelease === null) return 1;
+  if (b.prerelease === null) return -1;
+  if (a.prerelease < b.prerelease) return -1;
+  if (a.prerelease > b.prerelease) return 1;
+  return 0;
+}
+
+/**
+ * Read every resolved copy of the lockstep packages from the pnpm virtual
+ * store (node_modules/.pnpm/<pkg>@<version>[peer-suffix]/node_modules/
+ * <pkg>/package.json). The inner manifest is the authority; directory
+ * names are only a cheap prefix filter, so peer-suffix naming changes
+ * cannot skew the result. Multiple installed copies of one package
+ * surface as multiple versions.
+ *
+ * Throws when the virtual store is missing: "cannot verify" must fail the
+ * gate loudly instead of passing vacuously.
+ */
+export function collectResolvedVersions(root: string = ROOT): Map<string, string[]> {
+  const virtualStore = join(root, 'node_modules', '.pnpm');
+  if (!existsSync(virtualStore)) {
+    throw new Error(
+      `pnpm virtual store not found at ${virtualStore} - run pnpm install first; ` +
+        'resolved versions cannot be verified without it',
+    );
+  }
+
+  const found = new Map<string, Set<string>>();
+  for (const name of LOCKSTEP_PACKAGES) {
+    found.set(name, new Set());
+  }
+
+  for (const entry of readdirSync(virtualStore)) {
+    const name = LOCKSTEP_PACKAGES.find((candidate) => entry.startsWith(`${candidate}@`));
+    if (!name) continue;
+    const manifestPath = join(virtualStore, entry, 'node_modules', name, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      name?: unknown;
+      version?: unknown;
+    };
+    if (manifest.name === name && typeof manifest.version === 'string') {
+      found.get(name)?.add(manifest.version);
+    }
+  }
+
+  return new Map([...found].map(([name, versions]) => [name, [...versions].sort()]));
+}
+
+export type FloorViolationRule = 'below-floor' | 'version-skew' | 'unparseable-version';
+
+export interface FloorViolation {
+  rule: FloorViolationRule;
+  detail: string;
+}
+
+export interface FloorReport {
+  violations: FloorViolation[];
+  /** One human-readable line per tracked package: resolved versions or absence. */
+  summary: string[];
+}
+
+function mustParse(version: string): ParsedVersion {
+  const parsed = parseVersion(version);
+  if (!parsed) throw new Error(`unparseable version constant: ${version}`);
+  return parsed;
+}
+
+const FLOOR_PARSED = mustParse(REACT_RSC_FLOOR);
+
+export function evaluateFloor(resolved: ReadonlyMap<string, readonly string[]>): FloorReport {
+  const violations: FloorViolation[] = [];
+  const summary: string[] = [];
+  const distinctVersions = new Set<string>();
+  const presentLines: string[] = [];
+
+  for (const name of LOCKSTEP_PACKAGES) {
+    const versions = resolved.get(name) ?? [];
+    if (versions.length === 0) {
+      summary.push(
+        `${name}: absent from the dependency graph, skipped (guard engages when it lands)`,
+      );
+      continue;
+    }
+    summary.push(`${name}: ${versions.join(', ')}`);
+    presentLines.push(`${name}=${versions.join(',')}`);
+
+    for (const version of versions) {
+      distinctVersions.add(version);
+      const parsed = parseVersion(version);
+      if (!parsed) {
+        violations.push({
+          rule: 'unparseable-version',
+          detail:
+            `${name}@${version} is not parseable semver; ` +
+            `the >=${REACT_RSC_FLOOR} floor cannot be verified against it`,
+        });
+        continue;
+      }
+      if (compareVersions(parsed, FLOOR_PARSED) < 0) {
+        violations.push({
+          rule: 'below-floor',
+          detail:
+            `${name}@${version} resolves below ${REACT_RSC_FLOOR}, the final fix for the ` +
+            'Dec-2025 React RSC CVE series (CVE-2025-55182 "React2Shell" RCE, ' +
+            'CVE-2025-55184 DoS, CVE-2025-55183 source exposure, CVE-2025-67779 follow-up)',
+        });
+      }
+    }
+  }
+
+  if (distinctVersions.size > 1) {
+    violations.push({
+      rule: 'version-skew',
+      detail:
+        'react / react-dom / react-server-dom-webpack must resolve to one identical version ' +
+        `(RSC flight-protocol lockstep); found ${distinctVersions.size} distinct: ` +
+        presentLines.join('; '),
+    });
+  }
+
+  return { violations, summary };
+}
+
+function main(): void {
+  process.stdout.write('Validating React RSC CVE floor (resolved versions)...\n\n');
+
+  let resolved: Map<string, string[]>;
+  try {
+    resolved = collectResolvedVersions();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`validate:react-floor FAIL\n${message}\n`);
+    process.exit(1);
+  }
+
+  const { violations, summary } = evaluateFloor(resolved);
+
+  for (const line of summary) {
+    process.stdout.write(`  ${line}\n`);
+  }
+
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      process.stderr.write(`  [${violation.rule}] ${violation.detail}\n`);
+    }
+    process.stderr.write(
+      '\nReact RSC CVE floor: FAIL - hold react, react-dom, and react-server-dom-webpack ' +
+        `at >=${REACT_RSC_FLOOR}, lockstep-exact (react.dev advisories 2025-12-03 / 2025-12-11)\n`,
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `\nReact RSC CVE floor: PASS (floor ${REACT_RSC_FLOOR}, lockstep verified)\n`,
+  );
+}
+
+const isMainModule = process.argv[1] ? import.meta.url === `file://${process.argv[1]}` : false;
+if (isMainModule) main();


### PR DESCRIPTION
## What

Adds a hard-fail CI guard for the December-2025 React RSC CVE series (CVE-2025-55182 "React2Shell" RCE, CVE-2025-55184 DoS, CVE-2025-55183 source exposure, CVE-2025-67779 incomplete-fix follow-up; final fixed floor **19.2.4**):

- **New validator** `scripts/validate/react-rsc-floor.ts` (`pnpm validate:react-floor`): fails if any of `react`, `react-dom`, `react-server-dom-webpack` **resolves** below 19.2.4, or if the three disagree on resolved version (lockstep skew is itself a failure mode for the RSC flight protocol).
- Reads **resolved** versions from the pnpm virtual store (`node_modules/.pnpm` inner manifests), not declared ranges, so catalog drift or a pnpm override below the floor is caught. A missing virtual store fails closed instead of passing vacuously.
- **Package absent = PASS**: `react-server-dom-webpack` is not a dependency today; it arrives with `@revealui/router` 0.4.0 RSC mode, and the guard engages automatically at that point. Today's resolution (react / react-dom 19.2.7 via the workspace catalog) passes.
- Wired into the local gate Phase 1 (`scripts/gates/ci-gate.ts`) and the CI Quality job (`.github/workflows/ci.yml`), following the existing validator pattern (closest sibling: `validate:versions`). No regex: structured semver parse and comparison.
- Unit tests in `scripts/validate/__tests__/react-rsc-floor.test.ts` (20 tests): floor boundary (19.2.4 passes, 19.2.3 fails), pre-release-below-floor, lockstep skew (including multiple resolved copies of one package), absent-package pass, unparseable-version fail-closed, missing-store fail-closed, and a pnpm-layout drift guard (the collector must find react in the real store; an empty result means collector drift, not a react-free workspace).

## Why

The RSC action endpoint is exactly the surface this CVE series binds (unauthenticated RCE via flight-protocol deserialization at Server Function endpoints). The router design was written against react 19.2.6, so the floor was invisibly satisfied rather than deliberately held. This encodes it as CI enforcement before the router work resumes. Source: internal RSC-router design re-audit (2026-07-04), finding F8; the kickoff-spec amendment records that the CI floor-check lands separately as a Tier-0-safe change.

## Verification (local, WSL-native)

- `pnpm validate:react-floor` standalone: PASS. Output: `react: 19.2.7`, `react-dom: 19.2.7`, `react-server-dom-webpack: absent from the dependency graph, skipped (guard engages when it lands)`.
- `pnpm gate:quick` (Phase 1, 23 checks including the new one): PASS. `React RSC CVE floor (hard fail)` green.
- `pnpm exec vitest run scripts/validate/__tests__/react-rsc-floor.test.ts`: 20/20 passed.
- Biome clean on all touched files.
- `pnpm-lock.yaml` untouched (no dependency changes in this PR).

Note: the `scripts/validate/__tests__/` suite is local-run (no root turbo test task wires it into CI today, same as the existing suite there); the CI enforcement surface for this change is the Quality-job step plus the gate.

## Merge

Base `test`, manual merge, no `--auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
