### PR TITLE
feat(docs): declutter the docs landing page to one primary path

### DIFF
--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -10,7 +10,7 @@ export function DocsIndexPage() {
 
   const content = `# RevealUI Documentation
 
-Agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.
+Agentic business runtime. Users, content, products, payments, and AI come pre-wired, open source, and ready to deploy.
 
 ## Quick Start
 
@@ -24,67 +24,15 @@ pnpm dev
 
 Open [http://localhost:4000/admin](http://localhost:4000/admin) to see the admin dashboard.
 
-See the [Quick Start guide](/quick-start) for the full walkthrough, or browse the [Examples](/examples) for complete project starters.
+[**Read the Quick Start guide**](/quick-start) for the full walkthrough.
 
----
+## Next steps
 
-## Documentation Sections
+- [Build Your Business](/build-your-business) walks the whole path from scaffold to deploy.
+- [Examples](/examples) are complete starters: a blog, a subscription app, and a storefront.
+- [REST API](/api/rest-api) is the OpenAPI reference for every endpoint.
 
-### Getting Started
-- [Quick Start](/quick-start)  -  Get a local dev stack running
-- [Build Your Business](/build-your-business)  -  End-to-end tutorial: scaffold to deploy
-- [Examples](/examples)  -  Blog, subscription starter, e-commerce storefront
-
-### Core Guides
-- [Admin Guide](/admin-guide)  -  Collections, fields, access control, rich text
-- [Authentication](/auth)  -  Session-based auth, sign in/up, rate limiting
-- [Database](/database)  -  Drizzle ORM, migrations, type-safe queries
-- [CI/CD & Deployment](/ci-cd-guide)  -  Deploy to Vercel, Railway, or self-host
-- [Environment Variables](/environment-variables-guide)  -  All env var reference
-- [Testing](/testing)  -  Unit, integration, and E2E testing patterns
-
-### Architecture
-- [System Architecture](/architecture)  -  Monorepo structure, dual-DB design, patterns
-- [Performance](/performance)  -  Optimization, caching, CDN strategies
-- [Standards](/standards)  -  Code style, conventions, contribution guidelines
-
-### Reference
-- [Package Reference](/reference)  -  All packages: core, auth, db, contracts, presentation, router, CLI
-- [REST API](/api/rest-api)  -  OpenAPI reference for all endpoints
-- [Component Catalog](/component-catalog)  -  Pre-wired UI components
-- [AI](/ai)  -  AI agents, prompt/response/semantic caching
-- [Marketplace](/marketplace)  -  Extensibility and integrations
-
-### Pro & Enterprise
-- [Pro documentation](/pro)  -  MCP servers, open-model inference, editor integrations
-- [Enterprise](/forge)  -  Unlimited sites, users, and AI tasks
-- [Local-First Setup](/local-first)  -  Inference Snaps + RevVault + Nix: run the full stack on your own hardware
-
-### Blog
-- [Why We Built RevealUI](/blog/01-why-we-built-revealui)  -  The problem we're solving
-- [HTTP 402 Payments](/blog/02-http-402-payments)  -  Native payment-required protocol
-- [Multi-Agent Coordination](/blog/03-multi-agent-coordination)  -  AI agents working together
-- [The Air-Gap Capable Stack](/blog/04-local-first-ai-stack)  -  Local AI, encrypted secrets, reproducible environments
-- [The Five Primitives](/blog/05-five-primitives)  -  Users, content, products, payments, AI
-- [Open Source & Pro](/blog/06-open-source-and-pro)  -  Our monetization philosophy
-- [Agent-First Future](/blog/07-agent-first-future)  -  Building for the agent economy
-- [Getting Started in About 30 Minutes](/blog/08-getting-started)  -  From zero to deployed
-- [60 Components, One Dependency](/blog/09-component-library)  -  The UI layer you own
-- [Your Database, Your Storage, Your Sync](/blog/10-own-your-data)  -  Standard Postgres, S3 storage, built-in sync
-
----
-
-## Ready to ship?
-
-RevealUI ships as code you run — and as a hosted product you can sign up for in minutes.
-
-[**Start free**](https://admin.revealui.com/signup) · [See pricing](https://revealui.com/pricing)
-
----
-
-## Contributing
-
-Found an issue or want to improve the docs? See our [Contributing Guide](https://github.com/RevealUIStudio/revealui/blob/main/CONTRIBUTING.md).
+Everything else lives in the sidebar. Found a gap in these docs? See the [Contributing Guide](https://github.com/RevealUIStudio/revealui/blob/main/CONTRIBUTING.md).
 `;
 
   return <div>{renderMarkdown(content)}</div>;


### PR DESCRIPTION
## What

Declutters the docs site landing page (`apps/docs`, docs.revealui.com) to the ratified design direction: the calmest page in the room, one primary CTA per viewport, no competing CTA stacks, lead with what an owner-operator needs first.

The landing page reprinted the entire left-hand sidebar navigation in its body (a six-subsection "Documentation Sections" list, plus all ten blog posts) and closed with a two-button marketing CTA stack. The sidebar (`DocLayout`) is present on every page and already carries the full doc tree, so the in-body copy was pure duplication crowding a surface whose one job is getting a reader running.

## Keep / link / remove decisions

| Section (before) | Decision | Reason |
|---|---|---|
| H1 + intro tagline | Keep | On-canon door-opener; only the dash artifact was cleaned |
| Quick Start (install block + localhost line) | Keep | The get-running action, the primary job of a docs landing |
| "See the Quick Start guide / Examples" line | Keep, promote to one primary CTA | Becomes the single bold CTA (Read the Quick Start guide) |
| Documentation Sections → Getting Started | Remove | Duplicates the persistent sidebar's Getting Started section |
| Documentation Sections → Core Guides | Remove | Duplicates the sidebar's Core Guides section |
| Documentation Sections → Architecture | Remove | Duplicates the sidebar's Architecture section |
| Documentation Sections → Reference | Link out (curated) | Sidebar carries the full list; REST API kept as a next-step link |
| Documentation Sections → Pro & Enterprise | Remove | Duplicates the sidebar's Pro & Enterprise section |
| Documentation Sections → Blog (10 posts) | Remove | The full blog list lives in the sidebar's Blog section |
| "Ready to ship?" + Start free / See pricing CTAs | Remove | Competing CTA stack; marketing-funnel signup belongs on the marketing site, already linked from the sidebar footer |
| Contributing block | Merge | Folded into a single closing line |
| Next steps (Build Your Business, Examples, REST API) | Add-by-merge | The three owner-operator essentials, curated from the removed list into one short block |

The persistent sidebar (`app/components/DocLayout.tsx` via `app/lib/nav.ts`) is the full navigation and is unchanged, so removed links are not lost, only de-duplicated.

## Before / after

| | Sections (body blocks) | Primary CTAs |
|---|---|---|
| Before | 5 (Lead, Quick Start, Documentation Sections w/ 6 subsections, Ready to ship, Contributing) | 2 (Start free, See pricing) |
| After | 3 (Lead, Quick Start, Next steps) | 1 (Read the Quick Start guide) |

Diff: 1 file, +7 / -59.

## Copy changed (before → after)

- Intro: `Agentic business runtime. Users, content, products, payments, and AI  -  pre-wired, open source, and ready to deploy.` → `Agentic business runtime. Users, content, products, payments, and AI come pre-wired, open source, and ready to deploy.` (removed the dash artifact; reads aloud clean)
- Quick Start closing line: `See the [Quick Start guide](/quick-start) for the full walkthrough, or browse the [Examples](/examples) for complete project starters.` → `[**Read the Quick Start guide**](/quick-start) for the full walkthrough.` (single primary CTA)
- New Next steps block (three links lifted verbatim in intent from the removed Documentation Sections list): Build Your Business, Examples, REST API reference.
- Contributing: kept the same Contributing Guide link, folded into one closing sentence.

No new positioning was authored; no new sections, components, or dependencies were added. Reuses the existing markdown renderer; no local UI components introduced.

## Build / test

- `pnpm install --frozen-lockfile --prefer-offline` clean
- `pnpm exec turbo build --filter=docs` PASS (13/13 tasks)
- `pnpm --filter docs test` PASS (170/170 tests, 17 files)
- Biome clean on the touched file

Screenshots are pending owner sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
