### PR TITLE
feat(harnesses): add goal harness (goal-driven coordination, propose-only)

### DIFF
--- a/.changeset/add-goal-harness.md
+++ b/.changeset/add-goal-harness.md
@@ -1,0 +1,5 @@
+---
+'@revealui/harnesses': minor
+---
+
+Add the goal harness: goal-driven agent coordination with acceptance-criteria gating. New `GoalHarness` engine (exported at the root and at `@revealui/harnesses/goals`), `goals` + `goal_criteria` daemon tables, and DaemonStore goal methods. Completion is fail-closed (every criterion needs recorded evidence, every linked task must be completed) and the surface is propose-only: goals emit claimable tasks into the existing daemon task queue and never spawn agents.

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js"
     },
+    "./goals": {
+      "types": "./dist/goals/index.d.ts",
+      "import": "./dist/goals/index.js"
+    },
     "./protocol": {
       "types": "./dist/protocol/index.d.ts",
       "import": "./dist/protocol/index.js"
@@ -90,6 +94,7 @@
     "ai",
     "workboard",
     "json-rpc",
-    "agent"
+    "agent",
+    "goals"
   ]
 }

--- a/packages/harnesses/src/__tests__/goal-harness.test.ts
+++ b/packages/harnesses/src/__tests__/goal-harness.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for GoalHarness  -  goal-driven coordination over DaemonStore.
+ *
+ * Uses in-memory PGlite (no data directory) for isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: () => true,
+}));
+
+vi.mock('@revealui/core/license', () => ({
+  initializeLicense: async () => {},
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GoalHarness } from '../goals/goal-harness.js';
+import { DaemonStore } from '../storage/daemon-store.js';
+
+function must<T>(value: T | undefined | null): T {
+  if (value === undefined || value === null) throw new Error('expected a value');
+  return value;
+}
+
+describe('GoalHarness', () => {
+  let store: DaemonStore;
+  let harness: GoalHarness;
+
+  beforeEach(async () => {
+    // In-memory PGlite: no dataDir means ephemeral
+    store = new DaemonStore({ dataDir: '' });
+    await store.init();
+    harness = new GoalHarness({ store, agentId: 'tester' });
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it('creates a goal with initial criteria', async () => {
+    const { goal, criteria } = await harness.createGoal({
+      title: 'Ship the goal harness',
+      description: 'Goal-driven coordination for the daemon',
+      priority: 'high',
+      criteria: ['typecheck passes', 'tests pass'],
+    });
+    expect(goal.status).toBe('open');
+    expect(goal.priority).toBe('high');
+    expect(goal.owner).toBe('agent');
+    expect(goal.created_by).toBe('tester');
+    expect(criteria).toHaveLength(2);
+    expect(criteria[0]?.status).toBe('pending');
+  });
+
+  it('rejects an empty title', async () => {
+    await expect(harness.createGoal({ title: '' })).rejects.toThrow();
+  });
+
+  it('refuses to activate while a blocker is open', async () => {
+    const blocker = await harness.createGoal({ title: 'Blocker goal' });
+    const { goal } = await harness.createGoal({
+      title: 'Dependent goal',
+      blockedBy: [blocker.goal.id],
+    });
+
+    const refused = await harness.activateGoal(goal.id);
+    expect(refused.success).toBe(false);
+    expect(refused.unresolvedBlockers).toEqual([blocker.goal.id]);
+
+    await harness.abandonGoal(blocker.goal.id, 'not needed');
+    const activated = await harness.activateGoal(goal.id);
+    expect(activated.success).toBe(true);
+    expect(activated.goal?.status).toBe('active');
+  });
+
+  it('requires evidence to mark a criterion met', async () => {
+    const { criteria } = await harness.createGoal({ title: 'Evidence goal', criteria: ['c1'] });
+    const criterion = must(criteria[0]);
+
+    const refused = await harness.recordCriterion(criterion.id, 'met', '');
+    expect(refused.success).toBe(false);
+
+    const recorded = await harness.recordCriterion(criterion.id, 'met', 'vitest run: all passed');
+    expect(recorded.success).toBe(true);
+    expect(recorded.criterion?.status).toBe('met');
+    expect(recorded.criterion?.verified_by).toBe('tester');
+    expect(recorded.criterion?.verified_at).not.toBeNull();
+  });
+
+  it('proposes a claimable task for a criterion and tracks it in progress', async () => {
+    const { goal, criteria } = await harness.createGoal({ title: 'Task goal', criteria: ['c1'] });
+    const criterion = must(criteria[0]);
+
+    // Propose-only surface is gated on an active goal
+    const early = await harness.proposeTaskForCriterion(criterion.id);
+    expect(early.success).toBe(false);
+
+    await harness.activateGoal(goal.id);
+    const proposed = await harness.proposeTaskForCriterion(criterion.id);
+    expect(proposed.success).toBe(true);
+    expect(proposed.created).toBe(true);
+    const taskId = must(proposed.task).id;
+
+    // Shows up in the daemon task queue as claimable
+    const open = await store.listTasks({ status: 'open' });
+    expect(open.map((t) => t.id)).toContain(taskId);
+
+    // Idempotent while the linked task is live
+    const again = await harness.proposeTaskForCriterion(criterion.id);
+    expect(again.created).toBe(false);
+    expect(again.task?.id).toBe(taskId);
+
+    // Work the task through the existing claim/complete flow
+    await store.claimTask(taskId, 'worker-1');
+    await store.completeTask(taskId, 'worker-1');
+
+    const progress = await harness.progress(goal.id);
+    expect(progress?.tasks.completed).toBe(1);
+    // Task done but criterion still awaits verification
+    expect(progress?.readyToComplete).toBe(false);
+  });
+
+  it('fails closed on completion until every criterion is met', async () => {
+    const { goal, criteria } = await harness.createGoal({
+      title: 'Completion goal',
+      criteria: ['c1', 'c2'],
+    });
+    await harness.activateGoal(goal.id);
+
+    const refused = await harness.completeGoal(goal.id);
+    expect(refused.success).toBe(false);
+    expect(refused.unmet?.length).toBeGreaterThan(0);
+
+    await harness.recordCriterion(must(criteria[0]).id, 'met', 'verified manually');
+    await harness.recordCriterion(must(criteria[1]).id, 'met', 'verified manually');
+
+    const completed = await harness.completeGoal(goal.id);
+    expect(completed.success).toBe(true);
+    expect(completed.goal?.status).toBe('done');
+    expect(completed.goal?.closed_at).not.toBeNull();
+  });
+
+  it('refuses to complete a goal with no criteria', async () => {
+    const { goal } = await harness.createGoal({ title: 'No criteria' });
+    await harness.activateGoal(goal.id);
+    const refused = await harness.completeGoal(goal.id);
+    expect(refused.success).toBe(false);
+    expect(refused.unmet).toContain('no acceptance criteria defined');
+  });
+
+  it('treats terminal goals as immutable', async () => {
+    const { goal } = await harness.createGoal({ title: 'Short-lived goal' });
+    await harness.abandonGoal(goal.id, 'superseded');
+
+    const reactivate = await harness.activateGoal(goal.id);
+    expect(reactivate.success).toBe(false);
+
+    const lateCriterion = await harness.addCriterion(goal.id, 'late criterion');
+    expect(lateCriterion.success).toBe(false);
+  });
+
+  it('computes percent from met criteria', async () => {
+    const { goal, criteria } = await harness.createGoal({
+      title: 'Percent goal',
+      criteria: ['c1', 'c2'],
+    });
+    await harness.recordCriterion(must(criteria[0]).id, 'met', 'done and verified');
+    const progress = await harness.progress(goal.id);
+    expect(progress?.percent).toBe(50);
+    expect(progress?.criteria).toEqual({ total: 2, met: 1, failed: 0, pending: 1 });
+  });
+
+  it('derives next actions across the criterion lifecycle', async () => {
+    const { goal, criteria } = await harness.createGoal({ title: 'Loop goal', criteria: ['c1'] });
+    const criterion = must(criteria[0]);
+    await harness.activateGoal(goal.id);
+
+    let actions = await harness.nextActions(goal.id);
+    expect(actions[0]?.action).toBe('propose-task');
+
+    const proposed = await harness.proposeTaskForCriterion(criterion.id);
+    const taskId = must(proposed.task).id;
+    actions = await harness.nextActions(goal.id);
+    expect(actions[0]?.action).toBe('await-task');
+
+    await store.claimTask(taskId, 'worker-1');
+    await store.completeTask(taskId, 'worker-1');
+    actions = await harness.nextActions(goal.id);
+    expect(actions[0]?.action).toBe('verify');
+
+    await harness.recordCriterion(criterion.id, 'failed', 'verification found a regression');
+    actions = await harness.nextActions(goal.id);
+    expect(actions[0]?.action).toBe('rework');
+
+    // Rework: reset clears evidence and the task link so a fresh task can be proposed
+    const reset = await harness.resetCriterion(criterion.id);
+    expect(reset.success).toBe(true);
+    expect(reset.criterion?.task_id).toBeNull();
+    actions = await harness.nextActions(goal.id);
+    expect(actions[0]?.action).toBe('propose-task');
+  });
+
+  it('filters goal lists', async () => {
+    await harness.createGoal({ title: 'High goal', priority: 'high' });
+    const { goal: mediumGoal } = await harness.createGoal({ title: 'Medium goal' });
+    await harness.activateGoal(mediumGoal.id);
+
+    const high = await harness.listGoals({ priority: 'high' });
+    expect(high).toHaveLength(1);
+    expect(high[0]?.title).toBe('High goal');
+
+    const active = await harness.listGoals({ status: 'active' });
+    expect(active).toHaveLength(1);
+    expect(active[0]?.id).toBe(mediumGoal.id);
+  });
+
+  it('logs goal events to the daemon audit trail', async () => {
+    const { goal } = await harness.createGoal({ title: 'Audited goal', criteria: ['c1'] });
+    await harness.activateGoal(goal.id);
+
+    const events = await store.getRecentEvents(10);
+    const types = events.map((e) => e.event_type);
+    expect(types).toContain('goal.created');
+    expect(types).toContain('goal.activated');
+    expect(events.every((e) => e.agent_id === 'tester')).toBe(true);
+  });
+});

--- a/packages/harnesses/src/goals/goal-harness.ts
+++ b/packages/harnesses/src/goals/goal-harness.ts
@@ -1,0 +1,434 @@
+/**
+ * GoalHarness  -  goal-driven coordination engine over DaemonStore.
+ *
+ * Owns the goal lifecycle (open -> active -> done, with blocked/abandoned
+ * branches), enforces fail-closed completion (every criterion met, every
+ * linked task completed, evidence required for "met"), and derives progress
+ * plus next actions for agents.
+ *
+ * Propose-only by design: the engine creates claimable rows in the daemon
+ * `tasks` table and never spawns agents. Agent execution stays behind the
+ * daemon's separately-gated agent surface.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DaemonStore } from '../storage/daemon-store.js';
+import type { AgentTask, GoalCriterionRow, GoalRow } from '../storage/schema.js';
+import type {
+  CreateGoalInput,
+  GoalActionItem,
+  GoalOwner,
+  GoalPriority,
+  GoalProgress,
+  GoalStatus,
+  GoalWithCriteria,
+} from './goal-schema.js';
+import { createGoalInputSchema } from './goal-schema.js';
+
+/** Options for constructing a GoalHarness. */
+export interface GoalHarnessOptions {
+  /** Initialized DaemonStore providing persistence. */
+  store: DaemonStore;
+  /** Agent identity recorded on events and criterion verifications. */
+  agentId: string;
+}
+
+/** Result of a guarded goal state transition. */
+export interface GoalTransitionResult {
+  success: boolean;
+  reason?: string;
+  goal?: GoalRow;
+  /** Blocker goal ids still unresolved (activateGoal only). */
+  unresolvedBlockers?: string[];
+  /** Everything still gating completion (completeGoal only). */
+  unmet?: string[];
+}
+
+/** Result of a criterion mutation. */
+export interface CriterionRecordResult {
+  success: boolean;
+  reason?: string;
+  criterion?: GoalCriterionRow;
+}
+
+/** Result of proposing a claimable task for a criterion. */
+export interface ProposeTaskResult {
+  success: boolean;
+  reason?: string;
+  /** False when an existing live task was returned instead of a new one. */
+  created?: boolean;
+  task?: AgentTask;
+  criterion?: GoalCriterionRow;
+}
+
+const TERMINAL_STATUSES: ReadonlySet<GoalStatus> = new Set(['done', 'abandoned']);
+
+const ALLOWED_TRANSITIONS: ReadonlyMap<GoalStatus, ReadonlySet<GoalStatus>> = new Map<
+  GoalStatus,
+  ReadonlySet<GoalStatus>
+>([
+  ['open', new Set<GoalStatus>(['active', 'blocked', 'abandoned'])],
+  ['active', new Set<GoalStatus>(['blocked', 'done', 'abandoned'])],
+  ['blocked', new Set<GoalStatus>(['active', 'abandoned'])],
+  ['done', new Set<GoalStatus>()],
+  ['abandoned', new Set<GoalStatus>()],
+]);
+
+function canTransition(from: GoalStatus, to: GoalStatus): boolean {
+  return ALLOWED_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+export class GoalHarness {
+  private readonly store: DaemonStore;
+  private readonly agentId: string;
+
+  constructor(options: GoalHarnessOptions) {
+    this.store = options.store;
+    this.agentId = options.agentId;
+  }
+
+  /** Create a goal with optional initial acceptance criteria. */
+  async createGoal(input: CreateGoalInput): Promise<GoalWithCriteria> {
+    const parsed = createGoalInputSchema.parse(input);
+    const goalId = `goal-${randomUUID()}`;
+    const goal = await this.store.createGoal({
+      id: goalId,
+      title: parsed.title,
+      description: parsed.description,
+      priority: parsed.priority,
+      owner: parsed.owner,
+      parentGoalId: parsed.parentGoalId,
+      blockedBy: parsed.blockedBy,
+      createdBy: this.agentId,
+    });
+    const criteria: GoalCriterionRow[] = [];
+    for (const description of parsed.criteria) {
+      criteria.push(
+        await this.store.addGoalCriterion({ id: `crit-${randomUUID()}`, goalId, description }),
+      );
+    }
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.created',
+      payload: { goalId, title: parsed.title, criteria: criteria.length },
+    });
+    return { goal, criteria };
+  }
+
+  /** Get a goal together with its criteria. */
+  async getGoal(goalId: string): Promise<GoalWithCriteria | null> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return null;
+    const criteria = await this.store.listGoalCriteria(goalId);
+    return { goal, criteria };
+  }
+
+  /** List goals, optionally filtered. */
+  async listGoals(filter?: {
+    status?: GoalStatus;
+    priority?: GoalPriority;
+    owner?: GoalOwner;
+    parentGoalId?: string;
+  }): Promise<GoalRow[]> {
+    return this.store.listGoals(filter);
+  }
+
+  /** Activate a goal. Refuses while any blocked-by goal is unresolved. */
+  async activateGoal(goalId: string): Promise<GoalTransitionResult> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return { success: false, reason: `goal not found: ${goalId}` };
+    if (!canTransition(goal.status, 'active')) {
+      return { success: false, reason: `cannot activate a goal in status '${goal.status}'` };
+    }
+    const unresolved: string[] = [];
+    for (const blockerId of goal.blocked_by) {
+      const blocker = await this.store.getGoal(blockerId);
+      if (!(blocker && TERMINAL_STATUSES.has(blocker.status))) {
+        unresolved.push(blockerId);
+      }
+    }
+    if (unresolved.length > 0) {
+      return {
+        success: false,
+        reason: 'unresolved blockers',
+        unresolvedBlockers: unresolved,
+      };
+    }
+    const updated = await this.store.setGoalStatus(goalId, 'active', '');
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.activated',
+      payload: { goalId },
+    });
+    return { success: true, goal: updated ?? undefined };
+  }
+
+  /** Block a goal with a reason. */
+  async blockGoal(goalId: string, reason: string): Promise<GoalTransitionResult> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return { success: false, reason: `goal not found: ${goalId}` };
+    if (!canTransition(goal.status, 'blocked')) {
+      return { success: false, reason: `cannot block a goal in status '${goal.status}'` };
+    }
+    const updated = await this.store.setGoalStatus(goalId, 'blocked', reason);
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.blocked',
+      payload: { goalId, reason },
+    });
+    return { success: true, goal: updated ?? undefined };
+  }
+
+  /** Abandon a goal with a reason (terminal). */
+  async abandonGoal(goalId: string, reason: string): Promise<GoalTransitionResult> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return { success: false, reason: `goal not found: ${goalId}` };
+    if (!canTransition(goal.status, 'abandoned')) {
+      return { success: false, reason: `cannot abandon a goal in status '${goal.status}'` };
+    }
+    const updated = await this.store.setGoalStatus(goalId, 'abandoned', reason);
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.abandoned',
+      payload: { goalId, reason },
+    });
+    return { success: true, goal: updated ?? undefined };
+  }
+
+  /**
+   * Complete a goal. Fail-closed: refuses unless every criterion is met and
+   * every linked task is completed (a goal with zero criteria never completes).
+   */
+  async completeGoal(goalId: string): Promise<GoalTransitionResult> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return { success: false, reason: `goal not found: ${goalId}` };
+    if (!canTransition(goal.status, 'done')) {
+      return { success: false, reason: `cannot complete a goal in status '${goal.status}'` };
+    }
+    const progress = await this.progress(goalId);
+    if (!progress?.readyToComplete) {
+      return {
+        success: false,
+        reason: 'completion gated by unmet acceptance criteria',
+        unmet: progress?.unmet ?? [],
+      };
+    }
+    const updated = await this.store.setGoalStatus(goalId, 'done', '');
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.completed',
+      payload: { goalId },
+    });
+    return { success: true, goal: updated ?? undefined };
+  }
+
+  /** Add an acceptance criterion to a non-terminal goal. */
+  async addCriterion(goalId: string, description: string): Promise<CriterionRecordResult> {
+    const trimmed = description.trim();
+    if (trimmed.length === 0) {
+      return { success: false, reason: 'criterion description is required' };
+    }
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return { success: false, reason: `goal not found: ${goalId}` };
+    if (TERMINAL_STATUSES.has(goal.status)) {
+      return { success: false, reason: `goal is terminal ('${goal.status}')` };
+    }
+    const criterion = await this.store.addGoalCriterion({
+      id: `crit-${randomUUID()}`,
+      goalId,
+      description: trimmed,
+    });
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.criterion-added',
+      payload: { goalId, criterionId: criterion.id },
+    });
+    return { success: true, criterion };
+  }
+
+  /**
+   * Record a criterion verdict. Marking a criterion met requires non-empty
+   * evidence (what was run/observed)  -  claims without evidence are refused.
+   */
+  async recordCriterion(
+    criterionId: string,
+    verdict: 'met' | 'failed',
+    evidence = '',
+  ): Promise<CriterionRecordResult> {
+    const criterion = await this.store.getGoalCriterion(criterionId);
+    if (!criterion) return { success: false, reason: `criterion not found: ${criterionId}` };
+    const goal = await this.store.getGoal(criterion.goal_id);
+    if (goal && TERMINAL_STATUSES.has(goal.status)) {
+      return { success: false, reason: `goal is terminal ('${goal.status}')` };
+    }
+    if (verdict === 'met' && evidence.trim().length === 0) {
+      return { success: false, reason: 'evidence is required to mark a criterion met' };
+    }
+    const updated = await this.store.recordGoalCriterion({
+      id: criterionId,
+      status: verdict,
+      evidence,
+      verifiedBy: this.agentId,
+    });
+    if (!updated) return { success: false, reason: `criterion not found: ${criterionId}` };
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: verdict === 'met' ? 'goal.criterion-met' : 'goal.criterion-failed',
+      payload: { goalId: updated.goal_id, criterionId },
+    });
+    return { success: true, criterion: updated };
+  }
+
+  /** Reset a failed criterion to pending, clearing evidence and task link. */
+  async resetCriterion(criterionId: string): Promise<CriterionRecordResult> {
+    const criterion = await this.store.getGoalCriterion(criterionId);
+    if (!criterion) return { success: false, reason: `criterion not found: ${criterionId}` };
+    const goal = await this.store.getGoal(criterion.goal_id);
+    if (goal && TERMINAL_STATUSES.has(goal.status)) {
+      return { success: false, reason: `goal is terminal ('${goal.status}')` };
+    }
+    if (criterion.status !== 'failed') {
+      return {
+        success: false,
+        reason: `only failed criteria can be reset (status: '${criterion.status}')`,
+      };
+    }
+    const reset = await this.store.resetGoalCriterion(criterionId);
+    if (!reset) return { success: false, reason: `criterion not found: ${criterionId}` };
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.criterion-reset',
+      payload: { goalId: reset.goal_id, criterionId },
+    });
+    return { success: true, criterion: reset };
+  }
+
+  /**
+   * Propose a claimable daemon task for a pending criterion of an active goal.
+   * Idempotent while a live task is already linked (returns it, created=false).
+   */
+  async proposeTaskForCriterion(criterionId: string): Promise<ProposeTaskResult> {
+    const criterion = await this.store.getGoalCriterion(criterionId);
+    if (!criterion) return { success: false, reason: `criterion not found: ${criterionId}` };
+    const goal = await this.store.getGoal(criterion.goal_id);
+    if (!goal) return { success: false, reason: `goal not found: ${criterion.goal_id}` };
+    if (goal.status !== 'active') {
+      return {
+        success: false,
+        reason: `goal must be active to propose tasks (status: '${goal.status}')`,
+      };
+    }
+    if (criterion.status !== 'pending') {
+      return { success: false, reason: `criterion is '${criterion.status}', not pending` };
+    }
+    if (criterion.task_id) {
+      const existing = await this.store.getTask(criterion.task_id);
+      if (existing) return { success: true, created: false, task: existing, criterion };
+    }
+    const task = await this.store.createTask({
+      id: `goal-task-${randomUUID()}`,
+      description: `[goal ${goal.id}] ${goal.title} :: ${criterion.description}`,
+    });
+    const linked = await this.store.linkGoalCriterionTask(criterionId, task.id);
+    await this.store.logEvent({
+      agentId: this.agentId,
+      eventType: 'goal.task-proposed',
+      payload: { goalId: goal.id, criterionId, taskId: task.id },
+    });
+    return { success: true, created: true, task, criterion: linked ?? criterion };
+  }
+
+  /** Compute a progress snapshot for a goal. */
+  async progress(goalId: string): Promise<GoalProgress | null> {
+    const goal = await this.store.getGoal(goalId);
+    if (!goal) return null;
+    const criteria = await this.store.listGoalCriteria(goalId);
+    const criteriaCounts = { total: criteria.length, met: 0, failed: 0, pending: 0 };
+    const taskCounts = { total: 0, completed: 0, claimed: 0, open: 0 };
+    const unmet: string[] = [];
+    if (criteria.length === 0) unmet.push('no acceptance criteria defined');
+    for (const criterion of criteria) {
+      if (criterion.status === 'met') {
+        criteriaCounts.met++;
+      } else if (criterion.status === 'failed') {
+        criteriaCounts.failed++;
+        unmet.push(`criterion failed: ${criterion.description}`);
+      } else {
+        criteriaCounts.pending++;
+        unmet.push(`criterion pending: ${criterion.description}`);
+      }
+      if (criterion.task_id) {
+        const task = await this.store.getTask(criterion.task_id);
+        if (task) {
+          taskCounts.total++;
+          if (task.status === 'completed') {
+            taskCounts.completed++;
+          } else if (task.status === 'claimed') {
+            taskCounts.claimed++;
+            unmet.push(`task in progress: ${task.id}`);
+          } else {
+            taskCounts.open++;
+            unmet.push(`task unclaimed: ${task.id}`);
+          }
+        }
+      }
+    }
+    const percent =
+      criteriaCounts.total === 0
+        ? 0
+        : Math.round((criteriaCounts.met / criteriaCounts.total) * 100);
+    return {
+      goalId,
+      status: goal.status,
+      criteria: criteriaCounts,
+      tasks: taskCounts,
+      percent,
+      readyToComplete: unmet.length === 0,
+      unmet,
+    };
+  }
+
+  /** Derive the actionable next steps for a goal's unmet criteria. */
+  async nextActions(goalId: string): Promise<GoalActionItem[]> {
+    const criteria = await this.store.listGoalCriteria(goalId);
+    const actions: GoalActionItem[] = [];
+    for (const criterion of criteria) {
+      if (criterion.status === 'met') continue;
+      if (criterion.status === 'failed') {
+        actions.push({
+          criterionId: criterion.id,
+          description: criterion.description,
+          action: 'rework',
+          taskId: criterion.task_id,
+        });
+        continue;
+      }
+      if (!criterion.task_id) {
+        actions.push({
+          criterionId: criterion.id,
+          description: criterion.description,
+          action: 'propose-task',
+          taskId: null,
+        });
+        continue;
+      }
+      const task = await this.store.getTask(criterion.task_id);
+      if (task && task.status !== 'completed') {
+        actions.push({
+          criterionId: criterion.id,
+          description: criterion.description,
+          action: 'await-task',
+          taskId: task.id,
+        });
+      } else {
+        actions.push({
+          criterionId: criterion.id,
+          description: criterion.description,
+          action: 'verify',
+          taskId: criterion.task_id,
+        });
+      }
+    }
+    return actions;
+  }
+}

--- a/packages/harnesses/src/goals/goal-schema.ts
+++ b/packages/harnesses/src/goals/goal-schema.ts
@@ -1,0 +1,67 @@
+/**
+ * Goal harness contracts  -  Zod schemas and types for goal-driven coordination.
+ *
+ * A goal is a durable, verifiable objective. Acceptance criteria gate
+ * completion (evidence is required to mark a criterion met), and progress
+ * derives from the criteria plus the claimable daemon tasks linked to them.
+ * The goal layer is propose-only: it emits tasks into the daemon task queue
+ * for agents to claim and never spawns agents itself.
+ */
+
+import { z } from 'zod';
+import type { GoalCriterionRow, GoalRow } from '../storage/schema.js';
+
+export const GOAL_STATUSES = ['open', 'active', 'blocked', 'done', 'abandoned'] as const;
+export type GoalStatus = (typeof GOAL_STATUSES)[number];
+
+export const GOAL_PRIORITIES = ['blocker', 'high', 'medium', 'low'] as const;
+export type GoalPriority = (typeof GOAL_PRIORITIES)[number];
+
+export const GOAL_OWNERS = ['agent', 'human'] as const;
+export type GoalOwner = (typeof GOAL_OWNERS)[number];
+
+export const CRITERION_STATUSES = ['pending', 'met', 'failed'] as const;
+export type CriterionStatus = (typeof CRITERION_STATUSES)[number];
+
+export const GOAL_ACTIONS = ['propose-task', 'await-task', 'verify', 'rework'] as const;
+export type GoalAction = (typeof GOAL_ACTIONS)[number];
+
+/** Input contract for creating a goal (criteria are initial acceptance criteria). */
+export const createGoalInputSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(4000).default(''),
+  priority: z.enum(GOAL_PRIORITIES).default('medium'),
+  owner: z.enum(GOAL_OWNERS).default('agent'),
+  parentGoalId: z.string().min(1).optional(),
+  blockedBy: z.array(z.string().min(1)).default([]),
+  criteria: z.array(z.string().min(1).max(1000)).default([]),
+});
+export type CreateGoalInput = z.input<typeof createGoalInputSchema>;
+
+/** A goal together with its acceptance criteria. */
+export interface GoalWithCriteria {
+  goal: GoalRow;
+  criteria: GoalCriterionRow[];
+}
+
+/** Derived progress snapshot for a goal. */
+export interface GoalProgress {
+  goalId: string;
+  status: GoalRow['status'];
+  criteria: { total: number; met: number; failed: number; pending: number };
+  tasks: { total: number; completed: number; claimed: number; open: number };
+  /** 0-100, met criteria over total; 0 while no criteria exist. */
+  percent: number;
+  /** True when every criterion is met and every linked task is completed. */
+  readyToComplete: boolean;
+  /** Human-readable list of everything still gating completion. */
+  unmet: string[];
+}
+
+/** One actionable next step derived from a goal's criterion state. */
+export interface GoalActionItem {
+  criterionId: string;
+  description: string;
+  action: GoalAction;
+  taskId: string | null;
+}

--- a/packages/harnesses/src/goals/index.ts
+++ b/packages/harnesses/src/goals/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Goal harness  -  goal-driven coordination for the RevDev Harness daemon.
+ *
+ * @packageDocumentation
+ */
+
+export type {
+  CriterionRecordResult,
+  GoalHarnessOptions,
+  GoalTransitionResult,
+  ProposeTaskResult,
+} from './goal-harness.js';
+export { GoalHarness } from './goal-harness.js';
+export type {
+  CreateGoalInput,
+  CriterionStatus,
+  GoalAction,
+  GoalActionItem,
+  GoalOwner,
+  GoalPriority,
+  GoalProgress,
+  GoalStatus,
+  GoalWithCriteria,
+} from './goal-schema.js';
+export {
+  CRITERION_STATUSES,
+  createGoalInputSchema,
+  GOAL_ACTIONS,
+  GOAL_OWNERS,
+  GOAL_PRIORITIES,
+  GOAL_STATUSES,
+} from './goal-schema.js';

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -53,6 +53,31 @@ export {
   findHarnessProcesses,
   findProcesses,
 } from './detection/process-detector.js';
+// Goals (goal-driven coordination; propose-only)
+export type {
+  CreateGoalInput,
+  CriterionRecordResult,
+  CriterionStatus,
+  GoalAction,
+  GoalActionItem,
+  GoalHarnessOptions,
+  GoalOwner,
+  GoalPriority,
+  GoalProgress,
+  GoalStatus,
+  GoalTransitionResult,
+  GoalWithCriteria,
+  ProposeTaskResult,
+} from './goals/index.js';
+export {
+  CRITERION_STATUSES,
+  createGoalInputSchema,
+  GOAL_ACTIONS,
+  GOAL_OWNERS,
+  GOAL_PRIORITIES,
+  GOAL_STATUSES,
+  GoalHarness,
+} from './goals/index.js';
 // Harness Protocol (was VAUGHN until 2026-05-18; see docs/HARNESS_PROTOCOL.md)
 export type {
   ClaudeCodeSettings,
@@ -114,6 +139,8 @@ export type {
   AgentTask,
   DaemonEvent,
   FileReservation,
+  GoalCriterionRow,
+  GoalRow,
 } from './storage/schema.js';
 export { SCHEMA_SQL } from './storage/schema.js';
 export type { HarnessAdapter } from './types/adapter.js';

--- a/packages/harnesses/src/storage/daemon-store.ts
+++ b/packages/harnesses/src/storage/daemon-store.ts
@@ -16,6 +16,8 @@ import type {
   AgentWorktree,
   DaemonEvent,
   FileReservation,
+  GoalCriterionRow,
+  GoalRow,
   MergeRequest,
 } from './schema.js';
 import { SCHEMA_SQL } from './schema.js';
@@ -294,6 +296,13 @@ export class DaemonStore {
       [task.id, task.description],
     );
     return result.rows[0] as AgentTask;
+  }
+
+  /** Get a task by ID. */
+  async getTask(taskId: string): Promise<AgentTask | null> {
+    const db = this.getDb();
+    const result = await db.query<AgentTask>('SELECT * FROM tasks WHERE id = $1', [taskId]);
+    return result.rows[0] ?? null;
   }
 
   /** Claim a task atomically (CAS: fails if already claimed by another agent). */
@@ -687,5 +696,183 @@ export class DaemonStore {
       params,
     );
     return result.rows;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Goals
+  // ---------------------------------------------------------------------------
+
+  /** Create a goal. Duplicate ids fail loudly (goals are durable objectives). */
+  async createGoal(goal: {
+    id: string;
+    title: string;
+    description?: string;
+    priority?: GoalRow['priority'];
+    owner?: GoalRow['owner'];
+    parentGoalId?: string;
+    blockedBy?: string[];
+    createdBy?: string;
+  }): Promise<GoalRow> {
+    const db = this.getDb();
+    const result = await db.query<GoalRow>(
+      `INSERT INTO goals (id, title, description, priority, owner, parent_goal_id, blocked_by, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        goal.id,
+        goal.title,
+        goal.description ?? '',
+        goal.priority ?? 'medium',
+        goal.owner ?? 'agent',
+        goal.parentGoalId ?? null,
+        JSON.stringify(goal.blockedBy ?? []),
+        goal.createdBy ?? '',
+      ],
+    );
+    // RETURNING * always produces a row for a plain INSERT
+    return result.rows[0] as GoalRow;
+  }
+
+  /** Get a goal by ID. */
+  async getGoal(id: string): Promise<GoalRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalRow>('SELECT * FROM goals WHERE id = $1', [id]);
+    return result.rows[0] ?? null;
+  }
+
+  /** List goals, optionally filtered by status, priority, owner, and/or parent. */
+  async listGoals(filter?: {
+    status?: string;
+    priority?: string;
+    owner?: string;
+    parentGoalId?: string;
+  }): Promise<GoalRow[]> {
+    const db = this.getDb();
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
+
+    if (filter?.status) {
+      conditions.push(`status = $${paramIdx++}`);
+      params.push(filter.status);
+    }
+    if (filter?.priority) {
+      conditions.push(`priority = $${paramIdx++}`);
+      params.push(filter.priority);
+    }
+    if (filter?.owner) {
+      conditions.push(`owner = $${paramIdx++}`);
+      params.push(filter.owner);
+    }
+    if (filter?.parentGoalId) {
+      conditions.push(`parent_goal_id = $${paramIdx++}`);
+      params.push(filter.parentGoalId);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const result = await db.query<GoalRow>(
+      `SELECT * FROM goals ${where} ORDER BY created_at`,
+      params,
+    );
+    return result.rows;
+  }
+
+  /** Set a goal's status (records closed_at for terminal statuses). */
+  async setGoalStatus(
+    id: string,
+    status: GoalRow['status'],
+    reason: string,
+  ): Promise<GoalRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalRow>(
+      `UPDATE goals SET
+         status = $2,
+         status_reason = $3,
+         updated_at = NOW(),
+         closed_at = CASE WHEN $2 = 'done' OR $2 = 'abandoned' THEN NOW() ELSE NULL END
+       WHERE id = $1
+       RETURNING *`,
+      [id, status, reason],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /** Add an acceptance criterion to a goal. */
+  async addGoalCriterion(criterion: {
+    id: string;
+    goalId: string;
+    description: string;
+  }): Promise<GoalCriterionRow> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>(
+      `INSERT INTO goal_criteria (id, goal_id, description)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [criterion.id, criterion.goalId, criterion.description],
+    );
+    // RETURNING * always produces a row for a plain INSERT
+    return result.rows[0] as GoalCriterionRow;
+  }
+
+  /** Get a criterion by ID. */
+  async getGoalCriterion(id: string): Promise<GoalCriterionRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>('SELECT * FROM goal_criteria WHERE id = $1', [
+      id,
+    ]);
+    return result.rows[0] ?? null;
+  }
+
+  /** List criteria for a goal (oldest first). */
+  async listGoalCriteria(goalId: string): Promise<GoalCriterionRow[]> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>(
+      'SELECT * FROM goal_criteria WHERE goal_id = $1 ORDER BY created_at',
+      [goalId],
+    );
+    return result.rows;
+  }
+
+  /** Record a criterion verdict with evidence and verifier. */
+  async recordGoalCriterion(update: {
+    id: string;
+    status: 'met' | 'failed';
+    evidence: string;
+    verifiedBy: string;
+  }): Promise<GoalCriterionRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>(
+      `UPDATE goal_criteria SET status = $2, evidence = $3, verified_by = $4, verified_at = NOW()
+       WHERE id = $1
+       RETURNING *`,
+      [update.id, update.status, update.evidence, update.verifiedBy],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /** Reset a failed criterion to pending (clears evidence + task link for rework). */
+  async resetGoalCriterion(id: string): Promise<GoalCriterionRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>(
+      `UPDATE goal_criteria SET
+         status = 'pending', evidence = '', verified_by = NULL, verified_at = NULL, task_id = NULL
+       WHERE id = $1 AND status = 'failed'
+       RETURNING *`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /** Link a claimable task to a criterion. */
+  async linkGoalCriterionTask(
+    criterionId: string,
+    taskId: string,
+  ): Promise<GoalCriterionRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GoalCriterionRow>(
+      'UPDATE goal_criteria SET task_id = $2 WHERE id = $1 RETURNING *',
+      [criterionId, taskId],
+    );
+    return result.rows[0] ?? null;
   }
 }

--- a/packages/harnesses/src/storage/index.ts
+++ b/packages/harnesses/src/storage/index.ts
@@ -6,5 +6,7 @@ export type {
   AgentTask,
   DaemonEvent,
   FileReservation,
+  GoalCriterionRow,
+  GoalRow,
 } from './schema.js';
 export { SCHEMA_SQL } from './schema.js';

--- a/packages/harnesses/src/storage/schema.ts
+++ b/packages/harnesses/src/storage/schema.ts
@@ -1,12 +1,17 @@
 /**
  * PGlite schema for the RevDev Harness daemon.
  *
- * Five tables provide persistent state for multi-agent coordination:
+ * These tables provide persistent state for multi-agent coordination:
  *   - agent_sessions: active and historical agent sessions
  *   - agent_messages: inter-agent mailbox (point-to-point + broadcast)
  *   - file_reservations: advisory file locks with CAS semantics
  *   - tasks: claimable work items with CAS ownership
  *   - events: append-only event log for audit trail
+ *   - worktrees: per-agent git worktree registrations
+ *   - agent_memory: typed per-agent memory entries
+ *   - merge_requests: agent-branch merge lifecycle tracking
+ *   - goals: durable verifiable objectives (goal harness)
+ *   - goal_criteria: acceptance criteria gating goal completion
  *
  * Uses raw SQL (no Drizzle ORM) to keep the daemon dependency-free.
  * PGlite runs in-process  -  no external database needed.
@@ -122,6 +127,43 @@ export const SCHEMA_SQL = `
 
   CREATE INDEX IF NOT EXISTS idx_merge_requests_pr
     ON merge_requests (pr_number) WHERE pr_number IS NOT NULL;
+
+  CREATE TABLE IF NOT EXISTS goals (
+    id             TEXT PRIMARY KEY,
+    title          TEXT NOT NULL,
+    description    TEXT NOT NULL DEFAULT '',
+    status         TEXT NOT NULL DEFAULT 'open',
+    priority       TEXT NOT NULL DEFAULT 'medium',
+    owner          TEXT NOT NULL DEFAULT 'agent',
+    parent_goal_id TEXT,
+    blocked_by     JSONB NOT NULL DEFAULT '[]',
+    created_by     TEXT NOT NULL DEFAULT '',
+    status_reason  TEXT NOT NULL DEFAULT '',
+    created_at     TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMP NOT NULL DEFAULT NOW(),
+    closed_at      TIMESTAMP
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_goals_status
+    ON goals (status);
+
+  CREATE INDEX IF NOT EXISTS idx_goals_parent
+    ON goals (parent_goal_id) WHERE parent_goal_id IS NOT NULL;
+
+  CREATE TABLE IF NOT EXISTS goal_criteria (
+    id           TEXT PRIMARY KEY,
+    goal_id      TEXT NOT NULL,
+    description  TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    evidence     TEXT NOT NULL DEFAULT '',
+    verified_by  TEXT,
+    verified_at  TIMESTAMP,
+    task_id      TEXT,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_goal_criteria_goal
+    ON goal_criteria (goal_id);
 `;
 
 /** Session row shape. */
@@ -219,5 +261,35 @@ export interface AgentMemoryEntry {
   memory_type: 'thought' | 'action' | 'result' | 'decision' | 'disagreement';
   content: string;
   metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+/** Goal row shape. */
+export interface GoalRow {
+  id: string;
+  title: string;
+  description: string;
+  status: 'open' | 'active' | 'blocked' | 'done' | 'abandoned';
+  priority: 'blocker' | 'high' | 'medium' | 'low';
+  owner: 'agent' | 'human';
+  parent_goal_id: string | null;
+  blocked_by: string[];
+  created_by: string;
+  status_reason: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+}
+
+/** Goal acceptance-criterion row shape. */
+export interface GoalCriterionRow {
+  id: string;
+  goal_id: string;
+  description: string;
+  status: 'pending' | 'met' | 'failed';
+  evidence: string;
+  verified_by: string | null;
+  verified_at: string | null;
+  task_id: string | null;
   created_at: string;
 }

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'src/types/index.ts',
     'src/content/index.ts',
     'src/storage/index.ts',
+    'src/goals/index.ts',
   ],
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## What

Adds a goal harness to `@revealui/harnesses`: a goal-driven coordination layer where durable goals carry acceptance criteria and completion is fail-closed.

- `GoalHarness` engine (root export + new `@revealui/harnesses/goals` subpath): lifecycle `open -> active -> done` with `blocked`/`abandoned` branches, guarded by an explicit transition map (`Map`/`Set`, zero authored regex).
- Acceptance criteria gate completion: a criterion can only be marked **met** with recorded evidence; a goal with zero criteria, unmet criteria, or unfinished linked tasks refuses to complete.
- **Propose-only by design**: the engine emits claimable rows into the existing daemon `tasks` queue (claim/complete CAS flow unchanged) and never spawns agents — agent execution stays behind the daemon's separately gated agent surface.
- `blocked_by` gating on activation; progress snapshots (criteria + linked-task counts, percent, unmet list); derived next actions covering the full loop: propose-task -> await-task -> verify -> rework.
- Storage: new `goals` + `goal_criteria` tables in the PGlite schema; `DaemonStore` gains goal CRUD + `getTask`; every mutation is logged to the `events` audit trail.

## Why

Gives RevealUI a native, verifiable objective layer for multi-agent coordination: agents work toward explicit goals whose completion is earned via evidence, not asserted.

## Audit (pre-implementation)

No existing goal/objective concept anywhere in the package or fleet code (rg sweep). Closest primitives are the `tasks` table (CAS claim/complete) and the `events` log — both reused rather than duplicated. New storage code mirrors the existing `DaemonStore` section idioms (raw SQL, row interfaces, result-object guards). Deliberately NOT wired into the RPC server in this pass; RPC exposure is a follow-up so this change stays off the daemon's agent surface.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` (biome check) — clean, 110 files
- `pnpm test` — 18 files, **270 tests passed** (12 new `GoalHarness` tests + all existing suites, including `DaemonStore` against the extended schema)
- Changeset included (`@revealui/harnesses` minor)

Manual merge only (self-authored — owner merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
