### PR TITLE
feat(auth): establish session on successful email verification

### DIFF
--- a/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
@@ -1,18 +1,25 @@
 /**
  * Tests for GET /api/auth/verify-email
  *
- * Email verification via hashed token comparison. All paths redirect.
- * Rate limited by IP, fails closed if rate limit store is unavailable.
+ * Email verification via hashed token comparison. On a valid, unexpired,
+ * single-use token, establishes a session immediately (mirroring sign-up's
+ * auto-promoted first-user path) and redirects to the resolved destination
+ * (billing checkout when `?upgrade=` is present, `/welcome` or `/` otherwise).
+ * Every other path  -  expired, reused, garbage, or already-verified token  -
+ * must never create a session. Rate limited by IP, fails closed if the rate
+ * limit store is unavailable.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCheckRateLimit = vi.fn();
+const mockCreateSession = vi.fn();
 const mockGetUserByVerificationToken = vi.fn();
 const mockUpdateUser = vi.fn();
 
 vi.mock('@revealui/auth/server', () => ({
   checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  createSession: (...args: unknown[]) => mockCreateSession(...args),
 }));
 
 vi.mock('@revealui/utils/logger', () => ({
@@ -29,13 +36,27 @@ vi.mock('@revealui/db/queries/users', () => ({
 }));
 
 vi.mock('next/server', () => {
+  class MockCookies {
+    private store = new Map<string, { value: string; options: Record<string, unknown> }>();
+    set(name: string, value: string, options?: Record<string, unknown>) {
+      this.store.set(name, { value, options: options ?? {} });
+    }
+    get(name: string) {
+      return this.store.get(name);
+    }
+    has(name: string) {
+      return this.store.has(name);
+    }
+  }
   class MockNextResponse {
     body: unknown;
     status: number;
+    cookies: MockCookies;
     url?: string;
     constructor(body: unknown, init?: { status?: number }) {
       this.body = body;
       this.status = init?.status ?? 200;
+      this.cookies = new MockCookies();
     }
     static json(data: unknown, init?: { status?: number }) {
       return new MockNextResponse(data, init);
@@ -49,13 +70,24 @@ vi.mock('next/server', () => {
   return { NextResponse: MockNextResponse };
 });
 
-function makeRequest(token?: string) {
+type MockRes = {
+  status: number;
+  url?: string;
+  cookies: {
+    get: (n: string) => { value: string; options: Record<string, unknown> } | undefined;
+    has: (n: string) => boolean;
+  };
+};
+
+function makeRequest(token?: string, upgrade?: string) {
   const url = new URL('http://localhost:4000/api/auth/verify-email');
   if (token) url.searchParams.set('token', token);
+  if (upgrade) url.searchParams.set('upgrade', upgrade);
   return {
     headers: {
       get: (key: string) => {
         if (key === 'x-forwarded-for') return '10.0.0.1';
+        if (key === 'user-agent') return 'vitest';
         return null;
       },
     },
@@ -81,7 +113,8 @@ describe('GET /api/auth/verify-email', () => {
   it('redirects with missing_token when no token param', async () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest());
-    expect((res as { url: string }).url).toContain('error=missing_token');
+    expect((res as MockRes).url).toContain('error=missing_token');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
   it('redirects with too_many_attempts when rate limited', async () => {
@@ -93,7 +126,8 @@ describe('GET /api/auth/verify-email', () => {
 
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
-    expect((res as { url: string }).url).toContain('error=too_many_attempts');
+    expect((res as MockRes).url).toContain('error=too_many_attempts');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
   it('fails closed  -  redirects with error when rate limit check throws', async () => {
@@ -101,39 +135,127 @@ describe('GET /api/auth/verify-email', () => {
 
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
-    expect((res as { url: string }).url).toContain('error=verification_failed');
+    expect((res as MockRes).url).toContain('error=verification_failed');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
-  it('redirects with invalid_token when no matching user found', async () => {
+  it('garbage token: redirects with invalid_token and creates no session', async () => {
     mockGetUserByVerificationToken.mockResolvedValue(null);
 
     const GET = await loadRoute();
-    const res = await GET(makeRequest('bad-token'));
-    expect((res as { url: string }).url).toContain('error=invalid_token');
+    const res = await GET(makeRequest('garbage-token'));
+    expect((res as MockRes).url).toContain('error=invalid_token');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
-  it('redirects with already_verified when email already verified', async () => {
+  it('expired token: getUserByVerificationToken finds no row, redirects with invalid_token and creates no session', async () => {
+    // The query's WHERE clause excludes expired tokens, so an expired token
+    // surfaces identically to a garbage one  -  no matching row.
+    mockGetUserByVerificationToken.mockResolvedValue(null);
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('expired-token'));
+    expect((res as MockRes).url).toContain('error=invalid_token');
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('reused token: the token column is nulled after first use, so a second attempt finds no row and creates no session', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue(null);
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('already-consumed-token'));
+    expect((res as MockRes).url).toContain('error=invalid_token');
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('redirects with already_verified when email already verified, and creates no session', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: true });
 
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token'));
-    expect((res as { url: string }).url).toContain('message=already_verified');
+    expect((res as MockRes).url).toContain('message=already_verified');
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 
-  it('verifies email and redirects with success message', async () => {
+  it('fails closed when updateUser returns no row, and creates no session', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue(null);
 
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token'));
-    expect((res as { url: string }).url).toContain('message=email_verified');
+    expect((res as MockRes).url).toContain('error=verification_failed');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
-  it('redirects with error on unexpected DB failure', async () => {
+  it('valid token: establishes a session, sets cookies, and redirects to billing checkout with the upgrade param', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockCreateSession.mockResolvedValue({
+      token: 'session-token-abc',
+      session: { id: 'sess1', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('valid-token', 'pro'));
+
+    expect(mockCreateSession).toHaveBeenCalledWith('u1', expect.any(Object));
+    expect((res as MockRes).url).toContain('/account/billing?upgrade=pro');
+    expect((res as MockRes).cookies.get('revealui-session')?.value).toBe('session-token-abc');
+    expect((res as MockRes).cookies.get('revealui-role')?.value).toBe('viewer');
+  });
+
+  it('valid token without an upgrade param: redirects a non-admin to /welcome', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockCreateSession.mockResolvedValue({
+      token: 'session-token-xyz',
+      session: { id: 'sess2', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('valid-token'));
+
+    expect((res as MockRes).url).toContain('/welcome');
+    expect((res as MockRes).cookies.has('revealui-session')).toBe(true);
+  });
+
+  it('valid token for an admin without an upgrade param: redirects to /', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u2', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u2', role: 'admin', emailVerified: true });
+    mockCreateSession.mockResolvedValue({
+      token: 'session-token-admin',
+      session: { id: 'sess3', userId: 'u2' },
+    });
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('valid-token'));
+
+    expect((res as MockRes).url).toMatch(/\/$/);
+    expect((res as MockRes).cookies.get('revealui-role')?.value).toBe('admin');
+  });
+
+  it('ignores an unrecognized upgrade value (no open redirect)', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockCreateSession.mockResolvedValue({
+      token: 'session-token-abc',
+      session: { id: 'sess1', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('valid-token', 'enterprise'));
+
+    expect((res as MockRes).url).toContain('/welcome');
+    expect((res as MockRes).url).not.toContain('enterprise');
+  });
+
+  it('redirects with error on unexpected DB failure, and creates no session', async () => {
     mockGetUserByVerificationToken.mockRejectedValue(new Error('DB connection lost'));
 
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
-    expect((res as { url: string }).url).toContain('error=verification_failed');
+    expect((res as MockRes).url).toContain('error=verification_failed');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -4,17 +4,24 @@
  * GET /api/auth/verify-email?token=<token>
  *
  * Verifies a user's email address using the token sent during signup.
- * Redirects to the login page with a success/error message.
+ * On success, establishes a session immediately (the same mechanism
+ * sign-up uses for the auto-promoted first user) and redirects straight
+ * into the product instead of bouncing the user to a second manual login
+ * mid-purchase. Any invalid/expired/reused/garbage token never creates a
+ * session and preserves the existing failure redirects.
  *
  * Rate limited: 10 attempts per 15 minutes per IP.
  */
 
 import { createHash } from 'node:crypto';
-import { checkRateLimit } from '@revealui/auth/server';
+import { checkRateLimit, createSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { getUserByVerificationToken, updateUser } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
+import { resolveAuthDest } from '@/lib/utils/auth-redirect';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -22,6 +29,8 @@ export const runtime = 'nodejs';
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const token = request.nextUrl.searchParams.get('token');
   const rawUpgrade = request.nextUrl.searchParams.get('upgrade');
+  // Whitelist to known checkout plans  -  never forward an arbitrary value
+  // into a redirect destination.
   const upgrade: 'pro' | 'max' | null =
     rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
   const baseUrl = request.nextUrl.origin;
@@ -56,6 +65,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const db = getClient();
 
     // Hash the incoming raw token to compare against the stored hash.
+    // A reused token (already consumed) or a garbage token both fail this
+    // lookup: a valid, unexpired, single-use match is required to proceed.
     const tokenHash = createHash('sha256').update(token).digest('hex');
 
     const user = await getUserByVerificationToken(db, tokenHash);
@@ -68,16 +79,63 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return NextResponse.redirect(`${baseUrl}/login?message=already_verified`);
     }
 
-    // Mark email as verified
-    await updateUser(db, user.id, {
+    // Mark email as verified and consume the token in one update.
+    const updatedUser = await updateUser(db, user.id, {
       emailVerified: true,
       emailVerifiedAt: new Date(),
       emailVerificationToken: null,
     });
 
-    return NextResponse.redirect(
-      `${baseUrl}/login?message=email_verified${upgrade ? `&upgrade=${upgrade}` : ''}`,
-    );
+    if (!updatedUser) {
+      // Row vanished between lookup and update (e.g. concurrent deletion).
+      // Fail closed  -  no session on an unconfirmed write.
+      logger.error('verify-email: updateUser returned no row for a matched token', {
+        userId: user.id,
+      });
+      return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);
+    }
+
+    // Establish a session for this user, mirroring the session-creation
+    // mechanism sign-up uses for the auto-promoted first user.
+    const userAgent = request.headers.get('user-agent') || undefined;
+    const ipAddress =
+      request.headers.get('x-real-ip') ||
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      undefined;
+
+    const { token: sessionToken } = await createSession(updatedUser.id, {
+      userAgent,
+      ipAddress,
+    });
+
+    const dest = resolveAuthDest({
+      upgrade,
+      redirect: null,
+      fallback: isAdminRole(updatedUser.role) ? '/' : '/welcome',
+    });
+
+    const response = NextResponse.redirect(`${baseUrl}${dest}`);
+
+    // Set role cookie for proxy.ts role-aware gate (defense-in-depth).
+    response.cookies.set('revealui-role', updatedUser.role, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7,
+      domain: sessionCookieDomain(),
+    });
+
+    response.cookies.set('revealui-session', sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
+      domain: sessionCookieDomain({ logIfMissing: true }),
+    });
+
+    return response;
   } catch (error) {
     logger.error('Email verification failed', { error });
     return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);


### PR DESCRIPTION
## Summary

Identified in an internal onboarding audit (2026-07-09): sign-up gives no session to non-first users (`apps/admin/src/app/api/auth/sign-up/route.ts`), and the verify-email link only flips `emailVerified` then redirects to `/login?message=email_verified`, forcing a manual second login mid-purchase.

**Change:** after a valid, unexpired, single-use verification token flips `emailVerified`, the route now creates a session for that user using the exact same session-creation mechanism sign-up uses for the auto-promoted first user (`createSession` from `@revealui/auth/server`), then redirects to the destination `resolveAuthDest` would produce, preserving the `upgrade` param. Non-admins land on `/welcome`; admins land on `/`; either lands on `/account/billing?upgrade=pro|max` when the upgrade param is present.

Constraints honored:
- `upgrade` is whitelisted to `pro|max` (same pattern the route already used) — no open redirect.
- No session is created on any invalid/expired/reused/garbage token path — those all fall through to the pre-existing failure redirects, unchanged.
- A defensive branch was added for the case where `updateUser` returns no row after a matched token (e.g. a concurrent deletion) — fails closed to `verification_failed`, no session.
- The `already_verified` early-return path (a race where the token row is still present but `emailVerified` is already `true`) still redirects to `/login?message=already_verified` with no session, exactly as before.

## Test cases covered

`apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts` (13 tests):
- valid token → session created, `revealui-session` + `revealui-role` cookies set, redirect to `/account/billing?upgrade=pro` when the upgrade param is present
- valid token, no upgrade param → redirect to `/welcome` (non-admin) or `/` (admin), based on the updated user's role
- expired token → no matching row (query already excludes expired rows) → `error=invalid_token`, no session
- reused token → the token column is nulled on first use, so re-use finds no row → `error=invalid_token`, no session
- garbage token → no matching row → `error=invalid_token`, no session
- already-verified race → `message=already_verified`, no session, `updateUser` never called
- unrecognized upgrade value → ignored, no open redirect
- pre-existing paths preserved: missing token, rate-limited, rate-limit-store failure (fail closed), `updateUser` returning no row, unexpected DB failure

## Tests run

- `pnpm --filter admin vitest run src/app/api/auth/__tests__` — 8 files, 81 tests, all passing (includes the 13 in the file above plus the full auth route suite for regression)
- `pnpm --filter admin typecheck` — clean
- `pnpm gate:quick` — Phase 1 pass, CI gate pass

## Security review

**This PR awaits a security review before merge.** It changes when a session cookie is issued on an unauthenticated-adjacent surface (a GET request carrying only a mailed token). Please double-check the token-reuse and expiry reasoning above against the actual `getUserByVerificationToken` query semantics, and the upgrade-param whitelist against `resolveAuthDest`.
