### PR TITLE
ci(docker): add missing Pro/build package paths to push trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,19 +17,25 @@ on:
     paths:
       - apps/admin/**
       - apps/server/**
+      - packages/ai/**
       - packages/auth/**
       - packages/cache/**
       - packages/config/**
       - packages/contracts/**
       - packages/core/**
       - packages/db/**
+      - packages/dev/**
+      - packages/mcp/**
       - packages/openapi/**
       - packages/paywall/**
       - packages/presentation/**
       - packages/resilience/**
       - packages/router/**
       - packages/security/**
+      - packages/services/**
+      - packages/setup/**
       - packages/sync/**
+      - packages/tokens/**
       - packages/utils/**
       - package.json
       - pnpm-lock.yaml

--- a/scripts/security/rotate-kek.ts
+++ b/scripts/security/rotate-kek.ts
@@ -3,8 +3,8 @@
 /**
  * KEK rotation tool — re-encrypt every KEK-encrypted row with a new key.
  *
- * Two surfaces in scope (per the GAP-126 Phase 1 survey
- * (internal KEK-encrypted-surfaces doc):
+ * Two surfaces in scope (per the GAP-126 Phase 1 survey,
+ * internal KEK-encrypted-surfaces doc):
  *
  *   1. user_api_keys.encrypted_key  (NOT NULL, strict envelope)
  *   2. users.mfa_secret             (NULLABLE, rolling-migration aware)


### PR DESCRIPTION
## Summary

Adds 6 missing package paths to the `docker.yml` push trigger path filter, plus a cosmetic comment fix:

- `packages/ai/**` — direct runtime dep of apps/server and apps/admin (AI harness)
- `packages/mcp/**` — direct runtime dep of both apps (MCP hypervisor)
- `packages/services/**` — direct runtime dep of both apps (Stripe billing, Vercel)
- `packages/setup/**` — admin-specific environment setup utilities
- `packages/tokens/**` — design tokens; rides `presentation`, which already triggers
- `packages/dev/**` — shared Biome/TS/Tailwind/Vite configs; affects both app builds

These were absent from the initial trigger added in #1745. A change to any of these packages would not trigger a Docker rebuild, leaving the kit images stale.

Second commit: fixes an unbalanced parenthesis in the `rotate-kek.ts` comment (internal review follow-up from #1739).

## Test plan

- [ ] Verify `paths:` list in docker.yml now includes all 6 packages above
- [ ] Confirm CI passes (workflow file only, no runtime change)
- [ ] After merge: a push touching `packages/ai/**` etc. should trigger the docker build