### PR TITLE
ci: add doc-currency stale-fact scanner (markdown + marketing copy strings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,15 @@ jobs:
       - name: Marketing voice validation (hard fail)
         run: pnpm validate:marketing-voice
 
+      - name: Doc-currency validation (hard fail)
+        # Stale-fact drift guard: docs/**/*.md + apps/marketing/**/*.md prose,
+        # plus apps/marketing/app/content/**/*.ts marketing-copy string
+        # literals (TypeScript AST — string literals only, no
+        # identifiers/imports/comments). A baseline grandfathers the corpus
+        # at seed time; CI hard-fails only on NEW (file::ruleId)
+        # occurrences. Mirrors the local gate step in scripts/gates/ci-gate.ts.
+        run: pnpm validate:doc-currency --mode=ci
+
       - name: Migration journal validation (hard fail)
         run: pnpm validate:migrations
 

--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
     "validate:pricing-lockstep": "tsx scripts/validate/pricing-lockstep.ts",
     "validate:secret-paths": "vitest run scripts/sync/__tests__/secret-paths-lockstep.test.ts",
+    "validate:doc-currency": "tsx scripts/validate/doc-currency.ts",
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
     "vercel:sync": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
     "vercel:sync:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -320,6 +320,17 @@ async function gate(): Promise<void> {
         args: ['validate:marketing-voice'],
       },
       {
+        // Stale-fact drift guard: docs/**/*.md + apps/marketing/**/*.md prose,
+        // plus apps/marketing/app/content/**/*.ts marketing-copy string
+        // literals (TypeScript AST, no identifiers/imports/comments). A
+        // baseline grandfathers the corpus at seed time; CI hard-fails only
+        // on NEW (file::ruleId) occurrences. Mirrored in CI by the Quality
+        // job step in .github/workflows/ci.yml.
+        name: 'Doc-currency (hard fail)',
+        command: 'pnpm',
+        args: ['validate:doc-currency', '--mode=ci'],
+      },
+      {
         name: 'Design-context drift (hard fail)',
         command: 'pnpm',
         args: ['validate:design-context'],

--- a/scripts/validate/__tests__/doc-currency.test.ts
+++ b/scripts/validate/__tests__/doc-currency.test.ts
@@ -1,0 +1,340 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  COMMON_EXON,
+  extractStringLiterals,
+  type Hit,
+  hitKey,
+  loadBaseline,
+  parseArgs,
+  RULES,
+  ruleMatches,
+  scanAll,
+  scanContentFile,
+  scanMarkdownFile,
+  shouldSkipFile,
+  writeBaseline,
+} from '../doc-currency.js';
+
+function rule(id: string) {
+  const found = RULES.find((r) => r.id === id);
+  if (!found) throw new Error(`no such rule: ${id}`);
+  return found;
+}
+
+/** Run the same extract-then-match pipeline `scanContentFile` uses, but on
+ *  raw source text (no disk I/O) — mirrors the file-based scan logic while
+ *  keeping the test pure. */
+function ruleIdsInSource(source: string): string[] {
+  const ids: string[] = [];
+  for (const span of extractStringLiterals(source, 'fixture.ts')) {
+    const lower = span.text.toLowerCase();
+    for (const r of RULES) {
+      if (ruleMatches(lower, r)) ids.push(r.id);
+    }
+  }
+  return ids;
+}
+
+describe('ruleMatches', () => {
+  it('flags supabase mentioned as current', () => {
+    expect(ruleMatches('we use supabase for auth today', rule('supabase-as-current'))).toBe(true);
+  });
+
+  it('does not flag supabase when exonerated by a common marker', () => {
+    expect(
+      ruleMatches('supabase is being removed in favor of neon', rule('supabase-as-current')),
+    ).toBe(false);
+  });
+
+  it('does not flag a legitimate historical Railway reference', () => {
+    expect(ruleMatches('railway was dropped for fly', rule('railway-as-current'))).toBe(false);
+  });
+
+  it('flags Railway presented as a live target', () => {
+    expect(ruleMatches('deploy your app to railway', rule('railway-as-current'))).toBe(true);
+  });
+
+  it('flags RevealCoin presented as current', () => {
+    expect(ruleMatches('pay with revealcoin today', rule('revealcoin-as-current'))).toBe(true);
+  });
+
+  it('does not flag RevealCoin when marked cancelled', () => {
+    expect(ruleMatches('revealcoin was cancelled 2026-05-29', rule('revealcoin-as-current'))).toBe(
+      false,
+    );
+  });
+
+  it('flags the retired Forge tier name', () => {
+    expect(ruleMatches('sign up for the forge tier', rule('forge-tier-name'))).toBe(true);
+  });
+
+  it('does not flag Forge tier when marked renamed', () => {
+    expect(ruleMatches('the forge tier was renamed to enterprise', rule('forge-tier-name'))).toBe(
+      false,
+    );
+  });
+
+  it('flags Vercel Blob presented as canonical storage', () => {
+    expect(
+      ruleMatches('set the blob_read_write_token env var', rule('vercel-blob-as-current')),
+    ).toBe(true);
+  });
+
+  it('does not flag Vercel Blob when R2 is named in the same line', () => {
+    expect(
+      ruleMatches(
+        'vercel blob is retiring; use cloudflare r2 instead',
+        rule('vercel-blob-as-current'),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('stripe-not-live-claim', () => {
+  const stripeRule = rule('stripe-not-live-claim');
+
+  it('flags the regression fixture: marketing copy presenting Stripe as not yet flipped', () => {
+    // Pre-fix homepage/pricing-teaser style claim — Stripe live mode IS on,
+    // so this future-tense framing is stale drift.
+    const fixture =
+      'Paid tiers (Pro, Max, Enterprise) are previews. ' +
+      'Subscription billing opens when we flip Stripe live mode.';
+    expect(ruleMatches(fixture.toLowerCase(), stripeRule)).toBe(true);
+  });
+
+  it('fires the same fixture when extracted from a content .ts string literal', () => {
+    const source = `
+      export const PRICING_TEASER_SECTION = {
+        body: 'Paid tiers (Pro, Max, Enterprise) are previews. Subscription billing opens when we flip Stripe live mode.',
+      } as const;
+    `;
+    expect(ruleIdsInSource(source)).toContain('stripe-not-live-claim');
+  });
+
+  it('does not flag the corrected past-tense phrasing', () => {
+    expect(
+      ruleMatches('stripe live mode was flipped 2026-06-26; billing is live', stripeRule),
+    ).toBe(false);
+  });
+
+  it('does not use COMMON_EXON markers that would defeat the bespoke exon list', () => {
+    // "pending" / "not yet" / "before" are COMMON_EXON markers that must NOT
+    // exonerate this rule — the bespoke list intentionally omits them.
+    expect(ruleMatches('stripe is not flipped; billing is pending', stripeRule)).toBe(true);
+  });
+});
+
+describe('extractStringLiterals — AST scope', () => {
+  it('does not scan import module specifiers', () => {
+    const source = `import { Railway } from 'railway-sdk';\nexport const x = 'clean copy';`;
+    const texts = extractStringLiterals(source, 'fixture.ts').map((s) => s.text);
+    expect(texts).not.toContain('railway-sdk');
+    expect(texts).toContain('clean copy');
+  });
+
+  it('does not scan re-export module specifiers', () => {
+    const source = `export { Railway } from 'railway-sdk';`;
+    const texts = extractStringLiterals(source, 'fixture.ts').map((s) => s.text);
+    expect(texts).not.toContain('railway-sdk');
+  });
+
+  it('does not fire on an identifier named after a banned term', () => {
+    const source = `const railwayLegacyAdapter = 'ok';\nexport { railwayLegacyAdapter };`;
+    expect(ruleIdsInSource(source)).not.toContain('railway-as-current');
+  });
+
+  it('does not scan comments', () => {
+    const source = `
+      // Supabase is our primary database today, allegedly.
+      export const x = 'nothing to see here';
+    `;
+    expect(ruleIdsInSource(source)).not.toContain('supabase-as-current');
+  });
+
+  it('extracts no-substitution template literal text', () => {
+    const source = 'export const x = `we use supabase for auth`;';
+    const texts = extractStringLiterals(source, 'fixture.ts').map((s) => s.text);
+    expect(texts).toContain('we use supabase for auth');
+  });
+
+  it('extracts the literal spans of a template expression, not the interpolated identifier', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: fixture is TS source text, not a template literal itself
+    const source = 'declare const name: string;\nexport const x = `we use supabase for ${name}`;';
+    const spans = extractStringLiterals(source, 'fixture.ts').map((s) => s.text);
+    expect(spans.some((t) => t.includes('we use supabase for'))).toBe(true);
+    expect(spans).not.toContain('name');
+  });
+});
+
+describe('shouldSkipFile — historical exemptions', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-currency-skip-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('skips files under an archive/ path segment', () => {
+    expect(shouldSkipFile('docs/archive/old.md', path.join(tmpRoot, 'missing.md'))).toBe(true);
+  });
+
+  it('skips HANDOFF-*.md session snapshots', () => {
+    const abs = path.join(tmpRoot, 'HANDOFF-2026-01-01-topic.md');
+    fs.writeFileSync(abs, 'Supabase is our database.');
+    expect(shouldSkipFile('docs/HANDOFF-2026-01-01-topic.md', abs)).toBe(true);
+  });
+
+  it('skips a file whose head carries a SUPERSEDED banner', () => {
+    const abs = path.join(tmpRoot, 'old-plan.md');
+    fs.writeFileSync(abs, '# Old Plan\n\nStatus: SUPERSEDED\n\nSupabase is our database.');
+    expect(shouldSkipFile('docs/old-plan.md', abs)).toBe(true);
+  });
+
+  it('does not skip an ordinary current doc', () => {
+    const abs = path.join(tmpRoot, 'current.md');
+    fs.writeFileSync(abs, '# Current\n\nWe use Neon and ElectricSQL.');
+    expect(shouldSkipFile('docs/current.md', abs)).toBe(false);
+  });
+});
+
+describe('baseline round-trip + CI-mode suppression', () => {
+  let tmpRoot: string;
+  let baselinePath: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-currency-baseline-'));
+    baselinePath = path.join(tmpRoot, 'baseline.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes and reloads a baseline of (file::ruleId) pairs', () => {
+    const hits: Hit[] = [
+      { file: 'docs/a.md', line: 3, ruleId: 'supabase-as-current', excerpt: 'x' },
+      { file: 'docs/a.md', line: 3, ruleId: 'supabase-as-current', excerpt: 'x (dup)' },
+      { file: 'docs/b.md', line: 1, ruleId: 'railway-as-current', excerpt: 'y' },
+    ];
+    const count = writeBaseline(hits, baselinePath);
+    expect(count).toBe(2); // deduped by (file::ruleId)
+
+    const reloaded = loadBaseline(baselinePath);
+    expect(reloaded.has('docs/a.md::supabase-as-current')).toBe(true);
+    expect(reloaded.has('docs/b.md::railway-as-current')).toBe(true);
+    expect(reloaded.size).toBe(2);
+  });
+
+  it('CI mode: an existing baselined pair passes, a new pair fails', () => {
+    const baseline = new Set(['docs/a.md::supabase-as-current']);
+    const hits: Hit[] = [
+      { file: 'docs/a.md', line: 3, ruleId: 'supabase-as-current', excerpt: 'baselined' },
+      { file: 'docs/c.md', line: 5, ruleId: 'railway-as-current', excerpt: 'brand new' },
+    ];
+    const newHits = hits.filter((h) => !baseline.has(hitKey(h)));
+    expect(newHits).toHaveLength(1);
+    expect(newHits[0]?.file).toBe('docs/c.md');
+  });
+
+  it('returns an empty set when the baseline file does not exist', () => {
+    expect(loadBaseline(path.join(tmpRoot, 'nope.json')).size).toBe(0);
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults to cli mode, no flags', () => {
+    expect(parseArgs([])).toEqual({ quiet: false, updateBaseline: false, mode: 'cli' });
+  });
+
+  it('parses --mode=ci, --update-baseline, --quiet', () => {
+    expect(parseArgs(['--mode=ci', '--update-baseline', '--quiet'])).toEqual({
+      quiet: true,
+      updateBaseline: true,
+      mode: 'ci',
+    });
+  });
+
+  it('rejects an unknown flag', () => {
+    const result = parseArgs(['--bogus']);
+    expect(result.error).toBeDefined();
+  });
+
+  it('ignores an unrecognized --mode value (stays cli)', () => {
+    expect(parseArgs(['--mode=bogus']).mode).toBe('cli');
+  });
+});
+
+describe('COMMON_EXON', () => {
+  it('is non-empty and lowercase-safe (no authored regex hazard, plain substrings)', () => {
+    expect(COMMON_EXON.length).toBeGreaterThan(10);
+    for (const term of COMMON_EXON) expect(typeof term).toBe('string');
+  });
+});
+
+describe('scanMarkdownFile + scanContentFile — end-to-end on a real fixture tree', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-currency-e2e-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('flags a markdown line presenting Supabase as current, skips exonerated lines', () => {
+    const docsDir = path.join(tmpRoot, 'docs');
+    fs.mkdirSync(docsDir, { recursive: true });
+    const abs = path.join(docsDir, 'stack.md');
+    fs.writeFileSync(
+      abs,
+      ['# Stack', '', 'We use Supabase for auth.', 'Supabase is being removed for Neon.'].join(
+        '\n',
+      ),
+    );
+    const hits = scanMarkdownFile(tmpRoot, abs);
+    expect(hits.map((h) => h.ruleId)).toEqual(['supabase-as-current']);
+    expect(hits[0]?.line).toBe(3);
+  });
+
+  it('flags a marketing-copy content .ts string literal, ignores the import line', () => {
+    const contentDir = path.join(tmpRoot, 'apps/marketing/app/content');
+    fs.mkdirSync(contentDir, { recursive: true });
+    const abs = path.join(contentDir, 'sample.ts');
+    fs.writeFileSync(
+      abs,
+      [
+        "import { railwayLegacyAdapter } from 'railway-sdk';",
+        '',
+        'export const COPY = {',
+        "  body: 'We use Supabase for auth today.',",
+        '} as const;',
+      ].join('\n'),
+    );
+    const hits = scanContentFile(tmpRoot, abs);
+    expect(hits.map((h) => h.ruleId)).toEqual(['supabase-as-current']);
+  });
+
+  it('scanAll combines both surfaces and counts the files it walked', () => {
+    const docsDir = path.join(tmpRoot, 'docs');
+    const contentDir = path.join(tmpRoot, 'apps/marketing/app/content');
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.mkdirSync(contentDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'stack.md'), 'We use Supabase for auth.');
+    fs.writeFileSync(
+      path.join(contentDir, 'sample.ts'),
+      "export const COPY = { body: 'Deploy to Railway today.' } as const;",
+    );
+
+    const { hits, markdownCount, tsCount } = scanAll(tmpRoot);
+    expect(markdownCount).toBe(1);
+    expect(tsCount).toBe(1);
+    expect(hits.map((h) => h.ruleId).sort()).toEqual(['railway-as-current', 'supabase-as-current']);
+  });
+});

--- a/scripts/validate/doc-currency-baseline.json
+++ b/scripts/validate/doc-currency-baseline.json
@@ -1,9 +1,8 @@
 {
   "note": "Grandfathered doc-currency occurrences. Regenerate via `pnpm validate:doc-currency --update-baseline`. Each entry is a (file::ruleId) pair known to exist as of generation; CI fails only on NEW pairs. Shrinking this list is progress.",
-  "count": 27,
+  "count": 26,
   "keys": [
     "apps/marketing/app/content/marketplace.ts::supabase-as-current",
-    "apps/marketing/app/content/pricing-teaser.ts::stripe-not-live-claim",
     "docs/ARCHITECTURE.md::supabase-as-current",
     "docs/AUTH.md::supabase-as-current",
     "docs/CREDENTIAL-ROTATION-RUNBOOK.md::supabase-as-current",

--- a/scripts/validate/doc-currency-baseline.json
+++ b/scripts/validate/doc-currency-baseline.json
@@ -1,0 +1,33 @@
+{
+  "note": "Grandfathered doc-currency occurrences. Regenerate via `pnpm validate:doc-currency --update-baseline`. Each entry is a (file::ruleId) pair known to exist as of generation; CI fails only on NEW pairs. Shrinking this list is progress.",
+  "count": 27,
+  "keys": [
+    "apps/marketing/app/content/marketplace.ts::supabase-as-current",
+    "apps/marketing/app/content/pricing-teaser.ts::stripe-not-live-claim",
+    "docs/ARCHITECTURE.md::supabase-as-current",
+    "docs/AUTH.md::supabase-as-current",
+    "docs/CREDENTIAL-ROTATION-RUNBOOK.md::supabase-as-current",
+    "docs/DATABASE.md::supabase-as-current",
+    "docs/ENVIRONMENT-VARIABLES-GUIDE.md::supabase-as-current",
+    "docs/MASTER_PLAN.md::forge-tier-name",
+    "docs/PRO.md::supabase-as-current",
+    "docs/REFERENCE.md::supabase-as-current",
+    "docs/SECRETS.md::supabase-as-current",
+    "docs/THIRD_PARTY_LICENSES.md::vercel-blob-as-current",
+    "docs/agent-rules/evaluation-log.md::supabase-as-current",
+    "docs/agent-rules/safety.md::supabase-as-current",
+    "docs/blog/05-five-primitives.md::supabase-as-current",
+    "docs/blog/08-getting-started.md::supabase-as-current",
+    "docs/decisions/2026-05-01-supabase-removal.md::supabase-as-current",
+    "docs/decisions/2026-05-08-deployment-target-vercel-not-k8s.md::forge-tier-name",
+    "docs/fleet/revvault.md::supabase-as-current",
+    "docs/security/ACCESS_REVIEW_POLICY.md::supabase-as-current",
+    "docs/security/ASSET_INVENTORY.md::supabase-as-current",
+    "docs/security/BACKUP_VERIFICATION.md::supabase-as-current",
+    "docs/security/CHANGE_MANAGEMENT_POLICY.md::supabase-as-current",
+    "docs/security/INCIDENT_RESPONSE.md::supabase-as-current",
+    "docs/security/INFORMATION_SECURITY_POLICY.md::supabase-as-current",
+    "docs/security/VENDOR_RISK_ASSESSMENTS.md::railway-as-current",
+    "docs/security/VENDOR_RISK_ASSESSMENTS.md::supabase-as-current"
+  ]
+}

--- a/scripts/validate/doc-currency.ts
+++ b/scripts/validate/doc-currency.ts
@@ -1,0 +1,622 @@
+#!/usr/bin/env tsx
+// console-allowed
+
+/**
+ * Doc-Currency Validator — stale-fact drift guard for prose and marketing copy.
+ *
+ * Scans two surfaces for terms that present a retired, renamed, or reversed
+ * fact as if it were still current:
+ *
+ *   1. Markdown prose under `docs/**` and `apps/marketing/**` (line-based
+ *      substring scan, mirroring the fenced-import scanner style already
+ *      used by `docs-import-drift.ts`).
+ *   2. Marketing copy string literals under
+ *      `apps/marketing/app/content/**\/*.ts`, extracted via the TypeScript
+ *      compiler API. Only literal string content is scanned — string
+ *      literals, no-substitution template literals, and the literal text
+ *      spans of template expressions (head/middle/tail). Identifiers,
+ *      import/export module specifiers, and comments are never scanned.
+ *
+ * Zero authored regex — substring (`.includes`) + `Set<string>` only, per
+ * the repo's no-regex convention. The one exception is the TypeScript
+ * compiler API itself, used structurally (AST node kinds), never as a
+ * pattern-matching engine.
+ *
+ * Design (why it won't flag legitimate historical references):
+ *   1. SKIP whole files that are inherently historical: anything under an
+ *      archive/ or _closed/ path segment, any HANDOFF-*.md session
+ *      snapshot, or any file whose first ~20 lines carry a
+ *      SUPERSEDED/CANCELLED/HISTORICAL/ARCHIVED/RETIRED banner.
+ *   2. Per-occurrence EXONERATION: a banned term appearing alongside a
+ *      past-tense / correction marker (cancelled, dropped, retired, →, "no
+ *      longer", exempt, instead, legacy, …) is not a hit. This lets prose
+ *      say "Railway was dropped for Fly" without tripping.
+ *   3. BASELINE allow-list (doc-currency-baseline.json): the corpus's known
+ *      occurrences at seed time are grandfathered. CI hard-fails only on
+ *      NEW, non-exonerated hits (the gitleaks-baseline pattern) — shrinking
+ *      the baseline is progress, growing it needs justification.
+ *
+ * Usage:
+ *   tsx scripts/validate/doc-currency.ts                 # report (exit 0)
+ *   tsx scripts/validate/doc-currency.ts --mode=ci        # exit 1 on new drift
+ *   tsx scripts/validate/doc-currency.ts --update-baseline   # regenerate baseline
+ *
+ * Exit 0 = clean (or report mode). Exit 1 = new drift (ci mode). Exit 2 = bad arg.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const BASELINE_PATH = path.join(ROOT, 'scripts/validate/doc-currency-baseline.json');
+
+export interface Rule {
+  id: string;
+  /** A occurrence is a candidate hit if it contains (case-insensitive) ANY of these. */
+  anyOf: string[];
+  /** …UNLESS the same occurrence also contains ANY of these exoneration markers. */
+  unlessLineHas: string[];
+  message: string;
+}
+
+export interface Hit {
+  /** Relative to ROOT, forward-slash separated. */
+  file: string;
+  line: number;
+  ruleId: string;
+  excerpt: string;
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing — no regex; explicit string ops.
+// ---------------------------------------------------------------------------
+export function parseArgs(argv: readonly string[]): {
+  quiet: boolean;
+  updateBaseline: boolean;
+  mode: 'cli' | 'ci';
+  error?: string;
+} {
+  let quiet = false;
+  let updateBaseline = false;
+  let mode: 'cli' | 'ci' = 'cli';
+
+  for (const arg of argv) {
+    if (arg === '--quiet') quiet = true;
+    else if (arg === '--update-baseline') updateBaseline = true;
+    else if (arg.startsWith('--mode=')) {
+      const v = arg.slice('--mode='.length);
+      if (v === 'ci' || v === 'cli') mode = v;
+    } else {
+      return { quiet, updateBaseline, mode, error: `unknown arg: ${arg}` };
+    }
+  }
+  return { quiet, updateBaseline, mode };
+}
+
+// ---------------------------------------------------------------------------
+// Rules — derived from an internal audit (2026-07-09) of shipped
+// infrastructure and billing pivots that had not yet propagated to prose.
+// Generous exoneration: better to miss a stale reference than flag a
+// correct historical one — a noisy gate gets disabled, and the value here
+// comes from the gate existing and catching new drift, not zero misses.
+// ---------------------------------------------------------------------------
+
+/** Shared past-tense / correction markers — if any appears alongside the
+ *  banned term, the term is being discussed as past/known, not asserted as
+ *  current. */
+export const COMMON_EXON: readonly string[] = [
+  'cancel',
+  'dropped',
+  'drop ',
+  'remov',
+  'retir',
+  'superseded',
+  'supersede',
+  'deprecat',
+  'former',
+  'historical',
+  'history',
+  'archive',
+  'legacy',
+  'no longer',
+  'not required',
+  'not used',
+  'instead',
+  'migrat',
+  'replaced',
+  'sunset',
+  'void',
+  'was ',
+  'were ',
+  'used to',
+  'transitional',
+  'exempt',
+  '→',
+  '->',
+  '~~',
+  'do not',
+  "don't",
+  'never',
+  'pending',
+  'not yet',
+  'will be',
+  'once ',
+  'before ',
+  'n/a',
+  'obsolete',
+  'phased out',
+  'wind down',
+  'winding down',
+  'decommiss',
+];
+
+/**
+ * Bespoke exoneration list for `stripe-not-live-claim` — NOT `COMMON_EXON`,
+ * whose "not yet" / "pending" / "before" / "will be" markers would exonerate
+ * the exact phrasing a stale not-flipped claim uses. This list exonerates
+ * flip-done / rollback / past-tense markers instead.
+ */
+export const STRIPE_LIVE_EXON: readonly string[] = [
+  'flipped 2026-06-26',
+  'flipped on 2026-06-26',
+  'executed 2026-06-26',
+  'was flipped',
+  'has been flipped',
+  'now flipped',
+  'now live',
+  'went live',
+  'rollback',
+  'roll back',
+  '~~',
+  'previously',
+  'used to',
+  'formerly',
+  'no longer',
+  'historical',
+  'archive',
+  'superseded',
+  'retired',
+  'was ',
+  'were ',
+];
+
+export const RULES: readonly Rule[] = [
+  {
+    id: 'revealcoin-as-current',
+    anyOf: ['revealcoin', 'rvc ', '$rvc', '$rvui', 'rvui-payment', 'rvui payment'],
+    unlessLineHas: [...COMMON_EXON, 'cancelled 2026-05-29', 'shelved'],
+    message:
+      'RevealCoin/RVC/$RVUI was cancelled. Present it as past only, not a current or planned payment rail.',
+  },
+  {
+    id: 'railway-as-current',
+    anyOf: ['railway'],
+    unlessLineHas: [...COMMON_EXON, 'fly.io', 'fly machine', 'not railway'],
+    message:
+      'Railway was dropped as an infrastructure target (stack is Vercel + Neon + Fly). Do not present Railway as a live deployment target.',
+  },
+  {
+    id: 'vercel-blob-as-current',
+    anyOf: ['blob_read_write_token', 'vercel blob', '@vercel/blob', 'vercel/postgres'],
+    unlessLineHas: [...COMMON_EXON, 'r2', 'cloudflare'],
+    message:
+      'Vercel Blob is being retired in favor of Cloudflare R2 as canonical object storage. Do not instruct provisioning a new Blob token.',
+  },
+  {
+    id: 'supabase-as-current',
+    anyOf: ['supabase'],
+    unlessLineHas: [
+      ...COMMON_EXON,
+      'neon',
+      'electric',
+      'removal',
+      'boundary',
+      'rag',
+      'dual-db',
+      'dual db',
+    ],
+    message:
+      'Supabase is being removed in favor of the RevealUI-native stack (Neon + ElectricSQL). Present Supabase as transitional or legacy only.',
+  },
+  {
+    // Inverse of a retired `stripe-live-claim`: Stripe live mode was flipped
+    // ON, so a doc still asserting Stripe is NOT flipped / test-mode AS
+    // CURRENT is the drift. Uses the bespoke STRIPE_LIVE_EXON list, not
+    // COMMON_EXON — see the constant's doc comment for why.
+    id: 'stripe-not-live-claim',
+    anyOf: [
+      'stripe live mode is not flipped',
+      'stripe live-mode is not flipped',
+      'stripe live-flip is not',
+      'stripe live-flip has not',
+      'stripe live-flip is owner-gated and has not',
+      'stripe is not flipped',
+      'stripe not flipped',
+      'stripe live keys are not flipped',
+      'stripe live mode is still false',
+      'stripe live-mode is still false',
+      'stripe_live_mode is still false',
+      'payments are not live',
+      'billing is not live',
+      'stripe live mode has not executed',
+      'stripe live-flip has not executed',
+      'flip stripe live mode',
+      'flip stripe live-mode',
+    ],
+    unlessLineHas: STRIPE_LIVE_EXON,
+    message:
+      'Stripe live mode is on. Do not present Stripe billing as not yet flipped, or test-mode as the current state.',
+  },
+  {
+    id: 'forge-tier-name',
+    anyOf: [
+      'forge tier',
+      'forge perpetual',
+      'forge (enterprise)',
+      'enterprise (forge)',
+      '"forge" tier',
+    ],
+    unlessLineHas: [...COMMON_EXON, 'renamed', 'now enterprise'],
+    message:
+      'The billing tier "Forge" was renamed to "Enterprise". Use "Enterprise" going forward.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Shared matching helpers
+// ---------------------------------------------------------------------------
+
+export function ruleMatches(lowerText: string, rule: Rule): boolean {
+  let matched = false;
+  for (const term of rule.anyOf) {
+    if (lowerText.includes(term)) {
+      matched = true;
+      break;
+    }
+  }
+  if (!matched) return false;
+  for (const ex of rule.unlessLineHas) {
+    if (lowerText.includes(ex)) return false;
+  }
+  return true;
+}
+
+export function hitKey(h: Pick<Hit, 'file' | 'ruleId'>): string {
+  return `${h.file}::${h.ruleId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Historical-file skip — shared by markdown and TS content scanning.
+// ---------------------------------------------------------------------------
+
+const HISTORICAL_PATH_MARKERS: readonly string[] = ['/archive/', '/_closed/', '/handoffs/archive/'];
+
+const BANNER_MARKERS: readonly string[] = [
+  'superseded',
+  'cancelled',
+  'canceled',
+  'historical record',
+  'do not action',
+  'archived',
+  'retired',
+  'point-in-time snapshot',
+  'preserved for history',
+  'status: superseded',
+  'status: cancelled',
+  'status: historical',
+  'status: archived',
+  'status: closed',
+];
+
+export function isHistoricalPath(relSlash: string): boolean {
+  for (const m of HISTORICAL_PATH_MARKERS) if (relSlash.includes(m)) return true;
+  return false;
+}
+
+/** True when the file's first ~20 lines carry a superseded/historical banner,
+ *  or (markdown only) the basename is a HANDOFF-* session snapshot. */
+export function shouldSkipFile(rel: string, abs: string): boolean {
+  const relSlash = rel.split(path.sep).join('/');
+  if (isHistoricalPath(relSlash)) return true;
+  const base = path.basename(rel);
+  if (base.startsWith('HANDOFF-')) return true;
+  let head: string;
+  try {
+    head = fs.readFileSync(abs, 'utf8').slice(0, 2000).toLowerCase();
+  } catch {
+    return true;
+  }
+  const headLines = head.split('\n').slice(0, 20).join('\n');
+  for (const m of BANNER_MARKERS) if (headLines.includes(m)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown scan — line-based, mirrors the original fleet scanner.
+// ---------------------------------------------------------------------------
+
+const SKIP_DIR_SEGMENTS: ReadonlySet<string> = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  '.next',
+  'build',
+  '.turbo',
+]);
+
+const MARKDOWN_ROOTS: readonly string[] = ['docs', 'apps/marketing'];
+
+function walkMarkdownFiles(dir: string, acc: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (SKIP_DIR_SEGMENTS.has(e.name)) continue;
+      walkMarkdownFiles(path.join(dir, e.name), acc);
+    } else if (e.isFile() && e.name.endsWith('.md')) {
+      acc.push(path.join(dir, e.name));
+    }
+  }
+}
+
+export function collectMarkdownFiles(root: string): string[] {
+  const acc: string[] = [];
+  for (const rel of MARKDOWN_ROOTS) walkMarkdownFiles(path.join(root, rel), acc);
+  return acc;
+}
+
+export function scanMarkdownFile(root: string, abs: string): Hit[] {
+  const rel = path.relative(root, abs).split(path.sep).join('/');
+  if (shouldSkipFile(rel, abs)) return [];
+  let content: string;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return [];
+  }
+  const hits: Hit[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? '';
+    const lower = raw.toLowerCase();
+    for (const rule of RULES) {
+      if (!ruleMatches(lower, rule)) continue;
+      hits.push({ file: rel, line: i + 1, ruleId: rule.id, excerpt: raw.trim().slice(0, 160) });
+    }
+  }
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Marketing-copy TS scan — TypeScript compiler API, string-literal text only.
+// ---------------------------------------------------------------------------
+
+const CONTENT_ROOT_REL = 'apps/marketing/app/content';
+
+function isScannableContentFile(name: string): boolean {
+  if (!name.endsWith('.ts')) return false;
+  if (name.endsWith('.d.ts')) return false;
+  if (name.endsWith('.test.ts')) return false;
+  if (name === 'types.ts') return false;
+  return true;
+}
+
+function walkContentFiles(dir: string, acc: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (e.name === '__tests__' || e.name === 'node_modules') continue;
+      walkContentFiles(path.join(dir, e.name), acc);
+    } else if (e.isFile() && isScannableContentFile(e.name)) {
+      acc.push(path.join(dir, e.name));
+    }
+  }
+}
+
+export function collectContentFiles(root: string): string[] {
+  const acc: string[] = [];
+  walkContentFiles(path.join(root, CONTENT_ROOT_REL), acc);
+  return acc;
+}
+
+export interface StringLiteralSpan {
+  text: string;
+  /** 1-indexed line at the start of the literal. */
+  line: number;
+}
+
+const LITERAL_TEXT_KINDS: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.StringLiteral,
+  ts.SyntaxKind.NoSubstitutionTemplateLiteral,
+  ts.SyntaxKind.TemplateHead,
+  ts.SyntaxKind.TemplateMiddle,
+  ts.SyntaxKind.TemplateTail,
+]);
+
+/**
+ * Extract literal string text from a TypeScript source file: string
+ * literals, no-substitution template literals, and the literal text spans
+ * of template expressions (head/middle/tail — NOT the `${...}`
+ * expressions themselves). Import and export module specifiers are
+ * skipped entirely (their string content is a module path, never copy).
+ * Identifiers and comments are never visited by this walk in the first
+ * place — only literal-like AST nodes are matched.
+ */
+export function extractStringLiterals(sourceText: string, fileName: string): StringLiteralSpan[] {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const spans: StringLiteralSpan[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node)) return;
+    if (ts.isImportEqualsDeclaration(node)) return;
+    if (ts.isExportDeclaration(node) && node.moduleSpecifier !== undefined) return;
+
+    if (LITERAL_TEXT_KINDS.has(node.kind)) {
+      const literal = node as ts.LiteralLikeNode;
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      spans.push({ text: literal.text, line: line + 1 });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return spans;
+}
+
+export function scanContentFile(root: string, abs: string): Hit[] {
+  const rel = path.relative(root, abs).split(path.sep).join('/');
+  if (shouldSkipFile(rel, abs)) return [];
+  let content: string;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return [];
+  }
+  const hits: Hit[] = [];
+  for (const span of extractStringLiterals(content, abs)) {
+    const lower = span.text.toLowerCase();
+    for (const rule of RULES) {
+      if (!ruleMatches(lower, rule)) continue;
+      hits.push({
+        file: rel,
+        line: span.line,
+        ruleId: rule.id,
+        excerpt: span.text.trim().slice(0, 160),
+      });
+    }
+  }
+  return hits;
+}
+
+// ---------------------------------------------------------------------------
+// Combined scan
+// ---------------------------------------------------------------------------
+
+export function scanAll(root: string = ROOT): {
+  hits: Hit[];
+  markdownCount: number;
+  tsCount: number;
+} {
+  const markdownFiles = collectMarkdownFiles(root);
+  const contentFiles = collectContentFiles(root);
+
+  const hits: Hit[] = [];
+  for (const abs of markdownFiles) hits.push(...scanMarkdownFile(root, abs));
+  for (const abs of contentFiles) hits.push(...scanContentFile(root, abs));
+
+  return { hits, markdownCount: markdownFiles.length, tsCount: contentFiles.length };
+}
+
+// ---------------------------------------------------------------------------
+// Baseline
+// ---------------------------------------------------------------------------
+
+interface BaselineFile {
+  note: string;
+  count: number;
+  keys: string[];
+}
+
+export function loadBaseline(baselinePath: string = BASELINE_PATH): Set<string> {
+  if (!fs.existsSync(baselinePath)) return new Set();
+  try {
+    const parsed = JSON.parse(fs.readFileSync(baselinePath, 'utf8')) as { keys?: string[] };
+    return new Set(parsed.keys ?? []);
+  } catch {
+    return new Set();
+  }
+}
+
+export function writeBaseline(hits: readonly Hit[], baselinePath: string = BASELINE_PATH): number {
+  const keys = Array.from(new Set(hits.map(hitKey))).sort();
+  const payload: BaselineFile = {
+    note:
+      'Grandfathered doc-currency occurrences. Regenerate via `pnpm validate:doc-currency --update-baseline`. ' +
+      'Each entry is a (file::ruleId) pair known to exist as of generation; CI fails only on NEW pairs. ' +
+      'Shrinking this list is progress.',
+    count: keys.length,
+    keys,
+  };
+  fs.writeFileSync(baselinePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return keys.length;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) {
+    process.stderr.write(`[doc-currency] ${parsed.error}\n`);
+    process.exit(2);
+  }
+  const { quiet, updateBaseline, mode } = parsed;
+
+  const { hits, markdownCount, tsCount } = scanAll(ROOT);
+
+  if (updateBaseline) {
+    const count = writeBaseline(hits);
+    process.stdout.write(
+      `[doc-currency] baseline written: ${count} grandfathered (file::ruleId) pairs → ${path.relative(ROOT, BASELINE_PATH)}\n`,
+    );
+    process.exit(0);
+  }
+
+  const baseline = loadBaseline();
+  const newHits = hits.filter((h) => !baseline.has(hitKey(h)));
+
+  const ruleMsg = new Map(RULES.map((r) => [r.id, r.message]));
+
+  if (!quiet) {
+    const grandfathered = hits.length - newHits.length;
+    process.stdout.write(
+      `[doc-currency] scanned ${markdownCount} markdown file(s) + ${tsCount} marketing-copy file(s); ` +
+        `${hits.length} non-exonerated occurrence(s) — ${grandfathered} baselined, ${newHits.length} NEW.\n`,
+    );
+  }
+
+  if (newHits.length === 0) {
+    if (!quiet) process.stdout.write('[doc-currency] OK — no new stale-fact drift.\n');
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `\n[doc-currency] ${newHits.length} NEW stale-fact occurrence(s) (not in baseline):\n\n`,
+  );
+  const byRule = new Map<string, Hit[]>();
+  for (const h of newHits) {
+    const arr = byRule.get(h.ruleId) ?? [];
+    arr.push(h);
+    byRule.set(h.ruleId, arr);
+  }
+  for (const [ruleId, arr] of byRule) {
+    process.stderr.write(`  ● ${ruleId} — ${ruleMsg.get(ruleId) ?? ''}\n`);
+    for (const h of arr) {
+      process.stderr.write(`      ${h.file}:${h.line}  ${h.excerpt}\n`);
+    }
+    process.stderr.write('\n');
+  }
+  process.stderr.write(
+    'Fix the copy (present the fact as past/exonerated), OR — if this is a legitimate new historical record —\n' +
+      'add an exoneration marker, mark the file with a SUPERSEDED/HISTORICAL banner, or regenerate the baseline\n' +
+      'with `pnpm validate:doc-currency --update-baseline` (shrinking the baseline is the goal; growing it needs justification).\n',
+  );
+
+  process.exit(mode === 'ci' ? 1 : 0);
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (invokedDirectly) main();


### PR DESCRIPTION
## Why

Shipped infrastructure and billing pivots (a dropped provider, a renamed
billing tier, a flipped payment mode) have a way of never propagating to
prose. Docs, runbooks, and marketing copy quietly keep asserting the old
state as current, and nothing catches it until a customer or contributor
notices.

## What

Adds a stale-fact drift scanner, wired as a hard-fail CI + local gate check:

- **Markdown scan** — `docs/**/*.md` and `apps/marketing/**/*.md`, line-based
  substring matching (zero authored regex — `.includes` + `Set` only).
- **Marketing-copy scan** — `apps/marketing/app/content/**/*.ts`, using the
  TypeScript compiler API to extract only literal string content (string
  literals, no-substitution template literals, and the literal text spans of
  template expressions). Identifiers, import/export module specifiers, and
  comments are never scanned.
- **Six rules** ported from an internal stale-fact audit: a cancelled payment
  rail, a dropped infra target, a retiring storage provider, a database
  being removed, a billing tier rename, and an inverted rule catching copy
  that still presents Stripe billing as not-yet-flipped (it's on).
- **Historical-file exemptions**: `archive/` / `_closed/` path segments,
  `HANDOFF-*.md` snapshots, and any file whose head carries a
  SUPERSEDED/CANCELLED/HISTORICAL/ARCHIVED/RETIRED banner are skipped
  entirely. Per-occurrence exoneration markers (`dropped`, `retired`,
  `→`, `no longer`, …) let correct historical prose pass.
- **Baseline** (`scripts/validate/doc-currency-baseline.json`) grandfathers
  the current corpus (27 `file::ruleId` pairs, seeded from today's tree).
  CI fails only on NEW occurrences beyond the baseline; shrinking the
  baseline is the goal.

Wired as `validate:doc-currency` (`--mode=ci` hard-fails on new drift; the
default report mode always exits 0; `--update-baseline` regenerates), into
`scripts/gates/ci-gate.ts` Phase 1 and the CI `Quality` job, right after the
existing marketing-voice check it's a thematic sibling of.

## Verify

- `pnpm validate:doc-currency` — report mode, always exits 0
- `pnpm validate:doc-currency --mode=ci` — exits 0 against the seeded
  baseline (100 occurrences scanned, 100 baselined, 0 new)
- `pnpm vitest run scripts/validate/__tests__/doc-currency.test.ts` — 35/35
  passing, covering rule matching + exoneration, the TypeScript AST scope
  (imports/identifiers/comments excluded, template literals included),
  historical-file skip rules, and baseline round-trip/suppression
- `pnpm gate:quick` — full local gate green, including the new
  "Doc-currency (hard fail)" step
- `pnpm exec biome check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)