### PR TITLE
fix(ai): resolve built-in agent model from configured provider

### DIFF
--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -9,10 +9,15 @@ import {
   LinkButton,
   Textarea,
 } from '@revealui/presentation';
-import { Field, Label } from '@revealui/presentation/client';
+import { Callout, Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { type ChangeEvent, useReducer } from 'react';
+import { type ChangeEvent, useEffect, useReducer, useState } from 'react';
+import {
+  INFERENCE_PREREQUISITE_COPY,
+  type InferenceKeyMetadata,
+  resolveInferencePrerequisite,
+} from '@/lib/agents/inference-prerequisite';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
@@ -152,6 +157,27 @@ export default function NewAgentPage() {
 
   const [state, dispatch] = useReducer(formReducer, initialState);
   const { selectedTemplate, name, description, systemPrompt, submitting, error } = state;
+
+  // Resolve the inference-provider prerequisite up front. `null` means the check
+  // has not resolved yet (still loading, or the request failed) — we only block
+  // when we positively know no provider key is configured.
+  const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/user/api-keys')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: InferenceKeyMetadata | null) => {
+        if (active) setProviderConfigured(resolveInferencePrerequisite(data).configured);
+      })
+      .catch(() => {
+        // Leave the prerequisite unresolved on a fetch error so a flaky request
+        // never blocks agent creation.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   function applyTemplate(key: TemplateKey) {
     const tpl = TEMPLATES.find((t) => t.key === key);
@@ -381,6 +407,18 @@ export default function NewAgentPage() {
                   .
                 </p>
 
+                {providerConfigured === false && (
+                  <Callout variant="warning" role="alert" title={INFERENCE_PREREQUISITE_COPY.title}>
+                    {INFERENCE_PREREQUISITE_COPY.body}{' '}
+                    <Link
+                      href="/settings/api-keys"
+                      className="font-medium text-primary hover:underline"
+                    >
+                      {INFERENCE_PREREQUISITE_COPY.linkLabel}
+                    </Link>
+                  </Callout>
+                )}
+
                 {/* Error — inline banner; Alert primitive is a modal dialog, not applicable */}
                 {error && (
                   <div
@@ -395,7 +433,7 @@ export default function NewAgentPage() {
                 <div className="flex gap-3 pt-2">
                   <ButtonCVA
                     type="submit"
-                    disabled={submitting || !name.trim()}
+                    disabled={submitting || !name.trim() || providerConfigured === false}
                     variant="default"
                     size="sm"
                   >

--- a/apps/admin/src/lib/agents/__tests__/inference-prerequisite.test.ts
+++ b/apps/admin/src/lib/agents/__tests__/inference-prerequisite.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INFERENCE_PREREQUISITE_COPY,
+  resolveInferencePrerequisite,
+} from '../inference-prerequisite';
+
+describe('resolveInferencePrerequisite', () => {
+  it('reports the prerequisite unmet when no key metadata is present', () => {
+    expect(resolveInferencePrerequisite(null)).toEqual({
+      configured: false,
+      provider: null,
+    });
+  });
+
+  it('reports the prerequisite met and surfaces the configured provider', () => {
+    expect(
+      resolveInferencePrerequisite({ provider: 'inference-snaps', keyHint: 'sk-…abcd' }),
+    ).toEqual({
+      configured: true,
+      provider: 'inference-snaps',
+    });
+  });
+
+  it('treats any offered provider as satisfying the prerequisite', () => {
+    for (const provider of ['groq', 'huggingface', 'inference-snaps', 'ollama']) {
+      const result = resolveInferencePrerequisite({ provider, keyHint: null });
+      expect(result.configured).toBe(true);
+      expect(result.provider).toBe(provider);
+    }
+  });
+});
+
+describe('INFERENCE_PREREQUISITE_COPY', () => {
+  it('names no proprietary vendor and uses no em dashes', () => {
+    const text = `${INFERENCE_PREREQUISITE_COPY.title} ${INFERENCE_PREREQUISITE_COPY.body} ${INFERENCE_PREREQUISITE_COPY.linkLabel}`;
+    expect(text).not.toContain('—');
+    expect(text.toLowerCase()).not.toContain('claude');
+    expect(text.toLowerCase()).not.toContain('anthropic');
+  });
+});

--- a/apps/admin/src/lib/agents/inference-prerequisite.ts
+++ b/apps/admin/src/lib/agents/inference-prerequisite.ts
@@ -1,0 +1,41 @@
+/**
+ * Create-agent prerequisite logic.
+ *
+ * A new agent can only run once the account has an inference provider key on
+ * record (see the API Keys page). This resolves the account's key metadata into
+ * the state the create flow surfaces, so the operator learns the requirement up
+ * front instead of hitting a runtime failure on the first dispatch.
+ */
+
+/** Shape returned by `GET /api/user/api-keys` (no plaintext key). */
+export interface InferenceKeyMetadata {
+  provider: string;
+  keyHint: string | null;
+}
+
+export interface InferencePrerequisite {
+  /** True when the account has an inference provider key configured. */
+  configured: boolean;
+  /** The configured provider id, when one is present. */
+  provider: string | null;
+}
+
+/**
+ * Resolve the create-agent prerequisite from the account's key metadata.
+ * `null` metadata (no key on record) means the prerequisite is not met.
+ */
+export function resolveInferencePrerequisite(
+  metadata: InferenceKeyMetadata | null,
+): InferencePrerequisite {
+  if (!metadata) {
+    return { configured: false, provider: null };
+  }
+  return { configured: true, provider: metadata.provider };
+}
+
+/** User-facing copy for the unmet-prerequisite warning. */
+export const INFERENCE_PREREQUISITE_COPY = {
+  title: 'Connect an inference provider first',
+  body: 'Your agents run on the inference provider you configure. Add a provider key on the API Keys page and every agent you create will use it automatically.',
+  linkLabel: 'Open API Keys',
+} as const;

--- a/packages/ai/src/a2a/__tests__/a2a.test.ts
+++ b/packages/ai/src/a2a/__tests__/a2a.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { agentCardRegistry } from '../card.js';
+import { agentCardRegistry, PROVIDER_RESOLVED_MODEL } from '../card.js';
 import { handleA2AJsonRpc } from '../handler.js';
 import {
   appendArtifact,
@@ -58,6 +58,19 @@ describe('a2a agent card registry', () => {
       name: 'Ticket Agent',
       url: 'https://api.revealui.test/a2a',
     });
+  });
+
+  it('built-in agents defer model selection to the configured provider, not a vendor', () => {
+    for (const agentId of ['revealui-creator', 'revealui-ticket-agent']) {
+      const def = agentCardRegistry.getDef(agentId);
+      expect(def).toBeDefined();
+      // No hardcoded default: the model resolves from the account's configured
+      // open-model provider at dispatch time.
+      expect(def?.model).toBe(PROVIDER_RESOLVED_MODEL);
+      const serialized = JSON.stringify(def).toLowerCase();
+      expect(serialized).not.toContain('claude');
+      expect(serialized).not.toContain('anthropic');
+    }
   });
 
   it('supports register, update, unregister, and lookup', () => {

--- a/packages/ai/src/a2a/card.ts
+++ b/packages/ai/src/a2a/card.ts
@@ -14,6 +14,16 @@ import { type A2AAgentCard, agentDefinitionToCard } from '@revealui/contracts';
 // Built-in agent definitions
 // =============================================================================
 
+/**
+ * Built-in platform agents defer model selection to the inference provider the
+ * account configures on the API Keys page. The dispatch runtime resolves the
+ * real model from that provider, so the definition itself names no vendor. An
+ * empty value means "use the configured provider's model". Claude and other
+ * model ids stay valid where an operator wires a compatible provider; they are
+ * no longer the hardcoded default.
+ */
+export const PROVIDER_RESOLVED_MODEL = '';
+
 /** RevealUI platform meta-agent  -  "The Creator" */
 const THE_CREATOR_DEF: AgentDefinition = {
   id: 'revealui-creator',
@@ -23,7 +33,7 @@ const THE_CREATOR_DEF: AgentDefinition = {
     'The RevealUI platform agent. Scaffolds new AI agents, manages agent lifecycles, ' +
     'orchestrates multi-agent workflows, and acts as the primary interface for AI capabilities ' +
     'on the RevealUI platform.',
-  model: 'claude-opus-4-6',
+  model: PROVIDER_RESOLVED_MODEL,
   systemPrompt:
     'You are The Creator, the meta-agent for RevealUI. You design, configure, and deploy ' +
     'purpose-built AI agents for RevealUI users. You have access to agent scaffolding tools, ' +
@@ -83,7 +93,7 @@ const TICKET_AGENT_DEF: AgentDefinition = {
   description:
     'Handles support tickets, resolves user issues, and escalates when needed. ' +
     'Uses the RevealUI admin to create and update tickets.',
-  model: 'claude-sonnet-4-6',
+  model: PROVIDER_RESOLVED_MODEL,
   systemPrompt:
     'You are the RevealUI Ticket Agent. You help users resolve issues by creating tickets, ' +
     'searching for solutions, and escalating complex problems to the support team.',


### PR DESCRIPTION
## Problem

The first-run agent surface presumed a provider the configuration UI cannot supply. The built-in platform agents hardcoded proprietary Claude model ids, while the API Keys page (and the whole platform) offers only open-model providers. The create-agent flow never surfaced the provider-key prerequisite, so a user could scaffold an agent that then failed at first dispatch.

## Audit (file:line, both sides)

Config side (providers the key page actually offers):
- `apps/admin/src/app/(backend)/settings/api-keys/page.tsx:11-45` — `PROVIDERS` = `inference-snaps`, `ollama`, `groq`, `huggingface`; initial provider `inference-snaps`.
- `apps/admin/src/app/api/user/api-keys/route.ts:12` — POST schema enum restricts to the same four.
- `packages/contracts/src/providers.ts:8` — canonical `LLM_PROVIDERS` (open models only; the file comment states no proprietary providers).

Template side (hardcoded Claude):
- `packages/ai/src/a2a/card.ts:26` — `THE_CREATOR_DEF.model = 'claude-opus-4-6'`.
- `packages/ai/src/a2a/card.ts:86` — `TICKET_AGENT_DEF.model = 'claude-sonnet-4-6'`.

Already-aligned surfaces (for contrast, unchanged):
- `apps/admin/src/app/(backend)/agents/new/page.tsx:32,51-91` — create-agent templates already default to `AUTO_MODEL` ('').
- `apps/admin/src/lib/components/Agent/index.tsx:53-62` — chat model picker uses `ollama` / `huggingface`.

Why the hardcoded ids were dead as well as wrong:
- `packages/contracts/src/a2a/index.ts:346-370` — `agentDefinitionToCard` never emits `model`, so the A2A card output never carried the Claude id.
- `packages/ai/src/a2a/handler.ts:136-143` — dispatch calls the provider-resolved `llmClient`, never `def.model`.
- `packages/ai/src/llm/client.ts:597-662` — `createLLMClientFromEnv` resolves the provider from the open-model set (default `inference-snaps`).

## What changed

1. `packages/ai/src/a2a/card.ts` — both built-in agents now default to an exported `PROVIDER_RESOLVED_MODEL` sentinel (empty) so the model resolves from the account's configured open-model provider. Claude is no longer the hardcoded default; Claude and other ids remain valid for anyone who wires a compatible provider (the model field, pricing tables, and collab passthrough still accept them).
2. `apps/admin/src/app/(backend)/agents/new/page.tsx` — the create flow fetches the account key metadata on mount. When no provider key is configured it renders a `Callout` (reused `@revealui/presentation` warning primitive, no new local UI) linking to the API Keys page and blocks submit, instead of failing later. A flaky/failed fetch leaves the prerequisite unresolved and never blocks.
3. `apps/admin/src/lib/agents/inference-prerequisite.ts` — pure `resolveInferencePrerequisite` helper plus the shared warning copy.

## User-facing copy added

- Title: "Connect an inference provider first"
- Body: "Your agents run on the inference provider you configure. Add a provider key on the API Keys page and every agent you create will use it automatically."
- Link: "Open API Keys"

## Tests

- `packages/ai/src/a2a/__tests__/a2a.test.ts` — new guard: both built-in agents use `PROVIDER_RESOLVED_MODEL` and their serialized definitions name no proprietary vendor. Proven red without the fix (`expected 'claude-opus-4-6' to be ''`), green with it. Full suite: 14 passed.
- `apps/admin/src/lib/agents/__tests__/inference-prerequisite.test.ts` — new: prerequisite resolution for null vs each offered provider, plus a copy check (no em dash, no proprietary vendor). 4 passed.
- `@revealui/ai` build: clean. Admin `tsc --noEmit`: clean.
- `pnpm exec turbo build --filter=admin` fails at `next build --turbopack`, but the failure is pre-existing on the base branch and unrelated to this change: the error is an Edge Runtime incompatibility in `apps/admin/src/instrumentation.ts` (`process.exit` / `process.stderr`) reached via `packages/mcp/dist/oauth.js` → `remote-servers/route.ts`. None of those files are touched here (zero diff vs base), and the same build fails identically at base HEAD (verified by stashing this change and rebuilding: exit 1 at the same stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
