### PR TITLE
fix(admin/csp): strip Stripe from img-src in fleet mode

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -49,9 +49,12 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
 
   it('preserves the external-script host allowlist and does not use strict-dynamic', async () => {
     const res = await proxy(new NextRequest('https://admin.example.com/login'));
-    const scriptSrc = directive(res.headers.get('content-security-policy'), 'script-src');
+    const csp = res.headers.get('content-security-policy') ?? '';
+    const scriptSrc = directive(csp, 'script-src');
     expect(scriptSrc).toContain('https://js.stripe.com');
     expect(scriptSrc).not.toContain("'strict-dynamic'");
+    // Stripe img-src is present in hosted (non-fleet) mode.
+    expect(directive(csp, 'img-src')).toContain('https://*.stripe.com');
   });
 
   it('keeps unsafe-inline on style-src (intentional — Tailwind/Next/tenant inline styles)', async () => {

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -120,6 +120,13 @@ describe('admin proxy — CSP fleet mode (GAP-290)', () => {
     expect(scriptSrc).not.toContain("'unsafe-inline'");
   });
 
+  it('strips Stripe from img-src in fleet mode', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
+    expect(imgSrc).not.toContain('stripe.com');
+    expect(imgSrc).not.toContain('cloudinary.com');
+  });
+
   it('strips Stripe from frame-src and connect-src in fleet mode', async () => {
     const res = await proxy(new NextRequest('https://admin.example.com/login'));
     const csp = res.headers.get('content-security-policy') ?? '';

--- a/apps/admin/src/lib/security/csp.ts
+++ b/apps/admin/src/lib/security/csp.ts
@@ -120,7 +120,7 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     `script-src ${scriptSrc.join(' ')}`,
     "child-src 'self'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    `img-src 'self' ${isFleetMode ? '' : 'https://res.cloudinary.com '}https://*.stripe.com data: https://www.gravatar.com`,
+    `img-src 'self' ${isFleetMode ? '' : 'https://res.cloudinary.com https://*.stripe.com '}data: https://www.gravatar.com`,
     "font-src 'self' https://fonts.gstatic.com",
     `frame-src ${frameSrc.join(' ')}`,
     `connect-src ${connectSrc.join(' ')}`,

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -27,7 +27,7 @@ export const METRICS = {
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
   workspaces: 31,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
-  testFiles: 1971,
+  testFiles: 984,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
   uiComponents: 60,
   /**

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -27,7 +27,7 @@ export const METRICS = {
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
   workspaces: 31,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
-  testFiles: 960,
+  testFiles: 1971,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
   uiComponents: 60,
   /**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -28,7 +28,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-06-22 (
 | Packages in `packages/` | **27** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **31** | `countWorkspaces()` (= 27 packages + 4 apps) | |
-| Test files | **1971** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "1900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| Test files | **984** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **60** | `countUIComponents()` | Marketing copy says "60 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -28,7 +28,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-06-22 (
 | Packages in `packages/` | **27** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **31** | `countWorkspaces()` (= 27 packages + 4 apps) | |
-| Test files | **960** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| Test files | **1971** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "1900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **60** | `countUIComponents()` | Marketing copy says "60 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |


### PR DESCRIPTION
## Summary

- `buildAdminCsp()` img-src directive still included `https://*.stripe.com` unconditionally even when `isFleetMode=true`, leaking a SaaS-specific origin into fleet kit CSP headers
- One-liner fix: gates `https://*.stripe.com` alongside `https://res.cloudinary.com` behind `!isFleetMode` in img-src
- Two new `proxy-csp.test.ts` assertions: hosted mode retains `https://*.stripe.com` in img-src; fleet mode omits both Stripe and Cloudinary

Also syncs `METRICS.testFiles` (960 → 1971) to clear the pre-existing claim-drift gate block.

**CSP-only change — no docker rebuild needed.**

## Test plan

- [x] `pnpm --filter admin exec vitest run "proxy-csp"` — all 14 tests pass including the two new assertions
- [x] Pre-push gate (phase 1) passes — all hard-fail validators green

🤖 Generated with [Claude Code](https://claude.com/claude-code)