### PR TITLE
ci: add agent-payment and marketplace surfaces to the security review gate

### DIFF
--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -58,6 +58,15 @@ const SECURITY_PATHS = [
   'sanitize',
   'RichText/',
   'content-validation',
+  // Agent-payment + marketplace money surfaces. Added after an internal
+  // review found the x402 payment-verification path was not listed: a PR
+  // moving the verifier passed this gate unflagged and had to self-declare
+  // its review hold in the PR body.
+  'middleware/x402',
+  'packages/paywall/',
+  'routes/a2a',
+  'routes/marketplace',
+  'routes/revmarket',
 ];
 
 // A recorded reviewer verdict = an approving GH review OR one of these labels.


### PR DESCRIPTION
## Why

An internal review of #1793 (the x402 payment-verifier extraction into `@revealui/paywall`) found the Security review gate did not flag it: neither `middleware/x402`, `packages/paywall/`, nor the agent-payment routes are on the gate's sensitive-path list. A PR moving payment-verification code should never pass the gate silently; #1793 had to self-declare its review hold in the PR body.

## What

Adds five substrings to `SECURITY_PATHS` in `scripts/validate/security-review-gate.cjs`:

- `middleware/x402` (payment payload verification)
- `packages/paywall/` (license enforcement + x402 helpers, published)
- `routes/a2a` (agent-to-agent payment negotiation surface)
- `routes/marketplace`, `routes/revmarket` (marketplace transaction surfaces)

Matching additions to the fleet-side checker ride in a companion internal PR so the two lists stay in lockstep.

## Note on this PR itself

This changes enforcement behavior for every future PR, so it should get a non-author review before merge even though the gate does not flag its own file.

## Verify

- `node --check scripts/validate/security-review-gate.cjs` clean.
- Dry run against #1793's file list flags `packages/paywall/src/x402/index.ts` and `apps/server/src/middleware/x402.ts` as sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
