### PR TITLE
feat(admin,server): onboarding activation improvements

### DIFF
--- a/apps/admin/src/app/(backend)/agents/new/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/__tests__/page.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import NewAgentPage from '../page';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseLicense.mockReturnValue({ features: { ai: true }, isLoading: false });
+});
+
+describe('NewAgentPage', () => {
+  it('never defaults a template to a hardcoded Claude model id', () => {
+    render(<NewAgentPage />);
+
+    for (const label of ['Content Writer', 'Code Assistant', 'Support Agent', 'Data Analyst']) {
+      fireEvent.click(screen.getByRole('button', { name: new RegExp(label) }));
+      expect(
+        screen.getByText(/Auto \(resolved from your configured provider\)/),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/claude-/)).not.toBeInTheDocument();
+    }
+  });
+
+  it('links to Settings, API Keys for provider configuration', () => {
+    render(<NewAgentPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Content Writer/ }));
+
+    const link = screen.getByRole('link', { name: 'Settings, API Keys' });
+    expect(link).toHaveAttribute('href', '/settings/api-keys');
+  });
+});

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -22,6 +22,15 @@ import { apiFetch } from '@/lib/utils/csrf';
 
 type TemplateKey = 'content' | 'code' | 'support' | 'analytics';
 
+/**
+ * Empty string, mirroring the chat model picker's 'Auto' option (see
+ * MODEL_OPTIONS in src/lib/components/Agent/index.tsx). The dispatch runtime
+ * resolves the actual model from the account's configured provider
+ * (Settings > API Keys) — it never reads a hardcoded id off the agent
+ * definition, so the template default must not imply one specific vendor.
+ */
+const AUTO_MODEL = '';
+
 interface AgentTemplate {
   key: TemplateKey;
   label: string;
@@ -39,7 +48,7 @@ const TEMPLATES: AgentTemplate[] = [
     label: 'Content Writer',
     description: 'Creates blog posts, landing pages, product descriptions, and marketing copy.',
     capabilities: ['content-generation', 'seo', 'copywriting'],
-    model: 'claude-sonnet-4-6',
+    model: AUTO_MODEL,
     temperature: 0.8,
     maxTokens: 4096,
     systemPromptFn: (name) =>
@@ -51,7 +60,7 @@ const TEMPLATES: AgentTemplate[] = [
     description:
       'Reviews TypeScript/React code, generates implementations, fixes bugs, and enforces coding conventions.',
     capabilities: ['code-review', 'code-generation', 'debugging', 'refactoring'],
-    model: 'claude-sonnet-4-6',
+    model: AUTO_MODEL,
     temperature: 0.2,
     maxTokens: 8192,
     systemPromptFn: (name) =>
@@ -63,7 +72,7 @@ const TEMPLATES: AgentTemplate[] = [
     description:
       'Triages support tickets, answers common questions, and escalates complex issues to the team.',
     capabilities: ['ticket-management', 'search', 'escalation', 'customer-support'],
-    model: 'claude-haiku-4-5-20251001',
+    model: AUTO_MODEL,
     temperature: 0.3,
     maxTokens: 2048,
     systemPromptFn: (name) =>
@@ -75,7 +84,7 @@ const TEMPLATES: AgentTemplate[] = [
     description:
       'Queries application metrics, identifies trends, and generates actionable reports for the team.',
     capabilities: ['data-analysis', 'reporting', 'metrics', 'visualization'],
-    model: 'claude-sonnet-4-6',
+    model: AUTO_MODEL,
     temperature: 0.3,
     maxTokens: 4096,
     systemPromptFn: (name) =>
@@ -353,13 +362,24 @@ export default function NewAgentPage() {
 
                 {/* Model info (read-only) */}
                 <Card className="px-4 py-3 text-xs text-muted-foreground">
-                  <span className="font-medium text-foreground">Model:</span> {tpl?.model}
+                  <span className="font-medium text-foreground">Model:</span>{' '}
+                  {tpl?.model || 'Auto (resolved from your configured provider)'}
                   &nbsp;·&nbsp;
                   <span className="font-medium text-foreground">Temp:</span> {tpl?.temperature}
                   &nbsp;·&nbsp;
                   <span className="font-medium text-foreground">Max tokens:</span>{' '}
                   {tpl?.maxTokens?.toLocaleString()}
                 </Card>
+                <p className="text-xs text-muted-foreground">
+                  Model providers are configured in{' '}
+                  <Link
+                    href="/settings/api-keys"
+                    className="font-medium text-primary hover:underline"
+                  >
+                    Settings, API Keys
+                  </Link>
+                  .
+                </p>
 
                 {/* Error — inline banner; Alert primitive is a modal dialog, not applicable */}
                 {error && (

--- a/apps/admin/src/app/(frontend)/account/billing/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/__tests__/page.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseSession = vi.fn();
+vi.mock('@revealui/auth/react', () => ({
+  useSession: () => mockUseSession(),
+}));
+
+const mockPush = vi.fn();
+let searchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock('@/components/TestModeBanner', () => ({
+  TestModeBanner: () => null,
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (...args: Parameters<typeof fetch>) => fetch(...args),
+}));
+
+const mockSafeStripeRedirect = vi.fn();
+vi.mock('@/lib/utils/safe-stripe-redirect', () => ({
+  safeStripeRedirect: (url: string) => mockSafeStripeRedirect(url),
+}));
+
+import BillingPage from '../page';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchParams = new URLSearchParams();
+  mockUseSession.mockReturnValue({ data: { user: { id: 'u1' } }, isLoading: false });
+});
+
+describe('BillingPage checkout hardening', () => {
+  it('retries the subscription fetch once before giving up', async () => {
+    let subscriptionCalls = 0;
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/billing/subscription')) {
+        subscriptionCalls += 1;
+        if (subscriptionCalls === 1) return Promise.reject(new Error('network down'));
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ tier: 'pro', status: 'active', expiresAt: null }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response);
+    });
+
+    render(<BillingPage />);
+
+    await waitFor(() => {
+      expect(subscriptionCalls).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/could not load your subscription/)).not.toBeInTheDocument();
+  });
+
+  it('never auto-fires checkout when subscription data never loaded', async () => {
+    searchParams = new URLSearchParams('upgrade=pro');
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+
+    render(<BillingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not load your subscription/)).toBeInTheDocument();
+    });
+    expect(mockSafeStripeRedirect).not.toHaveBeenCalled();
+  });
+
+  it('shows a manual "Continue to checkout" fallback after both attempts fail with an upgrade param', async () => {
+    searchParams = new URLSearchParams('upgrade=max');
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+
+    render(<BillingPage />);
+
+    const button = await screen.findByRole('button', { name: 'Continue to checkout' });
+
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/billing/checkout')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ url: 'https://checkout.stripe.com/session/abc' }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response);
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockSafeStripeRedirect).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/session/abc',
+      );
+    });
+  });
+
+  it('does not render the fallback button without an upgrade param', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+
+    render(<BillingPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Continue to checkout' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -78,6 +78,7 @@ function BillingContent() {
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
+  const [subscriptionLoadFailed, setSubscriptionLoadFailed] = useState(false);
 
   const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
 
@@ -87,7 +88,7 @@ function BillingContent() {
     return `${t.price}${t.period ?? ''}`;
   };
 
-  const fetchSubscription = useCallback(async () => {
+  const attemptFetchSubscription = useCallback(async (): Promise<boolean> => {
     try {
       const [subRes, usageRes, pricingRes, seatsRes] = await Promise.all([
         fetch(`${apiUrl}/api/billing/subscription`, { credentials: 'include' }),
@@ -111,12 +112,34 @@ function BillingContent() {
         const data = (await seatsRes.json()) as SeatsData;
         setSeats(data);
       }
+      return subRes.ok;
     } catch {
-      setError('Failed to load subscription data');
-    } finally {
-      setIsLoading(false);
+      return false;
     }
   }, [apiUrl]);
+
+  /**
+   * Fetches subscription data with one automatic retry on failure. The
+   * auto-checkout effect below only fires once `subscription` is populated,
+   * so a hard failure here must never be silent  -  it has to leave a trail
+   * (`subscriptionLoadFailed`) the UI can act on, especially when the user
+   * arrived mid-purchase with an `?upgrade=` param.
+   */
+  const fetchSubscription = useCallback(async () => {
+    setError(null);
+    setSubscriptionLoadFailed(false);
+
+    let ok = await attemptFetchSubscription();
+    if (!ok) {
+      ok = await attemptFetchSubscription();
+    }
+
+    if (!ok) {
+      setError('Failed to load subscription data');
+      setSubscriptionLoadFailed(true);
+    }
+    setIsLoading(false);
+  }, [attemptFetchSubscription]);
 
   useEffect(() => {
     if (!sessionLoading && session) {
@@ -351,6 +374,20 @@ function BillingContent() {
       {error && (
         <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
           {error}
+        </div>
+      )}
+
+      {subscriptionLoadFailed && upgrade && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+          We could not load your subscription, so checkout did not start automatically.
+          <button
+            type="button"
+            onClick={() => void handleCheckout(upgrade)}
+            disabled={actionLoading}
+            className="ml-2 font-medium underline hover:text-red-900 disabled:cursor-not-allowed dark:hover:text-red-200"
+          >
+            Continue to checkout
+          </button>
         </div>
       )}
 

--- a/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+import WelcomePage from '../page';
+
+function setSearch(search: string) {
+  window.history.pushState({}, '', `/welcome${search}`);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setSearch('');
+});
+
+describe('WelcomePage', () => {
+  it('leads with license key + agent CTAs in the paid-success state', () => {
+    mockUseLicense.mockReturnValue({ tier: 'pro' });
+    setSearch('?success=true');
+    render(<WelcomePage />);
+
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map((l) => l.getAttribute('href'));
+    expect(hrefs[0]).toBe('/account/license');
+    expect(hrefs[1]).toBe('/agents');
+
+    expect(screen.getByText('Your license key')).toBeInTheDocument();
+    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
+    // Only one "Run your first agent" CTA in the paid-success state.
+    expect(screen.getAllByText('Run your first agent')).toHaveLength(1);
+  });
+
+  it('keeps the original CTA order and appends the agent CTA for non-paid success', () => {
+    mockUseLicense.mockReturnValue({ tier: 'free' });
+    setSearch('?success=true');
+    render(<WelcomePage />);
+
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map((l) => l.getAttribute('href'));
+    const sourceIdx = hrefs.indexOf('https://github.com/RevealUIStudio/revealui');
+    const agentIdx = hrefs.indexOf('/agents');
+    expect(sourceIdx).toBe(0);
+    expect(agentIdx).toBeGreaterThan(sourceIdx);
+    expect(hrefs).not.toContain('/account/license');
+    expect(screen.queryByText('Your license key')).not.toBeInTheDocument();
+  });
+
+  it('appends the agent CTA on a first-time (no success param) visit', () => {
+    mockUseLicense.mockReturnValue({ tier: 'free' });
+    render(<WelcomePage />);
+
+    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
+    expect(screen.queryByText('Your license key')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -13,13 +13,19 @@ const CLI_INSTALL_COMMAND = 'pnpm create revealui my-app';
  * Post-purchase welcome page.
  *
  * Reachable at `/welcome` (with optional `?success=true` from Stripe checkout
- * return). Lands a paying customer on three concrete first actions instead of
+ * return). Lands a paying customer on concrete first actions instead of
  * a billing dashboard. Without this, a Pro customer paying $49/mo would be
  * confronted with a CMS admin and no guidance.
  *
  * The success banner only renders when `?success=true` is in the URL —
- * direct visits (revisiting the page later) show the same three CTAs
+ * direct visits (revisiting the page later) show the same CTAs
  * without the celebratory framing.
+ *
+ * When the paid-success state renders (`?success=true` and a paid tier),
+ * the license key and first-agent CTAs lead, ahead of the CLI/source/guide
+ * CTAs — a paying customer's next move is using what they paid for, not
+ * reading docs. Non-paid variants keep the original order and simply gain
+ * the agent CTA at the end.
  *
  * The `?denied=admin` banner renders when the proxy redirected an
  * authenticated non-admin here from an admin-only route. It explains why they
@@ -40,6 +46,7 @@ export default function WelcomePage() {
 
   const tierLabel = TIER_LABELS[tier] ?? 'Free';
   const isPaidTier = tier !== 'free';
+  const isPaidSuccess = isPostPurchase && isPaidTier;
 
   const handleCopyCli = async () => {
     try {
@@ -82,17 +89,57 @@ export default function WelcomePage() {
         </h1>
         <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
           {isPostPurchase
-            ? 'Three concrete first actions to put your subscription to work.'
-            : 'New here? Start with one of these three tracks.'}
+            ? 'Concrete first actions to put your subscription to work.'
+            : 'New here? Start with one of these tracks.'}
         </p>
       </div>
 
-      {/* Three CTAs */}
+      {/* CTAs */}
       <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-3">
-        {/* CTA 1: Install the CLI */}
+        {isPaidSuccess && (
+          <>
+            {/* CTA 1: License key */}
+            <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+              <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <span className="text-lg font-semibold">1</span>
+              </div>
+              <h2 className="text-lg font-semibold text-foreground">Your license key</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Find your license key and manage your subscription from account settings.
+              </p>
+              <a
+                href="/account/license"
+                className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
+              >
+                View your license
+                <span aria-hidden="true">&rarr;</span>
+              </a>
+            </div>
+
+            {/* CTA 2: Run your first agent */}
+            <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+              <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <span className="text-lg font-semibold">2</span>
+              </div>
+              <h2 className="text-lg font-semibold text-foreground">Run your first agent</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Talk to an agent and watch it take a real action in your workspace.
+              </p>
+              <a
+                href="/agents"
+                className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
+              >
+                Open agents
+                <span aria-hidden="true">&rarr;</span>
+              </a>
+            </div>
+          </>
+        )}
+
+        {/* CTA: Install the CLI */}
         <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
           <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <span className="text-lg font-semibold">1</span>
+            <span className="text-lg font-semibold">{isPaidSuccess ? 3 : 1}</span>
           </div>
           <h2 className="text-lg font-semibold text-foreground">Install the CLI</h2>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -111,10 +158,10 @@ export default function WelcomePage() {
           </div>
         </div>
 
-        {/* CTA 2: Clone the starter */}
+        {/* CTA: Clone the starter */}
         <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
           <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <span className="text-lg font-semibold">2</span>
+            <span className="text-lg font-semibold">{isPaidSuccess ? 4 : 2}</span>
           </div>
           <h2 className="text-lg font-semibold text-foreground">Clone the source</h2>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -132,10 +179,10 @@ export default function WelcomePage() {
           </a>
         </div>
 
-        {/* CTA 3: Read the first guide */}
+        {/* CTA: Read the first guide */}
         <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
           <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <span className="text-lg font-semibold">3</span>
+            <span className="text-lg font-semibold">{isPaidSuccess ? 5 : 3}</span>
           </div>
           <h2 className="text-lg font-semibold text-foreground">Read the quick-start</h2>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -152,6 +199,26 @@ export default function WelcomePage() {
             <span aria-hidden="true">&rarr;</span>
           </a>
         </div>
+
+        {!isPaidSuccess && (
+          /* CTA 4: Run your first agent (appended for non-paid variants) */
+          <div className="rounded-2xl border border-border bg-card p-6 shadow-sm transition hover:shadow-md">
+            <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <span className="text-lg font-semibold">4</span>
+            </div>
+            <h2 className="text-lg font-semibold text-foreground">Run your first agent</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Talk to an agent and watch it take a real action in your workspace.
+            </p>
+            <a
+              href="/agents"
+              className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/80"
+            >
+              Open agents
+              <span aria-hidden="true">&rarr;</span>
+            </a>
+          </div>
+        )}
       </div>
 
       {/* Account-management footer */}

--- a/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
@@ -1,39 +1,44 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SITE_NAME } from '@/lib/utils/siteBranding';
 
 const DISMISSED_KEY = 'revealui-onboarding-dismissed';
 
+type ItemKey = 'agents' | 'agentTasks' | 'pages' | 'products';
+
 interface ChecklistItem {
+  key: ItemKey;
   label: string;
   description: string;
   href: string;
-  external?: boolean;
 }
 
 const items: ChecklistItem[] = [
   {
+    key: 'agents',
+    label: 'Run your first agent',
+    description: 'Talk to an agent and watch it take an action on your behalf.',
+    href: '/agents',
+  },
+  {
+    key: 'agentTasks',
+    label: 'See the receipt',
+    description: 'Every agent action leaves a task record you can inspect.',
+    href: '/agent-tasks',
+  },
+  {
+    key: 'pages',
     label: 'Create your first page',
     description: 'Add a homepage, about page, or blog post to get started.',
     href: '/pages',
   },
   {
+    key: 'products',
     label: 'Add a product',
     description: 'Set up your first product with pricing and details.',
     href: '/products',
-  },
-  {
-    label: 'Configure settings',
-    description: 'Set your site name, branding, and preferences.',
-    href: '/settings',
-  },
-  {
-    label: 'Explore the docs',
-    description: 'Guides for content, payments, AI, and deployment.',
-    href: 'https://docs.revealui.com',
-    external: true,
   },
 ];
 
@@ -45,8 +50,70 @@ function wasDismissed(): boolean {
   }
 }
 
+/** Resolve a boolean from a same-origin admin collections proxy (pages, products). */
+async function hasAnyDoc(collection: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/collections/${collection}?limit=1&depth=0`, {
+      credentials: 'include',
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { docs?: unknown[] };
+    return (data.docs?.length ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive checklist completion from live data rather than click tracking, so
+ * the checklist reflects what the account has actually done. Every source
+ * fails closed to `false` on its own  -  a 403 from an ungated tier or a
+ * network hiccup on one item just leaves that item unchecked, it never
+ * throws. `null` is returned only when derivation could not be attempted at
+ * all, so the caller falls back to the plain static list.
+ */
+async function fetchCompletionState(apiUrl: string): Promise<Record<ItemKey, boolean> | null> {
+  try {
+    const [agentsDone, agentTasksDone, pagesDone, productsDone] = await Promise.all([
+      fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' })
+        .then((r) => (r.ok ? r.json() : { agents: [] }))
+        .then((data: { agents?: unknown[] }) => (data.agents?.length ?? 0) > 0)
+        .catch(() => false),
+      fetch(`${apiUrl}/a2a/agent-tasks/exists`, { credentials: 'include' })
+        .then((r) => (r.ok ? r.json() : { exists: false }))
+        .then((data: { exists?: boolean }) => data.exists ?? false)
+        .catch(() => false),
+      hasAnyDoc('pages'),
+      hasAnyDoc('products'),
+    ]);
+
+    return {
+      agents: agentsDone,
+      agentTasks: agentTasksDone,
+      pages: pagesDone,
+      products: productsDone,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export default function OnboardingChecklist() {
   const [dismissed, setDismissed] = useState(wasDismissed);
+  const [completion, setCompletion] = useState<Record<ItemKey, boolean> | null>(null);
+
+  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
+
+  useEffect(() => {
+    if (dismissed) return;
+    let cancelled = false;
+    fetchCompletionState(apiUrl).then((state) => {
+      if (!cancelled) setCompletion(state);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dismissed, apiUrl]);
 
   if (dismissed) return null;
 
@@ -78,20 +145,23 @@ export default function OnboardingChecklist() {
       </div>
 
       <div className="grid gap-2 sm:grid-cols-2">
-        {items.map((item) => {
-          const props = item.external
-            ? { target: '_blank' as const, rel: 'noopener noreferrer' }
-            : {};
+        {items.map((item, index) => {
+          const checked = completion?.[item.key] ?? false;
 
           return (
             <Link
               key={item.href}
               href={item.href}
               className="flex items-start gap-3 rounded-lg border border-zinc-700/50 bg-zinc-800 p-3 transition-colors hover:border-zinc-500 hover:bg-zinc-750"
-              {...props}
             >
-              <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-zinc-600 text-xs text-zinc-500">
-                {items.indexOf(item) + 1}
+              <span
+                className={`mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-xs ${
+                  checked
+                    ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
+                    : 'border-zinc-600 text-zinc-500'
+                }`}
+              >
+                {checked ? <span aria-hidden="true">&#10003;</span> : index + 1}
               </span>
               <div>
                 <p className="text-sm font-medium text-white">{item.label}</p>

--- a/apps/admin/src/lib/components/BeforeDashboard/__tests__/OnboardingChecklist.test.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/__tests__/OnboardingChecklist.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OnboardingChecklist from '../OnboardingChecklist';
+
+const DISMISSED_KEY = 'revealui-onboarding-dismissed';
+
+function mockFetchImpl(handlers: {
+  agents?: { ok: boolean; body?: unknown };
+  agentTasks?: { ok: boolean; body?: unknown };
+  pages?: { ok: boolean; body?: unknown };
+  products?: { ok: boolean; body?: unknown };
+}) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/a2a/agents')) {
+      const h = handlers.agents ?? { ok: true, body: { agents: [] } };
+      return Promise.resolve({ ok: h.ok, json: () => Promise.resolve(h.body) } as Response);
+    }
+    if (url.includes('/a2a/agent-tasks/exists')) {
+      const h = handlers.agentTasks ?? { ok: true, body: { exists: false } };
+      return Promise.resolve({ ok: h.ok, json: () => Promise.resolve(h.body) } as Response);
+    }
+    if (url.includes('/api/collections/pages')) {
+      const h = handlers.pages ?? { ok: true, body: { docs: [] } };
+      return Promise.resolve({ ok: h.ok, json: () => Promise.resolve(h.body) } as Response);
+    }
+    if (url.includes('/api/collections/products')) {
+      const h = handlers.products ?? { ok: true, body: { docs: [] } };
+      return Promise.resolve({ ok: h.ok, json: () => Promise.resolve(h.body) } as Response);
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('OnboardingChecklist', () => {
+  it('renders nothing when previously dismissed', () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    global.fetch = mockFetchImpl({});
+    render(<OnboardingChecklist />);
+    expect(screen.queryByText('Getting Started')).not.toBeInTheDocument();
+  });
+
+  it('renders the four data-derived items in order', async () => {
+    global.fetch = mockFetchImpl({});
+    render(<OnboardingChecklist />);
+    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
+    expect(screen.getByText('See the receipt')).toBeInTheDocument();
+    expect(screen.getByText('Create your first page')).toBeInTheDocument();
+    expect(screen.getByText('Add a product')).toBeInTheDocument();
+
+    const links = screen.getAllByRole('link');
+    expect(links.map((l) => l.getAttribute('href'))).toEqual([
+      '/agents',
+      '/agent-tasks',
+      '/pages',
+      '/products',
+    ]);
+  });
+
+  it('shows a checkmark for items with existing data', async () => {
+    global.fetch = mockFetchImpl({
+      agents: { ok: true, body: { agents: [{ name: 'demo' }] } },
+      agentTasks: { ok: true, body: { exists: true } },
+      pages: { ok: true, body: { docs: [{ id: '1' }] } },
+      products: { ok: true, body: { docs: [] } },
+    });
+    render(<OnboardingChecklist />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('✓')).toHaveLength(3);
+    });
+    // "Add a product" stays unchecked (no docs)
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('renders every item unchecked when a source 403s (ungated tier)', async () => {
+    global.fetch = mockFetchImpl({
+      agents: { ok: true, body: { agents: [] } },
+      agentTasks: { ok: false, body: { error: 'AI feature requires Pro' } },
+      pages: { ok: true, body: { docs: [] } },
+      products: { ok: true, body: { docs: [] } },
+    });
+    render(<OnboardingChecklist />);
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('✓')).toHaveLength(0);
+    });
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('falls back to the unchecked static list when fetch throws entirely', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+    render(<OnboardingChecklist />);
+
+    // Never breaks the dashboard: items still render, none crash-derived.
+    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryAllByText('✓')).toHaveLength(0);
+    });
+  });
+
+  it('dismisses and persists to localStorage', async () => {
+    global.fetch = mockFetchImpl({});
+    render(<OnboardingChecklist />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByText('Getting Started')).not.toBeInTheDocument();
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe('1');
+  });
+});

--- a/apps/server/src/routes/__tests__/a2a-edge.test.ts
+++ b/apps/server/src/routes/__tests__/a2a-edge.test.ts
@@ -419,6 +419,64 @@ describe('GET /a2a/agents/:id/tasks', () => {
   });
 });
 
+describe('GET /a2a/agent-tasks/exists', () => {
+  beforeEach(resetMocks);
+
+  it('returns 401 when caller is not authenticated', async () => {
+    const app = makeA2AApp();
+    const res = await app.request(get('/agent-tasks/exists'));
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Authentication');
+  });
+
+  it('returns exists: true when at least one agent_actions row exists', async () => {
+    const chain = makeSelectChain([{ id: 'action-1' }]);
+    mockGetClient.mockReturnValue({
+      select: vi.fn().mockReturnValue(chain),
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any);
+
+    const app = makeA2AApp({ id: 'user-1' });
+    const res = await app.request(get('/agent-tasks/exists'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { exists: boolean };
+    expect(body.exists).toBe(true);
+  });
+
+  it('returns exists: false when no agent_actions rows exist', async () => {
+    const chain = makeSelectChain([]);
+    mockGetClient.mockReturnValue({
+      select: vi.fn().mockReturnValue(chain),
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any);
+
+    const app = makeA2AApp({ id: 'user-1' });
+    const res = await app.request(get('/agent-tasks/exists'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { exists: boolean };
+    expect(body.exists).toBe(false);
+  });
+
+  it('returns exists: false when the DB query fails', async () => {
+    const chain = makeSelectChain([], { throws: true });
+    mockGetClient.mockReturnValue({
+      select: vi.fn().mockReturnValue(chain),
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+    } as any);
+
+    const app = makeA2AApp({ id: 'user-1' });
+    const res = await app.request(get('/agent-tasks/exists'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { exists: boolean };
+    expect(body.exists).toBe(false);
+  });
+});
+
 describe('GET /a2a/stream/:taskId  -  SSE stream', () => {
   beforeEach(resetMocks);
 

--- a/apps/server/src/routes/__tests__/analytics.test.ts
+++ b/apps/server/src/routes/__tests__/analytics.test.ts
@@ -27,6 +27,12 @@ vi.mock('@revealui/db/schema', () => ({
     accountId: 'account_id',
     userId: 'user_id',
     status: 'status',
+    role: 'role',
+    createdAt: 'created_at',
+  },
+  accounts: {
+    id: 'id',
+    status: 'status',
   },
   usageMeters: {
     accountId: 'account_id',
@@ -36,6 +42,13 @@ vi.mock('@revealui/db/schema', () => ({
     durationMs: 'duration_ms',
     errored: 'errored',
     source: 'source',
+    createdAt: 'created_at',
+  },
+  users: {
+    id: 'id',
+    createdAt: 'created_at',
+    lastActiveAt: 'last_active_at',
+    deletedAt: 'deleted_at',
   },
 }));
 
@@ -43,6 +56,7 @@ vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ _and: args })),
   eq: vi.fn((col: unknown, val: unknown) => ({ _eq: [col, val] })),
   gte: vi.fn((col: unknown, val: unknown) => ({ _gte: [col, val] })),
+  isNull: vi.fn((col: unknown) => ({ _isNull: col })),
   sql: Object.assign(
     (strings: TemplateStringsArray, ..._values: unknown[]) => ({ _sql: strings.join('') }),
     {},
@@ -335,6 +349,85 @@ describe('GET /analytics/by-source', () => {
     expect(body.sources[0]?.source).toBe('agent');
     expect(body.sources[0]?.errored).toBe(2);
     expect(body.sources[1]?.source).toBe('user');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /analytics/activation
+// ---------------------------------------------------------------------------
+
+function adminUser(): MockUser {
+  return { id: 'u_admin', email: 'admin@example.com', name: 'Admin User', role: 'admin' };
+}
+
+function dbForActivation(perAccountRows: unknown[], day7Rows: unknown[]) {
+  const calls: number[] = [];
+  return {
+    select: vi.fn().mockImplementation(() => {
+      const idx = calls.length;
+      calls.push(idx);
+      return idx === 0 ? makeAggregateChain(perAccountRows) : makeAggregateChain(day7Rows);
+    }),
+  };
+}
+
+describe('GET /analytics/activation', () => {
+  it('returns 401 when no user is set', async () => {
+    const app = createApp();
+    const res = await app.request('/analytics/activation', { method: 'GET' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for a non-admin authenticated user', async () => {
+    mockedGetClient.mockReturnValue(dbForActivation([], []) as never);
+    const app = createApp(authedUser());
+    const res = await app.request('/analytics/activation', { method: 'GET' });
+    expect(res.status).toBe(403);
+  });
+
+  it('computes activation counts and day-7 return rate for an admin', async () => {
+    const db = dbForActivation(
+      [
+        {
+          accountId: 'acct_1',
+          ownerCreatedAt: '2026-01-01T00:00:00Z',
+          firstAgentActionAt: '2026-01-02T00:00:00Z',
+        },
+        { accountId: 'acct_2', ownerCreatedAt: '2026-01-01T00:00:00Z', firstAgentActionAt: null },
+      ],
+      [{ eligibleUsers: 10, returnedUsers: 3 }],
+    );
+    mockedGetClient.mockReturnValue(db as never);
+
+    const app = createApp(adminUser());
+    const res = await app.request('/analytics/activation', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Record<string, unknown> };
+    expect(body.data.accountsWithFirstAgentAction).toBe(1);
+    expect(body.data.accountsWithoutFirstAgentAction).toBe(1);
+    expect(body.data.averageTimeToFirstAgentActionMs).toBe(24 * 60 * 60 * 1000);
+    expect(body.data.medianTimeToFirstAgentActionMs).toBe(24 * 60 * 60 * 1000);
+    expect(body.data.day7EligibleUsers).toBe(10);
+    expect(body.data.day7ReturnedUsers).toBe(3);
+    expect(body.data.day7ReturnRate).toBe(30);
+  });
+
+  it('returns nulls for the time-to-activation stats when no account has activated', async () => {
+    const db = dbForActivation(
+      [{ accountId: 'acct_1', ownerCreatedAt: '2026-01-01T00:00:00Z', firstAgentActionAt: null }],
+      [{ eligibleUsers: 0, returnedUsers: 0 }],
+    );
+    mockedGetClient.mockReturnValue(db as never);
+
+    const app = createApp(adminUser());
+    const res = await app.request('/analytics/activation', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Record<string, unknown> };
+    expect(body.data.averageTimeToFirstAgentActionMs).toBeNull();
+    expect(body.data.medianTimeToFirstAgentActionMs).toBeNull();
+    expect(body.data.day7ReturnRate).toBeNull();
   });
 });
 

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -603,6 +603,45 @@ a2a.openapi(
   },
 );
 
+/**
+ * Cheapest possible existence check for onboarding-checklist derivation  -
+ * requires auth + 'ai' feature, same gate as the task-history route above.
+ * A single-row LIMIT 1 across all agents (agent_actions carries no
+ * account scoping today), not a count.
+ */
+a2a.openapi(
+  createRoute({
+    method: 'get',
+    path: '/agent-tasks/exists',
+    tags: ['a2a'],
+    summary: 'Check whether any agent task has ever run',
+    middleware: [requireFeature('ai', { mode: 'entitlements' })] as const,
+    responses: {
+      200: {
+        content: { 'application/json': { schema: z.object({ exists: z.boolean() }) } },
+        description: 'Whether at least one agent task exists',
+      },
+      401: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'Authentication required',
+      },
+    },
+  }),
+  async (c) => {
+    const user = c.get('user');
+    if (!user) {
+      return c.json({ error: 'Authentication required' }, 401);
+    }
+    try {
+      const db = getClient();
+      const rows = await db.select({ id: agentActions.id }).from(agentActions).limit(1);
+      return c.json({ exists: rows.length > 0 });
+    } catch {
+      return c.json({ exists: false });
+    }
+  },
+);
+
 /** Update an agent's mutable fields  -  requires auth + 'ai' feature */
 a2a.openapi(
   createRoute({

--- a/apps/server/src/routes/analytics.ts
+++ b/apps/server/src/routes/analytics.ts
@@ -22,9 +22,9 @@
 
 import { getClient } from '@revealui/db';
 import type { DatabaseClient } from '@revealui/db/client';
-import { accountMemberships, usageMeters } from '@revealui/db/schema';
+import { accountMemberships, accounts, usageMeters, users } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, eq, gte, isNull, sql } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
@@ -48,6 +48,21 @@ const DEFAULT_DAYS = 30;
 function requireUser(c: Context): UserContext {
   const user = c.get('user') as UserContext | undefined;
   if (!user) throw new HTTPException(401, { message: 'Authentication required' });
+  return user;
+}
+
+/**
+ * The activation endpoint aggregates across every account, unlike the
+ * single-account-scoped endpoints above  -  it is a platform-wide funnel
+ * view, not a tenant's own usage. Require admin on top of the router's
+ * 'analytics' entitlement gate so a Pro-tier customer in hosted
+ * multi-tenant mode cannot read other tenants' activation data.
+ */
+function requireAdmin(c: Context): UserContext {
+  const user = requireUser(c);
+  if (user.role !== 'admin') {
+    throw new HTTPException(403, { message: 'Admin role required' });
+  }
   return user;
 }
 
@@ -319,6 +334,132 @@ app.openapi(
       accountId,
       days,
       sources,
+    });
+  },
+);
+
+// ─── GET /api/analytics/activation ────────────────────────────────────────
+
+const ActivationShape = z.object({
+  accountsWithFirstAgentAction: z.number(),
+  accountsWithoutFirstAgentAction: z.number(),
+  averageTimeToFirstAgentActionMs: z.number().nullable(),
+  medianTimeToFirstAgentActionMs: z.number().nullable(),
+  day7EligibleUsers: z.number(),
+  day7ReturnedUsers: z.number(),
+  day7ReturnRate: z.number().nullable(),
+});
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/activation',
+    tags: ['Analytics'],
+    summary: 'Platform-wide onboarding activation funnel (admin only)',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: ActivationShape }),
+          },
+        },
+        description: 'Time-to-first-agent-action and day-7 return rate across all accounts',
+      },
+      403: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'Admin role required',
+      },
+    },
+  }),
+  async (c) => {
+    requireAdmin(c);
+    const db = c.get('db') ?? getClient();
+
+    // Per-account: the owner's signup time vs. that account's first
+    // agent-sourced usage_meters event. Correlated subqueries are fine here
+    // -  accounts is a small, admin-only aggregation, not a hot path.
+    const perAccountRows = await db
+      .select({
+        accountId: accounts.id,
+        ownerCreatedAt: sql<string | null>`(
+          select ${users.createdAt} from ${accountMemberships}
+          join ${users} on ${users.id} = ${accountMemberships.userId}
+          where ${accountMemberships.accountId} = ${accounts.id}
+            and ${accountMemberships.role} = 'owner'
+            and ${accountMemberships.status} = 'active'
+          order by ${accountMemberships.createdAt} asc
+          limit 1
+        )`,
+        firstAgentActionAt: sql<string | null>`(
+          select min(${usageMeters.createdAt}) from ${usageMeters}
+          where ${usageMeters.accountId} = ${accounts.id}
+            and ${usageMeters.source} = 'agent'
+        )`,
+      })
+      .from(accounts)
+      .where(eq(accounts.status, 'active'));
+
+    const ttfaaMsList: number[] = [];
+    let withFirstAgentAction = 0;
+    let withoutFirstAgentAction = 0;
+
+    for (const row of perAccountRows) {
+      if (row.firstAgentActionAt) {
+        withFirstAgentAction += 1;
+        if (row.ownerCreatedAt) {
+          const ms =
+            new Date(row.firstAgentActionAt).getTime() - new Date(row.ownerCreatedAt).getTime();
+          if (ms >= 0) ttfaaMsList.push(ms);
+        }
+      } else {
+        withoutFirstAgentAction += 1;
+      }
+    }
+
+    ttfaaMsList.sort((a, b) => a - b);
+    const averageTimeToFirstAgentActionMs =
+      ttfaaMsList.length > 0
+        ? Math.round(ttfaaMsList.reduce((sum, ms) => sum + ms, 0) / ttfaaMsList.length)
+        : null;
+    const medianTimeToFirstAgentActionMs =
+      ttfaaMsList.length > 0 ? ttfaaMsList[Math.floor(ttfaaMsList.length / 2)] : null;
+
+    // Day-7 return: among users old enough for the 7-day window to have
+    // elapsed, how many were still (or again) active 7+ days after signup.
+    // Sparse until users.lastActiveAt (throttled writer) has accumulated
+    // history  -  this returns whatever exists today rather than backfilling.
+    const [day7Row] = await db
+      .select({
+        eligibleUsers: sql<number>`coalesce(count(*) filter (
+          where ${users.createdAt} <= now() - interval '7 days'
+        ), 0)::int`,
+        returnedUsers: sql<number>`coalesce(count(*) filter (
+          where ${users.createdAt} <= now() - interval '7 days'
+            and ${users.lastActiveAt} is not null
+            and ${users.lastActiveAt} >= ${users.createdAt} + interval '7 days'
+        ), 0)::int`,
+      })
+      .from(users)
+      .where(isNull(users.deletedAt));
+
+    const day7EligibleUsers = Number(day7Row?.eligibleUsers ?? 0);
+    const day7ReturnedUsers = Number(day7Row?.returnedUsers ?? 0);
+    const day7ReturnRate =
+      day7EligibleUsers > 0
+        ? Number(((day7ReturnedUsers / day7EligibleUsers) * 100).toFixed(2))
+        : null;
+
+    return c.json({
+      success: true as const,
+      data: {
+        accountsWithFirstAgentAction: withFirstAgentAction,
+        accountsWithoutFirstAgentAction: withoutFirstAgentAction,
+        averageTimeToFirstAgentActionMs,
+        medianTimeToFirstAgentActionMs,
+        day7EligibleUsers,
+        day7ReturnedUsers,
+        day7ReturnRate,
+      },
     });
   },
 );

--- a/packages/auth/src/server/__tests__/session-last-active.test.ts
+++ b/packages/auth/src/server/__tests__/session-last-active.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the throttled users.lastActiveAt writer inside getSession().
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+interface UpdateCall {
+  values: Record<string, unknown>;
+}
+
+const updateCalls: UpdateCall[] = [];
+let selectQueue: unknown[][] = [];
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: vi.fn(() => ({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(selectQueue.shift() ?? [])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateCalls.push({ values });
+        return { where: vi.fn(() => Promise.resolve()) };
+      }),
+    })),
+  })),
+}));
+
+import { getSession } from '../session.js';
+
+const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+function sessionRow() {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    tokenHash: 'irrelevant',
+    expiresAt: FUTURE,
+    deletedAt: null,
+    userAgent: null,
+    ipAddress: null,
+  };
+}
+
+function userRow(lastActiveAt: Date | null) {
+  return {
+    id: 'user-1',
+    deletedAt: null,
+    lastActiveAt,
+  };
+}
+
+function headersWithCookie(): Headers {
+  const headers = new Headers();
+  headers.set('cookie', 'revealui-session=some-token');
+  return headers;
+}
+
+describe('getSession lastActiveAt throttling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateCalls.length = 0;
+    selectQueue = [];
+  });
+
+  it('writes lastActiveAt when it has never been set', async () => {
+    selectQueue = [[sessionRow()], [userRow(null)]];
+
+    await getSession(headersWithCookie());
+
+    const userUpdate = updateCalls.find((c) => 'lastActiveAt' in c.values);
+    expect(userUpdate).toBeDefined();
+  });
+
+  it('writes lastActiveAt when stale (older than 60 minutes)', async () => {
+    const staleAt = new Date(Date.now() - 61 * 60 * 1000);
+    selectQueue = [[sessionRow()], [userRow(staleAt)]];
+
+    await getSession(headersWithCookie());
+
+    const userUpdate = updateCalls.find((c) => 'lastActiveAt' in c.values);
+    expect(userUpdate).toBeDefined();
+  });
+
+  it('skips the write when lastActiveAt is within the throttle window', async () => {
+    const recentAt = new Date(Date.now() - 5 * 60 * 1000);
+    selectQueue = [[sessionRow()], [userRow(recentAt)]];
+
+    await getSession(headersWithCookie());
+
+    const userUpdate = updateCalls.find((c) => 'lastActiveAt' in c.values);
+    expect(userUpdate).toBeUndefined();
+  });
+});

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -32,6 +32,9 @@ const DEFAULT_SESSION_BINDING: SessionBindingConfig = {
   warnOnIpChange: true,
 };
 
+/** Minimum interval between users.lastActiveAt writes for a given user. */
+const LAST_ACTIVE_THROTTLE_MS = 60 * 60 * 1000;
+
 let sessionBindingConfig: SessionBindingConfig = { ...DEFAULT_SESSION_BINDING };
 
 /** Override session binding behaviour (useful for tests or strict deployments). */
@@ -223,6 +226,20 @@ export async function getSession(
     } catch {
       // Log but don't fail - last activity update is not critical
       logger.warn('Error updating last activity');
+    }
+
+    // Throttled users.lastActiveAt writer  -  fire-and-forget, never awaited,
+    // so auth latency is unaffected. Only touches the row when the stored
+    // value is null or older than the throttle window, keeping write volume
+    // to roughly one row-update per active user per hour instead of one per
+    // request.
+    if (!user.lastActiveAt || Date.now() - user.lastActiveAt.getTime() > LAST_ACTIVE_THROTTLE_MS) {
+      db.update(users)
+        .set({ lastActiveAt: new Date() })
+        .where(eq(users.id, user.id))
+        .catch(() => {
+          logger.warn('Error updating user lastActiveAt');
+        });
     }
 
     return {


### PR DESCRIPTION
## Summary

Five onboarding-activation improvements identified in an internal onboarding audit (2026-07-09):

1. **Onboarding checklist derives completion from live data.** `OnboardingChecklist` now leads with agent-first items ("Run your first agent" → `/agents`, "See the receipt" → `/agent-tasks`) followed by "Create your first page" and "Add a product". Completion checkmarks come from real account data (agents registered, an agent task has run, a page exists, a product exists) instead of client-side click tracking. Added a minimal `GET /a2a/agent-tasks/exists` endpoint since no cheap existing endpoint answered "has any agent task ever run" — everything else reuses existing endpoints (`GET /a2a/agents`, `GET /api/collections/{pages,products}?limit=1`). Any fetch failure falls back to the plain unchecked list; the dashboard never breaks. localStorage dismiss behavior is unchanged.

2. **`/welcome` leads with the license key and first agent after checkout.** When the page renders in the paid-success state (`?success=true` with a paid tier), the first two CTAs become "Your license key" (`/account/license`) and "Run your first agent" (`/agents`), ahead of the CLI/source/quick-start CTAs. Non-paid variants keep their existing order and gain a "Run your first agent" CTA at the end.

3. **New-agent templates no longer default to a hardcoded Claude model id.** Templates hardcoded `claude-sonnet-4-6` / `claude-haiku-4-5-20251001` while Settings → API Keys only configures groq, huggingface, inference-snaps, or ollama. Tracing the dispatch path confirmed the agent definition's `model` field isn't actually read by the runtime — the LLM client resolves its model from the account's configured provider (env or BYOK), so the hardcoded id was cosmetic and misleading. Templates now default to the same provider-neutral value the chat model picker uses for "Auto" (`''`), with the read-only model summary showing "Auto (resolved from your configured provider)" and a new helper line linking to Settings → API Keys.

4. **`users.lastActiveAt` writer + activation analytics.** The column existed with no writer. Added a throttled, fire-and-forget update inside the session-validation path (`getSession`) that only touches the row when it's null or older than 60 minutes, so auth latency and write volume are unaffected. Extended the Pro-gated `/api/analytics` router with `GET /api/analytics/activation`: per-account time-to-first-agent-action (owner's `users.createdAt` → first `usage_meters` row with `source='agent'`), counts of accounts with/without a first agent action, and a day-7 return rate derived from `lastActiveAt` (will be sparse until the writer accumulates history). **Judgment call:** this endpoint aggregates across every account, unlike the other analytics endpoints which are scoped to the caller's own account — added an `admin`-role check on top of the existing `analytics` Pro-tier gate so a Pro customer in hosted multi-tenant mode can't read other tenants' activation data.

5. **Checkout auto-fire hardening.** `account/billing` auto-fires Stripe checkout only when subscription data has loaded and shows the customer is eligible — that guard already existed. The gap was silent failure: a failed subscription fetch left the page stalled with no retry and no recovery path. Added one automatic retry, and if it still fails while an `?upgrade=pro|max` param is present, the page now shows a visible error line and an explicit "Continue to checkout" button that manually triggers the same checkout flow. Auto-fire is still never triggered without subscription data — the button is a fallback, not a bypass.

## Tests run

- `pnpm --filter admin vitest run` (targeted): `OnboardingChecklist.test.tsx`, `welcome/__tests__/page.test.tsx`, `agents/new/__tests__/page.test.tsx`, `account/billing/__tests__/page.test.tsx` — 4 files, 15 tests, all passing
- `pnpm --filter @revealui/auth vitest run` (targeted): `session-last-active.test.ts`, `session.test.ts` (both), `session-binding.test.ts` — all passing
- `pnpm --filter server vitest run` (targeted): `analytics.test.ts`, `a2a.test.ts`, `a2a-edge.test.ts` — all passing (analytics: 17/17 including 4 new activation tests; a2a-edge: 31/31 including 4 new `agent-tasks/exists` tests)
- `pnpm --filter admin typecheck`, `pnpm --filter server typecheck`, `pnpm --filter @revealui/auth typecheck` — all clean
- `pnpm gate:quick` — Phase 1 pass, CI gate pass (Biome, boundary/claim-drift/security/etc. all green)

## Notes

- Did not touch `apps/marketing` (owned by a concurrent lane).
- Item 3's fix is a default-value + copy change only; Claude model ids remain selectable as an intentional model choice elsewhere in the system, per the audit's scope — this PR just stops the create-agent form from implying one as the default.
