### PR TITLE
fix(admin): site-scope dashboard pages list and create

### DIFF
--- a/apps/admin/src/__tests__/api/proxy-routes.test.ts
+++ b/apps/admin/src/__tests__/api/proxy-routes.test.ts
@@ -34,6 +34,16 @@ vi.mock('@revealui/utils/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+// Pages are site-scoped: the list/create proxy resolves the default site
+// server-side. Mock the resolver so the target URL is deterministic.
+import { resolveDefaultSiteId } from '@/lib/db/defaultSite';
+
+vi.mock('@/lib/db/defaultSite', () => ({
+  resolveDefaultSiteId: vi.fn().mockResolvedValue('fleet-marketing'),
+}));
+
+const mockResolveDefaultSiteId = vi.mocked(resolveDefaultSiteId);
+
 // ---------------------------------------------------------------------------
 // Route imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -219,6 +229,82 @@ describe('POST /api/collections/[collection]', () => {
       params: Promise.resolve({ collection: 'posts' }),
     });
     expect(res.status).toBe(503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests  -  pages are site-scoped (default-site convention)
+// The API exposes page list/create only under /sites/:siteId/pages. The proxy
+// supplies the site scope: an explicit siteId when selected, otherwise the
+// server-resolved default site. Every other collection stays on the flat path.
+// ---------------------------------------------------------------------------
+
+describe('pages site-scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveDefaultSiteId.mockResolvedValue('fleet-marketing');
+  });
+
+  it('GET pages lists the default site and preserves other query params', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ success: true, data: [] }));
+    const req = new NextRequest('http://localhost/api/collections/pages?limit=1&depth=0');
+    const res = await collectionsGet(req, { params: Promise.resolve({ collection: 'pages' }) });
+    expect(res.status).toBe(200);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/content/sites/fleet-marketing/pages');
+    expect(url).toContain('limit=1');
+    expect(url).toContain('depth=0');
+    // The { data } envelope from the site-scoped list normalizes to { docs }.
+    const body = await res.json();
+    expect(Array.isArray(body.docs)).toBe(true);
+  });
+
+  it('GET pages honors an explicit siteId without forwarding it as a query param', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ success: true, data: [] }));
+    const req = new NextRequest('http://localhost/api/collections/pages?siteId=acme');
+    const res = await collectionsGet(req, { params: Promise.resolve({ collection: 'pages' }) });
+    expect(res.status).toBe(200);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/content/sites/acme/pages');
+    expect(url).not.toContain('siteId');
+    expect(mockResolveDefaultSiteId).not.toHaveBeenCalled();
+  });
+
+  it('POST pages create attaches the default site', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ success: true, data: { id: 'p1' } }, 201));
+    const req = new NextRequest('http://localhost/api/collections/pages', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Home', slug: 'home', path: '/' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await collectionsPost(req, { params: Promise.resolve({ collection: 'pages' }) });
+    expect(res.status).toBe(201);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/content/sites/fleet-marketing/pages');
+  });
+
+  it('POST pages create honors an explicit siteId in the body', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ success: true, data: { id: 'p1' } }, 201));
+    const req = new NextRequest('http://localhost/api/collections/pages', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Home', slug: 'home', path: '/', siteId: 'acme' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await collectionsPost(req, { params: Promise.resolve({ collection: 'pages' }) });
+    expect(res.status).toBe(201);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/content/sites/acme/pages');
+    expect(mockResolveDefaultSiteId).not.toHaveBeenCalled();
+  });
+
+  it('leaves a non-pages collection on the flat content path', async () => {
+    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ docs: [] }));
+    const req = new NextRequest('http://localhost/api/collections/products?limit=1');
+    await collectionsGet(req, { params: Promise.resolve({ collection: 'products' }) });
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/content/products?limit=1');
+    expect(url).not.toContain('/sites/');
+    expect(mockResolveDefaultSiteId).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/admin/src/app/api/collections/[collection]/route.ts
+++ b/apps/admin/src/app/api/collections/[collection]/route.ts
@@ -1,6 +1,7 @@
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
+import { resolveDefaultSiteId } from '@/lib/db/defaultSite';
 import { apiForwardHeaders } from '@/lib/utils/api-proxy-headers';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
@@ -8,6 +9,45 @@ const API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
   process.env.REVEALUI_PUBLIC_SERVER_URL ||
   'http://localhost:3004';
+
+/**
+ * Pages are the one site-scoped content collection: the API exposes list/create
+ * only under `/sites/:siteId/pages`, while every other collection lists/creates
+ * flat under `/:collection`. The dashboard supplies the site scope here — an
+ * explicit `siteId` when a site is selected, otherwise the server-resolved
+ * default site (single-site operators never choose one). All other collections
+ * keep the flat path unchanged.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function resolveListTarget(
+  collection: string,
+  searchParams: URLSearchParams,
+): Promise<string> {
+  if (collection !== 'pages') {
+    return `${API_URL}/api/content/${collection}?${searchParams.toString()}`;
+  }
+  const forwarded = new URLSearchParams(searchParams);
+  const explicit = forwarded.get('siteId');
+  forwarded.delete('siteId');
+  const siteId = explicit && explicit.length > 0 ? explicit : await resolveDefaultSiteId();
+  const query = forwarded.toString();
+  return `${API_URL}/api/content/sites/${encodeURIComponent(siteId)}/pages${query ? `?${query}` : ''}`;
+}
+
+async function resolveCreateTarget(collection: string, body: unknown): Promise<string> {
+  if (collection !== 'pages') {
+    return `${API_URL}/api/content/${collection}`;
+  }
+  const explicit =
+    isRecord(body) && typeof body.siteId === 'string' && body.siteId.length > 0
+      ? body.siteId
+      : undefined;
+  const siteId = explicit ?? (await resolveDefaultSiteId());
+  return `${API_URL}/api/content/sites/${encodeURIComponent(siteId)}/pages`;
+}
 
 function apiUnavailable(collection: string, error: unknown): NextResponse {
   const err = error instanceof Error ? error : new Error(String(error));
@@ -51,12 +91,9 @@ export async function GET(
   const { searchParams } = new URL(request.url);
 
   try {
-    const apiResponse = await fetch(
-      `${API_URL}/api/content/${collection}?${searchParams.toString()}`,
-      {
-        headers: await apiForwardHeaders(request),
-      },
-    );
+    const apiResponse = await fetch(await resolveListTarget(collection, searchParams), {
+      headers: await apiForwardHeaders(request),
+    });
     return proxyResponse(apiResponse);
   } catch (err) {
     return apiUnavailable(collection, err);
@@ -76,7 +113,7 @@ export async function POST(
   const body = await request.json();
 
   try {
-    const apiResponse = await fetch(`${API_URL}/api/content/${collection}`, {
+    const apiResponse = await fetch(await resolveCreateTarget(collection, body), {
       method: 'POST',
       headers: await apiForwardHeaders(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),

--- a/apps/admin/src/lib/db/__tests__/defaultSite.test.ts
+++ b/apps/admin/src/lib/db/__tests__/defaultSite.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getRestClient } = vi.hoisted(() => ({
+  getRestClient: vi.fn(() => ({})),
+}));
+
+vi.mock('@revealui/db/client', () => ({
+  getRestClient,
+}));
+
+import { getAllSites } from '@revealui/db/queries/sites';
+
+vi.mock('@revealui/db/queries/sites', () => ({
+  getAllSites: vi.fn(),
+}));
+
+import { DEFAULT_CMS_SITE_ID, resolveDefaultSiteId } from '../defaultSite';
+
+const mockGetAllSites = vi.mocked(getAllSites);
+
+type Sites = Awaited<ReturnType<typeof getAllSites>>;
+const asSites = (rows: Array<{ id: string }>): Sites => rows as unknown as Sites;
+
+describe('resolveDefaultSiteId', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the single site id for a single-site operator (no picker needed)', async () => {
+    mockGetAllSites.mockResolvedValueOnce(asSites([{ id: 'acme' }]));
+    await expect(resolveDefaultSiteId()).resolves.toBe('acme');
+  });
+
+  it('falls back to the canonical CMS site when no sites exist yet', async () => {
+    mockGetAllSites.mockResolvedValueOnce(asSites([]));
+    await expect(resolveDefaultSiteId()).resolves.toBe(DEFAULT_CMS_SITE_ID);
+  });
+
+  it('falls back to the canonical CMS site when more than one site exists', async () => {
+    mockGetAllSites.mockResolvedValueOnce(asSites([{ id: 'a' }, { id: 'b' }]));
+    await expect(resolveDefaultSiteId()).resolves.toBe(DEFAULT_CMS_SITE_ID);
+  });
+
+  it('requests at most two sites so single-versus-many stays distinguishable', async () => {
+    mockGetAllSites.mockResolvedValueOnce(asSites([{ id: 'a' }]));
+    await resolveDefaultSiteId();
+    expect(mockGetAllSites).toHaveBeenCalledWith(expect.anything(), { limit: 2 });
+  });
+});

--- a/apps/admin/src/lib/db/defaultSite.ts
+++ b/apps/admin/src/lib/db/defaultSite.ts
@@ -1,0 +1,28 @@
+import { getRestClient } from '@revealui/db/client';
+import { getAllSites } from '@revealui/db/queries/sites';
+
+/**
+ * Canonical CMS site that dashboard-authored pages belong to when the operator
+ * runs a single site and the dashboard shows no site picker. Shared by the
+ * typed pages bridge (engine write path) and the content proxy (list/create
+ * forwarding) so both surfaces resolve one default and never drift apart.
+ */
+export const DEFAULT_CMS_SITE_ID = 'fleet-marketing';
+
+/**
+ * Resolve the site a page list or create belongs to when the caller supplies no
+ * explicit siteId. A single-site operator gets their one site with no picker to
+ * choose from. A fresh instance with no sites, or a multi-site instance, falls
+ * back to the canonical CMS site until the dashboard grows a picker (multi-site
+ * scoping is a later phase). The resolution runs server-side against the sites
+ * table so the client never has to know which site it is editing.
+ */
+export async function resolveDefaultSiteId(): Promise<string> {
+  const db = getRestClient();
+  const sites = await getAllSites(db, { limit: 2 });
+  const [only] = sites;
+  if (sites.length === 1 && only) {
+    return only.id;
+  }
+  return DEFAULT_CMS_SITE_ID;
+}

--- a/apps/admin/src/lib/db/typedCollectionStorage.ts
+++ b/apps/admin/src/lib/db/typedCollectionStorage.ts
@@ -12,6 +12,7 @@ import { pages } from '@revealui/db/schema/pages';
 import { type Tenant as DbTenant, tenants } from '@revealui/db/schema/tenants';
 import { type User as DbUser, users } from '@revealui/db/schema/users';
 import { and, asc, count, desc, eq, isNull, or, type SQL, sql } from 'drizzle-orm';
+import { DEFAULT_CMS_SITE_ID } from './defaultSite';
 
 type UserWhereCondition = NonNullable<RevealFindOptions['where']>;
 type UserSort = NonNullable<RevealFindOptions['sort']>;
@@ -419,14 +420,6 @@ async function findTypedTenants(
 type DbPage = typeof pages.$inferSelect;
 type NewPage = typeof pages.$inferInsert;
 
-/**
- * Site every CMS-authored page belongs to until the dashboard grows a site
- * picker. The canonical `pages` table requires a NOT NULL site_id; the
- * dynamic-SQL engine path can never satisfy it — pages writes are ONLY viable
- * through this bridge.
- */
-const DEFAULT_PAGE_SITE_ID = 'fleet-marketing';
-
 function pagePathFromSlug(slug: string): string {
   return slug === 'home' ? '/' : `/${slug}`;
 }
@@ -649,9 +642,7 @@ async function createTypedPage(
   const values: NewPage = {
     id: typeof data.id === 'string' && data.id.length > 0 ? data.id : `rvl_${crypto.randomUUID()}`,
     siteId:
-      typeof data.siteId === 'string' && data.siteId.length > 0
-        ? data.siteId
-        : DEFAULT_PAGE_SITE_ID,
+      typeof data.siteId === 'string' && data.siteId.length > 0 ? data.siteId : DEFAULT_CMS_SITE_ID,
     title,
     slug,
     path:


### PR DESCRIPTION
## What

The admin dashboard's Pages list and create flows were broken against the content API. This makes them site-scoped, per the internal spec's foundation repairs for the visual-edit-sessions program (audit finding B2).

## The unscoped paths (audit, file:line)

The admin content proxy forwarded page list/create to the flat content path, but the API server never exposed a flat pages route:

- [apps/admin/src/app/api/collections/[collection]/route.ts:55](apps/admin/src/app/api/collections/[collection]/route.ts) — `GET` targeted `${API_URL}/api/content/${collection}` (for `pages`, `/api/content/pages`).
- [apps/admin/src/app/api/collections/[collection]/route.ts:79](apps/admin/src/app/api/collections/[collection]/route.ts) — `POST` targeted the same flat path.
- [apps/server/src/routes/content/pages.ts:80](apps/server/src/routes/content/pages.ts) and [:131](apps/server/src/routes/content/pages.ts) — the server exposes page list/create **only** under `/api/content/sites/{siteId}/pages`. No flat `/pages` list/create exists, so both dashboard flows 404d.
- [apps/server/src/routes/content/index.ts:57](apps/server/src/routes/content/index.ts) — confirms pages is the one site-scoped content collection; posts, media, products, users, orders all list/create flat.

The item-level proxy ([apps/admin/src/app/api/collections/[collection]/[id]/route.ts:42](apps/admin/src/app/api/collections/[collection]/[id]/route.ts)) already targeted `/api/content/pages/:id`, which does exist, so only the list/create entry point was broken.

The live consumer of the broken list path is the onboarding checklist ([apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx:56](apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx)), whose "Create your first page" check always read false because the list 404d.

## The fix + default-site convention

The proxy now supplies the site scope for `pages` only; every other collection keeps its flat path unchanged:

- `GET /api/collections/pages` → `/api/content/sites/{siteId}/pages`, preserving other query params (e.g. `status`, `limit`).
- `POST /api/collections/pages` → `/api/content/sites/{siteId}/pages`.

**Site resolution:**

1. An explicit `siteId` (query param on list, body field on create) wins — this is the hook for a future site picker.
2. Otherwise the site is resolved server-side in [apps/admin/src/lib/db/defaultSite.ts](apps/admin/src/lib/db/defaultSite.ts): a single-site operator gets their one site with no picker to choose from; a fresh instance with no sites, or a multi-site instance, falls back to the canonical CMS site until the dashboard grows a picker.

The default-site resolver and its canonical-site constant are shared with the typed pages bridge ([apps/admin/src/lib/db/typedCollectionStorage.ts](apps/admin/src/lib/db/typedCollectionStorage.ts)), which previously carried a private copy of the constant. The engine write path and the content proxy now resolve one default and cannot drift apart. This reuses the existing typed bridge and the existing site-scoped API route — no parallel read/write path is added.

Authorization is unchanged: the resolver only picks a candidate site id; the forwarded request still carries the operator's session cookie, and the API enforces site ownership. If the resolved site is not accessible, the API returns 403 (the onboarding check fails closed to unchecked, never throws).

## Tests

- New `apps/admin/src/lib/db/__tests__/defaultSite.test.ts` — default-site resolution: single site → that id; zero or many sites → canonical site; asks for at most two sites so single-versus-many stays distinguishable.
- Extended `apps/admin/src/__tests__/api/proxy-routes.test.ts` — pages list/create target the site-scoped URL with the default site; explicit `siteId` is honored (and not forwarded as a query param); non-pages collections stay flat. Verified these four assertions go red when the site-scope branch is removed.

Results:

- `pnpm --filter admin exec vitest run` on the pages bridge, default-site, proxy-routes, and onboarding-checklist suites: **56 passed**.
- `pnpm exec turbo build --filter=admin`: **19 tasks successful**.
- `pnpm --filter admin typecheck` (`tsc --noEmit`, strict): **clean**.
- Biome: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
