### PR TITLE
feat(presentation): add theme-aware canonical wordmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ revealui/
 │   ├── core/           # Runtime engine, REST API, plugins
 │   ├── db/             # Drizzle ORM schema (85 tables, NeonDB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
-│   ├── presentation/   # 60 UI components (Tailwind v4)
+│   ├── presentation/   # 61 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR
 │   ├── setup/          # Environment setup utilities
 │   ├── sync/           # ElectricSQL real-time sync

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You have:
 - **Content management:** define collections in TypeScript, get a full REST API, admin UI, and MCP tools instantly
 - **Billing:** Stripe checkout, subscriptions, trials, webhooks, grace periods, and a billing portal
 - **Admin dashboard:** manage users, content, billing, and settings out of the box
-- **60 UI components:** built with Tailwind CSS v4, zero external UI dependencies
+- **61 UI components:** built with Tailwind CSS v4, zero external UI dependencies
 - **14 MCP servers:** agents discover and use your business data through the same API humans use
 - **Type-safe throughout:** Zod schemas shared between client, server, database, and agent tools
 
@@ -168,7 +168,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | [`@revealui/contracts`](packages/contracts)             | Zod schemas + TypeScript types (single source)    |
 | [`@revealui/db`](packages/db)                           | Drizzle ORM schema (85 tables), dual-DB client     |
 | [`@revealui/auth`](packages/auth)                       | Session auth, password reset, rate limiting       |
-| [`@revealui/presentation`](packages/presentation)       | 60 UI components (Tailwind v4, zero ext deps)     |
+| [`@revealui/presentation`](packages/presentation)       | 61 UI components (Tailwind v4, zero ext deps)     |
 | [`@revealui/openapi`](packages/openapi)                 | OpenAPI route helpers and Swagger generation       |
 | [`@revealui/router`](packages/router)                   | Lightweight file-based router with SSR            |
 | [`@revealui/config`](packages/config)                   | Type-safe environment configuration               |

--- a/apps/admin/src/lib/globals/Footer/Component.tsx
+++ b/apps/admin/src/lib/globals/Footer/Component.tsx
@@ -1,3 +1,4 @@
+import { RevealUIWordmark } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { getCachedGlobal } from '@/lib/cms/getGlobals';
 import { CMSLink } from '@/lib/components/Link/index';
@@ -31,10 +32,26 @@ export async function Footer() {
   return (
     <footer className="border-t border-border bg-black dark:bg-card text-white">
       <div className="container py-8 gap-8 flex flex-col md:flex-row md:justify-between">
-        <Link className="flex items-center" href="/">
-          <picture>
-            <img alt="RevealUI Logo" className="max-w-24 invert-0" src="/revealui-logo.svg" />
-          </picture>
+        {/*
+          This footer is a fixed-dark surface regardless of page theme
+          (`bg-black` in light mode, `dark:bg-card` in dark mode - both
+          dark). Pin the wordmark's brand-ink and accent tokens to their
+          dark-theme values directly, rather than letting them inherit the
+          page's ambient [data-theme]: on a light-themed page the inherited
+          light-theme ink is a dark navy that reads as invisible against
+          this always-black surface.
+        */}
+        <Link
+          className="flex items-center"
+          href="/"
+          style={
+            {
+              '--rvui-brand-text': 'oklch(0.78 0.100 240)',
+              '--rvui-accent': 'oklch(0.80 0.165 85)',
+            } as React.CSSProperties
+          }
+        >
+          <RevealUIWordmark className="text-2xl" />
         </Link>
 
         <nav className="flex flex-col md:flex-row gap-4">

--- a/apps/admin/src/lib/globals/Header/RevealUIHeader.tsx
+++ b/apps/admin/src/lib/globals/Header/RevealUIHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import { RevealUIWordmark } from '@revealui/presentation/server';
 import { ButtonLink, PlainButtonLink } from '@/components/revealui/elements';
 import {
   NavbarLink,
@@ -37,17 +37,7 @@ export function RevealUIHeader({ header }: RevealUIHeaderProps) {
       })}
       logo={
         <NavbarLogo href="/">
-          {/* Use existing Logo component, but adapt for navbar size */}
-          <div className="flex items-center">
-            <Image
-              src="/revealui-logo.svg"
-              alt="RevealUI Logo"
-              width={113}
-              height={28}
-              className="h-7 w-auto dark:invert"
-              priority
-            />
-          </div>
+          <RevealUIWordmark className="text-2xl" />
         </NavbarLogo>
       }
       actions={

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -29,7 +29,7 @@ export const METRICS = {
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
   testFiles: 984,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
-  uiComponents: 60,
+  uiComponents: 61,
   /**
    * MCP servers in `packages/mcp/src/servers/*.ts` (excluding underscore-prefixed
    * utilities). Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon concrete

--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -86,9 +86,9 @@ const POST_METADATA: PostMeta[] = [
   },
   {
     slug: 'component-library',
-    title: '60 Components, One Dependency',
+    title: '61 Components, One Dependency',
     excerpt:
-      'A native React component library with 60 components and a single runtime dependency. No Radix, no MUI, no lock-in, just components you own.',
+      'A native React component library with 61 components and a single runtime dependency. No Radix, no MUI, no lock-in, just components you own.',
     publishedAt: '2026-06-08T12:00:00.000Z',
     author: 'RevealUI Team',
     file: '09-component-library.md',

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,7 +207,7 @@ RevealUI uses two frontend frameworks for two distinct surfaces. The choice is i
 
 ### Shared frontend layer
 
-Both surfaces share `@revealui/presentation` (60 native UI components, Tailwind v4, zero external UI deps), `@revealui/auth` (session auth), and `@revealui/contracts` (Zod schemas + types). The framework split is at the framework boundary; the component library and contracts are unified.
+Both surfaces share `@revealui/presentation` (61 native UI components, Tailwind v4, zero external UI deps), `@revealui/auth` (session auth), and `@revealui/contracts` (Zod schemas + types). The framework split is at the framework boundary; the component library and contracts are unified.
 
 For the full library + rationale, see [`guides/technology-stack.md`](./guides/technology-stack.md).
 

--- a/docs/BUILD_YOUR_BUSINESS.md
+++ b/docs/BUILD_YOUR_BUSINESS.md
@@ -158,7 +158,7 @@ tsx scripts/seed-products.ts
 
 ## 4. Add a pricing page
 
-RevealUI ships 60 UI components. Use them to build a pricing page in your frontend app.
+RevealUI ships 61 UI components. Use them to build a pricing page in your frontend app.
 
 In `apps/mainframe/src/pages/pricing.tsx`:
 
@@ -355,7 +355,7 @@ This is the foundation. The five primitives  -  People, Content, Offers, Payment
 ## Next steps
 
 - **Add more collections**  -  orders, reviews, blog posts, anything your business needs
-- **Customize the UI**  -  `packages/presentation` has 60 components to build with
+- **Customize the UI**  -  `packages/presentation` has 61 components to build with
 - **Add AI**  -  Pro tier adds AI agents; see the [AI guide](./AI.md)
 - **Invite your team**  -  role-based access control is already wired in
 

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -1541,7 +1541,7 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Component Summary by Package
 
-### @revealui/presentation (60 components)
+### @revealui/presentation (61 components)
 - 6 Primitives (Box, Flex, Grid, Text, Heading, Slot)
 - 14 Form Controls (Button, LinkButton, Input, Textarea, Select, Checkbox, Radio, etc.)
 - 8 Data Display (Card, Table, Avatar, Badge, etc.)
@@ -1569,4 +1569,4 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 ---
 
 **Last Updated:** 2026-05-02
-**Packages:** `@revealui/presentation` (60 components), `@revealui/core` (21 components)
+**Packages:** `@revealui/presentation` (61 components), `@revealui/core` (21 components)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,7 @@ Six **[design principles](./JOSHUA.md)** govern every architectural decision: Ju
 
 - [Package Reference](./REFERENCE.md): Core, contracts, DB, config, presentation, utils, router, CLI
 - [Core Stability](./CORE_STABILITY.md): API stability tiers, production verification status, version policy
-- [Component Catalog](./COMPONENT_CATALOG.md): 60 native UI components in `@revealui/presentation` (80 total with `@revealui/core` admin/richtext)
+- [Component Catalog](./COMPONENT_CATALOG.md): 61 native UI components in `@revealui/presentation` (80 total with `@revealui/core` admin/richtext)
 - [AI](./AI.md): AI package overview, prompt/response/semantic caching
 - [Pro](./PRO.md): Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services`), MCP integration, open-model inference, x402, marketplace
 - [RevFleet](./REVFLEET.md): Companion products (RevDev, RevVault, RevCon, RevForge, RevSkills) — what each does and how they compose

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -29,7 +29,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-06-22 (
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **31** | `countWorkspaces()` (= 27 packages + 4 apps) | |
 | Test files | **984** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
-| UI components in `packages/presentation/` | **60** | `countUIComponents()` | Marketing copy says "60 native React components" or similar. |
+| UI components in `packages/presentation/` | **61** | `countUIComponents()` | Marketing copy says "61 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **85** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |
 | Access-control enforcement tests | **59** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -175,7 +175,7 @@ For more → [Troubleshooting Guide](./TROUBLESHOOTING.md)
 ## Next Steps
 
 - [Full documentation](./INDEX.md)
-- [Component catalog](./COMPONENT_CATALOG.md)  -  60 native UI components in `@revealui/presentation` (80 total with `@revealui/core` admin/richtext)
+- [Component catalog](./COMPONENT_CATALOG.md)  -  61 native UI components in `@revealui/presentation` (80 total with `@revealui/core` admin/richtext)
 - [Example projects](./EXAMPLES.md)  -  blog, subscription starter, storefront
 - [Deployment guide](./guides/deployment.md)  -  Vercel + Fly, environment variables, production checklist
 - [AI agents](./AI.md)  -  agent orchestration, open-model inference, MCP framework (Pro)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -2007,7 +2007,7 @@ See `.env.template` in the repo root for the full list with descriptions.
 
 # @revealui/presentation
 
-60 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
+61 native UI components for building RevealUI apps. Zero external UI dependencies  -  only `clsx` and `cva`.
 
 ```bash
 npm install @revealui/presentation
@@ -2727,7 +2727,7 @@ Behaviour-only versions of form controls  -  bring your own styles.
 ## Related
 
 - [`@revealui/core`](/reference/core)  -  Uses `presentation` for admin UI components
-- [Component catalog](/component-catalog)  -  Visual index of all 60 components
+- [Component catalog](/component-catalog)  -  Visual index of all 61 components
 
 ---
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -22,7 +22,7 @@ Full content management engine with collections, access control, hooks, field ty
 and a REST API. The heart of RevealUI and the most mature part of the codebase.
 
 ### UI component library
-**60 native React components in `@revealui/presentation`** (80 total with `@revealui/core` admin/richtext), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
+**61 native React components in `@revealui/presentation`** (80 total with `@revealui/core` admin/richtext), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
 **85 PostgreSQL tables** with Drizzle ORM, **61 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).

--- a/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
+++ b/docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md
@@ -21,7 +21,7 @@ Brutally honest audit of what RevealUI documentation claimed versus what the cod
 
 ## Executive Summary
 
-RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 60 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
+RevealUI's core framework is **real and substantial**  -  auth, billing, runtime engine, 61 UI components, 81-table database, and an extensive test suite. The documentation is mostly accurate but has version drift, stale counts, broken internal links, and a few areas where aspirational language outpaces implementation. The biggest gaps are in examples (3 of 6 are README-only), ElectricSQL sync (basic), and Forge self-hosting (infrastructure skeletons only).
 
 ---
 
@@ -55,7 +55,7 @@ RevealUI's core framework is **real and substantial**  -  auth, billing, runtime
 |---------|----------|
 | React 19 | `react@^19.2.3` in package.json |
 | Next.js 16 | Catalog reference, App Router throughout |
-| 50+ UI components | **60 components** in presentation package |
+| 50+ UI components | **61 components** in presentation package |
 | Session-only auth (no JWT) | bcrypt-12, RBAC/ABAC, 2FA, WebAuthn, OAuth |
 | Stripe checkout/subscriptions/webhooks | 1,100-line webhook handler, 12 event types |
 | Drizzle ORM dual-DB (NeonDB + Supabase) | Schema + queries + boundary enforcement |

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -231,7 +231,7 @@ Some numbers on what's actually shipped:
 
 - **31 workspaces** across the monorepo (4 apps + 27 packages — 21 MIT, 5 Fair Source, 1 internal)
 - **85 database tables** via Drizzle ORM on NeonDB (Postgres)
-- **60 UI components** in `@revealui/presentation` — one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
+- **61 UI components** in `@revealui/presentation` — one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **14 first-party MCP servers** in `@revealui/mcp`
 - **Extensive test coverage** across unit, integration, and E2E layers (run `pnpm test` for the current count)
 - **Full OpenAPI spec** with Swagger UI at `/docs`

--- a/docs/blog/09-component-library.md
+++ b/docs/blog/09-component-library.md
@@ -1,5 +1,5 @@
 ---
-title: "60 Components, One Dependency"
+title: "61 Components, One Dependency"
 description: "*By Joshua Vaughn, RevealUI Studio*"
 visibility: public
 status: narrative
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 Open the `package.json` of a typical React app and trace the dependency tree under your UI. A component library. The headless-primitive library it sits on. An icon set. A class-merging utility. A variants helper. A few polyfills the library pulls in. Every one of those is a version you have to track, a breaking change you have to absorb on someone else's schedule, and a styling opinion you have to work around.
 
-RevealUI's UI layer, `@revealui/presentation`, has exactly one third-party runtime dependency. Not one UI framework. One npm package: `tailwind-merge`. Its design tokens come from a sibling in-house package, `@revealui/tokens`. Everything else, the 60 components and the machinery that powers them, is in the box and MIT licensed.
+RevealUI's UI layer, `@revealui/presentation`, has exactly one third-party runtime dependency. Not one UI framework. One npm package: `tailwind-merge`. Its design tokens come from a sibling in-house package, `@revealui/tokens`. Everything else, the 61 components and the machinery that powers them, is in the box and MIT licensed.
 
 This post is about why a component library should be something you own outright, and how this one is built.
 
@@ -23,7 +23,7 @@ I have done that enough times to want a different deal.
 
 ## What ships in the box
 
-`@revealui/presentation` is 60 native React components. Not wrappers around another library. Components, built directly on Tailwind v4 and React.
+`@revealui/presentation` is 61 native React components. Not wrappers around another library. Components, built directly on Tailwind v4 and React.
 
 The set is meant to cover real business software, not just a demo: `accordion`, `alert`, `avatar`, `badge`, `breadcrumb`, `callout`, `card`, `checkbox`, `code-block`, `combobox`, `dialog`, `drawer`, `divider`, `description-list`, and on through the list. Form controls, overlays, navigation, data display. The pieces you reach for on day one and the ones you need in month three.
 
@@ -84,7 +84,7 @@ That split matters for a framework. The styled components get you to a working p
 
 ## Theming is tokens, not hardcoded colors
 
-Colors are not baked into the components. They resolve through a semantic design-token layer in `tokens.css`: `bg-background`, `text-foreground`, `border-border`, `text-primary`, and so on. The tokens carry RevealUI's cobalt palette and adapt to light and dark. Retheme the whole system by changing the token values in one place; you do not touch 60 component files to change your brand color.
+Colors are not baked into the components. They resolve through a semantic design-token layer in `tokens.css`: `bg-background`, `text-foreground`, `border-border`, `text-primary`, and so on. The tokens carry RevealUI's cobalt palette and adapt to light and dark. Retheme the whole system by changing the token values in one place; you do not touch 61 component files to change your brand color.
 
 Because the tokens are semantic rather than literal, a component never says "blue." It says "primary," and the token decides what primary means in the current theme.
 

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -7,7 +7,7 @@ audience: user
 author: Joshua Vaughn
 ---
 
-Marketing numbers rot. A landing page says "60 components," the team ships three more, and now the page is wrong and nobody notices, because the page and the code live in different worlds and no one is paid to keep them in sync.
+Marketing numbers rot. A landing page says "61 components," the team ships three more, and now the page is wrong and nobody notices, because the page and the code live in different worlds and no one is paid to keep them in sync.
 
 On revealui.com, that cannot happen. Every count we publish is checked against the actual code on every push, and if a number drifts from the truth, the build fails before the change can merge. The marketing site is not allowed to lie.
 
@@ -31,7 +31,7 @@ export const METRICS = {
 } as const;
 ```
 
-A page that wants to say "60 UI components" imports `METRICS.uiComponents`. It never types `60`. Change the underlying number in one place and the copy follows automatically, on the marketing site, in the docs, and in the product roadmap, with no copy edit at all.
+A page that wants to say "61 UI components" imports `METRICS.uiComponents`. It never types `60`. Change the underlying number in one place and the copy follows automatically, on the marketing site, in the docs, and in the product roadmap, with no copy edit at all.
 
 ## The validator that does the counting
 
@@ -45,7 +45,7 @@ claim-drift: docs/blog/09-component-library.md
   -> fix the copy or fix the count, but they must agree
 ```
 
-That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 27 packages, 60 UI components, 14 first-party MCP servers, 85 database tables, 59 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 27 packages, 61 UI components, 14 first-party MCP servers, 85 database tables, 59 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
 
 ## The validator practices what we preach
 

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -48,7 +48,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 | PKG-002 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) | npm | Public |
 | PKG-003 | @revealui/db | Drizzle ORM schema (85 tables), dual-DB support | npm | Public |
 | PKG-004 | @revealui/auth | Session auth, password reset, rate limiting | npm | Public |
-| PKG-005 | @revealui/presentation | 60 native UI components (Tailwind v4) | npm | Public |
+| PKG-005 | @revealui/presentation | 61 native UI components (Tailwind v4) | npm | Public |
 | PKG-006 | @revealui/router | Lightweight file-based router with SSR | npm | Public |
 | PKG-007 | @revealui/config | Type-safe env config (Zod + lazy Proxy) | npm | Public |
 | PKG-008 | @revealui/utils | Logger, DB helpers, validation | npm | Public |

--- a/packages/presentation/src/__tests__/components/wordmark.test.tsx
+++ b/packages/presentation/src/__tests__/components/wordmark.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RevealUIWordmark } from '../../components/wordmark.js';
+
+describe('RevealUIWordmark', () => {
+  it('renders the monogram as a decorative SVG', () => {
+    const { container } = render(<RevealUIWordmark />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders "Reveal" and "UI" as separate, readable HTML text nodes', () => {
+    const { container, getByText } = render(<RevealUIWordmark />);
+    expect(getByText('Reveal')).toBeInTheDocument();
+    expect(getByText('UI')).toBeInTheDocument();
+    // The wordmark is real HTML, not SVG <text> — no <text> element should be present.
+    expect(container.querySelector('text')).toBeNull();
+  });
+
+  it('uses the brand display font stack, not Space Grotesk', () => {
+    const { getByText } = render(<RevealUIWordmark />);
+    const textWrapper = getByText('Reveal').parentElement;
+    expect(textWrapper?.style.fontFamily).toContain('Inter Tight');
+    expect(textWrapper?.style.fontFamily).not.toContain('Space Grotesk');
+  });
+
+  it('colors "Reveal" with the brand-text token and "UI" with the accent token', () => {
+    const { getByText } = render(<RevealUIWordmark />);
+    expect(getByText('Reveal').style.color).toContain('--rvui-brand-text');
+    expect(getByText('UI').style.color).toContain('--rvui-accent');
+  });
+
+  it('renders the Solar Amber outline stroke by default', () => {
+    const { container } = render(<RevealUIWordmark />);
+    const strokedGroup = container.querySelector('g[stroke]');
+    expect(strokedGroup).not.toHaveAttribute('stroke', 'none');
+  });
+
+  it('omits the outline stroke when reveal is false', () => {
+    const { container } = render(<RevealUIWordmark reveal={false} />);
+    const strokedGroup = container.querySelector('g[stroke]');
+    expect(strokedGroup).toHaveAttribute('stroke', 'none');
+  });
+
+  it('merges a custom className onto the outer wrapper', () => {
+    const { container } = render(<RevealUIWordmark className="text-4xl" />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.getAttribute('class')).toContain('text-4xl');
+  });
+});

--- a/packages/presentation/src/assets/brand/README.md
+++ b/packages/presentation/src/assets/brand/README.md
@@ -35,18 +35,42 @@ pupil shape.
 - `revealui-mark-mono.svg` — single-colour mark (`currentColor`, no amber
   stroke). In app code prefer the `RevealUIMark` React component from
   `@revealui/presentation`, which renders this same glyph.
-- `revealui-logo.svg` / `revealui-logo-dark.svg` — horizontal lockups (mark +
-  wordmark). **Not yet updated to the new emblem** — the wordmark lockup is a
-  separate, still-open decision, so these two files still carry the prior
-  glyph. Treat as known drift until that decision lands.
+- `wordmark-light.svg` / `wordmark-dark.svg` — the canonical wordmark (mark +
+  "RevealUI" lockup). Canon adopted 2026-07-11 (owner decision): the
+  design-system project's wordmark pair. Use `wordmark-light.svg` on light
+  surfaces, `wordmark-dark.svg` on dark surfaces. **Known limitation:** the
+  "RevealUI" text in these files is live SVG `<text>`, not outlined paths.
+  SVG `<text>` does not inherit the host page's fonts, so on a machine
+  without "Inter Tight" installed it silently falls back to that platform's
+  default sans-serif. There is no font-outlining tooling in this repo yet
+  (see "Regenerating" below); outlining this text into paths is a follow-up.
+  **In app code, prefer the `RevealUIWordmark` React component** from
+  `@revealui/presentation` — it renders "RevealUI" as real HTML text, which
+  reliably inherits page fonts, and it reuses `RevealUIMark`'s exact
+  monogram paths. Reach for the static files only where a file is required
+  (README badges, email templates).
+- `revealui-logo.svg` / `revealui-logo-dark.svg` — the prior horizontal
+  lockup (mark + wordmark). Superseded by `wordmark-light.svg` /
+  `wordmark-dark.svg` and `RevealUIWordmark` above. Still referenced by
+  `apps/admin` at the time of writing; retire once nothing references it.
 - `icon-maskable.svg`, `icon-192.png`, `icon-512.png` — full-bleed PWA
   maskable icon + its rasters. **Not yet updated to the new emblem** and,
   as of 2026-07-10, unreferenced by any app (no `manifest.json` /
   `site.webmanifest` wires them up). Known drift; update or remove in a
   follow-up.
 
-The wordmark in the lockups is outlined Inter Tight Bold (vector paths, no runtime
-font dependency).
+The wordmark in the `revealui-logo*.svg` lockups is outlined Inter Tight Bold
+(vector paths, no runtime font dependency). The newer `wordmark-*.svg` pair
+is not outlined yet (see above) — that's the known defect this canon carries
+forward until outlining tooling exists.
+
+Minor cross-format note: `wordmark-*.svg` preserves the design tool's
+monogram markup byte-for-byte, which draws the outline stroke at
+`stroke-width="3"`. The `RevealUIMark` component (and `revealui-mark.svg`)
+draws the same paths at `stroke-width="3.4"`. Both read as the same mark at
+normal sizes; reconciling the two stroke weights is a follow-up for the
+design tool, not something this change silently "fixed" in either
+direction.
 
 ## Per-app deployables
 

--- a/packages/presentation/src/assets/brand/wordmark-dark.svg
+++ b/packages/presentation/src/assets/brand/wordmark-dark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 470 100" fill="none">
+  <!--
+    Static file export of the RevealUI wordmark, for contexts that need a
+    plain SVG file (README badges, email templates). Use on dark surfaces.
+
+    Known limitation: the "RevealUI" text below is live SVG <text>, not
+    outlined paths. SVG <text> does not inherit the host page's fonts, so
+    when this file is loaded via <img>/favicon/email contexts on a machine
+    without "Inter Tight" installed, it silently falls back to that
+    platform's default sans-serif instead of the brand display face. There
+    is no font-outlining tooling in this repo yet; outlining this text into
+    paths (or embedding a subset font) is a documented follow-up, see
+    ../../../README.md in this directory.
+
+    Prefer the RevealUIWordmark React component from @revealui/presentation
+    wherever React is available. It renders "RevealUI" as real HTML, which
+    reliably inherits page fonts, and is the primary consumption path.
+  -->
+  <defs>
+    <linearGradient id="s" x1="24" y1="11" x2="24" y2="86" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#002a63"></stop><stop offset="1" stop-color="#003d94"></stop></linearGradient>
+    <linearGradient id="u" x1="44" y1="11" x2="44" y2="65" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#003d94"></stop><stop offset="1" stop-color="#002a63"></stop></linearGradient>
+    <linearGradient id="l" x1="30" y1="48" x2="70" y2="86" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#003d94"></stop><stop offset="1" stop-color="#eeb300"></stop></linearGradient>
+  </defs>
+  <path d="M26 50 H44 L69 86 H51 L32 61 H26 Z" fill="url(#l)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <path fill-rule="evenodd" d="M34 11 h13 a27 27 0 0 1 0 54 h-13 v-15 h12 a12 12 0 0 0 0 -24 h-12 z" fill="url(#u)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <path d="M17 11 h17 v75 h-17 z" fill="url(#s)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <text x="100" y="68" font-family="'Inter Tight', 'Inter', system-ui, sans-serif" font-weight="700" font-size="54" letter-spacing="-1" fill="#f8fafd">Reveal<tspan fill="#eeb300">UI</tspan></text>
+</svg>

--- a/packages/presentation/src/assets/brand/wordmark-light.svg
+++ b/packages/presentation/src/assets/brand/wordmark-light.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 470 100" fill="none">
+  <!--
+    Static file export of the RevealUI wordmark, for contexts that need a
+    plain SVG file (README badges, email templates). Use on light surfaces.
+
+    Known limitation: the "RevealUI" text below is live SVG <text>, not
+    outlined paths. SVG <text> does not inherit the host page's fonts, so
+    when this file is loaded via <img>/favicon/email contexts on a machine
+    without "Inter Tight" installed, it silently falls back to that
+    platform's default sans-serif instead of the brand display face. There
+    is no font-outlining tooling in this repo yet; outlining this text into
+    paths (or embedding a subset font) is a documented follow-up, see
+    ../../../README.md in this directory.
+
+    Prefer the RevealUIWordmark React component from @revealui/presentation
+    wherever React is available. It renders "RevealUI" as real HTML, which
+    reliably inherits page fonts, and is the primary consumption path.
+  -->
+  <defs>
+    <linearGradient id="s" x1="24" y1="11" x2="24" y2="86" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#002a63"></stop><stop offset="1" stop-color="#003d94"></stop></linearGradient>
+    <linearGradient id="u" x1="44" y1="11" x2="44" y2="65" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#003d94"></stop><stop offset="1" stop-color="#002a63"></stop></linearGradient>
+    <linearGradient id="l" x1="30" y1="48" x2="70" y2="86" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#003d94"></stop><stop offset="1" stop-color="#eeb300"></stop></linearGradient>
+  </defs>
+  <path d="M26 50 H44 L69 86 H51 L32 61 H26 Z" fill="url(#l)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <path fill-rule="evenodd" d="M34 11 h13 a27 27 0 0 1 0 54 h-13 v-15 h12 a12 12 0 0 0 0 -24 h-12 z" fill="url(#u)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <path d="M17 11 h17 v75 h-17 z" fill="url(#s)" stroke="#eeb300" stroke-width="3" stroke-linejoin="round"></path>
+  <text x="100" y="68" font-family="'Inter Tight', 'Inter', system-ui, sans-serif" font-weight="700" font-size="54" letter-spacing="-1" fill="#003d94">Reveal<tspan fill="#eeb300">UI</tspan></text>
+</svg>

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -174,3 +174,4 @@ export { Textarea } from './textarea-headless.js';
 export { Timeline, TimelineItem } from './timeline.js';
 export { ToastProvider, useToast } from './toast.js';
 export { Tooltip } from './tooltip.js';
+export { RevealUIWordmark, type RevealUIWordmarkProps } from './wordmark.js';

--- a/packages/presentation/src/components/wordmark.tsx
+++ b/packages/presentation/src/components/wordmark.tsx
@@ -1,0 +1,43 @@
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+import { RevealUIMark } from './brand-mark.js';
+
+export interface RevealUIWordmarkProps {
+  /** Sizing + layout utilities on the outer wrapper. Font size drives the whole lockup. */
+  className?: string;
+  /** Render the Solar Amber outline stroke on the monogram. Default `true`. */
+  reveal?: boolean;
+}
+
+/**
+ * The RevealUI wordmark — the faceted "R" monogram plus "RevealUI" set in the
+ * brand display face.
+ *
+ * The "RevealUI" text is real HTML, not SVG `<text>`: SVG text does not
+ * inherit page fonts in `<img>`/favicon contexts (it falls back to an
+ * arbitrary system font), so this is the reliable way to get the display
+ * face applied. "Reveal" tracks `--rvui-brand-text` and "UI" tracks
+ * `--rvui-accent`, both of which flip automatically between the light and
+ * dark token ladders in `@revealui/tokens` — no theme prop needed. The
+ * monogram is the same canonical paths as `RevealUIMark`; see that
+ * component and `src/assets/brand/` for the source of truth.
+ */
+export function RevealUIWordmark({
+  className,
+  reveal = true,
+}: RevealUIWordmarkProps): React.JSX.Element {
+  return (
+    <span className={cn('inline-flex items-center gap-[0.2em] text-2xl', className)}>
+      <RevealUIMark reveal={reveal} className="h-[1em] w-auto shrink-0" />
+      <span
+        className="font-extrabold tracking-tight"
+        style={{
+          fontFamily: 'var(--rvui-font-display, "Inter Tight", "Inter", system-ui, sans-serif)',
+        }}
+      >
+        <span style={{ color: 'var(--rvui-brand-text, #003d94)' }}>Reveal</span>
+        <span style={{ color: 'var(--rvui-accent, #eeb300)' }}>UI</span>
+      </span>
+    </span>
+  );
+}

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -58,6 +58,7 @@ export {
   type SplitAuthLayoutProps,
 } from './components/split-auth-layout.js';
 export { Textarea as TextareaCVA, type TextareaProps } from './components/Textarea.js';
+export { RevealUIWordmark, type RevealUIWordmarkProps } from './components/wordmark.js';
 
 // Note: Checkbox and Select CVA versions use state and are in client.ts
 


### PR DESCRIPTION
## Summary

Adopts the design project's wordmark pair as the canonical RevealUI wordmark (owner decision 2026-07-11), extending the existing brand-mark home at `packages/presentation/src/assets/brand/` (established by #1803) rather than creating a parallel one.

- Adds `RevealUIWordmark`, a React component in `@revealui/presentation` that renders the monogram (by reusing `RevealUIMark`'s exact canonical paths, byte-identical to the staged design source) plus "RevealUI" as real HTML text. "Reveal" tracks `--rvui-brand-text`, "UI" tracks `--rvui-accent`, both of which flip automatically between the light/dark token ladders in `@revealui/tokens`, no theme prop needed. This is the primary consumption path.
- Ships static `wordmark-light.svg` / `wordmark-dark.svg` in the brand asset home, monogram byte-faithful to the staged design source, for contexts that need a plain file (README badges, email templates).
- Switches `apps/admin`'s header (`RevealUIHeader.tsx`) and footer (`Footer/Component.tsx`) off the old `revealui-logo.svg` (which used a `dark:invert` CSS-filter hack that recolors brand blue/amber to the wrong hues, and a footer usage with a fixed ink color that reads poorly against the footer's always-dark surface) onto `RevealUIWordmark`.
- Bumps the `UI components: 60 → 61` claim across `docs/`, `README.md`, `CONTRIBUTING.md`, and `apps/marketing/app/content/site.ts` `METRICS.uiComponents` — required by the repo's claim-drift CI gate now that a new component is exported.

## Known defect fixed (code drives design)

The staged design files rendered "RevealUI" as live SVG `<text>` in `'Space Grotesk'`, which is off the brand canon (`'Inter Tight'` per `packages/tokens/design-context/brand-meta.json`) and does not inherit page fonts when loaded via `<img>`/favicon contexts anyway. `RevealUIWordmark` renders the text as HTML instead, which reliably inherits page fonts. The static SVG files keep the corrected font-family string but carry the same SVG-`<text>`-doesn't-inherit-fonts limitation as a documented, honest caveat (in-file comment + this PR body) — there is no font-outlining tooling in this repo currently (checked: `@shuding/opentype.js` is only a transitive dependency via `apps/server`'s OG-image route, not a committed, reusable outlining script). Outlining this text into paths is a follow-up.

## Known cross-format inconsistency (not silently reconciled)

The static `wordmark-*.svg` files preserve the design tool's monogram markup byte-for-byte per the design canon, which draws the outline stroke at `stroke-width="3"`. The `RevealUIMark` component (which `RevealUIWordmark` reuses) and `revealui-mark.svg` draw the same paths at `stroke-width="3.4"`. Both read as the same mark at normal sizes. Reconciling the two stroke weights is a follow-up for the design tool, documented in `packages/presentation/src/assets/brand/README.md`.

## Both-theme verification

Rendered `RevealUIWordmark` server-side to static markup, loaded it in a real Chromium instance (Playwright) alongside the actual `packages/tokens/src/tokens.css`, and read back `getComputedStyle` under `html[data-theme="light"]` and `html[data-theme="dark"]` (the exact mechanism `apps/admin`'s `InitTheme` uses):

- `[data-theme="light"]`: "Reveal" resolves to `oklch(0.3 0.18 244)` (dark ink) on a paper `oklch(0.985 0.005 250)` background — legible.
- `[data-theme="dark"]`: "Reveal" resolves to `oklch(0.78 0.1 240)` (light periwinkle) on a `oklch(0.16 0.03 260)` background — legible.
- "UI" resolves to the theme-appropriate amber (`oklch(0.78 0.165 85)` / `oklch(0.8 0.165 85)`) in both.

For the admin footer specifically: the footer's surface is fixed-dark regardless of page theme (`bg-black` in light mode, `dark:bg-card` in dark mode). I discovered mid-implementation that a nested `data-theme="dark"` wrapper does **not** actually reset `--rvui-*` custom properties (`tokens.css` only defines `:root` defaults and a `[data-theme="light"]` override block — there's no `[data-theme="dark"]` rule to reset a subtree back to dark under a light-themed ancestor). So `Footer/Component.tsx` pins `--rvui-brand-text` / `--rvui-accent` directly via inline style instead, with a comment explaining why. Verified via the same computed-style method under both `html[data-theme="light"]` and `html[data-theme="dark"]` ambient pages: the footer's wordmark renders identically (`oklch(0.78 0.1 240)` / `oklch(0.8 0.165 85)`) regardless of ambient theme, confirming the pin works.

## Test plan

- [x] `pnpm --filter @revealui/presentation test` — 971 passed (964 existing + 7 new for `RevealUIWordmark`)
- [x] `pnpm --filter @revealui/presentation typecheck` — clean
- [x] `pnpm turbo typecheck --filter=admin...` — presentation package builds/typechecks clean; admin's pre-existing unrelated failures (missing `dist/` for `@revealui/services` and `@revealui/ai`, Pro/FSL packages, in this fresh worktree) are untouched by this diff — zero errors reference `RevealUIHeader.tsx`, `Footer/Component.tsx`, or the new `wordmark.tsx`/`wordmark.test.tsx`
- [x] `pnpm exec biome check` on all touched files with the workspace's pinned 2.5.2 binary after a fresh `pnpm install --frozen-lockfile`
- [x] Full `pnpm gate` phase 1 (changed-only) — all 24 checks pass, including the claim-drift hard-fail this PR had to fix
- [x] Both-theme visual + computed-style verification (see above)

## Follow-ups (not done here, flagged for the owner)

- `apps/admin/public/revealui-logo.svg` is now unreferenced anywhere in the repo (confirmed via repo-wide grep) — retirable, but left in place per instruction not to delete files the owner may still reference.
- `packages/presentation/src/assets/brand/revealui-logo.svg` / `revealui-logo-dark.svg` are superseded by `wordmark-light.svg` / `wordmark-dark.svg` — noted in the brand README as superseded, not deleted.
- Font-outlining the `wordmark-*.svg` static files into paths (no in-repo tooling yet).
- Reconciling the `stroke-width="3"` (design tool) vs `stroke-width="3.4"` (current canonical `RevealUIMark`) monogram stroke weight.
- `icon-maskable.svg` / PWA raster set is still unreferenced/pre-#1803 drift, out of scope here (pre-existing, noted in the brand README before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
