### PR TITLE
fix(paywall): make the /x402 subpath export real by extracting server helpers

### DIFF
--- a/.changeset/paywall-x402-subpath.md
+++ b/.changeset/paywall-x402-subpath.md
@@ -1,0 +1,5 @@
+---
+"@revealui/paywall": minor
+---
+
+Implement the `@revealui/paywall/x402` subpath. Previously the package advertised this export in its docs but shipped only a stub (`export {}`); it now ships the real HTTP 402 agent payment negotiation helpers: `getX402Config`, `getAdvertisedCurrencyLabel`, `encodePaymentRequired`, `buildPaymentRequired`, `buildPaymentMethods`, and `verifyPayment` (which verifies USDC-on-Base payments via a facilitator and accepts optional `X402VerifyHooks` for logging/metrics). These were extracted from RevealUI's own server middleware, which now imports them from this package instead of maintaining its own copy.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,6 +16,7 @@
     "@revealui/db": "workspace:*",
     "@revealui/mcp": "workspace:*",
     "@revealui/openapi": "workspace:*",
+    "@revealui/paywall": "workspace:*",
     "@revealui/security": "workspace:*",
     "@sentry/node": "^10.63.0",
     "drizzle-orm": "catalog:",

--- a/apps/server/src/middleware/x402.ts
+++ b/apps/server/src/middleware/x402.ts
@@ -1,17 +1,18 @@
 /**
- * x402 Native Payment Middleware Utilities (Phase 5.2)
+ * x402 Native Payment Middleware (Phase 5.2) — RevealUI server glue.
  *
- * Implements HTTP-native micropayments via the x402 protocol:
- * https://x402.org
- *
- * Supports USDC on Base (EVM) — verified via the Coinbase facilitator.
+ * The reusable x402 protocol logic (config reading, payload encode/decode,
+ * payment-required builders, and facilitator verification) lives in
+ * `@revealui/paywall/x402`, published as part of the MIT `@revealui/paywall`
+ * package. This file is the thin app-specific layer that wires the RevealUI
+ * structured logger and Prometheus-style metrics into payment verification.
  *
  * Payment flow:
- *   1. Agent request arrives → quota exhausted
+ *   1. Agent request arrives, quota exhausted
  *   2. Server: HTTP 402 + X-PAYMENT-REQUIRED: <base64 PaymentRequired>
  *   3. Agent: pays USDC on Base, signs proof
  *   4. Agent: retries with X-PAYMENT-PAYLOAD: <base64 PaymentPayload>
- *   5. Server: verifies proof → allows request
+ *   5. Server: verifies proof, allows request
  *
  * Gated behind X402_ENABLED env var (defaults to false). Ship the code,
  * activate when a USDC receiving wallet is configured.
@@ -19,180 +20,31 @@
 
 import { logger } from '@revealui/core/observability/logger';
 import { trackX402PaymentVerify } from '@revealui/core/observability/metrics';
+import {
+  buildPaymentMethods,
+  buildPaymentRequired,
+  encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
+  getX402Config,
+  verifyPayment as verifyPaymentCore,
+} from '@revealui/paywall/x402';
 
-// =============================================================================
-// Minimal x402 protocol types (subset of @x402/core types we need)
-// =============================================================================
-
-interface PaymentRequirementsV1 {
-  scheme: string;
-  network: string;
-  maxAmountRequired: string; // USDC atomic units (6 decimals): 1000 = $0.001
-  resource: string; // canonical URL of the resource being paid for
-  description: string;
-  mimeType: string;
-  outputSchema: Record<string, unknown>;
-  payTo: string; // receiving wallet address
-  maxTimeoutSeconds: number;
-  asset: string; // USDC contract address on the network
-  extra: Record<string, unknown>;
-}
-
-interface PaymentRequiredV1 {
-  x402Version: 1;
-  error?: string;
-  accepts: PaymentRequirementsV1[];
-}
-
-interface PaymentPayloadV1 {
-  x402Version: 1;
-  scheme: string;
-  network: string;
-  payload: Record<string, unknown>;
-}
-
-interface VerifyRequestBody {
-  x402Version: 1;
-  paymentPayload: PaymentPayloadV1;
-  paymentRequirements: PaymentRequirementsV1;
-}
-
-interface VerifyResponseBody {
-  isValid: boolean;
-  invalidReason?: string;
-}
-
-// =============================================================================
-// USDC contract addresses
-// =============================================================================
-
-const USDC_ADDRESSES: Record<string, string> = {
-  'evm:base': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-  'evm:base-sepolia': '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+export type { X402Config } from '@revealui/paywall/x402';
+export {
+  buildPaymentMethods,
+  buildPaymentRequired,
+  encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
+  getX402Config,
 };
-
-// Default Coinbase-hosted facilitator (no API key required for public verify)
-const DEFAULT_FACILITATOR_URL = 'https://x402.org/facilitator';
-
-// USDC has 6 decimal places: $0.001 = 1000 atomic units
-const USDC_DECIMALS = 6;
-
-// =============================================================================
-// Config
-// =============================================================================
-
-export interface X402Config {
-  enabled: boolean;
-  receivingAddress: string;
-  network: string; // e.g. 'evm:base' or 'evm:base-sepolia'
-  pricePerTask: string; // human-readable USDC e.g. '0.001'
-  usdcAsset: string;
-  facilitatorUrl: string;
-  maxTimeoutSeconds: number;
-}
-
-/**
- * Returns the currency-advertised label for the `x402_payment_required_total`
- * counter. Always `'usdc-only'` — USDC on Base is the sole settlement currency.
- */
-export function getAdvertisedCurrencyLabel(): 'usdc-only' {
-  return 'usdc-only';
-}
-
-/** Read x402 configuration from environment variables (lazy  -  never throws on missing). */
-export function getX402Config(): X402Config {
-  const network = process.env.X402_NETWORK ?? 'evm:base';
-  return {
-    enabled: process.env.X402_ENABLED === 'true',
-    receivingAddress: process.env.X402_RECEIVING_ADDRESS ?? '',
-    network,
-    pricePerTask: process.env.X402_PRICE_PER_TASK ?? '0.001',
-    usdcAsset: USDC_ADDRESSES[network] ?? USDC_ADDRESSES['evm:base'],
-    facilitatorUrl: process.env.X402_FACILITATOR_URL ?? DEFAULT_FACILITATOR_URL,
-    maxTimeoutSeconds: 300,
-  };
-}
-
-// =============================================================================
-// Encoding / Decoding
-// =============================================================================
-
-/** Encode a PaymentRequired object as base64 for the X-PAYMENT-REQUIRED header. */
-export function encodePaymentRequired(req: PaymentRequiredV1): string {
-  return Buffer.from(JSON.stringify(req), 'utf-8').toString('base64');
-}
-
-/** Decode the X-PAYMENT-PAYLOAD header from a client request. */
-function decodePaymentPayload(header: string): PaymentPayloadV1 | null {
-  try {
-    const json = Buffer.from(header, 'base64').toString('utf-8');
-    return JSON.parse(json) as PaymentPayloadV1;
-  } catch {
-    return null;
-  }
-}
-
-// =============================================================================
-// Payment requirement builder
-// =============================================================================
-
-/**
- * Convert a human-readable USDC amount (e.g. '0.001') to atomic units (e.g. '1000').
- * USDC has 6 decimal places.
- */
-function toAtomicUnits(humanAmount: string): string {
-  const amount = Number.parseFloat(humanAmount);
-  if (!Number.isFinite(amount) || amount <= 0) return '1000'; // fallback: $0.001
-  return String(Math.round(amount * 10 ** USDC_DECIMALS));
-}
-
-/**
- * Build a PaymentRequired object for a single agent task or marketplace call.
- *
- * Includes USDC on Base as the settlement method.
- *
- * @param resource    - Canonical URL of the endpoint being accessed
- * @param customPrice - Optional override for the USDC price (e.g. marketplace per-server pricing).
- *                      Defaults to X402_PRICE_PER_TASK env var ('0.001').
- */
-export function buildPaymentRequired(resource: string, customPrice?: string): PaymentRequiredV1 {
-  const config = getX402Config();
-  const price = customPrice ?? config.pricePerTask;
-
-  const accepts: PaymentRequirementsV1[] = [
-    // USDC on Base (EVM)
-    {
-      scheme: 'exact',
-      network: config.network,
-      maxAmountRequired: toAtomicUnits(price),
-      resource,
-      description: `RevealUI agent task — ${price} USDC per call`,
-      mimeType: 'application/json',
-      outputSchema: {},
-      payTo: config.receivingAddress,
-      maxTimeoutSeconds: config.maxTimeoutSeconds,
-      asset: config.usdcAsset,
-      extra: { name: 'USDC', version: '2' },
-    },
-  ];
-
-  return { x402Version: 1, accepts };
-}
-
-// =============================================================================
-// Payment verification
-// =============================================================================
 
 /**
  * Verify a client's X-PAYMENT-PAYLOAD header value.
  *
- * Verifies the `exact` (EVM/USDC) scheme via the Coinbase facilitator, which
- * handles replay protection in-house.
- *
- * Emits the `x402_payment_verify_total` counter and
- * `x402_payment_verify_duration_seconds` histogram for every dispatched
- * verification. Decode failures (malformed base64) are not counted —
- * they're caller bugs, not verification outcomes.
+ * Thin wrapper around `@revealui/paywall/x402`'s `verifyPayment`: binds the
+ * RevealUI logger + `x402_payment_verify_total`/`x402_payment_verify_duration_seconds`
+ * metrics as observability hooks. Decode failures (malformed base64) are not
+ * counted, matching the package's own contract.
  *
  * @param payloadHeader - Raw base64 value from X-PAYMENT-PAYLOAD header
  * @param resource      - Canonical resource URL (must match what was sent in 402)
@@ -204,96 +56,9 @@ export async function verifyPayment(
   resource: string,
   route: string = 'unknown',
 ): Promise<{ valid: true } | { valid: false; error: string }> {
-  const config = getX402Config();
-
-  const paymentPayload = decodePaymentPayload(payloadHeader);
-  if (!paymentPayload) {
-    return { valid: false, error: 'Could not decode X-PAYMENT-PAYLOAD (invalid base64 or JSON)' };
-  }
-
-  const start = Date.now();
-  const result = await verifyEvmPayment(paymentPayload, resource, config);
-  trackX402PaymentVerify(route, 'exact', result.valid ? 'valid' : 'invalid', Date.now() - start);
-  return result;
-}
-
-/**
- * Verify a USDC payment via the Coinbase facilitator (EVM flow).
- */
-async function verifyEvmPayment(
-  paymentPayload: PaymentPayloadV1,
-  resource: string,
-  config: X402Config,
-): Promise<{ valid: true } | { valid: false; error: string }> {
-  // Rebuild the requirements so the facilitator can verify against them
-  const requirements = buildPaymentRequired(resource).accepts[0];
-  if (!requirements) {
-    return { valid: false, error: 'Internal: could not build payment requirements' };
-  }
-
-  const body: VerifyRequestBody = {
-    x402Version: 1,
-    paymentPayload,
-    paymentRequirements: requirements,
-  };
-
-  try {
-    const resp = await fetch(`${config.facilitatorUrl}/verify`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!resp.ok) {
-      const text = await resp.text().catch(() => `HTTP ${resp.status}`);
-      logger.warn('x402 facilitator returned non-OK status', {
-        status: resp.status,
-        body: text.slice(0, 200),
-      });
-      return { valid: false, error: `Facilitator error: HTTP ${resp.status}` };
-    }
-
-    const result = (await resp.json()) as VerifyResponseBody;
-
-    if (!result.isValid) {
-      return { valid: false, error: result.invalidReason ?? 'Payment rejected by facilitator' };
-    }
-
-    return { valid: true };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    logger.warn('x402 facilitator request failed', { error: message });
-    return { valid: false, error: `Facilitator unreachable: ${message}` };
-  }
-}
-
-// =============================================================================
-// Well-known payment methods payload
-// =============================================================================
-
-/**
- * Build the /.well-known/payment-methods.json payload.
- * Returns null when x402 is disabled.
- */
-export function buildPaymentMethods(baseUrl: string): Record<string, unknown> | null {
-  const config = getX402Config();
-  if (!(config.enabled && config.receivingAddress)) return null;
-
-  const accepts: Record<string, unknown>[] = [
-    {
-      scheme: 'exact',
-      network: config.network,
-      maxAmountRequired: toAtomicUnits(config.pricePerTask),
-      resource: `${baseUrl}/api/agent-stream`,
-      description: `RevealUI agent task — ${config.pricePerTask} USDC per call`,
-      mimeType: 'application/json',
-      payTo: config.receivingAddress,
-      maxTimeoutSeconds: config.maxTimeoutSeconds,
-      asset: config.usdcAsset,
-      extra: { name: 'USDC', version: '2' },
-    },
-  ];
-
-  return { version: '1.0', accepts };
+  return verifyPaymentCore(payloadHeader, resource, route, {
+    onFacilitatorWarn: (message, meta) => logger.warn(message, meta),
+    onVerified: (verifiedRoute, durationMs, valid) =>
+      trackX402PaymentVerify(verifiedRoute, 'exact', valid ? 'valid' : 'invalid', durationMs),
+  });
 }

--- a/docs/architecture/x402.md
+++ b/docs/architecture/x402.md
@@ -12,7 +12,8 @@ RevealUI implements [x402](https://x402.org) — HTTP-native micropayments — f
 
 | Surface | State |
 |---|---|
-| x402 middleware (`apps/server/src/middleware/x402.ts`) | Code-complete, gated behind `X402_ENABLED` |
+| x402 core logic (`packages/paywall/src/x402/index.ts`, published as `@revealui/paywall/x402`) | Code-complete, framework-agnostic |
+| x402 server glue (`apps/server/src/middleware/x402.ts`) | Code-complete, gated behind `X402_ENABLED` |
 | USDC verification (Coinbase facilitator) | Active when enabled |
 | Quota-exhaust → 402 (`apps/server/src/middleware/task-quota.ts`) | Active when enabled |
 | A2A `tasks/send` → `pending-payment` → 402 | Active (GAP-149) |
@@ -74,7 +75,7 @@ Agent                                  Server
   │ ◀─────────────────────────────────────│
 ```
 
-Verification lives in [`apps/server/src/middleware/x402.ts:215`](../../apps/server/src/middleware/x402.ts) (`verifyPayment`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed).
+Verification lives in [`packages/paywall/src/x402/index.ts:215`](../../packages/paywall/src/x402/index.ts) (`verifyPayment`, published as `@revealui/paywall/x402`): the `exact` scheme is checked against the Coinbase facilitator's `/verify` endpoint (10s timeout, fail-closed). [`apps/server/src/middleware/x402.ts`](../../apps/server/src/middleware/x402.ts) is a thin wrapper that binds the RevealUI logger and metrics as observability hooks.
 
 ## Payment requirements
 
@@ -204,7 +205,7 @@ This reverts to the pre-x402 posture: no 402 emission, no payment verification. 
 
 ## Cross-references
 
-- Source: [`apps/server/src/middleware/x402.ts`](../../apps/server/src/middleware/x402.ts)
+- Source: [`packages/paywall/src/x402/index.ts`](../../packages/paywall/src/x402/index.ts) (published as `@revealui/paywall/x402`), server glue: [`apps/server/src/middleware/x402.ts`](../../apps/server/src/middleware/x402.ts)
 - A2A integration: [`apps/server/src/routes/a2a.ts`](../../apps/server/src/routes/a2a.ts), [`packages/ai/src/a2a/handler.ts`](../../packages/ai/src/a2a/handler.ts)
 - Marketplace: [`apps/server/src/routes/marketplace.ts`](../../apps/server/src/routes/marketplace.ts)
 - Boot validation: [`apps/server/src/lib/validate-startup.ts`](../../apps/server/src/lib/validate-startup.ts)

--- a/packages/paywall/src/x402/__tests__/index.test.ts
+++ b/packages/paywall/src/x402/__tests__/index.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildPaymentMethods,
+  buildPaymentRequired,
+  encodePaymentRequired,
+  getAdvertisedCurrencyLabel,
+  getX402Config,
+  verifyPayment,
+} from '../index.js';
+
+const originalEnv = { ...process.env };
+
+function setEnv(overrides: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('X402_')) {
+      delete process.env[key];
+    }
+  }
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+describe('getAdvertisedCurrencyLabel', () => {
+  it('always returns usdc-only', () => {
+    expect(getAdvertisedCurrencyLabel()).toBe('usdc-only');
+  });
+});
+
+describe('getX402Config', () => {
+  it('returns disabled by default when no env vars set', () => {
+    const config = getX402Config();
+    expect(config.enabled).toBe(false);
+    expect(config.receivingAddress).toBe('');
+    expect(config.network).toBe('evm:base');
+    expect(config.pricePerTask).toBe('0.001');
+    expect(config.facilitatorUrl).toBe('https://x402.org/facilitator');
+    expect(config.maxTimeoutSeconds).toBe(300);
+  });
+
+  it('reads enabled state from X402_ENABLED', () => {
+    setEnv({ X402_ENABLED: 'true' });
+    expect(getX402Config().enabled).toBe(true);
+
+    setEnv({ X402_ENABLED: 'false' });
+    expect(getX402Config().enabled).toBe(false);
+
+    setEnv({ X402_ENABLED: 'yes' });
+    expect(getX402Config().enabled).toBe(false); // only 'true' enables
+  });
+
+  it('selects correct USDC asset for network, falling back for unknown networks', () => {
+    setEnv({ X402_NETWORK: 'evm:base' });
+    expect(getX402Config().usdcAsset).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+
+    setEnv({ X402_NETWORK: 'evm:base-sepolia' });
+    expect(getX402Config().usdcAsset).toBe('0x036CbD53842c5426634e7929541eC2318f3dCF7e');
+
+    setEnv({ X402_NETWORK: 'evm:unknown' });
+    expect(getX402Config().usdcAsset).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+  });
+
+  it('reads custom price per task and facilitator URL', () => {
+    setEnv({
+      X402_PRICE_PER_TASK: '0.01',
+      X402_FACILITATOR_URL: 'https://custom.facilitator/verify',
+    });
+    const config = getX402Config();
+    expect(config.pricePerTask).toBe('0.01');
+    expect(config.facilitatorUrl).toBe('https://custom.facilitator/verify');
+  });
+});
+
+describe('encodePaymentRequired', () => {
+  it('produces valid base64 that roundtrips to the original object', () => {
+    const req = buildPaymentRequired('https://api.example.com/api/agent-stream');
+    const encoded = encodePaymentRequired(req);
+
+    expect(() => Buffer.from(encoded, 'base64')).not.toThrow();
+
+    const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'));
+    expect(decoded.x402Version).toBe(1);
+    expect(decoded.accepts).toHaveLength(1);
+    expect(decoded.accepts[0].resource).toBe('https://api.example.com/api/agent-stream');
+  });
+});
+
+describe('buildPaymentRequired', () => {
+  beforeEach(() => {
+    setEnv({
+      X402_RECEIVING_ADDRESS: '0xTestWallet',
+      X402_PRICE_PER_TASK: '0.001',
+      X402_NETWORK: 'evm:base',
+    });
+  });
+
+  it('builds a valid PaymentRequired with correct structure', () => {
+    const result = buildPaymentRequired('https://api.example.com/api/agent-stream');
+
+    expect(result.x402Version).toBe(1);
+    expect(result.accepts).toHaveLength(1);
+
+    const req = result.accepts[0];
+    expect(req.scheme).toBe('exact');
+    expect(req.network).toBe('evm:base');
+    expect(req.resource).toBe('https://api.example.com/api/agent-stream');
+    expect(req.payTo).toBe('0xTestWallet');
+    expect(req.asset).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(req.maxTimeoutSeconds).toBe(300);
+    expect(req.mimeType).toBe('application/json');
+  });
+
+  it('converts price to USDC atomic units (6 decimals)', () => {
+    setEnv({ X402_PRICE_PER_TASK: '0.001' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '1000',
+    );
+
+    setEnv({ X402_PRICE_PER_TASK: '1.0' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '1000000',
+    );
+
+    setEnv({ X402_PRICE_PER_TASK: '0.5' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '500000',
+    );
+  });
+
+  it('falls back to 1000 atomic units for invalid price', () => {
+    setEnv({ X402_PRICE_PER_TASK: 'not-a-number' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '1000',
+    );
+
+    setEnv({ X402_PRICE_PER_TASK: '-5' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '1000',
+    );
+
+    setEnv({ X402_PRICE_PER_TASK: '0' });
+    expect(buildPaymentRequired('https://example.com/test').accepts[0].maxAmountRequired).toBe(
+      '1000',
+    );
+  });
+
+  it('uses the same resource URL for both the 402 response and verification', () => {
+    const resource = 'https://api.revealui.com/api/agent-stream';
+    const paymentRequired = buildPaymentRequired(resource);
+    const rebuilt = buildPaymentRequired(resource);
+    expect(paymentRequired.accepts[0].resource).toBe(resource);
+    expect(rebuilt.accepts[0].resource).toBe(paymentRequired.accepts[0].resource);
+  });
+});
+
+describe('buildPaymentMethods', () => {
+  it('returns null when x402 is disabled', () => {
+    setEnv({ X402_ENABLED: 'false' });
+    expect(buildPaymentMethods('https://api.example.com')).toBeNull();
+  });
+
+  it('returns null when enabled but no receiving address', () => {
+    setEnv({ X402_ENABLED: 'true' });
+    expect(buildPaymentMethods('https://api.example.com')).toBeNull();
+  });
+
+  it('returns a valid payload when enabled with an address', () => {
+    setEnv({
+      X402_ENABLED: 'true',
+      X402_RECEIVING_ADDRESS: '0xTestWallet',
+      X402_PRICE_PER_TASK: '0.001',
+      X402_NETWORK: 'evm:base',
+    });
+
+    const result = buildPaymentMethods('https://api.example.com');
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe('1.0');
+
+    const accepts = result!.accepts as Array<Record<string, unknown>>;
+    expect(accepts).toHaveLength(1);
+    expect(accepts[0].resource).toBe('https://api.example.com/api/agent-stream');
+    expect(accepts[0].payTo).toBe('0xTestWallet');
+    expect(accepts[0].scheme).toBe('exact');
+    expect(accepts[0].network).toBe('evm:base');
+  });
+});
+
+describe('verifyPayment', () => {
+  beforeEach(() => {
+    setEnv({
+      X402_ENABLED: 'true',
+      X402_RECEIVING_ADDRESS: '0xTestWallet',
+      X402_FACILITATOR_URL: 'https://test-facilitator.example.com',
+    });
+  });
+
+  it('rejects invalid base64 payload without invoking any hook', async () => {
+    const onFacilitatorWarn = vi.fn();
+    const onVerified = vi.fn();
+
+    const result = await verifyPayment('not-valid-json!!!', 'https://example.com/test', 'unknown', {
+      onFacilitatorWarn,
+      onVerified,
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('Could not decode');
+    }
+    expect(onFacilitatorWarn).not.toHaveBeenCalled();
+    expect(onVerified).not.toHaveBeenCalled();
+  });
+
+  it('rejects payload that decodes to invalid JSON', async () => {
+    const badBase64 = Buffer.from('not json at all {{{', 'utf-8').toString('base64');
+    const result = await verifyPayment(badBase64, 'https://example.com/test');
+    expect(result.valid).toBe(false);
+  });
+
+  it('works with no hooks supplied (hooks are fully optional)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ isValid: true }) }),
+    );
+
+    const payload = {
+      x402Version: 1,
+      scheme: 'exact',
+      network: 'evm:base',
+      payload: { txHash: '0xabc' },
+    };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+
+    const result = await verifyPayment(encoded, 'https://example.com/test');
+    expect(result.valid).toBe(true);
+  });
+
+  it('calls facilitator, returns valid on success, and invokes onVerified', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ isValid: true }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    const onVerified = vi.fn();
+
+    const payload = {
+      x402Version: 1,
+      scheme: 'exact',
+      network: 'evm:base',
+      payload: { txHash: '0xabc' },
+    };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+
+    const result = await verifyPayment(encoded, 'https://example.com/test', 'a2a', { onVerified });
+    expect(result.valid).toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://test-facilitator.example.com/verify');
+    expect(options.method).toBe('POST');
+
+    const body = JSON.parse(options.body);
+    expect(body.x402Version).toBe(1);
+    expect(body.paymentPayload).toEqual(payload);
+    expect(body.paymentRequirements.resource).toBe('https://example.com/test');
+
+    expect(onVerified).toHaveBeenCalledTimes(1);
+    const [route, durationMs, valid] = onVerified.mock.calls[0];
+    expect(route).toBe('a2a');
+    expect(typeof durationMs).toBe('number');
+    expect(valid).toBe(true);
+  });
+
+  it('returns invalid when facilitator rejects payment', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ isValid: false, invalidReason: 'Insufficient funds' }),
+      }),
+    );
+
+    const payload = {
+      x402Version: 1,
+      scheme: 'exact',
+      network: 'evm:base',
+      payload: { txHash: '0xabc' },
+    };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+
+    const result = await verifyPayment(encoded, 'https://example.com/test');
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe('Insufficient funds');
+    }
+  });
+
+  it('handles facilitator HTTP errors and invokes onFacilitatorWarn', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      }),
+    );
+    const onFacilitatorWarn = vi.fn();
+
+    const payload = { x402Version: 1, scheme: 'exact', network: 'evm:base', payload: {} };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+
+    const result = await verifyPayment(encoded, 'https://example.com/test', 'unknown', {
+      onFacilitatorWarn,
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('HTTP 500');
+    }
+    expect(onFacilitatorWarn).toHaveBeenCalledTimes(1);
+    expect(onFacilitatorWarn.mock.calls[0][0]).toBe('x402 facilitator returned non-OK status');
+  });
+
+  it('handles network errors gracefully and invokes onFacilitatorWarn', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const onFacilitatorWarn = vi.fn();
+
+    const payload = { x402Version: 1, scheme: 'exact', network: 'evm:base', payload: {} };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+
+    const result = await verifyPayment(encoded, 'https://example.com/test', 'unknown', {
+      onFacilitatorWarn,
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('ECONNREFUSED');
+    }
+    expect(onFacilitatorWarn).toHaveBeenCalledTimes(1);
+    expect(onFacilitatorWarn.mock.calls[0][0]).toBe('x402 facilitator request failed');
+  });
+});

--- a/packages/paywall/src/x402/index.ts
+++ b/packages/paywall/src/x402/index.ts
@@ -1,18 +1,314 @@
 /**
  * @revealui/paywall/x402
  *
- * HTTP 402 Payment Required  -  agent-to-agent payment negotiation.
+ * HTTP 402 Payment Required. Agent-to-agent payment negotiation.
  *
- * Enables automated payment flows where AI agents can negotiate
- * access to gated APIs by responding to 402 status codes with
- * payment payloads.
+ * Enables automated payment flows where AI agents can negotiate access to
+ * gated APIs by responding to 402 status codes with payment payloads:
+ * https://x402.org
  *
- * Helpers (Phase 2):
- * - Payment payload verification
- * - Price negotiation headers
- * - Agent payment flow middleware
+ * Supports USDC on Base (EVM), verified via the Coinbase facilitator.
+ *
+ * Payment flow:
+ *   1. Agent request arrives, quota exhausted
+ *   2. Server: HTTP 402 + X-PAYMENT-REQUIRED: <base64 PaymentRequired>
+ *   3. Agent: pays USDC on Base, signs proof
+ *   4. Agent: retries with X-PAYMENT-PAYLOAD: <base64 PaymentPayload>
+ *   5. Server: verifies proof, allows request
+ *
+ * This module is framework- and app-agnostic: it has no dependency on any
+ * particular logger or metrics stack. Callers that want observability hook
+ * in via the optional `X402VerifyHooks` parameter to `verifyPayment`.
  *
  * @packageDocumentation
  */
 
-export {};
+// =============================================================================
+// Minimal x402 protocol types (subset of @x402/core types we need)
+// =============================================================================
+
+export interface PaymentRequirementsV1 {
+  scheme: string;
+  network: string;
+  maxAmountRequired: string; // USDC atomic units (6 decimals): 1000 = $0.001
+  resource: string; // canonical URL of the resource being paid for
+  description: string;
+  mimeType: string;
+  outputSchema: Record<string, unknown>;
+  payTo: string; // receiving wallet address
+  maxTimeoutSeconds: number;
+  asset: string; // USDC contract address on the network
+  extra: Record<string, unknown>;
+}
+
+export interface PaymentRequiredV1 {
+  x402Version: 1;
+  error?: string;
+  accepts: PaymentRequirementsV1[];
+}
+
+export interface PaymentPayloadV1 {
+  x402Version: 1;
+  scheme: string;
+  network: string;
+  payload: Record<string, unknown>;
+}
+
+interface VerifyRequestBody {
+  x402Version: 1;
+  paymentPayload: PaymentPayloadV1;
+  paymentRequirements: PaymentRequirementsV1;
+}
+
+interface VerifyResponseBody {
+  isValid: boolean;
+  invalidReason?: string;
+}
+
+// =============================================================================
+// USDC contract addresses
+// =============================================================================
+
+const BASE_USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+const USDC_ADDRESSES: Record<string, string> = {
+  'evm:base': BASE_USDC_ADDRESS,
+  'evm:base-sepolia': '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+};
+
+// Default Coinbase-hosted facilitator (no API key required for public verify)
+const DEFAULT_FACILITATOR_URL = 'https://x402.org/facilitator';
+
+// USDC has 6 decimal places: $0.001 = 1000 atomic units
+const USDC_DECIMALS = 6;
+
+// =============================================================================
+// Config
+// =============================================================================
+
+export interface X402Config {
+  enabled: boolean;
+  receivingAddress: string;
+  network: string; // e.g. 'evm:base' or 'evm:base-sepolia'
+  pricePerTask: string; // human-readable USDC e.g. '0.001'
+  usdcAsset: string;
+  facilitatorUrl: string;
+  maxTimeoutSeconds: number;
+}
+
+/**
+ * Returns the currency-advertised label for a `*_payment_required_total`
+ * counter. Always `'usdc-only'`, since USDC on Base is the sole settlement currency.
+ */
+export function getAdvertisedCurrencyLabel(): 'usdc-only' {
+  return 'usdc-only';
+}
+
+/** Read x402 configuration from environment variables (lazy, never throws on missing). */
+export function getX402Config(): X402Config {
+  const network = process.env.X402_NETWORK ?? 'evm:base';
+  return {
+    enabled: process.env.X402_ENABLED === 'true',
+    receivingAddress: process.env.X402_RECEIVING_ADDRESS ?? '',
+    network,
+    pricePerTask: process.env.X402_PRICE_PER_TASK ?? '0.001',
+    usdcAsset: USDC_ADDRESSES[network] ?? BASE_USDC_ADDRESS,
+    facilitatorUrl: process.env.X402_FACILITATOR_URL ?? DEFAULT_FACILITATOR_URL,
+    maxTimeoutSeconds: 300,
+  };
+}
+
+// =============================================================================
+// Encoding / Decoding
+// =============================================================================
+
+/** Encode a PaymentRequired object as base64 for the X-PAYMENT-REQUIRED header. */
+export function encodePaymentRequired(req: PaymentRequiredV1): string {
+  return Buffer.from(JSON.stringify(req), 'utf-8').toString('base64');
+}
+
+/** Decode the X-PAYMENT-PAYLOAD header from a client request. */
+function decodePaymentPayload(header: string): PaymentPayloadV1 | null {
+  try {
+    const json = Buffer.from(header, 'base64').toString('utf-8');
+    return JSON.parse(json) as PaymentPayloadV1;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Payment requirement builder
+// =============================================================================
+
+/**
+ * Convert a human-readable USDC amount (e.g. '0.001') to atomic units (e.g. '1000').
+ * USDC has 6 decimal places.
+ */
+function toAtomicUnits(humanAmount: string): string {
+  const amount = Number.parseFloat(humanAmount);
+  if (!Number.isFinite(amount) || amount <= 0) return '1000'; // fallback: $0.001
+  return String(Math.round(amount * 10 ** USDC_DECIMALS));
+}
+
+/**
+ * Build a PaymentRequired object for a single agent task or marketplace call.
+ *
+ * Includes USDC on Base as the settlement method.
+ *
+ * @param resource    - Canonical URL of the endpoint being accessed
+ * @param customPrice - Optional override for the USDC price (e.g. marketplace per-server pricing).
+ *                      Defaults to X402_PRICE_PER_TASK env var ('0.001').
+ */
+export function buildPaymentRequired(resource: string, customPrice?: string): PaymentRequiredV1 {
+  const config = getX402Config();
+  const price = customPrice ?? config.pricePerTask;
+
+  const accepts: PaymentRequirementsV1[] = [
+    // USDC on Base (EVM)
+    {
+      scheme: 'exact',
+      network: config.network,
+      maxAmountRequired: toAtomicUnits(price),
+      resource,
+      description: `RevealUI agent task — ${price} USDC per call`,
+      mimeType: 'application/json',
+      outputSchema: {},
+      payTo: config.receivingAddress,
+      maxTimeoutSeconds: config.maxTimeoutSeconds,
+      asset: config.usdcAsset,
+      extra: { name: 'USDC', version: '2' },
+    },
+  ];
+
+  return { x402Version: 1, accepts };
+}
+
+// =============================================================================
+// Payment verification
+// =============================================================================
+
+/**
+ * Observability hooks a caller can bind to its own logger/metrics stack.
+ * All hooks are optional and no-op by default, so this module carries no
+ * dependency on any particular logging or metrics implementation.
+ */
+export interface X402VerifyHooks {
+  /** Called when the facilitator call itself fails (non-OK status or network error). */
+  onFacilitatorWarn?: (message: string, meta: Record<string, unknown>) => void;
+  /** Called once per dispatched verification (decode failures are not counted). */
+  onVerified?: (route: string, durationMs: number, valid: boolean) => void;
+}
+
+/**
+ * Verify a client's X-PAYMENT-PAYLOAD header value.
+ *
+ * Verifies the `exact` (EVM/USDC) scheme via the Coinbase facilitator, which
+ * handles replay protection in-house.
+ *
+ * @param payloadHeader - Raw base64 value from X-PAYMENT-PAYLOAD header
+ * @param resource      - Canonical resource URL (must match what was sent in 402)
+ * @param route         - Route label for metrics (e.g. 'a2a', 'marketplace')
+ * @param hooks         - Optional observability hooks (see `X402VerifyHooks`)
+ * @returns `{ valid: true }` or `{ valid: false, error: string }`
+ */
+export async function verifyPayment(
+  payloadHeader: string,
+  resource: string,
+  route: string = 'unknown',
+  hooks: X402VerifyHooks = {},
+): Promise<{ valid: true } | { valid: false; error: string }> {
+  const config = getX402Config();
+
+  const paymentPayload = decodePaymentPayload(payloadHeader);
+  if (!paymentPayload) {
+    return { valid: false, error: 'Could not decode X-PAYMENT-PAYLOAD (invalid base64 or JSON)' };
+  }
+
+  const start = Date.now();
+  const result = await verifyEvmPayment(paymentPayload, resource, config, hooks);
+  hooks.onVerified?.(route, Date.now() - start, result.valid);
+  return result;
+}
+
+/**
+ * Verify a USDC payment via the Coinbase facilitator (EVM flow).
+ */
+async function verifyEvmPayment(
+  paymentPayload: PaymentPayloadV1,
+  resource: string,
+  config: X402Config,
+  hooks: X402VerifyHooks,
+): Promise<{ valid: true } | { valid: false; error: string }> {
+  // Rebuild the requirements so the facilitator can verify against them
+  const requirements = buildPaymentRequired(resource).accepts[0];
+  if (!requirements) {
+    return { valid: false, error: 'Internal: could not build payment requirements' };
+  }
+
+  const body: VerifyRequestBody = {
+    x402Version: 1,
+    paymentPayload,
+    paymentRequirements: requirements,
+  };
+
+  try {
+    const resp = await fetch(`${config.facilitatorUrl}/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => `HTTP ${resp.status}`);
+      hooks.onFacilitatorWarn?.('x402 facilitator returned non-OK status', {
+        status: resp.status,
+        body: text.slice(0, 200),
+      });
+      return { valid: false, error: `Facilitator error: HTTP ${resp.status}` };
+    }
+
+    const result = (await resp.json()) as VerifyResponseBody;
+
+    if (!result.isValid) {
+      return { valid: false, error: result.invalidReason ?? 'Payment rejected by facilitator' };
+    }
+
+    return { valid: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    hooks.onFacilitatorWarn?.('x402 facilitator request failed', { error: message });
+    return { valid: false, error: `Facilitator unreachable: ${message}` };
+  }
+}
+
+// =============================================================================
+// Well-known payment methods payload
+// =============================================================================
+
+/**
+ * Build the /.well-known/payment-methods.json payload.
+ * Returns null when x402 is disabled.
+ */
+export function buildPaymentMethods(baseUrl: string): Record<string, unknown> | null {
+  const config = getX402Config();
+  if (!(config.enabled && config.receivingAddress)) return null;
+
+  const accepts: Record<string, unknown>[] = [
+    {
+      scheme: 'exact',
+      network: config.network,
+      maxAmountRequired: toAtomicUnits(config.pricePerTask),
+      resource: `${baseUrl}/api/agent-stream`,
+      description: `RevealUI agent task — ${config.pricePerTask} USDC per call`,
+      mimeType: 'application/json',
+      payTo: config.receivingAddress,
+      maxTimeoutSeconds: config.maxTimeoutSeconds,
+      asset: config.usdcAsset,
+      extra: { name: 'USDC', version: '2' },
+    },
+  ];
+
+  return { version: '1.0', accepts };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       '@revealui/openapi':
         specifier: workspace:*
         version: link:../../packages/openapi
+      '@revealui/paywall':
+        specifier: workspace:*
+        version: link:../../packages/paywall
       '@revealui/security':
         specifier: workspace:*
         version: link:../../packages/security


### PR DESCRIPTION
## Why

`@revealui/paywall` (published, MIT) advertises a `@revealui/paywall/x402` subpath ("HTTP 402 agent payment negotiation") in its main entry doc comment and in its `package.json` `exports` map, but the implementation file was a doc comment plus `export {}` — a broken public contract for anyone installing the package and following the docs.

## What

- Extracted the reusable x402 protocol helpers (types, config reading, base64 encode/decode, payment-required/payment-methods builders, and facilitator-backed `verifyPayment`) out of `apps/server/src/middleware/x402.ts` into `packages/paywall/src/x402/index.ts`. This module has no dependency on any app or on `@revealui/core` — it takes an optional `X402VerifyHooks` object (`onFacilitatorWarn`, `onVerified`) so callers can wire in their own logger/metrics without the package depending on either.
- `apps/server/src/middleware/x402.ts` is now a thin glue layer: it imports the package's helpers, re-exports the config/builder functions unchanged, and wraps `verifyPayment` to bind RevealUI's structured logger and Prometheus-style metrics via the hooks. No env var name, default, or enablement logic changed (`X402_ENABLED` still defaults to false).
- Added `@revealui/paywall` as a workspace dependency of `apps/server`.
- Added package-level unit tests at `packages/paywall/src/x402/__tests__/index.test.ts` (20 tests) covering config reading, encode/decode, payment-required/payment-methods building, and `verifyPayment` including the hooks contract.
- Added a changeset (`@revealui/paywall`: minor) since this adds real capability to a published package.
- Updated `docs/architecture/x402.md`: its Works-Cited citation pointed at a now-nonexistent line in the shrunken middleware file; repointed it (and the Status table / Cross-references) at the new package location.

The server's existing `apps/server/src/middleware/__tests__/x402.test.ts` (21 tests) required **zero changes** — same import path, same exported names, same behavior.

## Holds

This touches payment surfaces. Holds for a recorded security verdict before merge per review policy.

## Verify

```
pnpm --filter @revealui/paywall test        # 129 passed (9 files), incl. new x402 suite (20 tests)
pnpm --filter server exec vitest run src/middleware/__tests__/x402.test.ts   # 21 passed, unchanged
pnpm --filter @revealui/paywall typecheck   # clean
pnpm turbo build --filter=@revealui/paywall --filter=server   # both build clean
pnpm gate:quick                              # PASS (Phase 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
