### PR TITLE
docs: amend retired git identity email in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,9 @@ Agentic business runtime. People, content, offers, payments, and agents  -  pre-
 - Lexical (rich text), ElectricSQL (sync), Stripe (payments)
 
 ## Git Identity
-RevealUI Studio <founder@revealui.com>
+RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>
+
+> Amended 2026-07-10. The prior founder@revealui.com address is retired: commits carrying it render Unverified under required signatures. Do not restore it.
 
 ## Branch Pipeline
 ```

--- a/docs/agent-rules/conventions.md
+++ b/docs/agent-rules/conventions.md
@@ -35,7 +35,8 @@ Standards for TypeScript, git, and configuration in the RevealUI monorepo.
 - Chore: `chore/<short-description>`
 
 ### Identity
-- Professional repos (RevealUIStudio): RevealUI Studio <founder@revealui.com>
+- Professional repos (RevealUIStudio): RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>
+- Amended 2026-07-10. The prior founder@revealui.com address is retired: commits carrying it render Unverified under required signatures. Do not restore it.
 
 ## Parameterization
 


### PR DESCRIPTION
## Summary
- The `## Git Identity` block in `CLAUDE.md` and `## Identity` block in `docs/agent-rules/conventions.md` still printed the retired `RevealUI Studio <founder@revealui.com>` line.
- That address is retired as of 2026-07-10: it belongs to the `RevealUIStudio` account being converted to an org, so SSH-signed commits carrying it render Unverified, and this repo's `main` required-signatures ruleset silently blocks the merge.
- Updated both to the current identity `RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>` with a short retirement note.

## Lines changed
- `CLAUDE.md:24` — `RevealUI Studio <founder@revealui.com>` → `RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>` (plus a new note line beneath it)
- `docs/agent-rules/conventions.md:38` — `- Professional repos (RevealUIStudio): RevealUI Studio <founder@revealui.com>` → same line with the noreply address (plus a new note line beneath it)

## Test plan
- [x] Doc-only change, no code paths affected
- [x] Grepped repo-wide for `founder@revealui.com` and left non-git-identity contact/ownership mentions (README, SECURITY docs, blog, etc.) untouched per scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
