### PR TITLE
fix(admin): suppress fleet-mode billing surfaces — /upgrade and /account/billing

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -187,3 +187,47 @@ describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => 
     expect(res.headers.get('location')).toContain('/login');
   });
 });
+
+describe('admin proxy — fleet-mode page guard (GAP-289)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ needed: false }) });
+    vi.stubEnv('REVEALUI_FLEET_MODE', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redirects /upgrade to /dashboard for an authenticated admin in fleet mode', async () => {
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/upgrade', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=admin' },
+      }),
+    );
+    const location = res.headers.get('location');
+    expect(location).toContain('/dashboard');
+    expect(location).not.toContain('/upgrade');
+  });
+
+  it('redirects /account/billing to /dashboard for an authenticated admin in fleet mode', async () => {
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/account/billing', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=admin' },
+      }),
+    );
+    const location = res.headers.get('location');
+    expect(location).toContain('/dashboard');
+    expect(location).not.toContain('/billing');
+  });
+
+  it('does not redirect /upgrade in non-fleet mode', async () => {
+    vi.unstubAllEnvs();
+    const res = await proxy(
+      new NextRequest('https://admin.example.com/upgrade', {
+        headers: { cookie: 'revealui-session=tok; revealui-role=admin' },
+      }),
+    );
+    expect(res.headers.get('location')).toBeNull();
+  });
+});

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -216,6 +216,19 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
+  // Fleet-mode page guard: upgrade and billing pages are SaaS-only surfaces.
+  // Fleet kits ship with a forge license rather than a Stripe subscription;
+  // redirect these routes to /dashboard so fleet users don't see Stripe checkout UI.
+  if (
+    process.env.REVEALUI_FLEET_MODE === 'true' &&
+    (pathname === '/upgrade' || pathname === '/account/billing')
+  ) {
+    const dashboardUrl = request.nextUrl.clone();
+    dashboardUrl.pathname = '/dashboard';
+    dashboardUrl.search = '';
+    return NextResponse.redirect(dashboardUrl);
+  }
+
   // Strip overrideAccess from external API requests — only server-side code may use it.
   // This prevents clients from bypassing collection access control via query parameter.
   if (pathname.startsWith('/api') && request.nextUrl.searchParams.has('overrideAccess')) {


### PR DESCRIPTION
## Summary

Fixes the two billing surfaces that leaked in fleet mode despite the rest of the billing UI being correctly gated.

**Root cause:** `AdminSidebarLayout` already guards `FreeTierBanner` and `UpgradeDialog` behind `isFleetMode`, and the static-rendering leak was fixed by the `force-dynamic` change in PR #1764. But `/upgrade` (Stripe pricing tiers + checkout) and `/account/billing` (Stripe subscription management) had no fleet-mode guard at all — a fleet admin could navigate there directly.

**Fix:** Added a proxy-level redirect in `src/proxy.ts`. When `REVEALUI_FLEET_MODE=true`, requests to `/upgrade` or `/account/billing` from an authenticated session are redirected to `/dashboard`. The proxy is the correct enforcement layer (single choke-point, runs before any page code, no client-side bypass).

**Scope — complete billing surface audit:**
| Surface | Status |
|---------|--------|
| `FreeTierBanner` | Already gated via `isFleetMode` prop in `AdminSidebarLayout`; static-render leak fixed by PR #1764 |
| `UpgradeDialog` | Same — already gated |
| `Header` / `Footer` / `SpeedInsights` | Already suppressed in `(frontend)/layout.tsx` |
| `/upgrade` page | Fixed here — proxy redirect to `/dashboard` |
| `/account/billing` page | Fixed here — proxy redirect to `/dashboard` |
| `LicenseGate` / `UpgradePrompt` | Driven by forge license feature grants (not a UI suppression gap) |

## Test plan

- [x] `proxy-csp.test.ts` — 3 new GAP-289 cases (redirect /upgrade, redirect /account/billing, no redirect in non-fleet) — 17/17 pass
- [ ] Owner: boot fleet demo kit (`REVEALUI_FLEET_MODE=true`), confirm `/upgrade` and `/account/billing` redirect to `/dashboard`
- [ ] Owner: confirm FreeTierBanner is absent in fleet mode (depends on #1764 in `test`)

Internal audit reference: GAP-289.