### PR TITLE
docs(roadmap): close out future-tense marker sweep

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ audience: developer
 
 This roadmap reflects our current priorities and planned direction. It is updated regularly and may shift based on community feedback and business needs.
 
-**Last updated:** 2026-06-11
+**Last updated:** 2026-07-11
 
 ---
 
@@ -97,20 +97,6 @@ RevealUI is the runtime at the center of a three-project ecosystem. Each project
 
 ### Near-Term (Q2 2026)
 
-#### admin Dashboard Agent Chat
-Give users the ability to interact with an AI agent directly from the admin dashboard. Ask it to create content, query data, manage collections, and automate workflows  -  all through natural language.
-
-- Streaming responses with markdown rendering
-- admin-aware tools (create/update/delete posts, query collections, manage users)
-- Conversation history and persistence
-- Confirmation prompts for destructive actions
-
-#### Documentation Improvements
-- Deploy docs site to `docs.revealui.com`
-- Expand quick-start guide with video walkthroughs
-- API reference for all packages
-- Collection cookbook with common patterns
-
 #### Ecosystem Integration — [#528](https://github.com/RevealUIStudio/revealui/issues/528)
 - RevVault desktop app integration in Studio _(already built: `VaultPanel.tsx` connects via Tauri to RevVault)_
 - RevVault rotation engine as a Pro feature  -  automated credential lifecycle management. _Currently: the Rust rotation subsystem ships in the [RevVault repo](https://github.com/RevealUIStudio/revvault) at `crates/core/src/rotation/` (executor, provider framework, sync hooks) with a `revvault rotate <provider>` CLI supporting `--dry-run` (`crates/cli/src/commands/rotate.rs`); a small set of internal interactive rotation scripts covers providers not yet migrated._
@@ -146,8 +132,8 @@ Docker images for fully self-hosted deployment. Domain-locked licensing, air-gap
 
 ### Long-Term (Q4 2026+)
 
-#### Visual Builder
-A no-code visual builder for creating RevealUI sites. Drag-and-drop page building, component customization, and one-click deployment.
+#### Visual Editing — [#1816](https://github.com/RevealUIStudio/revealui/issues/1816)
+Edit a site's content by clicking on the real rendered page from the admin dashboard. A live-preview canvas supports block-level editing, starting with text and rich text and extending to images, links, and block insert and reorder. Edits publish atomically with instant cache invalidation, and every session keeps drafts, snapshots, and a full event record. New sites get a template-seeded guided setup, and agents can propose edits into a session for a person to review before publish.
 
 #### SOC2 Type II Compliance — [#516](https://github.com/RevealUIStudio/revealui/issues/516)
 RevealUI Fleet security certification for teams that require it.


### PR DESCRIPTION
## Summary

Closes out the future-tense marker sweep on `docs/ROADMAP.md`, the last surfaces of the docs-honesty program: every remaining forward-looking capability claim now either cites a public tracker or has been removed.

## Decision table

| Marker | Decision | Reason |
|---|---|---|
| "Visual Builder" (no-code, drag-and-drop, one-click deployment) | **Reworded + linked** to [#1816](https://github.com/RevealUIStudio/revealui/issues/1816) as "Visual Editing" | The activated program is click-to-edit live-preview editing over an existing site, not a no-code site builder. Rewrote to describe the real shape from the issue: live-preview canvas, block-level editing (text/rich text first), atomic publish with cache invalidation, template-seeded guided setup, and reviewable agent-proposed edits. Dropped the "no-code" and "one-click deployment" language since neither is accurate, and added no timeline. |
| RevealCoin / x402 section | **No change needed** | Searched the file for any RevealCoin framing; none exists. RevealCoin was fully removed from the public docs and codebase well before today (see `0235aab9c` docs removal, `363d4b548` code-subsystem removal). The one x402 mention that remains (Agent Marketplace section, linked to [#526](https://github.com/RevealUIStudio/revealui/issues/526)) already sits under an honest non-RevealCoin heading and is already correctly labeled "disabled by default" with live charging gated on specific criteria. Nothing to rework or delete. |
| "admin Dashboard Agent Chat" (Near-Term, no tracker) | **Removed** | Verified against code: this is not a future claim, it already ships. `apps/admin/src/lib/components/Agent/index.tsx` (961 lines) + `apps/admin/src/app/(backend)/chat/page.tsx` implement streaming responses, admin tool calls with confirmation prompts for destructive actions, and conversation persistence via `useConversations`. It is nav-linked (`AdminSidebarLayout.tsx`, label "Chat") and license-gated behind the `aiLocal` feature. Listing it under "Planned" was stale, not just unlinked. Removed rather than rewritten in place since the honest treatment is a Completed-section entry, which is a content addition outside today's sweep scope — flagging for a follow-up if the owner wants it added there. |
| "Documentation Improvements" (Near-Term, no tracker) | **Removed** | Four sub-claims, none tracked. "Deploy docs site to `docs.revealui.com`" is already true and already covered in the Completed section ("Production deploys - admin, API, Marketing, Docs on Vercel"), so restating it as a future task was stale. The other three (video walkthroughs, API reference for all packages, collection cookbook) have no code evidence (checked `docs/api` — only REST API docs exist, no per-package reference; no cookbook file; no video content) and no open issue. Removed per the sweep convention: an untracked future-tense claim is removed, not left dangling. |

## Mirror handling

`apps/docs/public/ROADMAP.md` and `apps/docs/dist/ROADMAP.md` are **not** tracked in git — both are gitignored (`apps/docs/.gitignore:18` and `:2`) and generated at build time by `apps/docs/scripts/copy-docs.sh`, which copies `docs/*.md` into `apps/docs/public/` on every build. Only `docs/ROADMAP.md` (the source) needed editing; verified the build regenerates the mirror correctly (see Verification below).

## Verification

- `pnpm install --frozen-lockfile --prefer-offline` — clean install.
- `pnpm exec turbo build --filter=docs` — succeeded, 13/13 tasks (12 cached).
- Confirmed `apps/docs/dist/ROADMAP.md` and `apps/docs/public/ROADMAP.md` both reflect the reworded Visual Editing entry post-build.
- `pnpm validate:claims` (claim-drift validator) — clean pass:
  - Claims scanned: 84, mismatches: 0
  - Future-tense files scanned: 4, unlinked future-tense markers: 0
  - Aspirational-feature scan files: 13, unqualified aspirational features: 0
  - Phantom-package mentions: 0, license-membership mismatches: 0

## Note for a follow-up (out of scope today)

While verifying the "admin Dashboard Agent Chat" removal, confirmed the feature is fully shipped, nav-linked, and license-gated. Recommend a separate small PR adding it to the Completed section if the owner wants the roadmap to reflect it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
