### PR TITLE
feat(docs): generate design-system previews from @revealui/presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist/
 .next/
 out/
 
+# Design-system preview generator output (apps/docs gen:previews)
+preview-dist/
+
 # Misc
 .DS_Store
 *.pem

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -2,6 +2,9 @@
 dist/
 .vinxi/
 
+# gen:previews Tailwind compile scratch (removed after each run; safety net)
+.gen-preview-css-tmp/
+
 # CHIP-3 D5a: the repo-root /docs tree is copied into public/ at build time —
 # by apps/docs/scripts/copy-docs.sh (full copy) and the vite docs-copy plugin
 # (markdown only). Everything they emit is a generated build artifact and must

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -38,6 +38,7 @@
     "check:links": "tsx scripts/check-links.ts",
     "clean": "rm -rf .next dist .turbo public/docs",
     "dev": "bash scripts/copy-docs.sh && vite dev",
+    "gen:previews": "pnpm --filter @revealui/presentation build && tsx scripts/gen-previews/index.ts",
     "lint": "biome check .",
     "preview": "vite preview",
     "start": "vite preview",

--- a/apps/docs/scripts/gen-previews/__tests__/gen-previews.test.ts
+++ b/apps/docs/scripts/gen-previews/__tests__/gen-previews.test.ts
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type GenerateResult, generate } from '../generate.js';
+import { listComponentNames } from '../render.js';
+import { kebabCase } from '../util.js';
+
+let outDir: string;
+let result: GenerateResult;
+
+beforeAll(async () => {
+  outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'preview-gen-test-'));
+  result = await generate({ outDir, compileCssStep: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(outDir, { recursive: true, force: true });
+});
+
+function isDsCardMarker(line: string, expectedName?: string): boolean {
+  const ok =
+    line.startsWith('<!-- @dsCard group="Components (from code)"') &&
+    line.includes(' name="') &&
+    line.trimEnd().endsWith('-->');
+  if (!expectedName) return ok;
+  return ok && line.includes(`name="${expectedName}"`);
+}
+
+async function firstLine(rel: string): Promise<string> {
+  const content = await fs.readFile(path.join(outDir, rel), 'utf8');
+  return content.split('\n', 1)[0] ?? '';
+}
+
+describe('design-system preview generator', () => {
+  it('emits a file for every public component export', async () => {
+    const names = listComponentNames();
+    expect(names.length).toBeGreaterThan(100);
+    for (const name of names) {
+      const rel = path.join('generated/components', `${kebabCase(name)}.html`);
+      const stat = await fs.stat(path.join(outDir, rel)).catch(() => null);
+      expect(stat, `missing preview for ${name}`).not.toBeNull();
+    }
+    expect(result.components.length).toBe(names.length);
+  });
+
+  it('starts every component HTML with a valid @dsCard marker', async () => {
+    for (const component of result.components) {
+      const line = await firstLine(path.join('generated/components', component.fileName));
+      expect(isDsCardMarker(line, component.name), `${component.name}: ${line}`).toBe(true);
+    }
+  });
+
+  it('marks the catalog index with a @dsCard Component Catalog marker', async () => {
+    const line = await firstLine('generated/index.html');
+    expect(isDsCardMarker(line, 'Component Catalog')).toBe(true);
+  });
+
+  it('compiles a non-empty _preview.css with tokens and used classes', async () => {
+    const css = await fs.readFile(path.join(outDir, 'generated/_preview.css'), 'utf8');
+    expect(css.length).toBeGreaterThan(1000);
+    expect(css).toContain('--rvui-');
+    // A class the Button preview actually renders must be present in the CSS.
+    const buttonHtml = await fs.readFile(
+      path.join(outDir, 'generated/components/button.html'),
+      'utf8',
+    );
+    expect(buttonHtml).toContain('inline-flex');
+    expect(css).toContain('.inline-flex');
+    expect(css).toContain('bg-primary');
+  });
+
+  it('renders expected variant/example sections for key components', async () => {
+    const cases: Array<{ file: string; needles: string[] }> = [
+      { file: 'button.html', needles: ['Variants', 'Button Group', '<button'] },
+      { file: 'card.html', needles: ['Card Grid', 'dsc-canvas'] },
+      { file: 'dialog.html', needles: ['Open state', 'Delete project'] },
+      { file: 'table.html', needles: ['dsc-canvas', '<table'] },
+    ];
+    for (const { file, needles } of cases) {
+      const html = await fs.readFile(path.join(outDir, 'generated/components', file), 'utf8');
+      expect(html.length, `${file} empty`).toBeGreaterThan(200);
+      for (const needle of needles) {
+        expect(html.includes(needle), `${file} missing ${needle}`).toBe(true);
+      }
+    }
+  });
+
+  it('writes a manifest whose hashes verify against the emitted files', async () => {
+    const manifest = JSON.parse(await fs.readFile(path.join(outDir, 'manifest.json'), 'utf8')) as {
+      sourceCommit: string;
+      generatedAt: string;
+      files: Record<string, string>;
+    };
+    expect(manifest.sourceCommit.length).toBeGreaterThan(0);
+    expect(Date.parse(manifest.generatedAt)).not.toBeNaN();
+    const entries = Object.entries(manifest.files);
+    expect(entries.length).toBe(result.emittedFiles.length);
+    for (const [rel, hash] of entries) {
+      const buf = await fs.readFile(path.join(outDir, rel));
+      const actual = createHash('sha256').update(buf).digest('hex');
+      expect(actual, `hash mismatch for ${rel}`).toBe(hash);
+    }
+  });
+});

--- a/apps/docs/scripts/gen-previews/css.ts
+++ b/apps/docs/scripts/gen-previews/css.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import tailwindcss from '@tailwindcss/vite';
+import { build } from 'vite';
+import { docsRoot, presentationRoot } from './paths.js';
+
+/**
+ * Compile the Tailwind v4 CSS covering every class the generated markup uses,
+ * plus the canonical --rvui-* tokens. Reuses the docs app's own Tailwind entry
+ * (app/index.css: @import "tailwindcss", tokens.css, and the @theme token
+ * bridge) so the output matches what the docs/marketing apps ship, and adds no
+ * new dependency (@tailwindcss/vite + vite are docs devDeps).
+ */
+export async function compileCss(
+  generatedComponentsDir: string,
+  outCssPath: string,
+): Promise<void> {
+  const tmpDir = path.join(docsRoot, '.gen-preview-css-tmp');
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  await fs.mkdir(tmpDir, { recursive: true });
+
+  const entryCss = [
+    '@import "../app/index.css";',
+    `@source "${presentationRoot}/src";`,
+    `@source "${generatedComponentsDir}";`,
+    '',
+  ].join('\n');
+  const entryHtml =
+    '<!doctype html><html><head><link rel="stylesheet" href="./entry.css" /></head><body></body></html>';
+
+  await fs.writeFile(path.join(tmpDir, 'entry.css'), entryCss);
+  await fs.writeFile(path.join(tmpDir, 'index.html'), entryHtml);
+
+  try {
+    await build({
+      root: tmpDir,
+      logLevel: 'silent',
+      plugins: [tailwindcss()],
+      build: {
+        outDir: path.join(tmpDir, 'dist'),
+        emptyOutDir: true,
+        cssMinify: false,
+        rollupOptions: { input: path.join(tmpDir, 'index.html') },
+      },
+    });
+
+    const assetsDir = path.join(tmpDir, 'dist', 'assets');
+    const files = await fs.readdir(assetsDir);
+    const cssFiles = files.filter((f) => f.endsWith('.css')).sort();
+    if (cssFiles.length === 0) {
+      throw new Error('Tailwind compile produced no CSS asset');
+    }
+    const parts = await Promise.all(
+      cssFiles.map((f) => fs.readFile(path.join(assetsDir, f), 'utf8')),
+    );
+    await fs.writeFile(outCssPath, `${parts.join('\n').trim()}\n`);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/apps/docs/scripts/gen-previews/generate.ts
+++ b/apps/docs/scripts/gen-previews/generate.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as React from 'react';
+import { compileCss } from './css.js';
+import { defaultOutDir, repoRoot } from './paths.js';
+import { buildCuratedRegistry } from './registry.js';
+import {
+  type ComponentRenderResult,
+  listComponentNames,
+  renderCatalogPage,
+  renderComponentPage,
+} from './render.js';
+import { seededRandom, sha256 } from './util.js';
+
+export interface GenerateOptions {
+  /** Output bundle root. Defaults to <repoRoot>/preview-dist. */
+  outDir?: string;
+  /** Compile _preview.css (the slow step). Defaults to true. */
+  compileCssStep?: boolean;
+}
+
+export interface GenerateStats {
+  total: number;
+  curated: number;
+  default: number;
+  stub: number;
+}
+
+export interface GenerateResult {
+  outDir: string;
+  sourceCommit: string;
+  generatedAt: string;
+  components: ComponentRenderResult[];
+  stats: GenerateStats;
+  emittedFiles: string[];
+  cssBytes: number;
+}
+
+function sourceCommit(): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot }).toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Render every public @revealui/presentation component to a static @dsCard
+ * preview page, compile the shared Tailwind CSS, and write a hash manifest.
+ * Deterministic given the same source commit: stable ordering, seeded
+ * Math.random, timestamps confined to manifest.json.
+ */
+export async function generate(options: GenerateOptions = {}): Promise<GenerateResult> {
+  const outDir = options.outDir ?? defaultOutDir;
+  const compileCssStep = options.compileCssStep ?? true;
+
+  // Showcase story modules use the classic JSX runtime and expect a global React.
+  (globalThis as Record<string, unknown>).React = React;
+
+  const generatedDir = path.join(outDir, 'generated');
+  const componentsDir = path.join(generatedDir, 'components');
+  await fs.rm(outDir, { recursive: true, force: true });
+  await fs.mkdir(componentsDir, { recursive: true });
+
+  const curated = await buildCuratedRegistry();
+  const names = listComponentNames();
+
+  // Determinism: freeze Math.random for the render pass only.
+  const realRandom = Math.random;
+  Math.random = seededRandom(0x5eed);
+  let results: ComponentRenderResult[];
+  try {
+    results = names.map((name) => renderComponentPage(name, curated.get(name)));
+  } finally {
+    Math.random = realRandom;
+  }
+
+  for (const result of results) {
+    await fs.writeFile(path.join(componentsDir, result.fileName), result.html);
+  }
+
+  const catalogHtml = renderCatalogPage(results);
+  await fs.writeFile(path.join(generatedDir, 'index.html'), catalogHtml);
+
+  const cssPath = path.join(generatedDir, '_preview.css');
+  if (compileCssStep) {
+    await compileCss(componentsDir, cssPath);
+  } else {
+    await fs.writeFile(cssPath, '/* css compile skipped */\n');
+  }
+
+  const stats: GenerateStats = {
+    total: results.length,
+    curated: results.filter((r) => r.status === 'curated').length,
+    default: results.filter((r) => r.status === 'default').length,
+    stub: results.filter((r) => r.status === 'stub').length,
+  };
+
+  const emittedRel = [
+    ...results.map((r) => path.posix.join('generated/components', r.fileName)),
+    'generated/index.html',
+    'generated/_preview.css',
+  ].sort();
+
+  const filesManifest: Record<string, string> = {};
+  for (const rel of emittedRel) {
+    const buf = await fs.readFile(path.join(outDir, rel));
+    filesManifest[rel] = sha256(buf);
+  }
+
+  const generatedAt = new Date().toISOString();
+  const manifest = {
+    sourceCommit: sourceCommit(),
+    generatedAt,
+    files: filesManifest,
+  };
+  await fs.writeFile(path.join(outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const cssBytes = (await fs.stat(cssPath)).size;
+
+  return {
+    outDir,
+    sourceCommit: manifest.sourceCommit,
+    generatedAt,
+    components: results,
+    stats,
+    emittedFiles: emittedRel,
+    cssBytes,
+  };
+}

--- a/apps/docs/scripts/gen-previews/index.ts
+++ b/apps/docs/scripts/gen-previews/index.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { generate } from './generate.js';
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+async function bundleSize(dir: string): Promise<number> {
+  let total = 0;
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) total += await bundleSize(full);
+    else total += (await fs.stat(full)).size;
+  }
+  return total;
+}
+
+async function main(): Promise<void> {
+  const compileCssStep = !process.argv.includes('--no-css');
+  const started = Date.now();
+  const result = await generate({ compileCssStep });
+  const size = await bundleSize(result.outDir);
+
+  const stubbed = result.components.filter((c) => c.status === 'stub').map((c) => c.name);
+
+  process.stdout.write(
+    [
+      'design-system previews generated',
+      `  out:        ${result.outDir}`,
+      `  commit:     ${result.sourceCommit}`,
+      `  components: ${result.stats.total} (curated ${result.stats.curated}, default ${result.stats.default}, stub ${result.stats.stub})`,
+      `  _preview.css: ${formatBytes(result.cssBytes)}${compileCssStep ? '' : ' (skipped)'}`,
+      `  bundle:     ${formatBytes(size)} across ${result.emittedFiles.length + 1} files`,
+      stubbed.length ? `  stubbed:    ${stubbed.join(', ')}` : '  stubbed:    none',
+      `  took:       ${((Date.now() - started) / 1000).toFixed(1)}s`,
+      '',
+    ].join('\n'),
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exit(1);
+});

--- a/apps/docs/scripts/gen-previews/paths.ts
+++ b/apps/docs/scripts/gen-previews/paths.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** apps/docs */
+export const docsRoot = path.resolve(here, '../..');
+
+/** repo root (monorepo top) */
+export const repoRoot = path.resolve(docsRoot, '../..');
+
+/** @revealui/presentation package root */
+export const presentationRoot = path.resolve(repoRoot, 'packages/presentation');
+
+/**
+ * Authoritative component surface: the source component barrel. Imported for
+ * its export NAMES only (never rendered from — see render.tsx, which renders
+ * from the built dist barrel to share the workspace React instance).
+ */
+export const componentSourceBarrel = path.join(presentationRoot, 'src/components/index.ts');
+
+/** Built barrel used for actual rendering (bundled against the hoisted React). */
+export const distBarrel = path.join(presentationRoot, 'dist/index.js');
+
+/** Docs Tailwind v4 entry (token bridge + @source globs) reused to compile CSS. */
+export const docsIndexCss = path.join(docsRoot, 'app/index.css');
+
+/** Docs showcase registry (curated example source, reused). */
+export const showcaseRegistry = path.join(docsRoot, 'app/components/showcase/registry.ts');
+
+/** Default output bundle root. */
+export const defaultOutDir = path.join(repoRoot, 'preview-dist');

--- a/apps/docs/scripts/gen-previews/registry.tsx
+++ b/apps/docs/scripts/gen-previews/registry.tsx
@@ -1,0 +1,361 @@
+/**
+ * Curated example registry — the single module that maps a component export
+ * name to preview sections, seeded from the docs-app showcase stories
+ * (extend-before-create: the showcase already owns curated example content).
+ *
+ * Two overrides on top of the showcase reuse:
+ *  - alias map: showcases keyed by concept-slug fan out to the styled + headless
+ *    export pairs (e.g. `button` → Button and ButtonCVA).
+ *  - overlay snapshots: Dialog/Drawer/Tooltip/Toast portal to document.body or
+ *    render from client state, so `renderToStaticMarkup` can never capture their
+ *    open state. Those four get a hand-composed representative snapshot built
+ *    from the real exported sub-parts.
+ *
+ * A component with no curated entry is not dropped — render.tsx falls back to a
+ * default harness. Adding a component to @revealui/presentation therefore needs
+ * zero edits here to appear in the output.
+ */
+import * as React from 'react';
+import * as Ui from '../../../../packages/presentation/dist/index.js';
+import { showcaseEntries } from '../../app/components/showcase/registry.js';
+import type { ShowcaseStory } from '../../app/components/showcase/types.js';
+
+export interface PreviewSection {
+  label: string;
+  node: React.ReactNode;
+}
+
+export interface CuratedEntry {
+  subtitle: string;
+  sections: PreviewSection[];
+}
+
+/** Showcase slugs that are not components on the presentation component surface. */
+const SKIP_SLUGS = new Set(['animations', 'theme', 'icons']);
+
+/** Concept-slug → the component export name(s) that story represents. */
+const SLUG_ALIASES: Record<string, string[]> = {
+  button: ['Button', 'ButtonCVA'],
+  checkbox: ['Checkbox', 'CheckboxCVA'],
+  input: ['Input', 'InputCVA'],
+  select: ['Select', 'SelectCVA'],
+  textarea: ['Textarea', 'TextareaCVA'],
+  linkbutton: ['LinkButton'],
+  toast: ['ToastProvider'],
+};
+
+function kebabToPascal(slug: string): string {
+  return slug
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function pluralize(word: string): string {
+  return word.endsWith('s') ? word : `${word}s`;
+}
+
+/**
+ * Wrapper so a showcase render function runs INSIDE React's render pass. Some
+ * examples call hooks (useState) at the top of their render fn; invoking them
+ * eagerly outside a component triggers "Invalid hook call".
+ */
+function Lazy({ render }: { render: () => React.ReactNode }): React.ReactNode {
+  return <>{render()}</>;
+}
+
+function lazyNode(render: () => React.ReactNode): React.ReactNode {
+  return <Lazy render={render} />;
+}
+
+function controlDefaults(story: ShowcaseStory): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, control] of Object.entries(story.controls)) {
+    out[key] = control.default;
+  }
+  return out;
+}
+
+function storySubtitle(story: ShowcaseStory): string {
+  if (story.variantGrid) {
+    return Object.entries(story.variantGrid)
+      .map(([axis, values]) => `${values.length} ${pluralize(axis)}`)
+      .join(', ');
+  }
+  const count = story.examples?.length ?? 0;
+  if (count > 0) return `${count} example${count === 1 ? '' : 's'}`;
+  const firstSentence = story.description.split('.')[0]?.trim() ?? '';
+  return firstSentence.length > 64 ? `${firstSentence.slice(0, 61)}...` : firstSentence;
+}
+
+function variantMatrixNode(
+  story: ShowcaseStory,
+  defaults: Record<string, unknown>,
+): React.ReactNode {
+  const axes = Object.entries(story.variantGrid ?? {});
+  if (axes.length === 1) {
+    const [prop, values] = axes[0] as [string, string[]];
+    return (
+      <div className="dsc-variant-row">
+        {values.map((value) => (
+          <div className="dsc-variant-cell" key={value}>
+            <div className="dsc-variant-preview">
+              {lazyNode(() => story.render({ ...defaults, [prop]: value }))}
+            </div>
+            <span className="dsc-variant-tag">{value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  const [rowProp, rowValues] = axes[0] as [string, string[]];
+  const [colProp, colValues] = axes[1] as [string, string[]];
+  return (
+    <table className="dsc-variant-matrix">
+      <thead>
+        <tr>
+          <th className="dsc-variant-th">
+            {rowProp} \ {colProp}
+          </th>
+          {colValues.map((col) => (
+            <th className="dsc-variant-th" key={col}>
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rowValues.map((row) => (
+          <tr key={row}>
+            <td className="dsc-variant-th">{row}</td>
+            {colValues.map((col) => (
+              <td className="dsc-variant-td" key={col}>
+                {lazyNode(() => story.render({ ...defaults, [rowProp]: row, [colProp]: col }))}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function sectionsFromStory(story: ShowcaseStory): PreviewSection[] {
+  const defaults = controlDefaults(story);
+  const sections: PreviewSection[] = [];
+  if (story.variantGrid) {
+    sections.push({ label: 'Variants', node: variantMatrixNode(story, defaults) });
+  } else {
+    sections.push({ label: 'Default', node: lazyNode(() => story.render(defaults)) });
+  }
+  for (const example of story.examples ?? []) {
+    sections.push({ label: example.name, node: lazyNode(() => example.render()) });
+  }
+  return sections;
+}
+
+const noop = (): void => undefined;
+
+/**
+ * Authored static snapshots for components the showcase reuse cannot cover:
+ *  - Dialog/Drawer/Tooltip/Toast portal to document.body or render from client
+ *    state, so their open state cannot be captured by static server rendering;
+ *    composed here from the real exported sub-parts.
+ *  - PricingTable has required props and no showcase story.
+ */
+function authoredSnapshots(): Record<string, CuratedEntry> {
+  const {
+    DialogTitle,
+    DialogDescription,
+    DialogBody,
+    DialogActions,
+    ButtonCVA,
+    DrawerHeader,
+    DrawerBody,
+    DrawerFooter,
+    PricingTable,
+  } = Ui as Record<string, React.ComponentType<Record<string, unknown>>>;
+
+  const pricingTiers = [
+    {
+      id: 'free',
+      name: 'Free',
+      price: '$0',
+      period: '/mo',
+      description: 'For side projects and evaluation.',
+      features: ['1 site', 'Community support', 'Core components'],
+      cta: 'Get started',
+      ctaHref: '#',
+      highlighted: false,
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      price: '$29',
+      period: '/mo',
+      description: 'For teams shipping in production.',
+      features: ['Unlimited sites', 'AI agents', 'Priority support'],
+      cta: 'Start free trial',
+      ctaHref: '#',
+      highlighted: true,
+    },
+    {
+      id: 'enterprise',
+      name: 'Enterprise',
+      price: 'Custom',
+      description: 'For organizations with advanced needs.',
+      features: ['SSO and SCIM', 'Dedicated support', 'Custom SLAs'],
+      cta: 'Contact sales',
+      ctaHref: '#',
+      highlighted: false,
+    },
+  ];
+
+  return {
+    PricingTable: {
+      subtitle: '3 tiers, highlighted plan',
+      sections: [
+        {
+          label: 'Three tiers',
+          node: React.createElement(PricingTable, { tiers: pricingTiers }),
+        },
+      ],
+    },
+    Dialog: {
+      subtitle: 'Modal panel (representative snapshot)',
+      sections: [
+        {
+          label: 'Open state',
+          node: (
+            <div className="dsc-dialog-panel">
+              {React.createElement(DialogTitle, {}, 'Delete project')}
+              {React.createElement(
+                DialogDescription,
+                {},
+                'This action is permanent and cannot be undone.',
+              )}
+              {React.createElement(
+                DialogBody,
+                {},
+                <p className="dsc-body-text">
+                  The project and all of its data will be removed for every member of the workspace.
+                </p>,
+              )}
+              {React.createElement(
+                DialogActions,
+                {},
+                <>
+                  {React.createElement(ButtonCVA, { variant: 'outline' }, 'Cancel')}
+                  {React.createElement(ButtonCVA, { variant: 'destructive' }, 'Delete')}
+                </>,
+              )}
+            </div>
+          ),
+        },
+      ],
+    },
+    Drawer: {
+      subtitle: 'Slide-out panel (representative snapshot)',
+      sections: [
+        {
+          label: 'Open state',
+          node: (
+            <div className="dsc-drawer-panel">
+              {React.createElement(DrawerHeader, { onClose: noop }, 'Filters')}
+              {React.createElement(
+                DrawerBody,
+                {},
+                <p className="dsc-body-text">
+                  Refine the results using the controls in this panel.
+                </p>,
+              )}
+              {React.createElement(
+                DrawerFooter,
+                {},
+                <>
+                  {React.createElement(ButtonCVA, { variant: 'outline' }, 'Reset')}
+                  {React.createElement(ButtonCVA, { variant: 'primary' }, 'Apply')}
+                </>,
+              )}
+            </div>
+          ),
+        },
+      ],
+    },
+    Tooltip: {
+      subtitle: 'Hover label (representative snapshot)',
+      sections: [
+        {
+          label: 'Visible state',
+          node: (
+            <div className="dsc-tooltip-demo">
+              {React.createElement(ButtonCVA, { variant: 'outline' }, 'Hover me')}
+              <span className="dsc-tooltip-bubble" role="tooltip">
+                Saves your changes
+              </span>
+            </div>
+          ),
+        },
+      ],
+    },
+    ToastProvider: {
+      subtitle: 'Notification stack (representative snapshot)',
+      sections: [
+        {
+          label: 'Toasts',
+          node: (
+            <div className="dsc-toast-stack">
+              <div className="dsc-toast">
+                <p className="dsc-toast-title">Changes saved</p>
+                <p className="dsc-toast-desc">Your workspace is up to date.</p>
+              </div>
+              <div className="dsc-toast dsc-toast-success">
+                <span className="dsc-toast-icon">✓</span>
+                <div>
+                  <p className="dsc-toast-title">Deployment complete</p>
+                  <p className="dsc-toast-desc">docs.revealui.com is live.</p>
+                </div>
+              </div>
+              <div className="dsc-toast dsc-toast-error">
+                <span className="dsc-toast-icon">!</span>
+                <div>
+                  <p className="dsc-toast-title">Upload failed</p>
+                  <p className="dsc-toast-desc">Check your connection and retry.</p>
+                </div>
+              </div>
+            </div>
+          ),
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Build the curated registry: export name → CuratedEntry. Async because the
+ * docs showcase stories are lazy-loaded.
+ */
+export async function buildCuratedRegistry(): Promise<Map<string, CuratedEntry>> {
+  const map = new Map<string, CuratedEntry>();
+
+  for (const entry of showcaseEntries) {
+    if (SKIP_SLUGS.has(entry.slug)) continue;
+    const mod = await entry.loader();
+    const story = mod.default;
+    const targets = SLUG_ALIASES[entry.slug] ?? [kebabToPascal(entry.slug)];
+    const curated: CuratedEntry = {
+      subtitle: storySubtitle(story),
+      sections: sectionsFromStory(story),
+    };
+    for (const name of targets) {
+      map.set(name, curated);
+    }
+  }
+
+  // Authored snapshots override any showcase-derived entry for those names.
+  for (const [name, curated] of Object.entries(authoredSnapshots())) {
+    map.set(name, curated);
+  }
+
+  return map;
+}

--- a/apps/docs/scripts/gen-previews/render.tsx
+++ b/apps/docs/scripts/gen-previews/render.tsx
@@ -1,0 +1,228 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as Ui from '../../../../packages/presentation/dist/index.js';
+import * as SourceComponents from '../../../../packages/presentation/src/components/index.js';
+import type { CuratedEntry, PreviewSection } from './registry.js';
+import { escapeComment, escapeHtml, isPascalCase, kebabCase } from './util.js';
+
+const CARD_GROUP = 'Components (from code)';
+
+function isComponentExport(name: string, value: unknown): boolean {
+  const isFn = typeof value === 'function';
+  const isExotic = typeof value === 'object' && value !== null && '$$typeof' in (value as object);
+  return (isFn || isExotic) && isPascalCase(name) && !name.startsWith('use');
+}
+
+/**
+ * Authoritative component surface: the source component barrel's exports,
+ * filtered to renderable components and sorted for deterministic output.
+ */
+export function listComponentNames(): string[] {
+  const source = SourceComponents as Record<string, unknown>;
+  return Object.keys(source)
+    .filter((name) => isComponentExport(name, source[name]))
+    .sort((a, b) => a.localeCompare(b, 'en'));
+}
+
+/** Render a React node to static markup, or null if it throws or is empty. */
+function renderNodeSafe(node: React.ReactNode): string | null {
+  try {
+    const html = renderToStaticMarkup(React.createElement(React.Fragment, null, node));
+    return html.length > 0 ? html : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Render curated sections, dropping any that fail to render statically. */
+function renderCuratedSections(sections: PreviewSection[]): string[] {
+  const out: string[] = [];
+  for (const section of sections) {
+    const markup = renderNodeSafe(section.node);
+    if (markup) out.push(sectionHtml(section.label, markup));
+  }
+  return out;
+}
+
+/**
+ * Default harness for components without a curated example. Tries a no-children
+ * render first (void elements like input/hr break with children), then a
+ * with-children render.
+ */
+function renderDefaultHarness(name: string): { sections: string[]; subtitle: string } {
+  const Component = (Ui as Record<string, React.ComponentType<Record<string, unknown>>>)[name];
+  if (!Component) {
+    return { sections: [], subtitle: 'No preview' };
+  }
+  const attempts: React.ReactNode[] = [
+    React.createElement(Component, {}),
+    React.createElement(Component, {}, 'Sample'),
+  ];
+  for (const node of attempts) {
+    const markup = renderNodeSafe(node);
+    if (markup) {
+      return { sections: [sectionHtml('Default', markup)], subtitle: 'Default preview' };
+    }
+  }
+  return { sections: [], subtitle: 'No standalone preview' };
+}
+
+function sectionHtml(label: string, markup: string): string {
+  return `<section class="dsc-section">
+      <div class="dsc-section-label">${escapeHtml(label)}</div>
+      <div class="dsc-canvas">${markup}</div>
+    </section>`;
+}
+
+const STUB_NOTE =
+  'This component requires a parent context or composition and has no standalone static preview. See the composed components for its rendered form.';
+
+export interface ComponentRenderResult {
+  name: string;
+  fileName: string;
+  subtitle: string;
+  status: 'curated' | 'default' | 'stub';
+  html: string;
+}
+
+/** Build the full HTML page for a single component. */
+export function renderComponentPage(
+  name: string,
+  curated: CuratedEntry | undefined,
+): ComponentRenderResult {
+  let sections: string[] = [];
+  let subtitle: string;
+  let status: ComponentRenderResult['status'];
+
+  if (curated) {
+    sections = renderCuratedSections(curated.sections);
+    subtitle = curated.subtitle;
+    status = sections.length > 0 ? 'curated' : 'stub';
+  } else {
+    const harness = renderDefaultHarness(name);
+    sections = harness.sections;
+    subtitle = harness.subtitle;
+    status = sections.length > 0 ? 'default' : 'stub';
+  }
+
+  if (sections.length === 0) {
+    sections = [`<section class="dsc-section"><p class="dsc-stub">${STUB_NOTE}</p></section>`];
+  }
+
+  const html = pageHtml({ name, subtitle, body: sections.join('\n    ') });
+  return { name, fileName: `${kebabCase(name)}.html`, subtitle, status, html };
+}
+
+interface PageHtmlInput {
+  name: string;
+  subtitle: string;
+  body: string;
+}
+
+function dsCard(name: string, subtitle: string): string {
+  return `<!-- @dsCard group="${escapeComment(CARD_GROUP)}" name="${escapeComment(name)}" subtitle="${escapeComment(subtitle)}" -->`;
+}
+
+function pageHtml({ name, subtitle, body }: PageHtmlInput): string {
+  return `${dsCard(name, subtitle)}
+<link rel="stylesheet" href="../_preview.css" />
+<style>${PAGE_STYLE}</style>
+<div class="dsc-root" data-theme="dark">
+  <header class="dsc-header">
+    <div>
+      <h1 class="dsc-title">${escapeHtml(name)}</h1>
+      <p class="dsc-subtitle">${escapeHtml(subtitle)}</p>
+    </div>
+    <div class="dsc-theme-toggle" role="group" aria-label="Theme">
+      <button type="button" class="dsc-theme-btn is-active" data-theme-set="dark">Dark</button>
+      <button type="button" class="dsc-theme-btn" data-theme-set="light">Light</button>
+    </div>
+  </header>
+  <main class="dsc-sections">
+    ${body}
+  </main>
+</div>
+<script>${TOGGLE_SCRIPT}</script>
+`;
+}
+
+/** Catalog index page linking every component preview. */
+export function renderCatalogPage(results: ComponentRenderResult[]): string {
+  const rows = results
+    .map(
+      (r) =>
+        `      <li class="dsc-cat-item"><a class="dsc-cat-link" href="components/${r.fileName}"><span class="dsc-cat-name">${escapeHtml(r.name)}</span><span class="dsc-cat-sub">${escapeHtml(r.subtitle)}</span></a></li>`,
+    )
+    .join('\n');
+  return `${dsCard('Component Catalog', `${results.length} components generated from @revealui/presentation`)}
+<link rel="stylesheet" href="_preview.css" />
+<style>${PAGE_STYLE}</style>
+<div class="dsc-root" data-theme="dark">
+  <header class="dsc-header">
+    <div>
+      <h1 class="dsc-title">Component Catalog</h1>
+      <p class="dsc-subtitle">${results.length} components generated from @revealui/presentation</p>
+    </div>
+  </header>
+  <main class="dsc-sections">
+    <ul class="dsc-catalog">
+${rows}
+    </ul>
+  </main>
+</div>
+`;
+}
+
+const TOGGLE_SCRIPT = `
+(function () {
+  var root = document.currentScript.previousElementSibling;
+  if (!root) return;
+  root.querySelectorAll('.dsc-theme-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var mode = btn.getAttribute('data-theme-set');
+      root.setAttribute('data-theme', mode);
+      root.querySelectorAll('.dsc-theme-btn').forEach(function (b) {
+        b.classList.toggle('is-active', b === btn);
+      });
+    });
+  });
+})();
+`.trim();
+
+const PAGE_STYLE = `
+.dsc-root { min-height: 100vh; background: var(--rvui-surface-0); color: var(--rvui-text-0); font-family: var(--rvui-font-sans, ui-sans-serif, system-ui, sans-serif); padding: 24px; box-sizing: border-box; }
+.dsc-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 24px; }
+.dsc-title { font-size: 20px; font-weight: 700; margin: 0; }
+.dsc-subtitle { font-size: 13px; color: var(--rvui-text-2); margin: 4px 0 0; }
+.dsc-theme-toggle { display: inline-flex; gap: 2px; padding: 2px; border-radius: 8px; background: var(--rvui-surface-2); }
+.dsc-theme-btn { border: 0; cursor: pointer; padding: 4px 12px; border-radius: 6px; font-size: 12px; font-weight: 500; color: var(--rvui-text-2); background: transparent; }
+.dsc-theme-btn.is-active { background: var(--rvui-brand); color: var(--rvui-text-on-brand, #fff); }
+.dsc-sections { display: flex; flex-direction: column; gap: 20px; max-width: 100%; }
+.dsc-section { border: 1px solid var(--rvui-border); border-radius: 12px; overflow: hidden; }
+.dsc-section-label { font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--rvui-text-2); padding: 8px 16px; border-bottom: 1px solid var(--rvui-border); background: var(--rvui-surface-1); }
+.dsc-canvas { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; padding: 28px; background: var(--rvui-surface-0); overflow-x: auto; }
+.dsc-stub { padding: 20px 16px; margin: 0; font-size: 13px; color: var(--rvui-text-2); }
+.dsc-body-text { font-size: 14px; color: var(--rvui-text-1); margin: 0; }
+.dsc-variant-row { display: flex; flex-wrap: wrap; gap: 20px; }
+.dsc-variant-cell { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+.dsc-variant-tag { font-size: 10px; font-family: var(--rvui-font-mono, ui-monospace, monospace); color: var(--rvui-text-2); }
+.dsc-variant-matrix { border-collapse: collapse; }
+.dsc-variant-th { font-size: 10px; font-family: var(--rvui-font-mono, ui-monospace, monospace); color: var(--rvui-text-2); padding: 8px 12px; text-align: left; border: 1px solid var(--rvui-border); background: var(--rvui-surface-1); }
+.dsc-variant-td { padding: 16px; text-align: center; border: 1px solid var(--rvui-border); }
+.dsc-dialog-panel { width: 100%; max-width: 420px; padding: 28px; border-radius: 16px; background: var(--rvui-surface-1); box-shadow: var(--rvui-shadow-lg, 0 12px 40px rgba(0,0,0,0.35)); border: 1px solid var(--rvui-border-subtle, var(--rvui-border)); }
+.dsc-drawer-panel { width: 100%; max-width: 360px; padding: 20px; border-radius: 12px; background: var(--rvui-surface-1); border: 1px solid var(--rvui-border); box-shadow: var(--rvui-shadow-lg, 0 12px 40px rgba(0,0,0,0.35)); }
+.dsc-tooltip-demo { position: relative; display: inline-flex; padding-top: 44px; }
+.dsc-tooltip-bubble { position: absolute; top: 0; left: 50%; transform: translateX(-50%); background: var(--rvui-surface-3, #333); color: var(--rvui-text-0); font-size: 12px; padding: 6px 10px; border-radius: 6px; white-space: nowrap; box-shadow: var(--rvui-shadow-md, 0 6px 20px rgba(0,0,0,0.3)); }
+.dsc-toast-stack { display: flex; flex-direction: column; gap: 10px; width: 100%; max-width: 360px; }
+.dsc-toast { display: flex; gap: 10px; padding: 12px 14px; border-radius: 10px; background: var(--rvui-surface-1); border: 1px solid var(--rvui-border); }
+.dsc-toast-success { border-color: var(--rvui-success, #16a34a); }
+.dsc-toast-error { border-color: var(--rvui-error, #dc2626); }
+.dsc-toast-icon { font-weight: 700; }
+.dsc-toast-title { font-size: 13px; font-weight: 600; margin: 0; color: var(--rvui-text-0); }
+.dsc-toast-desc { font-size: 12px; margin: 2px 0 0; color: var(--rvui-text-2); }
+.dsc-catalog { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 10px; }
+.dsc-cat-item { margin: 0; }
+.dsc-cat-link { display: flex; flex-direction: column; gap: 2px; padding: 12px 14px; border: 1px solid var(--rvui-border); border-radius: 10px; text-decoration: none; background: var(--rvui-surface-1); }
+.dsc-cat-name { font-size: 14px; font-weight: 600; color: var(--rvui-text-0); }
+.dsc-cat-sub { font-size: 11px; color: var(--rvui-text-2); }
+`.trim();

--- a/apps/docs/scripts/gen-previews/util.ts
+++ b/apps/docs/scripts/gen-previews/util.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+
+function isUpper(ch: string): boolean {
+  return ch >= 'A' && ch <= 'Z';
+}
+
+function isLower(ch: string): boolean {
+  return ch >= 'a' && ch <= 'z';
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= '0' && ch <= '9';
+}
+
+/**
+ * PascalCase / camelCase export name → kebab-case file slug.
+ * Char-scan (no authored regex, per fleet M2): a dash is inserted before an
+ * uppercase letter that either follows a lowercase/digit, or starts a new word
+ * inside an acronym run (uppercase followed by lowercase). e.g. RevealUIMark →
+ * reveal-ui-mark, ButtonCVA → button-cva.
+ */
+export function kebabCase(name: string): string {
+  const out: string[] = [];
+  for (let i = 0; i < name.length; i++) {
+    const ch = name[i] as string;
+    if (isUpper(ch) && i > 0) {
+      const prev = name[i - 1] as string;
+      const next = i + 1 < name.length ? (name[i + 1] as string) : '';
+      const boundary = isLower(prev) || isDigit(prev) || (isUpper(prev) && isLower(next));
+      if (boundary) out.push('-');
+    }
+    out.push(ch.toLowerCase());
+  }
+  return out.join('');
+}
+
+export function isPascalCase(name: string): boolean {
+  return name.length > 0 && isUpper(name[0] as string);
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .split('&')
+    .join('&amp;')
+    .split('<')
+    .join('&lt;')
+    .split('>')
+    .join('&gt;')
+    .split('"')
+    .join('&quot;');
+}
+
+/** Escape a value for use inside an HTML comment (dsCard marker). */
+export function escapeComment(value: string): string {
+  return value.split('--').join('––').split('\r').join(' ').split('\n').join(' ').trim();
+}
+
+export function sha256(content: string | Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/** Deterministic PRNG (mulberry32) used to replace Math.random during render. */
+export function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "dev:up": "bash scripts/dev-tools/revealui-shell.sh",
     "dev:watched": "tsx scripts/dev-tools/dev-watchdog.ts",
     "docs:generate:api": "tsx scripts/docs/generate-api.ts",
+    "gen:previews": "pnpm --filter docs gen:previews",
     "revforge:issue-license": "tsx scripts/setup/issue-revforge-license.ts",
     "format": "biome format --write .",
     "gate": "tsx scripts/gates/ci-gate.ts",


### PR DESCRIPTION
## What

Adds a **design-system preview generator** (P2 / Loop A of the design-code-sync lane): one command renders **every** public `@revealui/presentation` component to a static, self-contained preview page carrying the `@dsCard` marker that the claude.ai/design project uses to build its card index. This replaces the hand-recreated component artifacts with output derived from actual component code.

## Command

```bash
pnpm --filter docs gen:previews   # or: pnpm gen:previews (root passthrough)
```

Builds `@revealui/presentation`, then writes a gitignored `preview-dist/`:

```
preview-dist/
  manifest.json                       # sourceCommit, generatedAt, per-file sha256
  generated/
    index.html                        # @dsCard catalog linking every component
    _preview.css                      # compiled Tailwind v4 + canonical --rvui-* tokens
    components/<kebab-name>.html       # one @dsCard page per public component export
```

## How it works (extend-before-create)

- **Enumeration is derived from code**, not a hand list: the authoritative component surface is `packages/presentation/src/components/index.ts`. A component added later appears with **zero generator edits** (a default harness renders it even with no curated example).
- **Curated examples are reused from the docs-app showcase** (`app/components/showcase/registry.ts`) via one registry module. No re-authoring of ~50 example sets.
- **Overlays** that portal to `document.body` or render from client state (Dialog, Drawer, Tooltip, Toast) get a hand-composed representative snapshot built from the real exported sub-parts, since `renderToStaticMarkup` cannot capture their open state. `PricingTable` (required props, no showcase) gets a curated example too.
- **CSS** is compiled by reusing the docs app's own Tailwind v4 entry (`app/index.css` — the `@theme` token bridge + `@source` globs) through a targeted Vite build. **No new dependency, no lockfile change.**
- Each page references `../_preview.css` by relative path, styles both dark and light via an inline `[data-theme]` toggle, and loads no external resources.

## Output stats (at source commit)

- **157 components**: 50 curated (rich variants + examples), 97 default harness, 10 stub.
- Bundle ~1.58 MB across 160 files; `_preview.css` ~233 KB (321 `--rvui-` token refs).
- **Stubbed (explicitly, not dropped):** `CheckboxIndicator`, `ComboboxOption`, `DropdownButton/Item/Menu/Shortcut`, `KbdShortcut`, `ListboxOption`, `Tab`, `TabPanel` — compound sub-parts that require parent context and have no standalone static form. Their parent components (Checkbox, Combobox, Dropdown, Kbd, Listbox, Tabs) render fully.

## Verification

- `pnpm --filter docs test` — 6 vitest cases green: a file per public export, valid `@dsCard` first line on every page, `_preview.css` non-empty with tokens + used classes, manifest hashes verify, and structural section checks for Button/Card/Dialog/Table.
- **Determinism:** two runs produce a byte-identical tree (timestamps confined to `manifest.json`).
- **Biome 2.5.2** (matching CI, after a fresh `pnpm install --frozen-lockfile`): clean, exit 0. No authored regex (fleet M2).
- **Honest scope:** verified **structurally** (markup non-emptiness + expected variant/section presence + CSP-safety: the only stylesheet/script/font/image references are the relative `_preview.css` and inline `<style>`/`<script>`; remaining external strings are anchor `href`s in example content and the SVG `xmlns` namespace, neither of which loads a resource). I did **not** run headless browser screenshots.

Do not merge — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)