### PR TITLE
feat(admin): group dashboard tiles into operate-first hierarchy

### DIFF
--- a/apps/admin/src/lib/components/BeforeDashboard/index.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/index.tsx
@@ -3,17 +3,31 @@ import { SITE_NAME } from '@/lib/utils/siteBranding';
 import PoweredByRevealUI from '../PoweredByRevealUI/index';
 import OnboardingChecklist from './OnboardingChecklist';
 
-const adminLinks = [
+interface NavLink {
+  href: string;
+  label: string;
+  description: string;
+}
+
+const operateLinks: NavLink[] = [
   {
     href: '/agents',
     label: 'Agents',
-    description: 'A2A agent cards and MCP server integrations',
+    description: 'Manage the agents that run your business and the tools they can use.',
   },
   {
     href: '/agent-tasks',
     label: 'Agent Tasks',
-    description: 'Task execution history across all AI agents',
+    description: 'See every action your agents have taken, one task record at a time.',
   },
+  {
+    href: '/audit',
+    label: 'Audit Trail',
+    description: 'Check the receipt for every action taken on your infrastructure.',
+  },
+];
+
+const systemLinks: NavLink[] = [
   {
     href: '/monitoring',
     label: 'Monitoring',
@@ -30,11 +44,6 @@ const adminLinks = [
     description: 'Error tracking and diagnostics',
   },
   {
-    href: '/audit',
-    label: 'Audit Trail',
-    description: 'Security and compliance audit log',
-  },
-  {
     href: '/webhooks',
     label: 'Webhooks',
     description: 'Webhook deliveries and event status',
@@ -46,6 +55,20 @@ const adminLinks = [
   },
 ];
 
+const NavTile = ({ href, label, description, muted }: NavLink & { muted?: boolean }) => (
+  <Link
+    href={href}
+    className={
+      muted
+        ? 'rounded-lg border border-zinc-800 bg-zinc-800/40 p-4 transition-colors hover:border-zinc-600 hover:bg-zinc-800'
+        : 'rounded-lg border border-zinc-700 bg-zinc-800 p-4 transition-colors hover:border-zinc-500 hover:bg-zinc-750'
+    }
+  >
+    <p className={`text-sm font-medium ${muted ? 'text-zinc-300' : 'text-white'}`}>{label}</p>
+    <p className="mt-0.5 text-xs text-zinc-400">{description}</p>
+  </Link>
+);
+
 const BeforeDashboard = () => {
   return (
     <div className="relative mx-auto w-full rounded-lg bg-zinc-900 p-8 shadow-md">
@@ -53,18 +76,27 @@ const BeforeDashboard = () => {
 
       <OnboardingChecklist />
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {adminLinks.map(({ href, label, description }) => (
-          <Link
-            key={href}
-            href={href}
-            className="rounded-lg border border-zinc-700 bg-zinc-800 p-4 transition-colors hover:border-zinc-500 hover:bg-zinc-750"
-          >
-            <p className="text-sm font-medium text-white">{label}</p>
-            <p className="mt-0.5 text-xs text-zinc-400">{description}</p>
-          </Link>
-        ))}
-      </div>
+      <section className="mb-6">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-300">
+          Operate
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {operateLinks.map((link) => (
+            <NavTile key={link.href} {...link} />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+          Diagnostics and configuration
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {systemLinks.map((link) => (
+            <NavTile key={link.href} {...link} muted />
+          ))}
+        </div>
+      </section>
 
       <PoweredByRevealUI />
     </div>


### PR DESCRIPTION
## What

Curate the admin dashboard's onboarding navigation into a clear hierarchy. The `BeforeDashboard` component rendered **eight co-equal ops tiles** in a flat grid directly below the agent-first onboarding checklist. A first-session owner-operator got no sense of where to start, and the agent-and-receipts framing the checklist establishes was immediately contradicted by an undifferentiated wall of equal tiles.

This groups the same eight destinations into two weighted groups. No destination is added, removed, or renamed.

## Before / after tile structure

**Before** (one flat grid, 8 equal tiles):

```
Agents · Agent Tasks · Monitoring · Logs · Errors · Audit Trail · Webhooks · Settings
```

**After** (two groups, primary leads):

```
Operate                         (primary, full-brightness tiles)
  Agents · Agent Tasks · Audit Trail

Diagnostics and configuration   (secondary, quieter tiles + dimmer heading)
  Monitoring · Logs · Errors · Webhooks · Settings
```

## Grouping rationale

The primary **Operate** group is the agents-and-receipts story the onboarding checklist already tells: run an agent (Agents), see what it did (Agent Tasks), and check the record of every action (Audit Trail). It leads the page with full-brightness tiles and a present-weight heading.

The **Diagnostics and configuration** group holds the tiles a first-session operator does not need first: system monitoring, logs, error tracking, webhooks, and settings. It sits second under a quieter heading with a more muted tile treatment, so it reads as available-when-needed rather than as a competing top-level frame.

This is the third and final surface of the onboarding coherence pass, following the checklist rewrite and the welcome-page CTA reordering. It reuses the existing `Link` + Tailwind tile pattern already in the file; no new components or nav machinery.

## Copy changed

Only the three **Operate** tiles were rewritten, into full-clause read-aloud copy that reinforces the agents-and-receipts narrative. The five demoted tiles keep their terse operational labels, which suits their quieter, available-when-needed role.

| Tile | Before | After |
|------|--------|-------|
| Agents | `A2A agent cards and MCP server integrations` | `Manage the agents that run your business and the tools they can use.` |
| Agent Tasks | `Task execution history across all AI agents` | `See every action your agents have taken, one task record at a time.` |
| Audit Trail | `Security and compliance audit log` | `Check the receipt for every action taken on your infrastructure.` |

No em dashes; each new line passes the read-aloud test.

## Build and tests

- `pnpm exec turbo build --filter=admin` — 19/19 tasks successful
- `pnpm --filter admin exec vitest run src/lib/components/BeforeDashboard` — 6/6 passing (existing `OnboardingChecklist` suite)
- Biome clean on the touched file; design-system adherence lint reports no findings for this file

Screenshots pending owner review (visual regression baselines are owner-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
