### PR TITLE
fix(server): keep purchased tier when perpetual support lapses

### DIFF
--- a/apps/server/src/routes/__tests__/license.test.ts
+++ b/apps/server/src/routes/__tests__/license.test.ts
@@ -326,7 +326,7 @@ describe('POST /verify  -  DB revocation override', () => {
     exp: Math.floor(Date.now() / 1000) + 86400,
   };
 
-  function mockDb(rows: { status: string }[]) {
+  function mockDb(rows: { status: string; supportExpiresAt?: Date | null; perpetual?: boolean }[]) {
     vi.mocked(getClient).mockReturnValueOnce({
       select: () => ({
         from: () => ({
@@ -426,6 +426,104 @@ describe('POST /verify  -  DB revocation override', () => {
     const body = await parseBody(res);
     expect(body.valid).toBe(false);
     expect(body.reason).toBe('invalid');
+  });
+
+  // ── Perpetual support lapse ────────────────────────────────────────────────
+  // A perpetual license is sold as permanent ownership. When the annual support
+  // contract lapses, the purchased tier and its entitlements are frozen in place,
+  // not revoked  -  only update delivery and support stop. Verifies the fix for
+  // the downgrade-to-free-tier defect on this path.
+
+  const PAST = new Date(Date.now() - 86_400_000);
+  const FUTURE = new Date(Date.now() + 86_400_000);
+
+  const PERPETUAL_PAYLOAD = {
+    tier: 'enterprise' as const,
+    customerId: 'cus_perp',
+    perpetual: true,
+    // Perpetual payloads carry no `exp`.
+  };
+
+  it('keeps tier features and limits when a perpetual license support contract has lapsed', async () => {
+    mockedValidate.mockResolvedValue(PERPETUAL_PAYLOAD as never);
+    mockDb([{ status: 'active', perpetual: true, supportExpiresAt: PAST }]);
+
+    const app = createApp();
+    const res = await app.request('/verify', post('/verify', { licenseKey: 'perpetual.jwt' }));
+    expect(res.status).toBe(200);
+    const body = await parseBody(res);
+
+    expect(body.valid).toBe(true);
+    expect(body.reason).toBe('support_expired');
+    expect(body.supportExpired).toBe(true);
+    expect(body.supportExpiresAt).toBe(PAST.toISOString());
+
+    // The purchased tier survives the lapse  -  this is the ownership promise.
+    expect(body.tier).toBe('enterprise');
+    expect(body.features.ai).toBe(true);
+    expect(body.features.analytics).toBe(true);
+    // Enterprise limits are unbounded, not the free tier's 1 site / 3 users.
+    expect(body.maxSites).toBeNull();
+    expect(body.maxUsers).toBeNull();
+  });
+
+  it('keeps tier features and limits when the DB row is already marked support_expired', async () => {
+    // The nightly sweep marks lapsed perpetuals as status='support_expired'.
+    mockedValidate.mockResolvedValue({
+      tier: 'pro' as const,
+      customerId: 'cus_perp',
+      perpetual: true,
+    } as never);
+    mockDb([{ status: 'support_expired', perpetual: true, supportExpiresAt: PAST }]);
+
+    const app = createApp();
+    const res = await app.request('/verify', post('/verify', { licenseKey: 'perpetual.jwt' }));
+    const body = await parseBody(res);
+
+    expect(body.valid).toBe(true);
+    expect(body.reason).toBe('support_expired');
+    expect(body.supportExpired).toBe(true);
+    expect(body.tier).toBe('pro');
+    expect(body.features.ai).toBe(true);
+    expect(body.features.collaboration).toBe(true);
+    // Pro defaults, not the free tier's 1 / 3.
+    expect(body.maxSites).toBe(5);
+    expect(body.maxUsers).toBe(25);
+  });
+
+  it('reports a perpetual license with active support as valid, supportExpired:false', async () => {
+    mockedValidate.mockResolvedValue(PERPETUAL_PAYLOAD as never);
+    mockDb([{ status: 'active', perpetual: true, supportExpiresAt: FUTURE }]);
+
+    const app = createApp();
+    const res = await app.request('/verify', post('/verify', { licenseKey: 'perpetual.jwt' }));
+    const body = await parseBody(res);
+
+    expect(body.valid).toBe(true);
+    expect(body.reason).toBe('valid');
+    expect(body.supportExpired).toBe(false);
+    expect(body.supportExpiresAt).toBe(FUTURE.toISOString());
+    expect(body.tier).toBe('enterprise');
+    // A perpetual license never expires.
+    expect(body.expiresAt).toBeNull();
+  });
+
+  it('leaves subscription licenses unaffected by the support-lapse path', async () => {
+    // VALID_PAYLOAD is a non-perpetual pro subscription with a future exp.
+    mockedValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDb([{ status: 'active' }]);
+
+    const app = createApp();
+    const res = await app.request('/verify', post('/verify', { licenseKey: 'subscription.jwt' }));
+    const body = await parseBody(res);
+
+    expect(body.valid).toBe(true);
+    expect(body.reason).toBe('valid');
+    expect(body.supportExpired).toBe(false);
+    // No support contract is read for a non-perpetual license.
+    expect(body.supportExpiresAt).toBeNull();
+    expect(body.tier).toBe('pro');
+    expect(body.expiresAt).toBe(new Date(VALID_PAYLOAD.exp * 1000).toISOString());
   });
 });
 

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -2436,7 +2436,7 @@ app.openapi(reportOverageRoute, async (c) => {
 // POST /api/billing/sweep-expired-licenses  -  Internal cron: mark expired licenses as 'expired'
 // Finds non-perpetual licenses where expiresAt < now() and status = 'active', updates them to
 // status = 'expired'. Also finds perpetual licenses where supportExpiresAt < now() and marks
-// them as 'support_expired' (license remains valid, premium features downgrade to free).
+// them as 'support_expired' (license and its purchased tier remain valid; updates and support stop).
 // Clears the DB status cache so changes take effect immediately.
 // Protected by X-Cron-Secret. Run daily (or hourly for tighter enforcement).
 const SweepExpiredLicensesResponseSchema = z.object({
@@ -2517,8 +2517,8 @@ app.openapi(sweepExpiredLicensesRoute, async (c) => {
 
   // ── Phase 2: Mark perpetual licenses with expired support ───────────────
   // Perpetual licenses never expire, but their support contract does.
-  // status = 'support_expired' signals that premium features are downgraded
-  // to free tier while basic admin access remains perpetual.
+  // status = 'support_expired' signals that the support contract lapsed. The
+  // purchased tier and its entitlements are retained; only updates and support stop.
   const supportExpiring = await db
     .select({ id: licenses.id })
     .from(licenses)

--- a/apps/server/src/routes/license.ts
+++ b/apps/server/src/routes/license.ts
@@ -38,7 +38,7 @@ const LicenseVerifyResponseSchema = z.object({
     .optional()
     .openapi({
       description:
-        'Why the license is invalid or degraded. "expired": JWT past expiry or DB status expired. "revoked": explicitly revoked in the DB (chargeback, refund, cancellation). "support_expired": perpetual license with expired support contract (basic admin still valid, premium features downgraded). "invalid": bad signature or malformed JWT. "misconfigured": server public key not configured.',
+        'Why the license is invalid or degraded. "expired": JWT past expiry or DB status expired. "revoked": explicitly revoked in the DB (chargeback, refund, cancellation). "support_expired": perpetual license whose support contract has lapsed (the purchased tier and its features are retained; only updates and support stop). "invalid": bad signature or malformed JWT. "misconfigured": server public key not configured.',
       example: 'revoked',
     }),
   tier: z.enum(['free', 'pro', 'max', 'enterprise']).openapi({
@@ -287,8 +287,14 @@ app.openapi(verifyRoute, async (c) => {
   const isSupportExpired =
     payload.perpetual === true && supportExpiresAt !== null && supportExpiresAt < now;
 
-  // Perpetual license with expired support: license is still valid but premium
-  // features are downgraded to free tier. Basic admin access remains perpetual.
+  const features = getFeaturesForTier(payload.tier);
+  const defaultMaxSites = payload.tier === 'enterprise' ? null : (payload.maxSites ?? 5);
+  const defaultMaxUsers = payload.tier === 'enterprise' ? null : (payload.maxUsers ?? 25);
+
+  // A lapsed support contract freezes the purchased tier, it does not revoke it.
+  // Perpetual licenses are sold as permanent ownership, so entitlements stay at
+  // the tier that was bought. What lapses is update delivery and support, and
+  // neither is gated on this path. Only `supportExpired` changes here.
   if (dbStatus === 'support_expired' || isSupportExpired) {
     return c.json(
       {
@@ -296,9 +302,10 @@ app.openapi(verifyRoute, async (c) => {
         reason: 'support_expired' as const,
         tier: payload.tier,
         customerId: payload.customerId,
-        features: getFeaturesForTier('free'),
-        maxSites: 1,
-        maxUsers: 3,
+        features,
+        maxSites: defaultMaxSites,
+        maxUsers: defaultMaxUsers,
+        // Perpetual payloads omit `exp`, so there is no expiry to report.
         expiresAt: null,
         supportExpiresAt: supportExpiresAt?.toISOString() ?? null,
         supportExpired: true,
@@ -306,10 +313,6 @@ app.openapi(verifyRoute, async (c) => {
       200,
     );
   }
-
-  const features = getFeaturesForTier(payload.tier);
-  const defaultMaxSites = payload.tier === 'enterprise' ? null : (payload.maxSites ?? 5);
-  const defaultMaxUsers = payload.tier === 'enterprise' ? null : (payload.maxUsers ?? 25);
 
   return c.json(
     {


### PR DESCRIPTION
## Summary

A perpetual license is sold as permanent ownership of a tier ("License key never expires"). `POST /api/license/verify` did the opposite when the annual support contract lapsed: it returned `getFeaturesForTier('free')`, `maxSites: 1`, `maxUsers: 3`. An Enterprise Perpetual customer who declined to renew support reported as a free deployment.

A support lapse **freezes** the purchased tier, it does not revoke it. What stops is update delivery and support, and neither is gated on this path. The `support_expired` response now carries the license's own tier features and limits, and still sets `supportExpired: true` so clients can prompt for renewal.

This is a live surface, not a hypothetical: in-app perpetual and renewal purchase paths are already shipped.

## Changes

- `apps/server/src/routes/license.ts` — the `support_expired` branch reuses the tier's `features` / `maxSites` / `maxUsers` instead of the free-tier constants. The tier-limit computation is hoisted above the branch so both paths share one definition.
- `apps/server/src/routes/license.ts` — the OpenAPI `reason` description no longer promises a downgrade that no longer happens.
- `apps/server/src/routes/billing.ts` — two comments describing the sweep's `support_expired` status said "premium features downgrade to free". Comments only, no behavior change.
- `apps/server/src/routes/__tests__/license.test.ts` — four new cases.

## Tests

There was no coverage of the support-expired path at all before this. Added:

| Case | Asserts |
|---|---|
| Lapsed perpetual (`supportExpiresAt` past) | tier `enterprise` retained, `ai`/`analytics` true, limits `null`/`null`, `supportExpired: true` |
| DB row already swept to `support_expired` | tier `pro` retained, limits 5/25, `supportExpired: true` |
| Perpetual with active support | `reason: valid`, `supportExpired: false`, `expiresAt: null` |
| Subscription license | unchanged: `reason: valid`, `expiresAt` from `exp`, no support contract read |

Verified the tests fail against the pre-fix route (the two lapse cases fail; the two regression guards pass either way), so they genuinely pin the behavior.

```
Test Files  5 passed (5)
     Tests  63 passed (63)
```
(license, license-edge, webhook-license-roundtrip, health-license, middleware/support-expiry)

`billing-comprehensive` 72/72. `pnpm --filter server typecheck` clean. Biome clean.

## Scope note for the reviewer

The **identical demotion exists on the enforcement path** and is deliberately not fixed here. `checkSupportExpiry` (`apps/server/src/middleware/license.ts:485-497`) sets `tier: 'free'` and `features: {}` once the 30-day grace is exhausted, and it is mounted globally on `/api/*`, `/api/v1/*` and `/a2a/*` (`index.ts:702-709`), feeding `requireFeature` / `requireAIAccess` / task-quota. So after this PR the API correctly *reports* the retained tier while the middleware still *denies* those features past grace.

That is a coherent intermediate state (the report becomes honest) but not the end state. It is separated because it needs a posture ruling this PR has no mandate to make: `packages/core/src/license.ts:36-38` defines `read-only` ("reads allowed, writes blocked") and `expired` ("degraded to free tier") as different modes, and the middleware currently sets the `read-only` header while applying `expired` semantics. Whether a lapsed perpetual past grace is read-only or full read-write at the frozen tier is an open product decision. Tracked internally; `tier: 'free'` + `features: {}` is wrong under either answer.

## Risk

Low. The change only widens what a lapsed perpetual receives, and only on a reporting endpoint. No consumer read `supportExpired` or depended on the free-tier response shape (checked across the repo). Subscription and revoked/expired/unverifiable paths are untouched and still covered by their existing tests.

Licensing surface, so this needs a recorded security verdict from a non-author party before merge.

Internal audit reference: the lapsed-support licensing review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
