### PR TITLE
fix(repo): remove FUNDING.yml sponsor entries pointing at unenabled listing

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: RevealUIStudio
-custom: ["https://revealui.com/sponsor"]


### PR DESCRIPTION
## Summary
- Removes the `github: RevealUIStudio` and `custom:` entries from `.github/FUNDING.yml`. The GitHub Sponsors listing for RevealUIStudio does not exist (`hasSponsorsListing: false`), so the repo's native Sponsor button and the custom link both 404'd.
- Closes the residual left after the frontend-excellence Phase 1 PR (#1798) removed all marketing-side sponsor CTAs (`/sponsor` route, `SponsorPage.tsx`, `content/sponsor.ts`, footer link) but was scoped to `apps/marketing` and couldn't touch repo-root config.

## Test plan
- [x] `pnpm gate` passes locally
- [x] No functional/runtime code touched — config-only change