### PR TITLE
docs: reconcile count triad against code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ pnpm build:admin            # Build auth + Admin
 
 ### Testing
 ```bash
-pnpm test                   # Run all tests (turbo, 15 concurrency)
+pnpm test                   # Run all tests (turbo, concurrency 2)
 pnpm test:coverage          # Tests with coverage
 pnpm test:e2e               # Playwright E2E tests
 pnpm test:integration       # Integration tests
@@ -231,7 +231,7 @@ Biome, boundary, claim-drift, typecheck, tests, and build all block pushes. Audi
 - Resource limits: enforceSiteLimit on site creation, advisory-locked user limit in admin sign-up
 - Encryption keys: non-extractable by default (configurable via `extractable` option)
 - Rich text: isSafeUrl() blocks javascript:/vbscript:/data: in Lexical link/image rendering
-- Webhook rate limiting: 100 req/min on /api/webhooks
+- Webhook rate limiting: 500 req/min on /api/webhooks
 - Cross-DB cleanup: `@revealui/db/cleanup` for orphaned legacy-Supabase data after site deletion (relevant during migration; will retire once phase-out completes)
 - RBAC + ABAC policy engine in core (enforcement tests in `packages/core/src/__tests__/auth/` and `packages/core/src/collections/operations/__tests__/access-enforcement.test.ts` prove role isolation)
 - GDPR compliance framework (consent, deletion, anonymization)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 
 ## Packages
 
-### OSS Packages (MIT) — 20
+### OSS Packages (MIT) — 21
 
 | Package                                                 | Purpose                                           |
 | ------------------------------------------------------- | ------------------------------------------------- |
@@ -182,6 +182,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | [`@revealui/dev`](packages/dev)                         | Shared configs (Biome, TypeScript, Tailwind)      |
 | [`@revealui/test`](packages/test)                       | E2E specs, integration tests, fixtures, mocks     |
 | [`@revealui/paywall`](packages/paywall)                 | Runtime license enforcement, feature gating, upgrade UI |
+| [`@revealui/tokens`](packages/tokens)                   | Design tokens (CSS variables, typed TS export, brand canon) |
 | [`create-revealui`](packages/create-revealui)           | `npm create revealui` initializer                 |
 | [`revealui`](packages/revealui)                         | Meta-installer (proxies to `create-revealui`; unpublished) |
 
@@ -299,7 +300,7 @@ revealui/
 - **[Admin Guide](docs/ADMIN_GUIDE.md):** Collections, fields, access control
 - **[Testing](docs/TESTING.md):** Vitest, Playwright, coverage
 - **[Deployment](docs/guides/deployment.md):** Vercel, Fly, or self-host
-- **[All docs](docs/INDEX.md):** Full index (25 guides)
+- **[All docs](docs/INDEX.md):** Full documentation index
 
 ## Contributing
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -6,7 +6,7 @@ status: verified
 audience: user
 ---
 
-> Last verified: 2026-05-26
+> Last verified: 2026-07-11
 
 This page is an honest account of what RevealUI can and can't do right now.
 If you're evaluating RevealUI for a project, read this before the marketing page.
@@ -22,10 +22,10 @@ Full content management engine with collections, access control, hooks, field ty
 and a REST API. The heart of RevealUI and the most mature part of the codebase.
 
 ### UI component library
-**61 native React components in `@revealui/presentation`** (80 total with `@revealui/core` admin/richtext), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
+**61 native React components in `@revealui/presentation`** (plus admin and rich-text UI in `@revealui/core`), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn) — just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
-**85 PostgreSQL tables** with Drizzle ORM, **61 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
+**85 PostgreSQL tables** with Drizzle ORM, **72 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
 
 ### Rich text editing
 Lexical-based rich text editor with custom nodes, serialization, and a plugin system.
@@ -36,7 +36,7 @@ ElectricSQL integration for real-time data synchronization. Proxy, auth, and sha
 have been verified working between Fly and NeonDB. Off by default — opt-in via env vars when you want it.
 
 ### CLI scaffolding
-**`create-revealui` published to npm at v0.5.6**. `@revealui/cli` is at v0.7.1. Bootstraps a new RevealUI project with working config, database setup, and development server.
+**`create-revealui` published to npm at v0.5.12**. `@revealui/cli` is at v0.8.3. Bootstraps a new RevealUI project with working config, database setup, and development server.
 
 ### CI and code quality
 3-phase CI gate (lint, typecheck, test, build) with an extensive test suite across
@@ -59,7 +59,7 @@ Webhook handlers for `checkout.session.completed`, `customer.subscription.update
 
 ### REST API
 Hono-based API with OpenAPI spec generation, Swagger docs, authentication middleware,
-rate limiting, CSRF protection, and 120+ route files. Serves the admin dashboard. Deployed to `api.revealui.com`. **Has not handled production traffic from paying users.**
+rate limiting, CSRF protection, and route handlers across `apps/server/src/routes`. Serves the admin dashboard. Deployed to `api.revealui.com`. **Has not handled production traffic from paying users.**
 
 ### AI agent system
 LLM provider abstraction (default: Ollama; opt-in: Groq, HuggingFace, OpenAI-compatible), CRDT-based memory (`WorkingMemory`, `EpisodicMemory`, `SemanticMemory`, `ProceduralMemory`), tool registry, streaming runtime, and orchestration layer. Embeddings default to Ollama `nomic-embed-text` (768 dim). Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, `@revealui/services`) are Fair Source / FSL-1.1-MIT.
@@ -102,18 +102,21 @@ Honest list of things that are not done, not deployed, or not verified.
 
 | Metric | Value | Verified |
 |--------|-------|----------|
-| Workspaces (apps + packages) | 30 | Yes |
+| Workspaces (apps + packages) | 31 | Yes |
 | Apps | 4 (`admin`, `server`, `docs`, `marketing`) | Yes |
-| OSS packages (MIT) | 20 | Yes |
+| OSS packages (MIT) | 21 | Yes |
 | Pro packages (FSL-1.1-MIT) | 5 (`ai`, `engines`, `harnesses`, `mcp`, `services`) | Yes |
 | Internal packages | 1 (`@revealui/scripts`, unlicensed build tooling) | Yes |
-| UI components | 59 in `@revealui/presentation` (80 with `@revealui/core`) | Yes |
+| UI components | 61 in `@revealui/presentation` | Yes |
 | Database tables | 85 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
-| MCP servers (`packages/mcp/src/servers/`) | 13 | Yes |
+| CHECK constraints | 72 | Yes (run `grep -rh 'check(' packages/db/src/schema/*.ts \| wc -l`) |
+| MCP servers | 14 | Yes (run `ls packages/mcp/src/servers/*.ts` and count non-`_` files) |
 | Test cases | run `pnpm test` for current count | Reproducible |
 | Test files | run `find . -name "*.test.ts*" -not -path "*/node_modules/*"` | Reproducible |
-| API route files | 120+ | Approximate |
+| API route files | run `find apps/server/src/routes -name '*.ts' -not -name '*.test.ts' \| wc -l` | Reproducible |
 | Real production users | 0 | Yes |
+
+> Counting rules (enforced in CI by `pnpm validate:claims`, canonical values in `apps/marketing/app/content/site.ts` `METRICS`): **UI components** counts `.tsx` files in `packages/presentation/src/components/` excluding `_`-prefixed helpers. **MCP servers** counts `.ts` files in `packages/mcp/src/servers/` excluding `index*` and `_`-prefixed helpers, which includes the `adapter.ts` framework module (so the honest total is 14, not 13). **Workspaces** counts `packages/*` plus `apps/*` that carry a `package.json`. **Database tables** counts `pgTable(` declarations; the **license split** is read from each `packages/*/package.json` `license` field.
 
 ---
 


### PR DESCRIPTION
## Count-triad reconciliation

Reconciles the three canonical docs (`docs/WHAT_WORKS_TODAY.md`, `CLAUDE.md`, `README.md`) against the code. Method: every countable claim verified against source with `file:line` on both sides; where doc and code disagreed, the code wins and the doc was corrected. Prose-only, no code changes.

### Reconciliation table

| Claim | Doc (file:line) | Code (file:line) | Verdict |
|-------|-----------------|------------------|---------|
| create-revealui version | WHAT_WORKS_TODAY.md:39 (`v0.5.6`) | packages/create-revealui/package.json:3 (`0.5.12`); npm `create-revealui` = 0.5.12 | DOC-DRIFT -> 0.5.12 |
| cli version | WHAT_WORKS_TODAY.md:39 (`v0.7.1`) | packages/cli/package.json:3 (`0.8.3`); npm `@revealui/cli` = 0.8.3 | DOC-DRIFT -> 0.8.3 |
| CHECK constraints | WHAT_WORKS_TODAY.md:28 (`61`) | `grep -rh 'check(' packages/db/src/schema/*.ts \| wc -l` = 72 | DOC-DRIFT -> 72 |
| MCP servers | WHAT_WORKS_TODAY.md:112 (`13`) | scripts/validate/claim-drift.ts:260-270 `countMCPServers` = 14; site.ts:38 METRICS `mcpServers: 14` | DOC-DRIFT -> 14 |
| MCP servers | README.md:47, README.md:60 (`14`) | same as above = 14 | MATCHES |
| UI components (presentation) | WHAT_WORKS_TODAY.md:110 (`59`) | claim-drift.ts:248-258 `countUIComponents` = 61; site.ts:32 `uiComponents: 61` | DOC-DRIFT -> 61 |
| UI components (presentation) | WHAT_WORKS_TODAY.md:25 (`61`), README.md:46, README.md:171 (`61`) | 61 | MATCHES |
| Component total "80 / 59 / 21" | WHAT_WORKS_TODAY.md:25, :110 | presentation = 61 (was 59); core split not enforced and drifting | DOC-DRIFT -> dropped fragile total, anchored to enforced 61 |
| Workspaces | WHAT_WORKS_TODAY.md:105 (`30`) | claim-drift.ts:272-274 `countWorkspaces` = 31 (27 pkgs + 4 apps); site.ts:28 `workspaces: 31` | DOC-DRIFT -> 31 |
| Workspaces | WHAT_WORKS_TODAY.md:130 (`31`) | 31 | MATCHES |
| OSS packages (MIT) | WHAT_WORKS_TODAY.md:107 (`20`), README.md:163 (`20`) | claim-drift.ts:428-458 `countLicenseSplit` = 21 MIT; site.ts:44 `mit: 21` | DOC-DRIFT -> 21 (README table was missing `@revealui/tokens`; row added) |
| OSS packages (MIT) | CLAUDE.md OSS list (`21`, lists 21) | 21 | MATCHES |
| Pro packages (FSL) | all three (`5`) | 5 FSL (ai, engines, harnesses, mcp, services) | MATCHES |
| Internal packages | all three (`1`) | 1 (`@revealui/scripts`, no license) | MATCHES |
| Packages total | README.md:284 (`27`), README.md:79 (`27`) | claim-drift.ts:228 `countPackages` = 27 | MATCHES |
| Database tables | all three (`85`) | `grep -rh 'pgTable(' packages/db/src/schema/ \| wc -l` = 85; site.ts:40 `dbTables: 85` | MATCHES |
| API route files | WHAT_WORKS_TODAY.md:62, :115 (`120+`) | `find apps/server/src/routes -name '*.ts' -not -name '*.test.ts'` = 71 files (427 endpoint registrations) | DOC-DRIFT -> reworded to reproducible command / prose |
| Docs index guides | README.md:302 (`25 guides`) | docs/INDEX.md = 36 `.md` links | DOC-DRIFT -> reworded (dropped fragile count) |
| App ports | CLAUDE.md, README (`server 3004, admin 4000, docs 3002, marketing 3000`) | index.ts:1341 (3004), admin package.json:78 (4000), docs vite.config.ts:318 (3002), marketing vite.config.ts:17 (3000) | MATCHES |
| Tier prices | README.md:146-148 ($49 / $299 / $1,499) | scripts/setup/stripe-catalog.ts unitAmount 4900 / 29900 / 149900 | MATCHES |
| Embedding dim | WHAT_WORKS_TODAY.md:65 (`768`) | packages/ai/src/memory/vector/vector-memory-service.ts:79-80 (`768`) | MATCHES |
| bcrypt rounds | WHAT_WORKS_TODAY.md:54, CLAUDE.md (`12`) | packages/auth/src/server/auth.ts:368 (`bcrypt.hash(password, 12)`) | MATCHES |
| Preflight checks | CLAUDE.md:138 (`15 checks`) | scripts/validate/pre-launch.ts = 15 check calls | MATCHES |
| Webhook rate limit | CLAUDE.md:234 (`100 req/min`) | apps/server/src/index.ts:480 (`maxRequests: 500`, window ONE_MINUTE) | DOC-DRIFT -> 500 |
| Test concurrency | CLAUDE.md:118 (`15 concurrency`) | package.json:205 (`turbo run test --concurrency=2`) | DOC-DRIFT -> reworded to `concurrency 2` |
| Enforcement tests | WHAT_WORKS_TODAY.md:69 (`50+`) | claim-drift.ts `countEnforcementTests` = 60 (>= 50) | MATCHES (floor phrasing) |
| Stack versions | CLAUDE.md (React 19, Next 16, TS 6, Biome 2, Vitest 4) | pnpm-workspace catalog (react 19.2.7, next 16.2.0, typescript 6.0.3, biome 2.5.2, vitest 4.1.10) | MATCHES |

### Counting rules encoded in the doc

Added a note under the WHAT_WORKS_TODAY.md numbers table (mirrors the enforced logic in `scripts/validate/claim-drift.ts` and the canonical values in `apps/marketing/app/content/site.ts` `METRICS`):

- **UI components** = `.tsx` files in `packages/presentation/src/components/` excluding `_`-prefixed helpers.
- **MCP servers** = `.ts` files in `packages/mcp/src/servers/` excluding `index*` and `_`-prefixed helpers. This **includes** the `adapter.ts` framework module, which is why the honest total is **14, not 13**. Recorded explicitly so the count cannot silently drift on the adapter/server boundary again.
- **Workspaces** = `packages/*` plus `apps/*` carrying a `package.json`.
- **Database tables** = `pgTable(` declarations; **license split** read from each `packages/*/package.json` `license` field.
- Where counts drift often (route files, guide count), the magic number was replaced with a reproducible command, following the repo's existing "run X for current count" pattern.

### Mirror handling

`apps/docs/public/*.md` is **build-generated and gitignored** (`apps/docs/.gitignore:18-19`); `apps/docs/scripts/copy-docs.sh` copies `docs/*` into `public/` at build time. `README.md` and `CLAUDE.md` are repo-root files and are never mirrored there. So there is **no tracked mirror copy to edit in lockstep**. Verified after the docs build that the generated `apps/docs/public/WHAT_WORKS_TODAY.md` reflects the corrected numbers, and confirmed the file is untracked via `git check-ignore`.

### Validator + build results

- `pnpm install --frozen-lockfile --prefer-offline` — clean (exit 0).
- `pnpm validate:claims` — **0 mismatches**; validator prints actual metrics: 27 packages, 31 workspaces, 61 UI components, 14 MCP servers, 85 DB tables, 21 MIT / 5 FSL / 1 internal. All future-tense / aspirational / license-membership / marketing-METRICS gates clean.
- `pnpm exec turbo build --filter=docs` — **13/13 tasks successful**; mirror regenerates and renders.

### Out-of-scope drift observed (not changed here)

`docs/COMPONENT_CATALOG.md:12` and `docs/INDEX.md:49` still carry the stale "80 total, 59 in presentation, 21 core" component phrasing (presentation is now 61). Flagged for a follow-up sweep; left untouched to keep this change scoped to the three triad files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
