### PR TITLE
test(server): prod-required coverage — spec ⊇ boot lists (GAP-259 P0-5)

### DIFF
--- a/apps/server/src/lib/required-env.ts
+++ b/apps/server/src/lib/required-env.ts
@@ -1,0 +1,65 @@
+/**
+ * Boot-time required-env lists — a PURE leaf module (no imports).
+ *
+ * Extracted from validate-startup.ts (GAP-259 P0-5) so lightweight coverage
+ * tests (scripts/sync/__tests__/prod-required-coverage.test.ts) can read these
+ * lists without dragging validate-startup's heavy runtime chain
+ * (@revealui/db/client, drizzle-orm, @revealui/config, @revealui/core).
+ * validate-startup.ts remains the sole runtime consumer.
+ */
+
+// Required-always env vars expressed as alias groups: each group is satisfied
+// when AT LEAST ONE of its names is set. This handles the Postgres connection
+// string having two equally-valid names in the codebase: `POSTGRES_URL` is the
+// historical Vercel-default name (used by validateStartup since the api app
+// was scaffolded), while `DATABASE_URL` is the name read by drizzle-orm's
+// rate-limit middleware path and several @neondatabase/serverless integrations.
+// Either is acceptable as long as ONE of them is set; the runtime resolves the
+// connection string from whichever is present. Treating them as aliases also
+// papers over the Vercel `vercel pull` quirk where Sensitive-marked vars
+// (POSTGRES_URL became sensitive on 2026-05-01) are excluded from the pulled
+// `.env.production.local` even though they're available at runtime — see the
+// 2026-05-01 deploy.yml validate-prod-env failure.
+export const REQUIRED_ALWAYS_GROUPS: ReadonlyArray<readonly string[]> = [
+  ['POSTGRES_URL', 'DATABASE_URL'],
+  ['NODE_ENV'],
+] as const;
+
+export const REQUIRED_IN_PRODUCTION_HOSTED = [
+  'REVEALUI_SECRET',
+  'REVEALUI_KEK',
+  'REVEALUI_PUBLIC_SERVER_URL',
+  'NEXT_PUBLIC_SERVER_URL',
+  'SENTRY_DSN',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'REVEALUI_LICENSE_PRIVATE_KEY',
+  'REVEALUI_CRON_SECRET',
+  'CORS_ORIGIN',
+  // Alert destination for unreconciled Stripe webhooks and other ops-critical
+  // signals. Without it, ops email falls back to a hard-coded default; making
+  // this required forces an explicit decision per environment.
+  'REVEALUI_ALERT_EMAIL',
+  // Sentry DSN for error capture. The Sentry init in apps/server/src/index.ts
+  // is guarded by `if (process.env.SENTRY_DSN)`, so a missing value silently
+  // drops all Sentry coverage with no boot-time failure. Making this required
+  // ensures we never boot a hosted production deployment without Sentry wired —
+  // the checkout-route HTTPException capture and sendCronFailureAlert Sentry
+  // path both depend on it. GAP-S1 / Phase 1 audit J-P0-1.
+  'SENTRY_DSN',
+  // Billing portal configuration ID controls which plans customers can switch
+  // to and which cancellation flows are offered. Without it the portal falls
+  // back to Stripe's default (all plans visible, no flow customisation).
+  // Required here so we never flip live-mode without the portal wired. (#827)
+  'REVEALUI_BILLING_PORTAL_CONFIG_ID',
+  // Transactional email transport (Gmail API with domain-wide delegation — see
+  // packages/services/src/email/index.ts → getEmailProvider). Without BOTH of
+  // these, getEmailProvider() falls back to a no-op that drops every send, so
+  // receipt / license-activation / refund emails (and, in the admin app, signup
+  // verification) silently never arrive while the deploy boots clean with no
+  // signal. Require them so a hosted deploy with broken email transport fails
+  // loudly at boot instead of silently degrading. EMAIL_FROM is intentionally
+  // not required — it has a safe default (noreply@revealui.com).
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+  'GOOGLE_PRIVATE_KEY',
+] as const;

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -12,6 +12,7 @@ import {
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
+import { REQUIRED_ALWAYS_GROUPS, REQUIRED_IN_PRODUCTION_HOSTED } from './required-env.js';
 
 export type EnvMap = Record<string, string | undefined>;
 
@@ -131,62 +132,6 @@ export function detectDeploymentMode(
 ): DeploymentMode {
   return isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient) ? 'hosted' : 'forge';
 }
-
-// Required-always env vars expressed as alias groups: each group is satisfied
-// when AT LEAST ONE of its names is set. This handles the Postgres connection
-// string having two equally-valid names in the codebase: `POSTGRES_URL` is the
-// historical Vercel-default name (used by validateStartup since the api app
-// was scaffolded), while `DATABASE_URL` is the name read by drizzle-orm's
-// rate-limit middleware path and several @neondatabase/serverless integrations.
-// Either is acceptable as long as ONE of them is set; the runtime resolves the
-// connection string from whichever is present. Treating them as aliases also
-// papers over the Vercel `vercel pull` quirk where Sensitive-marked vars
-// (POSTGRES_URL became sensitive on 2026-05-01) are excluded from the pulled
-// `.env.production.local` even though they're available at runtime — see the
-// 2026-05-01 deploy.yml validate-prod-env failure.
-const REQUIRED_ALWAYS_GROUPS: ReadonlyArray<readonly string[]> = [
-  ['POSTGRES_URL', 'DATABASE_URL'],
-  ['NODE_ENV'],
-] as const;
-
-const REQUIRED_IN_PRODUCTION_HOSTED = [
-  'REVEALUI_SECRET',
-  'REVEALUI_KEK',
-  'REVEALUI_PUBLIC_SERVER_URL',
-  'NEXT_PUBLIC_SERVER_URL',
-  'SENTRY_DSN',
-  'STRIPE_SECRET_KEY',
-  'STRIPE_WEBHOOK_SECRET',
-  'REVEALUI_LICENSE_PRIVATE_KEY',
-  'REVEALUI_CRON_SECRET',
-  'CORS_ORIGIN',
-  // Alert destination for unreconciled Stripe webhooks and other ops-critical
-  // signals. Without it, ops email falls back to a hard-coded default; making
-  // this required forces an explicit decision per environment.
-  'REVEALUI_ALERT_EMAIL',
-  // Sentry DSN for error capture. The Sentry init in apps/server/src/index.ts
-  // is guarded by `if (process.env.SENTRY_DSN)`, so a missing value silently
-  // drops all Sentry coverage with no boot-time failure. Making this required
-  // ensures we never boot a hosted production deployment without Sentry wired —
-  // the checkout-route HTTPException capture and sendCronFailureAlert Sentry
-  // path both depend on it. GAP-S1 / Phase 1 audit J-P0-1.
-  'SENTRY_DSN',
-  // Billing portal configuration ID controls which plans customers can switch
-  // to and which cancellation flows are offered. Without it the portal falls
-  // back to Stripe's default (all plans visible, no flow customisation).
-  // Required here so we never flip live-mode without the portal wired. (#827)
-  'REVEALUI_BILLING_PORTAL_CONFIG_ID',
-  // Transactional email transport (Gmail API with domain-wide delegation — see
-  // packages/services/src/email/index.ts → getEmailProvider). Without BOTH of
-  // these, getEmailProvider() falls back to a no-op that drops every send, so
-  // receipt / license-activation / refund emails (and, in the admin app, signup
-  // verification) silently never arrive while the deploy boots clean with no
-  // signal. Require them so a hosted deploy with broken email transport fails
-  // loudly at boot instead of silently degrading. EMAIL_FROM is intentionally
-  // not required — it has a safe default (noreply@revealui.com).
-  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
-  'GOOGLE_PRIVATE_KEY',
-] as const;
 
 const REQUIRED_IN_PRODUCTION_FORGE = [
   'REVEALUI_SECRET',

--- a/scripts/sync/__tests__/prod-required-coverage.test.ts
+++ b/scripts/sync/__tests__/prod-required-coverage.test.ts
@@ -1,0 +1,65 @@
+/**
+ * GAP-259 P0-5 — prod-required coverage.
+ *
+ * Asserts that validate-startup's boot-time enforcement (REQUIRED_IN_PRODUCTION_HOSTED
+ * ∪ the REQUIRED_ALWAYS_GROUPS alias groups) is a SUPERSET of every canonical
+ * SECRET_PATHS entry flagged `requiredInProdHosted`. This closes the license/secret
+ * path drift class from the enforcement side: a secret the spec declares
+ * required-at-boot can never silently drop out of the validate-startup lists
+ * without failing this test.
+ *
+ * The "correct validate-startup path" (P0-5 acceptance) is captured by unioning the
+ * alias groups: POSTGRES_URL is required via REQUIRED_ALWAYS_GROUPS
+ * (['POSTGRES_URL','DATABASE_URL']), not the flat REQUIRED_IN_PRODUCTION_HOSTED list.
+ *
+ * Both imports are pure leaf modules (required-env.ts + secret-paths.ts), so this
+ * test is hermetic — it does not load validate-startup's db/orm/config chain.
+ *
+ * Zero authored regex — Set membership only (fleet no-regex posture).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  REQUIRED_ALWAYS_GROUPS,
+  REQUIRED_IN_PRODUCTION_HOSTED,
+} from '../../../apps/server/src/lib/required-env.js';
+import { SECRET_PATHS } from '../secret-paths.js';
+
+// Every env var validate-startup enforces at hosted-prod boot: the flat required
+// list plus every name in an always-required alias group (a group is satisfied
+// when ANY member is set, so each member is an accepted enforcer of that secret).
+const ENFORCED_AT_BOOT: ReadonlySet<string> = new Set([
+  ...REQUIRED_IN_PRODUCTION_HOSTED,
+  ...REQUIRED_ALWAYS_GROUPS.flat(),
+]);
+
+const flaggedEntries = SECRET_PATHS.filter((d) => d.requiredInProdHosted);
+
+describe('prod-required coverage (GAP-259 P0-5)', () => {
+  it('has requiredInProdHosted entries to check', () => {
+    expect(flaggedEntries.length).toBeGreaterThan(0);
+  });
+
+  it('every requiredInProdHosted spec entry declares its envVars', () => {
+    for (const entry of flaggedEntries) {
+      expect(
+        entry.envVars,
+        `${entry.path} is requiredInProdHosted but declares no envVars`,
+      ).toBeDefined();
+      expect(entry.envVars?.length ?? 0, `${entry.path} envVars is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('REQUIRED_IN_PRODUCTION_HOSTED ∪ alias groups ⊇ every flagged entry env var', () => {
+    for (const entry of flaggedEntries) {
+      for (const envVar of entry.envVars ?? []) {
+        expect(
+          ENFORCED_AT_BOOT.has(envVar),
+          `${entry.path} → ${envVar} is flagged requiredInProdHosted but is NOT enforced at ` +
+            'boot (missing from both REQUIRED_IN_PRODUCTION_HOSTED and REQUIRED_ALWAYS_GROUPS ' +
+            'in apps/server/src/lib/required-env.ts)',
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -58,6 +58,13 @@ export interface SecretPathDef {
   consumers: string[];
   /** Feeds P0-5 (⊇ REQUIRED_IN_PRODUCTION_HOSTED). Set only where confirmed required-at-boot. */
   requiredInProdHosted?: boolean;
+  /**
+   * Env var name(s) this vault path is consumed as. REQUIRED for entries with
+   * `requiredInProdHosted` — P0-5 (prod-required-coverage.test.ts) asserts each
+   * is enforced at hosted-prod boot, via validate-startup's
+   * REQUIRED_IN_PRODUCTION_HOSTED or a REQUIRED_ALWAYS_GROUPS alias group.
+   */
+  envVars?: string[];
   /** Declared in-flight rename target (zero-downtime). The value has NOT moved yet. */
   migratingTo?: string;
   /** ISO date the migration was declared. Lingering past one release window is a finding. */
@@ -176,6 +183,7 @@ export const SECRET_PATHS: SecretPathDef[] = [
     tier: 'prod',
     consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
     requiredInProdHosted: true,
+    envVars: ['POSTGRES_URL', 'DATABASE_URL'],
     note: 'canonical Neon pooled url - feeds POSTGRES_URL + DATABASE_URL',
   },
   {
@@ -248,6 +256,7 @@ export const SECRET_PATHS: SecretPathDef[] = [
     tier: 'prod',
     consumers: ['vercel:api', 'fly:worker'],
     requiredInProdHosted: true,
+    envVars: ['REVEALUI_ALERT_EMAIL'],
     note: 'required at prod boot - apps/api refuses to start without it',
   },
   // ── Admin subsystem ───────────────────────────────────────────────────────
@@ -406,6 +415,7 @@ export const SECRET_PATHS: SecretPathDef[] = [
     tier: 'prod',
     consumers: ['vercel:api', 'fly:worker'],
     requiredInProdHosted: true,
+    envVars: ['SENTRY_DSN'],
     note: 'server DSN - required by validate-startup REQUIRED_IN_PRODUCTION_HOSTED',
   },
   {


### PR DESCRIPTION
## What

GAP-259 **P0-5** — a coverage test asserting that validate-startup's boot-time enforcement is a **superset** of the canonical secret spec: for every `SECRET_PATHS` entry flagged `requiredInProdHosted`, its env var(s) must be enforced at hosted-prod boot. A secret the spec declares required-at-boot can no longer silently drop out of the validate-startup lists without failing CI.

- **`scripts/sync/secret-paths.ts`** — adds `SecretPathDef.envVars` (the canonical home for the path→env-var mapping) and populates the 3 flagged entries: `postgres-url`→`[POSTGRES_URL, DATABASE_URL]`, `alert-email`→`[REVEALUI_ALERT_EMAIL]`, `sentry/dsn`→`[SENTRY_DSN]`.
- **`apps/server/src/lib/required-env.ts`** *(new, pure leaf)* — `REQUIRED_ALWAYS_GROUPS` + `REQUIRED_IN_PRODUCTION_HOSTED` extracted from `validate-startup.ts` so the coverage test is **hermetic** (doesn't drag validate-startup's `@revealui/db`/drizzle/`@revealui/config`/`@revealui/core` chain). `validate-startup.ts` now imports them — its behavior is unchanged.
- **`scripts/sync/__tests__/prod-required-coverage.test.ts`** *(new)* — derives entirely from the spec + the leaf lists; zero authored regex (Set membership only).

The **"correct validate-startup path"** (P0-5 acceptance) is captured by unioning the alias groups: `POSTGRES_URL` is required via `REQUIRED_ALWAYS_GROUPS` (`['POSTGRES_URL','DATABASE_URL']`), not the flat `REQUIRED_IN_PRODUCTION_HOSTED` list — the test would otherwise false-fail on it.

## Why the leaf module (4 files, not 2-3)

The full acceptance requires cross-reading validate-startup's lists, but importing `validate-startup.ts` pulls its heavy runtime graph (live DB billing-catalog fetch), which fails to resolve in a lightweight test project. Extracting the two lists into a pure leaf is the correct decoupling — a spec-coverage check shouldn't depend on the DB/ORM graph. Owner-approved the 4-file shape.

## Verification (WSL-native, `.wt/gap-259-p05`)

- Coverage test **3 green** + `secret-paths` lockstep **15 green** (hermetic, no graph build).
- `biome check` clean (all 4 files).
- Scoped `tsc --noEmit` of the new pure code (leaf + spec + test) clean.
- Pre-push secrets scan + code standards passed.

## Merge posture

Touches `validate-startup.ts` (security-sensitive boot surface) → recorded coordinator verdict before merge; manual merge, **owner merges** (self-authored). Base `test`. GAP-259 closes once **P0-4** (fail-loud canary) also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
