### PR TITLE
fix(test): update E2E role cookie from 'user' to 'viewer'

### DIFF
--- a/packages/test/src/e2e/signup-flow.spec.ts
+++ b/packages/test/src/e2e/signup-flow.spec.ts
@@ -655,7 +655,7 @@ test.describe('Admin Dashboard Access @auth @admin', () => {
       },
       {
         name: 'revealui-role',
-        value: 'user',
+        value: 'viewer',
         domain: hostname,
         path: '/',
       },


### PR DESCRIPTION
## Summary
- Updates the E2E non-admin simulation cookie from `value: 'user'` to `value: 'viewer'` in `signup-flow.spec.ts`
- `'user'` is not a valid DB role after the role-aware proxy gate (#1774); `'viewer'` is the correct lowest-privilege role

## Test plan
- [x] Pre-push gate passes (all 23 checks green)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)