### PR TITLE
fix(marketing): map font tokens to self-hosted variable families

### DIFF
--- a/apps/marketing/app/__tests__/brand-fonts.test.ts
+++ b/apps/marketing/app/__tests__/brand-fonts.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Production font regression gate.
+ *
+ * Guards the bug chain that shipped the marketing site rendering in
+ * system-ui / ui-monospace fallbacks on www.revealui.com (verified live
+ * 2026-07-10):
+ *
+ *   1. index.html linked Inter / Inter Tight / JetBrains Mono from
+ *      fonts.googleapis.com, but the production CSP (vercel.json:
+ *      font-src 'self' data:) blocks that host, so the stylesheet never
+ *      loaded.
+ *   2. The app self-hosts the same fonts via @fontsource-variable/*, which
+ *      register the "* Variable" family names ("Inter Variable" etc.), yet
+ *      the canonical @revealui/tokens stack asks for 'Inter' / 'Inter Tight'
+ *      / 'JetBrains Mono', which resolve to no self-hosted face.
+ *
+ * The fix, asserted here:
+ *   (a) index.html references no third-party font host.
+ *   (b) app/index.css redeclares the three --rvui-font-* tokens so the
+ *       fontsource "* Variable" families lead each stack.
+ *   (c) each declared "* Variable" family is one the installed fontsource
+ *       package actually registers (so the mapping resolves to a real face),
+ *       and every fontsource package is imported in entry.client.tsx.
+ */
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const APP_DIR = join(import.meta.dirname, '..');
+
+const INDEX_HTML = readFileSync(join(APP_DIR, '..', 'index.html'), 'utf8');
+const INDEX_CSS = readFileSync(join(APP_DIR, 'index.css'), 'utf8');
+const ENTRY_CLIENT = readFileSync(join(APP_DIR, 'entry.client.tsx'), 'utf8');
+
+// token → fontsource package that supplies its self-hosted face, plus the
+// family name that package registers via @font-face.
+const FONT_MAP = [
+  {
+    token: '--rvui-font-sans',
+    fontsourcePackage: '@fontsource-variable/inter',
+    variableFamily: "'Inter Variable'",
+  },
+  {
+    token: '--rvui-font-display',
+    fontsourcePackage: '@fontsource-variable/inter-tight',
+    variableFamily: "'Inter Tight Variable'",
+  },
+  {
+    token: '--rvui-font-mono',
+    fontsourcePackage: '@fontsource-variable/jetbrains-mono',
+    variableFamily: "'JetBrains Mono Variable'",
+  },
+] as const;
+
+describe('marketing brand fonts', () => {
+  it('index.html references no CSP-blocked third-party font host', () => {
+    expect(INDEX_HTML).not.toContain('fonts.googleapis.com');
+    expect(INDEX_HTML).not.toContain('fonts.gstatic.com');
+  });
+
+  it('app CSS redeclares each font token so a self-hosted variable family leads', () => {
+    for (const { token, variableFamily } of FONT_MAP) {
+      expect(INDEX_CSS).toContain(`${token}: ${variableFamily}`);
+    }
+  });
+
+  it('each declared variable family is registered by the installed fontsource package', () => {
+    for (const { fontsourcePackage, variableFamily } of FONT_MAP) {
+      const packageCss = readFileSync(require.resolve(`${fontsourcePackage}/index.css`), 'utf8');
+      // fontsource declares @font-face { font-family: 'Inter Variable'; ... }
+      expect(packageCss).toContain(`font-family: ${variableFamily}`);
+    }
+  });
+
+  it('every fontsource package is imported in the client entry', () => {
+    for (const { fontsourcePackage } of FONT_MAP) {
+      expect(ENTRY_CLIENT).toContain(`import '${fontsourcePackage}'`);
+    }
+  });
+});

--- a/apps/marketing/app/index.css
+++ b/apps/marketing/app/index.css
@@ -19,6 +19,24 @@
 @import "tailwindcss";
 @import "@revealui/presentation/tokens.css";
 
+/* ── Self-hosted variable-font family mapping (production font fix) ──
+ * The self-hosted fonts come from @fontsource-variable/{inter,inter-tight,
+ * jetbrains-mono} (imported in app/entry.client.tsx). Fontsource registers
+ * these under the "* Variable" family names ("Inter Variable",
+ * "Inter Tight Variable", "JetBrains Mono Variable"), so the canonical token
+ * stack from @revealui/tokens ('Inter', 'Inter Tight', 'JetBrains Mono')
+ * does not resolve to any self-hosted face on its own. The CSP in vercel.json
+ * intentionally blocks third-party font hosts (font-src 'self' data:), so
+ * Google Fonts cannot fill the gap either. Redeclare the tokens here, after
+ * the canonical import, so the "* Variable" families lead each stack while the
+ * original fallbacks stay intact. The canonical values in @revealui/tokens are
+ * left untouched. */
+:root {
+  --rvui-font-sans: 'Inter Variable', 'Inter', system-ui, sans-serif;
+  --rvui-font-display: 'Inter Tight Variable', 'Inter Tight', 'Inter', system-ui, sans-serif;
+  --rvui-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+}
+
 /* Tailwind v4 does not scan node_modules by default. Without this, the utility
  * classes baked into @revealui/presentation components (ButtonCVA's bg-primary,
  * Input / Callout / FormField styles, etc.) are never generated and the native

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -18,9 +18,10 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inter+Tight:wght@700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <!-- Fonts are self-hosted via @fontsource-variable/* (imported in
+         app/entry.client.tsx). No third-party font host is referenced here:
+         the CSP in vercel.json (font-src 'self' data:) blocks external font
+         CDNs, so a hosted Google Fonts link would be dead weight. -->
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="RevealUI | Your business grows with you, and stays at the frontier." />


### PR DESCRIPTION
## Problem

The brand fonts never render on www.revealui.com. Every page falls back to `system-ui` / `ui-monospace`. Verified live 2026-07-10.

### The bug chain (all verified against code)

1. `apps/marketing/index.html` linked Inter / Inter Tight / JetBrains Mono from `fonts.googleapis.com` (plus two preconnects).
2. The production CSP (`apps/marketing/vercel.json`) is `style-src 'self' 'unsafe-inline'; font-src 'self' data:`. Neither `fonts.googleapis.com` nor `fonts.gstatic.com` is allowed, so the browser blocks that stylesheet.
3. The app also self-hosts the same fonts via `@fontsource-variable/{inter,inter-tight,jetbrains-mono}` (imported in `app/entry.client.tsx`). Fontsource registers those under the family names `Inter Variable`, `Inter Tight Variable`, `JetBrains Mono Variable`.
4. The design tokens from `@revealui/tokens` declare `--rvui-font-sans: 'Inter', ...`, `--rvui-font-display: 'Inter Tight', 'Inter', ...`, `--rvui-font-mono: 'JetBrains Mono', ...`. Nothing maps `'Inter'` to `'Inter Variable'`.
5. Net: the token stack resolves to no self-hosted face, the Google Fonts stylesheet is CSP-blocked, so every page renders in the system fallbacks.

## Fix

- In `apps/marketing/app/index.css`, after the canonical `@revealui/presentation/tokens.css` import, redeclare the three `--rvui-font-*` tokens so the self-hosted `* Variable` families lead each stack (original fallbacks kept). Later source order at equal specificity wins, so this overrides the canonical values only in the marketing app.
- Remove the CSP-blocked Google Fonts `<link>` and both preconnects from `apps/marketing/index.html`.
- `packages/tokens` (the canonical values) and the CSP in `vercel.json` are left untouched. The durable canonical-token change is tracked separately.

Verified the fontsource imports cover the weights used: all three are variable fonts (100 to 900 axis) and all three are imported in `app/entry.client.tsx`.

### Production build verification

Built the marketing app and inspected the output:
- `dist/index.html` contains zero `fonts.googleapis.com` / `fonts.gstatic.com` references.
- The built CSS registers all three `@font-face` families: `Inter Variable`, `Inter Tight Variable`, `JetBrains Mono Variable`.
- The built CSS shows the override winning: `--rvui-font-sans:"Inter Variable", "Inter", system-ui, sans-serif` follows the canonical `--rvui-font-sans:"Inter", system-ui, sans-serif`.

## Regression test

`apps/marketing/app/__tests__/brand-fonts.test.ts` (static, four assertions):
1. `index.html` references no third-party font host.
2. The app CSS redeclares each `--rvui-font-*` token with a `* Variable` family leading.
3. Each declared `* Variable` family is one the installed fontsource package actually registers (resolved via `require.resolve`).
4. Every fontsource package is imported in `app/entry.client.tsx`.

### Red/green proof

Stashed the two source fixes back to `origin/main` (keeping the test), ran the test, then restored.

Red (fix reverted, test present):
```
❯ app/__tests__/brand-fonts.test.ts (4 tests | 2 failed)
  × index.html references no CSP-blocked third-party font host
  × app CSS redeclares each font token so a self-hosted variable family leads
 Tests  2 failed | 2 passed (4)
```
(Assertions 3 and 4 are structural guards on the fontsource packages and entry imports, unaffected by the source revert, so they stay green by design.)

Green (fix applied):
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Playwright computed-style probe was not added: a post-deploy font/token verification gate is arriving in a parallel PR, and the static test plus the production-build inspection above already cover the resolution path.

## Checks

- Full marketing test suite (after building workspace deps): 10 files, 74 tests, all pass.
- `pnpm --filter marketing typecheck`: clean.
- `biome check .` on marketing: my files clean (5 pre-existing warnings elsewhere, unrelated).

## Note

A post-deploy font/token verification gate is arriving in a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
