### PR TITLE
fix(admin): static route (backend)/dashboard fixes RSC routing priority

### DIFF
--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -99,7 +99,7 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
   });
 });
 
-describe('admin proxy — /dashboard redirect to / (GAP-292)', () => {
+describe('admin proxy — /dashboard auth gate (GAP-292)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockResolvedValue({
@@ -108,22 +108,22 @@ describe('admin proxy — /dashboard redirect to / (GAP-292)', () => {
     });
   });
 
-  it('redirects an authenticated admin off /dashboard to /', async () => {
-    // (frontend)/[slug] has higher Next.js routing priority than (backend)/[[...segments]]
-    // for single-segment paths. Without this proxy redirect, authenticated admins
-    // hit the CMS catch-all which throws when getCachedRedirects() fails — "We hit a snag".
-    const res = await proxy(req('/dashboard', ADMIN_COOKIES));
-    expect(res.status).toBe(307);
-    expect(redirectPath(res)).toBe('/');
-  });
-
   it('redirects an unauthenticated /dashboard request to /login (auth gate)', async () => {
+    // /dashboard is not in PUBLIC_PATHS — auth gate protects it and redirects
+    // unauthenticated requests to /login with the original path preserved.
     const res = await proxy(req('/dashboard'));
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     const url = location ? new URL(location) : null;
     expect(url?.pathname).toBe('/login');
     expect(url?.searchParams.get('redirect')).toBe('/dashboard');
+  });
+
+  it('does not redirect an authenticated admin off /dashboard (served by static route)', async () => {
+    // /dashboard is served by (backend)/dashboard/page.tsx (static route, higher
+    // priority than (frontend)/[slug]). The proxy should pass it through — no redirect.
+    const res = await proxy(req('/dashboard', ADMIN_COOKIES));
+    expect(redirectPath(res)).toBeNull();
   });
 });
 

--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -99,6 +99,34 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
   });
 });
 
+describe('admin proxy — /dashboard redirect to / (GAP-292)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+  });
+
+  it('redirects an authenticated admin off /dashboard to /', async () => {
+    // (frontend)/[slug] has higher Next.js routing priority than (backend)/[[...segments]]
+    // for single-segment paths. Without this proxy redirect, authenticated admins
+    // hit the CMS catch-all which throws when getCachedRedirects() fails — "We hit a snag".
+    const res = await proxy(req('/dashboard', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('redirects an unauthenticated /dashboard request to /login (auth gate)', async () => {
+    const res = await proxy(req('/dashboard'));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    const url = location ? new URL(location) : null;
+    expect(url?.pathname).toBe('/login');
+    expect(url?.searchParams.get('redirect')).toBe('/dashboard');
+  });
+});
+
 describe('admin proxy — /forgot-password is not public (S1)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -199,25 +199,27 @@ describe('admin proxy — fleet-mode page guard (GAP-289)', () => {
     vi.unstubAllEnvs();
   });
 
-  it('redirects /upgrade to /dashboard for an authenticated admin in fleet mode', async () => {
+  it('redirects /upgrade to / for an authenticated admin in fleet mode', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/upgrade', {
         headers: { cookie: 'revealui-session=tok; revealui-role=admin' },
       }),
     );
     const location = res.headers.get('location');
-    expect(location).toContain('/dashboard');
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe('/');
     expect(location).not.toContain('/upgrade');
   });
 
-  it('redirects /account/billing to /dashboard for an authenticated admin in fleet mode', async () => {
+  it('redirects /account/billing to / for an authenticated admin in fleet mode', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/account/billing', {
         headers: { cookie: 'revealui-session=tok; revealui-role=admin' },
       }),
     );
     const location = res.headers.get('location');
-    expect(location).toContain('/dashboard');
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe('/');
     expect(location).not.toContain('/billing');
   });
 

--- a/apps/admin/src/app/(backend)/dashboard/page.tsx
+++ b/apps/admin/src/app/(backend)/dashboard/page.tsx
@@ -1,0 +1,49 @@
+import { AdminDashboard } from '@revealui/core/admin';
+import { serializeConfig } from '@revealui/core/admin/utils/serializeConfig';
+import type { RevealConfig } from '@revealui/core/types/core';
+import Link from 'next/link';
+import config from '../../../../revealui.config';
+
+// Static route for /dashboard — wins over (frontend)/[slug] dynamic route.
+// (frontend)/[slug] has higher Next.js routing priority than the
+// (backend)/[[...segments]] catch-all for single-segment paths, so
+// /dashboard was incorrectly intercepted by the CMS catch-all and threw
+// when the admin engine wasn't ready. A static segment always beats a
+// dynamic segment regardless of route group, so this file takes /dashboard
+// before [slug] is considered.
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const serializedConfig = serializeConfig(config as RevealConfig);
+  // White-label: resolve server-side; client files can't read these env vars
+  // at runtime (build-time inlining). `||` not `??`: unset vars arrive as ''.
+  const siteName =
+    process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
+
+  return (
+    <div className="relative">
+      <Link
+        href="/settings"
+        className="absolute right-28 top-5 z-10 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title="Settings"
+      >
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.991l1.004.827c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"
+          />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+      </Link>
+      <AdminDashboard config={serializedConfig} siteName={siteName} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/admin/src/app/(frontend)/[slug]/page.tsx
@@ -37,6 +37,10 @@ const RESERVED_AUTH_SLUGS = new Set([
   'forgot-password',
   'reset-password',
   'setup',
+  // /dashboard has a dedicated static route in (backend)/dashboard/page.tsx.
+  // Defense-in-depth: if routing priority ever changes, hard-404 here rather
+  // than falling through to RevealUIRedirects with a reserved slug.
+  'dashboard',
 ]);
 
 // Removed generateStaticParams to prevent build-time initialization

--- a/apps/admin/src/lib/components/RevealUIRedirects/index.tsx
+++ b/apps/admin/src/lib/components/RevealUIRedirects/index.tsx
@@ -13,7 +13,15 @@ interface Props {
 export const RevealUIRedirects = async ({ disableNotFound, url }: Props) => {
   const slug = url.startsWith('/') ? url : `${url}`;
 
-  const redirects = await getCachedRedirects()();
+  let redirects: Redirect[];
+  try {
+    redirects = await getCachedRedirects()();
+  } catch {
+    // Admin engine not ready (e.g. cold boot before initialization completes).
+    // Fall through to notFound() rather than propagating to the error boundary.
+    if (disableNotFound) return null;
+    return notFound();
+  }
 
   const redirectItem = redirects.find((redirectItem: Redirect) => redirectItem.from === slug);
 

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -216,20 +216,6 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
-  // /dashboard is served by (backend)/[[...segments]] but (frontend)/[slug] has
-  // higher Next.js routing priority for single-segment paths. When no CMS page
-  // exists for slug "dashboard" the CMS catch-all calls getCachedRedirects()
-  // with no error handling — if getRevealUIInstance() throws, that propagates
-  // to (frontend)/error.tsx ("We hit a snag"). Redirect authenticated admins
-  // to / (the real admin home, served by (backend)) before Next.js can route
-  // them to the (frontend) group at all.
-  if (pathname === '/dashboard') {
-    const homeUrl = request.nextUrl.clone();
-    homeUrl.pathname = '/';
-    homeUrl.search = '';
-    return NextResponse.redirect(homeUrl);
-  }
-
   // Fleet-mode page guard: upgrade and billing pages are SaaS-only surfaces.
   // Fleet kits ship with a forge license rather than a Stripe subscription;
   // redirect these routes to / (the admin home) so fleet users don't see Stripe checkout UI.

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -216,17 +216,31 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
+  // /dashboard is served by (backend)/[[...segments]] but (frontend)/[slug] has
+  // higher Next.js routing priority for single-segment paths. When no CMS page
+  // exists for slug "dashboard" the CMS catch-all calls getCachedRedirects()
+  // with no error handling — if getRevealUIInstance() throws, that propagates
+  // to (frontend)/error.tsx ("We hit a snag"). Redirect authenticated admins
+  // to / (the real admin home, served by (backend)) before Next.js can route
+  // them to the (frontend) group at all.
+  if (pathname === '/dashboard') {
+    const homeUrl = request.nextUrl.clone();
+    homeUrl.pathname = '/';
+    homeUrl.search = '';
+    return NextResponse.redirect(homeUrl);
+  }
+
   // Fleet-mode page guard: upgrade and billing pages are SaaS-only surfaces.
   // Fleet kits ship with a forge license rather than a Stripe subscription;
-  // redirect these routes to /dashboard so fleet users don't see Stripe checkout UI.
+  // redirect these routes to / (the admin home) so fleet users don't see Stripe checkout UI.
   if (
     process.env.REVEALUI_FLEET_MODE === 'true' &&
     (pathname === '/upgrade' || pathname === '/account/billing')
   ) {
-    const dashboardUrl = request.nextUrl.clone();
-    dashboardUrl.pathname = '/dashboard';
-    dashboardUrl.search = '';
-    return NextResponse.redirect(dashboardUrl);
+    const homeUrl = request.nextUrl.clone();
+    homeUrl.pathname = '/';
+    homeUrl.search = '';
+    return NextResponse.redirect(homeUrl);
   }
 
   // Strip overrideAccess from external API requests — only server-side code may use it.


### PR DESCRIPTION
## Summary

- Creates `app/(backend)/dashboard/page.tsx` — a **static route** that wins over `(frontend)/[slug]` (dynamic segment) for `/dashboard`, giving the admin engine a real URL without any redirect
- Adds `'dashboard'` to `RESERVED_AUTH_SLUGS` in `(frontend)/[slug]/page.tsx` — defense-in-depth hard-404 if routing priority ever changes
- Wraps `getCachedRedirects()()` in try-catch in `RevealUIRedirects` — graceful `notFound()` for any slug when the admin engine isn't ready, not just `/dashboard`
- Fixes fleet-mode billing guard: `/upgrade` and `/account/billing` redirect to `/` instead of `/dashboard` (independent correctness fix — same PR since proxy.ts is already under sec-review)

## Root cause

Next.js routing priority: `(frontend)/[slug]` (single dynamic segment) always resolves before `(backend)/[[...segments]]` (optional catch-all), regardless of route group. When no CMS page exists for slug `"dashboard"`, the catch-all called `RevealUIRedirects` which called `getCachedRedirects()()` with no error handling — if the admin engine wasn't ready, the throw propagated to `(frontend)/error.tsx` ("We hit a snag").

**Static segments always beat dynamic segments in Next.js**, regardless of route group. `(backend)/dashboard/page.tsx` claims `/dashboard` before `[slug]` is considered. `AdminDashboard` is URL-unaware (internal state machine, not URL hooks), so it renders its home/dashboard view identically at `/dashboard` and `/`.

## Commit history

1. `fix(admin): redirect /dashboard → / in proxy` — initial proxy-level workaround
2. `fix(admin): static route (backend)/dashboard fixes routing priority` — routing-layer fix; reverts proxy redirect; adds defense-in-depth

## Security surface

`proxy.ts` is touched (fleet-mode billing guard fix only — no auth logic changed). `RevealUIRedirects` is touched (adds error handling). Requires a non-author sec-review verdict recorded on this PR before merge (internal audit follow-up, guardrail 2).

## Test plan

- [x] `pnpm --filter admin exec vitest run src/__tests__/proxy-auth-redirect.test.ts src/__tests__/proxy-csp.test.ts` — 29 tests pass
- [x] Pre-push gate (phase 1) — PASS (both commits)
- [ ] Manual verify: boot dev server, authenticate as admin, navigate to `/dashboard` → renders admin engine dashboard at `/dashboard` URL (no redirect)
- [ ] Sec-review verdict recorded on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)