### PR TITLE
feat(server): read-only write-gate for lapsed perpetual support (GAP-310)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -64,6 +64,7 @@ import { errorHandler } from './middleware/error.js';
 import {
   checkLicenseStatus,
   checkSupportExpiry,
+  enforceReadOnlyWrites,
   requireAIAccess,
   requireDomain,
   requireFeature,
@@ -709,6 +710,14 @@ app.use('/api/v1/*', supportExpiryCheck);
 app.use('/a2a/*', entitlementMiddleware());
 app.use('/a2a/*', licenseStatusCheck);
 app.use('/a2a/*', supportExpiryCheck);
+
+// GAP-310: block writes for lapsed-perpetual (read-only) licenses. Runs after
+// checkSupportExpiry (which sets the read-only signal) and before the feature
+// gates + route handlers. Governed by LICENSE_READ_ONLY_ENFORCE
+// (off default / shadow / enforce); inert unless a license is in read-only mode.
+app.use('/api/*', enforceReadOnlyWrites());
+app.use('/api/v1/*', enforceReadOnlyWrites());
+app.use('/a2a/*', enforceReadOnlyWrites());
 
 // License enforcement  -  gate premium routes by feature
 // Agent stream + tasks: free tier allowed with local inference, Pro+ for cloud providers

--- a/apps/server/src/middleware/__tests__/support-expiry.test.ts
+++ b/apps/server/src/middleware/__tests__/support-expiry.test.ts
@@ -15,6 +15,11 @@ vi.mock('@revealui/core/license', () => ({
 vi.mock('@revealui/core/features', () => ({
   isFeatureEnabled: vi.fn(() => true),
   getRequiredTier: vi.fn(() => 'pro'),
+  // Non-free tiers get real features; free is empty. Lets the read-only tests
+  // assert that a lapsed license retains (or loses) features per mode.
+  getFeaturesForTier: vi.fn((tier: string) =>
+    tier === 'free' ? {} : { ai: true, dashboard: true, analytics: true },
+  ),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
@@ -22,7 +27,8 @@ vi.mock('@revealui/core/observability/logger', () => ({
 }));
 
 import { getLicensePayload } from '@revealui/core/license';
-import { checkSupportExpiry, resetSupportExpiryCache } from '../license.js';
+import { logger } from '@revealui/core/observability/logger';
+import { checkSupportExpiry, enforceReadOnlyWrites, resetSupportExpiryCache } from '../license.js';
 
 const mockedGetLicensePayload = vi.mocked(getLicensePayload);
 
@@ -66,6 +72,8 @@ function createApp(
 
 afterEach(() => {
   resetSupportExpiryCache();
+  delete process.env.LICENSE_READ_ONLY_ENFORCE;
+  vi.mocked(logger.info).mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -252,5 +260,129 @@ describe('checkSupportExpiry', () => {
     // Should query again
     await app.request('/resource');
     expect(queryFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read-only write gate (GAP-310)
+// ---------------------------------------------------------------------------
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A perpetual license whose support lapsed 60 days ago (past the 30-day grace). */
+function lapsedPerpetual() {
+  mockedGetLicensePayload.mockReturnValue({
+    tier: 'pro',
+    customerId: 'cus_lapsed',
+    perpetual: true,
+  });
+  return vi
+    .fn()
+    .mockResolvedValue({ supportExpiresAt: new Date(Date.now() - 60 * DAY_MS), perpetual: true });
+}
+
+/** Mount entitlements → checkSupportExpiry → enforceReadOnlyWrites → echo handler. */
+function createGateApp(queryFn: QueryFn) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('entitlements', { accountId: 'acc_1', tier: 'pro', features: { ai: true } });
+    await next();
+  });
+  // biome-ignore lint/suspicious/noExplicitAny: test helper  -  middleware type is flexible
+  app.use('*', checkSupportExpiry(queryFn) as any);
+  // biome-ignore lint/suspicious/noExplicitAny: test helper  -  middleware type is flexible
+  app.use('*', enforceReadOnlyWrites() as any);
+  app.all('*', (c) => c.json({ ok: true, entitlements: c.get('entitlements') }));
+  return app;
+}
+
+describe('enforceReadOnlyWrites (GAP-310)', () => {
+  it('enforce: a lapsed perpetual retains its tier + features for reads', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'enforce';
+    const app = createGateApp(lapsedPerpetual());
+
+    const res = await app.request('/api/admin/resource'); // GET = read
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      entitlements: { tier: string; features: object; readOnly?: boolean };
+    };
+    expect(body.entitlements.tier).toBe('pro');
+    expect(Object.keys(body.entitlements.features).length).toBeGreaterThan(0);
+    expect(body.entitlements.readOnly).toBe(true);
+  });
+
+  it('enforce: a write on a non-exempt route is blocked with 403 + read-only header', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'enforce';
+    const app = createGateApp(lapsedPerpetual());
+
+    const res = await app.request('/api/admin/resource', { method: 'POST' });
+    expect(res.status).toBe(403);
+    expect(res.headers.get('X-License-Mode')).toBe('read-only');
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('support_expired_read_only');
+  });
+
+  it('enforce: renewal, auth, license-verify, and webhook writes stay reachable (no lockout)', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'enforce';
+    const app = createGateApp(lapsedPerpetual());
+
+    for (const path of [
+      '/api/billing/checkout-support-renewal',
+      '/api/auth/signin',
+      '/api/license/verify',
+      '/api/webhooks/stripe',
+    ]) {
+      const res = await app.request(path, { method: 'POST' });
+      expect(res.status, `${path} must be exempt`).toBe(200);
+    }
+  });
+
+  it('enforce: /a2a task dispatch (POST) is blocked while result polling (GET) is allowed', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'enforce';
+    const app = createGateApp(lapsedPerpetual());
+
+    const dispatch = await app.request('/a2a/tasks', { method: 'POST' });
+    expect(dispatch.status).toBe(403);
+
+    const poll = await app.request('/a2a/tasks/abc123'); // GET = read
+    expect(poll.status).toBe(200);
+  });
+
+  it('shadow: a would-be-blocked write proceeds but is logged, and the tier stays downgraded', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'shadow';
+    const app = createGateApp(lapsedPerpetual());
+
+    const res = await app.request('/api/admin/resource', { method: 'POST' });
+    expect(res.status).toBe(200); // shadow blocks nothing
+    expect(vi.mocked(logger.info)).toHaveBeenCalled();
+    const body = (await res.json()) as { entitlements: { tier: string } };
+    expect(body.entitlements.tier).toBe('free'); // no loosening in shadow
+  });
+
+  it('off (default): identical to pre-GAP-310 — write allowed, tier downgraded, nothing logged', async () => {
+    // LICENSE_READ_ONLY_ENFORCE unset → off
+    const app = createGateApp(lapsedPerpetual());
+
+    const res = await app.request('/api/admin/resource', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entitlements: { tier: string; readOnly?: boolean } };
+    expect(body.entitlements.tier).toBe('free');
+    expect(body.entitlements.readOnly).toBeUndefined();
+    expect(vi.mocked(logger.info)).not.toHaveBeenCalled();
+  });
+
+  it('enforce: a within-grace perpetual is unaffected — writes allowed, no read-only signal', async () => {
+    process.env.LICENSE_READ_ONLY_ENFORCE = 'enforce';
+    mockedGetLicensePayload.mockReturnValue({
+      tier: 'pro',
+      customerId: 'cus_grace',
+      perpetual: true,
+    });
+    const queryFn = vi
+      .fn()
+      .mockResolvedValue({ supportExpiresAt: new Date(Date.now() - 10 * DAY_MS), perpetual: true });
+    const app = createGateApp(queryFn);
+
+    const res = await app.request('/api/admin/resource', { method: 'POST' });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/server/src/middleware/license.ts
+++ b/apps/server/src/middleware/license.ts
@@ -5,7 +5,12 @@
  * Uses the cached license state from @revealui/core  -  no DB call per request.
  */
 
-import { type FeatureFlags, getRequiredTier, isFeatureEnabled } from '@revealui/core/features';
+import {
+  type FeatureFlags,
+  getFeaturesForTier,
+  getRequiredTier,
+  isFeatureEnabled,
+} from '@revealui/core/features';
 import {
   getCurrentTier,
   getGraceConfig,
@@ -14,6 +19,7 @@ import {
   hostMatchesLicensedDomains,
   type LicenseTier,
 } from '@revealui/core/license';
+import { logger } from '@revealui/core/observability/logger';
 import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -86,7 +92,106 @@ type RequestEntitlements = {
   graceUntil?: Date | null;
   tier?: LicenseTier;
   features?: Partial<Record<keyof FeatureFlags, boolean>>;
+  /**
+   * True when the license is in read-only mode (perpetual support lapsed past
+   * grace): the purchased tier + features are retained for reads, but writes
+   * are blocked by {@link enforceReadOnlyWrites}. GAP-310.
+   */
+  readOnly?: boolean;
 };
+
+// ---------------------------------------------------------------------------
+// Read-only enforcement for lapsed perpetual support (GAP-310)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only enforcement mode, from `LICENSE_READ_ONLY_ENFORCE`:
+ *   - `off` (default): inert — the historical free-tier downgrade is preserved
+ *     and nothing is blocked. Behavior is byte-identical to pre-GAP-310.
+ *   - `shadow`: the tier stays downgraded (no loosening) and the write-gate LOGS
+ *     what it would block without blocking — used to confirm the exempt set is
+ *     complete before enforcing.
+ *   - `enforce`: the purchased tier is retained for reads AND writes are blocked.
+ *     Both halves land together (the gap invariant: restoring the tier without
+ *     the write-block would be a strict loosening).
+ */
+export type ReadOnlyMode = 'off' | 'shadow' | 'enforce';
+
+/** Context key carrying the read-only signal from checkSupportExpiry to the gate. */
+type ReadOnlyPending = { tier: LicenseTier; mode: ReadOnlyMode };
+
+function getReadOnlyEnforcementMode(): ReadOnlyMode {
+  const value = process.env.LICENSE_READ_ONLY_ENFORCE;
+  if (value === 'enforce') return 'enforce';
+  if (value === 'shadow') return 'shadow';
+  return 'off';
+}
+
+/**
+ * Paths always allowed even for a read-only (lapsed-support) license, matched by
+ * prefix (zero authored regex per the fleet no-regex rule). This is the
+ * load-bearing safety surface of the gate: a miss either locks the customer out
+ * (can't renew or sign in) or leaks a write, so entries err toward the clearly
+ * safe read/escape routes.
+ */
+const READ_ONLY_EXEMPT: readonly string[] = [
+  // The renewal escape hatch — a lapsed customer MUST be able to buy back support.
+  '/api/billing/checkout-support-renewal',
+  '/api/v1/billing/checkout-support-renewal',
+  // Auth / session — must be able to sign in to reach anything at all.
+  '/api/auth/',
+  '/api/v1/auth/',
+  '/api/studio-auth/',
+  '/api/v1/studio-auth/',
+  '/api/terminal-auth/',
+  '/api/v1/terminal-auth/',
+  // License verify/features are reads despite arriving as POST; machines re-check.
+  '/api/license/verify',
+  '/api/v1/license/verify',
+  '/api/license/features',
+  '/api/v1/license/features',
+  // Machine webhooks (Stripe etc.). Renewal settles here — never block a machine write.
+  '/api/webhooks/',
+  '/api/v1/webhooks/',
+  // Safe diagnostics.
+  '/api/pricing',
+  '/api/v1/pricing',
+  '/health',
+];
+
+/**
+ * Explicit read/write overrides for the few routes the HTTP-method baseline gets
+ * wrong (reads-over-POST, GETs with side effects, `/a2a` semantics). Keyed by
+ * path prefix, first match wins, and evaluated BEFORE the method baseline so an
+ * override can actually override it. Starts empty on purpose — shadow-mode
+ * logging surfaces real misclassifications, which then earn an explicit entry
+ * (the design's "grows only when a real false-classification is found").
+ */
+const READ_ONLY_OVERRIDES: ReadonlyArray<{ prefix: string; kind: 'read' | 'write' }> = [];
+
+const WRITE_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function isReadOnlyExempt(path: string): boolean {
+  for (const prefix of READ_ONLY_EXEMPT) {
+    if (path === prefix || path.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Classify a request as `read` or `write` for read-only enforcement.
+ * Order: explicit override → HTTP-method baseline. (Exempt paths are handled by
+ * the caller before this runs.) The override precedes the method baseline so it
+ * can correct method-baseline mistakes; `/a2a` task dispatch is a POST (already a
+ * write) and result polling is a GET (already a read), so the baseline covers
+ * both until a real exception is observed.
+ */
+function classifyReadOnlyRequest(method: string, path: string): 'read' | 'write' {
+  for (const override of READ_ONLY_OVERRIDES) {
+    if (path === override.prefix || path.startsWith(override.prefix)) return override.kind;
+  }
+  return WRITE_METHODS.has(method.toUpperCase()) ? 'write' : 'read';
+}
 
 type FeatureGateMode = 'hybrid' | 'entitlements';
 type FeatureGateOptions = {
@@ -482,17 +587,35 @@ export const checkSupportExpiry = (
         c.header('X-Support-Status', 'grace');
         c.header('X-Support-Grace-Remaining', String(graceRemainingDays));
       } else {
-        // Grace exhausted — read-only mode.
-        // The perpetual license keeps basic admin read access,
-        // but writes and premium features are blocked.
+        // Grace exhausted — read-only mode (GAP-310). In `enforce`, retain the
+        // purchased tier for reads and mark `readOnly` so the write-gate blocks
+        // writes (both halves land together). In `off`/`shadow`, preserve the
+        // historical free-tier downgrade so nothing loosens before enforcement.
+        const mode = getReadOnlyEnforcementMode();
         const requestEntitlements = getRequestEntitlements(c);
         if (requestEntitlements) {
-          c.set('entitlements', {
-            ...requestEntitlements,
-            tier: 'free' as const,
-            features: {},
-            subscriptionStatus: 'support_expired',
-          });
+          if (mode === 'enforce') {
+            c.set('entitlements', {
+              ...requestEntitlements,
+              tier: payload.tier,
+              features: getFeaturesForTier(payload.tier),
+              subscriptionStatus: 'support_expired',
+              readOnly: true,
+            });
+          } else {
+            c.set('entitlements', {
+              ...requestEntitlements,
+              tier: 'free' as const,
+              features: {},
+              subscriptionStatus: 'support_expired',
+            });
+          }
+        }
+
+        // Hand the write-gate its signal. Skipped in `off` so that mode stays a
+        // true no-op; set in `shadow` so the gate can log would-be blocks.
+        if (mode !== 'off') {
+          c.set('readOnlyPending', { tier: payload.tier, mode } satisfies ReadOnlyPending);
         }
 
         c.header('X-Support-Status', 'expired');
@@ -501,6 +624,66 @@ export const checkSupportExpiry = (
     }
 
     await next();
+  };
+};
+
+/**
+ * Write-gate for lapsed-perpetual-support (read-only) licenses — GAP-310.
+ *
+ * Consumes the `readOnlyPending` signal set by {@link checkSupportExpiry}. Mount
+ * AFTER checkSupportExpiry (which sets the signal) and BEFORE the feature gates
+ * and route handlers, on the same path prefixes checkSupportExpiry covers.
+ *
+ * Behavior by mode (see {@link ReadOnlyMode}):
+ *   - `off`: no signal is set, so this is a pass-through.
+ *   - `shadow`: logs what it WOULD block; blocks nothing.
+ *   - `enforce`: blocks non-exempt writes with 403; reads and exempt writes pass.
+ *
+ * The tier-restore half lives in checkSupportExpiry and is gated on the SAME
+ * mode, so the tier is only restored when writes are actually blocked (both
+ * halves together — the gap invariant).
+ */
+export const enforceReadOnlyWrites = (): MiddlewareHandler => {
+  return async (c, next) => {
+    const pending = c.get('readOnlyPending') as ReadOnlyPending | undefined;
+    if (!pending || pending.mode === 'off') {
+      await next();
+      return;
+    }
+
+    const path = c.req.path;
+    const method = c.req.method;
+
+    // Reads and exempt routes always pass, in every mode.
+    if (isReadOnlyExempt(path) || classifyReadOnlyRequest(method, path) === 'read') {
+      await next();
+      return;
+    }
+
+    // A write on a non-exempt route by a read-only (lapsed-support) license.
+    if (pending.mode === 'shadow') {
+      logger.info('license.read-only would block write (shadow mode)', {
+        path,
+        method,
+        tier: pending.tier,
+      });
+      await next();
+      return;
+    }
+
+    // enforce: block the write with an actionable, honest message.
+    c.header('X-License-Mode', 'read-only');
+    c.header('X-Support-Status', 'expired');
+    return c.json(
+      {
+        error: 'support_expired_read_only',
+        message:
+          'Your license is active and your tier is retained for reads, but support has lapsed so writes are blocked. Renew support to restore write access.',
+        renewUrl: PRICING_URL,
+        supportEmail: SUPPORT_EMAIL,
+      },
+      403,
+    );
   };
 };
 


### PR DESCRIPTION
## What

Implements read-only enforcement for a lapsed-perpetual-support license (GAP-310): retain the purchased tier for **reads**, block **writes**, with a precise, fail-safe write classifier and a staged rollout flag.

## The defect (grounded on `test` @ 1811154b0)

`apps/server/src/middleware/license.ts`, on grace exhaustion, set `tier: 'free', features: {}` while emitting `X-License-Mode: read-only`. The header lied about the entitlements; downstream feature gates don't distinguish read from write, so an empty `features` map blocked the customer's own **reads**. That contradicts the core `LicenseMode` contract (`packages/core/src/license.ts`), where `read-only` retains the tier and blocks only writes.

## The fix

- **`checkSupportExpiry`** now, on grace exhaustion in `enforce` mode, retains `payload.tier` + `getFeaturesForTier(tier)` and sets `readOnly: true`; in `off`/`shadow` it preserves the historical free-tier downgrade. The tier is restored **only when writes are actually blocked** — both halves land together (the gap invariant; restoring the tier alone would be a strict loosening).
- **`enforceReadOnlyWrites`** — a new gate mounted after `checkSupportExpiry` and before the feature gates on `/api/*`, `/api/v1/*`, `/a2a/*`. Classifies via **exempt-set → route-override → HTTP-method baseline** (zero authored regex), and in `enforce` rejects a non-exempt write with `403` + an actionable renew message.
- **Exempt set** (the load-bearing safety piece): renewal checkout, auth/session, license verify/features, Stripe webhooks, pricing/health. A miss here is a lockout (can't renew) or a leak, so it errs toward the clearly-safe read/escape routes.
- **`LICENSE_READ_ONLY_ENFORCE`** gates the whole behavior: `off` (default — **byte-identical to today**) / `shadow` (logs would-be blocks, no loosening) / `enforce`.

## Design decisions (departures from the spec, both deliberate)

The design spec is `.jv docs/gap-specs/GAP-310-write-classification-design.md`. Two points were corrected during the adversarial read:

1. **Shadow vs. the no-loosening invariant.** The spec (§3.5) made tier-restore unconditional with only the write-*block* flagged — which at runtime loosens access during the shadow window (the gap forbids this). Resolved owner-side: **gate both halves** on the same flag, so shadow observes without loosening and enforce restores+blocks atomically. Customer-facing honesty is already covered by the #1797 validate route.
2. **Classifier ordering.** The spec (§3.2) ordered exempt → method → override, but an override can't override a method baseline that matched first. Implemented as exempt → **override → method**.

## Rollout

`enforce` is an **owner-gated** flip. This PR ships `off` by default; recommended path is shadow → confirm the exempt log is clean → enforce.

## Tests (red-first)

7 new cases in `support-expiry.test.ts`: reads retain tier+features, writes → 403, exempt escape hatches reachable, `/a2a` dispatch(POST)=block vs poll(GET)=allow, shadow logs without loosening, `off` is inert, within-grace unaffected. **Proven red** by removing the gate: exactly the 7 new tests fail, the 9 pre-existing pass. `tsc --noEmit` and Biome clean.

## Merge gate

Licensing surface — **guardrail-2 requires a recorded non-author verdict before merge** (`sec-review:approved` label). GAP-308 (validate route) is already done (#1797); GAP-310 closes when `enforce` ships.
