### PR TITLE
ci: add push trigger to docker.yml for kit-affecting merges

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,30 @@ name: Build & Push Forge Docker Images
 # (supply-chain parity with the npm --provenance release flow).
 
 on:
+  push:
+    branches: [test, main]
+    paths:
+      - apps/admin/**
+      - apps/server/**
+      - packages/auth/**
+      - packages/cache/**
+      - packages/config/**
+      - packages/contracts/**
+      - packages/core/**
+      - packages/db/**
+      - packages/openapi/**
+      - packages/paywall/**
+      - packages/presentation/**
+      - packages/resilience/**
+      - packages/router/**
+      - packages/security/**
+      - packages/sync/**
+      - packages/utils/**
+      - package.json
+      - pnpm-lock.yaml
+      - turbo.json
+      - .github/workflows/docker.yml
+      - .github/actions/setup-pnpm-node/**
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

Previously `docker.yml` was `workflow_dispatch` only. Kit-affecting merges to `test`/`main` left `:latest` silently stale — operators had to remember to manually dispatch the workflow. This caused the known boot regression where a `CMD` change in `Dockerfile.forge` didn't propagate to GHCR images until a manual dispatch was run.

- Adds a `push` trigger on `[test, main]` scoped to the paths that affect Forge Docker output: app source (`admin`, `server`), every bundled package, `pnpm-lock.yaml`, `turbo.json`, the workflow file itself, and the setup action.
- **No change to existing `workflow_dispatch` behavior.**
- **No change to any tag logic.**

## Design decision for owner review at merge

**`:latest` tag semantics.** The existing condition is:

```yaml
type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
```

This means:
- Merges to **`main`** → push `:latest` + `:sha-<short>` (unchanged from today's manual dispatch behavior)
- Merges to **`test`** → push `:sha-<short>` only (`:latest` NOT updated)

**The question:** should `:latest` also be pushed from `test`? Currently self-hosted kits track `:latest`, so only `main`-sourced images land in production kits on `docker compose pull`. A `test`-only build stays at the previous `:latest` until a `main` merge follows.

If you want `test` merges to also refresh `:latest` (for demo/QA kits that pull `:latest`), change the condition above to:
```yaml
type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' }}
```

Otherwise, merge as-is and `:latest` stays `main`-only. This is the conservative default — leaving the decision explicit in the PR body so it's recorded.

## Path filter rationale

Scoped to kit-affecting changes only — pure-docs, ADR, test-data, and non-Forge-image paths do not trigger a rebuild. The list mirrors the packages the Forge `Dockerfile` stages bundle. Open to narrowing or expanding at review.

## Test plan

- [ ] CI gate passes on this branch
- [ ] Owner confirms `:latest` tag semantics (main-only vs test+main) at merge
- [ ] After merge to `test`: verify a subsequent kit-affecting commit auto-triggers a docker.yml run