### PR TITLE
fix(admin): wire CSP nonce into (backend) layout

### DIFF
--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -1,4 +1,6 @@
 import { RootLayout } from '@revealui/core/admin';
+import { headers } from 'next/headers';
+import Script from 'next/script';
 /* RevealUI Admin Layout - Local implementation */
 import type React from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -14,6 +16,12 @@ type Args = {
   children: React.ReactNode;
 };
 
+// Force dynamic rendering so Next.js reads the per-request CSP nonce (set by
+// src/proxy.ts) and stamps it on its own inline bootstrap/RSC scripts. Without
+// this the shell is statically pre-rendered at build time with zero nonces, and
+// the CSP blocks every hydration script → spinner forever on (backend)/* pages.
+export const dynamic = 'force-dynamic';
+
 // White-label: read tenant identity in the server component and prop-drill
 // to the client sidebar (env vars in `'use client'` files get inlined at
 // framework build time, missing the kit's stamped value at runtime).
@@ -21,16 +29,26 @@ type Args = {
 const siteName = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 const isFleetMode = process.env.REVEALUI_FLEET_MODE === 'true';
 
-const Layout = ({ children }: Args) => (
-  <RootLayout config={config} importMap={importMap}>
-    <LicenseProvider>
-      <ErrorBoundary>
-        <AdminSidebarLayout siteName={siteName} isFleetMode={isFleetMode}>
-          {children}
-        </AdminSidebarLayout>
-      </ErrorBoundary>
-    </LicenseProvider>
-  </RootLayout>
-);
-
-export default Layout;
+export default async function Layout({ children }: Args) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+  return (
+    <RootLayout config={config} importMap={importMap}>
+      {nonce ? (
+        <Script
+          id="revealui-admin-nonce"
+          nonce={nonce}
+          strategy="beforeInteractive"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: inline nonce carrier; fixed literal string, no user content
+          dangerouslySetInnerHTML={{ __html: 'window.__RVUI__=1;' }}
+        />
+      ) : null}
+      <LicenseProvider>
+        <ErrorBoundary>
+          <AdminSidebarLayout siteName={siteName} isFleetMode={isFleetMode}>
+            {children}
+          </AdminSidebarLayout>
+        </ErrorBoundary>
+      </LicenseProvider>
+    </RootLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- The `/(backend)/*` admin pages (audit, revenue, agents, media) were being statically pre-rendered at build time
- The per-request CSP nonce set by the proxy never made it into the static HTML shell, so the browser CSP blocked every inline hydration script — pages hung on a spinner with no hydration
- Detected via internal audit; confirmed A/B by stripping the CSP header (pages render) vs restoring it with this fix

## Changes to `apps/admin/src/app/(backend)/layout.tsx`

1. **`export const dynamic = 'force-dynamic'`** — opts the entire `(backend)` route segment into per-request rendering, giving Next.js access to the request headers where the nonce lives on each request

2. **Async Server Component reading `x-nonce`** — reads the per-request nonce from the request header set by `src/proxy.ts` and renders a `<Script nonce={nonce} strategy="beforeInteractive">`, which Next.js uses to stamp the same nonce on all its own inline bootstrap and RSC payload `<script>` tags — satisfying `script-src 'self' 'nonce-<X>'` without `'unsafe-inline'`

## Unchanged

- `src/proxy.ts` — already generates and threads the nonce correctly via `x-nonce` request header and CSP response header
- `packages/core/src/client/admin/layout.tsx` (`RootLayout`) — no `next/*` imports added to the core package (intentional; `withRevealUI` avoids this coupling)
- The `(frontend)` route group — already had nonce support via `InitTheme`; this PR brings `(backend)` to parity

## Test plan

- [ ] Boot the fleet demo kit with `REVEALUI_FLEET_MODE=true`
- [ ] Navigate to `/audit` (or `/revenue`, `/agents`, `/media`)
- [ ] Open DevTools → Console: confirm 0 CSP violations
- [ ] Confirm pages fully hydrate (sidebar interactive, no spinner)
- [ ] Open DevTools → Network → Doc response: confirm `Content-Security-Policy` header with `'nonce-<X>'`
- [ ] View page source: confirm every `<script>` tag carries a matching `nonce="<X>"` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)