### PR TITLE
fix(admin): Viewer role + select contrast + hasMany multi-select (GAP-291)

### DIFF
--- a/apps/admin/src/lib/collections/Users/index.ts
+++ b/apps/admin/src/lib/collections/Users/index.ts
@@ -67,11 +67,15 @@ const Users: RevealCollectionConfig<User> = {
       options: [
         {
           label: 'Super Admin',
-          value: 'super-admin', // Differentiate value
+          value: 'super-admin',
         },
         {
           label: 'Admin',
-          value: 'admin', // Differentiate value
+          value: 'admin',
+        },
+        {
+          label: 'Viewer',
+          value: 'viewer',
         },
       ],
     },

--- a/packages/core/src/client/admin/components/DocumentForm.tsx
+++ b/packages/core/src/client/admin/components/DocumentForm.tsx
@@ -601,27 +601,49 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
         />
       );
 
-    case 'select':
+    case 'select': {
+      const isMulti = (field as unknown as { hasMany?: boolean }).hasMany === true;
+      const selectClasses = `${baseClasses} text-foreground bg-card`;
+      const optionNodes = field.options?.map((option) => {
+        const optValue = typeof option === 'string' ? option : option.value;
+        const optLabel = typeof option === 'string' ? option : option.label;
+        return (
+          <option key={optValue} value={optValue}>
+            {optLabel}
+          </option>
+        );
+      });
+      if (isMulti) {
+        const selected = Array.isArray(value) ? (value as string[]) : value ? [String(value)] : [];
+        return (
+          <select
+            id={field.name}
+            multiple
+            value={selected}
+            onChange={(e) => {
+              const vals = Array.from(e.target.selectedOptions).map((o) => o.value);
+              onChange(vals);
+            }}
+            className={`${selectClasses} h-32`}
+            required={field.required}
+          >
+            {optionNodes}
+          </select>
+        );
+      }
       return (
         <select
           id={field.name}
           value={formatTextValue(value)}
           onChange={(e) => onChange(e.target.value)}
-          className={baseClasses}
+          className={selectClasses}
           required={field.required}
         >
           <option value="">Select an option</option>
-          {field.options?.map((option) => {
-            const optValue = typeof option === 'string' ? option : option.value;
-            const optLabel = typeof option === 'string' ? option : option.label;
-            return (
-              <option key={optValue} value={optValue}>
-                {optLabel}
-              </option>
-            );
-          })}
+          {optionNodes}
         </select>
       );
+    }
 
     case 'radio':
       return (


### PR DESCRIPTION
## Summary

- Adds **Viewer** role option (`value: 'viewer'`) to the Users collection `roles` select field so the RevForge demo kit RBAC click-through (step 5) can create a non-admin user that demonstrates an access boundary
- Fixes **role picker contrast**: native `<select>` had no explicit color/background; in the cobalt dark theme the browser-default white background combined with the inherited light text color made the selected text invisible until hover. Added `text-foreground bg-card` to both single and multi-select paths.
- Fixes **hasMany multi-select**: `select` fields with `hasMany: true` (e.g. `Users.roles`) previously rendered as single-select; now renders as `<select multiple>` with correct array value read/write (Ctrl/Cmd+click to select multiple roles)

## Files changed

- `apps/admin/src/lib/collections/Users/index.ts` — add Viewer option
- `packages/core/src/client/admin/components/DocumentForm.tsx` — contrast fix + hasMany support

## Test plan

- [ ] In admin, Users → edit any user: roles picker now shows Super Admin / Admin / Viewer options and text is visible without hover
- [ ] Multi-select: can select both Admin and Viewer simultaneously (Ctrl/Cmd+click)
- [ ] Create a second user with Viewer role; log in as that user; confirm no access to admin-only areas (step 5 of demo-kit-clickthrough.md)
- [ ] CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)