### PR TITLE
fix(admin): suppress SaaS billing UI in fleet mode

### DIFF
--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -45,7 +45,7 @@ export default async function Layout({ children }: Args) {
           dangerouslySetInnerHTML={{ __html: 'window.__RVUI__=1;' }}
         />
       ) : null}
-      <LicenseProvider>
+      <LicenseProvider isFleetMode={isFleetMode}>
         <ErrorBoundary>
           <AdminSidebarLayout siteName={siteName} isFleetMode={isFleetMode} isAdmin={isAdmin}>
             {children}

--- a/apps/admin/src/app/(frontend)/layout.tsx
+++ b/apps/admin/src/app/(frontend)/layout.tsx
@@ -86,7 +86,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           ) : null}
         </head>
         <body>
-          <Providers>
+          <Providers isFleetMode={isFleetMode}>
             <ErrorBoundary>
               <AdminBar
                 adminBarProps={{

--- a/apps/admin/src/lib/providers/LicenseProvider.tsx
+++ b/apps/admin/src/lib/providers/LicenseProvider.tsx
@@ -16,9 +16,7 @@ export interface LicenseContextValue {
   refetch: () => Promise<void>;
 }
 
-async function resolveTier(): Promise<string> {
-  // Skip if API URL is not configured  -  prevents CORS errors in local dev
-  // and avoids calling the production API from self-hosted instances.
+async function resolveSaasTier(): Promise<string> {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
   if (!apiUrl) return 'free';
 
@@ -37,7 +35,13 @@ async function resolveTier(): Promise<string> {
   return 'free';
 }
 
-export function LicenseProvider({ children }: { children: React.ReactNode }) {
+interface LicenseProviderProps {
+  children: React.ReactNode;
+  isFleetMode?: boolean;
+}
+
+export function LicenseProvider({ children, isFleetMode = false }: LicenseProviderProps) {
+  const resolveTier = isFleetMode ? () => Promise.resolve('enterprise') : resolveSaasTier;
   return (
     <PaywallProvider paywall={paywall} resolveTier={resolveTier}>
       {children}

--- a/apps/admin/src/lib/providers/index.tsx
+++ b/apps/admin/src/lib/providers/index.tsx
@@ -5,7 +5,12 @@ import { HeaderThemeProvider } from './HeaderTheme/index';
 import { LicenseProvider } from './LicenseProvider';
 import { ThemeProvider } from './Theme/index';
 
-export const Providers = ({ children }: { children: React.ReactNode }) => {
+interface ProvidersProps {
+  children: React.ReactNode;
+  isFleetMode?: boolean;
+}
+
+export const Providers = ({ children, isFleetMode = false }: ProvidersProps) => {
   return (
     <ElectricProvider
       serviceUrl={process.env.NEXT_PUBLIC_ELECTRIC_SERVICE_URL}
@@ -13,9 +18,9 @@ export const Providers = ({ children }: { children: React.ReactNode }) => {
     >
       <ThemeProvider>
         <HeaderThemeProvider>
-          <LicenseProvider>
+          <LicenseProvider isFleetMode={isFleetMode}>
             {children}
-            <UpgradeDialog />
+            {isFleetMode ? null : <UpgradeDialog />}
           </LicenseProvider>
         </HeaderThemeProvider>
       </ThemeProvider>


### PR DESCRIPTION
## Summary
- In fleet mode, `resolveTier` now returns `'enterprise'` directly instead of calling the SaaS billing API (which defaults to 'free' when no Stripe subscription exists)
- Hides the `UpgradeDialog` in fleet mode since fleet instances are licensed at the enterprise tier
- Passes `isFleetMode` prop through both layout trees to `LicenseProvider`

Surfaced during internal audit — fleet-mode admin dashboard incorrectly showed "Free plan" banner and "Upgrade to Pro" gates despite valid enterprise license.

## Test plan
- [ ] Boot fleet kit with `REVEALUI_FLEET_MODE=true`
- [ ] Verify no "Free plan" / "Start your Pro trial" banner on dashboard
- [ ] Verify no "Upgrade to Pro" gates on monitoring pages
- [ ] Verify SaaS (non-fleet) mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)