### PR TITLE
feat(admin): role-aware proxy gate — unblock non-admin users

### DIFF
--- a/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
+++ b/apps/admin/src/__tests__/proxy-auth-redirect.test.ts
@@ -1,12 +1,11 @@
 /**
- * Admin proxy — authenticated-user redirect off /login + /signup (#1107).
+ * Admin proxy — role-aware auth gate and redirect tests.
  *
- * An admin holding a valid `revealui-session` has no reason to see the
- * login/signup screens. Verifies `src/proxy.ts` redirects such a user to '/',
- * scoped to /login + /signup only, and leaves the other public auth-flow pages
- * (forgot/reset/rotate-password, mfa, setup) reachable. The `revealui-role`
- * cookie is normalized to 'admin' | 'user' at sign-in, so the redirect predicate
- * matches the auth gate's admit check — no redirect loop.
+ * The `revealui-role` cookie carries the actual DB role (owner, admin, editor,
+ * viewer, agent, contributor). The proxy uses this for two purposes:
+ * 1. Redirect authenticated users off /login + /signup (admins → /, others → /welcome)
+ * 2. Gate admin-only paths (/settings, /users) — non-admin roles → /welcome?denied=admin
+ * 3. All other authenticated paths are open to any role
  *
  * No regex authored (fleet posture): assertions use URL parsing + equality.
  */
@@ -34,9 +33,11 @@ function redirectPath(res: Response): string | null {
 }
 
 const ADMIN_COOKIES = 'revealui-session=sess-abc; revealui-role=admin';
-const USER_COOKIES = 'revealui-session=sess-abc; revealui-role=user';
+const OWNER_COOKIES = 'revealui-session=sess-abc; revealui-role=owner';
+const VIEWER_COOKIES = 'revealui-session=sess-abc; revealui-role=viewer';
+const EDITOR_COOKIES = 'revealui-session=sess-abc; revealui-role=editor';
 
-describe('admin proxy — authenticated redirect off /login + /signup (#1107)', () => {
+describe('admin proxy — authenticated redirect off /login + /signup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockResolvedValue({
@@ -47,6 +48,12 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
 
   it('redirects an authenticated admin off /login to /', async () => {
     const res = await proxy(req('/login', ADMIN_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/');
+  });
+
+  it('redirects an authenticated owner off /login to /', async () => {
+    const res = await proxy(req('/login', OWNER_COOKIES));
     expect(res.status).toBe(307);
     expect(redirectPath(res)).toBe('/');
   });
@@ -62,9 +69,16 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
     expect(redirectPath(res)).not.toBe('/');
   });
 
-  it('does not redirect an authenticated non-admin (role=user) off /login', async () => {
-    const res = await proxy(req('/login', USER_COOKIES));
-    expect(redirectPath(res)).not.toBe('/');
+  it('redirects an authenticated viewer off /login to /welcome', async () => {
+    const res = await proxy(req('/login', VIEWER_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/welcome');
+  });
+
+  it('redirects an authenticated editor off /login to /welcome', async () => {
+    const res = await proxy(req('/login', EDITOR_COOKIES));
+    expect(res.status).toBe(307);
+    expect(redirectPath(res)).toBe('/welcome');
   });
 
   it('does not redirect an authenticated admin off /forgot-password', async () => {
@@ -76,24 +90,57 @@ describe('admin proxy — authenticated redirect off /login + /signup (#1107)', 
     const res = await proxy(req('/rotate-password', ADMIN_COOKIES));
     expect(redirectPath(res)).not.toBe('/');
   });
+});
 
-  it('sends an authenticated non-admin off an admin route to /welcome, not /login', async () => {
-    // The bug: a signed-in user-role account hitting an admin route was bounced
-    // to /login (the form they just used) — a silent flash-and-reappear loop.
-    // Fix: redirect to /welcome with a ?denied=admin notice instead.
-    const res = await proxy(req('/settings', USER_COOKIES));
+describe('admin proxy — role-aware admin-only gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ needed: false }),
+    });
+  });
+
+  it('sends a viewer off /settings to /welcome?denied=admin', async () => {
+    const res = await proxy(req('/settings', VIEWER_COOKIES));
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     const url = location ? new URL(location) : null;
     expect(url?.pathname).toBe('/welcome');
-    expect(url?.pathname).not.toBe('/login');
     expect(url?.searchParams.get('denied')).toBe('admin');
   });
 
+  it('sends a viewer off /users to /welcome?denied=admin', async () => {
+    const res = await proxy(req('/users', VIEWER_COOKIES));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    const url = location ? new URL(location) : null;
+    expect(url?.pathname).toBe('/welcome');
+    expect(url?.searchParams.get('denied')).toBe('admin');
+  });
+
+  it('lets an admin through to /settings', async () => {
+    const res = await proxy(req('/settings', ADMIN_COOKIES));
+    expect(redirectPath(res)).toBeNull();
+  });
+
+  it('lets an owner through to /settings', async () => {
+    const res = await proxy(req('/settings', OWNER_COOKIES));
+    expect(redirectPath(res)).toBeNull();
+  });
+
+  it('lets a viewer through to non-admin paths like /dashboard', async () => {
+    const res = await proxy(req('/dashboard', VIEWER_COOKIES));
+    expect(redirectPath(res)).toBeNull();
+  });
+
+  it('lets an editor through to non-admin paths like /content', async () => {
+    const res = await proxy(req('/content', EDITOR_COOKIES));
+    expect(redirectPath(res)).toBeNull();
+  });
+
   it('does not bounce an authenticated non-admin off /welcome (no loop)', async () => {
-    // /welcome is session-only, so the target of the deny redirect is itself
-    // reachable — guarantees the deny path terminates instead of looping.
-    const res = await proxy(req('/welcome', USER_COOKIES));
+    const res = await proxy(req('/welcome', VIEWER_COOKIES));
     expect(redirectPath(res)).not.toBe('/login');
     expect(redirectPath(res)).not.toBe('/welcome');
   });
@@ -109,8 +156,6 @@ describe('admin proxy — /dashboard auth gate (GAP-292)', () => {
   });
 
   it('redirects an unauthenticated /dashboard request to /login (auth gate)', async () => {
-    // /dashboard is not in PUBLIC_PATHS — auth gate protects it and redirects
-    // unauthenticated requests to /login with the original path preserved.
     const res = await proxy(req('/dashboard'));
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
@@ -119,10 +164,13 @@ describe('admin proxy — /dashboard auth gate (GAP-292)', () => {
     expect(url?.searchParams.get('redirect')).toBe('/dashboard');
   });
 
-  it('does not redirect an authenticated admin off /dashboard (served by static route)', async () => {
-    // /dashboard is served by (backend)/dashboard/page.tsx (static route, higher
-    // priority than (frontend)/[slug]). The proxy should pass it through — no redirect.
+  it('does not redirect an authenticated admin off /dashboard', async () => {
     const res = await proxy(req('/dashboard', ADMIN_COOKIES));
+    expect(redirectPath(res)).toBeNull();
+  });
+
+  it('does not redirect an authenticated viewer off /dashboard (role-aware gate)', async () => {
+    const res = await proxy(req('/dashboard', VIEWER_COOKIES));
     expect(redirectPath(res)).toBeNull();
   });
 });

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -147,7 +147,7 @@ describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => 
   it('lets an authenticated non-admin (paying customer) reach /welcome without bouncing to /login', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/welcome?success=true&tier=pro', {
-        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+        headers: { cookie: 'revealui-session=tok; revealui-role=viewer' },
       }),
     );
     // Post-checkout landing is session-gated, not admin-gated: no redirect.
@@ -159,24 +159,19 @@ describe('admin proxy — /welcome auth gate (post-checkout subscriber)', () => 
     expect(res.headers.get('location')).toContain('/login');
   });
 
-  it('still enforces the admin role on other backend pages (non-admin session is sent to /welcome, not /login)', async () => {
+  it('lets an authenticated viewer through to /posts (role-aware gate: not admin-only)', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/posts', {
-        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+        headers: { cookie: 'revealui-session=tok; revealui-role=viewer' },
       }),
     );
-    // Admin role is still enforced: a non-admin cannot reach /posts. It now lands
-    // on /welcome (their session home) with a denial notice rather than being
-    // bounced to the login form they already used.
-    const location = res.headers.get('location');
-    expect(location).toContain('/welcome');
-    expect(location).not.toContain('/login');
+    expect(res.headers.get('location')).toBeNull();
   });
 
   it('lets an authenticated non-admin (subscriber) reach /account/billing without bouncing to /login', async () => {
     const res = await proxy(
       new NextRequest('https://admin.example.com/account/billing?upgrade=pro', {
-        headers: { cookie: 'revealui-session=tok; revealui-role=user' },
+        headers: { cookie: 'revealui-session=tok; revealui-role=viewer' },
       }),
     );
     expect(res.headers.get('location')).toBeNull();

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -24,7 +24,6 @@ import { getOAuthAccountByProviderUser } from '@revealui/db/queries/oauth-accoun
 import { countActiveUsers } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
-import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
@@ -156,9 +155,9 @@ export async function GET(
 
     const response = NextResponse.redirect(new URL(redirectTo, baseUrl));
 
-    // Set role hint cookie for proxy.ts admin gate (defense-in-depth).
-    const userRole = (user as { role?: string }).role ?? 'user';
-    response.cookies.set('revealui-role', isAdminRole(userRole) ? 'admin' : 'user', {
+    // Set role cookie for proxy.ts role-aware gate (defense-in-depth).
+    const userRole = (user as { role?: string }).role ?? 'viewer';
+    response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -16,7 +16,6 @@ import { getUserById } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import type { AuthenticationResponseJSON, WebAuthnCredential } from '@simplewebauthn/server';
 import { type NextRequest, NextResponse } from 'next/server';
-import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import {
   createApplicationErrorResponse,
@@ -155,9 +154,9 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
 
-    // Set role hint cookie
-    const userRole = user.role ?? 'user';
-    response.cookies.set('revealui-role', isAdminRole(userRole) ? 'admin' : 'user', {
+    // Set role cookie for proxy.ts role-aware gate
+    const userRole = user.role ?? 'viewer';
+    response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -11,7 +11,6 @@ import config from '@revealui/config';
 import { SignInRequestContract } from '@revealui/contracts';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
-import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import {
   createApplicationErrorResponse,
@@ -109,10 +108,11 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
       ...(result.requiresPasswordRotation ? { requiresPasswordRotation: true } : {}),
     });
 
-    // Set role hint cookie for proxy.ts admin gate (defense-in-depth, not the security boundary).
-    // The real enforcement is at the API level via collection access.read checks.
-    const userRole = result.user.role ?? 'user';
-    response.cookies.set('revealui-role', isAdminRole(userRole) ? 'admin' : 'user', {
+    // Set role cookie for proxy.ts role-aware gate (defense-in-depth, not the
+    // security boundary). Carries the actual DB role so the proxy can route
+    // admin-only paths without blocking non-admin users entirely.
+    const userRole = result.user.role ?? 'viewer';
+    response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -15,7 +15,6 @@ import { users } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
 import { count, eq, sql } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
-import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { grantSuperAdminRoleById } from '@/lib/auth/roles';
 import { getTosAcceptance } from '@/lib/auth/tos';
 import { sendVerificationEmail } from '@/lib/email/verification';
@@ -261,9 +260,9 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
     const isVerified = resolvedUser?.emailVerified ?? false;
 
     if (result.sessionToken && isVerified) {
-      // Set role hint cookie for proxy.ts admin gate (defense-in-depth).
-      const userRole = resolvedUser?.role ?? 'user';
-      response.cookies.set('revealui-role', isAdminRole(userRole) ? 'admin' : 'user', {
+      // Set role cookie for proxy.ts role-aware gate (defense-in-depth).
+      const userRole = resolvedUser?.role ?? 'viewer';
+      response.cookies.set('revealui-role', userRole, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -54,16 +54,18 @@ const PUBLIC_PATHS = new Set([
   '/setup',
 ]);
 
-// Session-only paths in the (backend) route group: require an authenticated
-// session but NOT the admin role. `/welcome` is the post-checkout landing
-// (Stripe `success_url` in apps/server billing.ts) and every self-serve
-// subscriber has role `user`, not `admin` — gating it on admin would bounce a
-// paying customer to /login at the moment of conversion. The page is a client
-// component that renders only the user's own tier + generic CTAs (no privileged
-// data), so a valid session is sufficient.
-// `/account/billing` is also session-only: subscribers arriving from /welcome
-// via the "Billing portal" link need to reach checkout without admin role.
-const SESSION_ONLY_PATHS = new Set(['/welcome', '/account/billing']);
+// Roles that grant full dashboard access including admin-only paths.
+const ADMIN_ROLES: ReadonlySet<string> = new Set(['owner', 'admin', 'super-admin']);
+
+// Admin-only paths require owner/admin role. Non-admin authenticated users
+// are redirected to /welcome when they try to access these.
+const ADMIN_ONLY_PREFIXES = ['/settings', '/users'] as const;
+
+function isAdminOnlyPath(pathname: string): boolean {
+  return ADMIN_ONLY_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
 
 // Legacy `/admin/*` paths from before the chip-2 URL flatten (#644) — 301 to
 // flat path. Catches stale bookmarks and any external links written against
@@ -155,28 +157,24 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     }
   }
 
-  // Already-authenticated admins have no reason to see the login/signup screens.
-  // Redirect them to the dashboard. Scoped to /login + /signup ONLY — /setup,
-  // /rotate-password, /reset-password, /mfa stay reachable for an
-  // authenticated or partially-authenticated user (forced rotation, MFA enrollment,
-  // etc.). The `revealui-role` cookie is normalized to 'admin' | 'user' at sign-in
-  // (defense-in-depth UI hint), and this predicate matches the auth gate's admit
-  // check below, so an admin sent to '/' always passes that gate — no redirect loop.
+  // Already-authenticated users have no reason to see the login/signup screens.
+  // Admins go to /, non-admins go to /welcome.
   if (pathname === '/login' || pathname === '/signup') {
     const session = request.cookies.get('revealui-session')?.value;
     const role = request.cookies.get('revealui-role')?.value;
-    if (session && role === 'admin') {
+    if (session && role) {
       const homeUrl = request.nextUrl.clone();
-      homeUrl.pathname = '/';
+      homeUrl.pathname = ADMIN_ROLES.has(role) ? '/' : '/welcome';
       homeUrl.search = '';
       return NextResponse.redirect(homeUrl);
     }
   }
 
-  // Auth gate: protect (backend) pages — every path that isn't public and
-  // isn't internal needs a session + admin role. The role cookie is a
-  // defense-in-depth UI hint (set at login). Real enforcement is at the API
-  // level via collection access.read checks.
+  // Auth gate: protect (backend) pages. Every path that isn't public and
+  // isn't internal needs an authenticated session. Admin-only paths
+  // (/settings, /users) additionally require an admin role. The role cookie
+  // is a defense-in-depth UI hint — real enforcement is at the API level via
+  // collection access.read checks.
   const isInternal = pathname.startsWith('/api/') || pathname.startsWith('/_next/');
   const isPublic = PUBLIC_PATHS.has(pathname) || pathname.startsWith('/legal/');
   if (!(isInternal || isPublic)) {
@@ -188,17 +186,11 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       return NextResponse.redirect(loginUrl);
     }
 
-    // Admin-role requirement. Skipped for session-only paths (e.g. /welcome),
-    // which any authenticated user may reach.
-    if (!SESSION_ONLY_PATHS.has(pathname)) {
+    // Role-aware gate: admin-only paths require owner/admin/super-admin.
+    // All other authenticated paths are open to any role.
+    if (isAdminOnlyPath(pathname)) {
       const role = request.cookies.get('revealui-role')?.value;
-      if (role !== 'admin') {
-        // Authenticated but not an admin. Redirect to /welcome (their session-only
-        // home), NOT /login. Bouncing an already-signed-in user to the login form
-        // they just used produces a silent flash-and-reappear loop with no feedback
-        // (a user-role account sent to an admin route via a ?redirect= intent).
-        // The `denied` param lets /welcome explain that the admin area needs an
-        // admin role.
+      if (!role || !ADMIN_ROLES.has(role)) {
         const welcomeUrl = request.nextUrl.clone();
         welcomeUrl.pathname = '/welcome';
         welcomeUrl.search = '';


### PR DESCRIPTION
## Summary

- Replace binary `admin`/`user` cookie gate with a role-aware gate that carries the actual DB role (`owner`, `admin`, `editor`, `viewer`, `agent`, `contributor`) in the `revealui-role` cookie
- Only `/settings` and `/users` paths require admin role — all other authenticated paths are now open to any role
- Non-admin users hitting `/login` or `/signup` are redirected to `/welcome` instead of being blocked entirely
- Updated all 4 auth routes (sign-in, sign-up, OAuth callback, passkey) to write the actual DB role to the cookie instead of binary `admin`/`user`
- Updated proxy tests to cover the new role-aware behavior (19 test cases)

## Changes

| File | Change |
|------|--------|
| `apps/admin/src/proxy.ts` | Replace `SESSION_ONLY_PATHS` with `ADMIN_ONLY_PREFIXES` (`/settings`, `/users`); role-aware gate logic |
| `apps/admin/src/app/api/auth/sign-in/route.ts` | Cookie carries actual DB role, default `viewer` |
| `apps/admin/src/app/api/auth/sign-up/route.ts` | Same cookie change |
| `apps/admin/src/app/api/auth/callback/[provider]/route.ts` | Same cookie change + remove unused `isAdminRole` import |
| `apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts` | Same cookie change + remove unused `isAdminRole` import |
| `apps/admin/src/__tests__/proxy-auth-redirect.test.ts` | Rewritten for role-aware behavior (owner, admin, viewer, editor) |
| `apps/admin/src/__tests__/proxy-csp.test.ts` | Updated `role=user` → `role=viewer`, fixed `/posts` assertion |

## Test plan

- [x] All proxy unit tests pass (19 test cases across 2 files)
- [x] Full admin test suite passes (1918 tests, 139 files)
- [x] Pre-push CI gate passes (all 23 checks)
- [x] TypeScript compiles clean (no new errors in changed files)
- [ ] Manual test: sign in as admin → can access `/settings` and `/users`
- [ ] Manual test: sign in as viewer → can access `/dashboard` but not `/settings`
- [ ] Manual test: viewer hitting `/settings` redirects to `/welcome?denied=admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)