### PR TITLE
docs(tokens): correct canonical token source path in design-context pack

### DIFF
--- a/packages/tokens/design-context/README.md
+++ b/packages/tokens/design-context/README.md
@@ -2,22 +2,24 @@
 title: "RevealUI Design Context — Claude Design Pack"
 description: "Drop this folder into a Claude Design session."
 visibility: internal
-status: generated
+status: verified
 audience: maintainer
 ---
 
-<!-- GENERATED from packages/presentation/src/tokens.css — DO NOT EDIT — run pnpm --filter @revealui/presentation gen:design-context -->
+<!-- tokens.css and MANIFEST.sha256 in this pack are generated from packages/tokens/src/tokens.css — DO NOT EDIT those two files by hand — run pnpm --filter @revealui/tokens gen:manifest -->
 
 # RevealUI Design Context — Claude Design Pack
 
 Drop this folder into a Claude Design session.
 
-`tokens.css` here is a generated mirror of `packages/presentation/src/tokens.css` (canonical).
-**Do NOT edit this pack by hand** — edit the source token file and regenerate:
+`tokens.css` here is a generated mirror of `packages/tokens/src/tokens.css` (canonical).
+**Do NOT edit `tokens.css` or `MANIFEST.sha256` by hand** — edit the source token file and regenerate:
 
 ```bash
-pnpm --filter @revealui/presentation gen:design-context
+pnpm --filter @revealui/tokens gen:manifest
 ```
+
+`README.md` and `brand.md` are hand-authored.
 
 ## What is in this pack
 
@@ -25,7 +27,7 @@ pnpm --filter @revealui/presentation gen:design-context
 | ---- | ----------- |
 | `tokens.css` | Verbatim copy of the canonical token file |
 | `brand-meta.json` | Hand-authored brand canon (name, hue, OKLCH values, type stacks) |
-| `brand.md` | Generated brand reference from `brand-meta.json` |
+| `brand.md` | Hand-authored brand reference derived from `brand-meta.json` |
 | `MANIFEST.sha256` | SHA-256 of the source `tokens.css` at generation time |
 
 ## Brand
@@ -34,4 +36,4 @@ pnpm --filter @revealui/presentation gen:design-context
 Light `--rvui-brand`: `oklch(0.36 0.190 240)`.
 Dark `--rvui-brand`: `oklch(0.58 0.150 240)` (lifted for WCAG AA).
 
-> GENERATED from packages/presentation/src/tokens.css — DO NOT EDIT — run pnpm --filter @revealui/presentation gen:design-context.
+> `tokens.css` and `MANIFEST.sha256` in this pack are GENERATED from packages/tokens/src/tokens.css — DO NOT EDIT those two files by hand — run pnpm --filter @revealui/tokens gen:manifest.

--- a/packages/tokens/design-context/brand.md
+++ b/packages/tokens/design-context/brand.md
@@ -2,11 +2,11 @@
 title: "Cobalt — Electric Verdigris"
 description: "Voice/headline rules consolidation deferred to lane Phase 3 (DS-V1). Canonical voice corpus: .jv messaging-funnel-audit/voice-and-headline-rules.md"
 visibility: internal
-status: generated
+status: verified
 audience: maintainer
 ---
 
-<!-- GENERATED from packages/presentation/src/tokens.css — DO NOT EDIT — run pnpm --filter @revealui/presentation gen:design-context -->
+<!-- Hand-authored from packages/tokens/design-context/brand-meta.json. Brand tokens mirror the canonical packages/tokens/src/tokens.css. -->
 
 # Cobalt — Electric Verdigris
 
@@ -32,5 +32,5 @@ Voice/headline rules consolidation deferred to lane Phase 3 (DS-V1). Canonical v
 
 ---
 
-> This file is GENERATED from packages/presentation/src/tokens.css — DO NOT EDIT — run pnpm --filter @revealui/presentation gen:design-context.
-> Edit `packages/presentation/src/tokens.css` (canonical) then re-run the generator.
+> This file is hand-authored from `packages/tokens/design-context/brand-meta.json`.
+> Brand tokens mirror `packages/tokens/src/tokens.css` (canonical). Keep both in sync when brand values change.


### PR DESCRIPTION
## Summary

- `packages/tokens/design-context/README.md` and `brand.md` claimed the canonical token source is `packages/presentation/src/tokens.css`, and that both files are generated by a `pnpm --filter @revealui/presentation gen:design-context` script.
- Neither claim is true. Verified in code:
  - `packages/presentation/package.json`'s `build` script copies `../tokens/src/tokens.css` into its own dist — presentation is a consumer, not the source.
  - `scripts/validate/design-context-drift.ts` (the actual CI drift gate) already hashes `packages/tokens/src/tokens.css` as canonical.
  - No `gen:design-context` script exists anywhere in the repo. The only generator in this directory is `packages/tokens/scripts/gen-manifest.cjs`, invoked via `pnpm --filter @revealui/tokens gen:manifest`, and it only writes `MANIFEST.sha256` and mirrors `tokens.css` — it never touches `README.md` or `brand.md`.
- So `README.md` and `brand.md` are hand-authored (git history confirms only the original Phase 1 extraction commit ever touched them). Corrected the path, the generator command, the frontmatter `status` field (`generated` → `verified`), and the file-provenance banners so they no longer claim a nonexistent regeneration path.
- Swept the rest of `packages/tokens/design-context/` and `packages/tokens/README.md` for the same stale claim: no other file in `packages/tokens/` names `presentation` as canonical, and `packages/tokens/README.md` does not exist.

## Out of scope (flagged, not fixed)

Three more references to the stale `packages/presentation/src/tokens.css` path exist outside `packages/tokens/`, out of this PR's scope:
- `design-system/.gitignore:17`
- `docs/MARKETING_METRICS.md:113,177`
- `.husky/pre-commit:50`

## Test plan

- [x] `pnpm --filter @revealui/tokens gen:manifest:check` → `manifest in sync`
- [x] `pnpm --filter @revealui/tokens test` → 31/31 passed
- [x] `pnpm tsx scripts/validate/design-context-drift.ts` → ok
- [x] Full pre-push gate (Phase 1 + CI Gate) ran on push and passed, including the hard-fail "Design-context drift" check

🤖 Generated with [Claude Code](https://claude.com/claude-code)