### PR TITLE
docs: neutralize private-hub citations in public docs and comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Key postures — full definitions in `docs/methodology.md`.
 - Extensive test suite across unit, integration, and E2E layers (run `pnpm test` for current count)
 - Pinned overrides enforce minimum safe versions for transitive deps (see `pnpm.overrides` block in root `package.json`)
 - React 19 (resolved patch tracked via `pnpm-lock.yaml`; minimum-safe range pinned per `pnpm.overrides`; CVE-2025-55182 React2Shell mitigated)
-- GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; future triage trackers land in the private `revealui-jv` repo per the issue-redaction convention
+- GitHub security alerts (CodeQL + Dependabot) monitored via the Security tab; future triage trackers land in the private coordination hub per the issue-redaction convention
 - AST-based code-pattern analyzer: execSync injection, TOCTOU, ReDoS (ret parser + contracts schemas)
 - Pre-push gate runs affected tests on protected branches
 - Run `pnpm audit:any` and `pnpm audit:console` for current any/console counts (warn-only)

--- a/apps/admin/src/components/TestModeBanner.tsx
+++ b/apps/admin/src/components/TestModeBanner.tsx
@@ -6,7 +6,7 @@
  * Shows a warning above billing CTAs when Stripe is running in test mode
  * (publishable key prefix `pk_test_*` OR no key configured). Live mode is
  * gated on the billing-readiness audit per the locked posture in
- * `revealui-jv` MASTER_PLAN; this banner makes the test-mode posture
+ * the internal master plan; this banner makes the test-mode posture
  * explicit so users do not assume cards will be charged.
  *
  * Detection: client-side `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` prefix.

--- a/apps/marketing/app/components/landing/Fork.tsx
+++ b/apps/marketing/app/components/landing/Fork.tsx
@@ -3,7 +3,7 @@
 // landed: "built for me" is now the non-technical mode itself (the in-hero
 // Technical/Non-technical switch), so this fork only carries the two technical
 // paths — build it yourself (A) and build it for your clients (C).
-// Original spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §4.3.
+// Original spec: internal non-technical-lane spec (2026-05-14) §4.3.
 
 import { HOME_FORK } from '../../content/home';
 

--- a/apps/marketing/app/content/capabilities.ts
+++ b/apps/marketing/app/content/capabilities.ts
@@ -1,5 +1,5 @@
 // Sourced from: app/components/landing/WhatsShipped.tsx (Phase 1c, no copy changes).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from './site';
 

--- a/apps/marketing/app/content/contact.ts
+++ b/apps/marketing/app/content/contact.ts
@@ -1,4 +1,4 @@
-// Sourced from: app/routes/ContactPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/ContactPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from './site';
 

--- a/apps/marketing/app/content/fair-source.ts
+++ b/apps/marketing/app/content/fair-source.ts
@@ -4,7 +4,7 @@
 // MIT" was off-by-one — pre-Phase-3 audit counted create-revealui (MIT, separate
 // workspace) into the 21 but didn't account for the internal-only `test` workspace.
 // New phrasing: "20 of 26 MIT" + explicit accounting in the body prose.
-// Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
+// Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 
 import { METRICS, SITE } from './site';
 import type { FaqItem } from './types';

--- a/apps/marketing/app/content/for-operators-how-it-works.ts
+++ b/apps/marketing/app/content/for-operators-how-it-works.ts
@@ -7,8 +7,8 @@
 // - OQ-6: agency-site coupling — CTA routes to ${SITE.urls.agency}/contact.
 //
 // Voice constraints honored:
-// - The 5 voice rules (R1-R5) per docs/lanes/_closed/messaging-funnel-audit/
-//   voice-and-headline-rules.md.
+// - The 5 voice rules (R1-R5) per the internal messaging-funnel audit
+//   (voice-and-headline rules).
 // - Operator-lane register per non-technical-lane spec §7 (first-person plural
 //   about the studio + third-person about the runtime + second-person about
 //   the operator).

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -1,4 +1,4 @@
-// Sourced from `~/revfleet/.jv/docs/specs/2026-05-28-for-operators-page-1-copy.md`
+// Sourced from the internal for-operators page-1 copy spec (2026-05-28)
 // (the COMMIT-phase copy artifact for spec-2026-05-14-non-technical-lane.md Phase 1).
 // Voice §5 self-check 12/12 documented in that spec.
 // Locked decisions from spec §9.4: CTA "Book a build call" (OQ-3); nav label

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -6,7 +6,7 @@
 // FSL package detail references METRICS: 21 MIT + 5 FSL + 1 internal = 27 total
 // (matches validator licenseSplit; counted against packages/ on 2026-06-17 —
 // @revealui/tokens addition took MIT 20→21 and total 26→27).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 
 import { METRICS, SITE } from './site';
 import type { Cta, FaqItem } from './types';

--- a/apps/marketing/app/content/legal/privacy.ts
+++ b/apps/marketing/app/content/legal/privacy.ts
@@ -1,4 +1,4 @@
-// Sourced from: app/routes/PrivacyPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/PrivacyPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from '../site';
 

--- a/apps/marketing/app/content/legal/terms.ts
+++ b/apps/marketing/app/content/legal/terms.ts
@@ -1,4 +1,4 @@
-// Sourced from: app/routes/TermsPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/TermsPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from '../site';
 import type { LegalSection } from './privacy';

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -1,5 +1,5 @@
 // Sourced from: app/components/NavBar.tsx, app/components/Footer.tsx (Phase 1c, no copy changes).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from './site';
 import type { NavLink } from './types';

--- a/apps/marketing/app/content/persona.ts
+++ b/apps/marketing/app/content/persona.ts
@@ -1,5 +1,5 @@
 // Sourced from: app/components/landing/Persona.tsx (Phase 1c extraction).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 // 2026-05-23: founder-first plain-language rewrite of section heading + card
 //   copy (owner-directed). Jargon (procurement review, identity gates, RBAC +
 //   ABAC, hash-chained, runtime) translated into outcomes founders recognize.

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -1,4 +1,4 @@
-// Sourced from: app/routes/PricingPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/PricingPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from './site';
 import type { FaqItem } from './types';

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -1,5 +1,5 @@
 // Sourced from: app/components/landing/PricingTeaser.tsx (Phase 1c, no copy changes).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 // Tier copy lives here; runtime pricing (prices/periods) fetched from /api/pricing in the component.
 
 import type { LicenseTierId } from '@revealui/contracts/pricing';

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -3,7 +3,7 @@
 //   - HomePrimitive: label + body only (used by landing Primitives.tsx)
 //   - ProductsPrimitive: full forYou/forAgents/together/features deep-dive (used by ProductsPage.tsx)
 //   Both are canonical here. Phase 4 reconciles any copy redundancy.
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 // Agents primitive MCP count is sourced from METRICS.mcpServers
 // (currently 14, per docs/MARKETING_METRICS.md §1) — never hardcoded here.
 

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -1,10 +1,10 @@
 // RevFleet product family roster — the actual products RevealUI Studio ships.
 //
 // Sourced from per-product README audit (2026-05-18) cross-referenced against
-// docs/lanes/marketing-overhaul/plan.md §2.1 (canonical status table). Owner
+// the internal marketing-overhaul plan §2.1 (canonical status table). Owner
 // directive 2026-05-18 redirected /products from "5 primitives deep-dive" to
 // "RevFleet product family lineup". RevealCoin permanently excluded per
-// the 2026-05-29 cancellation ADR (.jv docs/decisions/2026-05-29-revealcoin-cancelled.md;
+// the 2026-05-29 cancellation ADR (internal;
 // supersedes the prior shelved-state memory). The legacy primitives data
 // (PRODUCTS_PRIMITIVES in content/primitives.ts) stays exported for future
 // relocation to a /concepts or /platform page per lane owner's discretion.

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -1,7 +1,7 @@
 // Sourced from: app/components/landing/Proof.tsx (Phase 1c extraction).
 // Phase 3 (2026-05-18) update: "21 of 27 packages MIT" trust card heading now
 // uses METRICS license split (21 MIT). Pre-Phase-3 audit had off-by-one count.
-// Per docs/lanes/marketing-overhaul/plan.md §4.4 + docs/MARKETING_METRICS.md §1.
+// Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 
 import { METRICS, SITE } from './site';
 

--- a/apps/marketing/app/content/roadmap.ts
+++ b/apps/marketing/app/content/roadmap.ts
@@ -1,4 +1,4 @@
-// Sourced from: app/routes/RoadmapPage.tsx (Phase 1, no copy changes). Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Sourced from: app/routes/RoadmapPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 // Phase 4 complete: page renders at /roadmap via RoadmapPage.tsx; /coming-soon 308-redirects in vercel.json.
 
 import { SITE } from './site';

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -2,7 +2,7 @@
 // Sourced from extraction of inline JSX content in:
 //   app/components/Footer.tsx, app/components/GetStarted.tsx,
 //   app/components/landing/Hero.tsx, app/routes/*.tsx
-// Per docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
+// Per the internal marketing-overhaul plan §4.4 (Phase 1).
 // Phase 1b additions: repoRoadmap, apiDocs.
 // Phase 1c additions: adminLogin, x, linkedin, forum, repoChangelog, repoLicense.
 // Phase 3 addition: METRICS export — canonical numbers from docs/MARKETING_METRICS.md §1

--- a/apps/marketing/app/content/sponsor.ts
+++ b/apps/marketing/app/content/sponsor.ts
@@ -1,6 +1,6 @@
 // Sponsor page content.
 // Sourced from extraction of app/routes/SponsorPage.tsx (Phase 1, no copy changes).
-// Per docs/lanes/marketing-overhaul/plan.md §4.4.
+// Per the internal marketing-overhaul plan §4.4.
 
 import { SITE } from './site';
 import type { Cta } from './types';

--- a/apps/marketing/app/content/types.ts
+++ b/apps/marketing/app/content/types.ts
@@ -1,6 +1,6 @@
 // Shared content types for marketing/app/content/*
 // Sourced from extraction of inline JSX content per
-// docs/lanes/marketing-overhaul/plan.md §4.4 (Phase 1).
+// the internal marketing-overhaul plan §4.4 (Phase 1).
 
 export interface Cta {
   readonly label: string;

--- a/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
@@ -1,6 +1,6 @@
 // Page 2 of the operator lane — process description that removes the fear
 // by making the engagement concrete and bounded.
-// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §3.3 Page 2.
+// Spec: internal non-technical-lane spec (2026-05-14) §3.3 Page 2.
 // Phase 4 of the spec's §8 sequence.
 
 import { Footer } from '../components/Footer';

--- a/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
@@ -2,7 +2,7 @@
 // the future self-serve "RevealUI Cloud" offering and disavows that it ships
 // today. Phase 5 of the non-technical-lane spec.
 //
-// Spec: ~/revfleet/.jv/docs/spec-2026-05-14-non-technical-lane.md §3.3 Page 3.
+// Spec: internal non-technical-lane spec (2026-05-14) §3.3 Page 3.
 // Locked decisions: §9.4 OQ-1 ("RevealUI Cloud"), OQ-2 (ship with the lane).
 
 import { Footer } from '../components/Footer';

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -58,7 +58,7 @@ The previous `.cursor/mcp-config.json` configuration file is not present in this
 
 ## Branch Protection
 
-Branch protection for the RevealUI Studio fleet is declared as code in the **private** `revealui-jv` coordination repo. The desired state for each repo lives at `branch-protection/<repo>.json`; a small bash + `jq` + `gh api` script (`scripts/apply-branch-protection.sh`) diffs declarations against live GitHub state and pushes them via `PUT /repos/{owner}/{repo}/branches/{branch}/protection`. The script is idempotent.
+Branch protection for the RevealUI Studio fleet is declared as code in the private coordination hub. The desired state for each repo lives at `branch-protection/<repo>.json`; a small bash + `jq` + `gh api` script (`scripts/apply-branch-protection.sh`) diffs declarations against live GitHub state and pushes them via `PUT /repos/{owner}/{repo}/branches/{branch}/protection`. The script is idempotent.
 
 ### Posture
 

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -7,7 +7,7 @@ description: "This page has been split. See FLEET.md for the runtime kit; see PR
 category: redirect
 ---
 
-This page has been split into two distinct guides per the 7-tier rename (ADR `RevealUIStudio/revealui-jv/docs/decisions/2026-05-03-revfleet-rename.md`):
+This page has been split into two distinct guides per the 7-tier rename (internal ADR 2026-05-03, RevFleet rename):
 
 - **[`docs/FLEET.md`](./FLEET.md)** — RevealUI Fleet self-hosted runtime kit (Tier 4): Docker Compose stack, domain lock, license keys, upgrades, HA, backup/restore.
 - **[`docs/PRO.md`](./PRO.md#enterprise-tier)** — Enterprise tier (Tier 5): SaaS billing posture, hosted vs self-hosted, $1,499/mo.

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -145,7 +145,7 @@ Canonical defaults (when "open-model AI" is mentioned in marketing): Gemma 4, Ph
   - "The OSS business runtime where your agents are first-class users."
   - "Auth, billing, content, and AI primitives — governed by one policy, audited by hash-chained logs, owned by you. From `npx create-revealui` to first paying customer in a weekend."
 
-## 8. Voice rules (defined in the private revealui-jv coordination repo)
+## 8. Voice rules (defined in the private coordination hub)
 
 Five testable rules — Phase 5 audits every page against these:
 
@@ -171,7 +171,7 @@ When this doc disagrees with marketing copy, file a `gh issue` titled `marketing
 ---
 
 **Related references:**
-- Lane plans, voice rules, positioning shifts, and brand naming are maintained in the private revealui-jv coordination repo.
+- Lane plans, voice rules, positioning shifts, and brand naming are maintained in the private coordination hub.
 - Validator source: `scripts/validate/claim-drift.ts`
 - Pricing canonical: `packages/contracts/src/pricing.ts`
 - Brand tokens: `packages/presentation/src/tokens.css`

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -9,17 +9,17 @@ repo: revealui
 last-updated: 2026-05-01
 owner: RevealUI Studio
 staleness-status: STALE
-note: public snapshot — canonical version at revealui-jv/docs/MASTER_PLAN.md (last updated 2026-05-10). Quarterly refresh cadence per ADR revealui-jv:docs/decisions/2026-05-11-master-plan-public-quarterly-snapshot.md.
+note: public snapshot — canonical version in the private coordination hub (last updated 2026-05-10). Quarterly refresh cadence per internal ADR 2026-05-11 (master-plan public quarterly snapshot).
 ---
 
 # RevealUI Master Plan
 
 > **AGENTS:** This is the PUBLIC SNAPSHOT. The canonical, day-to-day version lives in the internal planning hub.
-> **Cadence:** quarterly refresh (Mar 11 / Jun 11 / Sep 11 / Dec 11) per ADR `revealui-jv:docs/decisions/2026-05-11-master-plan-public-quarterly-snapshot.md`. For current state, see public RevealUI signals: blog posts, release notes, GitHub Issues, and `pnpm validate:claims` output.
+> **Cadence:** quarterly refresh (Mar 11 / Jun 11 / Sep 11 / Dec 11) per internal ADR 2026-05-11 (master-plan public quarterly snapshot). For current state, see public RevealUI signals: blog posts, release notes, GitHub Issues, and `pnpm validate:claims` output.
 > Always read and update the internal version. Do NOT update this file outside the quarterly refresh.
 
 **Last Updated:** 2026-05-01 (Current Reality block refreshed; numbering aligned to Phase 5)
-**Status:** Public snapshot  -  canonical version in revealui-jv
+**Status:** Public snapshot  -  canonical version in the private coordination hub
 **Owner:** RevealUI Studio
 
 > This document supersedes all previous roadmaps, action plans, and status docs.
@@ -673,7 +673,7 @@ Phase D  -  Agent publisher tools (agent):
 
 **Goal:** Achieve SOC2 Type II certification covering the Common Criteria (Security) Trust Service Criteria. Required to close Enterprise tier deals.
 
-**Gap file:** `docs/gaps/GAP-047.yml`
+**Gap file:** GAP-047 (internal tracker)
 
 **Existing controls (already implemented):**
 - RBAC/ABAC policy engine, session auth, bcrypt (12 rounds), brute-force protection
@@ -866,7 +866,7 @@ Holster:          "Here is the shared state where coordination happens"
 - [x] Audit config formats for backwards-compat fields that can be dropped
 - [x] Audit hook scripts for patterns that pre-date the current architecture
 - [x] Audit test files for mocks of removed or renamed interfaces
-- [x] Document every finding in a tracking issue with file paths and recommended action (remove, codemod, or consolidate) — tracked in the private revealui-jv repo's audit log (62 findings, 6 categories, 17 actionable in Tier 1)
+- [x] Document every finding in a tracking issue with file paths and recommended action (remove, codemod, or consolidate) — tracked in the private coordination hub's audit log (62 findings, 6 categories, 17 actionable in Tier 1)
 
 ### Phase B: Codemod Infrastructure
 

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -88,6 +88,6 @@ See `docs/methodology.md` for the canonical M2-M12 statement — audit-first SDL
 
 - Deployment guide: [`docs/FLEET.md`](./FLEET.md) — RevealUI Fleet self-hosted runtime kit
 - Methodology: `docs/methodology.md`
-- Internal glossary (private): `RevealUIStudio/revealui-jv/docs/glossary.md`
-- ADR for rename: `RevealUIStudio/revealui-jv/docs/decisions/2026-05-03-revfleet-rename.md`
+- Internal glossary: private coordination hub
+- ADR for rename: internal ADR 2026-05-03 (private coordination hub)
 - Per-product pages: [`docs/fleet/`](./fleet/)

--- a/docs/architecture/ADR-005-two-repo-model.md
+++ b/docs/architecture/ADR-005-two-repo-model.md
@@ -9,11 +9,11 @@ audience: user
 **Date:** 2026-04-08
 **Status:** Superseded by the four-repo model (2026-05-18) — see note below
 
-> **⚠️ Superseded — preserved for history.** The two-repo split has since expanded into a **four-repo model**: **revealui** (public framework — OSS MIT + Pro FSL-1.1-MIT), **agency** (public marketing site, `revealuistudio.com`), **revmarket** (transactional MCP-marketplace venue — a separate trust boundary; staged inside `revealui/packages/marketplace-*` until its own repo is created), and **revealui-jv** (private coordination hub). The framework-vs-venue split is an owner-locked architecture decision (2026-05-18). The public-framework + private-coordination rationale below still holds for the revealui ↔ revealui-jv pair.
+> **⚠️ Superseded — preserved for history.** The two-repo split has since expanded into a **four-repo model**: **revealui** (public framework — OSS MIT + Pro FSL-1.1-MIT), **agency** (public marketing site, `revealuistudio.com`), **revmarket** (transactional MCP-marketplace venue — a separate trust boundary; staged inside `revealui/packages/marketplace-*` until its own repo is created), and a **private coordination hub**. The framework-vs-venue split is an owner-locked architecture decision (2026-05-18). The public-framework + private-coordination rationale below still holds for the public-framework ↔ private-hub pair.
 
 ## Context
 
-RevealUI started as a single private monorepo (`revealui-jv`) containing all code, business docs, and planning. When the project went public, the repo was forked into a public repo (`RevealUI`) with Pro packages gitignored. Over time, the private repo accumulated stale code copies, sync friction, and confusion about which repo was authoritative.
+RevealUI started as a single private monorepo containing all code, business docs, and planning. When the project went public, the repo was forked into a public repo (`RevealUI`) with Pro packages gitignored. Over time, the private repo accumulated stale code copies, sync friction, and confusion about which repo was authoritative.
 
 After adopting Fair Source licensing (ADR-003), all source code moved to the public repo. The private repo needed a new purpose or deletion.
 
@@ -24,7 +24,7 @@ After adopting Fair Source licensing (ADR-003), all source code moved to the pub
 | Repo | Visibility | Purpose |
 |------|-----------|---------|
 | `RevealUIStudio/revealui` (public) | Public | All code: OSS (MIT) + Pro (FSL-1.1-MIT). Apps, packages, scripts, public docs. |
-| `RevealUIStudio/revealui-jv` (private) | Private | Internal coordination hub: MASTER_PLAN, feature gaps, roadmap, business docs, agent workboard. |
+| Private coordination hub | Private | Internal coordination hub: MASTER_PLAN, feature gaps, roadmap, business docs, agent workboard. |
 
 ### What lives where
 
@@ -41,7 +41,7 @@ The repos are fully independent. No submodules, no git-level coupling. Coordinat
 ## Alternatives Considered
 
 - **Single public repo**: Moving MASTER_PLAN and business docs into the public repo. Rejected because release timelines, pricing strategy, and agency outreach templates are competitively sensitive.
-- **Delete revealui-jv**: The private repo still serves a purpose as the single source of truth for planning and agent coordination. Deleting it would scatter this information across GitHub issues, which are public.
+- **Delete the private hub repo**: The private repo still serves a purpose as the single source of truth for planning and agent coordination. Deleting it would scatter this information across GitHub issues, which are public.
 - **Git submodules**: Rejected outright. Submodules add complexity to cloning, CI, and contributor onboarding for marginal benefit. The user has explicitly prohibited their use.
 
 ## Consequences

--- a/docs/decisions/2026-05-08-deployment-target-vercel-not-k8s.md
+++ b/docs/decisions/2026-05-08-deployment-target-vercel-not-k8s.md
@@ -9,7 +9,7 @@ audience: user
 **Date:** 2026-05-08
 **Status:** Decided — final
 **Phase:** 5 — Agent-First Infrastructure
-**Audit:** [`docs/audits/2026-05-08-fleet-doc-quality-audit.md`](https://github.com/RevealUIStudio/revealui-jv) (revealui-jv repo, commit `e0a59018c`)
+**Audit:** internal fleet doc-quality audit 2026-05-08 (private coordination hub, commit `e0a59018c`)
 **Companion PR:** [revealui#782](https://github.com/RevealUIStudio/revealui/pull/782) — folds the doc-quality `CI_CD_GUIDE.md` shrink with the dead-infra deletion this ADR documents.
 
 ## Context
@@ -25,7 +25,7 @@ Inventory of what existed:
 - `infrastructure/docker/Dockerfile.base`, `Dockerfile.admin` — zero references; per-app `Dockerfile.forge` is the live path
 - `infrastructure/docker/nginx/`, `infrastructure/docker/prometheus/` — zero references; HTTPS termination + observability not part of any active stack
 
-None of these were wired into [`.github/workflows/`](../../.github/workflows/), `package.json` scripts, `turbo.json`, any cross-fleet repo (`revealui-jv`, `revcon`, `revdev`), or `docker-compose.{yml,forge.yml}` (the only refs were commented-out nginx volume mounts removed alongside this ADR).
+None of these were wired into [`.github/workflows/`](../../.github/workflows/), `package.json` scripts, `turbo.json`, any cross-fleet repo (the private coordination hub, `revcon`, `revdev`), or `docker-compose.{yml,forge.yml}` (the only refs were commented-out nginx volume mounts removed alongside this ADR).
 
 ## Decision
 
@@ -96,7 +96,7 @@ The newer starting point would not be the historical scaffolding regardless. For
 
 ## References
 
-- Audit: fleet doc-quality audit (2026-05-08), tracked in the private revealui-jv repo
+- Audit: fleet doc-quality audit (2026-05-08), tracked in the private coordination hub
 - [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) — Vercel production pipeline (validate → migrate → matrix-deploy → smoke → auto-rollback)
 - [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml) — Forge Docker image build + GHCR push
 - [`docker-compose.forge.yml`](../../docker-compose.forge.yml) — Forge self-hosted stack with license enforcement

--- a/docs/features/ai.yml
+++ b/docs/features/ai.yml
@@ -32,7 +32,7 @@ package-notes:
 limitations:
   - id: dist-only
     surface: api
-    summary: "@revealui/ai is dist-only in public repo — source in private revealui-jv"
+    summary: "@revealui/ai is dist-only in public repo — source in the private coordination hub"
   - id: llm-providers
     surface: api
     summary: "Open models only — inference snaps (local, recommended), Ollama (local, fallback), cloud via self-hosted harness (Pro+). No proprietary providers."

--- a/docs/features/ci.yml
+++ b/docs/features/ci.yml
@@ -34,7 +34,7 @@ api-surface:
     endpoint: ".github/workflows/release-pro.yml — Pro dist-only (stub)"
     openapi: false
     tested: false
-    notes: "Intentional no-op — Pro packages publish from private revealui-jv repo"
+    notes: "Intentional no-op — Pro packages publish from the private coordination hub"
 
 local-gate:
   command: "pnpm gate"

--- a/docs/features/mcp.yml
+++ b/docs/features/mcp.yml
@@ -72,7 +72,7 @@ test-coverage:
 limitations:
   - id: dist-only
     surface: api
-    summary: "@revealui/mcp is dist-only in public repo — source in private revealui-jv"
+    summary: "@revealui/mcp is dist-only in public repo — source in the private coordination hub"
   - id: license-required
     surface: api
     summary: "Requires Pro/Enterprise tier — current checks are license-centric and should converge on account-level entitlements"

--- a/docs/features/services.yml
+++ b/docs/features/services.yml
@@ -73,7 +73,7 @@ test-coverage:
 limitations:
   - id: dist-only
     surface: api
-    summary: "@revealui/services is dist-only in public repo — source in private revealui-jv"
+    summary: "@revealui/services is dist-only in public repo — source in the private coordination hub"
   - id: payload-vulns
     surface: api
     summary: "Transitive payload IDOR + SSRF vulns (mitigated by CSP/CORS, upgrade when 3.75+ compatible)"

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -66,7 +66,7 @@ Hooks NEVER write to the workboard by design. The workboard is a manual coordina
 
 ### Workboard automation (M10)
 
-Two scripts govern the fleet-level workboard (maintained in the private revealui-jv coordination repo):
+Two scripts govern the fleet-level workboard (maintained in the private coordination hub):
 
 - `workboard-check.js` — read-only drift detector, fired on session-start. Reports stale rows and unresolved gaps without modifying the file.
 - `workboard-sweep.js` — idempotent cleanup. The agent reviews the diff and commits manually; the script never auto-commits.
@@ -101,10 +101,10 @@ Hooks architecture detail: `~/.claude/rules/hooks-architecture.md` (private).
 
 | Topic | Canonical source |
 |-------|-----------------|
-| Audit-first SDLC (M5) | `RevealUIStudio/revealui-jv/.claude/rules/audit-first-sdlc.md` (private) |
+| Audit-first SDLC (M5) | internal audit-first SDLC rule (private coordination hub) |
 | No-regex (M2) | `~/.claude/rules/` global rules |
 | Versioning (M6) | `~/.claude/rules/versioning.md` |
 | Secrets (M4) | `~/.claude/rules/secrets.md` + `docs/SECRETS.md` |
 | Hooks architecture (M8/M9/M10) | `~/.claude/rules/hooks-architecture.md` (private) |
-| 7-tier rename glossary (M1) | `RevealUIStudio/revealui-jv/docs/glossary.md` (private) |
+| 7-tier rename glossary (M1) | internal glossary (private coordination hub) |
 | Charge-readiness detail (M11) | `docs/MASTER_PLAN.md` §Billing |

--- a/docs/runbook-agent-dispatch-flag.md
+++ b/docs/runbook-agent-dispatch-flag.md
@@ -101,6 +101,6 @@ needs to consult the entitlement row.
 - Phase A — queue primitive: `packages/db/src/jobs/`,
   `apps/server/src/routes/jobs/run.ts`
 - Phase B — cron safety-net: `apps/server/src/routes/cron/jobs-safety-net.ts`
-- Design doc: tracked internally in the private revealui-jv repo
+- Design doc: tracked internally in the private coordination hub
 - Flag-removal follow-up: filed at PR-merge time, scheduled
   ≥ 2 weeks of clean prod operation before removal.

--- a/docs/runbooks/gitleaks.md
+++ b/docs/runbooks/gitleaks.md
@@ -66,4 +66,4 @@ A failure dumps a JSON report as the `gitleaks-report` artifact (uploaded on fai
 - Workflow: `.github/workflows/security.yml` → `gitleaks` job
 - Working-tree allowlist (paths/patterns): `.gitleaks.toml` `[allowlist]`
 - Per-finding allowlist: `.gitleaksignore`
-- Rotation prerequisite: rotate the leaked credential *before* bumping the cutoff (rotation procedures live in the private revealui-jv rotation toolkit; follow whichever script matches the credential class)
+- Rotation prerequisite: rotate the leaked credential *before* bumping the cutoff (rotation procedures live in the private coordination hub's rotation toolkit; follow whichever script matches the credential class)

--- a/docs/runbooks/vercel-env-sync.md
+++ b/docs/runbooks/vercel-env-sync.md
@@ -115,12 +115,12 @@ Outputs JSON describing every variable's diff state per project (Add / Update / 
 
 ## Out of scope (deferred to v2)
 
-- Preview + development env target sync — production-only in v1 per [`vercel-env-canonical-mapping.md`](../../../revealui-jv/docs/vercel-env-canonical-mapping.md) Q4
+- Preview + development env target sync — production-only in v1 per the internal canonical env-var mapping doc Q4
 - Per-var Sensitive flag policy — gated on revvault adding `var_type` plumbing per concern C2 in the design doc
 - Auto-rotation chain — `revvault rotate <path>` triggering Vercel sync; design doc Phase 5
 
 ## See also
 
-- Design doc: [`revvault-vercel-sync.md` (private revealui-jv repo)](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/revvault-vercel-sync.md)
-- Canonical env-var mapping: [`vercel-env-canonical-mapping.md` (private revealui-jv repo)](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/vercel-env-canonical-mapping.md)
+- Design doc: internal revvault-vercel sync design (private coordination hub)
+- Canonical env-var mapping: internal canonical-mapping doc (private coordination hub)
 - Secrets rule: [`~/revfleet/.claude/rules/secrets.md`](../../../.claude/rules/secrets.md)

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -140,9 +140,9 @@
 
   The previously published `1.4.0` dist predated the manifest-derived refactor in `packages/contracts/src/revealcoin.ts:59-79` (`deriveNetworkRecord` + the `RVUI_MINT_ADDRESSES` / `RVUI_MINT_AUTHORITY` exports). External consumers of `@revealui/contracts@1.4.0` from npm therefore read the wrong `mainnet-beta` value (the devnet mint address copied across networks). Bumping to `1.4.1` with a clean `pnpm --filter @revealui/contracts build` republishes the correct manifest-derived behavior — empty string for unconfigured networks, the real address only when `REVEALCOIN_MANIFEST.networks[network].mintAddress` is non-empty.
 
-  Behavioral fix only. No exported types or schemas change. Per `~/revfleet/.jv/.claude/rules/versioning.md` `@revealui/contracts` exception, patch is the correct semver level (no breaking change).
+  Behavioral fix only. No exported types or schemas change. Per the internal versioning-rule `@revealui/contracts` exception, patch is the correct semver level (no breaking change).
 
-  Audit reference: `~/revfleet/.jv/docs/audits/2026-05-08-charge-readiness-deep-audit.md` §5 Phase 0. Related: revealui#763 (revealcoin frontend mainnet honesty) — same dishonesty class on the frontend; this PR closes the npm-consumer side.
+  Audit reference: internal charge-readiness deep audit (2026-05-08) §5 Phase 0. Related: revealui#763 (revealcoin frontend mainnet honesty) — same dishonesty class on the frontend; this PR closes the npm-consumer side.
 
 - 2eb63dc: Pre-flip pricing honesty: reframe Enterprise tier as RevealUI Fleet OEM (white-label deployment), drop services from public API response, update FEATURE_LABELS for accuracy.
 

--- a/packages/contracts/src/a2a/index.ts
+++ b/packages/contracts/src/a2a/index.ts
@@ -194,7 +194,7 @@ export type A2AMessage = z.infer<typeof A2AMessageSchema>;
  *                       Emitted when the agent's `AgentDefinition.pricing`
  *                       is set and no proof was supplied. RevealUI
  *                       extension; not in the upstream Google A2A spec.
- *                       See GAP-149 in revealui-jv for the wiring plan;
+ *                       See GAP-149 (internal tracker) for the wiring plan;
  *                       PR 1 (schema-only) introduces the state, PR 2
  *                       wires the handler to emit + accept it.
  * - `working`          — actively running

--- a/packages/db/migrations/0010_unreconciled_webhooks.sql
+++ b/packages/db/migrations/0010_unreconciled_webhooks.sql
@@ -14,7 +14,7 @@
 -- apply against a production DB that already has the table. On a fresh DB
 -- it creates the table + indexes from scratch.
 --
--- See ~/suite/.jv/docs/cr8-p3-02-retention-design.md for the discovery
+-- See the internal retention design record (cr8-p3-02) for the discovery
 -- context (was found while scoping the operational-hygiene retention work).
 
 CREATE TABLE IF NOT EXISTS "unreconciled_webhooks" (

--- a/packages/db/src/cleanup/log-retention.ts
+++ b/packages/db/src/cleanup/log-retention.ts
@@ -6,7 +6,7 @@
  *
  * Retention window comes from `REVEALUI_LOG_RETENTION_DAYS` (default 90).
  * See docs/security/ for the privacy-policy-facing commitment and
- * ~/revfleet/.jv/docs/cr8-p3-02-retention-design.md for the decision record.
+ * the internal retention design record (cr8-p3-02) for the decision record.
  *
  * Audit logs (`audit_log`) are intentionally excluded — they are
  * append-only by design with tamper-evident hash chains, retained

--- a/packages/db/src/cleanup/operational-retention.ts
+++ b/packages/db/src/cleanup/operational-retention.ts
@@ -5,7 +5,7 @@
  * tables past their retention windows. Keeps hot tables lean; no PII
  * concerns (these are internal operational state, not user data).
  *
- * See ~/revfleet/.jv/docs/cr8-p3-02-retention-design.md for the decision
+ * See the internal retention design record (cr8-p3-02) for the decision
  * record. Part of the CR8-P3-02 arc:
  *   - PR1 (revealui#495): app_logs + error_events retention
  *   - PR2 (revealui#499): jobs + processed_webhook_events retention

--- a/packages/db/src/crypto.ts
+++ b/packages/db/src/crypto.ts
@@ -22,7 +22,7 @@
  *   operator promotes `REVEALUI_KEK_NEXT` → `REVEALUI_KEK` and removes
  *   `REVEALUI_KEK_NEXT`. No downtime.
  *
- * See `~/revfleet/.jv/docs/runbooks/rotate-kek.md` §Zero-downtime path for the
+ * See the internal KEK-rotation runbook §Zero-downtime path for the
  * operator flow.
  */
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -540,7 +540,7 @@ allowedModels, defaultModel, namespace: server, onEvent })` and pass
 
   Stages 2 (apps/server `/openapi.json` route exposing the contracts doc) and 3 (revdev/apps/console oapi-codegen + revvault Rust progenitor consumer wiring) are deferred to follow-on PRs — Stage 1 is complete-on-its-own infrastructure.
 
-  Per [`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/decisions/2026-05-03-contracts-protocol-pyramid.md) §"Phase 3" in the internal `revealui-jv` repo.
+  Per the internal contracts-protocol-pyramid ADR (2026-05-03) §"Phase 3".
 
 ### Patch Changes
 

--- a/packages/mcp/src/author/index.ts
+++ b/packages/mcp/src/author/index.ts
@@ -12,7 +12,7 @@
  * **Phase 1.6 (stubs only).** This module ships the namespace + interfaces
  * + an explicit `AuthorSdkNotImplementedError` per function. The concrete
  * implementation lands after the first external venue requirement surfaces
- * (per `docs/lanes/marketplace-extraction/plan.md` Risk R8 — "Phase 1.6
+ * (per the internal marketplace-extraction plan Risk R8 — "Phase 1.6
  * author SDK design constrains future venue plugins; ship stubs only,
  * flesh out API in a follow-up ADR after first external venue interest").
  *

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -23,7 +23,7 @@
 
   Stages 2 (apps/server `/openapi.json` route exposing the contracts doc) and 3 (revdev/apps/console oapi-codegen + revvault Rust progenitor consumer wiring) are deferred to follow-on PRs — Stage 1 is complete-on-its-own infrastructure.
 
-  Per [`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/decisions/2026-05-03-contracts-protocol-pyramid.md) §"Phase 3" in the internal `revealui-jv` repo.
+  Per the internal contracts-protocol-pyramid ADR (2026-05-03) §"Phase 3".
 
 ## 0.2.3
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -84,7 +84,7 @@ The committed `contracts.openapi.json` is the single source of truth — Go and 
 
 The emitter consumes `@revealui/mcp/contracts-server`'s `getContractsCatalog()` helper (added in the same PR) so the schema list is single-sourced via the contracts MCP server's registry — no risk of the OpenAPI mirror drifting from the MCP server's resource list.
 
-See [`docs/decisions/2026-05-03-contracts-protocol-pyramid.md`](https://github.com/RevealUIStudio/revealui-jv) §"Phase 3" in the internal `revealui-jv` repo for the full L3-OpenAPI rationale within the protocol-pyramid (L1 Zod → L2 MCP+A2A → L3 OpenAPI).
+See the internal contracts-protocol-pyramid ADR (2026-05-03) §"Phase 3" for the full L3-OpenAPI rationale within the protocol-pyramid (L1 Zod → L2 MCP+A2A → L3 OpenAPI).
 
 ## Related
 

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -132,7 +132,7 @@
 
   Supports all standard `Button` variants (`variant`, `size`, `isLoading`, `disabled`, `external`). Disabled state preserves the anchor's `href` and uses `aria-disabled="true"` + `tabIndex={-1}` + `onClick` preventDefault to enforce the disabled semantics without changing the underlying anchor contract. Loading state shows a spinner + `aria-busy="true"` + `pointer-events:none`.
 
-  Spec: [`docs/specs/linkbutton-primitive.md`](https://github.com/RevealUIStudio/revealui-jv) (revealui-jv).
+  Spec: internal LinkButton primitive spec (private coordination hub).
 
   Zero new runtime dependencies. The `LinkBehaviorProvider` is a tiny React context — `@revealui/presentation` continues to ship with React/ReactDOM as the only peer deps.
 

--- a/packages/test/src/integration/database/log-retention.integration.test.ts
+++ b/packages/test/src/integration/database/log-retention.integration.test.ts
@@ -7,7 +7,7 @@
  *
  * Module: packages/db/src/cleanup/log-retention.ts
  * Schemas: packages/db/src/schema/app-logs.ts, error-events.ts
- * Design: ~/revfleet/.jv/docs/cr8-p3-02-retention-design.md
+ * Design: internal retention design record (cr8-p3-02)
  */
 
 import { cleanupOldLogs } from '@revealui/db/cleanup';

--- a/packages/test/src/integration/database/operational-retention.integration.test.ts
+++ b/packages/test/src/integration/database/operational-retention.integration.test.ts
@@ -11,7 +11,7 @@
  *
  * Module: packages/db/src/cleanup/operational-retention.ts
  * Schemas: packages/db/src/schema/{jobs,webhook-events}.ts
- * Design: ~/revfleet/.jv/docs/cr8-p3-02-retention-design.md
+ * Design: internal retention design record (cr8-p3-02)
  */
 
 import { cleanupOperational } from '@revealui/db/cleanup';

--- a/scripts/analyze/audit-text-palette.ts
+++ b/scripts/analyze/audit-text-palette.ts
@@ -299,7 +299,7 @@ function main(): void {
     'Convention: prefer text-foreground / text-muted-foreground / text-primary semantic tokens.\n',
   );
   process.stdout.write(
-    'See: docs/decisions/2026-05-19-semantic-text-tokens.md (in revealui-jv) or design-system/CLAUDE.md.\n\n',
+    'See: the internal semantic-text-tokens ADR (2026-05-19) or design-system/CLAUDE.md.\n\n',
   );
 
   const sortedFiles = Array.from(byFile.keys()).sort();

--- a/scripts/security/rotate-kek.ts
+++ b/scripts/security/rotate-kek.ts
@@ -3,8 +3,8 @@
 /**
  * KEK rotation tool — re-encrypt every KEK-encrypted row with a new key.
  *
- * Two surfaces in scope (per the GAP-126 Phase 1 survey at
- * `revealui-jv/docs/security/kek-encrypted-surfaces.md`):
+ * Two surfaces in scope (per the GAP-126 Phase 1 survey
+ * (internal KEK-encrypted-surfaces doc):
  *
  *   1. user_api_keys.encrypted_key  (NOT NULL, strict envelope)
  *   2. users.mfa_secret             (NULLABLE, rolling-migration aware)

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -30,8 +30,8 @@
 #                               sensitivity on re-create whenever any remote row
 #                               of the same key is already sensitive.
 #
-# Owner-ratified conventions: see ~/revfleet/.jv/docs/vercel-env-canonical-mapping.md
-# Design doc: ~/revfleet/.jv/docs/revvault-vercel-sync.md
+# Owner-ratified conventions: see the internal canonical env-var mapping doc
+# Design doc: internal revvault-vercel sync design (private coordination hub)
 # Requires revvault >= 0.3.0 (sensitive markers + preserve-on-recreate; older
 # binaries fail loudly on the inline `sensitive` key — by design) and PR #40
 # (per-var path overrides via `vars` table)

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -975,7 +975,7 @@ const SCAN_DIRS = [
  * Files excluded from claim-drift scanning:
  *   - CRASH-POSTMORTEMS.md: historical document where counts were accurate at time of writing.
  *   - docs/MASTER_PLAN.md: per `single-source-of-truth.md`, the canonical plan lives in
- *     ~/revfleet/.jv/docs/MASTER_PLAN.md; this public-repo copy is an allowed-stale snapshot
+ *     the private coordination hub's master plan; this public-repo copy is an allowed-stale snapshot
  *     and is also hook-blocked from agent edits, so numeric counts here cannot be kept in sync.
  */
 const EXCLUDE_FILES = ['docs/system-tune/CRASH-POSTMORTEMS.md', 'docs/MASTER_PLAN.md'];
@@ -1438,7 +1438,7 @@ interface FleetProductMatch {
  * docs-pro/{ai,inference,editors}/index.md, ROADMAP.md, blog posts,
  * HARNESS_PROTOCOL.md, SECRETS.md, REST API reference) is queued for
  * follow-up PRs after the remaining attribution in those files is tightened.
- * The honesty audit at `~/revfleet/.jv/docs/audits/docs-claims-2026-04-26.md`
+ * The internal honesty audit (docs-claims, 2026-04-26)
  * tracks the coverage queue.
  */
 const FLEET_ATTRIBUTION_SCAN_FILES = [


### PR DESCRIPTION
## Summary

Reader-facing docs, source comments, changelogs, and one SQL migration comment cited the private coordination repo by name, by path, or by live github.com link. This PR replaces every such citation with the neutral "private coordination hub" / "internal <topic> doc" phrasing already established in the fleet's other public repos.

Surfaced by an internal audit 2026-07-04 (full-tree sweep, exact-match verification pass after applying).

## Scope

- **Text-only.** No code paths, exports, or behavior change — 56 files, 77 lines, each a one-for-one phrasing swap in a comment, doc line, changelog entry, or YAML `summary`/`notes` string.
- **Deliberately excluded** (ship separately with their tests): the runtime strings that embed the same citations — the server startup banner, the `@revealui/mcp/author` tracking-issue constant, and the OpenAPI spec description + its emitter.
- Leak-scanner tooling under `scripts/leak-scan/` and scanner configs are untouched (they encode these patterns by design).

## Verification

- Batch applied via explicit fixed-string replacement with a uniqueness check per site (76/76 applied, fail-loud on any 0-or-2+ match); re-grep of the whole tree afterwards returns zero remaining citations outside the excluded runtime files.
- Repo leak scanner run before/after: this diff removes private-path/name findings and introduces none.

Manual merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
