### PR TITLE
fix(admin): make RichText checklist normalization pure

### DIFF
--- a/apps/admin/src/lib/components/RichText/index.tsx
+++ b/apps/admin/src/lib/components/RichText/index.tsx
@@ -180,7 +180,10 @@ const RichText = ({ className, content, enableGutter = true, enableProse = true 
     return null;
   }
 
-  normalizeChecklists(content.root as unknown as Record<string, unknown>);
+  // Normalize into a fresh copy — never mutate the caller's (possibly shared)
+  // content object — then serialize the copy.
+  const normalizedRoot = normalizeChecklists(content.root as unknown as Record<string, unknown>);
+  const normalizedContent = { ...content, root: normalizedRoot };
 
   return (
     <div
@@ -193,7 +196,7 @@ const RichText = ({ className, content, enableGutter = true, enableProse = true 
         className,
       )}
     >
-      {serializeLexicalState(content as unknown as SerializedEditorState, {
+      {serializeLexicalState(normalizedContent as unknown as SerializedEditorState, {
         renderBlock,
         renderLink,
         renderUpload,

--- a/apps/admin/src/lib/components/RichText/index.tsx
+++ b/apps/admin/src/lib/components/RichText/index.tsx
@@ -47,26 +47,29 @@ type MediaBlockFields = Extract<Page['blocks'][0], { blockType: 'mediaBlock' }>;
 // `checked: true` is ever serialized upstream), so normalize before
 // serializing — otherwise an unchecked item is indistinguishable from a
 // plain list item.
-function normalizeChecklists(node: Record<string, unknown>): void {
+//
+// Pure: returns a normalized copy and never mutates the input `node`. The
+// caller's `content` object may be shared or memoized across renders, so an
+// in-place `checked = false` would leak into other consumers and make a second
+// render observe the first render's side effect.
+function normalizeChecklists(node: Record<string, unknown>): Record<string, unknown> {
   const children = node.children;
   if (!Array.isArray(children)) {
-    return;
+    return node;
   }
-  if (node.type === 'list' && node.listType === 'check') {
-    for (const item of children) {
-      if (item && typeof item === 'object') {
-        const itemRecord = item as Record<string, unknown>;
-        if (itemRecord.checked !== true) {
-          itemRecord.checked = false;
-        }
-      }
+  const isCheckList = node.type === 'list' && node.listType === 'check';
+  const normalizedChildren = children.map((child) => {
+    if (!child || typeof child !== 'object') {
+      return child;
     }
-  }
-  for (const child of children) {
-    if (child && typeof child === 'object') {
-      normalizeChecklists(child as Record<string, unknown>);
+    let childRecord = child as Record<string, unknown>;
+    // Fill the omitted `checked: false` on direct items of a check list.
+    if (isCheckList && childRecord.checked !== true) {
+      childRecord = { ...childRecord, checked: false };
     }
-  }
+    return normalizeChecklists(childRecord);
+  });
+  return { ...node, children: normalizedChildren };
 }
 
 // App-specific renderers injected into the shared @revealui/core serializer.

--- a/apps/admin/src/lib/components/__tests__/RichText-normalize-purity.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/RichText-normalize-purity.test.tsx
@@ -71,7 +71,8 @@ describe('RichText checklist normalization purity', () => {
     expect(content).toEqual(before);
     const list = (content.root as unknown as { children: Array<{ children: unknown[] }> })
       .children[0];
-    const uncheckedItem = list.children[1] as Record<string, unknown>;
+    const uncheckedItem = list?.children[1] as Record<string, unknown> | undefined;
+    expect(uncheckedItem).toBeDefined();
     expect(uncheckedItem).not.toHaveProperty('checked');
   });
 

--- a/apps/admin/src/lib/components/__tests__/RichText-normalize-purity.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/RichText-normalize-purity.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Purity regression for the RichText checklist normalizer.
+ *
+ * `normalizeChecklists` fills the `checked: false` that Lexical omits on
+ * unchecked check-list items. It must do so on a COPY — the caller's `content`
+ * object may be shared or memoized across renders, so an in-place mutation would
+ * leak into other consumers and make a second render observe the first render's
+ * side effect.
+ */
+import { render } from '@testing-library/react';
+import type { ImgHTMLAttributes } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/image', () => ({
+  default: ({ fill: _fill, priority: _priority, ...rest }: Record<string, unknown>) => {
+    // biome-ignore lint/performance/noImgElement: test stand-in for next/image
+    // biome-ignore lint/a11y/useAltText: alt is forwarded via rest when present
+    return <img {...(rest as ImgHTMLAttributes<HTMLImageElement>)} />;
+  },
+}));
+vi.mock('@/lib/blocks/Banner/Component', () => ({ BannerBlock: () => <div /> }));
+vi.mock('@/lib/blocks/CallToAction/Component', () => ({ CallToActionBlock: () => <div /> }));
+vi.mock('@/lib/blocks/Code/Component', () => ({ CodeBlock: () => <div /> }));
+vi.mock('@/lib/blocks/MediaBlock/Component', () => ({ MediaBlock: () => <div /> }));
+
+import RichText, { type RichTextContent } from '../RichText/index';
+
+/** A check list with one checked item and one unchecked item (no `checked` key). */
+function checklistContent(): RichTextContent {
+  return {
+    root: {
+      type: 'root',
+      direction: null,
+      format: '',
+      indent: 0,
+      version: 1,
+      children: [
+        {
+          type: 'list',
+          listType: 'check',
+          tag: 'ul',
+          version: 1,
+          children: [
+            {
+              type: 'listitem',
+              version: 1,
+              checked: true,
+              children: [{ type: 'text', text: 'done', format: 0, version: 1 }],
+            },
+            {
+              // Unchecked item: Lexical omits `checked` entirely here.
+              type: 'listitem',
+              version: 1,
+              children: [{ type: 'text', text: 'todo', format: 0, version: 1 }],
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as RichTextContent;
+}
+
+describe('RichText checklist normalization purity', () => {
+  it('does not mutate the caller content object', () => {
+    const content = checklistContent();
+    const before = structuredClone(content);
+
+    render(<RichText content={content} />);
+
+    // The input tree is untouched — the unchecked item still has no `checked`.
+    expect(content).toEqual(before);
+    const list = (content.root as unknown as { children: Array<{ children: unknown[] }> })
+      .children[0];
+    const uncheckedItem = list.children[1] as Record<string, unknown>;
+    expect(uncheckedItem).not.toHaveProperty('checked');
+  });
+
+  it('renders a shared content object identically across two renders', () => {
+    const content = checklistContent();
+
+    const first = render(<RichText content={content} />).container.innerHTML;
+    const second = render(<RichText content={content} />).container.innerHTML;
+
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

`normalizeChecklists` in the admin `RichText` component wrote `checked: false` into the caller's content tree in place. Low risk on a server render with a fresh fetch, but a shared or memoized content object would observe the first render's side effect. Internal audit follow-up (same review series as the render-path hardening PRs).

## Changes

- `normalizeChecklists` is now pure: a recursive pre-walk that returns a normalized copy (`{ ...node, children }` spreads; the omitted `checked: false` is filled on a copied list item, never on the input). The component serializes the normalized copy.
- New regression suite `RichText-normalize-purity.test.tsx`: (1) the caller's content object is untouched after render — deep-equal to a pre-render `structuredClone`, and the unchecked item still has no `checked` key; (2) a shared content object renders identically across two renders.

## Verification

- Admin components test dir: 5 files / 42 tests green (includes the existing `RichText-serializer-xss` suite on the same surface).
- `apps/admin` `tsc --noEmit` clean.
- Rendering behavior unchanged: same normalized tree reaches the shared `@revealui/core` serializer.

History note: builds on a prior session's WIP commit (kept intact); completion + tests in the follow-up commits. Manual merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
