### PR TITLE
fix(admin): harden checkout auto-fire with backoff retry and failure log

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/__tests__/page.test.tsx
@@ -7,9 +7,13 @@ vi.mock('@revealui/auth/react', () => ({
 }));
 
 const mockPush = vi.fn();
+// Stable reference, matching real next/navigation useRouter(). A fresh object
+// per render would make effects that list `router` in their deps re-fire on
+// every re-render, which does not happen in production.
+const mockRouter = { push: mockPush };
 let searchParams = new URLSearchParams();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => mockRouter,
   useSearchParams: () => searchParams,
 }));
 
@@ -26,6 +30,11 @@ vi.mock('@/lib/utils/safe-stripe-redirect', () => ({
   safeStripeRedirect: (url: string) => mockSafeStripeRedirect(url),
 }));
 
+const mockLoggerError = vi.fn();
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { error: (...args: unknown[]) => mockLoggerError(...args) },
+}));
+
 import BillingPage from '../page';
 
 afterEach(() => {
@@ -39,7 +48,7 @@ beforeEach(() => {
 });
 
 describe('BillingPage checkout hardening', () => {
-  it('retries the subscription fetch once before giving up', async () => {
+  it('retries the subscription fetch after a transient failure', async () => {
     let subscriptionCalls = 0;
     global.fetch = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
@@ -63,6 +72,28 @@ describe('BillingPage checkout hardening', () => {
       expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
     });
     expect(screen.queryByText(/could not load your subscription/)).not.toBeInTheDocument();
+  });
+
+  it('bounds the retry at three attempts and logs the persistent failure', async () => {
+    searchParams = new URLSearchParams('upgrade=pro');
+    let subscriptionCalls = 0;
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).includes('/api/billing/subscription')) {
+        subscriptionCalls += 1;
+      }
+      return Promise.reject(new Error('network down'));
+    });
+
+    render(<BillingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not load your subscription/)).toBeInTheDocument();
+    });
+    expect(subscriptionCalls).toBe(3);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Billing subscription fetch failed after retries',
+      expect.objectContaining({ attempts: 3, plan: 'pro' }),
+    );
   });
 
   it('never auto-fires checkout when subscription data never loaded', async () => {

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -15,12 +15,25 @@ import {
   CardHeader,
   CardTitle,
 } from '@revealui/presentation';
+import { logger } from '@revealui/utils/logger';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
+
+// Bounded retry for the subscription fetch that gates auto-checkout. A short
+// linear backoff spaces the attempts so a brief blip on the buyer's connection
+// (or a cold API instance) resolves before we surrender to the manual fallback.
+const MAX_SUBSCRIPTION_FETCH_ATTEMPTS = 3;
+const SUBSCRIPTION_RETRY_BASE_DELAY_MS = 150;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 interface SubscriptionData {
   tier: LicenseTierId;
@@ -119,27 +132,36 @@ function BillingContent() {
   }, [apiUrl]);
 
   /**
-   * Fetches subscription data with one automatic retry on failure. The
-   * auto-checkout effect below only fires once `subscription` is populated,
-   * so a hard failure here must never be silent  -  it has to leave a trail
-   * (`subscriptionLoadFailed`) the UI can act on, especially when the user
-   * arrived mid-purchase with an `?upgrade=` param.
+   * Fetches subscription data with a bounded retry (short linear backoff
+   * between attempts). The auto-checkout effect below only fires once
+   * `subscription` is populated, so a hard failure here must never be silent
+   * - it logs the failure and leaves a trail (`subscriptionLoadFailed`) the UI
+   * can act on, especially when the user arrived mid-purchase with an
+   * `?upgrade=` param.
    */
   const fetchSubscription = useCallback(async () => {
     setError(null);
     setSubscriptionLoadFailed(false);
 
-    let ok = await attemptFetchSubscription();
-    if (!ok) {
+    let ok = false;
+    for (let attempt = 1; attempt <= MAX_SUBSCRIPTION_FETCH_ATTEMPTS; attempt += 1) {
       ok = await attemptFetchSubscription();
+      if (ok) break;
+      if (attempt < MAX_SUBSCRIPTION_FETCH_ATTEMPTS) {
+        await delay(SUBSCRIPTION_RETRY_BASE_DELAY_MS * attempt);
+      }
     }
 
     if (!ok) {
+      logger.error('Billing subscription fetch failed after retries', {
+        attempts: MAX_SUBSCRIPTION_FETCH_ATTEMPTS,
+        plan: upgrade,
+      });
       setError('Failed to load subscription data');
       setSubscriptionLoadFailed(true);
     }
     setIsLoading(false);
-  }, [attemptFetchSubscription]);
+  }, [attemptFetchSubscription, upgrade]);
 
   useEffect(() => {
     if (!sessionLoading && session) {


### PR DESCRIPTION
## Problem

In the paid signup flow (signup -> verify -> login -> auto-checkout), the post-login auto-fire lands on `/account/billing?upgrade=pro|max` and gates on a subscription/plan fetch before firing checkout to Stripe.

The base already retried that fetch twice and rendered a visible "Continue to checkout" fallback, so it was **not** a silent dead end. But two spec requirements were unmet:

- The retry fired **immediately** with no backoff, so a brief connection blip or a cold API instance was unlikely to be survived by a second instant attempt.
- A persistent failure was **never logged**, leaving no operational trail when a buyer got stuck at the fallback.

Silent-path / gating code:
- [page.tsx:144-150](apps/admin/src/app/(frontend)/account/billing/page.tsx#L144) - the pre-change `fetchSubscription` (2 immediate attempts, no log).
- [page.tsx:188-196](apps/admin/src/app/(frontend)/account/billing/page.tsx#L188) - the auto-checkout effect that only fires once `subscription` is populated.
- [page.tsx:380-392](apps/admin/src/app/(frontend)/account/billing/page.tsx#L380) - the pre-existing visible fallback CTA.

## Change

- **Bounded retry with backoff.** `fetchSubscription` now loops up to `MAX_SUBSCRIPTION_FETCH_ATTEMPTS` (3) with a short linear backoff (`SUBSCRIPTION_RETRY_BASE_DELAY_MS` 150ms then 300ms) between attempts, breaking on the first success.
- **Log the persistent failure.** On exhausting the retries it calls the shared `logger.error` (no `console.*`) with `{ attempts, plan }`, then keeps the existing `subscriptionLoadFailed` trail that drives the visible fallback.
- Visible fallback CTA copy is unchanged (full-clause "Continue to checkout"); no new user-facing strings, no new dependencies.

### Reuse note
`@revealui/resilience` has a retry helper, but it imports `node:crypto` (browser-unsafe) and is not an admin dependency, so I extended the file's existing hand-rolled retry rather than pull it into a client bundle.

## Tests

`pnpm --filter admin exec vitest run` on the billing page suite - **5 passed**.

Added `bounds the retry at three attempts and logs the persistent failure`, which asserts 3 subscription attempts and a `logger.error` call. It also fixes the `next/navigation` mock to return a **stable** router reference (matching real `useRouter`), so effects listing `router` in deps do not re-fire per render.

**Red-first: yes.** Stashed `page.tsx`, ran the new test against the base file - it failed `expected 3, received 2` (base does 2 attempts and never logs). Restored the fix; green.

`pnpm --filter admin exec tsc --noEmit` clean; `pnpm --filter admin build` clean; Biome clean on both touched files.

## Security checker

`security-pr-review-check.js --diff origin/test` -> **"no security-sensitive files - no coordinator gate"** (pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
