### PR TITLE
feat(admin): route posts read+write through the typed Drizzle bridge

### DIFF
--- a/apps/admin/src/lib/db/__tests__/typedCollectionStorage.test.ts
+++ b/apps/admin/src/lib/db/__tests__/typedCollectionStorage.test.ts
@@ -92,7 +92,7 @@ describe('typedCollectionStorage', () => {
     const storage = createTypedCollectionStorage();
     const result = await storage?.find?.(
       {
-        slug: 'posts',
+        slug: 'media',
         fields: [],
       },
       {},
@@ -493,7 +493,196 @@ describe('typedCollectionStorage pages bridge', () => {
 
     const storage = createTypedCollectionStorage();
     await expect(
-      storage?.create?.({ slug: 'posts', fields: [] }, { data: { title: 'x' } }),
+      storage?.create?.({ slug: 'media', fields: [] }, { data: { title: 'x' } }),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Posts — blog read + write bridge (twin of the pages bridge)
+// ---------------------------------------------------------------------------
+
+const postRow = {
+  id: 'post_1',
+  schemaVersion: '1',
+  version: 1,
+  title: 'Hello World',
+  slug: 'hello-world',
+  excerpt: 'An intro',
+  content: { root: { children: [] } },
+  featuredImageId: 'media_1',
+  authorId: 'user_1',
+  status: 'published',
+  published: true,
+  meta: { title: 'Hello World' },
+  categories: ['cat_1'],
+  createdAt: new Date('2026-07-01T00:00:00Z'),
+  updatedAt: new Date('2026-07-02T00:00:00Z'),
+  publishedAt: new Date('2026-07-02T00:00:00Z'),
+  deletedAt: null,
+};
+
+const postsCollection = { slug: 'posts', fields: [] };
+
+describe('typedCollectionStorage posts bridge', () => {
+  beforeEach(() => {
+    process.env.POSTGRES_URL = 'postgresql://example';
+  });
+
+  it('maps a post row for findByID (single authorId -> authors[], _status mirror)', async () => {
+    const { chain } = createPagesChain([[postRow]]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const doc = await storage?.findByID?.(postsCollection, { id: 'post_1' });
+
+    expect(doc).toMatchObject({
+      id: 'post_1',
+      title: 'Hello World',
+      slug: 'hello-world',
+      excerpt: 'An intro',
+      featuredImageId: 'media_1',
+      authorId: 'user_1',
+      authors: ['user_1'],
+      categories: ['cat_1'],
+      meta: { title: 'Hello World' },
+      status: 'published',
+      _status: 'published',
+    });
+  });
+
+  it('handles the access-merged and-where (slug + _status -> status column)', async () => {
+    const { chain } = createPagesChain([[postRow], [{ value: 1 }]]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const result = await storage?.find?.(postsCollection, {
+      where: {
+        and: [{ slug: { equals: 'hello-world' } }, { _status: { equals: 'published' } }],
+      },
+      limit: 1,
+      page: 1,
+    });
+
+    expect(result).toMatchObject({
+      totalDocs: 1,
+      docs: [expect.objectContaining({ id: 'post_1', _status: 'published' })],
+    });
+  });
+
+  it('signals not-handled for where shapes it cannot express (or)', async () => {
+    const { chain } = createPagesChain([]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const result = await storage?.find?.(postsCollection, {
+      where: { or: [{ slug: { equals: 'hello-world' } }] },
+      limit: 1,
+      page: 1,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  /**
+   * Prove-red: the camelCase-column round-trip. The dynamic-SQL write path
+   * emits `publishedAt` / `featuredImageId` / `authors` verbatim as SQL column
+   * identifiers, which do not exist on the snake_case `posts` table (the
+   * camelCase-column trap). The typed bridge maps each to its Drizzle column:
+   * camelCase Drizzle fields (`publishedAt`, `featuredImageId`, `authorId`)
+   * that Drizzle renders as the correct snake_case columns, `authors[]`
+   * collapsed to the single `author_id`, and `_status` to `status`.
+   */
+  it('creates a post, mapping camelCase/hasMany fields onto real columns', async () => {
+    const inserted = {
+      ...postRow,
+      id: 'post_new',
+      title: 'Second Post',
+      slug: 'second-post',
+      status: 'draft',
+      published: false,
+      publishedAt: null,
+    };
+    const { chain, calls } = createPagesChain([[inserted]]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const doc = await storage?.create?.(postsCollection, {
+      data: {
+        title: 'Second Post',
+        slug: 'second-post',
+        content: { root: { children: [] } },
+        featuredImageId: 'media_9',
+        authors: ['user_7', 'user_8'],
+        categories: [{ id: 'cat_2' }, 'cat_3'],
+        publishedAt: '2026-07-05T00:00:00Z',
+        _status: 'draft',
+      },
+    });
+
+    expect(calls.values[0]).toMatchObject({
+      title: 'Second Post',
+      slug: 'second-post',
+      featuredImageId: 'media_9',
+      authorId: 'user_7',
+      categories: ['cat_2', 'cat_3'],
+      status: 'draft',
+      published: false,
+    });
+    // publishedAt is coerced to a Date, never passed through as a camelCase string column.
+    expect((calls.values[0] as { publishedAt: unknown }).publishedAt).toBeInstanceOf(Date);
+    expect(doc).toMatchObject({ id: 'post_new', slug: 'second-post', _status: 'draft' });
+  });
+
+  it('throws (handled-but-invalid) when create is missing a slug', async () => {
+    const { chain } = createPagesChain([]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    await expect(
+      storage?.create?.(postsCollection, { data: { title: 'No Slug' } }),
+    ).rejects.toThrow('posts create requires');
+  });
+
+  it('updates a post, mirroring _status -> status/published and authors -> authorId', async () => {
+    const updated = { ...postRow, status: 'published', published: true, authorId: 'user_2' };
+    const { chain, calls } = createPagesChain([[postRow], [updated]]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const doc = await storage?.update?.(postsCollection, {
+      id: 'post_1',
+      data: { authors: ['user_2'], _status: 'published' },
+    });
+
+    expect(calls.set[0]).toMatchObject({
+      authorId: 'user_2',
+      status: 'published',
+      published: true,
+    });
+    expect(doc).toMatchObject({ authorId: 'user_2', authors: ['user_2'], _status: 'published' });
+  });
+
+  it('throws handled-but-not-found on update of a missing (or soft-deleted) post', async () => {
+    const { chain } = createPagesChain([[]]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    await expect(
+      storage?.update?.(postsCollection, { id: 'ghost', data: { title: 'X' } }),
+    ).rejects.toThrow('not found');
+  });
+
+  it('soft-deletes and returns the deleted document', async () => {
+    // deleteTypedPost awaits: own getPostById, then deletePost's soft-delete
+    // update (deletePost has no inner read, unlike deletePage).
+    const { chain, calls } = createPagesChain([[postRow], []]);
+    getRestClient.mockReturnValue(chain);
+
+    const storage = createTypedCollectionStorage();
+    const doc = await storage?.delete?.(postsCollection, { id: 'post_1' });
+
+    expect(doc).toMatchObject({ id: 'post_1', slug: 'hello-world' });
+    expect(calls.set[0]).toMatchObject({ deletedAt: expect.any(Date) });
   });
 });

--- a/apps/admin/src/lib/db/typedCollectionStorage.ts
+++ b/apps/admin/src/lib/db/typedCollectionStorage.ts
@@ -8,6 +8,8 @@ import type {
 } from '@revealui/core/types';
 import { getRestClient } from '@revealui/db/client';
 import { createPage, deletePage, getPageById, updatePage } from '@revealui/db/queries/pages';
+import { createPost, deletePost, getPostById, updatePost } from '@revealui/db/queries/posts';
+import { posts } from '@revealui/db/schema/admin';
 import { pages } from '@revealui/db/schema/pages';
 import { type Tenant as DbTenant, tenants } from '@revealui/db/schema/tenants';
 import { type User as DbUser, users } from '@revealui/db/schema/users';
@@ -749,6 +751,337 @@ async function deleteTypedPage(
   return mapPageDocument(existing);
 }
 
+// ─── Posts (blog model — READ + WRITE bridge) ──────────────────────────────
+
+type DbPost = typeof posts.$inferSelect;
+type NewPost = typeof posts.$inferInsert;
+
+/**
+ * The admin `posts` collection field set (hasMany `authors`, camelCase
+ * `publishedAt`/`featuredImageId`, relationship `categories`) does not line up
+ * with the snake_case `posts` columns. The engine's dynamic-SQL write path
+ * emits the camelCase field names verbatim as column identifiers, so those
+ * writes never reach the real columns (the camelCase-column trap). Routing
+ * posts through this typed bridge maps every field to its Drizzle column so
+ * the edit path persists correctly — the posts twin of the pages bridge.
+ */
+
+function normalizeCategoryIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.length > 0) {
+      ids.push(entry);
+    } else if (typeof entry === 'number') {
+      ids.push(String(entry));
+    } else if (isRecord(entry) && (typeof entry.id === 'string' || typeof entry.id === 'number')) {
+      ids.push(String(entry.id));
+    }
+  }
+  return ids;
+}
+
+/**
+ * The collection models `authors` as hasMany, but the `posts` table stores a
+ * single `author_id` FK. Persist the first author; the remainder cannot be
+ * held by this table (a pre-existing data-model limitation, not introduced
+ * here). `mapPostDocument` reflects the stored author back as a one-element
+ * array so `populateAuthors` keeps its contract.
+ */
+function firstAuthorId(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const [first] = value;
+  if (typeof first === 'string' && first.length > 0) return first;
+  if (typeof first === 'number') return String(first);
+  if (isRecord(first) && (typeof first.id === 'string' || typeof first.id === 'number')) {
+    return String(first.id);
+  }
+  return null;
+}
+
+function postStatusFromData(data: RevealDataObject): string | undefined {
+  const raw = data._status ?? data.status;
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Map a canonical `posts` row to the collection document shape. `_status`
+ * mirrors the `status` column so `authenticatedOrPublished`, the drafts UI,
+ * and `revalidatePost` keep their existing contract; `authors` reflects the
+ * single stored FK as a one-element array for `populateAuthors`.
+ */
+function mapPostDocument(row: DbPost): RevealDocument {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    content: row.content,
+    featuredImageId: row.featuredImageId,
+    authorId: row.authorId,
+    authors: row.authorId ? [row.authorId] : [],
+    categories: Array.isArray(row.categories) ? row.categories : [],
+    meta: isRecord(row.meta) ? row.meta : undefined,
+    status: row.status,
+    _status: row.status,
+    published: row.published,
+    publishedAt: row.publishedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  } as unknown as RevealDocument;
+}
+
+function buildPostsWhere(where: RevealFindOptions['where']) {
+  const entries = flattenWhereEntries(where);
+  if (entries === null) return null;
+
+  const conditions: (SQL<unknown> | null)[] = [isNull(posts.deletedAt)];
+  for (const [field, condition] of entries ?? []) {
+    if (!(isRecord(condition) && 'equals' in condition)) {
+      return null;
+    }
+    const value = condition.equals;
+    switch (field) {
+      case 'id':
+        conditions.push(eq(posts.id, String(value)));
+        break;
+      case 'slug':
+        conditions.push(typeof value === 'string' ? eq(posts.slug, value) : null);
+        break;
+      case 'authorId':
+        conditions.push(typeof value === 'string' ? eq(posts.authorId, value) : null);
+        break;
+      case 'status':
+      case '_status':
+        conditions.push(typeof value === 'string' ? eq(posts.status, value) : null);
+        break;
+      default:
+        return null;
+    }
+  }
+
+  if (conditions.some((entry) => entry === null)) {
+    return null;
+  }
+  const validConditions = conditions.filter(isSqlCondition);
+  return validConditions.length === 1 ? validConditions[0] : and(...validConditions);
+}
+
+function buildPostsOrderBy(sort: RevealFindOptions['sort']) {
+  if (!sort) return [];
+  if (!isRecord(sort)) return null;
+
+  const orderBy = Object.entries(sort).map(([field, direction]) => {
+    switch (field) {
+      case 'title':
+        return direction === '-1' ? desc(posts.title) : asc(posts.title);
+      case 'slug':
+        return direction === '-1' ? desc(posts.slug) : asc(posts.slug);
+      case 'publishedAt':
+        return direction === '-1' ? desc(posts.publishedAt) : asc(posts.publishedAt);
+      case 'createdAt':
+        return direction === '-1' ? desc(posts.createdAt) : asc(posts.createdAt);
+      case 'updatedAt':
+        return direction === '-1' ? desc(posts.updatedAt) : asc(posts.updatedAt);
+      default:
+        return null;
+    }
+  });
+
+  return orderBy.some((entry) => entry === null) ? null : orderBy.filter(isSqlCondition);
+}
+
+async function findTypedPostByID(
+  collection: RevealCollectionConfig,
+  options: { id: string | number },
+): Promise<RevealDocument | null | undefined> {
+  if (collection.slug !== 'posts') {
+    return undefined;
+  }
+
+  const db = getRestClient();
+  const row = await getPostById(db, String(options.id));
+  return row ? mapPostDocument(row) : null;
+}
+
+async function findTypedPosts(
+  collection: RevealCollectionConfig,
+  options: RevealFindOptions,
+): Promise<RevealPaginatedResult | undefined> {
+  if (collection.slug !== 'posts') {
+    return undefined;
+  }
+
+  const where = buildPostsWhere(options.where);
+  if (where === null) {
+    return undefined;
+  }
+
+  const orderBy = buildPostsOrderBy(options.sort);
+  if (orderBy === null) {
+    return undefined;
+  }
+
+  const db = getRestClient();
+  const limit = options.limit ?? 10;
+  const page = options.page ?? 1;
+  const offset = (page - 1) * limit;
+
+  const rows = await db
+    .select()
+    .from(posts)
+    .where(where)
+    .orderBy(...(orderBy.length > 0 ? orderBy : [desc(posts.createdAt)]))
+    .limit(limit)
+    .offset(offset);
+  const [{ value: totalDocs = 0 } = { value: 0 }] = await db
+    .select({ value: count() })
+    .from(posts)
+    .where(where);
+
+  const totalPages = totalDocs > 0 ? Math.ceil(totalDocs / limit) : 0;
+
+  return {
+    docs: rows.map(mapPostDocument),
+    totalDocs,
+    limit,
+    totalPages,
+    page,
+    pagingCounter: totalDocs > 0 ? offset + 1 : 0,
+    hasPrevPage: page > 1,
+    hasNextPage: page < totalPages,
+    prevPage: page > 1 ? page - 1 : null,
+    nextPage: page < totalPages ? page + 1 : null,
+  };
+}
+
+async function createTypedPost(
+  collection: RevealCollectionConfig,
+  options: { data: RevealDataObject; req?: RevealRequest },
+): Promise<RevealDocument | undefined> {
+  if (collection.slug !== 'posts') {
+    return undefined;
+  }
+
+  const { data } = options;
+  const slug = typeof data.slug === 'string' && data.slug.length > 0 ? data.slug : undefined;
+  const title = typeof data.title === 'string' && data.title.length > 0 ? data.title : undefined;
+  if (!(slug && title)) {
+    // Collection validation runs before this seam; a missing slug/title here
+    // is a programming error, not a user error — fail loudly, never row-less.
+    throw new Error('posts create requires a non-empty title and slug');
+  }
+
+  const status = postStatusFromData(data) ?? 'draft';
+  const values: NewPost = {
+    id: typeof data.id === 'string' && data.id.length > 0 ? data.id : `rvl_${crypto.randomUUID()}`,
+    title,
+    slug,
+    excerpt: typeof data.excerpt === 'string' ? data.excerpt : null,
+    content: data.content ?? null,
+    featuredImageId:
+      typeof data.featuredImageId === 'string' && data.featuredImageId.length > 0
+        ? data.featuredImageId
+        : null,
+    authorId: firstAuthorId(data.authors),
+    status,
+    published: status === 'published',
+    meta: isRecord(data.meta) ? data.meta : null,
+    categories: normalizeCategoryIds(data.categories),
+    publishedAt: toDateOrNull(data.publishedAt),
+  };
+
+  const db = getRestClient();
+  const row = await createPost(db, values);
+  if (!row) {
+    throw new Error('posts create failed: no row returned');
+  }
+  return mapPostDocument(row);
+}
+
+async function updateTypedPost(
+  collection: RevealCollectionConfig,
+  options: { id: string | number; data: RevealDataObject; req?: RevealRequest },
+): Promise<RevealDocument | undefined> {
+  if (collection.slug !== 'posts') {
+    return undefined;
+  }
+
+  const db = getRestClient();
+  const id = String(options.id);
+
+  // getPostById filters soft-deleted rows; updatePost alone would resurrect
+  // them. Handled-but-not-found throws per the seam contract.
+  const existing = await getPostById(db, id);
+  if (!existing) {
+    throw new Error(`posts update: post not found: ${id}`);
+  }
+
+  const { data } = options;
+  const patch: Partial<NewPost> = {};
+
+  if (typeof data.title === 'string' && data.title.length > 0) {
+    patch.title = data.title;
+  }
+  if (typeof data.slug === 'string' && data.slug.length > 0) {
+    patch.slug = data.slug;
+  }
+  if ('excerpt' in data) {
+    patch.excerpt = typeof data.excerpt === 'string' ? data.excerpt : null;
+  }
+  if ('content' in data) {
+    patch.content = data.content ?? null;
+  }
+  if ('featuredImageId' in data) {
+    patch.featuredImageId =
+      typeof data.featuredImageId === 'string' && data.featuredImageId.length > 0
+        ? data.featuredImageId
+        : null;
+  }
+  if ('authors' in data) {
+    patch.authorId = firstAuthorId(data.authors);
+  }
+  if ('categories' in data) {
+    patch.categories = normalizeCategoryIds(data.categories);
+  }
+  if ('meta' in data) {
+    patch.meta = isRecord(data.meta) ? data.meta : null;
+  }
+  const status = postStatusFromData(data);
+  if (status) {
+    patch.status = status;
+    patch.published = status === 'published';
+  }
+  if ('publishedAt' in data) {
+    patch.publishedAt = toDateOrNull(data.publishedAt);
+  }
+
+  const row = await updatePost(db, id, patch);
+  if (!row) {
+    throw new Error(`posts update: post not found: ${id}`);
+  }
+  return mapPostDocument(row);
+}
+
+async function deleteTypedPost(
+  collection: RevealCollectionConfig,
+  options: { id: string | number; req?: RevealRequest },
+): Promise<RevealDocument | undefined> {
+  if (collection.slug !== 'posts') {
+    return undefined;
+  }
+
+  const db = getRestClient();
+  const id = String(options.id);
+  const existing = await getPostById(db, id);
+  if (!existing) {
+    throw new Error(`posts delete: post not found: ${id}`);
+  }
+
+  await deletePost(db, id);
+  return mapPostDocument(existing);
+}
+
 const typedCollectionHandlers: Record<string, TypedCollectionHandler> = {
   pages: {
     findByID: findTypedPageByID,
@@ -756,6 +1089,13 @@ const typedCollectionHandlers: Record<string, TypedCollectionHandler> = {
     create: createTypedPage,
     update: updateTypedPage,
     delete: deleteTypedPage,
+  },
+  posts: {
+    findByID: findTypedPostByID,
+    find: findTypedPosts,
+    create: createTypedPost,
+    update: updateTypedPost,
+    delete: deleteTypedPost,
   },
   tenants: {
     findByID: findTypedTenantByID,


### PR DESCRIPTION
## What

Extend the typed-storage collection bridge to **posts**, the twin of the pages read+write bridge (#1724). Posts writes previously rode the engine's dynamic-SQL path with the camelCase-column trap; they now go through a typed Drizzle handler against the `posts` schema. Follows the internal audit of 2026-07-02 and the merged pages-bridge pattern.

### The old dynamic-SQL posts path (the trap)

The engine builds SQL column identifiers straight from the camelCase collection field keys:

- create: `packages/core/src/collections/operations/create.ts:162` — `const columns = Object.keys(data).filter(...)`
- update: `packages/core/src/collections/operations/update.ts:204` — `const keys = Object.keys(data).filter(...)`

Those keys (`publishedAt`, `featuredImageId`, the hasMany `authors`) never match the snake_case `posts` columns (`published_at`, `featured_image_id`, single `author_id`), and the `posts` table has no `_json` overflow column, so dashboard post writes silently missed real columns. Posts had **no** bridge handler (`apps/admin/src/lib/db/typedCollectionStorage.ts` shipped `pages`/`tenants`/`users` only), so every write fell to that path.

### The fix (`apps/admin/src/lib/db/typedCollectionStorage.ts`)

New `posts` handler with `findByID`/`find`/`create`/`update`/`delete`, using the same `undefined` = not-handled contract as the pages handler:

- **Reads** map the canonical row to the collection doc; `_status` mirrors the `status` column so `authenticatedOrPublished`, the drafts UI, and `revalidatePost` keep their contract; the single `author_id` is reflected back as a one-element `authors` array for `populateAuthors`. The where-parser flattens the access-merged `{and:[...]}` shape and translates `_status` to the `status` column; shapes it can't express (`or`, non-equals) signal not-handled and the engine falls through.
- **Writes** map each collection field to its Drizzle column: `authors[]` to `author_id` (first author; the remainder cannot be held by this table, a pre-existing data-model limitation documented in the handler), `categories` normalized to `string[]`, `_status`/`status` to the `status` column plus the `published` boolean, `publishedAt` coerced to a `Date`. Handled-but-not-found and missing title/slug throw (never a silent fall-through to the trap).

### Parity with the pages bridge

Same file, same handler shape, same not-handled/throw contract, same test shape. The `posts` handler mirrors `pages` field-for-field on the seam, so the future edit-session layer can treat pages and posts uniformly. No third bridge shape introduced.

## Verification

- `pnpm install --frozen-lockfile --prefer-offline` — clean.
- `turbo build --filter=@revealui/core --filter=@revealui/db` — green; `admin` app **compiled successfully** (3.7min). The build's integrated TypeScript phase was killed by the sandbox (OOM); standalone `tsc --noEmit` for `admin` passes **clean** (verified separately).
- Typed-storage suite **23/23** (8 new posts tests: findByID author/_status mapping, access-merged and-where, not-handled `or`, camelCase create round-trip, missing-slug throw, update `_status` to status/published + authors to author_id, not-found throw, soft-delete). Two prior tests that used `posts` as an "unsupported" slug were repointed to `media` (posts is now handled).
- Affected `db` + `collections` + `blocks` suites **250/250**. Biome clean.

### Prove-red

Stashing the handler and running the camelCase create round-trip goes **red**: `create` on `posts` returns `undefined` (unhandled, so the dynamic-SQL trap), so `calls.values[0]` is `undefined` and the assertion fails. With the handler, the Drizzle insert receives `authorId: 'user_7'` (from `authors: ['user_7','user_8']`), `featuredImageId`, normalized `categories`, `status`/`published`, and a `Date` `publishedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
