### PR TITLE
chore: point runtime tracking strings at public surfaces

### DIFF
--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -231,8 +231,8 @@ const REQUIRED_IN_PRODUCTION_FORGE = [
  *   - When `STRIPE_LIVE_MODE` is unset or any other value: enforces `sk_test_`
  *     / `pk_test_` prefixes and emits a loud boot-time warning that the API
  *     is running with TEST Stripe keys in production. This is the
- *     pre-launch / pre-LLC / pre-billing-audit posture (gated on GAP-124
- *     in revealui-jv).
+ *     pre-launch / pre-LLC / pre-billing-audit posture (gated on GAP-124,
+ *     internal tracker).
  *
  * Honors `SKIP_ENV_VALIDATION=true` so Docker-build and other build-only
  * contexts can compile without live credentials present. Forge customer
@@ -727,7 +727,7 @@ export function emitStripeTestModeWarning(): void {
     '⚠️  ║  the test environment.                                           ║',
     '⚠️  ║                                                                  ║',
     '⚠️  ║  Flip STRIPE_LIVE_MODE=true ONLY after the billing-readiness     ║',
-    '⚠️  ║  audit (revealui-jv GAP-124) closes — every money-touching path ║',
+    '⚠️  ║  audit (internal GAP-124) closes — every money-touching path    ║',
     '⚠️  ║  must be bulletproof first.                                      ║',
     '⚠️  ╚══════════════════════════════════════════════════════════════════╝',
     '',

--- a/packages/mcp/src/author/__tests__/author.test.ts
+++ b/packages/mcp/src/author/__tests__/author.test.ts
@@ -31,7 +31,7 @@ describe('@revealui/mcp/author — Phase 1.6 stub surface', () => {
       const err = new AuthorSdkNotImplementedError('publish', '@revealui/mcp/author/publish');
 
       expect(err.message).toContain(AUTHOR_SDK_TRACKING_ISSUE);
-      expect(AUTHOR_SDK_TRACKING_ISSUE).toContain('revealui-jv/issues/');
+      expect(AUTHOR_SDK_TRACKING_ISSUE).toContain('RevealUIStudio/revealui/issues');
     });
 
     it('mentions Phase 1.6 + L2 lock so readers know the deliberate-stub posture', () => {

--- a/packages/mcp/src/author/errors.ts
+++ b/packages/mcp/src/author/errors.ts
@@ -12,8 +12,8 @@
  * a phantom success that surfaces as missing artifacts downstream.
  */
 
-/** Tracking issue for the full author-SDK implementation surface. */
-export const AUTHOR_SDK_TRACKING_ISSUE = 'https://github.com/RevealUIStudio/revealui-jv/issues/47';
+/** Public tracker for the full author-SDK implementation surface. */
+export const AUTHOR_SDK_TRACKING_ISSUE = 'https://github.com/RevealUIStudio/revealui/issues';
 
 export class AuthorSdkNotImplementedError extends Error {
   /** The exported function name that was called (e.g. "scaffold"). */

--- a/packages/openapi/contracts.openapi.json
+++ b/packages/openapi/contracts.openapi.json
@@ -4,7 +4,7 @@
   "info": {
     "title": "RevealUI Contracts (Types Mirror)",
     "version": "0.6.1",
-    "description": "OpenAPI 3.1 mirror of `@revealui/contracts` Zod schemas, emitted by `@revealui/openapi`'s `scripts/emit-from-mcp.ts` from the MCP contracts catalog. Drives cross-language codegen (Go via `oapi-codegen`, Rust via `progenitor`) so per-language consumers replace hand-mirrors with generated types from a single source of truth. See `docs/decisions/2026-05-03-contracts-protocol-pyramid.md` §Phase 3 in the revealui-jv repo.",
+    "description": "OpenAPI 3.1 mirror of `@revealui/contracts` Zod schemas, emitted by `@revealui/openapi`'s `scripts/emit-from-mcp.ts` from the MCP contracts catalog. Drives cross-language codegen (Go via `oapi-codegen`, Rust via `progenitor`) so per-language consumers replace hand-mirrors with generated types from a single source of truth. See the internal contracts-protocol-pyramid ADR (2026-05-03) §Phase 3.",
     "license": {
       "name": "MIT",
       "identifier": "MIT"

--- a/packages/openapi/scripts/emit-from-mcp.ts
+++ b/packages/openapi/scripts/emit-from-mcp.ts
@@ -131,8 +131,8 @@ export function buildContractsOpenApi(): OpenApiSpec {
         'contracts catalog. Drives cross-language codegen (Go via ' +
         '`oapi-codegen`, Rust via `progenitor`) so per-language consumers ' +
         'replace hand-mirrors with generated types from a single source of ' +
-        'truth. See `docs/decisions/2026-05-03-contracts-protocol-pyramid.md` ' +
-        '§Phase 3 in the revealui-jv repo.',
+        'truth. See the internal contracts-protocol-pyramid ADR (2026-05-03) ' +
+        '§Phase 3.',
       license: { name: 'MIT', identifier: 'MIT' },
     },
     components: { schemas },


### PR DESCRIPTION
## Summary

Sibling of #1739 (docs-only sweep). Three **runtime-emitted** strings cited the private coordination repo; this PR neutralizes them with their tests in lockstep. Surfaced by an internal audit 2026-07-04.

## Changes

1. **`@revealui/mcp/author`** — `AUTHOR_SDK_TRACKING_ISSUE` pointed npm consumers at a private issue URL (a 404 for anyone outside the org). Now points at the public repo issue tracker; the stub error message keeps its `Track via <url>` shape. Test assertion updated in lockstep.
2. **`@revealui/openapi`** — the spec `info.description` named the private repo. Emitter string neutralized and `contracts.openapi.json` regenerated via `emit:contracts`; `check:contracts` confirms 108 components match the committed reference.
3. **`apps/server` startup banner** — the Stripe test-mode warning printed the private repo name to stderr on every non-live boot. Neutralized with box width preserved; the `GAP-124` anchor stays, so the existing banner test passes **unchanged**. The adjacent doc comment in the same file is neutralized here too (kept out of #1739 to avoid a cross-PR conflict on this file).

## Verification

- `@revealui/mcp` author suite: 10/10
- `apps/server` validate-startup suite: 106/106
- `@revealui/openapi` full suite: 153/153 (includes emit-from-mcp tests)
- `check:contracts` drift gate: green

File-disjoint from #1739. Manual merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
