### PR TITLE
fix(admin): gate hosted-SDK loads and billing banner behind fleet mode

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -1,5 +1,5 @@
 /**
- * Admin proxy CSP tests (GAP-219 hardening).
+ * Admin proxy CSP tests (GAP-219 hardening; GAP-290 fleet-mode gate).
  *
  * Verifies the per-request nonce Content-Security-Policy set by `src/proxy.ts`:
  *   - script-src carries a 'nonce-…' and NO 'unsafe-inline'
@@ -7,6 +7,7 @@
  *   - the same unified policy is the single CSP source for page and /api responses
  *   - a fresh nonce is generated per request
  *   - style-src intentionally retains 'unsafe-inline'
+ *   - hosted SDK domains are stripped in fleet mode (REVEALUI_FLEET_MODE=true)
  *
  * No regex is authored here (per the fleet no-regex posture) — the CSP string is
  * inspected with `split('; ')` + `startsWith` + `includes`.

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -13,7 +13,7 @@
  * inspected with `split('; ')` + `startsWith` + `includes`.
  */
 import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import proxy from '../proxy';
 
@@ -83,6 +83,48 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
       'script-src',
     );
     expect(a).not.toBe(b);
+  });
+});
+
+describe('admin proxy — CSP fleet mode (GAP-290)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+    vi.stubEnv('REVEALUI_FLEET_MODE', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('strips hosted-SDK domains from script-src in fleet mode', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const scriptSrc = directive(res.headers.get('content-security-policy'), 'script-src');
+    expect(scriptSrc).not.toContain('https://js.stripe.com');
+    expect(scriptSrc).not.toContain('https://checkout.stripe.com');
+    expect(scriptSrc).not.toContain('https://maps.googleapis.com');
+    expect(scriptSrc).not.toContain('https://res.cloudinary.com');
+    expect(scriptSrc).not.toContain('https://cdn.vercel-insights.com');
+  });
+
+  it('still carries a nonce in fleet mode', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const scriptSrc = directive(res.headers.get('content-security-policy'), 'script-src');
+    expect(scriptSrc).toContain("'nonce-");
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it('strips Stripe from frame-src and connect-src in fleet mode', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    const frameSrc = directive(csp, 'frame-src');
+    const connectSrc = directive(csp, 'connect-src');
+    expect(frameSrc).not.toContain('stripe.com');
+    expect(connectSrc).not.toContain('stripe.com');
+    expect(connectSrc).not.toContain('maps.googleapis.com');
   });
 });
 

--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -19,12 +19,15 @@ type Args = {
 // framework build time, missing the kit's stamped value at runtime).
 // `||` not `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
 const siteName = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
+const isFleetMode = process.env.REVEALUI_FLEET_MODE === 'true';
 
 const Layout = ({ children }: Args) => (
   <RootLayout config={config} importMap={importMap}>
     <LicenseProvider>
       <ErrorBoundary>
-        <AdminSidebarLayout siteName={siteName}>{children}</AdminSidebarLayout>
+        <AdminSidebarLayout siteName={siteName} isFleetMode={isFleetMode}>
+          {children}
+        </AdminSidebarLayout>
       </ErrorBoundary>
     </LicenseProvider>
   </RootLayout>

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -100,8 +100,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               {isFleetMode ? null : <Footer />}
             </ErrorBoundary>
           </Providers>
-          {/* Vercel Speed Insights for performance monitoring */}
-          {process.env.NEXT_PUBLIC_VERCEL_ENV ? <SpeedInsights /> : null}
+          {/* Vercel Speed Insights — SaaS deployments only, not fleet kits */}
+          {process.env.NEXT_PUBLIC_VERCEL_ENV && !isFleetMode ? <SpeedInsights /> : null}
         </body>
       </html>
     );

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -212,6 +212,7 @@ function AdminSidebarContent({ siteName }: { siteName: string }) {
 export function AdminSidebarLayout({
   children,
   siteName = 'RevealUI',
+  isFleetMode = false,
 }: {
   children: React.ReactNode;
   /**
@@ -221,12 +222,18 @@ export function AdminSidebarLayout({
    * inlined at framework build time and miss the kit's stamped value.
    */
   siteName?: string;
+  /**
+   * Fleet-mode flag passed from the parent server component. When true,
+   * SaaS-only UI (subscriber billing banner, upgrade dialog) is suppressed —
+   * fleet kits use a forge license, not a Stripe subscription.
+   */
+  isFleetMode?: boolean;
 }) {
   return (
     <SidebarLayout navbar={<span />} sidebar={<AdminSidebarContent siteName={siteName} />}>
-      <FreeTierBanner />
+      {isFleetMode ? null : <FreeTierBanner />}
       {children}
-      <UpgradeDialog />
+      {isFleetMode ? null : <UpgradeDialog />}
     </SidebarLayout>
   );
 }

--- a/apps/admin/src/lib/security/csp.ts
+++ b/apps/admin/src/lib/security/csp.ts
@@ -15,12 +15,13 @@
  *     `Content-Security-Policy` header and applies it to its framework, bundle,
  *     and inline bootstrap scripts (plus `<Script>` components).
  *   - We deliberately KEEP the external-script host allowlist (Stripe, Maps,
- *     Cloudinary, Vercel insights) and do NOT use `'strict-dynamic'`, which
- *     would make those host-sources be ignored. So `<script src>` to allow-
- *     listed hosts keeps working exactly as before; only inline scripts now
- *     require the nonce. (`'unsafe-inline'` is ignored by CSP3 browsers whenever
- *     a nonce is present, so dropping it is the intended tightening, not a
- *     behaviour change for compliant browsers.)
+ *     Cloudinary, Vercel insights) in non-fleet mode and do NOT use
+ *     `'strict-dynamic'`, which would make those host-sources be ignored. In
+ *     fleet mode (`REVEALUI_FLEET_MODE=true`) the hosted third-party SDK domains
+ *     are omitted — fleet kits are self-hosted and must not phone home to
+ *     SaaS-specific endpoints. (`'unsafe-inline'` is ignored by CSP3 browsers
+ *     whenever a nonce is present, so dropping it is the intended tightening,
+ *     not a behaviour change for compliant browsers.)
  *   - `'unsafe-eval'` stays dev-only — React uses `eval` for dev error overlays;
  *     production React/Next do not.
  *   - `style-src` keeps `'unsafe-inline'` by design: Tailwind v4, Next, and the
@@ -45,6 +46,13 @@ export interface AdminCspOptions {
   apiUrl: string;
   /** `NEXT_PUBLIC_SERVER_URL` — optional deployment origin; `''` when unset. */
   serverUrl: string;
+  /**
+   * `REVEALUI_FLEET_MODE === 'true'` — running as a fleet kit.
+   * When true, hosted third-party SDK domains (Stripe.js, Vercel Analytics,
+   * Google Maps, Cloudinary) are omitted from every CSP directive. Fleet kits
+   * are self-hosted and must not include SaaS-specific external origins.
+   */
+  isFleetMode?: boolean;
 }
 
 /**
@@ -67,34 +75,38 @@ export function generateNonce(): string {
  * the admin's same-origin live-preview iframe keeps working.
  */
 export function buildAdminCsp(options: AdminCspOptions): string {
-  const { nonce, isDev, isVercel, isVercelProd, apiUrl, serverUrl } = options;
+  const { nonce, isDev, isVercel, isVercelProd, apiUrl, serverUrl, isFleetMode = false } = options;
   const vercelPreview = isVercel && !isVercelProd;
 
   const scriptSrc = [
     "'self'",
     `'nonce-${nonce}'`,
     ...(isDev ? ["'unsafe-eval'"] : []),
-    'https://checkout.stripe.com',
-    'https://js.stripe.com',
-    'https://maps.googleapis.com',
-    'https://res.cloudinary.com',
-    'https://cdn.vercel-insights.com',
+    ...(isFleetMode
+      ? []
+      : [
+          'https://checkout.stripe.com',
+          'https://js.stripe.com',
+          'https://maps.googleapis.com',
+          'https://res.cloudinary.com',
+          'https://cdn.vercel-insights.com',
+        ]),
     ...(vercelPreview ? ['https://vercel.live', 'https://*.vercel.live'] : []),
   ];
 
   const frameSrc = [
     "'self'",
-    'https://checkout.stripe.com',
-    'https://js.stripe.com',
-    'https://hooks.stripe.com',
+    ...(isFleetMode
+      ? []
+      : ['https://checkout.stripe.com', 'https://js.stripe.com', 'https://hooks.stripe.com']),
     ...(vercelPreview ? ['https://vercel.live', 'https://*.vercel.live'] : []),
   ];
 
   const connectSrc = [
     "'self'",
-    'https://checkout.stripe.com',
-    'https://api.stripe.com',
-    'https://maps.googleapis.com',
+    ...(isFleetMode
+      ? []
+      : ['https://checkout.stripe.com', 'https://api.stripe.com', 'https://maps.googleapis.com']),
     apiUrl,
     ...(serverUrl ? [serverUrl] : []),
     ...(vercelPreview
@@ -108,11 +120,11 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     `script-src ${scriptSrc.join(' ')}`,
     "child-src 'self'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' https://res.cloudinary.com https://*.stripe.com data: https://www.gravatar.com",
+    `img-src 'self' ${isFleetMode ? '' : 'https://res.cloudinary.com '}https://*.stripe.com data: https://www.gravatar.com`,
     "font-src 'self' https://fonts.gstatic.com",
     `frame-src ${frameSrc.join(' ')}`,
     `connect-src ${connectSrc.join(' ')}`,
-    'object-src https://res.cloudinary.com',
+    ...(isFleetMode ? [] : ['object-src https://res.cloudinary.com']),
     "base-uri 'self'",
     "form-action 'self'",
     'upgrade-insecure-requests',

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -93,6 +93,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     isVercelProd: process.env.VERCEL_ENV === 'production',
     apiUrl: (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim(),
     serverUrl: (process.env.NEXT_PUBLIC_SERVER_URL || '').trim(),
+    isFleetMode: process.env.REVEALUI_FLEET_MODE === 'true',
   });
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);


### PR DESCRIPTION
## Summary

- **CSP** (`src/lib/security/csp.ts`): adds `isFleetMode?: boolean` to `AdminCspOptions`; when true, strips Stripe.js, Google Maps, Cloudinary, and Vercel Insights domains from `script-src`, `frame-src`, `connect-src`, `img-src`, and `object-src`
- **Proxy** (`src/proxy.ts`): reads `REVEALUI_FLEET_MODE` at request time and passes it to `buildAdminCsp`
- **SpeedInsights** (`src/app/(frontend)/layout.tsx`): gates Vercel SpeedInsights behind `!isFleetMode` in addition to the existing `NEXT_PUBLIC_VERCEL_ENV` check
- **Billing banner** (`src/lib/components/AdminSidebarLayout.tsx`): suppresses `FreeTierBanner` ("You're on the Free plan — Start your Pro trial") and `UpgradeDialog` when `isFleetMode` is true — fleet kits use a forge license, not a Stripe subscription, so the SaaS-subscriber UI is misleading
- **Backend layout** (`src/app/(backend)/layout.tsx`): reads `REVEALUI_FLEET_MODE` server-side and prop-drills `isFleetMode` to `AdminSidebarLayout` (same pattern as the existing `siteName` prop)
- **Tests**: adds a `fleet mode (GAP-290)` describe block to `proxy-csp.test.ts` with three assertions (SDK domains absent from `script-src`, nonce still present, Stripe absent from `frame-src`/`connect-src`)

Discovered during internal audit of fleet-kit demo behaviour; all items identified as SaaS-specific UI that should not appear in self-hosted fleet deployments.

## Test plan

- [ ] `pnpm --filter admin test src/__tests__/proxy-csp.test.ts` — all suites pass (including new fleet-mode suite)
- [ ] Quality gate (phase 1) passed at push time
- [ ] Verify in stamped RevLabs kit: boot with `REVEALUI_FLEET_MODE=true`, confirm no "Free plan" banner on dashboard, no CSP violations on `/audit`, no external SDK network requests